### PR TITLE
Sprouts squad community management

### DIFF
--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 
 import { SectionCtaAnchor } from '@/components/sections/shared/section-cta-link';
 import { SectionContainer } from '@/components/sections/shared/section-container';
+import { SectionHeader } from '@/components/sections/shared/section-header';
 import { SectionShell } from '@/components/sections/shared/section-shell';
 import type { SproutsSquadCommunityContent } from '@/content';
 
@@ -39,11 +40,12 @@ export function SproutsSquadCommunity({
           height={250}
           className='h-auto w-[250px] es-sprouts-community-logo'
         />
-        <h2
-          className='max-w-[620px] text-[clamp(1.9rem,6vw,55px)] leading-[1.12] sm:-mt-6 lg:-mt-[52px] es-sprouts-community-heading'
-        >
-          {content.heading}
-        </h2>
+        <SectionHeader
+          title={content.heading}
+          align='left'
+          className='max-w-[620px]'
+          titleClassName='!mt-0 text-[clamp(1.9rem,6vw,55px)] leading-[1.12] sm:-mt-6 lg:-mt-[52px] es-sprouts-community-heading'
+        />
 
         <SectionCtaAnchor
           href={content.ctaHref}

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -31,6 +31,9 @@ describe('SproutsSquadCommunity section', () => {
 
     expect(container.querySelector('.es-sprouts-community-overlay')).not.toBeNull();
     expect(container.querySelector('img.es-sprouts-community-logo')).not.toBeNull();
+    expect(
+      container.querySelector('.es-section-header')?.className,
+    ).toContain('es-section-header--left');
 
     const heading = screen.getByRole('heading', {
       level: 2,


### PR DESCRIPTION
Standardize Sprouts Squad Community section by replacing custom `<h2>` with left-aligned `SectionHeader`.

---
<p><a href="https://cursor.com/agents?id=bc-aaa26a89-3a74-4280-9c2e-2e7e5cb197b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaa26a89-3a74-4280-9c2e-2e7e5cb197b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

