### PR TITLE
Terms policy white background

### DIFF
--- a/apps/public_www/src/components/sections/privacy-policy.tsx
+++ b/apps/public_www/src/components/sections/privacy-policy.tsx
@@ -13,7 +13,7 @@ export function PrivacyPolicy({ content }: PrivacyPolicyProps) {
       id='privacy-policy'
       ariaLabel={content.title}
       dataFigmaNode='privacy-policy'
-      className='es-section-bg-overlay'
+      className='es-section-bg-overlay es-bg-surface-white'
     >
       <SectionContainer>
         <SectionHeader

--- a/apps/public_www/src/components/sections/terms-and-conditions.tsx
+++ b/apps/public_www/src/components/sections/terms-and-conditions.tsx
@@ -13,7 +13,7 @@ export function TermsAndConditions({ content }: TermsAndConditionsProps) {
       id='terms-and-conditions'
       ariaLabel={content.title}
       dataFigmaNode='terms-and-conditions'
-      className='es-section-bg-overlay'
+      className='es-section-bg-overlay es-bg-surface-white'
     >
       <SectionContainer>
         <SectionHeader

--- a/apps/public_www/tests/components/sections/privacy-policy.test.tsx
+++ b/apps/public_www/tests/components/sections/privacy-policy.test.tsx
@@ -8,6 +8,11 @@ describe('PrivacyPolicy section', () => {
   it('renders title and all configured policy section headings', () => {
     render(<PrivacyPolicy content={enContent.privacyPolicy} />);
 
+    const section = screen.getByRole('region', {
+      name: enContent.privacyPolicy.title,
+    });
+    expect(section.className).toContain('es-bg-surface-white');
+
     expect(
       screen.getByRole('heading', { name: enContent.privacyPolicy.title }),
     ).toBeInTheDocument();

--- a/apps/public_www/tests/components/sections/terms-and-conditions.test.tsx
+++ b/apps/public_www/tests/components/sections/terms-and-conditions.test.tsx
@@ -8,6 +8,11 @@ describe('TermsAndConditions section', () => {
   it('renders title, sections, and language precedence clause', () => {
     render(<TermsAndConditions content={enContent.termsAndConditions} />);
 
+    const section = screen.getByRole('region', {
+      name: enContent.termsAndConditions.title,
+    });
+    expect(section.className).toContain('es-bg-surface-white');
+
     expect(
       screen.getByRole('heading', { name: enContent.termsAndConditions.title }),
     ).toBeInTheDocument();


### PR DESCRIPTION
Set the background color of the Terms & Conditions and Privacy Policy sections to white using a theme variable, as requested by the user.

---
<p><a href="https://cursor.com/agents/bc-ec2b8f91-9f78-462e-9faf-969d9379d6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec2b8f91-9f78-462e-9faf-969d9379d6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

