### PR TITLE
Asset table button layout

### DIFF
--- a/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { MouseEvent } from 'react';
+
 import type { AdminAsset, AssetVisibility } from '@/types/assets';
 
 import { ASSET_VISIBILITIES } from '@/types/assets';
@@ -19,12 +21,14 @@ export interface AssetListPanelProps {
   };
   isLoadingAssets: boolean;
   isLoadingMoreAssets: boolean;
+  isDeletingAssetId: string | null;
   assetsError: string;
   nextCursor: string | null;
   onQueryChange: (value: string) => void;
   onVisibilityChange: (value: AssetVisibility | '') => void;
   onLoadMore: () => Promise<void>;
   onSelectAsset: (assetId: string) => void;
+  onDeleteAsset: (assetId: string) => Promise<void>;
 }
 
 function formatDate(value: string | null): string {
@@ -45,19 +49,52 @@ function toTitleCase(value: string): string {
     .join(' ');
 }
 
+function DeleteIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      aria-hidden='true'
+    >
+      <polyline points='3 6 5 6 21 6' />
+      <path d='M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2' />
+      <line x1='10' y1='11' x2='10' y2='17' />
+      <line x1='14' y1='11' x2='14' y2='17' />
+    </svg>
+  );
+}
+
 export function AssetListPanel({
   assets,
   selectedAssetId,
   filters,
   isLoadingAssets,
   isLoadingMoreAssets,
+  isDeletingAssetId,
   assetsError,
   nextCursor,
   onQueryChange,
   onVisibilityChange,
   onLoadMore,
   onSelectAsset,
+  onDeleteAsset,
 }: AssetListPanelProps) {
+  const handleDeleteAsset = async (asset: AdminAsset, event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    const confirmed = window.confirm(
+      `Delete "${asset.title}"? This removes the asset record and S3 object.`
+    );
+    if (!confirmed) {
+      return;
+    }
+    await onDeleteAsset(asset.id);
+  };
+
   return (
     <Card
       title='Assets'
@@ -91,25 +128,26 @@ export function AssetListPanel({
       ) : null}
 
       <div className='overflow-x-auto rounded-md border border-slate-200'>
-        <table className='w-full min-w-[760px] divide-y divide-slate-200 text-left'>
+        <table className='w-full min-w-[860px] divide-y divide-slate-200 text-left'>
           <thead className='bg-slate-100 text-xs uppercase tracking-[0.08em] text-slate-700'>
             <tr>
               <th className='px-4 py-3 font-semibold'>Title</th>
               <th className='px-4 py-3 font-semibold'>Visibility</th>
               <th className='px-4 py-3 font-semibold'>File</th>
               <th className='px-4 py-3 font-semibold'>Updated</th>
+              <th className='px-4 py-3 font-semibold text-right'>Operations</th>
             </tr>
           </thead>
           <tbody className='divide-y divide-slate-200 bg-white text-sm'>
             {isLoadingAssets ? (
               <tr>
-                <td className='px-4 py-8 text-slate-600' colSpan={4}>
+                <td className='px-4 py-8 text-slate-600' colSpan={5}>
                   Loading assets...
                 </td>
               </tr>
             ) : assets.length === 0 ? (
               <tr>
-                <td className='px-4 py-8 text-slate-600' colSpan={4}>
+                <td className='px-4 py-8 text-slate-600' colSpan={5}>
                   No assets found for the current filters.
                 </td>
               </tr>
@@ -132,6 +170,20 @@ export function AssetListPanel({
                     <td className='px-4 py-3 text-slate-700'>{toTitleCase(asset.visibility)}</td>
                     <td className='px-4 py-3 text-slate-700'>{asset.fileName || '—'}</td>
                     <td className='px-4 py-3 text-slate-700'>{formatDate(asset.updatedAt)}</td>
+                    <td className='px-4 py-3 text-right'>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='danger'
+                        className='h-8 w-8 p-0'
+                        onClick={(event) => void handleDeleteAsset(asset, event)}
+                        disabled={isDeletingAssetId === asset.id}
+                        title='Delete asset'
+                        aria-label='Delete asset'
+                      >
+                        <DeleteIcon className='h-4 w-4' />
+                      </Button>
+                    </td>
                   </tr>
                 );
               })

--- a/apps/admin_web/src/components/admin/assets/assets-page.tsx
+++ b/apps/admin_web/src/components/admin/assets/assets-page.tsx
@@ -57,9 +57,7 @@ export function AssetsPage() {
           key={selectedAsset?.id ?? 'new-asset'}
           selectedAsset={selectedAsset}
           isSavingAsset={isSavingAsset}
-          isDeletingCurrentAsset={
-            Boolean(selectedAssetId) && isDeletingAssetId === selectedAssetId
-          }
+          isDeletingCurrentAsset={Boolean(selectedAssetId) && isDeletingAssetId === selectedAssetId}
           assetMutationError={assetMutationError}
           uploadState={uploadState}
           uploadError={uploadError}
@@ -86,13 +84,6 @@ export function AssetsPage() {
                 assetType: 'document',
                 contentType: 'application/pdf',
               });
-            } catch {
-              // The hook stores the actionable error state for UI display.
-            }
-          }}
-          onDelete={async (assetId) => {
-            try {
-              await deleteAssetEntry(assetId);
             } catch {
               // The hook stores the actionable error state for UI display.
             }
@@ -131,12 +122,20 @@ export function AssetsPage() {
         filters={filters}
         isLoadingAssets={isLoadingAssets}
         isLoadingMoreAssets={isLoadingMoreAssets}
+        isDeletingAssetId={isDeletingAssetId}
         assetsError={assetsError}
         nextCursor={nextCursor}
         onQueryChange={setQueryFilter}
         onVisibilityChange={setVisibilityFilter}
         onLoadMore={loadMoreAssets}
         onSelectAsset={selectAsset}
+        onDeleteAsset={async (assetId) => {
+          try {
+            await deleteAssetEntry(assetId);
+          } catch {
+            // The hook stores the actionable error state for UI display.
+          }
+        }}
       />
     </div>
   );


### PR DESCRIPTION
Move the delete asset button to the asset table's operations column and restyle link actions with a "Links" label, aligning with the file input, as per the `siutindei` reference.

---
<p><a href="https://cursor.com/agents/bc-c5c96cae-2e17-4f49-a7dc-d19156f5e27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5c96cae-2e17-4f49-a7dc-d19156f5e27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

