### PR TITLE
Es-ida-intro-image-wrap styling

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -430,8 +430,7 @@
     background-image: url('/images/evolvesprouts-logo.svg');
     background-repeat: no-repeat;
     background-position: center;
-    background-size: 72% auto;
-    filter: sepia(1) opacity(7%) hue-rotate(-50deg) saturate(250%);
+    background-size: 130%;
   }
 
   .es-hero-section {


### PR DESCRIPTION
Remove `filter` and set `background-size` to `130%` for `.es-ida-intro-image-wrap::before`.

---
<p><a href="https://cursor.com/agents/bc-4e74f923-38a5-49ef-9fcd-5ef86d59f9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e74f923-38a5-49ef-9fcd-5ef86d59f9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

