### PR TITLE
Training course submenu click

### DIFF
--- a/apps/public_www/src/components/sections/navbar/menu-items.tsx
+++ b/apps/public_www/src/components/sections/navbar/menu-items.tsx
@@ -143,8 +143,11 @@ function DesktopMenuItem({
   const submenuListId = useId();
   const submenuWrapperRef = useRef<HTMLLIElement | null>(null);
   const submenuToggleButtonRef = useRef<HTMLButtonElement | null>(null);
+  const isSubmenuOpenedByHoverRef = useRef(false);
   const closeSubmenu = useCallback(
     ({ restoreFocus = true }: { restoreFocus?: boolean } = {}) => {
+      isSubmenuOpenedByHoverRef.current = false;
+
       if (restoreFocus) {
         const activeElement = document.activeElement;
         if (
@@ -203,6 +206,7 @@ function DesktopMenuItem({
       ref={submenuWrapperRef}
       className='relative'
       onMouseEnter={() => {
+        isSubmenuOpenedByHoverRef.current = true;
         setIsSubmenuOpen(true);
       }}
       onMouseLeave={() => {
@@ -218,7 +222,20 @@ function DesktopMenuItem({
         aria-controls={submenuListId}
         aria-label={`Toggle ${item.label} submenu`}
         onClick={() => {
-          setIsSubmenuOpen((value) => !value);
+          setIsSubmenuOpen((value) => {
+            if (!value) {
+              isSubmenuOpenedByHoverRef.current = false;
+              return true;
+            }
+
+            // Keep the first click open if hover already opened the submenu.
+            if (isSubmenuOpenedByHoverRef.current) {
+              isSubmenuOpenedByHoverRef.current = false;
+              return true;
+            }
+
+            return false;
+          });
         }}
       >
         {item.label}

--- a/apps/public_www/tests/components/sections/navbar.test.tsx
+++ b/apps/public_www/tests/components/sections/navbar.test.tsx
@@ -101,4 +101,23 @@ describe('Navbar desktop submenu accessibility', () => {
     expect(submenuToggle).toHaveAttribute('aria-expanded', 'false');
     expect(submenu).toHaveAttribute('aria-hidden', 'true');
   });
+
+  it('keeps training submenu open on first click after hover', () => {
+    render(<Navbar content={enContent.navbar} />);
+
+    const submenuToggle = screen.getByRole('button', {
+      name: 'Toggle Training Courses submenu',
+    });
+    const submenuWrapper = submenuToggle.closest('li');
+
+    expect(submenuWrapper).not.toBeNull();
+    fireEvent.mouseEnter(submenuWrapper as HTMLElement);
+    expect(submenuToggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(submenuToggle);
+    expect(submenuToggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(submenuToggle);
+    expect(submenuToggle).toHaveAttribute('aria-expanded', 'false');
+  });
 });


### PR DESCRIPTION
Fixes desktop "Training Course" submenu not opening on first click after hover.

The submenu was immediately closing on the first click after being opened by a hover event, due to conflicting state logic. This change ensures the first click after a hover keeps the submenu open.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6d9802d6-d0d7-4eeb-8be1-1289a070728c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d9802d6-d0d7-4eeb-8be1-1289a070728c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

