### PR TITLE
Contact form bullet points

### DIFF
--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -200,7 +200,7 @@ export function ContactUsForm({ content }: ContactUsFormProps) {
             <h2 className='es-type-title'>
               {content.promiseTitle}
             </h2>
-            <ul className='mt-4 list-disc space-y-2 pl-6'>
+            <ul className='mt-4 space-y-2'>
               {content.promises.map((promise) => (
                 <li
                   key={promise}

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -119,7 +119,7 @@ describe('ContactUsForm section', () => {
     }
   });
 
-  it('renders promise items as bulleted text without background cards', () => {
+  it('renders promise items as plain text without bullets or indentation', () => {
     render(<ContactUsForm content={enContent.contactUs.contactUsForm} />);
 
     const promiseList = screen
@@ -129,7 +129,8 @@ describe('ContactUsForm section', () => {
       })
       .nextElementSibling as HTMLUListElement | null;
     expect(promiseList).not.toBeNull();
-    expect(promiseList?.className).toContain('list-disc');
+    expect(promiseList?.className).not.toContain('list-disc');
+    expect(promiseList?.className).not.toContain('pl-6');
 
     const listItems = promiseList?.querySelectorAll('li') ?? [];
     expect(listItems.length).toBeGreaterThan(0);


### PR DESCRIPTION
Remove bullet point styling and indentation from the Contact Us right-column form's promise list as requested.

---
<p><a href="https://cursor.com/agents?id=bc-8e3007ab-323a-4220-96bb-9a4f28200a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e3007ab-323a-4220-96bb-9a4f28200a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

