### PR TITLE
Image background and overflow

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -875,6 +875,13 @@
     background-size: 100px 100px;
   }
 
+  .es-free-resources-media-background {
+    background-image: url('/images/family.webp');
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+  }
+
   .es-free-resources-card-title {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
@@ -932,6 +939,16 @@
     font-size: clamp(1rem, 1.6vw, 20px);
     font-weight: var(--figma-fontweights-600, 600);
     line-height: 1;
+  }
+
+  @media (min-width: 1024px) {
+    .es-free-resources-media-pane--bleed-left .es-free-resources-media-background {
+      left: -14%;
+    }
+
+    .es-free-resources-media-pane--bleed-right .es-free-resources-media-background {
+      right: -14%;
+    }
   }
 
   .es-my-best-auntie-overview-section {

--- a/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
+++ b/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
@@ -291,6 +291,10 @@ export function FreeResourcesForGentleParenting({
     splitImagePosition === 'left' ? 'lg:order-2' : 'lg:order-1';
   const splitMediaPaneOrderClassName =
     splitImagePosition === 'left' ? 'lg:order-1' : 'lg:order-2';
+  const splitMediaBleedClassName =
+    splitImagePosition === 'left'
+      ? 'es-free-resources-media-pane--bleed-right'
+      : 'es-free-resources-media-pane--bleed-left';
   const overlayCardAlignmentClassName =
     overlayCardPosition === 'left' ? 'justify-start' : 'justify-end';
 
@@ -371,7 +375,7 @@ export function FreeResourcesForGentleParenting({
               >
                 <div
                   data-testid='free-resource-text-pane'
-                  className={`relative z-0 p-4 sm:p-6 lg:p-[35px] ${splitTextPaneOrderClassName}`}
+                  className={`relative z-10 p-4 sm:p-6 lg:p-[35px] ${splitTextPaneOrderClassName}`}
                 >
                   <article
                     className='relative flex h-full min-h-[370px] flex-col overflow-hidden rounded-[15px] p-6 sm:min-h-[440px] sm:p-8 lg:min-h-[516px]'
@@ -388,14 +392,11 @@ export function FreeResourcesForGentleParenting({
 
                 <div
                   data-testid='free-resource-media-pane'
-                  className={`relative z-10 min-h-[280px] overflow-hidden sm:min-h-[370px] lg:min-h-[587px] ${splitMediaPaneOrderClassName}`}
+                  className={`es-free-resources-media-pane ${splitMediaBleedClassName} relative z-0 min-h-[280px] overflow-visible sm:min-h-[370px] lg:min-h-[587px] ${splitMediaPaneOrderClassName}`}
                 >
-                  <Image
-                    src={RESOURCE_IMAGE_SRC}
-                    alt={mediaAltText}
-                    fill
-                    className='object-cover'
-                    sizes='(min-width: 1024px) 58vw, 100vw'
+                  <div
+                    aria-hidden='true'
+                    className='pointer-events-none absolute inset-0 z-0 es-free-resources-media-background'
                   />
 
                   <div className='absolute left-1/2 top-[10%] z-10 flex -translate-x-1/2 flex-col items-center gap-2 sm:gap-3'>

--- a/apps/public_www/tests/components/sections/free-resources-for-gentle-parenting.test.tsx
+++ b/apps/public_www/tests/components/sections/free-resources-for-gentle-parenting.test.tsx
@@ -43,9 +43,14 @@ describe('Free resources for gentle parenting section', () => {
 
     expect(header.className).toContain('text-center');
     expect(layout).toHaveAttribute('data-layout', 'split');
-    expect(textPane.className).toContain('z-0');
-    expect(mediaPane.className).toContain('z-10');
+    expect(textPane.className).toContain('z-10');
+    expect(mediaPane.className).toContain('z-0');
+    expect(mediaPane.className).toContain('es-free-resources-media-pane');
+    expect(mediaPane.className).toContain(
+      'es-free-resources-media-pane--bleed-left',
+    );
     expect(mediaPane.className).toContain('lg:order-2');
+    expect(mediaPane.querySelector('img')).toBeNull();
   });
 
   it('applies the orange tile background pattern to the card container', () => {
@@ -147,6 +152,9 @@ describe('Free resources for gentle parenting section', () => {
     expect(layout).toHaveAttribute('data-layout', 'split');
     expect(textPane.className).toContain('lg:order-2');
     expect(mediaPane.className).toContain('lg:order-1');
+    expect(mediaPane.className).toContain(
+      'es-free-resources-media-pane--bleed-right',
+    );
   });
 
   it('supports overlay layout with right-positioned text card', () => {


### PR DESCRIPTION
Convert the Free Resources section's split layout image to a background layer with controlled overflow into the sibling content pane.

---
<p><a href="https://cursor.com/agents?id=bc-49a2afb1-6df0-4ebf-a4ac-8ba0b4bf5675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49a2afb1-6df0-4ebf-a4ac-8ba0b4bf5675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

