### PR TITLE
Course card tap hover

### DIFF
--- a/apps/public_www/src/components/sections/course-highlights.tsx
+++ b/apps/public_www/src/components/sections/course-highlights.tsx
@@ -183,7 +183,7 @@ function DecorativeCardArrow({ title }: { title: string }) {
     <button
       type='button'
       aria-label={`Show details for ${title}`}
-      className='absolute bottom-5 left-5 z-10 inline-flex h-[54px] w-[54px] appearance-none items-center justify-center rounded-full border-0 bg-white/15 p-0 ring-1 ring-white/35 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 lg:bottom-7 lg:left-7 lg:group-hover:h-[70px] lg:group-hover:w-[70px] lg:group-focus-within:h-[70px] lg:group-focus-within:w-[70px]'
+      className='absolute bottom-5 left-5 z-10 inline-flex h-[54px] w-[54px] appearance-none items-center justify-center rounded-full border-0 bg-white/15 p-0 ring-1 ring-white/35 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 lg:bottom-7 lg:left-7 lg:group-hover:h-[70px] lg:group-hover:w-[70px] group-focus-within:h-[70px] group-focus-within:w-[70px]'
     >
       <span className='inline-flex h-[44px] w-[44px] items-center justify-center rounded-full bg-[#ED622E] shadow-[0_4px_10px_rgba(0,0,0,0.18)]'>
         <svg
@@ -268,7 +268,7 @@ export function CourseHighlights({ content }: CourseHighlightsProps) {
                 >
                   <div
                     aria-hidden='true'
-                    className='pointer-events-none absolute inset-0 z-[1] bg-black/0 transition-all duration-300 lg:group-hover:bg-black/70 lg:group-hover:backdrop-blur-[4px] lg:group-focus-within:bg-black/70 lg:group-focus-within:backdrop-blur-[4px]'
+                    className='pointer-events-none absolute inset-0 z-[1] bg-black/0 transition-all duration-300 lg:group-hover:bg-black/70 lg:group-hover:backdrop-blur-[4px] group-focus-within:bg-black/70 group-focus-within:backdrop-blur-[4px]'
                   />
                   <div
                     aria-hidden='true'


### PR DESCRIPTION
Enable course highlight card reveal effects on mobile by removing `lg:` prefix from `group-focus-within` classes.

On mobile/tablet, tapping the arrow button in course highlight cards did not trigger the reveal effect (dark overlay + blur + arrow growth) because the `group-focus-within` Tailwind classes controlling these effects were prefixed with `lg:`, making them only activate on large screens. Removing the `lg:` prefix ensures these effects apply on all screen sizes when the button is focused.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f64e8685-9c85-49c5-bb61-7ed5f9dbf55e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f64e8685-9c85-49c5-bb61-7ed5f9dbf55e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

