### PR TITLE
Fix deploy workflow: substitute GitHub secrets/vars in param file

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -139,10 +139,21 @@ jobs:
               "WafWebAclArn",
           }
 
+          def resolve_value(raw: str) -> str:
+              """Replace <FROM_GITHUB_SECRET: X> / <FROM_GITHUB_VAR: X> placeholders."""
+              raw = raw.strip()
+              if raw.startswith("<FROM_GITHUB_SECRET:") and raw.endswith(">"):
+                  env_name = raw[len("<FROM_GITHUB_SECRET:") : -1].strip()
+                  return os.environ.get(env_name, "")
+              if raw.startswith("<FROM_GITHUB_VAR:") and raw.endswith(">"):
+                  env_name = raw[len("<FROM_GITHUB_VAR:") : -1].strip()
+                  return os.environ.get(env_name, "")
+              return raw
+
           for key, value in params.items():
               value_str = ""
               if value is not None:
-                  value_str = str(value).strip()
+                  value_str = resolve_value(str(value))
               if key != "WafWebAclArn" and not value_str:
                   continue
 
@@ -175,3 +186,8 @@ jobs:
           CDK_STACKS: ${{ github.event.inputs.cdk_stacks || vars.CDK_STACKS || 'all stacks' }}
           CDK_PARAM_FILE: ${{ vars.CDK_PARAM_FILE }}
           CDK_BOOTSTRAP_QUALIFIER: ${{ vars.CDK_BOOTSTRAP_QUALIFIER }}
+          CDK_PARAM_GOOGLE_CLIENT_SECRET: ${{ secrets.CDK_PARAM_GOOGLE_CLIENT_SECRET }}
+          CDK_PARAM_APPLE_PRIVATE_KEY: ${{ secrets.CDK_PARAM_APPLE_PRIVATE_KEY }}
+          CDK_PARAM_PUBLIC_API_KEY_VALUE: ${{ secrets.CDK_PARAM_PUBLIC_API_KEY_VALUE }}
+          CDK_PARAM_ADMIN_BOOTSTRAP_TEMP_PASSWORD: ${{ secrets.CDK_PARAM_ADMIN_BOOTSTRAP_TEMP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}


### PR DESCRIPTION
The production.json contains placeholder strings like <FROM_GITHUB_SECRET: X> and <FROM_GITHUB_VAR: X> that were never being resolved. Add resolve_value() to the Python param router and pass the required secrets/vars as environment variables to the step.