### PR TITLE
feat: scope token extraction to a specific frame via FIGMA_TOKEN_ROOT…

### DIFF
--- a/.github/workflows/deploy-public-www.yml
+++ b/.github/workflows/deploy-public-www.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Tokenize Figma data to Token Studio format
         run: npm run figma:tokenize
         working-directory: apps/public_www
+        env:
+          FIGMA_TOKEN_ROOT_NODE: ${{ vars.PUBLIC_WWW_FIGMA_TOKEN_ROOT_NODE }}
 
       - name: Restore Next.js build cache
         uses: actions/cache@v5

--- a/.github/workflows/figma-token-studio-sync.yml
+++ b/.github/workflows/figma-token-studio-sync.yml
@@ -105,6 +105,8 @@ jobs:
       - name: Tokenize Figma data to Token Studio format
         run: npm run figma:tokenize
         working-directory: apps/public_www
+        env:
+          FIGMA_TOKEN_ROOT_NODE: ${{ vars.PUBLIC_WWW_FIGMA_TOKEN_ROOT_NODE }}
 
       - name: Build CSS from Token Studio tokens
         run: npm run figma:build:studio

--- a/apps/public_www/.env.example
+++ b/apps/public_www/.env.example
@@ -14,6 +14,15 @@ FIGMA_OAUTH_REFRESH_TOKEN=
 
 FIGMA_FILE_KEY=
 
+# Scope token extraction to a specific frame/component by name or node ID.
+# Prevents picking up styles from imported libraries (e.g. Material Design
+# kits) that live elsewhere in the file.
+# Examples:
+#   FIGMA_TOKEN_ROOT_NODE=Desktop
+#   FIGMA_TOKEN_ROOT_NODE=Homepage Desktop
+#   FIGMA_TOKEN_ROOT_NODE=123:456
+FIGMA_TOKEN_ROOT_NODE=
+
 # Optional overrides for input files.
 # FIGMA_MDM_EXPORT_PATH=figma/mdm/exports/tokens.json
 # FIGMA_VARIABLES_FILE_PATH=figma/files/variables.local.json


### PR DESCRIPTION
…_NODE

The previous version extracted styles from the entire Figma document tree, picking up Material Design library styles (Roboto, android- text-styles, material-theme) that aren't part of the actual website design.

Added FIGMA_TOKEN_ROOT_NODE env var that scopes extraction to a specific frame/component by name or node ID. When set, only styles used within that subtree are tokenized.

When not set, the script lists all available top-level frames so the user can pick the right one.

Updated both workflows (figma-token-studio-sync, deploy-public-www) to pass PUBLIC_WWW_FIGMA_TOKEN_ROOT_NODE variable. Updated .env.example with the new variable.