### PR TITLE
Section spacing drifts

### DIFF
--- a/apps/public_www/src/components/sections/footer.tsx
+++ b/apps/public_www/src/components/sections/footer.tsx
@@ -190,7 +190,7 @@ export function Footer({ content }: FooterProps) {
 
   return (
     <footer data-figma-node='footer' className='w-full es-footer-root'>
-      <section className='w-full px-4 pb-8 pt-9 sm:px-6 sm:pb-10 sm:pt-11 lg:px-8 lg:pb-12 lg:pt-16'>
+      <section className='w-full px-4 py-16 sm:px-6 sm:py-20 lg:px-8 lg:py-[100px]'>
         <SectionContainer>
           <div className='mb-7 hidden justify-center sm:flex lg:hidden'>
             <Image

--- a/apps/public_www/src/components/sections/hero-banner.tsx
+++ b/apps/public_www/src/components/sections/hero-banner.tsx
@@ -36,7 +36,7 @@ export function HeroBanner({ content }: HeroBannerProps) {
     <section
       aria-label={content.headline}
       data-figma-node='banner'
-      className='relative w-full overflow-hidden px-4 pb-10 pt-8 sm:px-6 sm:pb-12 sm:pt-10 lg:px-8 lg:pb-16 lg:pt-0 es-hero-section'
+      className='relative w-full overflow-hidden px-4 py-16 sm:px-6 sm:py-20 lg:px-8 lg:py-[100px] es-hero-section'
     >
       <div
         aria-hidden='true'

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -17,7 +17,7 @@ export function SproutsSquadCommunity({
       id='sprouts-squad-community'
       ariaLabel={content.heading}
       dataFigmaNode='sprouts-squad-community'
-      className='relative isolate overflow-hidden !px-0 !py-0 es-sprouts-community-section'
+      className='relative isolate overflow-hidden es-sprouts-community-section'
     >
       <Image
         src='/images/footer-community-bg.webp'
@@ -31,7 +31,7 @@ export function SproutsSquadCommunity({
         className='pointer-events-none absolute inset-0 es-sprouts-community-overlay'
       />
 
-      <SectionContainer className='flex min-h-[420px] flex-col justify-center gap-7 px-4 py-14 sm:min-h-[530px] sm:px-6 sm:py-20 lg:min-h-[740px] lg:gap-9 lg:px-8'>
+      <SectionContainer className='flex min-h-[420px] flex-col justify-center gap-7 sm:min-h-[530px] lg:min-h-[740px] lg:gap-9'>
         <Image
           src='/images/evolvesprouts-logo.svg'
           alt=''


### PR DESCRIPTION
Normalize spacing for Hero, Sprouts, and Footer top block sections to align with the `SectionShell` rhythm.

This PR removes custom padding/margin overrides in `hero-banner.tsx`, `sprouts-squad-community.tsx`, and `footer.tsx` to ensure consistent vertical spacing across these sections, as identified in the initial spacing audit. The negative margin on the footer logo was explicitly preserved.

---
<p><a href="https://cursor.com/agents?id=bc-83f6667a-4c06-432f-9a6b-775f07a6c901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83f6667a-4c06-432f-9a6b-775f07a6c901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

