### PR TITLE
Mobile quick links footer click area

### DIFF
--- a/apps/public_www/src/components/sections/footer.tsx
+++ b/apps/public_www/src/components/sections/footer.tsx
@@ -27,7 +27,7 @@ function resolveCurrentYearCopyright(value: string): string {
 }
 
 const FOOTER_LOGO_CLASSNAME =
-  'h-auto w-full max-w-[600px] -mt-[100px] -mb-[100px]';
+  'h-auto w-full max-w-[600px] -mt-[100px] mb-0 sm:-mb-[100px]';
 
 const socialIcons: Record<string, ReactNode> = {
   facebook: (


### PR DESCRIPTION
Adjusts mobile footer logo spacing to fix a non-clickable area in the "Quick Links" accordion.

The large negative bottom margin on the footer logo caused it to overlap the first accordion row ("Quick Links") on mobile, making the area between the text and chevron unresponsive to taps. Removing this negative margin on mobile resolves the hit-testing issue.

---
<p><a href="https://cursor.com/agents?id=bc-0c9a4368-3542-4d5a-b590-915ad34e650a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c9a4368-3542-4d5a-b590-915ad34e650a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

