### PR TITLE
Homepage WhatsApp button

### DIFF
--- a/apps/public_www/src/app/layout.tsx
+++ b/apps/public_www/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import type { ReactNode } from 'react';
 
+import { WhatsappContactButton } from '@/components/whatsapp-contact-button';
+import { DEFAULT_LOCALE, getContent } from '@/content';
 import './globals.css';
 
 const stagingBadgeScript = `
@@ -38,6 +40,8 @@ export const viewport: Viewport = {
   userScalable: false,
 };
 
+const whatsappContact = getContent(DEFAULT_LOCALE).whatsappContact;
+
 export default function RootLayout({
   children,
 }: {
@@ -56,6 +60,10 @@ export default function RootLayout({
           {stagingBadgeScript}
         </Script>
         {children}
+        <WhatsappContactButton
+          href={whatsappContact.href}
+          ariaLabel={whatsappContact.ariaLabel}
+        />
       </body>
     </html>
   );

--- a/apps/public_www/src/components/whatsapp-contact-button.tsx
+++ b/apps/public_www/src/components/whatsapp-contact-button.tsx
@@ -1,0 +1,59 @@
+interface WhatsappContactButtonProps {
+  href: string;
+  ariaLabel: string;
+}
+
+const WHATSAPP_ICON_PATH =
+  'M380.9 97.1c-41.9-42-97.7-65.1-157-65.1c-122.4 0-222 ' +
+  '99.6-222 222c0 39.1 10.2 77.3 29.6 111L0 480l117.7-30.9c32.4 ' +
+  '17.7 68.9 27 106.1 27h.1c122.3 0 224.1-99.6 224.1-222c0-59.3-25.2-' +
+  '115-67.1-157zm-157 341.6c-33.2 0-65.7-8.9-94-25.7l-6.7-4-69.8 ' +
+  '18.3l18.6-68.1l-4.4-7c-18.5-29.4-28.2-63.3-28.2-98.2c0-101.7 ' +
+  '82.8-184.5 184.6-184.5c49.3 0 95.6 19.2 130.4 54.1s56.2 81.2 ' +
+  '56.1 130.5c0 101.8-84.9 184.6-186.6 184.6zM325.1 300.5c-5.5-2.8-' +
+  '32.8-16.2-37.9-18c-5.1-1.9-8.8-2.8-12.5 2.8s-14.3 18-17.6 21.8c-' +
+  '3.2 3.7-6.5 4.2-12 1.4c-32.6-16.3-54-29.1-75.5-66c-5.7-9.8 ' +
+  '5.7-9.1 16.3-30.3c1.8-3.7 .9-6.9-.5-9.7s-12.5-30.1-17.1-41.2c-' +
+  '4.5-10.8-9.1-9.3-12.5-9.5c-3.2-.2-6.9-.2-10.6-.2s-9.7 1.4-14.8 ' +
+  '6.9c-5.1 5.6-19.4 19-19.4 46.3s19.9 53.7 22.6 57.4c2.8 3.7 ' +
+  '39.1 59.7 94.8 83.8c35.2 15.2 49 16.5 66.6 13.9c10.7-1.6 32.8-13.4 ' +
+  '37.4-26.4s4.6-24.1 3.2-26.4c-1.3-2.5-5-3.9-10.5-6.6z';
+
+const buttonClassName =
+  'fixed right-5 z-50 flex h-16 w-16 items-center justify-center ' +
+  'rounded-full bg-white shadow-[0_16px_35px_5px_#e8c3ac] transition-' +
+  'transform duration-150 hover:scale-105 focus-visible:outline ' +
+  'focus-visible:outline-2 focus-visible:outline-offset-4 ' +
+  'focus-visible:outline-[#25D366] sm:right-[30px]';
+
+const iconClassName = 'h-11 w-11 fill-[#25D366]';
+
+export function WhatsappContactButton({
+  href,
+  ariaLabel,
+}: WhatsappContactButtonProps) {
+  if (!href) {
+    return null;
+  }
+
+  return (
+    <a
+      href={href}
+      target='_blank'
+      rel='noopener noreferrer'
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      className={buttonClassName}
+      style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 28px)' }}
+    >
+      <svg
+        aria-hidden='true'
+        viewBox='0 0 448 512'
+        className={iconClassName}
+        xmlns='http://www.w3.org/2000/svg'
+      >
+        <path d={WHATSAPP_ICON_PATH} />
+      </svg>
+    </a>
+  );
+}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -18,6 +18,10 @@
     "subheadline": "Expert-led courses designed for young learners.",
     "cta": "Get Started"
   },
+  "whatsappContact": {
+    "href": "https://wa.me/message/ZQHVW4DEORD5A1?src=qr",
+    "ariaLabel": "Contact us on WhatsApp"
+  },
   "courseModule": {
     "eyebrow": "Empowering Education",
     "title": "Our Courses",


### PR DESCRIPTION
Add a global floating WhatsApp contact button to `apps/public_www` to enable easy contact across all pages.

The button is icon-only, opens in a new tab, and its link is configurable via `en.json`. It is placed in the root layout to appear on all routes, as requested.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9839b5ef-41b7-4723-bea2-970e64247dcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9839b5ef-41b7-4723-bea2-970e64247dcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

