### PR TITLE
Cta whatsapp recipient

### DIFF
--- a/apps/public_www/src/components/pages/homepage.tsx
+++ b/apps/public_www/src/components/pages/homepage.tsx
@@ -22,6 +22,7 @@ export function HomePageSections({ content }: HomePageSectionsProps) {
   const heroCtaHref = buildWhatsappPrefilledHref(
     baseWhatsappHref,
     content.hero.ctaPrefillMessage,
+    siteConfig.businessPhoneNumber,
   ) || baseWhatsappHref;
 
   return (

--- a/apps/public_www/src/lib/site-config.ts
+++ b/apps/public_www/src/lib/site-config.ts
@@ -98,9 +98,19 @@ function normalizeConfiguredEmail(value: string | undefined): string | undefined
   return normalized;
 }
 
+function isWhatsappShortLink(url: URL): boolean {
+  return url.hostname === 'wa.me' && url.pathname.startsWith('/message/');
+}
+
+function normalizePhoneForWhatsapp(phone: string | undefined): string {
+  if (!phone) return '';
+  return phone.replace(/\D/g, '');
+}
+
 export function buildWhatsappPrefilledHref(
   baseWhatsappUrl: string | undefined,
   message: string | undefined,
+  phoneNumber?: string,
 ): string {
   const normalizedBaseUrl = normalizeConfiguredUrl(baseWhatsappUrl);
   if (!normalizedBaseUrl) {
@@ -113,10 +123,21 @@ export function buildWhatsappPrefilledHref(
   }
 
   const normalizedMessage = message?.trim() ?? '';
-  if (normalizedMessage) {
-    parsedUrl.searchParams.set('text', normalizedMessage);
+  if (!normalizedMessage) {
+    return parsedUrl.toString();
   }
 
+  if (isWhatsappShortLink(parsedUrl)) {
+    const digits = normalizePhoneForWhatsapp(phoneNumber);
+    if (!digits) {
+      return parsedUrl.toString();
+    }
+    const directUrl = new URL(`https://wa.me/${digits}`);
+    directUrl.searchParams.set('text', normalizedMessage);
+    return directUrl.toString();
+  }
+
+  parsedUrl.searchParams.set('text', normalizedMessage);
   return parsedUrl.toString();
 }
 

--- a/apps/public_www/tests/components/pages/homepage.test.tsx
+++ b/apps/public_www/tests/components/pages/homepage.test.tsx
@@ -1,9 +1,20 @@
 import { render, screen } from '@testing-library/react';
 import { type ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { HomePageSections } from '@/components/pages/homepage';
 import enContent from '@/content/en.json';
+
+const PHONE_ENV_KEY = 'NEXT_PUBLIC_BUSINESS_PHONE_NUMBER';
+const originalPhoneEnv = process.env[PHONE_ENV_KEY];
+
+afterEach(() => {
+  if (typeof originalPhoneEnv === 'string') {
+    process.env[PHONE_ENV_KEY] = originalPhoneEnv;
+  } else {
+    delete process.env[PHONE_ENV_KEY];
+  }
+});
 
 const heroBannerPropsSpy = vi.fn<
   [{ content: { headline: string }; ctaHref?: string }],
@@ -66,6 +77,7 @@ vi.mock('@/components/sections/sprouts-squad-community', () => ({
 
 describe('HomePageSections', () => {
   it('composes homepage sections with the expected content slices', () => {
+    process.env[PHONE_ENV_KEY] = '+852 9876 5432';
     heroBannerPropsSpy.mockClear();
     render(<HomePageSections content={enContent} />);
 
@@ -84,7 +96,7 @@ describe('HomePageSections', () => {
     ).toHaveTextContent('Best Auntie Training Course Designed by Ida');
     expect(heroBannerPropsSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        ctaHref: expect.stringContaining('https://wa.me/'),
+        ctaHref: expect.stringContaining('https://wa.me/85298765432'),
       }),
     );
     expect(heroBannerPropsSpy).toHaveBeenCalledWith(

--- a/apps/public_www/tests/lib/site-config.test.ts
+++ b/apps/public_www/tests/lib/site-config.test.ts
@@ -27,17 +27,41 @@ afterEach(() => {
 });
 
 describe('site-config', () => {
-  it('builds a WhatsApp href with prefilled text while preserving existing query params', () => {
+  it('builds a direct wa.me/<phone> href when base URL is a short link and phone is provided', () => {
+    const href = buildWhatsappPrefilledHref(
+      'https://wa.me/message/ABCDEFG?src=qr',
+      "Hi, I'd like to book a free session!",
+      '+852 9876 5432',
+    );
+
+    const parsed = new URL(href);
+    expect(parsed.pathname).toBe('/85298765432');
+    expect(parsed.searchParams.get('text')).toBe(
+      "Hi, I'd like to book a free session!",
+    );
+  });
+
+  it('returns the short link URL unchanged when no phone number is provided', () => {
     const href = buildWhatsappPrefilledHref(
       'https://wa.me/message/ABCDEFG?src=qr',
       "Hi, I'd like to book a free session!",
     );
 
     const parsed = new URL(href);
+    expect(parsed.pathname).toBe('/message/ABCDEFG');
     expect(parsed.searchParams.get('src')).toBe('qr');
-    expect(parsed.searchParams.get('text')).toBe(
-      "Hi, I'd like to book a free session!",
+    expect(parsed.searchParams.has('text')).toBe(false);
+  });
+
+  it('appends text param to direct wa.me/<phone> URLs without needing a separate phone number', () => {
+    const href = buildWhatsappPrefilledHref(
+      'https://wa.me/85298765432',
+      'Hello!',
     );
+
+    const parsed = new URL(href);
+    expect(parsed.pathname).toBe('/85298765432');
+    expect(parsed.searchParams.get('text')).toBe('Hello!');
   });
 
   it('returns an empty value when the base WhatsApp URL is invalid', () => {


### PR DESCRIPTION
Fixes the WhatsApp CTA on the hero banner to correctly prefill both the recipient and message, preventing WhatsApp from asking the user to select a contact.

The previous implementation appended the `text` query parameter to a `wa.me/message/` short link. This format does not support the `text` parameter, causing WhatsApp to display the message but fail to identify the recipient, thus prompting the user to choose a contact. The fix modifies `buildWhatsappPrefilledHref` to use the direct `wa.me/<phone_number>?text=...` format when a business phone number is provided.

---
<p><a href="https://cursor.com/agents/bc-843b95c8-694a-494a-ba2c-c811a02f75f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-843b95c8-694a-494a-ba2c-c811a02f75f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

