### PR TITLE
Section padding consistency

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -1,4 +1,25 @@
 @layer components {
+  .es-section-shell-spacing {
+    padding-top: 80px;
+    padding-right: 16px;
+    padding-bottom: 80px;
+    padding-left: 16px;
+  }
+
+  @media (min-width: 640px) {
+    .es-section-shell-spacing {
+      padding-right: 24px;
+      padding-left: 24px;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .es-section-shell-spacing {
+      padding-right: 32px;
+      padding-left: 32px;
+    }
+  }
+
   .es-connect-section {
     background-color: var(--es-color-surface-white, #FFFFFF);
     background-image: url('/images/evolvesprouts-logo.svg');

--- a/apps/public_www/src/components/sections/footer.tsx
+++ b/apps/public_www/src/components/sections/footer.tsx
@@ -190,7 +190,7 @@ export function Footer({ content }: FooterProps) {
 
   return (
     <footer data-figma-node='footer' className='w-full es-footer-root'>
-      <section className='w-full px-4 py-16 sm:px-6 sm:py-20 lg:px-8 lg:py-[100px]'>
+      <section className='w-full es-section-shell-spacing'>
         <SectionContainer>
           <div className='mb-7 hidden justify-center sm:flex lg:hidden'>
             <Image

--- a/apps/public_www/src/components/sections/shared/section-shell.tsx
+++ b/apps/public_www/src/components/sections/shared/section-shell.tsx
@@ -8,8 +8,7 @@ interface SectionShellProps {
   children: ReactNode;
 }
 
-const BASE_SECTION_CLASSNAME =
-  'w-full px-4 py-16 sm:px-6 sm:py-20 lg:px-8 lg:py-[100px]';
+const BASE_SECTION_CLASSNAME = 'w-full es-section-shell-spacing';
 
 export function SectionShell({
   id,

--- a/apps/public_www/tests/components/sections/footer.test.tsx
+++ b/apps/public_www/tests/components/sections/footer.test.tsx
@@ -62,6 +62,9 @@ describe('Footer external links', () => {
   it('keeps mobile logo non-interactive and full-width accordion tap targets', () => {
     render(<Footer content={enContent.footer} />);
 
+    const footerTopSection = document.querySelector('footer section');
+    expect(footerTopSection?.className).toContain('es-section-shell-spacing');
+
     const mobileFooterSection = document.querySelector('div.sm\\:hidden');
     expect(mobileFooterSection).not.toBeNull();
     expect(

--- a/apps/public_www/tests/components/sections/hero-banner.test.tsx
+++ b/apps/public_www/tests/components/sections/hero-banner.test.tsx
@@ -42,6 +42,7 @@ describe('HeroBanner section', () => {
     const section = container.querySelector('section[data-figma-node="banner"]');
     expect(section).not.toBeNull();
     expect(section?.className).toContain('es-hero-section');
+    expect(section?.className).toContain('es-section-shell-spacing');
 
     const frameBackground = container.querySelector('.es-hero-frame-bg');
     expect(frameBackground).not.toBeNull();


### PR DESCRIPTION
Move section padding from Tailwind utilities to CSS and standardize vertical padding to 80px across all breakpoints.

This change addresses the user's request to have consistent 80px vertical padding for sections on both mobile and desktop, and to move this styling from Tailwind utility classes into a dedicated CSS class for better maintainability.

---
<p><a href="https://cursor.com/agents?id=bc-a86916ca-8c90-41f1-b2d8-9dffe9b3206b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a86916ca-8c90-41f1-b2d8-9dffe9b3206b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

