### PR TITLE
Admin feedback title

### DIFF
--- a/apps/admin_web/src/components/admin/assets/asset-editor-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-editor-panel.tsx
@@ -366,7 +366,7 @@ export function AssetEditorPanel({
         </StatusBanner>
       ) : null}
       {linkNotice ? (
-        <StatusBanner variant='success' title='Share link'>
+        <StatusBanner variant='success'>
           {linkNotice}
         </StatusBanner>
       ) : null}

--- a/apps/admin_web/src/components/status-banner.tsx
+++ b/apps/admin_web/src/components/status-banner.tsx
@@ -10,7 +10,7 @@ const variantStyles = {
 
 export interface StatusBannerProps {
   variant: 'info' | 'error' | 'success';
-  title: string;
+  title?: string;
   children: ReactNode;
 }
 
@@ -19,12 +19,14 @@ export function StatusBanner({
   title,
   children,
 }: StatusBannerProps) {
+  const hasTitle = Boolean(title?.trim());
+
   return (
     <div
       className={`w-full rounded-lg border px-3 py-2.5 sm:px-4 sm:py-3 ${variantStyles[variant]}`}
     >
-      <p className='text-xs font-semibold sm:text-sm'>{title}</p>
-      <p className='mt-1 text-xs sm:text-sm'>{children}</p>
+      {hasTitle ? <p className='text-xs font-semibold sm:text-sm'>{title}</p> : null}
+      <p className={hasTitle ? 'mt-1 text-xs sm:text-sm' : 'text-xs sm:text-sm'}>{children}</p>
     </div>
   );
 }


### PR DESCRIPTION
Remove the title from the green success feedback for link buttons on the Admin Assets page to show only the description.

---
<p><a href="https://cursor.com/agents/bc-5496625e-e7b8-41d3-9815-9daedb54b25a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5496625e-e7b8-41d3-9815-9daedb54b25a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

