### PR TITLE
Patience section form UI

### DIFF
--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FormEvent } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
@@ -47,6 +47,7 @@ export function MediaForm({
   const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '';
   const crmApiClient = useMemo(() => createPublicCrmApiClient(), []);
   const [isFormVisible, setIsFormVisible] = useState(false);
+  const [isFormFadingIn, setIsFormFadingIn] = useState(false);
   const [firstName, setFirstName] = useState('');
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -70,6 +71,21 @@ export function MediaForm({
     hasFirstNameError ||
     hasEmailError ||
     isCaptchaUnavailable;
+
+  useEffect(() => {
+    if (!isFormVisible) {
+      setIsFormFadingIn(false);
+      return;
+    }
+
+    const animationFrameId = window.requestAnimationFrame(() => {
+      setIsFormFadingIn(true);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+    };
+  }, [isFormVisible]);
 
   function handleOpenForm() {
     setIsFormVisible(true);
@@ -144,7 +160,11 @@ export function MediaForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className={mergeClassNames('mt-auto w-full max-w-[420px] space-y-3', className)}
+      className={mergeClassNames(
+        'mt-7 w-full max-w-[420px] space-y-3 opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none',
+        isFormFadingIn ? 'opacity-100' : null,
+        className,
+      )}
       noValidate
     >
       <input

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -102,6 +102,27 @@ describe('MediaForm', () => {
     expect(screen.getByPlaceholderText(enContent.resources.formEmailLabel)).toBeInTheDocument();
   });
 
+  it('adds top spacing and fades in the form when CTA is clicked', async () => {
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+
+    const firstNameInput = screen.getByPlaceholderText(
+      enContent.resources.formFirstNameLabel,
+    );
+    const form = firstNameInput.closest('form');
+    if (!form) {
+      throw new Error('Expected media form to render after CTA click');
+    }
+    expect(form).toHaveClass('mt-7');
+    expect(form).toHaveClass('transition-opacity');
+    expect(form).toHaveClass('duration-300');
+
+    await waitFor(() => {
+      expect(form).toHaveClass('opacity-100');
+    });
+  });
+
   it('submits valid payload and renders success message', async () => {
     const request = vi.fn().mockResolvedValue(null);
     mockedCreateCrmApiClient.mockReturnValue({ request });


### PR DESCRIPTION
Add `mt-7` margin to the form node and a fade-in transition when the CTA reveals the form in the "Free resources / 4 ways to patience" section.

---
<p><a href="https://cursor.com/agents/bc-43c8636c-3869-44d6-8ffc-ac48d480d5b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43c8636c-3869-44d6-8ffc-ac48d480d5b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a small client-side animation state and adjusts spacing; no changes to submission payloads or API behavior.
> 
> **Overview**
> Adds a fade-in transition when the `MediaForm` is revealed via the CTA by introducing an `isFormFadingIn` state set on the next animation frame, and updates the form styling to start at `opacity-0` then transition to `opacity-100`.
> 
> Adjusts the revealed form’s layout by changing top spacing from `mt-auto` to `mt-7`, and extends the unit test suite to assert the new spacing and fade-in classes/behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b6311eec9b5640297389334a77df4dee85003a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->