### PR TITLE
Two column sections

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -87,6 +87,80 @@
     );
   }
 
+  .es-section-split-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .es-section-split-layout--ida {
+    gap: 1.75rem;
+  }
+
+  .es-section-split-layout--hero {
+    gap: 2rem;
+  }
+
+  .es-section-split-layout--contact-us {
+    gap: 2.5rem;
+  }
+
+  .es-section-split-layout--my-history {
+    gap: 2rem;
+  }
+
+  .es-section-split-layout--my-best-auntie-booking {
+    gap: 2rem;
+  }
+
+  .es-section-split-layout--why-us,
+  .es-section-split-layout--my-journey {
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 1024px) {
+    .es-section-split-layout {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .es-section-split-layout--ida {
+      gap: 2.5rem;
+    }
+
+    .es-section-split-layout--hero {
+      gap: 1.5rem;
+    }
+
+    .es-section-split-layout--contact-us {
+      gap: 2.25rem;
+    }
+
+    .es-section-split-layout--my-history {
+      gap: 3rem;
+    }
+
+    .es-section-split-layout--my-best-auntie-booking {
+      gap: 1.5rem;
+    }
+
+    .es-section-split-layout--why-us {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr);
+      gap: 2rem;
+    }
+
+    .es-section-split-layout--my-journey {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1.3fr);
+      gap: 2rem;
+    }
+
+    .es-section-split-layout--testimonials {
+      grid-template-columns: minmax(0, 500px) minmax(0, 1fr);
+    }
+
+    .es-section-split-layout--free-resources {
+      grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    }
+  }
+
   .es-my-journey-section {
     background-color: var(--es-color-surface-white, #FFFFFF);
     --es-section-bg-image: url('/images/evolvesprouts-logo.svg');

--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -149,7 +149,7 @@ export function ContactUsForm({ content }: ContactUsFormProps) {
         className='pointer-events-none absolute left-0 top-0 es-contact-us-left-decor'
       />
       <SectionContainer
-        className={buildSectionSplitLayoutClassName('gap-10 lg:gap-9')}
+        className={buildSectionSplitLayoutClassName('es-section-split-layout--contact-us')}
       >
         <section
           className='relative flex h-full items-start overflow-hidden px-6 py-8 sm:px-8 lg:px-10 lg:pt-[25%]'

--- a/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
+++ b/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
@@ -366,7 +366,7 @@ export function FreeResourcesForGentleParenting({
                 data-testid='free-resource-layout'
                 data-layout='split'
                 className={buildSectionSplitLayoutClassName(
-                  'overflow-hidden rounded-[16px] border border-black/5 es-free-resources-pattern-bg',
+                  'es-section-split-layout--free-resources overflow-hidden rounded-[16px] border border-black/5 es-free-resources-pattern-bg',
                 )}
               >
                 <div

--- a/apps/public_www/src/components/sections/hero-banner.tsx
+++ b/apps/public_www/src/components/sections/hero-banner.tsx
@@ -49,7 +49,9 @@ export function HeroBanner({ content }: HeroBannerProps) {
         className='pointer-events-none absolute left-0 top-0 bg-no-repeat es-hero-frame-bg'
       />
       <SectionContainer
-        className={buildSectionSplitLayoutClassName('items-center gap-8 lg:gap-6')}
+        className={buildSectionSplitLayoutClassName(
+          'es-section-split-layout--hero items-center',
+        )}
       >
         <div className='relative max-w-[620px] lg:pb-4 lg:pr-8 lg:pt-[70px]'>
           <div className='relative z-10'>

--- a/apps/public_www/src/components/sections/ida.tsx
+++ b/apps/public_www/src/components/sections/ida.tsx
@@ -22,7 +22,9 @@ export function Ida({ content }: IdaProps) {
       className='es-ida-section overflow-hidden'
     >
       <SectionContainer
-        className={buildSectionSplitLayoutClassName('items-center gap-7 lg:gap-10')}
+        className={buildSectionSplitLayoutClassName(
+          'es-section-split-layout--ida items-center',
+        )}
       >
         <div className='order-1 relative z-10 lg:order-2 lg:pl-8 xl:pl-[110px]'>
           <SectionHeader

--- a/apps/public_www/src/components/sections/my-best-auntie-booking.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie-booking.tsx
@@ -140,7 +140,7 @@ export function MyBestAuntieBooking({
         <SectionContainer>
           <div
             className={buildSectionSplitLayoutClassName(
-              'w-full min-w-0 items-center gap-8 lg:gap-6',
+              'es-section-split-layout--my-best-auntie-booking w-full min-w-0 items-center',
             )}
           >
             <section className='space-y-5 max-w-[620px] lg:pr-8'>

--- a/apps/public_www/src/components/sections/my-history.tsx
+++ b/apps/public_www/src/components/sections/my-history.tsx
@@ -21,7 +21,9 @@ export function MyHistory({ content }: MyHistoryProps) {
       className='es-section-bg-overlay es-my-history-section'
     >
       <SectionContainer
-        className={buildSectionSplitLayoutClassName('items-center gap-8 lg:gap-12')}
+        className={buildSectionSplitLayoutClassName(
+          'es-section-split-layout--my-history items-center',
+        )}
       >
         <div>
           <SectionHeader

--- a/apps/public_www/src/components/sections/my-journey.tsx
+++ b/apps/public_www/src/components/sections/my-journey.tsx
@@ -30,7 +30,9 @@ export function MyJourney({ content }: MyJourneyProps) {
         <SectionHeader eyebrow={content.eyebrow} title={content.title} />
 
         <div
-          className={buildSectionSplitLayoutClassName('mt-10 gap-6 lg:mt-12 lg:gap-8')}
+          className={buildSectionSplitLayoutClassName(
+            'es-section-split-layout--my-journey mt-10 lg:mt-12',
+          )}
         >
           <div className='relative overflow-hidden rounded-[30px] es-bg-surface-peach'>
             <Image

--- a/apps/public_www/src/components/sections/shared/section-container.tsx
+++ b/apps/public_www/src/components/sections/shared/section-container.tsx
@@ -12,7 +12,7 @@ type SectionContainerProps<T extends ElementType = 'div'> = {
   children: ReactNode;
 } & Omit<ComponentPropsWithoutRef<T>, 'as' | 'className' | 'children'>;
 
-export const SECTION_SPLIT_LAYOUT_CLASSNAME = 'grid lg:grid-cols-2';
+export const SECTION_SPLIT_LAYOUT_CLASSNAME = 'es-section-split-layout';
 
 export function buildSectionSplitLayoutClassName(className?: string): string {
   return mergeClassNames(SECTION_SPLIT_LAYOUT_CLASSNAME, className);

--- a/apps/public_www/src/components/sections/testimonials.tsx
+++ b/apps/public_www/src/components/sections/testimonials.tsx
@@ -207,7 +207,11 @@ export function Testimonials({ content }: TestimonialsProps) {
               key={`${activeStory.author ?? 'story'}-${activeIndex}`}
               className='min-w-full'
             >
-              <div className={buildSectionSplitLayoutClassName()}>
+              <div
+                className={buildSectionSplitLayoutClassName(
+                  'es-section-split-layout--testimonials',
+                )}
+              >
                 <div className='relative min-h-[260px] overflow-hidden rounded-[30px] es-bg-surface-peach sm:min-h-[360px] lg:min-h-[540px]'>
                   {activeStory.mainImageSrc ? (
                     <Image

--- a/apps/public_www/src/components/sections/why-us.tsx
+++ b/apps/public_www/src/components/sections/why-us.tsx
@@ -24,7 +24,9 @@ export function WhyUs({ content }: WhyUsProps) {
         <SectionHeader eyebrow={content.eyebrow} title={content.title} />
 
         <div
-          className={buildSectionSplitLayoutClassName('mt-10 gap-6 lg:mt-12 lg:gap-8')}
+          className={buildSectionSplitLayoutClassName(
+            'es-section-split-layout--why-us mt-10 lg:mt-12',
+          )}
         >
           <div
             className='relative isolate overflow-hidden rounded-[26px] border es-border-soft-alt p-6 es-why-us-hero-card'

--- a/apps/public_www/tests/components/sections/shared/section-container.test.tsx
+++ b/apps/public_www/tests/components/sections/shared/section-container.test.tsx
@@ -48,7 +48,7 @@ describe('buildSectionSplitLayoutClassName', () => {
 
   it('merges custom classes with the shared two-column split class', () => {
     expect(buildSectionSplitLayoutClassName('items-center gap-8')).toBe(
-      'grid lg:grid-cols-2 items-center gap-8',
+      'es-section-split-layout items-center gap-8',
     );
   });
 });


### PR DESCRIPTION
Standardize section-level split layouts to a shared 2-column utility for consistency and maintainability.

This refactor introduces a shared `SECTION_SPLIT_LAYOUT_CLASSNAME` and `buildSectionSplitLayoutClassName` in `SectionContainer.tsx` and applies them to all identified section-level split layouts. Card-list grids that adapt to more than two columns at larger breakpoints remain unchanged, as per user request.

---
<p><a href="https://cursor.com/agents?id=bc-1e662ad2-3cce-4399-a04b-fc4608ea89f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e662ad2-3cce-4399-a04b-fc4608ea89f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

