### PR TITLE
fix: enable trailingSlash and render full homepage at root

### DIFF
--- a/apps/public_www/next.config.js
+++ b/apps/public_www/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  trailingSlash: false,
+  trailingSlash: true,
   images: {
     unoptimized: true,
   },

--- a/apps/public_www/src/app/page.tsx
+++ b/apps/public_www/src/app/page.tsx
@@ -1,22 +1,30 @@
 import { getContent, DEFAULT_LOCALE } from '@/content';
+import { Navbar } from '@/components/sections/navbar';
+import { HeroBanner } from '@/components/sections/hero-banner';
+import { CourseModule } from '@/components/sections/course-module';
+import { FreeResources } from '@/components/sections/free-resources';
+import { WhyJoining } from '@/components/sections/why-joining';
+import { RealStories } from '@/components/sections/real-stories';
+import { Footer } from '@/components/sections/footer';
 
 /**
  * Root page — renders the default locale (English) homepage.
- * Locale-specific pages are at /en, /zh-CN, /zh-HK.
+ * Locale-specific pages are at /en/, /zh-CN/, /zh-HK/.
  */
 export default function RootPage() {
   const content = getContent(DEFAULT_LOCALE);
 
   return (
-    <main className='min-h-screen'>
-      <div className='flex items-center justify-center py-24'>
-        <div className='text-center'>
-          <h1 className='text-4xl font-bold'>{content.hero.headline}</h1>
-          <p className='mt-4 text-lg text-slate-600'>
-            {content.hero.subheadline}
-          </p>
-        </div>
-      </div>
-    </main>
+    <>
+      <Navbar content={content.navbar} />
+      <main className='min-h-screen'>
+        <HeroBanner content={content.hero} />
+        <CourseModule content={content.courseModule} />
+        <FreeResources content={content.freeResources} />
+        <WhyJoining content={content.whyJoining} />
+        <RealStories content={content.realStories} />
+      </main>
+      <Footer content={content.footer} />
+    </>
   );
 }


### PR DESCRIPTION
trailingSlash: true makes Next.js static export produce en/index.html instead of en.html, which S3/CloudFront resolves correctly for /en/ URLs.

Root page now renders the full composed homepage (navbar + all sections + footer) with the default locale, matching the /en/ page instead of showing a bare placeholder.