### PR TITLE
Www layout overflow

### DIFF
--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -142,7 +142,7 @@ export function ContactUsForm({ content }: ContactUsFormProps) {
       id='contact-us-form'
       ariaLabel={content.title}
       dataFigmaNode='contact-us-form'
-      className='overflow-hidden es-contact-us-section'
+      className='relative overflow-hidden es-contact-us-section'
     >
       <div
         aria-hidden='true'

--- a/apps/public_www/src/components/sections/hero-banner.tsx
+++ b/apps/public_www/src/components/sections/hero-banner.tsx
@@ -42,7 +42,7 @@ export function HeroBanner({ content }: HeroBannerProps) {
       id='hero-banner'
       ariaLabel={content.headline}
       dataFigmaNode='banner'
-      className='w-full overflow-hidden es-hero-section'
+      className='relative w-full overflow-hidden es-hero-section'
     >
       <div
         aria-hidden='true'


### PR DESCRIPTION
Fix horizontal page overflow on Home and Contact Us pages by adding `relative` to `SectionShell` wrappers.

This change anchors the large absolutely-positioned decorative elements (`es-hero-frame-bg` and `es-contact-us-left-decor`) to their respective sections, preventing them from expanding the document's scroll width while preserving their visual design.

---
<p><a href="https://cursor.com/agents?id=bc-52f3567e-bee4-4cc6-8ede-c6720b61aa35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52f3567e-bee4-4cc6-8ede-c6720b61aa35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

