### PR TITLE
Ida intro image display

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -416,6 +416,24 @@
     background-color: var(--figma-colors-frame-2147235259, #FFEEE3);
   }
 
+  .es-ida-intro-image-wrap {
+    position: relative;
+    isolation: isolate;
+  }
+
+  .es-ida-intro-image-wrap::before {
+    content: '';
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background-image: url('/images/evolvesprouts-logo.svg');
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 72% auto;
+    filter: sepia(1) opacity(7%) hue-rotate(-50deg) saturate(250%);
+  }
+
   .es-hero-section {
     padding-top: 0;
     background-color: var(--es-color-surface-white, #FFFFFF);

--- a/apps/public_www/src/components/sections/ida-intro.tsx
+++ b/apps/public_www/src/components/sections/ida-intro.tsx
@@ -65,7 +65,7 @@ export function IdaIntro({ content }: IdaIntroProps) {
           </div>
         </div>
 
-        <div className='mx-auto w-full max-w-[573px] lg:order-1 lg:ml-0 lg:mr-auto'>
+        <div className='es-ida-intro-image-wrap mx-auto w-full max-w-[400px] lg:order-1 lg:ml-0 lg:mr-auto'>
           <Image
             src='/images/about-us/ida-degregorio-evolvesprouts-3.webp'
             alt={content.imageAlt}
@@ -73,8 +73,8 @@ export function IdaIntro({ content }: IdaIntroProps) {
             height={841}
             priority
             fetchPriority='high'
-            sizes='(max-width: 640px) 92vw, (max-width: 1024px) 70vw, 764px'
-            className='h-auto w-full'
+            sizes='(max-width: 640px) 92vw, 400px'
+            className='relative z-10 h-auto w-full'
           />
         </div>
       </SectionContainer>

--- a/apps/public_www/tests/components/sections/ida-intro.test.tsx
+++ b/apps/public_www/tests/components/sections/ida-intro.test.tsx
@@ -32,6 +32,9 @@ describe('IdaIntro', () => {
       'href',
       content.ctaHref,
     );
-    expect(screen.getByRole('img', { name: content.imageAlt })).toBeInTheDocument();
+    const image = screen.getByRole('img', { name: content.imageAlt });
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveClass('relative', 'z-10');
+    expect(image.closest('div')).toHaveClass('es-ida-intro-image-wrap', 'max-w-[400px]');
   });
 });


### PR DESCRIPTION
Adjust the IDA intro section image to `max-width: 400px` and add the Evolve Sprouts logo as a subtle background.

---
<p><a href="https://cursor.com/agents/bc-adeb5036-9390-4510-86e6-b5e1a4591b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adeb5036-9390-4510-86e6-b5e1a4591b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

