### PR TITLE
WhatsApp icon mobile alignment

### DIFF
--- a/apps/public_www/src/components/shared/whatsapp-contact-button.tsx
+++ b/apps/public_www/src/components/shared/whatsapp-contact-button.tsx
@@ -22,12 +22,12 @@ const WHATSAPP_ICON_PATH =
   '37.4-26.4s4.6-24.1 3.2-26.4c-1.3-2.5-5-3.9-10.5-6.6z';
 
 const buttonClassName =
-  'fixed right-5 z-50 flex h-16 w-16 items-center justify-center ' +
+  'fixed right-[30px] z-50 flex h-16 w-16 items-center justify-center ' +
   'es-whatsapp-contact-button-safe-bottom ' +
   'rounded-full bg-white shadow-es-whatsapp transition-' +
   'transform duration-150 hover:scale-105 focus-visible:outline ' +
   'focus-visible:outline-2 focus-visible:outline-offset-4 ' +
-  'focus-visible:outline-[var(--es-color-whatsapp)] sm:right-[30px]';
+  'focus-visible:outline-[var(--es-color-whatsapp)]';
 
 const iconClassName = 'h-11 w-11 fill-current text-es-whatsapp';
 

--- a/apps/public_www/tests/components/shared/whatsapp-contact-button.test.tsx
+++ b/apps/public_www/tests/components/shared/whatsapp-contact-button.test.tsx
@@ -43,5 +43,6 @@ describe('WhatsappContactButton', () => {
     );
     expect(link.querySelector('svg')).not.toBeNull();
     expect(link.className).toContain('es-whatsapp-contact-button-safe-bottom');
+    expect(link.className).toContain('right-[30px]');
   });
 });


### PR DESCRIPTION
Adjust WhatsApp icon's mobile positioning to prevent it from hugging the viewport edge.

---
<p><a href="https://cursor.com/agents?id=bc-998ec7a7-f34f-49c7-9e45-cd9e52c91ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-998ec7a7-f34f-49c7-9e45-cd9e52c91ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

