### PR TITLE
XSS protection maintenance

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -201,6 +201,14 @@ repo root
 - Never use `style={...}` or `style=""` in JSX (MANDATORY).
 - Never use `CSSProperties` / `React.CSSProperties` in app code (MANDATORY).
 
+### Public WWW XSS policy (MANDATORY for `apps/public_www/**`)
+
+- Do not use `dangerouslySetInnerHTML`.
+- Do not use `eval()` or `new Function()`.
+- Keep `csp:inject` and `csp:validate` required in the public website build
+  pipeline.
+- During code review, reject changes introducing any of these patterns.
+
 ### Public WWW component and test structure (MANDATORY for `apps/public_www/**`)
 
 - Place page composition components in `apps/public_www/src/components/pages/**`.

--- a/apps/public_www/eslint.config.mjs
+++ b/apps/public_www/eslint.config.mjs
@@ -13,6 +13,7 @@ const eslintConfig = [
   {
     files: ['**/*.{ts,tsx,js,jsx,mjs,cjs}'],
     rules: {
+      'react/no-danger': 'error',
       'no-restricted-imports': [
         'error',
         {


### PR DESCRIPTION
Enforce XSS protection for `apps/public_www` by adding a lint rule for `dangerouslySetInnerHTML` and documenting a code review policy.

---
<p><a href="https://cursor.com/agents?id=bc-4057f5f3-e1ed-417e-b6ec-de5ce561625f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4057f5f3-e1ed-417e-b6ec-de5ce561625f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

