### PR TITLE
fix(public_www): rewrite footer to match Figma layout structure

### DIFF
--- a/apps/public_www/public/images/evolve-sprouts-logo-large.svg
+++ b/apps/public_www/public/images/evolve-sprouts-logo-large.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="470" height="482" viewBox="0 0 470 482" fill="none">
+  <!-- Large Evolve Sprouts mascot placeholder using brand colors -->
+  <!-- Matches "evolve-sprouts 1" in Figma (470×482) -->
+  <!-- Body base -->
+  <ellipse cx="235" cy="310" rx="166" ry="141" fill="#174879"/>
+  <!-- Face/head -->
+  <ellipse cx="235" cy="252" rx="133" ry="133" fill="#E76C3D"/>
+  <!-- Head crest -->
+  <ellipse cx="235" cy="164" rx="82" ry="70" fill="#B31D1F"/>
+  <!-- Sprout leaves -->
+  <path d="M235 38 C255 77, 303 97, 313 68 C323 38, 273 29, 235 38Z" fill="#5D9D49"/>
+  <path d="M235 38 C215 77, 167 97, 157 68 C147 38, 197 29, 235 38Z" fill="#A8CB44"/>
+  <path d="M235 15 C245 48, 284 68, 290 42 C296 17, 254 9, 235 15Z" fill="#135227"/>
+  <path d="M235 15 C225 48, 186 68, 180 42 C174 17, 216 9, 235 15Z" fill="#2A7834"/>
+  <!-- Stem -->
+  <rect x="231" y="8" width="8" height="43" rx="4" fill="#2A7834"/>
+  <!-- Eyes -->
+  <circle cx="196" cy="242" r="16" fill="#FFFFFF"/>
+  <circle cx="274" cy="242" r="16" fill="#FFFFFF"/>
+  <circle cx="200" cy="240" r="8" fill="#1C3542"/>
+  <circle cx="278" cy="240" r="8" fill="#1C3542"/>
+  <circle cx="202" cy="238" r="3" fill="#FFFFFF"/>
+  <circle cx="280" cy="238" r="3" fill="#FFFFFF"/>
+  <!-- Beak/smile -->
+  <path d="M215 282 Q235 308 255 282" stroke="#B31D1F" stroke-width="5" fill="none" stroke-linecap="round"/>
+  <!-- Cheeks -->
+  <circle cx="180" cy="268" r="12" fill="#FFBA89" opacity="0.5"/>
+  <circle cx="290" cy="268" r="12" fill="#FFBA89" opacity="0.5"/>
+  <!-- Feet -->
+  <ellipse cx="185" cy="440" rx="39" ry="16" fill="#E76C3D"/>
+  <ellipse cx="285" cy="440" rx="39" ry="16" fill="#E76C3D"/>
+  <!-- Legs -->
+  <rect x="178" y="400" width="14" height="45" rx="7" fill="#1C3542"/>
+  <rect x="278" y="400" width="14" height="45" rx="7" fill="#1C3542"/>
+  <!-- Wing accents -->
+  <ellipse cx="107" cy="310" rx="49" ry="78" transform="rotate(-15 107 310)" fill="#135227" opacity="0.7"/>
+  <ellipse cx="363" cy="310" rx="49" ry="78" transform="rotate(15 363 310)" fill="#135227" opacity="0.7"/>
+  <!-- Wing highlights -->
+  <ellipse cx="115" cy="300" rx="30" ry="50" transform="rotate(-15 115 300)" fill="#5D9D49" opacity="0.5"/>
+  <ellipse cx="355" cy="300" rx="30" ry="50" transform="rotate(15 355 300)" fill="#5D9D49" opacity="0.5"/>
+  <!-- Belly pattern -->
+  <ellipse cx="235" cy="330" rx="60" ry="50" fill="#F5F6F5" opacity="0.2"/>
+  <!-- Text wordmark below mascot -->
+  <text x="235" y="475" text-anchor="middle" font-family="Poppins, sans-serif" font-size="28" font-weight="700" fill="#174879">evolve sprouts</text>
+</svg>

--- a/apps/public_www/public/images/evolve-sprouts-logo.svg
+++ b/apps/public_www/public/images/evolve-sprouts-logo.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="246" viewBox="0 0 240 246" fill="none">
+  <!-- Simplified Evolve Sprouts mascot placeholder using brand colors -->
+  <!-- Body base -->
+  <ellipse cx="120" cy="160" rx="85" ry="72" fill="#174879"/>
+  <!-- Face/head -->
+  <ellipse cx="120" cy="130" rx="68" ry="68" fill="#E76C3D"/>
+  <!-- Head crest -->
+  <ellipse cx="120" cy="85" rx="42" ry="36" fill="#B31D1F"/>
+  <!-- Sprout leaves -->
+  <path d="M120 20 C130 40, 155 50, 160 35 C165 20, 140 15, 120 20Z" fill="#5D9D49"/>
+  <path d="M120 20 C110 40, 85 50, 80 35 C75 20, 100 15, 120 20Z" fill="#A8CB44"/>
+  <path d="M120 8 C125 25, 145 35, 148 22 C151 9, 130 5, 120 8Z" fill="#135227"/>
+  <!-- Stem -->
+  <rect x="118" y="8" width="4" height="22" rx="2" fill="#2A7834"/>
+  <!-- Eyes -->
+  <circle cx="100" cy="125" r="8" fill="#FFFFFF"/>
+  <circle cx="140" cy="125" r="8" fill="#FFFFFF"/>
+  <circle cx="102" cy="124" r="4" fill="#1C3542"/>
+  <circle cx="142" cy="124" r="4" fill="#1C3542"/>
+  <!-- Beak/smile -->
+  <path d="M110 145 Q120 158 130 145" stroke="#B31D1F" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Feet -->
+  <ellipse cx="95" cy="225" rx="20" ry="8" fill="#E76C3D"/>
+  <ellipse cx="145" cy="225" rx="20" ry="8" fill="#E76C3D"/>
+  <!-- Wing accents -->
+  <ellipse cx="55" cy="160" rx="25" ry="40" transform="rotate(-15 55 160)" fill="#135227" opacity="0.7"/>
+  <ellipse cx="185" cy="160" rx="25" ry="40" transform="rotate(15 185 160)" fill="#135227" opacity="0.7"/>
+</svg>

--- a/apps/public_www/public/images/footer-bg.svg
+++ b/apps/public_www/public/images/footer-bg.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1490" height="836" viewBox="0 0 1490 836">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FFD8BD"/>
+      <stop offset="50%" stop-color="#FFEEE3"/>
+      <stop offset="100%" stop-color="#F6DECD"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ED622E" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#174879" stop-opacity="0.04"/>
+    </linearGradient>
+  </defs>
+  <rect width="1490" height="836" fill="url(#bg)"/>
+  <rect width="1490" height="836" fill="url(#accent)"/>
+  <!-- Decorative circles evoking children/community -->
+  <circle cx="900" cy="350" r="180" fill="#ED622E" opacity="0.06"/>
+  <circle cx="1100" cy="500" r="120" fill="#5D9D49" opacity="0.07"/>
+  <circle cx="750" cy="550" r="100" fill="#174879" opacity="0.05"/>
+  <circle cx="1200" cy="250" r="80" fill="#A8CB44" opacity="0.08"/>
+  <circle cx="500" cy="300" r="140" fill="#FFBA89" opacity="0.1"/>
+  <circle cx="300" cy="600" r="90" fill="#B2DDA4" opacity="0.09"/>
+  <!-- Leaf-like shapes -->
+  <ellipse cx="1050" cy="200" rx="60" ry="30" transform="rotate(-30 1050 200)" fill="#5D9D49" opacity="0.06"/>
+  <ellipse cx="650" cy="680" rx="50" ry="25" transform="rotate(20 650 680)" fill="#A8CB44" opacity="0.07"/>
+  <ellipse cx="1300" cy="600" rx="45" ry="22" transform="rotate(-15 1300 600)" fill="#135227" opacity="0.05"/>
+</svg>

--- a/apps/public_www/src/components/sections/footer.tsx
+++ b/apps/public_www/src/components/sections/footer.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 
 import type { FooterContent } from '@/content';
@@ -10,13 +11,24 @@ interface FooterProps {
 /*  Design-token constants (from figma-tokens.css)                    */
 /* ------------------------------------------------------------------ */
 
+/** Main footer background — #FFEEE3 peach */
 const FOOTER_BG =
   'var(--figma-colors-frame-2147235259, #FFEEE3)';
+
+/** Dark text for headings — #333333 */
 const HEADING_COLOR =
   'var(--figma-colors-join-our-sprouts-squad-community, #333333)';
+
+/** Secondary text for links — #4A4A4A */
 const LINK_COLOR = 'var(--figma-colors-home, #4A4A4A)';
+
+/** CTA button orange — #ED622E */
 const CTA_BG = 'var(--figma-colors-frame-2147235222-2, #ED622E)';
+
+/** White text on CTA — #FFFFFF */
 const CTA_TEXT = 'var(--figma-colors-desktop, #FFFFFF)';
+
+/** Brand navy blue — #174879 */
 const BRAND_COLOR =
   'var(--figma-colors-frame-2147235242, #174879)';
 
@@ -24,6 +36,10 @@ const BRAND_COLOR =
 /*  Typography style objects (mapped to figma typography tokens)       */
 /* ------------------------------------------------------------------ */
 
+/**
+ * Hero heading — Poppins 700, 77px / 107 line-height, 0.77 letter-spacing
+ * Token: --figma-typography-join-our-sprouts-squad-community
+ */
 const headingStyle: React.CSSProperties = {
   fontFamily:
     'var(--figma-fontfamilies-poppins, Poppins), sans-serif',
@@ -33,14 +49,25 @@ const headingStyle: React.CSSProperties = {
   color: HEADING_COLOR,
 };
 
+/**
+ * CTA button — Lato 600, 28px / 28 line-height
+ * Token: --figma-typography-sign-up-to-our-monthly-newsletter
+ */
 const ctaStyle: React.CSSProperties = {
   backgroundColor: CTA_BG,
   color: CTA_TEXT,
   fontFamily:
     'var(--figma-fontfamilies-lato, Lato), sans-serif',
+  fontSize: 'var(--figma-fontsizes-28, 28px)',
   fontWeight: 'var(--figma-fontweights-600, 600)' as string,
+  lineHeight:
+    'var(--figma-lineheights-sign-up-to-our-monthly-newsletter, 100%)',
 };
 
+/**
+ * Column title — Urbanist 600, 24px / 28 line-height, -0.5 letter-spacing
+ * Token: --figma-typography-quick-links
+ */
 const columnTitleStyle: React.CSSProperties = {
   fontFamily:
     'var(--figma-fontfamilies-urbanist, Urbanist), sans-serif',
@@ -52,6 +79,10 @@ const columnTitleStyle: React.CSSProperties = {
   color: HEADING_COLOR,
 };
 
+/**
+ * Link text — Lato 400, 18px / 28 line-height, 0.5 letter-spacing
+ * Token: --figma-typography-home
+ */
 const linkStyle: React.CSSProperties = {
   fontFamily:
     'var(--figma-fontfamilies-lato, Lato), sans-serif',
@@ -62,6 +93,10 @@ const linkStyle: React.CSSProperties = {
   color: LINK_COLOR,
 };
 
+/**
+ * Copyright — Poppins 500, 16px / 28 line-height
+ * Token: --figma-typography-2025-evolvesprouts
+ */
 const copyrightStyle: React.CSSProperties = {
   fontFamily:
     'var(--figma-fontfamilies-poppins, Poppins), sans-serif',
@@ -73,7 +108,7 @@ const copyrightStyle: React.CSSProperties = {
 };
 
 /* ------------------------------------------------------------------ */
-/*  Social-media icon SVGs (inline to avoid extra asset deps)         */
+/*  Social-media icon SVGs (16×16, matching Figma icon frames)        */
 /* ------------------------------------------------------------------ */
 
 const socialIcons: Record<string, React.ReactNode> = {
@@ -131,7 +166,11 @@ const socialIcons: Record<string, React.ReactNode> = {
 /*  Sub-components                                                    */
 /* ------------------------------------------------------------------ */
 
-/** Renders a single footer link column (Quick Links, Services, etc.) */
+/**
+ * Renders a single footer link column.
+ * Matches Figma "Frame 1000007078/79/81/80" — vertical layout,
+ * 17px item spacing, title with 16px bottom padding.
+ */
 function FooterColumn({
   title,
   items,
@@ -142,11 +181,9 @@ function FooterColumn({
   hasSocialIcons?: boolean;
 }) {
   return (
-    <div className='flex flex-col gap-[17px]'>
-      <h3
-        className='pb-4'
-        style={columnTitleStyle}
-      >
+    <div className='flex w-full max-w-[223px] flex-col gap-[17px]'>
+      {/* Column title — pb-4 matches the 16px bottom padding in Figma */}
+      <h3 className='pb-4' style={columnTitleStyle}>
         {title}
       </h3>
       <ul className='flex flex-col gap-[17px]'>
@@ -154,8 +191,12 @@ function FooterColumn({
           <li key={item.label}>
             <Link
               href={item.href}
-              className='inline-flex items-center gap-[14px] transition-opacity hover:opacity-70'
-              style={linkStyle}
+              className='inline-flex items-center transition-opacity hover:opacity-70'
+              style={{
+                ...linkStyle,
+                /* Social links use 14px icon-text gap, regular links 8px */
+                gap: hasSocialIcons ? '14px' : '8px',
+              }}
               {...(item.href.startsWith('http')
                 ? { target: '_blank', rel: 'noopener noreferrer' }
                 : {})}
@@ -181,6 +222,25 @@ function FooterColumn({
 /*  Main Footer component                                             */
 /* ------------------------------------------------------------------ */
 
+/**
+ * Footer component matching the Figma design spec (footer.json).
+ *
+ * Layout hierarchy (Figma → HTML):
+ *   footer GROUP (1920×1483)
+ *     └ Frame 2147235259 (fill: #FFEEE3)
+ *         ├ "Background Image" FRAME (1920×859)
+ *         │   ├ "7 2" RECTANGLE — background photo (1490×836)
+ *         │   ├ "Scrim" RECTANGLE — overlay (1920×859)
+ *         │   ├ Heading TEXT (847×214)
+ *         │   ├ Small logo GROUP (240×246)
+ *         │   └ CTA button FRAME (500×82)
+ *         ├ Quick Links column (223×269)
+ *         ├ Services column (223×179)
+ *         ├ About Us column (223×179)
+ *         ├ Connect on column (223×224)
+ *         ├ Large logo FRAME (470×482)
+ *         └ Copyright TEXT (172×28)
+ */
 export function Footer({ content }: FooterProps) {
   return (
     <footer
@@ -188,88 +248,126 @@ export function Footer({ content }: FooterProps) {
       className='w-full'
       style={{ backgroundColor: FOOTER_BG }}
     >
-      {/* ---- CTA / Community Section ---- */}
-      <section
-        className='relative w-full overflow-hidden px-4 pb-12 pt-16 sm:px-6 sm:pb-16 sm:pt-20 lg:px-8 lg:pb-20 lg:pt-28'
-        aria-label={content.communityHeading}
-      >
-        <div className='mx-auto flex max-w-7xl flex-col items-start gap-8 lg:flex-row lg:items-center lg:justify-between'>
-          {/* Heading */}
-          <h2
-            className='max-w-[640px] text-4xl leading-tight sm:text-5xl lg:text-[77px] lg:leading-[107px]'
-            style={headingStyle}
-          >
-            {content.communityHeading}
-          </h2>
+      {/* ============================================================ */}
+      {/* HERO / CTA SECTION                                           */}
+      {/* Matches "Background Image" frame: 1920×859, fill #FFEEE3     */}
+      {/* Contains: bg photo → scrim → heading + small logo + CTA      */}
+      {/* ============================================================ */}
+      <section className='relative w-full overflow-hidden'>
+        {/* Aspect-ratio wrapper: 859/1920 ≈ 44.7% — preserves Figma proportions */}
+        <div className='relative w-full pb-[60%] sm:pb-[50%] lg:pb-[44.7%]'>
+          {/* Background image (1490×836 in Figma, named "7 2") */}
+          {/* Replace /images/footer-bg.svg with the real photo when available */}
+          <Image
+            src='/images/footer-bg.svg'
+            alt=''
+            fill
+            className='object-cover object-center'
+            priority={false}
+          />
 
-          {/* Brand mark (text logo fallback — no image asset) */}
-          <div className='hidden lg:block'>
-            <span
-              className='text-4xl font-semibold tracking-tight'
-              style={{
-                fontFamily:
-                  'var(--figma-fontfamilies-poppins, Poppins), sans-serif',
-                color: BRAND_COLOR,
-              }}
-            >
-              {content.brand}
-            </span>
+          {/* Scrim overlay (1920×859 in Figma) — semi-transparent warm wash */}
+          <div
+            className='absolute inset-0 z-[1]'
+            style={{
+              background:
+                'linear-gradient(180deg, rgba(255,238,227,0.3) 0%, rgba(255,238,227,0.75) 100%)',
+            }}
+          />
+
+          {/* Content overlay — heading, small logo, CTA */}
+          <div className='absolute inset-0 z-[2] flex flex-col justify-center px-4 sm:px-6 lg:px-8'>
+            <div className='mx-auto w-full max-w-[1465px]'>
+              {/* Row: heading (left) + small logo (right) */}
+              <div className='flex items-center justify-between gap-6'>
+                {/* Heading — 847×214 in Figma, Poppins 77px bold */}
+                <h2
+                  className='max-w-[500px] text-3xl leading-tight sm:max-w-[650px] sm:text-4xl sm:leading-tight md:text-5xl md:leading-tight lg:max-w-[847px] lg:text-[77px] lg:leading-[107px]'
+                  style={headingStyle}
+                >
+                  {content.communityHeading}
+                </h2>
+
+                {/* Small Evolve Sprouts logo — 240×246 in Figma */}
+                {/* Replace with exported logo asset when available */}
+                <div className='hidden shrink-0 lg:block'>
+                  <Image
+                    src='/images/evolve-sprouts-logo.svg'
+                    alt={content.brand}
+                    width={240}
+                    height={246}
+                    className='h-auto w-[160px] xl:w-[240px]'
+                  />
+                </div>
+              </div>
+
+              {/* CTA button — 500×82 in Figma, #ED622E rounded-lg */}
+              <div className='mt-6 sm:mt-8 lg:mt-10'>
+                <Link
+                  href='/newsletter'
+                  className='inline-flex h-[52px] items-center justify-center rounded-lg px-5 transition-opacity hover:opacity-90 sm:h-[64px] sm:px-6 sm:text-xl lg:h-[82px] lg:w-[500px] lg:px-6'
+                  style={ctaStyle}
+                >
+                  {content.newsletterCta}
+                </Link>
+              </div>
+            </div>
           </div>
         </div>
+      </section>
 
-        {/* Newsletter CTA button */}
-        <div className='mx-auto mt-8 max-w-7xl sm:mt-10 lg:mt-12'>
-          <Link
-            href='/newsletter'
-            className='inline-flex h-[60px] items-center justify-center rounded-lg px-6 text-lg font-semibold transition-opacity hover:opacity-90 sm:h-[72px] sm:px-8 sm:text-xl lg:h-[82px] lg:px-10 lg:text-[28px]'
-            style={ctaStyle}
-          >
-            {content.newsletterCta}
-          </Link>
+      {/* ============================================================ */}
+      {/* LINK COLUMNS + LARGE LOGO                                    */}
+      {/* Figma: 4 columns (223px each) on left, large logo (470×482)  */}
+      {/* on right, all positioned below the hero section.             */}
+      {/* ============================================================ */}
+      <section className='w-full px-4 py-10 sm:px-6 sm:py-12 lg:px-8 lg:py-16'>
+        <div className='mx-auto flex max-w-[1465px] flex-col gap-10 lg:flex-row lg:items-start lg:justify-between lg:gap-6'>
+          {/* Link columns — 4 columns, each max 223px wide */}
+          <div className='grid flex-1 grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4 lg:gap-6'>
+            <FooterColumn
+              title={content.quickLinks.title}
+              items={content.quickLinks.items}
+            />
+            <FooterColumn
+              title={content.services.title}
+              items={content.services.items}
+            />
+            <FooterColumn
+              title={content.aboutUs.title}
+              items={content.aboutUs.items}
+            />
+            <FooterColumn
+              title={content.connectOn.title}
+              items={content.connectOn.items}
+              hasSocialIcons
+            />
+          </div>
+
+          {/* Large Evolve Sprouts logo — 470×482 in Figma */}
+          {/* Replace with exported logo asset when available */}
+          <div className='flex justify-center lg:shrink-0 lg:justify-end'>
+            <Image
+              src='/images/evolve-sprouts-logo-large.svg'
+              alt={content.brand}
+              width={470}
+              height={482}
+              className='h-auto w-[240px] sm:w-[300px] lg:w-[380px] xl:w-[470px]'
+            />
+          </div>
         </div>
       </section>
 
-      {/* ---- Link columns ---- */}
-      <section className='w-full px-4 pb-12 pt-4 sm:px-6 lg:px-8 lg:pb-16'>
-        <div className='mx-auto grid max-w-7xl grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-4 lg:gap-8'>
-          <FooterColumn
-            title={content.quickLinks.title}
-            items={content.quickLinks.items}
-          />
-          <FooterColumn
-            title={content.services.title}
-            items={content.services.items}
-          />
-          <FooterColumn
-            title={content.aboutUs.title}
-            items={content.aboutUs.items}
-          />
-          <FooterColumn
-            title={content.connectOn.title}
-            items={content.connectOn.items}
-            hasSocialIcons
-          />
-        </div>
-      </section>
-
-      {/* ---- Bottom bar: brand + copyright ---- */}
-      <section className='w-full border-t border-black/5 px-4 py-8 sm:px-6 lg:px-8'>
-        <div className='mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 sm:flex-row'>
-          <Link
-            href='/'
-            className='text-2xl font-semibold tracking-tight transition-opacity hover:opacity-80 lg:text-[37px]'
-            style={{
-              fontFamily:
-                'var(--figma-fontfamilies-poppins, Poppins), sans-serif',
-              color: BRAND_COLOR,
-            }}
-          >
-            {content.brand}
-          </Link>
-
+      {/* ============================================================ */}
+      {/* COPYRIGHT BAR                                                */}
+      {/* Matches: "© 2025 Evolvesprouts" TEXT (172×28)                */}
+      {/* Poppins 500 / 16px / 28 line-height / #333333               */}
+      {/* ============================================================ */}
+      <div className='w-full px-4 pb-8 sm:px-6 lg:px-8'>
+        <div className='mx-auto max-w-[1465px]'>
           <p style={copyrightStyle}>{content.copyright}</p>
         </div>
-      </section>
+      </div>
     </footer>
   );
 }


### PR DESCRIPTION
Previous implementation did not match the Figma design spec. This rewrite faithfully reproduces the layout hierarchy from footer.json:

1. HERO/CTA SECTION (matches 'Background Image' frame, 1920×859):
   - Background image with aspect-ratio wrapper (60%/50%/44.7% responsive)
   - Scrim overlay with warm gradient
   - Heading left-aligned (Poppins 77px bold, responsive down to 30px)
   - Small Evolve Sprouts logo (240×246) right-aligned on desktop
   - Orange CTA button (500×82, #ED622E, Lato 600/28px)

2. LINK COLUMNS + LARGE LOGO (side-by-side on desktop):
   - 4 columns (Quick Links, Services, About Us, Connect on) each 223px max
   - Large Evolve Sprouts mascot logo (470×482) to the right of columns
   - Columns: 1-col mobile → 2-col tablet → 4-col desktop
   - 17px gap between items, 16px title bottom padding (per Figma spec)

3. COPYRIGHT BAR:
   - Left-aligned copyright text (Poppins 500/16px/28lh, #333333)

Placeholder assets added (to be replaced with real Figma exports):
- public/images/footer-bg.svg — warm gradient background placeholder
- public/images/evolve-sprouts-logo.svg — 240×246 small logo placeholder
- public/images/evolve-sprouts-logo-large.svg — 470×482 large logo placeholder

All placeholders use the exact brand colors from the design spec.