### PR TITLE
Api gateway permissions

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1818,19 +1818,11 @@ export class ApiStack extends cdk.Stack {
 
     const publicShareAssets = assets.addResource("share");
     const publicShareAssetByToken = publicShareAssets.addResource("{token}");
-    const publicShareAssetByTokenGet = publicShareAssetByToken.addMethod("GET", adminIntegration, {
+    publicShareAssetByToken.addMethod("GET", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.NONE,
-    });
-    const publicShareAssetByTokenGetCfn = publicShareAssetByTokenGet.node
-      .defaultChild as apigateway.CfnMethod;
-    publicShareAssetByTokenGetCfn.addMetadata("checkov", {
-      skip: [
-        {
-          id: "CKV_AWS_59",
-          comment:
-            "Public bearer-link route by design; access requires unguessable share token and resolves to a short-lived signed download URL",
-        },
-      ],
+      // Keep the bearer-link UX public while preventing open API access:
+      // CloudFront injects x-api-key for this origin behavior.
+      apiKeyRequired: true,
     });
 
     // Route media-domain share links to API Gateway.
@@ -1839,6 +1831,9 @@ export class ApiStack extends cdk.Stack {
       {
         originPath: `/${api.deploymentStage.stageName}`,
         protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+        customHeaders: {
+          "x-api-key": publicApiKeyValue.valueAsString,
+        },
       }
     );
     assetDownloadDistribution.addBehavior("v1/assets/share/*", assetShareApiOrigin, {

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -72,6 +72,10 @@ paths:
       description: |
         Public bearer endpoint that resolves a stable share token and redirects
         to a fresh CloudFront-signed download URL.
+        Requests are authenticated with API key at API Gateway; CloudFront
+        forwards the request and injects `x-api-key` for end users.
+      security:
+        - ApiKeyAuth: []
       responses:
         "302":
           description: Redirect to signed download URL.

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -369,7 +369,7 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | `/v1/user/assets/{id}/download` | GET | User Auth | `EvolvesproutsAdminFunction` | |
 | `/v1/assets/public` | GET | Device Attestation + API Key | `EvolvesproutsAdminFunction` | |
 | `/v1/assets/public/{id}/download` | GET | Device Attestation + API Key | `EvolvesproutsAdminFunction` | |
-| `/v1/assets/share/{token}` | GET | None | `EvolvesproutsAdminFunction` | Public bearer-link resolver (302 redirect) |
+| `/v1/assets/share/{token}` | GET | API Key (CloudFront origin header) | `EvolvesproutsAdminFunction` | Public bearer-link resolver (302 redirect) |
 
 ### API Gateway Gateway Responses
 

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -309,6 +309,9 @@ share URLs as database-backed bearer tokens.
 - Admin APIs create/reuse, rotate, and revoke each asset token.
 - Public route `/v1/assets/share/{token}` resolves the token and redirects to
   a fresh CloudFront-signed URL for the underlying S3 object.
+- API Gateway enforces an API key on `/v1/assets/share/{token}` and the media
+  CloudFront behavior injects `x-api-key` at origin so browser users do not
+  need to provide credentials directly.
 - CloudFront public key material is configured in infrastructure; matching
   private key material is stored in AWS Secrets Manager and loaded by Lambda.
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -27,7 +27,8 @@ their primary responsibilities.
   and `/v1/assets/share/*`
 - Auth: Cognito JWT — admin group for `/v1/admin/*`,
   any authenticated user for `/v1/user/*`,
-  device attestation + API key for `/v1/assets/public/*`
+  device attestation + API key for `/v1/assets/public/*`,
+  API key for `/v1/assets/share/*` (injected by media CloudFront at origin)
 - Purpose: asset metadata CRUD, grant management, stable share-link lifecycle
   (create/rotate/revoke), and signed upload/download URL generation in
   `backend/src/app/api/admin.py`.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -275,7 +275,8 @@ Process to add a new public API path:
   share/download GET routes to avoid stale signed-link responses.
 - Admin-generated share links are built with `ASSET_SHARE_LINK_BASE_URL`
   (`https://media.evolvesprouts.com`) and served through a CloudFront behavior
-  that forwards `v1/assets/share/*` to API Gateway.
+  that forwards `v1/assets/share/*` to API Gateway and injects the
+  required `x-api-key` origin header.
 - The CloudFront signer private key must be stored in AWS Secrets Manager and
   loaded at runtime; never commit private keys in source control.
 - CloudFront distributions serving client assets must restrict S3 origin access


### PR DESCRIPTION
Harden API Gateway access for `/v1/assets/share/{token}` GET endpoint to require an API key, resolving CKV_AWS_59.

CloudFront is configured to inject the API key for `v1/assets/share/*` requests, ensuring existing public share links continue to function without exposing the API key to end-users.

---
<p><a href="https://cursor.com/agents/bc-dad93e69-0695-4bef-821c-8b0b0217aef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dad93e69-0695-4bef-821c-8b0b0217aef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

