### PR TITLE
Sprout squad email input

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -273,6 +273,25 @@
     letter-spacing: 0.4px;
   }
 
+  .es-sprouts-community-email-input {
+    outline: none;
+    box-shadow: none;
+  }
+
+  .es-sprouts-community-email-input:focus,
+  .es-sprouts-community-email-input:focus-visible,
+  .es-sprouts-community-email-input:invalid {
+    outline: none;
+    box-shadow: none;
+    border-color: var(--es-color-border-input);
+  }
+
+  .es-sprouts-community-email-input.es-form-input-error:focus,
+  .es-sprouts-community-email-input.es-form-input-error:focus-visible,
+  .es-sprouts-community-email-input.es-form-input-error:invalid {
+    border-color: var(--es-color-text-danger, #B42318);
+  }
+
   .es-why-us-section {
     background-color: var(--figma-colors-frame-2147235259, #FFEEE3);
     --es-section-bg-image: url('/images/evolvesprouts-logo.svg');

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -117,11 +117,11 @@ export function SproutsSquadCommunity({
             >
               <form
                 onSubmit={handleSubmit}
+                noValidate
                 className='flex min-h-0 flex-col gap-3 overflow-hidden'
               >
                 <input
                   type='email'
-                  required
                   autoComplete='email'
                   value={email}
                   onChange={(event) => {
@@ -131,7 +131,7 @@ export function SproutsSquadCommunity({
                     setIsEmailTouched(true);
                   }}
                   placeholder={content.emailPlaceholder}
-                  className={`es-focus-ring es-form-input ${
+                  className={`es-form-input es-sprouts-community-email-input ${
                     hasEmailError ? 'es-form-input-error' : ''
                   }`}
                   aria-label={content.emailPlaceholder}

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -73,12 +73,38 @@ describe('SproutsSquadCommunity section', () => {
     expect(
       screen.getByPlaceholderText(enContent.sproutsSquadCommunity.emailPlaceholder),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: enContent.sproutsSquadCommunity.ctaLabel }),
-    ).toBeInTheDocument();
+    const emailInput = screen.getByPlaceholderText(
+      enContent.sproutsSquadCommunity.emailPlaceholder,
+    );
+    expect(emailInput).toHaveClass('es-sprouts-community-email-input');
+    expect(emailInput).not.toHaveAttribute('required');
+
+    const submitButton = screen.getByRole('button', {
+      name: enContent.sproutsSquadCommunity.ctaLabel,
+    });
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton.closest('form')).toHaveAttribute('novalidate');
     expect(
       screen.queryByRole('link', { name: enContent.sproutsSquadCommunity.ctaLabel }),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows email validation error when submit is clicked with empty email', () => {
+    render(<SproutsSquadCommunity content={enContent.sproutsSquadCommunity} />);
+
+    const emailInput = screen.getByPlaceholderText(
+      enContent.sproutsSquadCommunity.emailPlaceholder,
+    );
+    const submitButton = screen.getByRole('button', {
+      name: enContent.sproutsSquadCommunity.ctaLabel,
+    });
+
+    fireEvent.click(submitButton);
+
+    expect(
+      screen.getByText(enContent.sproutsSquadCommunity.emailValidationMessage),
+    ).toBeInTheDocument();
+    expect(emailInput).toHaveAttribute('aria-invalid', 'true');
   });
 
   it('shows email validation error for invalid email', () => {


### PR DESCRIPTION
Remove native browser validation tooltip and brown focus border from the Sprout Squad community email input to improve UX, retaining only the red error state for invalid input.

The existing native browser validation (`required` attribute) on the email input was causing an unwanted "Please fill out this field" tooltip. Additionally, a generic focus style was applying a brown border on click. This PR disables native validation and customizes the focus styling to only show a red border when the email input is invalid, aligning with the desired user experience.

---
<p><a href="https://cursor.com/agents/bc-db992cf7-7366-477a-a6a5-10fc22c0fe76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db992cf7-7366-477a-a6a5-10fc22c0fe76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

