### PR TITLE
Backend infrastructure dependencies

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "cd backend/infrastructure && npm ci",
+  "start": "cd backend/infrastructure && npm ci"
+}

--- a/docs/architecture/setup.md
+++ b/docs/architecture/setup.md
@@ -278,3 +278,14 @@ existing secrets when possible.
 Sign in with Apple is not currently configured in `backend/infrastructure/lib/api-stack.ts`.
 If Apple IdP support is reintroduced in the stack, add provider setup and
 associated `CDK_PARAM_*` documentation in this section.
+
+## Cloud agent environment bootstrap
+
+This repository configures Cursor cloud agents with
+`.cursor/environment.json`.
+
+- `install`: `cd backend/infrastructure && npm ci`
+- `start`: `cd backend/infrastructure && npm ci`
+
+Using `npm ci` keeps dependency installation aligned to
+`backend/infrastructure/package-lock.json`.


### PR DESCRIPTION
Configure cloud agent to preinstall Node dependencies for `backend/infrastructure` to ensure lockfile-aligned dependencies on startup.

---
<p><a href="https://cursor.com/agents/bc-3c4f0b0b-4d47-4fc4-8118-64478c080fc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4f0b0b-4d47-4fc4-8118-64478c080fc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

