### PR TITLE
Workflow dispatch event access

### DIFF
--- a/.github/workflows/amplify-promote.yml
+++ b/.github/workflows/amplify-promote.yml
@@ -1,6 +1,8 @@
 name: Amplify Promote
 
 on:
+  repository_dispatch:
+    types: [amplify-promote]
   workflow_dispatch:
     inputs:
       source_branch:

--- a/.github/workflows/cdk-bootstrap.yml
+++ b/.github/workflows/cdk-bootstrap.yml
@@ -1,6 +1,8 @@
 name: CDK Bootstrap
 
 on:
+  repository_dispatch:
+    types: [cdk-bootstrap]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -1,6 +1,8 @@
 name: CDK Diff
 
 on:
+  repository_dispatch:
+    types: [cdk-diff]
   workflow_dispatch:
     inputs:
       stacks:

--- a/.github/workflows/check-lockfiles.yml
+++ b/.github/workflows/check-lockfiles.yml
@@ -1,6 +1,8 @@
 name: Check Lockfiles
 
 on:
+  repository_dispatch:
+    types: [check-lockfiles]
   workflow_dispatch:
   pull_request:
   push:

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,6 +1,8 @@
 name: Deploy Backend
 
 on:
+  repository_dispatch:
+    types: [deploy-backend]
   workflow_dispatch:
     inputs:
       cdk_stacks:

--- a/.github/workflows/deploy-crm-web.yml
+++ b/.github/workflows/deploy-crm-web.yml
@@ -1,6 +1,8 @@
 name: Deploy CRM Web
 
 on:
+  repository_dispatch:
+    types: [deploy-crm-web]
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -1,6 +1,8 @@
 name: Deploy iOS
 
 on:
+  repository_dispatch:
+    types: [deploy-ios]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-mobile.yml
+++ b/.github/workflows/deploy-mobile.yml
@@ -1,6 +1,8 @@
 name: Deploy Mobile App
 
 on:
+  repository_dispatch:
+    types: [deploy-mobile]
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/deploy-public-www.yml
+++ b/.github/workflows/deploy-public-www.yml
@@ -1,6 +1,8 @@
 name: Deploy Public Website Staging
 
 on:
+  repository_dispatch:
+    types: [deploy-public-www]
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/figma-refresh-token.yml
+++ b/.github/workflows/figma-refresh-token.yml
@@ -11,6 +11,8 @@ name: Generate Figma OAuth Refresh Token
 # run summary. Copy it and add it as a repository secret manually.
 
 on:
+  repository_dispatch:
+    types: [figma-refresh-token]
   workflow_dispatch:
     inputs:
       authorization_code:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 
 on:
+  repository_dispatch:
+    types: [lint]
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/promote-public-www.yml
+++ b/.github/workflows/promote-public-www.yml
@@ -1,6 +1,8 @@
 name: Promote Public Website Release
 
 on:
+  repository_dispatch:
+    types: [promote-public-www]
   workflow_dispatch:
     inputs:
       promotion_mode:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     # Run security scans weekly on Mondays at 8:00 UTC
     - cron: '0 8 * * 1'
+  repository_dispatch:
+    types: [security]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
 on:
+  repository_dispatch:
+    types: [test]
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/verify-rulesets.yml
+++ b/.github/workflows/verify-rulesets.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Run weekly on Monday at 9am UTC
     - cron: "0 9 * * 1"
+  repository_dispatch:
+    types: [verify-rulesets]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add `repository_dispatch` as an alternative trigger to all workflows to allow GitHub App integrations with `contents: write` permission to trigger them.

The `workflow_dispatch` API requires `actions: write` permission, which caused a 403 error for integrations lacking this permission. `repository_dispatch` only requires `contents: write`, which is typically available. All existing triggers are preserved.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-cd5e0abb-5208-499b-a550-27a9f90d575a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd5e0abb-5208-499b-a550-27a9f90d575a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

