### PR TITLE
Hide contact method labels under icons

### DIFF
--- a/apps/public_www/src/components/sections/contact-us-form-contact-method-list.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form-contact-method-list.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 
-import { ExternalLinkInlineContent } from '@/components/shared/external-link-icon';
 import { SmartLink } from '@/components/shared/smart-link';
 import type { ContactUsContent } from '@/content';
 
@@ -28,9 +27,10 @@ export function ContactMethodList({ title, methods }: ContactMethodListProps) {
           <li key={method.key}>
             <SmartLink
               href={method.href}
-              className='inline-flex w-[100px] flex-col items-center gap-3 text-center es-section-body text-[1.05rem] leading-8 transition-opacity hover:opacity-80'
+              aria-label={method.label}
+              className='inline-flex w-[100px] flex-col items-center gap-3 text-center transition-opacity hover:opacity-80'
             >
-              {({ isExternalHttp }) => (
+              {() => (
                 <>
                   <span
                     aria-hidden='true'
@@ -45,9 +45,6 @@ export function ContactMethodList({ title, methods }: ContactMethodListProps) {
                       className='h-[100px] w-[100px]'
                     />
                   </span>
-                  <ExternalLinkInlineContent isExternalHttp={isExternalHttp}>
-                    {method.label}
-                  </ExternalLinkInlineContent>
                 </>
               )}
             </SmartLink>

--- a/apps/public_www/tests/components/sections/contact-us-form-contact-method-list.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form-contact-method-list.test.tsx
@@ -71,12 +71,13 @@ describe('ContactMethodList', () => {
     const emailLink = screen.getByRole('link', { name: 'Email us' });
     const whatsappLink = screen.getByRole('link', { name: 'WhatsApp' });
 
-    expect(emailLink.className).toContain('es-section-body');
+    expect(emailLink).toHaveAttribute('aria-label', 'Email us');
+    expect(whatsappLink).toHaveAttribute('aria-label', 'WhatsApp');
     expect(emailLink.className).toContain('flex-col');
     expect(emailLink.className).toContain('text-center');
     expect(emailLink.className).toContain('w-[100px]');
-    expect(emailLink.querySelector('svg[data-external-link-icon="true"]')).toBeNull();
-    expect(whatsappLink.querySelector('svg[data-external-link-icon="true"]')).not.toBeNull();
+    expect(screen.queryByText('Email us')).toBeNull();
+    expect(screen.queryByText('WhatsApp')).toBeNull();
 
     const emailIcon = screen.getByTestId('contact-method-icon-email').querySelector('img');
     const whatsappIcon = screen

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -172,7 +172,11 @@ describe('ContactUsForm section', () => {
       'https://www.linkedin.com/company/evolve-sprouts',
     );
     expect(formLink).toHaveAttribute('href', '#contact-form');
-    expect(within(list).getAllByRole('link').map((link) => link.textContent?.trim())).toEqual([
+    expect(
+      within(list)
+        .getAllByRole('link')
+        .map((link) => link.getAttribute('aria-label')),
+    ).toEqual([
       enContent.contactUs.contactUsForm.contactMethodLinks.form,
       enContent.contactUs.contactUsForm.contactMethodLinks.instagram,
       enContent.contactUs.contactUsForm.contactMethodLinks.linkedin,
@@ -180,9 +184,10 @@ describe('ContactUsForm section', () => {
       enContent.contactUs.contactUsForm.contactMethodLinks.mail,
     ]);
     for (const link of [emailLink, whatsappLink, instagramLink, linkedInLink, formLink]) {
-      expect(link.className).toContain('es-section-body');
-      expect(link.className).toContain('text-[1.05rem]');
-      expect(link.className).toContain('leading-8');
+      expect(link.className).toContain('w-[100px]');
+      expect(link.className).toContain('flex-col');
+      expect(link.className).toContain('items-center');
+      expect(link.getAttribute('aria-label')).not.toBeNull();
     }
     expect(screen.getByTestId('contact-method-icon-email').querySelector('img')).toHaveAttribute(
       'src',
@@ -204,11 +209,21 @@ describe('ContactUsForm section', () => {
       'src',
       '/images/contact-form.svg',
     );
-    expect(emailLink.querySelector('svg[data-external-link-icon="true"]')).toBeNull();
-    expect(formLink.querySelector('svg[data-external-link-icon="true"]')).toBeNull();
-    expect(whatsappLink.querySelector('svg[data-external-link-icon="true"]')).not.toBeNull();
-    expect(instagramLink.querySelector('svg[data-external-link-icon="true"]')).not.toBeNull();
-    expect(linkedInLink.querySelector('svg[data-external-link-icon="true"]')).not.toBeNull();
+    expect(
+      screen.queryByText(enContent.contactUs.contactUsForm.contactMethodLinks.form),
+    ).toBeNull();
+    expect(
+      screen.queryByText(enContent.contactUs.contactUsForm.contactMethodLinks.instagram),
+    ).toBeNull();
+    expect(
+      screen.queryByText(enContent.contactUs.contactUsForm.contactMethodLinks.linkedin),
+    ).toBeNull();
+    expect(
+      screen.queryByText(enContent.contactUs.contactUsForm.contactMethodLinks.whatsapp),
+    ).toBeNull();
+    expect(
+      screen.queryByText(enContent.contactUs.contactUsForm.contactMethodLinks.mail),
+    ).toBeNull();
   });
 
   it('omits channels that are missing in the provided contact configuration', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/accessibility tweak: removes visible link label/external-link icon from contact method tiles and updates tests accordingly.
> 
> **Overview**
> Updates the contact-method icon grid to be *icon-only*: the visible label text (and external-link inline icon treatment) is removed and each `SmartLink` now exposes the label via `aria-label`.
> 
> Tests are updated to assert link accessibility names/`aria-label`s and to verify that the label text is no longer rendered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 625a2f090849b897f5d90fb8ffa27aabc00346d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->