### PR TITLE
Dependabot security updates

### DIFF
--- a/apps/admin_web/package-lock.json
+++ b/apps/admin_web/package-lock.json
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+      "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/apps/admin_web/package.json
+++ b/apps/admin_web/package.json
@@ -39,6 +39,9 @@
   },
   "overrides": {
     "typescript-eslint": "8.55.1-alpha.4",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "@redocly/openapi-core": {
+      "minimatch": "5.1.8"
+    }
   }
 }


### PR DESCRIPTION
Patch `minimatch` transitive dependency in `apps/admin_web` to resolve Dependabot security alerts #25, #16, and #24.

---
<p><a href="https://cursor.com/agents/bc-8550a78f-6cb2-4090-8076-36218bc8b0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8550a78f-6cb2-4090-8076-36218bc8b0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

