### PR TITLE
Js-yaml security update

### DIFF
--- a/apps/admin_web/package-lock.json
+++ b/apps/admin_web/package-lock.json
@@ -4804,9 +4804,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/admin_web/package.json
+++ b/apps/admin_web/package.json
@@ -30,6 +30,7 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "typescript-eslint": "8.55.1-alpha.4"
+    "typescript-eslint": "8.55.1-alpha.4",
+    "js-yaml": "^4.1.1"
   }
 }


### PR DESCRIPTION
Upgrade transitive `js-yaml` to `4.1.1` to fix a prototype pollution vulnerability.

This update addresses a Dependabot alert for CVE-2022-25881, which allows an attacker to modify the prototype of parsed YAML documents via `__proto__` in `js-yaml` versions prior to `4.1.1`.

---
<p><a href="https://cursor.com/agents/bc-a831b68c-ee21-4000-91fe-db8eeb58fd9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a831b68c-ee21-4000-91fe-db8eeb58fd9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

