### PR TITLE
Events API CORS issue

### DIFF
--- a/apps/public_www/.env.example
+++ b/apps/public_www/.env.example
@@ -27,6 +27,7 @@ FIGMA_TOKEN_ROOT_NODE=
 # FIGMA_VARIABLES_FILE_PATH=figma/files/variables.local.json
 
 # Public website runtime CRM API base URL.
+# Use "/www" to route requests through the same-origin CloudFront proxy.
 NEXT_PUBLIC_WWW_CRM_API_BASE_URL=
 
 # Public website runtime API key for CRM API calls.

--- a/apps/public_www/README.md
+++ b/apps/public_www/README.md
@@ -67,6 +67,9 @@ To enable public website CRM API calls (including My Best Auntie discount code l
 - `NEXT_PUBLIC_WWW_CRM_API_BASE_URL`
 - `NEXT_PUBLIC_WWW_CRM_API_KEY`
 
+Use `NEXT_PUBLIC_WWW_CRM_API_BASE_URL=/www` to route requests through the
+same-origin CloudFront API proxy and avoid cross-origin CORS preflight issues.
+
 ## Build
 
 ```bash

--- a/apps/public_www/src/lib/crm-api-client.test.ts
+++ b/apps/public_www/src/lib/crm-api-client.test.ts
@@ -22,8 +22,22 @@ describe('crm-api-client', () => {
     expect(buildCrmApiUrl('https://api.evolvesprouts.com/www/', 'v1/discounts')).toBe(
       'https://api.evolvesprouts.com/www/v1/discounts',
     );
+    expect(buildCrmApiUrl('/www', '/v1/discounts')).toBe('/www/v1/discounts');
+    expect(buildCrmApiUrl('/www/', 'v1/discounts')).toBe('/www/v1/discounts');
     expect(buildCrmApiUrl('api.evolvesprouts.com/www', '/v1/discounts')).toBe('');
+    expect(buildCrmApiUrl('/', '/v1/discounts')).toBe('');
     expect(buildCrmApiUrl('   ', '/v1/discounts')).toBe('');
+  });
+
+  it('rewrites api.evolvesprouts.com URLs to same-origin proxy on public hosts', () => {
+    vi.stubGlobal('location', new URL('https://www-staging.evolvesprouts.com/en/events'));
+
+    expect(buildCrmApiUrl('https://api.evolvesprouts.com/www', '/v1/discounts')).toBe(
+      '/www/v1/discounts',
+    );
+    expect(buildCrmApiUrl('https://api.evolvesprouts.com/www/', 'v1/calendar/events')).toBe(
+      '/www/v1/calendar/events',
+    );
   });
 
   it('returns null when base URL or API key is invalid', () => {

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -34,6 +34,14 @@ The stack outputs:
 - `PublicWwwStagingDistributionDomain`
 - `PublicWwwStagingLoggingBucketName`
 
+Public WWW CloudFront includes:
+
+- Default behavior: static site content from S3 with extensionless path rewrite.
+- Additional behavior: `www/*` forwards to `api.evolvesprouts.com` using
+  HTTPS-only origin policy, disabled caching, and
+  `OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER` so API key headers and
+  query parameters pass through while preserving the API origin host header.
+
 ---
 
 ## CDK Bootstrap Stack (CDKToolkit)

--- a/docs/deployment/public-www.md
+++ b/docs/deployment/public-www.md
@@ -45,6 +45,11 @@ Public WWW CRM API configuration is provided at build time via:
 - GitHub variable `NEXT_PUBLIC_WWW_CRM_API_BASE_URL`
 - GitHub secret `NEXT_PUBLIC_WWW_CRM_API_KEY`
 
+`evolvesprouts-public-www` CloudFront now proxies `https://{www-domain}/www/*`
+to `https://api.evolvesprouts.com/www/*` with caching disabled for those
+requests. Set `NEXT_PUBLIC_WWW_CRM_API_BASE_URL` to `/www` to keep browser API
+calls same-origin and avoid cross-origin CORS preflight failures.
+
 ## CI/CD workflows
 
 ### Deploy to staging (automatic)


### PR DESCRIPTION
Implement same-origin proxy for `/www/*` API calls to resolve CORS blocking on public websites.

The previous setup caused CORS preflight failures when `www-staging.evolvesprouts.com` attempted to access `https://api.evolvesprouts.com/www/v1/calendar/events` because the `Access-Control-Allow-Origin` header was incorrectly set. This fix routes these calls through CloudFront as a same-origin request, bypassing the CORS issue.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d67fd046-4b0f-41e5-9264-e3df82868d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d67fd046-4b0f-41e5-9264-e3df82868d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

