### PR TITLE
Contact us hero background

### DIFF
--- a/apps/public_www/src/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.test.tsx
@@ -33,4 +33,24 @@ describe('ContactUsForm section', () => {
       'linear-gradient(black 60%, transparent 90%)',
     );
   });
+
+  it('renders promise items as bulleted text without background cards', () => {
+    render(<ContactUsForm content={enContent.contactUs.contactUsForm} />);
+
+    const promiseList = screen
+      .getByRole('heading', {
+        level: 2,
+        name: enContent.contactUs.contactUsForm.promiseTitle,
+      })
+      .nextElementSibling as HTMLUListElement | null;
+    expect(promiseList).not.toBeNull();
+    expect(promiseList?.className).toContain('list-disc');
+
+    const listItems = promiseList?.querySelectorAll('li') ?? [];
+    expect(listItems.length).toBeGreaterThan(0);
+    for (const listItem of listItems) {
+      expect(listItem.className).not.toContain('bg-white');
+      expect(listItem.className).not.toContain('shadow-');
+    }
+  });
 });

--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -163,11 +163,11 @@ export function ContactUsForm({ content }: ContactUsFormProps) {
             <h2 className='es-section-heading text-[clamp(1.5rem,3.6vw,2.2rem)]'>
               {content.promiseTitle}
             </h2>
-            <ul className='mt-4 space-y-3'>
+            <ul className='mt-4 list-disc space-y-2 pl-6'>
               {content.promises.map((promise) => (
                 <li
                   key={promise}
-                  className='rounded-xl bg-white px-4 py-3 text-base leading-7 text-[color:var(--site-primary-text)] shadow-[0_8px_20px_-18px_rgba(0,0,0,0.45)]'
+                  className='text-base leading-7 text-[color:var(--site-primary-text)]'
                 >
                   {promise}
                 </li>


### PR DESCRIPTION
Make the contact-us section left column background visually match the hero section.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-33f61bbc-a30b-41ce-8779-25b19bc8eb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33f61bbc-a30b-41ce-8779-25b19bc8eb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

