### PR TITLE
Course highlight blur description

### DIFF
--- a/apps/public_www/src/components/sections/course-highlight-card.tsx
+++ b/apps/public_www/src/components/sections/course-highlight-card.tsx
@@ -59,9 +59,9 @@ export function CourseHighlightCard({
   const arrowActive = isActive
     ? 'h-[70px] w-[70px]'
     : '';
-  const descriptionActive = isActive
-    ? 'opacity-100'
-    : '';
+  const descriptionVisibilityClassName = isActive
+    ? 'opacity-100 transition-opacity duration-300'
+    : 'opacity-0 transition-none';
 
   return (
     <article
@@ -125,7 +125,7 @@ export function CourseHighlightCard({
 
           {description && (
             <p
-              className={`max-w-[34ch] transition-opacity duration-300 es-course-highlight-description ${isActive ? '' : 'opacity-0'} lg:group-hover:opacity-100 ${descriptionActive}`}
+              className={`max-w-[34ch] es-course-highlight-description lg:group-hover:opacity-100 lg:group-hover:transition-opacity lg:group-hover:duration-300 ${descriptionVisibilityClassName}`}
             >
               {description}
             </p>

--- a/apps/public_www/tests/components/sections/course-highlight-card.test.tsx
+++ b/apps/public_www/tests/components/sections/course-highlight-card.test.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable @next/next/no-img-element */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CourseHighlightCard } from '@/components/sections/course-highlight-card';
+
+vi.mock('next/image', () => ({
+  default: ({
+    alt,
+    ...props
+  }: {
+    alt?: string;
+  } & Record<string, unknown>) => <img alt={alt ?? ''} {...props} />,
+}));
+
+function hasClassToken(className: string, token: string): boolean {
+  return className.split(/\s+/).includes(token);
+}
+
+describe('CourseHighlightCard description visibility transition', () => {
+  it('uses immediate hide classes when toggled inactive', () => {
+    render(
+      <CourseHighlightCard
+        id='age-specific'
+        title='Age Specific Strategies'
+        imageSrc='/images/course-highlights/course-card-1.webp'
+        imageWidth={344}
+        imageHeight={309}
+        imageClassName='h-[235px]'
+        description='Practical scripts and examples'
+        tone='gold'
+      />,
+    );
+
+    const toggleButton = screen.getByRole('button', {
+      name: 'Show details for Age Specific Strategies',
+    });
+    const description = screen.getByText('Practical scripts and examples');
+
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    expect(hasClassToken(description.className, 'opacity-0')).toBe(true);
+    expect(hasClassToken(description.className, 'transition-none')).toBe(true);
+
+    fireEvent.click(toggleButton);
+
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+    expect(hasClassToken(description.className, 'opacity-100')).toBe(true);
+    expect(hasClassToken(description.className, 'transition-opacity')).toBe(true);
+    expect(hasClassToken(description.className, 'duration-300')).toBe(true);
+
+    fireEvent.click(toggleButton);
+
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    expect(hasClassToken(description.className, 'opacity-0')).toBe(true);
+    expect(hasClassToken(description.className, 'transition-none')).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes delayed disappearance of course highlight card description when deactivating.

The description previously had an unconditional `transition-opacity duration-300` class, causing it to fade out over 300ms instead of hiding immediately when the card became inactive. This PR modifies the class logic to apply `transition-none` when inactive for immediate hide, while preserving the smooth fade-in transition when active.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-7141684d-71dc-4723-8f67-e94c6e604716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7141684d-71dc-4723-8f67-e94c6e604716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

