### PR TITLE
Preloaded resource usage

### DIFF
--- a/apps/public_www/src/app/layout.tsx
+++ b/apps/public_www/src/app/layout.tsx
@@ -16,6 +16,7 @@ const lato = Lato({
   weight: ['400', '700'],
   style: ['normal'],
   display: 'swap',
+  preload: false,
 });
 
 const poppins = Poppins({
@@ -24,6 +25,7 @@ const poppins = Poppins({
   weight: ['500', '600', '700'],
   style: ['normal'],
   display: 'swap',
+  preload: false,
 });
 
 const DOCUMENT_LOCALE_DIRECTIONS = Object.fromEntries(

--- a/apps/public_www/src/components/sections/ida.tsx
+++ b/apps/public_www/src/components/sections/ida.tsx
@@ -42,7 +42,6 @@ export function Ida({ content }: IdaProps) {
               width={1112}
               height={840}
               sizes='(min-width: 1280px) 1111px, (min-width: 1024px) 700px, 100vw'
-              priority
               className='h-auto w-full'
             />
           </div>

--- a/apps/public_www/src/components/sections/testimonials.tsx
+++ b/apps/public_www/src/components/sections/testimonials.tsx
@@ -211,7 +211,6 @@ export function Testimonials({ content }: TestimonialsProps) {
                       fill
                       sizes='(min-width: 1024px) 500px, 100vw'
                       className='rounded-[30px] object-cover'
-                      priority={activeIndex === 0}
                     />
                   ) : (
                     <div


### PR DESCRIPTION
Removes unintended font and image preloads to fix 'resource preloaded but not used' warnings.

This PR addresses 'resource preloaded but not used' warnings by disabling Next.js's automatic preloading for non-critical fonts and images that were not consumed shortly after page load.

---
<p><a href="https://cursor.com/agents?id=bc-9c2c3d9b-7cc8-4875-97c6-27ffc7d70ef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c2c3d9b-7cc8-4875-97c6-27ffc7d70ef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

