### PR TITLE
Core website structure

### DIFF
--- a/apps/public_www/public/scripts/hide-css-sensitive-duplicates.js
+++ b/apps/public_www/public/scripts/hide-css-sensitive-duplicates.js
@@ -1,0 +1,38 @@
+(function hideCssSensitiveDuplicatesWhenStylesMissing() {
+  var rootElement = document.documentElement;
+  var hiddenMarkerValue = 'hide-when-css-missing';
+  var cssLoadedMarkerName = '--es-css-loaded';
+  var cssLoadedMarkerValue = 'loaded';
+
+  function hasProjectStylesheetLoaded() {
+    var markerValue = window.getComputedStyle(rootElement)
+      .getPropertyValue(cssLoadedMarkerName)
+      .trim();
+    return markerValue === cssLoadedMarkerValue;
+  }
+
+  function hideFallbackElements() {
+    var fallbackElements = document.querySelectorAll(
+      '[data-css-fallback="' + hiddenMarkerValue + '"]',
+    );
+    for (var index = 0; index < fallbackElements.length; index += 1) {
+      fallbackElements[index].setAttribute('hidden', '');
+    }
+  }
+
+  function applyCssFallback() {
+    if (hasProjectStylesheetLoaded()) {
+      rootElement.setAttribute('data-css-status', 'loaded');
+      return;
+    }
+
+    rootElement.setAttribute('data-css-status', 'missing');
+    hideFallbackElements();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyCssFallback, { once: true });
+  } else {
+    applyCssFallback();
+  }
+})();

--- a/apps/public_www/src/app/layout.tsx
+++ b/apps/public_www/src/app/layout.tsx
@@ -67,6 +67,8 @@ export default function RootLayout({
       <body className='antialiased'>
         {/* eslint-disable-next-line @next/next/no-sync-scripts -- must run before hydration without inline wrappers */}
         <script src='/scripts/set-locale-document-attributes.js' />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts -- ensures duplicated responsive content is reduced when stylesheet loading fails */}
+        <script src='/scripts/hide-css-sensitive-duplicates.js' />
         <a
           href='#main-content'
           className='sr-only fixed left-4 top-4 z-[80] rounded-md bg-black px-4 py-2 text-sm font-semibold text-white focus:not-sr-only focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-black'

--- a/apps/public_www/src/app/styles/original/base.css
+++ b/apps/public_www/src/app/styles/original/base.css
@@ -1,5 +1,6 @@
 @layer base {
   :root {
+    --es-css-loaded: loaded;
     color-scheme: light;
     --figma-fontfamilies-lato: var(--font-lato);
     --figma-fontfamilies-poppins: var(--font-poppins);

--- a/apps/public_www/src/components/sections/footer.tsx
+++ b/apps/public_www/src/components/sections/footer.tsx
@@ -213,7 +213,10 @@ export function Footer({ content }: FooterProps) {
               items={content.services.items}
               className='lg:pl-6'
             />
-            <div className='hidden justify-center lg:flex lg:pt-2'>
+            <div
+              data-css-fallback='hide-when-css-missing'
+              className='hidden justify-center lg:flex lg:pt-2'
+            >
               <Image
                 src='/images/evolvesprouts-logo.svg'
                 alt={content.brand}
@@ -234,7 +237,7 @@ export function Footer({ content }: FooterProps) {
             />
           </div>
 
-          <div className='sm:hidden'>
+          <div data-css-fallback='hide-when-css-missing' className='sm:hidden'>
             <div className='pointer-events-none mb-7 flex justify-center'>
               <Image
                 src='/images/evolvesprouts-logo.svg'

--- a/apps/public_www/src/components/sections/my-best-auntie-overview.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie-overview.tsx
@@ -269,7 +269,7 @@ export function MyBestAuntieOverview({ content }: MyBestAuntieOverviewProps) {
             </svg>
           </div>
           {/* Mobile carousel (< md) with wave scrolling alongside cards */}
-          <div className='-mx-1 md:hidden'>
+          <div data-css-fallback='hide-when-css-missing' className='-mx-1 md:hidden'>
             <div className='scrollbar-hide snap-x snap-mandatory overflow-x-auto px-1 pb-2'>
               <ul className='relative inline-flex gap-4'>
                 {moduleSteps.map((module, index) => (

--- a/apps/public_www/src/components/sections/navbar.tsx
+++ b/apps/public_www/src/components/sections/navbar.tsx
@@ -263,7 +263,10 @@ export function Navbar({ content }: NavbarProps) {
             />
           </div>
 
-          <div className='ml-auto flex items-center gap-2 lg:hidden'>
+          <div
+            data-css-fallback='hide-when-css-missing'
+            className='ml-auto flex items-center gap-2 lg:hidden'
+          >
             <LanguageSelectorButton
               key={`mobile-language-navbar-${pathname}`}
               currentLocale={currentLocale}

--- a/apps/public_www/src/components/sections/testimonials.tsx
+++ b/apps/public_www/src/components/sections/testimonials.tsx
@@ -323,7 +323,10 @@ export function Testimonials({ content }: TestimonialsProps) {
           </div>
 
           {hasMultipleStories && (
-            <div className='flex items-center justify-center gap-[14px] px-6 pb-6 pt-5 sm:gap-[18px] sm:px-9 lg:hidden'>
+            <div
+              data-css-fallback='hide-when-css-missing'
+              className='flex items-center justify-center gap-[14px] px-6 pb-6 pt-5 sm:gap-[18px] sm:px-9 lg:hidden'
+            >
               <ButtonPrimitive
                 variant='control'
                 onClick={goToPreviousStory}

--- a/apps/public_www/tests/components/sections/footer.test.tsx
+++ b/apps/public_www/tests/components/sections/footer.test.tsx
@@ -69,9 +69,18 @@ describe('Footer external links', () => {
 
     const mobileFooterSection = document.querySelector('div.sm\\:hidden');
     expect(mobileFooterSection).not.toBeNull();
+    expect(mobileFooterSection).toHaveAttribute(
+      'data-css-fallback',
+      'hide-when-css-missing',
+    );
     expect(
       mobileFooterSection?.querySelector('div.pointer-events-none'),
     ).not.toBeNull();
+
+    const cssFallbackElements = document.querySelectorAll(
+      '[data-css-fallback="hide-when-css-missing"]',
+    );
+    expect(cssFallbackElements).toHaveLength(2);
 
     const accordionSummaries = document.querySelectorAll('summary');
     expect(accordionSummaries.length).toBeGreaterThan(0);

--- a/apps/public_www/tests/components/sections/my-best-auntie-overview.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-overview.test.tsx
@@ -29,6 +29,11 @@ describe('MyBestAuntieOverview section', () => {
       name: /best auntie training/i,
     });
     expect(section.className).toContain('es-my-best-auntie-overview-section');
+    const mobileCarouselWrapper = container.querySelector('div.-mx-1.md\\:hidden');
+    expect(mobileCarouselWrapper).toHaveAttribute(
+      'data-css-fallback',
+      'hide-when-css-missing',
+    );
 
     const moduleTitles = enContent.myBestAuntieOverview.modules.map(
       (module) => module.title,

--- a/apps/public_www/tests/components/sections/navbar.test.tsx
+++ b/apps/public_www/tests/components/sections/navbar.test.tsx
@@ -152,6 +152,11 @@ describe('Navbar desktop submenu accessibility', () => {
     });
     expect(openMenuButton.className).toContain('es-border-soft');
     expect(openMenuButton.className).toContain('bg-[#F6DECD]');
+    const mobileControlsContainer = openMenuButton.closest('div');
+    expect(mobileControlsContainer).toHaveAttribute(
+      'data-css-fallback',
+      'hide-when-css-missing',
+    );
 
     const languageSelectors = screen.getAllByRole('button', {
       name: /Selected language: English/i,

--- a/apps/public_www/tests/components/sections/section-structure-contract.test.tsx
+++ b/apps/public_www/tests/components/sections/section-structure-contract.test.tsx
@@ -8,6 +8,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const sectionsDirectory = path.resolve(__dirname, '../../../src/components/sections');
 const srcDirectory = path.resolve(__dirname, '../../../src');
+const appDirectory = path.resolve(__dirname, '../../../src/app');
+const publicScriptsDirectory = path.resolve(__dirname, '../../../public/scripts');
 
 const pageSectionFiles = [
   'hero-banner.tsx',
@@ -78,5 +80,25 @@ describe('App source typography class contract', () => {
       .sort((left, right) => left.localeCompare(right));
 
     expect(filesWithInlineClampClass).toEqual([]);
+  });
+});
+
+describe('No-CSS fallback contract', () => {
+  it('keeps the stylesheet marker and duplicate-hiding script wired', () => {
+    const layoutSource = readFileSync(path.join(appDirectory, 'layout.tsx'), 'utf-8');
+    const baseCssSource = readFileSync(
+      path.join(appDirectory, 'styles/original/base.css'),
+      'utf-8',
+    );
+    const fallbackScriptSource = readFileSync(
+      path.join(publicScriptsDirectory, 'hide-css-sensitive-duplicates.js'),
+      'utf-8',
+    );
+
+    expect(layoutSource).toContain('/scripts/hide-css-sensitive-duplicates.js');
+    expect(baseCssSource).toContain('--es-css-loaded: loaded;');
+    expect(fallbackScriptSource).toContain("var cssLoadedMarkerName = '--es-css-loaded';");
+    expect(fallbackScriptSource).toContain('[data-css-fallback="');
+    expect(fallbackScriptSource).toContain("setAttribute('hidden', '')");
   });
 });

--- a/apps/public_www/tests/components/sections/testimonials.test.tsx
+++ b/apps/public_www/tests/components/sections/testimonials.test.tsx
@@ -26,6 +26,10 @@ describe('Testimonials section', () => {
     expect(card.className).not.toContain('border-[#EFD7C7]');
     expect(card.className).not.toContain('rounded-card-lg');
     expect(card.className).not.toContain('shadow');
+    const mobileControls = container.querySelector(
+      '[data-css-fallback="hide-when-css-missing"]',
+    );
+    expect(mobileControls).not.toBeNull();
 
     const firstStory = enContent.testimonials.items[0];
     expect(


### PR DESCRIPTION
Add a CSS-off fallback script to hide duplicate responsive content, ensuring the public website remains understandable when stylesheets fail without impacting the CSS-on experience.

The existing structure renders separate desktop and mobile versions of certain components (navbar, footer, etc.) and uses CSS classes like `hidden` or `md:hidden` to control their visibility. When CSS fails to load, both versions become visible, leading to a noisy and confusing user experience. This PR introduces a JavaScript-based fallback that detects CSS loading failure and then hides the designated duplicate elements, providing a clean, single content flow. This preserves the intended visual experience when CSS is present while gracefully degrading when it's not.

---
<p><a href="https://cursor.com/agents/bc-2710f5a5-13b7-4152-a132-ff1d5bbbe188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2710f5a5-13b7-4152-a132-ff1d5bbbe188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

