### PR TITLE
Course highlight card tap

### DIFF
--- a/apps/public_www/src/components/sections/course-highlight-card.tsx
+++ b/apps/public_www/src/components/sections/course-highlight-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { type MouseEvent, useCallback, useRef, useState } from 'react';
 import Image from 'next/image';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
@@ -19,6 +19,17 @@ export interface CourseHighlightCardProps {
   imageClassName: string;
   description?: string;
   tone: CourseHighlightCardTone;
+}
+
+const INTERACTIVE_ELEMENT_SELECTOR =
+  'button, a, input, select, textarea, [role="button"]';
+
+function supportsHoverInteraction(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia('(hover: hover)').matches;
 }
 
 export function CourseHighlightCard({
@@ -51,6 +62,22 @@ export function CourseHighlightCard({
     setIsActive((prev) => !prev);
   }, []);
 
+  const handleCardSurfaceClick = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      const clickTarget = event.target as HTMLElement | null;
+      if (clickTarget?.closest(INTERACTIVE_ELEMENT_SELECTOR)) {
+        return;
+      }
+
+      if (supportsHoverInteraction()) {
+        return;
+      }
+
+      setIsActive((prev) => !prev);
+    },
+    [],
+  );
+
   // Build conditional class fragments for the active (tapped) state.
   // Desktop hover continues to work independently via lg:group-hover:*.
   const overlayActive = isActive
@@ -66,6 +93,7 @@ export function CourseHighlightCard({
   return (
     <article
       ref={articleRef}
+      onClick={handleCardSurfaceClick}
       className={`group relative isolate flex min-h-[320px] overflow-hidden rounded-[25px] p-5 sm:min-h-[345px] sm:p-7 lg:min-h-[457px] lg:p-8 ${toneClassName}`}
     >
       {/* Dark overlay — activated by desktop hover or mobile tap */}

--- a/apps/public_www/tests/components/sections/course-highlight-card.test.tsx
+++ b/apps/public_www/tests/components/sections/course-highlight-card.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { CourseHighlightCard } from '@/components/sections/course-highlight-card';
 
@@ -16,6 +16,38 @@ vi.mock('next/image', () => ({
 function hasClassToken(className: string, token: string): boolean {
   return className.split(/\s+/).includes(token);
 }
+
+const originalMatchMedia = window.matchMedia;
+
+function mockHoverCapability(canHover: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(hover: hover)' ? canHover : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+afterEach(() => {
+  if (originalMatchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+    return;
+  }
+
+  Reflect.deleteProperty(window, 'matchMedia');
+});
 
 describe('CourseHighlightCard description visibility transition', () => {
   it('uses immediate hide classes when toggled inactive', () => {
@@ -53,5 +85,73 @@ describe('CourseHighlightCard description visibility transition', () => {
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
     expect(hasClassToken(description.className, 'opacity-0')).toBe(true);
     expect(hasClassToken(description.className, 'transition-none')).toBe(true);
+  });
+
+  it('toggles when tapping the card surface on non-hover devices', () => {
+    mockHoverCapability(false);
+
+    render(
+      <CourseHighlightCard
+        id='age-specific'
+        title='Age Specific Strategies'
+        imageSrc='/images/course-highlights/course-card-1.webp'
+        imageWidth={344}
+        imageHeight={309}
+        imageClassName='h-[235px]'
+        description='Practical scripts and examples'
+        tone='gold'
+      />,
+    );
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('article');
+    const toggleButton = screen.getByRole('button', {
+      name: 'Show details for Age Specific Strategies',
+    });
+
+    expect(card).not.toBeNull();
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(card as HTMLElement);
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(card as HTMLElement);
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps desktop card-surface clicks inert when hover is available', () => {
+    mockHoverCapability(true);
+
+    render(
+      <CourseHighlightCard
+        id='age-specific'
+        title='Age Specific Strategies'
+        imageSrc='/images/course-highlights/course-card-1.webp'
+        imageWidth={344}
+        imageHeight={309}
+        imageClassName='h-[235px]'
+        description='Practical scripts and examples'
+        tone='gold'
+      />,
+    );
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('article');
+    const toggleButton = screen.getByRole('button', {
+      name: 'Show details for Age Specific Strategies',
+    });
+
+    expect(card).not.toBeNull();
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(card as HTMLElement);
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(toggleButton);
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
   });
 });


### PR DESCRIPTION
Enable full-card tap to toggle course highlight details on non-hover devices, improving mobile usability.

---
<p><a href="https://cursor.com/agents?id=bc-3555e811-64a1-4876-b686-778498e942ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3555e811-64a1-4876-b686-778498e942ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

