### PR TITLE
Contact us column padding

### DIFF
--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -172,7 +172,7 @@ export function ContactUsForm({ content }: ContactUsFormProps) {
       <SectionContainer
         className={buildSectionSplitLayoutClassName('es-section-split-layout--contact-us')}
       >
-        <div className='relative z-10 flex h-full items-start overflow-hidden px-6 py-8 sm:px-8 lg:px-10 lg:pt-[25%]'>
+        <div className='relative z-10 flex h-full items-start overflow-hidden py-8 lg:pt-[25%]'>
           <SectionHeader
             title={content.title}
             titleAs='h1'

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -82,6 +82,22 @@ describe('ContactUsForm section', () => {
     expect(decorativeLayer?.getAttribute('style')).toBeNull();
   });
 
+  it('does not apply horizontal padding to the left content column', () => {
+    render(<ContactUsForm content={enContent.contactUs.contactUsForm} />);
+
+    const splitLayout = document.querySelector(
+      '#contact-us-form .es-section-split-layout--contact-us',
+    ) as HTMLDivElement | null;
+    expect(splitLayout).not.toBeNull();
+
+    const leftColumn = splitLayout?.firstElementChild as HTMLDivElement | null;
+    expect(leftColumn).not.toBeNull();
+    expect(leftColumn?.className).toContain('py-8');
+    expect(leftColumn?.className).not.toContain('px-6');
+    expect(leftColumn?.className).not.toContain('sm:px-8');
+    expect(leftColumn?.className).not.toContain('lg:px-10');
+  });
+
   it('uses the same input styling pattern as the booking form', () => {
     render(<ContactUsForm content={enContent.contactUs.contactUsForm} />);
 


### PR DESCRIPTION
Remove horizontal padding from the left column of the Contact Us section in public www as requested.

---
<p><a href="https://cursor.com/agents?id=bc-52d356fa-5d98-4f64-b91c-623669cc1890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52d356fa-5d98-4f64-b91c-623669cc1890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

