### PR TITLE
Rewrite Figma OAuth workflow as single-phase to reduce latency

### DIFF
--- a/.github/workflows/figma-refresh-token.yml
+++ b/.github/workflows/figma-refresh-token.yml
@@ -1,19 +1,21 @@
 name: Generate Figma OAuth Refresh Token
 
+# Usage:
+#   1. Construct the Figma authorization URL (see the job summary or
+#      the figma/README.md in apps/public_www).
+#   2. Open it in your browser and click Allow.
+#   3. Copy the `code` from the redirect URL in your browser address bar.
+#   4. Trigger this workflow with the code pasted into authorization_code.
+#
+# The workflow exchanges the code immediately and stores the refresh
+# token as a repository secret.
+
 on:
   workflow_dispatch:
     inputs:
-      step:
-        description: 'Which phase to run'
-        required: true
-        default: 'get_auth_url'
-        type: choice
-        options:
-          - get_auth_url
-          - exchange_code
       authorization_code:
-        description: 'Figma authorization code (required for exchange_code step)'
-        required: false
+        description: 'Figma authorization code from the redirect URL'
+        required: true
         type: string
       callback_port:
         description: 'Port used in the callback URL (must match Figma app settings)'
@@ -25,72 +27,7 @@ permissions:
   contents: read
 
 jobs:
-  get-auth-url:
-    if: ${{ inputs.step == 'get_auth_url' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate secrets
-        run: |
-          if [ -z "$CLIENT_ID" ]; then
-            echo '::error::FIGMA_OAUTH_CLIENT_ID secret is not set.'
-            echo 'Add it under Settings > Secrets and variables > Actions.'
-            exit 1
-          fi
-        env:
-          CLIENT_ID: ${{ secrets.FIGMA_OAUTH_CLIENT_ID }}
-
-      - name: Generate authorization URL
-        run: |
-          PORT="${CALLBACK_PORT:-3845}"
-          REDIRECT_URI="http://localhost:${PORT}/callback"
-          STATE="$(openssl rand -hex 16)"
-          SCOPE="file_content:read"
-
-          AUTH_URL="https://www.figma.com/oauth?client_id=${CLIENT_ID}&redirect_uri=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${REDIRECT_URI}', safe=''))")&scope=${SCOPE}&state=${STATE}&response_type=code"
-
-          {
-            echo '## Figma OAuth — Step 1: Authorize'
-            echo ''
-            echo '### Open this URL in your browser'
-            echo ''
-            echo "\`\`\`"
-            echo "${AUTH_URL}"
-            echo "\`\`\`"
-            echo ''
-            echo '### What happens next'
-            echo ''
-            echo '1. Click **Allow** on the Figma authorization page.'
-            echo "2. Your browser will redirect to \`${REDIRECT_URI}?code=XXXXX&state=...\`"
-            echo '3. The page **will not load** (no local server is running) — that is expected.'
-            echo '4. **Copy the \`code\` value** from the browser address bar.'
-            echo '   - It is the part between \`?code=\` and \`&state=\`.'
-            echo ''
-            echo '### Then come back here and run Step 2'
-            echo ''
-            echo '> **Important:** The authorization code expires in a few minutes.'
-            echo '> Have the **Run workflow** form open and ready before you authorize'
-            echo '> so you can paste the code and trigger the exchange quickly.'
-            echo ''
-            echo '1. Go to **Actions** > **Generate Figma OAuth Refresh Token** > **Run workflow**.'
-            echo '2. Set **step** to \`exchange_code\`.'
-            echo '3. Paste the code into the **authorization_code** field.'
-            echo '4. Click **Run workflow**.'
-            echo ''
-            echo 'If you get \`invalid_grant\`, the code has expired. Re-open the'
-            echo 'authorization URL above (it is still valid) and try again faster.'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          echo ''
-          echo '=========================================='
-          echo 'Authorization URL generated.'
-          echo 'See the workflow run summary for the URL and next steps.'
-          echo '=========================================='
-        env:
-          CLIENT_ID: ${{ secrets.FIGMA_OAUTH_CLIENT_ID }}
-          CALLBACK_PORT: ${{ inputs.callback_port }}
-
   exchange-code:
-    if: ${{ inputs.step == 'exchange_code' }}
     runs-on: ubuntu-latest
     steps:
       - name: Validate inputs and secrets
@@ -106,7 +43,7 @@ jobs:
             ERRORS=1
           fi
           if [ -z "$AUTH_CODE" ]; then
-            echo '::error::authorization_code input is required for exchange_code step.'
+            echo '::error::authorization_code input is required.'
             ERRORS=1
           fi
 
@@ -123,7 +60,7 @@ jobs:
         run: |
           PORT="${CALLBACK_PORT:-3845}"
           REDIRECT_URI="http://localhost:${PORT}/callback"
-          TOKEN_URL="https://www.figma.com/api/oauth/token"
+          TOKEN_URL="https://api.figma.com/v1/oauth/token"
 
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${TOKEN_URL}" \
             -H "Content-Type: application/x-www-form-urlencoded" \
@@ -137,8 +74,10 @@ jobs:
           BODY=$(echo "$RESPONSE" | sed '$d')
 
           if [ "$HTTP_CODE" -ne 200 ]; then
-            echo "::error::Token exchange failed with HTTP ${HTTP_CODE}"
-            echo "Response: ${BODY}"
+            echo "exchange_ok=false" >> "$GITHUB_OUTPUT"
+            echo "error_status=${HTTP_CODE}" >> "$GITHUB_OUTPUT"
+            echo "error_body=${BODY}" >> "$GITHUB_OUTPUT"
+            echo "::error::Token exchange failed with HTTP ${HTTP_CODE}: ${BODY}"
             exit 1
           fi
 
@@ -148,8 +87,8 @@ jobs:
           USER_ID=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('user_id',''))")
 
           if [ -z "$REFRESH_TOKEN" ]; then
-            echo "::error::No refresh_token in response"
-            echo "Response: ${BODY}"
+            echo "exchange_ok=false" >> "$GITHUB_OUTPUT"
+            echo "::error::No refresh_token in response: ${BODY}"
             exit 1
           fi
 
@@ -159,6 +98,7 @@ jobs:
             echo "::add-mask::${ACCESS_TOKEN}"
           fi
 
+          echo "exchange_ok=true" >> "$GITHUB_OUTPUT"
           echo "refresh_token=${REFRESH_TOKEN}" >> "$GITHUB_OUTPUT"
           echo "expires_in=${EXPIRES_IN}" >> "$GITHUB_OUTPUT"
           echo "user_id=${USER_ID}" >> "$GITHUB_OUTPUT"
@@ -169,6 +109,7 @@ jobs:
           CALLBACK_PORT: ${{ inputs.callback_port }}
 
       - name: Store refresh token as secret
+        if: ${{ steps.exchange.outputs.exchange_ok == 'true' }}
         run: |
           echo "${REFRESH_TOKEN}" | gh secret set FIGMA_OAUTH_REFRESH_TOKEN
           echo 'FIGMA_OAUTH_REFRESH_TOKEN secret has been updated.'
@@ -179,11 +120,17 @@ jobs:
       - name: Publish result summary
         if: always()
         run: |
+          PORT="${CALLBACK_PORT:-3845}"
+          REDIRECT_URI="http://localhost:${PORT}/callback"
+          ENCODED_REDIRECT=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${REDIRECT_URI}', safe=''))")
+          AUTH_URL="https://www.figma.com/oauth?client_id=${CLIENT_ID}&redirect_uri=${ENCODED_REDIRECT}&scope=file_content:read&state=$(openssl rand -hex 16)&response_type=code"
+
           {
-            echo '## Figma OAuth — Step 2: Token Exchange'
+            echo '## Figma OAuth Refresh Token'
             echo ''
-            if [ -n "$REFRESH_TOKEN" ]; then
-              echo '**Status: Success**'
+
+            if [ "$EXCHANGE_OK" = "true" ]; then
+              echo '### Status: Success'
               echo ''
               echo 'The \`FIGMA_OAUTH_REFRESH_TOKEN\` repository secret has been created/updated automatically.'
               echo ''
@@ -192,15 +139,44 @@ jobs:
               echo "| Figma user ID | \`${USER_ID:-n/a}\` |"
               echo "| Access token expires in | ${EXPIRES_IN:-?}s |"
               echo ''
-              echo 'If automatic secret storage failed (permissions), copy the refresh token from the masked output above and add it manually:'
-              echo ''
-              echo '1. Go to **Settings** > **Secrets and variables** > **Actions**.'
-              echo '2. Create or update `FIGMA_OAUTH_REFRESH_TOKEN`.'
+              echo 'If automatic secret storage failed (permissions), add the secret manually'
+              echo 'under **Settings > Secrets and variables > Actions**.'
             else
-              echo '**Status: Failed** — see error details above.'
+              echo '### Status: Failed'
+              echo ''
+              echo 'The authorization code may have expired before the runner started.'
+              echo 'Figma codes are short-lived — you need to authorize and trigger the'
+              echo 'workflow quickly.'
+              echo ''
+              echo '### How to retry'
+              echo ''
+              echo '**Tip:** Open both tabs side-by-side before you start:'
+              echo '- Tab 1: The authorization URL below'
+              echo '- Tab 2: **Actions > Generate Figma OAuth Refresh Token > Run workflow**'
+              echo ''
+              echo '1. Open the authorization URL below in **Tab 1**.'
+              echo '2. Click **Allow** on the Figma page.'
+              echo "3. Figma redirects to \`${REDIRECT_URI}?code=XXXXX&state=...\`"
+              echo '   The page will not load — that is expected.'
+              echo '4. Copy the \`code\` value from the address bar'
+              echo '   (between \`?code=\` and \`&state=\`).'
+              echo '5. Switch to **Tab 2**, paste the code, and click **Run workflow**.'
             fi
+
+            echo ''
+            echo '---'
+            echo ''
+            echo '### Authorization URL'
+            echo ''
+            echo 'Open this in your browser to authorize (or re-authorize):'
+            echo ''
+            echo "\`\`\`"
+            echo "${AUTH_URL}"
+            echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
         env:
-          REFRESH_TOKEN: ${{ steps.exchange.outputs.refresh_token }}
+          CLIENT_ID: ${{ secrets.FIGMA_OAUTH_CLIENT_ID }}
+          CALLBACK_PORT: ${{ inputs.callback_port }}
+          EXCHANGE_OK: ${{ steps.exchange.outputs.exchange_ok }}
           EXPIRES_IN: ${{ steps.exchange.outputs.expires_in }}
           USER_ID: ${{ steps.exchange.outputs.user_id }}

--- a/apps/public_www/figma/README.md
+++ b/apps/public_www/figma/README.md
@@ -73,39 +73,43 @@ This approach keeps your client secret and refresh token inside GitHub
 and never exposes them locally. The only manual step is authorizing in
 a browser.
 
-**Phase 1 — Get the authorization URL**
+**Preparation — open two tabs side by side:**
 
-1. Go to **Actions** > **Generate Figma OAuth Refresh Token**.
-2. Click **Run workflow**.
-3. Set **step** to `get_auth_url`.
-4. Click **Run workflow**.
-5. Open the completed run and check the **Summary** tab — it contains
-   the Figma authorization URL.
+- **Tab 1:** The Figma authorization URL (see below).
+- **Tab 2:** **Actions > Generate Figma OAuth Refresh Token > Run workflow**.
 
-**Phase 2 — Authorize and copy the code**
+Construct the authorization URL by replacing `YOUR_CLIENT_ID` with your
+Figma OAuth app's Client ID:
 
-1. Open the authorization URL in your browser.
+```
+https://www.figma.com/oauth?client_id=YOUR_CLIENT_ID&redirect_uri=http%3A%2F%2Flocalhost%3A3845%2Fcallback&scope=file_content:read&state=1&response_type=code
+```
+
+> **Tip:** If you have already run the workflow once (even if it
+> failed), check the run's **Summary** tab — it contains a ready-made
+> authorization URL with your Client ID filled in.
+
+**Steps:**
+
+1. Open the authorization URL in **Tab 1**.
 2. Click **Allow** on the Figma consent page.
-3. Figma redirects to `http://localhost:3845/callback?code=XXXXX&state=...`.
+3. Figma redirects to
+   `http://localhost:3845/callback?code=XXXXX&state=...`.
    The page will **not load** (no local server is running) — that is
    expected.
 4. Copy the `code` value from the browser address bar (the string
    between `?code=` and `&state=`).
-
-**Phase 3 — Exchange the code**
-
-1. Go to **Actions** > **Generate Figma OAuth Refresh Token** >
-   **Run workflow**.
-2. Set **step** to `exchange_code`.
-3. Paste the code into **authorization_code**.
-4. Click **Run workflow**.
-5. The workflow exchanges the code for a refresh token and automatically
-   stores it as the `FIGMA_OAUTH_REFRESH_TOKEN` repository secret.
+5. Switch to **Tab 2**. Paste the code into the **authorization_code**
+   field and click **Run workflow** immediately.
+6. The workflow exchanges the code and automatically stores
+   `FIGMA_OAUTH_REFRESH_TOKEN` as a repository secret.
 
 Check the run **Summary** tab for confirmation.
 
-> **Note:** The authorization code is short-lived (a few minutes). If
-> the exchange fails with `invalid_grant`, re-run from Phase 1.
+> **Important:** Figma authorization codes expire quickly. Have Tab 2
+> ready to go *before* you authorize so you can paste the code and
+> trigger the workflow within seconds. If you see `invalid_grant`,
+> re-open the authorization URL in Tab 1 and try again.
 
 ---
 


### PR DESCRIPTION
The two-phase approach (get_auth_url then exchange_code) required two separate workflow runs. The runner startup delay on the second run caused authorization codes to expire before the exchange could happen.

Now the workflow is a single run:
- Takes the authorization_code as a required input
- Exchanges it immediately on the first step
- Always prints the auth URL in the summary (success or failure) so the user can re-authorize without a separate workflow run
- Reverts token URL to https://api.figma.com/v1/oauth/token (the www.figma.com/api/oauth/token path returned 404)
- Provides clear retry instructions in the summary on failure

Updated README to match the simplified single-phase flow.