### PR TITLE
Hero contact background properties

### DIFF
--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -138,16 +138,16 @@ export function ContactUsForm({ content }: ContactUsFormProps) {
       id='contact-us-form'
       ariaLabel={content.title}
       dataFigmaNode='contact-us-form'
-      className='es-contact-us-section'
+      className='relative overflow-hidden es-contact-us-section'
     >
+      <div
+        aria-hidden='true'
+        className='pointer-events-none absolute left-0 top-0 es-contact-us-left-decor'
+      />
       <SectionContainer className='grid gap-10 lg:grid-cols-2 lg:gap-9'>
         <section
           className='relative flex h-full items-start overflow-hidden px-6 py-8 sm:px-8 lg:px-10 lg:pt-[25%]'
         >
-          <div
-            aria-hidden='true'
-            className='pointer-events-none absolute left-0 top-0 es-contact-us-left-decor'
-          />
           <div className='relative z-10 space-y-6'>
             <h1 className='es-section-heading text-balance'>{content.title}</h1>
             <p className='es-section-body text-balance text-[1.05rem] leading-8'>

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -51,18 +51,14 @@ describe('ContactUsForm section', () => {
     process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = originalTurnstileSiteKey;
   });
 
-  it('uses class-based decorative background styling on the left panel', () => {
+  it('uses class-based decorative background styling on the section container', () => {
     render(<ContactUsForm content={enContent.contactUs.contactUsForm} />);
 
-    const leftPanelHeading = screen.getByRole('heading', {
-      level: 1,
-      name: enContent.contactUs.contactUsForm.title,
-    });
-    const leftPanel = leftPanelHeading.closest('section');
-    expect(leftPanel).not.toBeNull();
+    const sectionContainer = document.getElementById('contact-us-form');
+    expect(sectionContainer).not.toBeNull();
 
-    const decorativeLayer = leftPanel?.querySelector(
-      'div[aria-hidden="true"]',
+    const decorativeLayer = sectionContainer?.querySelector(
+      'div[aria-hidden="true"].es-contact-us-left-decor',
     ) as HTMLDivElement | null;
     expect(decorativeLayer).not.toBeNull();
     expect(decorativeLayer?.className).toContain('es-contact-us-left-decor');


### PR DESCRIPTION
Move the contact form's decorative background layer to the section container to align its placement with the Hero section's background structure.

---
<p><a href="https://cursor.com/agents?id=bc-19c6135b-9493-4766-a0e3-2627d6c946e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19c6135b-9493-4766-a0e3-2627d6c946e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

