### PR TITLE
Public www display size

### DIFF
--- a/apps/public_www/src/app/styles/original/base.css
+++ b/apps/public_www/src/app/styles/original/base.css
@@ -122,9 +122,9 @@
     @apply bg-slate-50 antialiased;
     color: var(--site-primary-text);
     font-family: var(--site-primary-font);
-    font-size: 20px;
-    line-height: 28px;
-    letter-spacing: 0.5px;
+    font-size: 16px;
+    line-height: 24px;
+    letter-spacing: 0.4px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -142,13 +142,13 @@
   }
 
   h1 {
-    font-size: clamp(2.2rem, 5.8vw, 60px);
-    line-height: clamp(2.7rem, 6.4vw, 66px);
+    font-size: clamp(2.2rem, 5vw, 45px);
+    line-height: clamp(2.7rem, 5.4vw, 50px);
   }
 
   h2 {
-    font-size: clamp(2rem, 4.2vw, 40px);
-    line-height: clamp(2.45rem, 4.9vw, 47px);
+    font-size: clamp(2rem, 3.5vw, 30px);
+    line-height: clamp(2.45rem, 4.2vw, 36px);
   }
 
   p {

--- a/apps/public_www/src/app/styles/original/components-core.css
+++ b/apps/public_www/src/app/styles/original/components-core.css
@@ -9,7 +9,7 @@
   .es-type-eyebrow {
     color: var(--site-heading-text);
     font-family: var(--site-primary-font);
-    font-size: var(--figma-fontsizes-18, 18px);
+    font-size: 14px;
     font-weight: 500;
     line-height: 1;
   }
@@ -17,16 +17,16 @@
   .es-type-title {
     color: var(--site-heading-text);
     font-family: var(--site-heading-font);
-    font-size: clamp(2rem, 5.8vw, 55px);
+    font-size: clamp(2rem, 5vw, 41px);
     font-weight: 700;
-    line-height: clamp(2.6rem, 7vw, 70px);
+    line-height: clamp(2.6rem, 6vw, 53px);
     letter-spacing: 0;
   }
 
   .es-type-subtitle {
     color: var(--site-heading-text);
     font-family: var(--site-heading-font);
-    font-size: clamp(1rem, 2.1vw, 22px);
+    font-size: clamp(1rem, 1.8vw, 18px);
     font-weight: 500;
     line-height: 1.4;
     letter-spacing: 0;
@@ -35,7 +35,7 @@
   .es-type-body {
     color: var(--site-primary-text);
     font-family: var(--site-primary-font);
-    font-size: clamp(1rem, 1.9vw, 22px);
+    font-size: clamp(1rem, 1.6vw, 18px);
     font-weight: 400;
     line-height: 1.55;
     letter-spacing: 0;
@@ -44,18 +44,18 @@
   .es-type-body-italic {
     color: var(--site-primary-text);
     font-family: var(--site-primary-font);
-    font-size: clamp(1rem, 2.2vw, 28px);
+    font-size: clamp(1rem, 1.9vw, 21px);
     font-weight: 400;
     font-style: italic;
-    line-height: clamp(1.5rem, 3vw, 50px);
-    letter-spacing: 0.28px;
+    line-height: clamp(1.5rem, 2.5vw, 38px);
+    letter-spacing: 0.21px;
   }
 
   .es-section-header {
     width: 100%;
     margin-left: auto;
     margin-right: auto;
-    max-width: 980px;
+    max-width: 740px;
   }
 
   .es-section-header .es-type-title {
@@ -331,14 +331,14 @@
   }
 
   .es-btn--primary {
-    min-height: 55px;
+    min-height: 46px;
     border-radius: 10px;
-    padding-left: 34px;
-    padding-right: 34px;
+    padding-left: 26px;
+    padding-right: 26px;
     background-color: var(--es-color-brand-orange);
     color: var(--figma-colors-desktop, #FFFFFF);
     font-family: var(--site-primary-font);
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 600;
     line-height: 1;
     letter-spacing: 0;
@@ -346,7 +346,7 @@
 
   @media (min-width: 640px) {
     .es-btn--primary {
-      min-height: 56px;
+      min-height: 48px;
     }
   }
 
@@ -367,7 +367,7 @@
     background-color: var(--es-color-surface-white);
     color: var(--es-color-text-brand-strong);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 600;
     line-height: 1;
   }
@@ -385,8 +385,8 @@
   }
 
   .es-btn--control {
-    width: 68px;
-    height: 68px;
+    width: 52px;
+    height: 52px;
     border-radius: 9999px;
     background-color: var(--es-color-surface-white);
     box-shadow: var(--es-shadow-control-strong);
@@ -404,14 +404,14 @@
   }
 
   .es-btn--pill {
-    min-height: 42px;
+    min-height: 36px;
     border-radius: 58.73px;
-    padding-left: 17px;
-    padding-right: 17px;
+    padding-left: 14px;
+    padding-right: 14px;
     background-color: var(--figma-colors-frame-2147235267, #F6DECD);
     color: var(--es-color-text-heading);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: var(--figma-fontsizes-18, 18px);
+    font-size: 16px;
     font-weight: var(--figma-fontweights-600, 600);
     line-height: var(--figma-lineheights-home-2, 100%);
   }
@@ -430,16 +430,16 @@
   }
 
   .es-btn--submenu {
-    min-height: 40px;
+    min-height: 34px;
     width: 100%;
     justify-content: flex-start;
     border-radius: 6px;
-    padding-left: 12px;
-    padding-right: 12px;
+    padding-left: 10px;
+    padding-right: 10px;
     background-color: var(--es-color-surface-submenu-idle, #FFF0E5);
     color: var(--es-color-text-heading);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: var(--figma-fontsizes-16, 16px);
+    font-size: 14px;
     font-weight: 500;
     line-height: var(--figma-lineheights-home-2, 100%);
   }
@@ -492,15 +492,15 @@
     position: relative;
     z-index: 10;
     width: 100%;
-    max-width: 1465px;
+    max-width: 1100px;
     margin-left: auto;
     margin-right: auto;
   }
 
   .es-icon-circle-lg {
     display: flex;
-    width: 72px;
-    height: 72px;
+    width: 56px;
+    height: 56px;
     flex-shrink: 0;
     align-items: center;
     justify-content: center;
@@ -509,8 +509,8 @@
   }
 
   .es-navbar-logo {
-    width: 150px;
-    height: 150px;
+    width: 115px;
+    height: 115px;
     background-color: var(--es-color-surface-white);
     object-fit: contain;
   }
@@ -527,8 +527,8 @@
   .es-link-external-icon {
     display: inline-block;
     flex-shrink: 0;
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
     border-bottom: 1px solid currentColor;
     padding-bottom: 1px;
   }

--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -1,22 +1,22 @@
 @layer components {
   .es-section-shell-spacing {
-    padding-top: 80px;
+    padding-top: 60px;
     padding-right: 16px;
-    padding-bottom: 80px;
+    padding-bottom: 60px;
     padding-left: 16px;
   }
 
   @media (min-width: 640px) {
     .es-section-shell-spacing {
-      padding-right: 24px;
-      padding-left: 24px;
+      padding-right: 20px;
+      padding-left: 20px;
     }
   }
 
   @media (min-width: 1024px) {
     .es-section-shell-spacing {
-      padding-right: 32px;
-      padding-left: 32px;
+      padding-right: 24px;
+      padding-left: 24px;
     }
   }
 
@@ -37,7 +37,7 @@
   .es-connect-card-title {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: clamp(1.2rem, 2.5vw, 1.7rem);
+    font-size: clamp(1.2rem, 2.1vw, 1.5rem);
     font-weight: 600;
     line-height: 1.25;
   }
@@ -296,22 +296,22 @@
   }
 
   .es-why-us-intro-title {
-    font-size: clamp(1.05rem, 2.2vw, 24px);
+    font-size: clamp(1.05rem, 1.9vw, 18px);
   }
 
   .es-why-us-pillar-title {
-    font-size: clamp(1.1rem, 1.9vw, 24px);
+    font-size: clamp(1.1rem, 1.6vw, 18px);
   }
 
   .es-course-highlight-title {
     color: var(--figma-colors-desktop, #FFFFFF);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: clamp(1.2rem, 2.9vw, 32px);
+    font-size: clamp(1.2rem, 2.5vw, 24px);
     font-weight: var(--figma-fontweights-600, 600);
     line-height: clamp(
       1.65rem,
-      3.9vw,
-      42px
+      3.3vw,
+      32px
     );
     letter-spacing: calc(var(--figma-letterspacing-age-specific-strategies, 0.37) * 1px);
   }
@@ -319,12 +319,12 @@
   .es-course-highlight-description {
     color: var(--figma-colors-desktop, #FFFFFF);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(0.95rem, 1.8vw, 19px);
+    font-size: clamp(0.95rem, 1.5vw, 15px);
     font-weight: var(--figma-fontweights-500, 500);
     line-height: clamp(
       1.35rem,
-      2.4vw,
-      30px
+      2vw,
+      23px
     );
     letter-spacing: calc(
       var(
@@ -382,17 +382,17 @@
   .es-my-best-auntie-description-card-title {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: 24px;
+    font-size: 20px;
     font-weight: 600;
-    line-height: 30px;
+    line-height: 26px;
   }
 
   .es-my-best-auntie-description-card-description {
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 400;
-    line-height: 30px;
+    line-height: 26px;
   }
 
   .es-my-history-section {
@@ -415,10 +415,10 @@
 
   .es-hero-frame-bg {
     background-image: url('/images/evolvesprouts-logo.svg');
-    width: 1500px;
-    height: 750px;
+    width: 1125px;
+    height: 563px;
     background-size: cover;
-    background-position: -750px -100px;
+    background-position: -563px -75px;
     filter: sepia(1) opacity(7%) hue-rotate(-50deg) saturate(250%);
     mask-image: linear-gradient(to bottom, black 60%, transparent 90%);
     -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent 90%);
@@ -428,8 +428,8 @@
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
     font-weight: 700;
-    font-size: clamp(2.15rem, 5.8vw, 60px);
-    line-height: clamp(2.65rem, 6.3vw, 66px);
+    font-size: clamp(2.15rem, 5vw, 45px);
+    line-height: clamp(2.65rem, 5.3vw, 50px);
     letter-spacing: 0;
   }
 
@@ -437,9 +437,9 @@
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
     font-weight: var(--figma-fontweights-400, 400);
-    font-size: clamp(1rem, 2.1vw, 25px);
-    line-height: clamp(1.45rem, 3.1vw, 44px);
-    letter-spacing: 0.5px;
+    font-size: clamp(1rem, 1.8vw, 19px);
+    line-height: clamp(1.45rem, 2.6vw, 33px);
+    letter-spacing: 0.4px;
   }
 
   .es-hero-highlight-word {
@@ -452,10 +452,10 @@
 
   .es-contact-us-left-decor {
     background-image: url('/images/evolvesprouts-logo.svg');
-    width: 1500px;
-    height: 750px;
+    width: 1125px;
+    height: 563px;
     background-size: cover;
-    background-position: -750px -100px;
+    background-position: -563px -75px;
     filter: sepia(1) opacity(7%) hue-rotate(-50deg) saturate(250%);
     mask-image: linear-gradient(to bottom, black 60%, transparent 90%);
     -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent 90%);
@@ -480,9 +480,9 @@
   .es-footer-column-title {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: var(--figma-fontsizes-24, 24px);
+    font-size: 20px;
     font-weight: var(--figma-fontweights-600, 600);
-    line-height: calc(var(--figma-lineheights-quick-links, 28) * 1px);
+    line-height: 24px;
     letter-spacing: calc(var(--figma-letterspacing-quick-links, -0.5) * 1px);
   }
 
@@ -529,7 +529,7 @@
   .es-testimonials-quote {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: clamp(1.25rem, 2.3vw, 28px);
+    font-size: clamp(1.25rem, 2vw, 21px);
     font-weight: var(--figma-fontweights-500, 500);
     line-height: 1.7;
     letter-spacing: 0.01em;
@@ -538,7 +538,7 @@
   .es-testimonials-author {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1.4rem, 2.8vw, var(--figma-fontsizes-32, 32px));
+    font-size: clamp(1.4rem, 2.4vw, 24px);
     font-weight: var(--figma-fontweights-700, 700);
     line-height: 1.15;
   }
@@ -546,7 +546,7 @@
   .es-testimonials-meta {
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1rem, 2.1vw, 1.2rem);
+    font-size: clamp(1rem, 1.8vw, 1.1rem);
     font-weight: var(--figma-fontweights-400, 400);
     line-height: 1.5;
     letter-spacing: var(--figma-letterspacing-mom-of-2, 0.5px);
@@ -582,7 +582,7 @@
   .es-faq-contact-question {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: clamp(1.1rem, 1.7vw, 28px);
+    font-size: clamp(1.1rem, 1.5vw, 21px);
     font-weight: 600;
     line-height: 1.42;
   }
@@ -591,7 +591,7 @@
   .es-faq-contact-answer {
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1rem, 1.3vw, 20px);
+    font-size: clamp(1rem, 1.1vw, 16px);
     font-weight: 400;
     line-height: 1.6;
   }
@@ -636,8 +636,8 @@
   }
 
   .es-my-best-auntie-booking-part-item {
-    padding-left: 50px;
-    padding-bottom: 100px;
+    padding-left: 38px;
+    padding-bottom: 75px;
   }
 
   .es-my-best-auntie-booking-part-chip--blue {
@@ -812,7 +812,7 @@
   .es-events-scheduled-heading {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: clamp(1.45rem, 3.5vw, 32px);
+    font-size: clamp(1.45rem, 3vw, 24px);
     font-weight: 600;
     line-height: 1.2;
     letter-spacing: 0;
@@ -840,7 +840,7 @@
   .es-events-card-title {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: clamp(1.4rem, 3vw, 32px);
+    font-size: clamp(1.4rem, 2.5vw, 24px);
     font-weight: 600;
     line-height: 1.25;
     letter-spacing: 0;
@@ -935,12 +935,12 @@
   .es-free-resources-card-title {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
-    font-size: clamp(1.75rem, 4.5vw, var(--figma-fontsizes-41, 41px));
+    font-size: clamp(1.75rem, 3.8vw, 31px);
     font-weight: var(--figma-fontweights-600, 600);
     line-height: clamp(
       2.15rem,
-      5.2vw,
-      calc(var(--figma-lineheights-age-specific-strategies, 50) * 1px)
+      4.4vw,
+      38px
     );
     letter-spacing: calc(
       var(
@@ -953,12 +953,12 @@
   .es-free-resources-card-body {
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1.1rem, 3.2vw, var(--figma-fontsizes-28, 28px));
+    font-size: clamp(1.1rem, 2.7vw, 21px);
     font-weight: var(--figma-fontweights-400, 400);
     line-height: clamp(
       1.7rem,
-      4vw,
-      calc(var(--figma-lineheights-gentle-strategies-for-busy-parents, 41) * 1px)
+      3.4vw,
+      31px
     );
     letter-spacing: calc(
       var(--figma-letterspacing-gentle-strategies-for-busy-parents, 0.28) * 1px
@@ -968,7 +968,7 @@
   .es-free-resources-checklist-title {
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1.05rem, 2.1vw, 20px);
+    font-size: clamp(1.05rem, 1.8vw, 16px);
     font-weight: var(--figma-fontweights-400, 400);
     line-height: 1.2;
     letter-spacing: calc(var(--figma-letterspacing-the-firstthen-trick, 0.336) * 1px);
@@ -977,7 +977,7 @@
   .es-free-resources-checklist-description {
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1rem, 1.9vw, 18px);
+    font-size: clamp(1rem, 1.6vw, 15px);
     font-weight: var(--figma-fontweights-400, 400);
     line-height: 1.4;
     letter-spacing: calc(var(--figma-letterspacing-home, 0.5) * 1px);
@@ -986,7 +986,7 @@
   .es-free-resources-media-pill-text {
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1rem, 1.6vw, 20px);
+    font-size: clamp(1rem, 1.4vw, 16px);
     font-weight: var(--figma-fontweights-600, 600);
     line-height: 1;
   }
@@ -1046,7 +1046,7 @@
   .es-my-best-auntie-overview-module-title {
     color: var(--figma-colors-week-01-04, #313131);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1.15rem, 2.2vw, 28px);
+    font-size: clamp(1.15rem, 1.9vw, 21px);
     font-weight: 700;
     line-height: 1.2;
   }
@@ -1054,7 +1054,7 @@
   .es-my-best-auntie-overview-module-week {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: clamp(1.1rem, 2vw, 22px);
+    font-size: clamp(1.1rem, 1.7vw, 17px);
     font-weight: 500;
     line-height: 1.2;
     letter-spacing: 0.3px;
@@ -1082,7 +1082,7 @@
 
   .es-my-best-auntie-overview-count-text {
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
-    font-size: 20px;
+    font-size: 16px;
     font-weight: 700;
     line-height: 1;
   }

--- a/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
@@ -197,7 +197,7 @@ export function MyBestAuntieThankYouModal({
             alt=''
             width={1488}
             height={855}
-            className='pointer-events-none absolute left-1/2 top-0 hidden w-[800px] -translate-x-1/2 -translate-y-[120px] lg:block'
+            className='pointer-events-none absolute left-1/2 top-0 hidden w-[600px] -translate-x-1/2 -translate-y-[90px] lg:block'
             aria-hidden='true'
           />
           <Image
@@ -205,7 +205,7 @@ export function MyBestAuntieThankYouModal({
             alt=''
             width={1196}
             height={568}
-            className='pointer-events-none absolute left-1/2 top-0 hidden w-[650px] -translate-x-1/2 -translate-y-10 lg:block'
+            className='pointer-events-none absolute left-1/2 top-0 hidden w-[488px] -translate-x-1/2 -translate-y-10 lg:block'
             aria-hidden='true'
           />
 
@@ -241,7 +241,7 @@ export function MyBestAuntieThankYouModal({
             </p>
           </div>
 
-          <section className='relative z-10 mx-auto mt-10 max-w-[950px] overflow-hidden rounded-2xl border es-border-panel es-bg-surface-muted px-4 py-7 shadow-[0_9px_9px_rgba(49,86,153,0.08),0_9px_18px_rgba(49,86,153,0.06)] sm:px-8 sm:py-10'>
+          <section className='relative z-10 mx-auto mt-10 max-w-[713px] overflow-hidden rounded-2xl border es-border-panel es-bg-surface-muted px-4 py-7 shadow-[0_9px_9px_rgba(49,86,153,0.08),0_9px_18px_rgba(49,86,153,0.06)] sm:px-8 sm:py-10'>
             <Image
               src='/images/evolvesprouts-logo.svg'
               alt=''

--- a/apps/public_www/src/components/sections/deferred-testimonials-client.tsx
+++ b/apps/public_www/src/components/sections/deferred-testimonials-client.tsx
@@ -79,11 +79,11 @@ export function DeferredTestimonialsClient({
           className='es-section-bg-overlay es-testimonials-section'
         >
           <SectionContainer>
-            <div className='mx-auto w-full max-w-[1488px]'>
+            <div className='mx-auto w-full max-w-[1116px]'>
               <SectionHeader
                 title={content.title}
               />
-              <div className='mt-10 h-[420px] bg-white lg:mt-14 lg:h-[540px]' />
+              <div className='mt-10 h-[315px] bg-white lg:mt-14 lg:h-[405px]' />
             </div>
           </SectionContainer>
         </SectionShell>

--- a/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
+++ b/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
@@ -322,7 +322,7 @@ export function FreeResourcesForGentleParenting({
                 className='relative overflow-hidden rounded-2xl border border-black/5 es-free-resources-pattern-bg'
               >
                 <div
-                  className='relative min-h-[620px] overflow-hidden sm:min-h-[700px] lg:min-h-[740px]'
+                  className='relative min-h-[465px] overflow-hidden sm:min-h-[525px] lg:min-h-[555px]'
                   data-testid='free-resource-media-pane'
                 >
                   <Image
@@ -378,7 +378,7 @@ export function FreeResourcesForGentleParenting({
                   className={`relative z-10 p-4 sm:p-6 lg:p-[35px] ${splitTextPaneOrderClassName}`}
                 >
                   <article
-                    className='relative flex h-full min-h-[370px] flex-col overflow-hidden rounded-2xl p-6 sm:min-h-[440px] sm:p-8 lg:min-h-[516px]'
+                    className='relative flex h-full min-h-[278px] flex-col overflow-hidden rounded-2xl p-6 sm:min-h-[330px] sm:p-8 lg:min-h-[387px]'
                   >
                     <ResourceCardContent
                       cardTitle={cardTitle}
@@ -392,7 +392,7 @@ export function FreeResourcesForGentleParenting({
 
                 <div
                   data-testid='free-resource-media-pane'
-                  className={`es-free-resources-media-pane ${splitMediaBleedClassName} relative z-0 min-h-[280px] overflow-visible sm:min-h-[370px] lg:min-h-[587px] ${splitMediaPaneOrderClassName}`}
+                  className={`es-free-resources-media-pane ${splitMediaBleedClassName} relative z-0 min-h-[210px] overflow-visible sm:min-h-[278px] lg:min-h-[440px] ${splitMediaPaneOrderClassName}`}
                 >
                   <div className='absolute left-1/2 top-[10%] z-10 flex -translate-x-1/2 flex-col items-center gap-2 sm:gap-3'>
                     <div className='rounded-full bg-white/95 px-5 py-2 shadow-pill sm:px-6'>

--- a/apps/public_www/src/components/sections/hero-banner.tsx
+++ b/apps/public_www/src/components/sections/hero-banner.tsx
@@ -62,7 +62,7 @@ export function HeroBanner({ content }: HeroBannerProps) {
               className='max-w-[610px]'
               titleClassName='es-hero-headline'
               description={content.subheadline}
-              descriptionClassName='mt-4 max-w-[610px] sm:mt-6 es-hero-subheadline'
+              descriptionClassName='mt-4 max-w-[458px] sm:mt-6 es-hero-subheadline'
             />
             <SectionCtaAnchor
               href={ROUTES.servicesMyBestAuntieTrainingCourse}
@@ -72,7 +72,7 @@ export function HeroBanner({ content }: HeroBannerProps) {
             </SectionCtaAnchor>
           </div>
         </div>
-        <div className='mx-auto w-full max-w-[764px] lg:ml-auto lg:mr-0'>
+        <div className='mx-auto w-full max-w-[573px] lg:ml-auto lg:mr-0'>
           <Image
             src={HERO_IMAGE_SRC}
             alt=''

--- a/apps/public_www/src/components/sections/ida.tsx
+++ b/apps/public_www/src/components/sections/ida.tsx
@@ -46,7 +46,7 @@ export function Ida({ content }: IdaProps) {
         </div>
 
         <div className='order-2 lg:order-1'>
-          <div className='w-full lg:ml-[-100px] lg:mr-[-50px] lg:w-[700px] xl:ml-[-180px] xl:mr-[-200px] xl:w-[1111px]'>
+          <div className='w-full lg:ml-[-75px] lg:mr-[-38px] lg:w-[525px] xl:ml-[-135px] xl:mr-[-150px] xl:w-[833px]'>
             <Image
               src='/images/about-us/ida-degregorio-evolvesprouts-1.webp'
               alt='Ida De Gregorio from Evolve Sprouts'

--- a/apps/public_www/src/components/sections/my-best-auntie-booking.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie-booking.tsx
@@ -169,7 +169,7 @@ export function MyBestAuntieBooking({
               </div>
             </section>
 
-            <aside className='mx-auto w-full min-w-0 max-w-[764px] lg:ml-auto lg:mr-0'>
+            <aside className='mx-auto w-full min-w-0 max-w-[573px] lg:ml-auto lg:mr-0'>
               <h2 className='text-[1.6rem] font-semibold es-text-heading'>
                 {content.eyebrow}
               </h2>

--- a/apps/public_www/src/components/sections/my-journey.tsx
+++ b/apps/public_www/src/components/sections/my-journey.tsx
@@ -41,7 +41,7 @@ export function MyJourney({ content }: MyJourneyProps) {
               width={539}
               height={675}
               sizes='(min-width: 1280px) 34vw, (min-width: 1024px) 38vw, 100vw'
-              className='h-full min-h-[360px] w-full object-cover lg:min-h-[540px]'
+              className='h-full min-h-[270px] w-full object-cover lg:min-h-[405px]'
             />
           </div>
 

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -26,7 +26,7 @@ export function SproutsSquadCommunity({
       />
 
       <SectionContainer>
-        <div className='flex min-h-[420px] flex-col justify-center gap-7 sm:min-h-[530px] lg:min-h-[740px] lg:gap-9'>
+        <div className='flex min-h-[315px] flex-col justify-center gap-7 sm:min-h-[400px] lg:min-h-[555px] lg:gap-9'>
           <Image
             src='/images/evolvesprouts-logo.svg'
             alt=''

--- a/apps/public_www/src/components/sections/testimonials.tsx
+++ b/apps/public_www/src/components/sections/testimonials.tsx
@@ -184,7 +184,7 @@ export function Testimonials({ content }: TestimonialsProps) {
       className='es-section-bg-overlay es-testimonials-section'
     >
       <SectionContainer>
-        <div className='mx-auto w-full max-w-[1488px]'>
+        <div className='mx-auto w-full max-w-[1116px]'>
         <SectionHeader
           eyebrow={badgeLabel}
           title={content.title}
@@ -212,7 +212,7 @@ export function Testimonials({ content }: TestimonialsProps) {
                   'es-section-split-layout--testimonials',
                 )}
               >
-                <div className='relative min-h-[260px] overflow-hidden rounded-card-lg es-bg-surface-peach sm:min-h-[360px] lg:min-h-[540px]'>
+                <div className='relative min-h-[195px] overflow-hidden rounded-card-lg es-bg-surface-peach sm:min-h-[270px] lg:min-h-[405px]'>
                   {activeStory.mainImageSrc ? (
                     <Image
                       src={activeStory.mainImageSrc}
@@ -223,7 +223,7 @@ export function Testimonials({ content }: TestimonialsProps) {
                     />
                   ) : (
                     <div
-                      className='flex h-full min-h-[260px] items-center justify-center rounded-card-lg sm:min-h-[360px] lg:min-h-[540px] es-testimonials-image-fallback'
+                      className='flex h-full min-h-[195px] items-center justify-center rounded-card-lg sm:min-h-[270px] lg:min-h-[405px] es-testimonials-image-fallback'
                     >
                       <ParentIcon />
                     </div>

--- a/apps/public_www/src/components/shared/overlay-surface.tsx
+++ b/apps/public_www/src/components/shared/overlay-surface.tsx
@@ -8,7 +8,7 @@ import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import { mergeClassNames } from '@/lib/class-name-utils';
 
 const DEFAULT_DIALOG_PANEL_CLASSNAME =
-  'relative w-full max-w-[1190px] overflow-hidden rounded-3xl border border-black/10 shadow-overlay';
+  'relative w-full max-w-[893px] overflow-hidden rounded-3xl border border-black/10 shadow-overlay';
 const DEFAULT_DRAWER_PANEL_CLASSNAME =
   'absolute inset-y-0 right-0 flex flex-col shadow-2xl transition-transform duration-300 ease-out';
 const DEFAULT_SCROLLABLE_BODY_CLASSNAME =

--- a/apps/public_www/src/components/shared/placeholder-page-layout.tsx
+++ b/apps/public_www/src/components/shared/placeholder-page-layout.tsx
@@ -4,7 +4,7 @@ import type { FooterContent, NavbarContent } from '@/content';
 import { PageLayout } from '@/components/shared/page-layout';
 
 const DEFAULT_PLACEHOLDER_MAIN_CLASSNAME =
-  'mx-auto flex min-h-[52vh] w-full max-w-[1465px] items-center px-4 py-16 sm:px-6 lg:px-8';
+  'mx-auto flex min-h-[52vh] w-full max-w-[1100px] items-center px-4 py-16 sm:px-6 lg:px-8';
 
 interface PlaceholderPageLayoutProps {
   navbarContent: NavbarContent;


### PR DESCRIPTION
Scale down typography, containers, and component sizing across the public website.

The public website appeared too large on desktop/iPads due to oversized design values (e.g., 20px body text, 1465px container width) originating from Figma, which made the site look correct only at 75% browser zoom. This PR adjusts these values to standard web conventions, effectively scaling down the entire site by approximately 25%.

---
<p><a href="https://cursor.com/agents?id=bc-3038907d-93b2-420c-9997-d59196735136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3038907d-93b2-420c-9997-d59196735136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

