### PR TITLE
Language selector z-index

### DIFF
--- a/apps/public_www/src/components/sections/navbar.tsx
+++ b/apps/public_www/src/components/sections/navbar.tsx
@@ -225,7 +225,7 @@ export function Navbar({ content }: NavbarProps) {
     <>
       <header
         data-figma-node='navbar'
-        className='es-navbar-surface w-full'
+        className='relative z-30 es-navbar-surface w-full'
       >
         <SectionContainer
           as='nav'

--- a/apps/public_www/tests/components/sections/navbar.test.tsx
+++ b/apps/public_www/tests/components/sections/navbar.test.tsx
@@ -46,6 +46,8 @@ describe('Navbar desktop submenu accessibility', () => {
 
     const header = document.querySelector('header[data-figma-node="navbar"]');
     expect(header?.className).toContain('es-navbar-surface');
+    expect(header?.className).toContain('relative');
+    expect(header?.className).toContain('z-30');
   });
 
   it('applies active and inactive classes to language menu items', () => {


### PR DESCRIPTION
Elevate the navbar's z-index to ensure the language selector dropdown always renders above the hero image.

The language selector dropdown was appearing behind the hero image on the homepage because both the navbar and hero containers had equal z-index stacking contexts, and the hero rendered later in the DOM. Adding `relative z-30` to the navbar explicitly raises its stacking context, resolving the visual layering conflict.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-049278c8-ca2b-4531-b25b-03423d6df5a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-049278c8-ca2b-4531-b25b-03423d6df5a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

