### PR TITLE
Es-btn-pill mobile menu

### DIFF
--- a/apps/public_www/src/app/styles/original/components-core.css
+++ b/apps/public_www/src/app/styles/original/components-core.css
@@ -418,6 +418,11 @@
     background-color: var(--figma-colors-frame-2147235267, #F6DECD);
   }
 
+  .es-btn--pill.es-navbar-mobile-pill-reset {
+    border-radius: 0;
+    background-color: transparent;
+  }
+
   .es-btn--submenu {
     min-height: 40px;
     width: 100%;
@@ -507,6 +512,10 @@
         --figma-colors-join-our-sprouts-squad-community,
         #333333
       ) !important;
+    }
+
+    .es-btn--pill.es-navbar-mobile-pill-reset:hover {
+      background-color: transparent !important;
     }
 
     .es-btn--submenu:hover {

--- a/apps/public_www/src/components/sections/navbar/menu-items.tsx
+++ b/apps/public_www/src/components/sections/navbar/menu-items.tsx
@@ -20,10 +20,11 @@ const NAV_TOP_LEVEL_LINK_CLASSNAME =
 const NAV_TOP_LEVEL_LINK_WITH_SUBMENU_CLASSNAME =
   `${NAV_TOP_LEVEL_LINK_CLASSNAME} pr-10`;
 const NAV_SUBMENU_LINK_CLASSNAME = '';
+const NAV_MOBILE_PILL_RESET_CLASSNAME = 'es-navbar-mobile-pill-reset';
 const NAV_MOBILE_TOP_LEVEL_LINK_CLASSNAME =
-  'flex-1';
+  `flex-1 ${NAV_MOBILE_PILL_RESET_CLASSNAME}`;
 export const MOBILE_PRIMARY_ACTION_CLASSNAME =
-  'w-full justify-between transition-colors';
+  `w-full justify-between transition-colors ${NAV_MOBILE_PILL_RESET_CLASSNAME}`;
 const NAV_LANGUAGE_CHEVRON_ICON_SRC = '/images/chevron.svg';
 const NAV_MOBILE_CHEVRON_ICON_SRC = '/images/chevron.svg';
 

--- a/apps/public_www/tests/components/sections/navbar.test.tsx
+++ b/apps/public_www/tests/components/sections/navbar.test.tsx
@@ -120,4 +120,27 @@ describe('Navbar desktop submenu accessibility', () => {
     fireEvent.click(submenuToggle);
     expect(submenuToggle).toHaveAttribute('aria-expanded', 'false');
   });
+
+  it('applies the pill reset class to mobile drawer pill controls', async () => {
+    render(<Navbar content={enContent.navbar} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Open navigation menu/i }));
+
+    const drawer = await screen.findByRole('dialog', {
+      name: /Mobile navigation menu/i,
+    });
+
+    const homeLink = within(drawer).getByRole('link', { name: 'Home' });
+    expect(homeLink.className).toContain('es-navbar-mobile-pill-reset');
+
+    const trainingCoursesToggle = within(drawer).getByRole('button', {
+      name: 'Toggle Training Courses submenu',
+    });
+    expect(trainingCoursesToggle.className).toContain('es-navbar-mobile-pill-reset');
+
+    const languageSelectorButton = within(drawer).getByRole('button', {
+      name: /Selected language: English/i,
+    });
+    expect(languageSelectorButton.className).toContain('es-navbar-mobile-pill-reset');
+  });
 });


### PR DESCRIPTION
Remove background color and border radius from `es-btn--pill` within the mobile navbar menu.

---
<p><a href="https://cursor.com/agents?id=bc-aec9b53b-f1c6-4d0e-af3e-f2b25229cbe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec9b53b-f1c6-4d0e-af3e-f2b25229cbe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

