### PR TITLE
Fix Figma API auth: use Bearer token instead of X-Figma-Token

### DIFF
--- a/apps/public_www/scripts/figma/pull-figma-tokens.mjs
+++ b/apps/public_www/scripts/figma/pull-figma-tokens.mjs
@@ -33,7 +33,7 @@ async function ensureJsonIfMissing(filePath, fallback) {
 async function fetchFigmaJson(endpoint, accessToken) {
   const response = await fetch(endpoint, {
     headers: {
-      'X-Figma-Token': accessToken,
+      Authorization: `Bearer ${accessToken}`,
     },
   });
 


### PR DESCRIPTION
X-Figma-Token is for Personal Access Tokens. OAuth access tokens (obtained via the refresh_token grant) require the standard Authorization: Bearer header. This caused a 403 'Invalid token' error on the file fetch endpoints.