### PR TITLE
Free guide submission error

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1173,6 +1173,12 @@ export class ApiStack extends cdk.Stack {
       })
     );
 
+    adminFunction.addEnvironment(
+      "AWS_PROXY_FUNCTION_ARN",
+      awsProxyFunction.functionArn
+    );
+    awsProxyFunction.grantInvoke(adminFunction);
+
     const sesSenderIdentityArn = cdk.Stack.of(this).formatArn({
       service: "ses",
       resource: "identity",

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -36,7 +36,8 @@ their primary responsibilities.
   stable share-link lifecycle (read/create/rotate/revoke + domain allowlist
   policy), share-link source-domain enforcement, conditional JWT
   authentication for restricted share-link resolutions, PATCH partial metadata
-  updates on `/v1/admin/assets/{id}`, media lead capture event publishing on
+  updates on `/v1/admin/assets/{id}`, media lead capture with Turnstile
+  verification (via `AwsApiProxyFunction`) and SNS event publishing on
   `/v1/media-request`, and signed upload/download URL generation in
   `backend/src/app/api/admin.py`.
 


### PR DESCRIPTION
Wire `AwsApiProxyFunction` to `EvolvesproutsAdminFunction` to enable Cloudflare Turnstile verification and fix the "Unable to submit" error for the free guide form.

The `EvolvesproutsAdminFunction` was unable to verify Cloudflare Turnstile tokens because it lacked the `AWS_PROXY_FUNCTION_ARN` environment variable and `lambda:InvokeFunction` permission to call the `AwsApiProxyFunction`. This caused a `RuntimeError` during verification, leading to a generic 500 error on form submission. A previous commit added the Turnstile secret but missed the proxy wiring necessary for the verification call.

---
<p><a href="https://cursor.com/agents/bc-4d29dd63-5139-4eaf-b3c7-397589226904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d29dd63-5139-4eaf-b3c7-397589226904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

