### PR TITLE
Svg arrow text integration

### DIFF
--- a/apps/public_www/src/app/styles/original/components-core.css
+++ b/apps/public_www/src/app/styles/original/components-core.css
@@ -520,6 +520,10 @@
     text-underline-offset: 4px;
   }
 
+  .es-link-external-label--with-icon > .es-link-external-icon {
+    margin-left: 3px;
+  }
+
   .es-link-external-icon {
     display: inline-block;
     flex-shrink: 0;

--- a/apps/public_www/src/components/shared/external-link-icon.tsx
+++ b/apps/public_www/src/components/shared/external-link-icon.tsx
@@ -50,12 +50,19 @@ export function ExternalLinkInlineContent({
   children,
   internalIcon = null,
 }: ExternalLinkInlineContentProps) {
+  if (isExternalHttp) {
+    return (
+      <span className='es-link-external-label es-link-external-label--with-icon'>
+        {children}
+        <ExternalLinkIcon />
+      </span>
+    );
+  }
+
   return (
     <>
-      <span className={isExternalHttp ? 'es-link-external-label' : undefined}>
-        {children}
-      </span>
-      {isExternalHttp ? <ExternalLinkIcon /> : internalIcon}
+      <span>{children}</span>
+      {internalIcon}
     </>
   );
 }

--- a/apps/public_www/tests/components/shared/external-link-icon.test.tsx
+++ b/apps/public_www/tests/components/shared/external-link-icon.test.tsx
@@ -25,10 +25,12 @@ describe('ExternalLinkInlineContent', () => {
       </ExternalLinkInlineContent>,
     );
 
-    expect(screen.getByText('Link label').className).toContain('es-link-external-label');
-    expect(
-      document.querySelector('svg[data-external-link-icon="true"]'),
-    ).not.toBeNull();
+    const label = screen.getByText('Link label');
+    expect(label.className).toContain('es-link-external-label');
+    expect(label.className).toContain('es-link-external-label--with-icon');
+    const externalIcon = label.querySelector('svg[data-external-link-icon="true"]');
+    expect(externalIcon).not.toBeNull();
+    expect(externalIcon?.parentElement).toBe(label);
 
     rerender(
       <ExternalLinkInlineContent


### PR DESCRIPTION
Move external link arrow SVG into the text span with a 3px gap to match the requested layout.

---
<p><a href="https://cursor.com/agents?id=bc-95b3e725-a43c-4bf7-ae6c-3a7229d1cf7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95b3e725-a43c-4bf7-ae6c-3a7229d1cf7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

