### PR TITLE
Media pane mobile styling

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -962,7 +962,7 @@
     background-image: url('/images/family.webp');
     background-position: bottom;
     background-repeat: no-repeat;
-    background-size: var(--es-free-resources-bg-size, 50% auto);
+    background-size: var(--es-free-resources-bg-size, 75% auto);
   }
 
   .es-free-resources-media-pane--bleed-left::before {

--- a/apps/public_www/src/components/sections/free-resources-split-layout.tsx
+++ b/apps/public_www/src/components/sections/free-resources-split-layout.tsx
@@ -40,7 +40,7 @@ export function FreeResourcesSplitLayout({
         data-testid='free-resource-media-pane'
         className={`es-free-resources-media-pane ${splitMediaBleedClassName} relative z-0 min-h-[210px] overflow-visible sm:min-h-[278px] lg:min-h-[440px] ${splitMediaPaneOrderClassName}`}
       >
-        <div className='absolute left-1/2 top-[10%] z-10 flex -translate-x-1/2 flex-col items-center gap-2 sm:gap-3'>
+        <div className='absolute left-1/2 top-[50%] z-10 flex -translate-x-1/2 flex-col items-center gap-2 sm:gap-3'>
           <div className='rounded-full bg-white/95 px-5 py-2 shadow-pill sm:px-6'>
             <p className='whitespace-nowrap es-free-resources-media-pill-text'>
               {mediaTitleLine1}

--- a/apps/public_www/tests/components/sections/free-resources-split-layout.test.tsx
+++ b/apps/public_www/tests/components/sections/free-resources-split-layout.test.tsx
@@ -29,6 +29,9 @@ describe('FreeResourcesSplitLayout', () => {
     expect(screen.getByTestId('free-resource-media-pane').className).toContain(
       'es-free-resources-media-pane--bleed-right',
     );
+    const mediaPillStack =
+      screen.getByText('Teach Patience').parentElement?.parentElement;
+    expect(mediaPillStack?.className).toContain('top-[50%]');
     expect(screen.getByText('Teach Patience')).toBeInTheDocument();
     expect(screen.getByText('to Young Children')).toBeInTheDocument();
     expect(screen.getByText('Split card content')).toBeInTheDocument();


### PR DESCRIPTION
Adjust mobile styling for `.es-free-resources-media-pane:before` background size and the media pane's `top` position.

---
<p><a href="https://cursor.com/agents/bc-d381f935-5edd-4103-9971-c4bfe596fce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d381f935-5edd-4103-9971-c4bfe596fce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

