### PR TITLE
Figma oauth 2.0

### DIFF
--- a/.github/workflows/deploy-public-www.yml
+++ b/.github/workflows/deploy-public-www.yml
@@ -40,7 +40,11 @@ jobs:
         run: npm run figma:pull
         working-directory: apps/public_www
         env:
-          FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
+          FIGMA_OAUTH_ACCESS_TOKEN: ${{ secrets.FIGMA_OAUTH_ACCESS_TOKEN }}
+          FIGMA_OAUTH_CLIENT_ID: ${{ secrets.FIGMA_OAUTH_CLIENT_ID }}
+          FIGMA_OAUTH_CLIENT_SECRET: ${{ secrets.FIGMA_OAUTH_CLIENT_SECRET }}
+          FIGMA_OAUTH_REFRESH_TOKEN: ${{ secrets.FIGMA_OAUTH_REFRESH_TOKEN }}
+          FIGMA_OAUTH_TOKEN_URL: ${{ vars.PUBLIC_WWW_FIGMA_OAUTH_TOKEN_URL }}
           FIGMA_FILE_KEY: ${{ vars.PUBLIC_WWW_FIGMA_FILE_KEY }}
 
       - name: Restore Next.js build cache

--- a/apps/public_www/.env.example
+++ b/apps/public_www/.env.example
@@ -1,8 +1,17 @@
 # Build-time variables for Figma token sync.
-# FIGMA_ACCESS_TOKEN and FIGMA_FILE_KEY are optional for local builds.
+# OAuth and FIGMA_FILE_KEY are optional for local builds.
 # If omitted, figma:pull will skip API sync and figma:build will use
 # available local exports.
-FIGMA_ACCESS_TOKEN=
+
+# Option A: use an already-minted OAuth access token.
+FIGMA_OAUTH_ACCESS_TOKEN=
+
+# Option B: mint an OAuth access token via refresh_token grant.
+FIGMA_OAUTH_CLIENT_ID=
+FIGMA_OAUTH_CLIENT_SECRET=
+FIGMA_OAUTH_REFRESH_TOKEN=
+# FIGMA_OAUTH_TOKEN_URL=https://api.figma.com/v1/oauth/token
+
 FIGMA_FILE_KEY=
 
 # Optional overrides for input files.

--- a/apps/public_www/README.md
+++ b/apps/public_www/README.md
@@ -7,7 +7,7 @@
 The app can consume design tokens from Figma:
 
 - `npm run figma:pull` pulls Figma file metadata and local variables into
-  `figma/files/`.
+  `figma/files/` using OAuth 2.0 credentials.
 - `npm run figma:build` builds normalized token artifacts and generates CSS
   variables consumed by the app.
 - `npm run figma:sync` runs both commands in sequence.
@@ -17,6 +17,12 @@ Directory layout:
 - `figma/files/`: raw Figma API payloads
 - `figma/mdm/exports/`: files exported by Figma MDM flow
 - `figma/mdm/artifacts/`: normalized artifacts generated for the website
+
+To run `figma:pull`, set `FIGMA_FILE_KEY` and either:
+
+- `FIGMA_OAUTH_ACCESS_TOKEN`, or
+- `FIGMA_OAUTH_CLIENT_ID`, `FIGMA_OAUTH_CLIENT_SECRET`, and
+  `FIGMA_OAUTH_REFRESH_TOKEN`.
 
 ## Development
 

--- a/apps/public_www/figma/README.md
+++ b/apps/public_www/figma/README.md
@@ -7,7 +7,7 @@ token pipeline.
 
 - `files/`
   - Raw Figma API payloads produced by:
-    - `npm run figma:pull`
+    - `npm run figma:pull` (OAuth 2.0 authenticated)
   - Expected files:
     - `file.json`
     - `variables.local.json`
@@ -29,3 +29,9 @@ token pipeline.
 
 `src/app/globals.css` imports this generated file so token updates from
 Figma flow through the website build.
+
+For `figma:pull`, set `FIGMA_FILE_KEY` and either:
+
+- `FIGMA_OAUTH_ACCESS_TOKEN`, or
+- `FIGMA_OAUTH_CLIENT_ID`, `FIGMA_OAUTH_CLIENT_SECRET`, and
+  `FIGMA_OAUTH_REFRESH_TOKEN`.

--- a/docs/deployment/public-www.md
+++ b/docs/deployment/public-www.md
@@ -129,8 +129,19 @@ bash scripts/deploy/deploy-public-www.sh
 
 The staging deploy workflow runs `npm run figma:pull` before `npm run build`.
 `npm run build` then runs `figma:build` to generate CSS tokens.
-If `FIGMA_ACCESS_TOKEN` or `FIGMA_FILE_KEY` is unavailable, pull is skipped
-and build falls back to local artifacts safely.
+If `FIGMA_FILE_KEY` or OAuth credentials are unavailable, pull is skipped and
+build falls back to local artifacts safely.
+
+The deploy workflow reads these GitHub values for OAuth 2.0 auth:
+
+- Secrets:
+  - `FIGMA_OAUTH_ACCESS_TOKEN` (optional direct token)
+  - `FIGMA_OAUTH_CLIENT_ID`
+  - `FIGMA_OAUTH_CLIENT_SECRET`
+  - `FIGMA_OAUTH_REFRESH_TOKEN`
+- Variables:
+  - `PUBLIC_WWW_FIGMA_FILE_KEY`
+  - `PUBLIC_WWW_FIGMA_OAUTH_TOKEN_URL` (optional override)
 
 ## SEO behavior
 


### PR DESCRIPTION
Migrate Figma integration from PAT to OAuth 2.0 for enhanced security.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9432bd6c-d7d6-4b06-9fb4-a419174bd8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9432bd6c-d7d6-4b06-9fb4-a419174bd8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

