### PR TITLE
Cta arrow standardization

### DIFF
--- a/apps/public_www/src/components/section-cta-link.tsx
+++ b/apps/public_www/src/components/section-cta-link.tsx
@@ -1,10 +1,17 @@
-import type { CSSProperties, ReactNode } from 'react';
-import Link from 'next/link';
+import type {
+  AnchorHTMLAttributes,
+  CSSProperties,
+  ReactNode,
+} from 'react';
 
 const BASE_SECTION_CTA_CLASSNAME =
-  'es-cta-primary es-cta-button es-focus-ring';
+  'es-cta-primary es-cta-button es-focus-ring gap-2';
 
-interface SectionCtaProps {
+interface SectionCtaProps
+  extends Omit<
+    AnchorHTMLAttributes<HTMLAnchorElement>,
+    'children' | 'className' | 'href' | 'style'
+  > {
   href: string;
   className?: string;
   style?: CSSProperties;
@@ -19,16 +26,23 @@ function buildClassName(className?: string): string {
   return `${BASE_SECTION_CTA_CLASSNAME} ${className}`;
 }
 
-export function SectionCtaLink({
-  href,
-  className,
-  style,
-  children,
-}: SectionCtaProps) {
+function CtaChevronIcon() {
   return (
-    <Link href={href} className={buildClassName(className)} style={style}>
-      {children}
-    </Link>
+    <svg
+      aria-hidden='true'
+      viewBox='0 0 20 20'
+      className='h-5 w-5 shrink-0'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path
+        d='M7 4L13 10L7 16'
+        stroke='var(--figma-colors-desktop, #FFFFFF)'
+        strokeWidth='2.2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
   );
 }
 
@@ -37,10 +51,17 @@ export function SectionCtaAnchor({
   className,
   style,
   children,
+  ...anchorProps
 }: SectionCtaProps) {
   return (
-    <a href={href} className={buildClassName(className)} style={style}>
-      {children}
+    <a
+      href={href}
+      className={buildClassName(className)}
+      style={style}
+      {...anchorProps}
+    >
+      <span>{children}</span>
+      <CtaChevronIcon />
     </a>
   );
 }

--- a/apps/public_www/src/components/sections/course-highlights.tsx
+++ b/apps/public_www/src/components/sections/course-highlights.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 import Image from 'next/image';
 
-import { SectionCtaLink } from '@/components/section-cta-link';
+import { SectionCtaAnchor } from '@/components/section-cta-link';
 import { SectionEyebrowChip } from '@/components/section-eyebrow-chip';
 import { SectionShell } from '@/components/section-shell';
 import type { CourseHighlightsContent } from '@/content';
@@ -309,28 +309,13 @@ export function CourseHighlights({ content }: CourseHighlightsProps) {
         )}
 
         <div className='mt-8 flex justify-center sm:mt-10 lg:mt-11'>
-          <SectionCtaLink
+          <SectionCtaAnchor
             href={ctaHref}
             className='h-[62px] w-full max-w-[488px] gap-2 rounded-[8px] px-5 sm:h-[70px] sm:px-7 lg:h-[78px]'
             style={ctaStyle}
           >
-            <span>{ctaLabel}</span>
-            <svg
-              aria-hidden='true'
-              viewBox='0 0 20 20'
-              className='h-5 w-5 shrink-0'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <path
-                d='M7 4L13 10L7 16'
-                stroke={WHITE}
-                strokeWidth='2.2'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              />
-            </svg>
-          </SectionCtaLink>
+            {ctaLabel}
+          </SectionCtaAnchor>
         </div>
       </div>
     </SectionShell>

--- a/apps/public_www/src/components/sections/hero-banner.tsx
+++ b/apps/public_www/src/components/sections/hero-banner.tsx
@@ -1,7 +1,7 @@
 import { Fragment, type CSSProperties, type ReactNode } from 'react';
 import Image from 'next/image';
 
-import { SectionCtaLink } from '@/components/section-cta-link';
+import { SectionCtaAnchor } from '@/components/section-cta-link';
 import type { HeroContent } from '@/content';
 
 interface HeroBannerProps {
@@ -98,13 +98,13 @@ export function HeroBanner({ content }: HeroBannerProps) {
             <p className='mt-4 max-w-[610px] sm:mt-6' style={subheadlineStyle}>
               {content.subheadline}
             </p>
-            <SectionCtaLink
+            <SectionCtaAnchor
               href='/training-courses'
               className='mt-6 h-[55px] rounded-[10px] px-[34px]'
               style={ctaStyle}
             >
               {content.cta}
-            </SectionCtaLink>
+            </SectionCtaAnchor>
           </div>
         </div>
         <div className='mx-auto w-full max-w-[764px] lg:ml-auto lg:mr-0'>

--- a/apps/public_www/src/components/sections/my-best-auntie-overview.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie-overview.tsx
@@ -1,6 +1,6 @@
 import { Fragment, type CSSProperties, type ReactNode } from 'react';
 
-import { SectionCtaLink } from '@/components/section-cta-link';
+import { SectionCtaAnchor } from '@/components/section-cta-link';
 import { SectionEyebrowChip } from '@/components/section-eyebrow-chip';
 import { SectionShell } from '@/components/section-shell';
 import type { MyBestAuntieOverviewContent } from '@/content';
@@ -401,16 +401,13 @@ export function MyBestAuntieOverview({ content }: MyBestAuntieOverviewProps) {
             </p>
           )}
 
-          <SectionCtaLink
+          <SectionCtaAnchor
             href={content.ctaHref}
             className='mt-8 h-[62px] w-full max-w-[491px] rounded-[10px] px-5 es-focus-ring-soft sm:h-[72px] sm:px-7 lg:mt-10 lg:h-[81px]'
             style={ctaStyle}
           >
-            <span>{computedCtaLabel}</span>
-            <span aria-hidden='true' className='pl-2'>
-              {'>'}
-            </span>
-          </SectionCtaLink>
+            {computedCtaLabel}
+          </SectionCtaAnchor>
         </div>
       </div>
     </SectionShell>

--- a/apps/public_www/src/components/sections/navbar.tsx
+++ b/apps/public_www/src/components/sections/navbar.tsx
@@ -3,8 +3,16 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 
+import { SectionCtaAnchor } from '@/components/section-cta-link';
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
@@ -25,8 +33,6 @@ const NAV_TEXT_COLOR =
   'var(--figma-colors-join-our-sprouts-squad-community, #333333)';
 const NAV_ACTIVE_TEXT = '#C84A16';
 const NAV_ACTIVE_BACKGROUND = '#F2A975';
-const CTA_BACKGROUND = '#C84A16';
-const CTA_TEXT_COLOR = 'var(--figma-colors-desktop, #FFFFFF)';
 const LOGO_SRC = '/images/evolvesprouts-logo.svg';
 const MOBILE_PANEL_WIDTH_CLASS = 'w-[min(88vw,360px)]';
 const MOBILE_MENU_TRANSITION_MS = 300;
@@ -45,11 +51,11 @@ const NAV_MOBILE_TOGGLE_BUTTON_CLASSNAME =
 const NAV_MOBILE_PRIMARY_ACTION_CLASSNAME =
   'es-focus-ring es-nav-pill w-full justify-between transition-colors';
 const NAV_MOBILE_BOOK_BUTTON_CLASSNAME =
-  'es-focus-ring es-nav-pill w-full justify-center text-center transition-colors';
+  'w-full rounded-[10px] px-4';
 const NAV_LANGUAGE_OPTION_CLASSNAME =
   'es-focus-ring es-nav-language-option';
 const NAV_DESKTOP_BOOK_BUTTON_CLASSNAME =
-  'es-cta-button h-[56px] rounded-[10px] px-[27px] hover:opacity-95';
+  'h-[56px] rounded-[10px] px-[27px]';
 const NAV_OPEN_MENU_BUTTON_CLASSNAME =
   'es-focus-ring es-nav-icon-button h-11 w-11 rounded-xl lg:hidden';
 const NAV_CLOSE_MENU_BUTTON_CLASSNAME =
@@ -65,8 +71,6 @@ const linkStyle = {
 };
 
 const ctaStyle = {
-  backgroundColor: CTA_BACKGROUND,
-  color: CTA_TEXT_COLOR,
   fontFamily:
     'var(--figma-fontfamilies-plus-jakarta-sans, Plus Jakarta Sans), sans-serif',
   fontSize: 'var(--figma-fontsizes-22, 22px)',
@@ -516,23 +520,23 @@ function BookNowButton({
   href,
   label,
   onClick,
-  style,
+  style = ctaStyle,
 }: {
   className: string;
   href: string;
   label: string;
   onClick?: () => void;
-  style?: Record<string, string | number>;
+  style?: CSSProperties;
 }) {
   return (
-    <Link
+    <SectionCtaAnchor
       href={href}
       className={className}
-      style={style ?? ctaStyle}
+      style={style}
       onClick={onClick}
     >
       {label}
-    </Link>
+    </SectionCtaAnchor>
   );
 }
 
@@ -1013,7 +1017,6 @@ export function Navbar({ content }: NavbarProps) {
                   label={content.bookNow.label}
                   onClick={closeMobileMenu}
                   className={NAV_MOBILE_BOOK_BUTTON_CLASSNAME}
-                  style={getTopLinkStyle(false)}
                 />
               </div>
             </div>

--- a/apps/public_www/src/components/sections/resources.tsx
+++ b/apps/public_www/src/components/sections/resources.tsx
@@ -320,7 +320,7 @@ export function Resources({ content }: ResourcesProps) {
                     className='mt-auto h-[58px] w-full max-w-[360px] rounded-[10px] px-5 es-focus-ring-medium sm:h-[67px] sm:px-6'
                     style={ctaStyle}
                   >
-                    <span className='whitespace-nowrap'>{ctaLabel}</span>
+                    {ctaLabel}
                   </SectionCtaAnchor>
                 </article>
               </div>

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 
+import { SectionCtaAnchor } from '@/components/section-cta-link';
 import { SectionShell } from '@/components/section-shell';
 import type { SproutsSquadCommunityContent } from '@/content';
 
@@ -13,8 +13,6 @@ const SECTION_BACKGROUND =
   'var(--figma-colors-frame-2147235259, #FFEEE3)';
 const HEADING_TEXT_COLOR =
   'var(--figma-colors-join-our-sprouts-squad-community, #333333)';
-const CTA_BACKGROUND = '#C84A16';
-const CTA_TEXT_COLOR = 'var(--figma-colors-desktop, #FFFFFF)';
 
 const headingStyle: CSSProperties = {
   color: HEADING_TEXT_COLOR,
@@ -25,8 +23,6 @@ const headingStyle: CSSProperties = {
 };
 
 const ctaStyle: CSSProperties = {
-  backgroundColor: CTA_BACKGROUND,
-  color: CTA_TEXT_COLOR,
   fontFamily: 'var(--figma-fontfamilies-lato, Lato), sans-serif',
   fontWeight: 'var(--figma-fontweights-600, 600)',
   lineHeight:
@@ -75,13 +71,13 @@ export function SproutsSquadCommunity({
           {content.heading}
         </h2>
 
-        <Link
+        <SectionCtaAnchor
           href={content.ctaHref}
-          className='es-cta-button h-14 w-full max-w-[500px] rounded-[10px] px-5 text-base sm:h-[62px] sm:text-lg lg:h-[74px] lg:max-w-[410px] lg:text-[26px]'
+          className='h-14 w-full max-w-[500px] rounded-[10px] px-5 text-base sm:h-[62px] sm:text-lg lg:h-[74px] lg:max-w-[410px] lg:text-[26px]'
           style={ctaStyle}
         >
           {content.ctaLabel}
-        </Link>
+        </SectionCtaAnchor>
       </div>
     </SectionShell>
   );


### PR DESCRIPTION
Standardize orange CTA buttons to consistently include a right-arrow chevron.

Previously, orange CTAs had inconsistent arrow behavior (some had no arrow, some used text `>` and some used an inline SVG). This PR centralizes arrow rendering within the `SectionCtaAnchor` component, making the SVG chevron the default for all orange CTAs and ensuring a consistent user experience.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-0967830c-63cd-490b-84e0-4fc85454b9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0967830c-63cd-490b-84e0-4fc85454b9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

