### PR TITLE
Evolvesprouts logo chips

### DIFF
--- a/apps/public_www/src/components/section-eyebrow-chip.tsx
+++ b/apps/public_www/src/components/section-eyebrow-chip.tsx
@@ -1,19 +1,20 @@
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties } from 'react';
+import Image from 'next/image';
 
 interface SectionEyebrowChipProps {
   label: string;
   labelStyle?: CSSProperties;
-  icon: ReactNode;
   className?: string;
   style?: CSSProperties;
 }
 
 const BASE_CHIP_CLASSNAME = 'inline-flex items-center gap-2 rounded-full border';
+const CHIP_LOGO_SRC = '/images/evolvesprouts-logo.svg';
+const CHIP_LOGO_SIZE = 31;
 
 export function SectionEyebrowChip({
   label,
   labelStyle,
-  icon,
   className,
   style,
 }: SectionEyebrowChipProps) {
@@ -23,7 +24,13 @@ export function SectionEyebrowChip({
 
   return (
     <div className={chipClassName} style={style}>
-      {icon}
+      <Image
+        src={CHIP_LOGO_SRC}
+        alt=''
+        width={CHIP_LOGO_SIZE}
+        height={CHIP_LOGO_SIZE}
+        className='h-[31px] w-[31px] shrink-0'
+      />
       <span style={labelStyle}>{label}</span>
     </div>
   );

--- a/apps/public_www/src/components/sections/course-module.tsx
+++ b/apps/public_www/src/components/sections/course-module.tsx
@@ -239,26 +239,6 @@ export function CourseModule({ content }: CourseModuleProps) {
               borderColor: '#EECAB0',
               backdropFilter: 'blur(14px)',
             }}
-            icon={
-              <span
-                aria-hidden='true'
-                className='relative inline-flex h-[31px] w-[31px] items-center justify-center rounded-full'
-                style={{ backgroundColor: 'rgba(23, 72, 121, 0.14)' }}
-              >
-                <span
-                  className='absolute left-[7px] top-[8px] h-[8px] w-[8px] rounded-full'
-                  style={{ backgroundColor: BRAND_BLUE }}
-                />
-                <span
-                  className='absolute right-[7px] top-[8px] h-[8px] w-[8px] rounded-full'
-                  style={{ backgroundColor: '#B31D1F' }}
-                />
-                <span
-                  className='absolute bottom-[7px] left-1/2 h-[8px] w-[8px] -translate-x-1/2 rounded-full'
-                  style={{ backgroundColor: '#5D9D49' }}
-                />
-              </span>
-            }
           />
 
           <h2 className='mt-6 text-balance' style={titleStyle}>

--- a/apps/public_www/src/components/sections/free-resources.tsx
+++ b/apps/public_www/src/components/sections/free-resources.tsx
@@ -18,11 +18,8 @@ const PANEL_BG = 'var(--figma-colors-frame-2147235252, #F8F8F8)';
 const MEDIA_BG = 'var(--figma-colors-rectangle-240648654, #D9D9D9)';
 const CTA_BG = 'var(--figma-colors-frame-2147235222-2, #ED622E)';
 const CTA_TEXT = 'var(--figma-colors-desktop, #FFFFFF)';
-const BRAND_BLUE = 'var(--figma-colors-frame-2147235242, #174879)';
 const BORDER_COLOR = '#EECAB0';
-const RED_ACCENT = '#B31D1F';
 const GREEN_ACCENT = '#5D9D49';
-const GREEN_LIGHT_ACCENT = '#A8CB44';
 
 const eyebrowStyle: CSSProperties = {
   color: HEADING_COLOR,
@@ -131,32 +128,6 @@ function resolveChecklistItems(items: unknown): string[] {
     .slice(0, 3);
 }
 
-function EyebrowGlyph() {
-  return (
-    <span
-      aria-hidden='true'
-      className='relative inline-flex h-[23px] w-[31px] items-center justify-center'
-    >
-      <span
-        className='absolute left-[2px] top-[7px] block h-[9px] w-[9px] rounded-full'
-        style={{ backgroundColor: BRAND_BLUE }}
-      />
-      <span
-        className='absolute right-[2px] top-[7px] block h-[9px] w-[9px] rounded-full'
-        style={{ backgroundColor: RED_ACCENT }}
-      />
-      <span
-        className='absolute bottom-[1px] left-1/2 block h-[10px] w-[10px] -translate-x-1/2 rounded-full'
-        style={{ backgroundColor: GREEN_ACCENT }}
-      />
-      <span
-        className='absolute left-[10px] top-[1px] block h-[6px] w-[10px] rounded-full'
-        style={{ backgroundColor: GREEN_LIGHT_ACCENT }}
-      />
-    </span>
-  );
-}
-
 function ChecklistIcon() {
   return (
     <svg
@@ -258,7 +229,6 @@ export function FreeResources({ content }: FreeResourcesProps) {
           <SectionEyebrowChip
             label={eyebrowLabel}
             labelStyle={eyebrowStyle}
-            icon={<EyebrowGlyph />}
             className='px-4 py-[11px] sm:px-5'
             style={{ borderColor: BORDER_COLOR }}
           />

--- a/apps/public_www/src/components/sections/real-stories.tsx
+++ b/apps/public_www/src/components/sections/real-stories.tsx
@@ -401,11 +401,6 @@ export function RealStories({ content }: RealStoriesProps) {
                 borderColor: BADGE_BORDER,
                 backgroundColor: 'rgba(255, 255, 255, 0.64)',
               }}
-              icon={
-                <span className='inline-flex h-[31px] w-[31px] items-center justify-center'>
-                  <BadgeMark className='h-[31px] w-[31px]' />
-                </span>
-              }
             />
 
             <div className='flex items-center gap-[14px] sm:gap-[21px]'>

--- a/apps/public_www/src/components/sections/why-joining.tsx
+++ b/apps/public_www/src/components/sections/why-joining.tsx
@@ -390,27 +390,6 @@ export function WhyJoining({ content }: WhyJoiningProps) {
               backgroundColor: WHITE,
               borderColor: '#FF9D59',
             }}
-            icon={
-              <span
-                aria-hidden='true'
-                className='relative inline-flex h-[23px] w-[31px] items-center justify-center'
-              >
-                <span
-                  className='absolute left-0 top-[6px] h-[10px] w-[10px] rounded-full'
-                  style={{
-                    backgroundColor: 'var(--figma-colors-frame-2147235242, #174879)',
-                  }}
-                />
-                <span
-                  className='absolute right-0 top-[6px] h-[10px] w-[10px] rounded-full'
-                  style={{ backgroundColor: '#B31D1F' }}
-                />
-                <span
-                  className='absolute bottom-0 left-1/2 h-[10px] w-[10px] -translate-x-1/2 rounded-full'
-                  style={{ backgroundColor: '#5D9D49' }}
-                />
-              </span>
-            }
           />
 
           <h2 className='mt-6 text-balance' style={sectionTitleStyle}>


### PR DESCRIPTION
Centralize the chip logo in `SectionEyebrowChip` to use `evolvesprouts-logo.svg` for all chip instances.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-fc46d3c1-3e3b-43d5-bfa3-2b002cf99da8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fc46d3c1-3e3b-43d5-bfa3-2b002cf99da8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

