### PR TITLE
Alternative distribution name

### DIFF
--- a/backend/infrastructure/lib/public-www-stack.ts
+++ b/backend/infrastructure/lib/public-www-stack.ts
@@ -8,7 +8,7 @@ import { Construct } from "constructs";
 interface WebsiteEnvironmentConfig {
   readonly idPrefix: "PublicWww" | "PublicWwwStaging";
   readonly environmentLabel: "production" | "staging";
-  readonly domainName: string;
+  readonly domainNames: string[];
   readonly certificateArn: string;
   readonly bucketNamePrefix: string;
   readonly loggingBucketNamePrefix: string;
@@ -49,7 +49,12 @@ export class PublicWwwStack extends cdk.Stack {
 
     const productionDomainName = new cdk.CfnParameter(this, "PublicWwwDomainName", {
       type: "String",
-      description: "Custom domain for production public website (CloudFront alias).",
+      description:
+        "Custom domain aliases for production public website (CloudFront aliases, comma-separated).",
+      allowedPattern:
+        "^[A-Za-z0-9.-]+(,[A-Za-z0-9.-]+)*$",
+      constraintDescription:
+        "Must be one or more domain names separated by commas without spaces.",
     });
 
     const productionCertificateArn = new cdk.CfnParameter(
@@ -66,7 +71,12 @@ export class PublicWwwStack extends cdk.Stack {
       "PublicWwwStagingDomainName",
       {
         type: "String",
-        description: "Custom domain for staging public website (CloudFront alias).",
+        description:
+          "Custom domain aliases for staging public website (CloudFront aliases, comma-separated).",
+        allowedPattern:
+          "^[A-Za-z0-9.-]+(,[A-Za-z0-9.-]+)*$",
+        constraintDescription:
+          "Must be one or more domain names separated by commas without spaces.",
       },
     );
 
@@ -97,7 +107,7 @@ export class PublicWwwStack extends cdk.Stack {
     const productionResources = this.createWebsiteEnvironment({
       idPrefix: "PublicWww",
       environmentLabel: "production",
-      domainName: productionDomainName.valueAsString,
+      domainNames: cdk.Fn.split(",", productionDomainName.valueAsString),
       certificateArn: productionCertificateArn.valueAsString,
       bucketNamePrefix: "evolvesprouts-public-www",
       loggingBucketNamePrefix: "evolvesprouts-public-www-logs",
@@ -112,7 +122,7 @@ export class PublicWwwStack extends cdk.Stack {
     const stagingResources = this.createWebsiteEnvironment({
       idPrefix: "PublicWwwStaging",
       environmentLabel: "staging",
-      domainName: stagingDomainName.valueAsString,
+      domainNames: cdk.Fn.split(",", stagingDomainName.valueAsString),
       certificateArn: stagingCertificateArn.valueAsString,
       bucketNamePrefix: "evolvesprouts-staging-www",
       loggingBucketNamePrefix: "evolvesprouts-staging-www-logs",
@@ -370,7 +380,7 @@ function handler(event) {
       `${config.idPrefix}Distribution`,
       {
         defaultRootObject: "index.html",
-        domainNames: [config.domainName],
+        domainNames: config.domainNames,
         certificate,
         minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
         httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,

--- a/backend/infrastructure/params/README.md
+++ b/backend/infrastructure/params/README.md
@@ -7,9 +7,11 @@ Use `production.json` as a template for CDK parameters.
 `production.json` now includes both production and staging parameters for the
 public website stacks:
 
-- `PublicWwwDomainName`
+- `PublicWwwDomainName` (comma-separated CloudFront aliases, for example
+  `www.evolvesprouts.com,evolvesprouts.com`)
 - `PublicWwwCertificateArn`
-- `PublicWwwStagingDomainName`
+- `PublicWwwStagingDomainName` (comma-separated CloudFront aliases, for example
+  `www-staging.evolvesprouts.com`)
 - `PublicWwwStagingCertificateArn`
 - `WafWebAclArn`
 

--- a/backend/infrastructure/params/production.json
+++ b/backend/infrastructure/params/production.json
@@ -29,7 +29,7 @@
   "AdminBootstrapTempPassword": "<FROM_GITHUB_SECRET: CDK_PARAM_ADMIN_BOOTSTRAP_TEMP_PASSWORD>",
   "CrmWebDomainName": "crm.evolvesprouts.com",
   "CrmWebCertificateArn": "arn:aws:acm:us-east-1:588024549699:certificate/6fe57a34-8eba-45a9-bcb4-3fa10eb56656",
-  "PublicWwwDomainName": "www.evolvesprouts.com",
+  "PublicWwwDomainName": "www.evolvesprouts.com,evolvesprouts.com",
   "PublicWwwCertificateArn": "arn:aws:acm:us-east-1:588024549699:certificate/6fe57a34-8eba-45a9-bcb4-3fa10eb56656",
   "PublicWwwStagingDomainName": "www-staging.evolvesprouts.com",
   "PublicWwwStagingCertificateArn": "arn:aws:acm:us-east-1:588024549699:certificate/6fe57a34-8eba-45a9-bcb4-3fa10eb56656",

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -20,8 +20,11 @@ The same CDK app also defines static website stacks:
 
 | Stack Name | Environment | Domain Parameter | Certificate Parameter | Notes |
 |-----------|-------------|------------------|-----------------------|-------|
-| `evolvesprouts-public-www` | Production | `PublicWwwDomainName` | `PublicWwwCertificateArn` | Production website |
+| `evolvesprouts-public-www` | Production | `PublicWwwDomainName` | `PublicWwwCertificateArn` | Production website (`www.evolvesprouts.com` and `evolvesprouts.com`) |
 | `evolvesprouts-public-www` | Staging | `PublicWwwStagingDomainName` | `PublicWwwStagingCertificateArn` | Staging website with `X-Robots-Tag: noindex, nofollow, noarchive` |
+
+`PublicWwwDomainName` and `PublicWwwStagingDomainName` accept comma-separated
+CloudFront aliases without spaces.
 
 The stack outputs:
 

--- a/docs/architecture/setup.md
+++ b/docs/architecture/setup.md
@@ -70,9 +70,10 @@ For the OIDC provider itself, add the same tags:
 - `CDK_BOOTSTRAP_QUALIFIER` (optional)
 - `CDK_PARAM_FILE` (e.g. `backend/infrastructure/params/production.json`)
   - For Public WWW deploys, include:
-    - `PublicWwwDomainName`
+    - `PublicWwwDomainName` (comma-separated aliases, for example
+      `www.evolvesprouts.com,evolvesprouts.com`)
     - `PublicWwwCertificateArn`
-    - `PublicWwwStagingDomainName`
+    - `PublicWwwStagingDomainName` (comma-separated aliases)
     - `PublicWwwStagingCertificateArn`
 - `NEXT_PUBLIC_WWW_CRM_API_BASE_URL` (for Public WWW builds)
 - `AMPLIFY_APP_ID`

--- a/docs/deployment/public-www.md
+++ b/docs/deployment/public-www.md
@@ -10,7 +10,7 @@ Public WWW uses a single CloudFormation stack:
 
 Inside the stack, production and staging use separate S3 + CloudFront assets:
 
-- Production URL: `https://www.evolvesprouts.com`
+- Production URLs: `https://www.evolvesprouts.com`, `https://evolvesprouts.com`
 - Staging URL: `https://www-staging.evolvesprouts.com`
 
 The release process is **staging first**:
@@ -27,6 +27,7 @@ staging.
 
 - ACM certificate in `us-east-1` covering:
   - `www.evolvesprouts.com`
+  - `evolvesprouts.com`
   - `www-staging.evolvesprouts.com`
 - CloudFront aliases configured for both domains
 
@@ -34,11 +35,14 @@ staging.
 
 Provide these parameters in `backend/infrastructure/params/production.json`:
 
-- `PublicWwwDomainName`: `www.evolvesprouts.com`
+- `PublicWwwDomainName`: `www.evolvesprouts.com,evolvesprouts.com`
 - `PublicWwwCertificateArn`: ACM certificate ARN for production
 - `PublicWwwStagingDomainName`: `www-staging.evolvesprouts.com`
 - `PublicWwwStagingCertificateArn`: ACM certificate ARN for staging
 - `WafWebAclArn`: optional CloudFront WAF ACL ARN (us-east-1)
+
+Use comma-separated alias values without spaces for `PublicWwwDomainName` and
+`PublicWwwStagingDomainName`.
 
 Public WWW CRM API configuration is provided at build time via:
 


### PR DESCRIPTION
Add `evolvesprouts.com` as an alternative domain name to the production public www CloudFront distribution to enable apex domain access.

---
<p><a href="https://cursor.com/agents?id=bc-e9aae046-d5bc-469c-8987-baf2ae46f70b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9aae046-d5bc-469c-8987-baf2ae46f70b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

