### PR TITLE
Contact-us section layout

### DIFF
--- a/apps/public_www/src/components/sections/contact-us-form-contact-method-list.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form-contact-method-list.tsx
@@ -20,36 +20,45 @@ export function ContactMethodList({ title, methods }: ContactMethodListProps) {
     <div className='mt-6'>
       <p className='es-section-body text-[1.05rem] leading-8'>{title}</p>
       <ul
-        className='mt-4 flex max-w-full flex-wrap items-start gap-4'
+        className='mt-4 flex max-w-full flex-wrap items-start'
         aria-label={title}
       >
-        {methods.map((method) => (
-          <li key={method.key}>
-            <SmartLink
-              href={method.href}
-              aria-label={method.label}
-              className='inline-flex w-[100px] flex-col items-center gap-3 text-center transition-opacity hover:opacity-80'
-            >
-              {() => (
-                <>
-                  <span
-                    aria-hidden='true'
-                    data-testid={`contact-method-icon-${method.key}`}
-                    className='inline-flex h-[100px] w-[100px] shrink-0 items-center justify-center es-text-heading'
-                  >
-                    <Image
-                      src={method.iconSrc}
-                      alt=''
-                      width={100}
-                      height={100}
-                      className='h-[100px] w-[100px]'
-                    />
-                  </span>
-                </>
-              )}
-            </SmartLink>
-          </li>
-        ))}
+        {methods.map((method) => {
+          const isLinkedInIcon = method.key === 'linkedin';
+          const linkWidthClassName = isLinkedInIcon ? 'w-auto' : 'w-[100px]';
+          const iconContainerWidthClassName = isLinkedInIcon ? 'w-auto' : 'w-[100px]';
+          const imageWidth = isLinkedInIcon ? 635 : 100;
+          const imageHeight = isLinkedInIcon ? 540 : 100;
+          const imageWidthClassName = isLinkedInIcon ? 'w-auto' : 'w-[100px]';
+
+          return (
+            <li key={method.key} className='m-[10px]'>
+              <SmartLink
+                href={method.href}
+                aria-label={method.label}
+                className={`inline-flex ${linkWidthClassName} flex-col items-center gap-3 text-center transition-opacity hover:opacity-80`}
+              >
+                {() => (
+                  <>
+                    <span
+                      aria-hidden='true'
+                      data-testid={`contact-method-icon-${method.key}`}
+                      className={`inline-flex h-[100px] ${iconContainerWidthClassName} shrink-0 items-center justify-center es-text-heading`}
+                    >
+                      <Image
+                        src={method.iconSrc}
+                        alt=''
+                        width={imageWidth}
+                        height={imageHeight}
+                        className={`h-[100px] ${imageWidthClassName}`}
+                      />
+                    </span>
+                  </>
+                )}
+              </SmartLink>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/apps/public_www/tests/components/sections/contact-us-form-contact-method-list.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form-contact-method-list.test.tsx
@@ -44,6 +44,12 @@ describe('ContactMethodList', () => {
             iconSrc: '/images/contact-email.svg',
           },
           {
+            key: 'linkedin',
+            href: 'https://www.linkedin.com/company/evolve-sprouts',
+            label: 'LinkedIn',
+            iconSrc: '/images/contact-linkedin.png',
+          },
+          {
             key: 'whatsapp',
             href: 'https://wa.me/message/ZQHVW4DEORD5A1?src=qr',
             label: 'WhatsApp',
@@ -64,33 +70,54 @@ describe('ContactMethodList', () => {
       'href',
       'mailto:hello@example.com',
     );
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute(
+      'href',
+      'https://www.linkedin.com/company/evolve-sprouts',
+    );
     expect(screen.getByRole('link', { name: 'WhatsApp' })).toHaveAttribute(
       'href',
       'https://wa.me/message/ZQHVW4DEORD5A1?src=qr',
     );
     const emailLink = screen.getByRole('link', { name: 'Email us' });
+    const linkedInLink = screen.getByRole('link', { name: 'LinkedIn' });
     const whatsappLink = screen.getByRole('link', { name: 'WhatsApp' });
 
     expect(emailLink).toHaveAttribute('aria-label', 'Email us');
+    expect(linkedInLink).toHaveAttribute('aria-label', 'LinkedIn');
     expect(whatsappLink).toHaveAttribute('aria-label', 'WhatsApp');
     expect(emailLink.className).toContain('flex-col');
     expect(emailLink.className).toContain('text-center');
     expect(emailLink.className).toContain('w-[100px]');
+    expect(linkedInLink.className).toContain('w-auto');
+    expect(whatsappLink.className).toContain('w-[100px]');
+    for (const listItem of list.querySelectorAll('li')) {
+      expect(listItem.className).toContain('m-[10px]');
+    }
     expect(screen.queryByText('Email us')).toBeNull();
+    expect(screen.queryByText('LinkedIn')).toBeNull();
     expect(screen.queryByText('WhatsApp')).toBeNull();
 
     const emailIcon = screen.getByTestId('contact-method-icon-email').querySelector('img');
+    const linkedInIcon = screen.getByTestId('contact-method-icon-linkedin').querySelector('img');
     const whatsappIcon = screen
       .getByTestId('contact-method-icon-whatsapp')
       .querySelector('img');
     const emailIconContainer = screen.getByTestId('contact-method-icon-email');
+    const linkedInIconContainer = screen.getByTestId('contact-method-icon-linkedin');
     expect(emailIconContainer.className).toContain('h-[100px]');
     expect(emailIconContainer.className).toContain('w-[100px]');
+    expect(linkedInIconContainer.className).toContain('h-[100px]');
+    expect(linkedInIconContainer.className).toContain('w-auto');
     expect(emailIcon).toHaveAttribute('src', '/images/contact-email.svg');
     expect(emailIcon).toHaveAttribute('width', '100');
     expect(emailIcon).toHaveAttribute('height', '100');
     expect(emailIcon?.className).toContain('h-[100px]');
     expect(emailIcon?.className).toContain('w-[100px]');
+    expect(linkedInIcon).toHaveAttribute('src', '/images/contact-linkedin.png');
+    expect(linkedInIcon).toHaveAttribute('width', '635');
+    expect(linkedInIcon).toHaveAttribute('height', '540');
+    expect(linkedInIcon?.className).toContain('h-[100px]');
+    expect(linkedInIcon?.className).toContain('w-auto');
     expect(whatsappIcon).toHaveAttribute('src', '/images/contact-whatsapp.svg');
     expect(whatsappIcon?.className).toContain('h-[100px]');
     expect(whatsappIcon?.className).toContain('w-[100px]');

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -138,6 +138,9 @@ describe('ContactUsForm section', () => {
     expect(list.className).toContain('flex-wrap');
     expect(list.className).toContain('max-w-full');
     expect(list.className).not.toContain('overflow-x-auto');
+    for (const listItem of list.querySelectorAll('li')) {
+      expect(listItem.className).toContain('m-[10px]');
+    }
     const contactMethodsTitle = screen.getByText(
       enContent.contactUs.contactUsForm.contactMethodsTitle,
     );
@@ -183,12 +186,16 @@ describe('ContactUsForm section', () => {
       enContent.contactUs.contactUsForm.contactMethodLinks.whatsapp,
       enContent.contactUs.contactUsForm.contactMethodLinks.mail,
     ]);
-    for (const link of [emailLink, whatsappLink, instagramLink, linkedInLink, formLink]) {
+    for (const link of [emailLink, whatsappLink, instagramLink, formLink]) {
       expect(link.className).toContain('w-[100px]');
       expect(link.className).toContain('flex-col');
       expect(link.className).toContain('items-center');
       expect(link.getAttribute('aria-label')).not.toBeNull();
     }
+    expect(linkedInLink.className).toContain('w-auto');
+    expect(linkedInLink.className).toContain('flex-col');
+    expect(linkedInLink.className).toContain('items-center');
+    expect(linkedInLink.getAttribute('aria-label')).not.toBeNull();
     expect(screen.getByTestId('contact-method-icon-email').querySelector('img')).toHaveAttribute(
       'src',
       '/images/contact-email.svg',
@@ -205,6 +212,14 @@ describe('ContactUsForm section', () => {
     expect(
       screen.getByTestId('contact-method-icon-linkedin').querySelector('img'),
     ).toHaveAttribute('src', '/images/contact-linkedin.png');
+    const linkedInIcon = screen.getByTestId('contact-method-icon-linkedin').querySelector('img');
+    const linkedInIconContainer = screen.getByTestId('contact-method-icon-linkedin');
+    expect(linkedInIconContainer.className).toContain('h-[100px]');
+    expect(linkedInIconContainer.className).toContain('w-auto');
+    expect(linkedInIcon).toHaveAttribute('width', '635');
+    expect(linkedInIcon).toHaveAttribute('height', '540');
+    expect(linkedInIcon?.className).toContain('h-[100px]');
+    expect(linkedInIcon?.className).toContain('w-auto');
     expect(screen.getByTestId('contact-method-icon-form').querySelector('img')).toHaveAttribute(
       'src',
       '/images/contact-form.svg',


### PR DESCRIPTION
Add 10px margin to contact method list items and preserve LinkedIn icon aspect ratio at 100px height.

---
<p><a href="https://cursor.com/agents/bc-1bf06333-802d-46b5-8896-a438b4938d5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bf06333-802d-46b5-8896-a438b4938d5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

