### PR TITLE
fix: align media-request routing with other public www endpoints

### DIFF
--- a/backend/infrastructure/lib/public-www-stack.ts
+++ b/backend/infrastructure/lib/public-www-stack.ts
@@ -307,15 +307,7 @@ function handler(event) {
       '/www/v1/media-request': true
     }
   };
-  var rewriteTargets = {
-    'POST:/www/v1/media-request': '/v1/media-request'
-  };
-
   if (allowlist[method] && allowlist[method][uri]) {
-    var rewriteKey = method + ':' + uri;
-    if (rewriteTargets[rewriteKey]) {
-      request.uri = rewriteTargets[rewriteKey];
-    }
     return request;
   }
 

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -50,6 +50,11 @@ _ROUTES: tuple[
         lambda event, method, _path: handle_media_request(event, method),
     ),
     (
+        "/www/v1/media-request",
+        True,
+        lambda event, method, _path: handle_media_request(event, method),
+    ),
+    (
         "/v1/admin/geographic-areas",
         False,
         handle_admin_geographic_areas_request,

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -42,8 +42,8 @@ Public WWW CloudFront includes:
   using HTTPS-only origin policy, disabled caching, and
   `OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER` so API key headers and
   query parameters pass through while preserving the API origin host header.
-  - Viewer-request allowlist includes `/www/v1/media-request` and rewrites
-    that path to `/v1/media-request` before forwarding to the API origin.
+  - Viewer-request allowlist gates allowed public API method/path pairs
+    (e.g. `/www/v1/media-request`, `/www/v1/reservations`).
 - Response headers policy for browser hardening:
   `Strict-Transport-Security`, `X-Content-Type-Options`,
   `X-Frame-Options`, `Referrer-Policy`, `Content-Security-Policy`,

--- a/tests/test_admin_router.py
+++ b/tests/test_admin_router.py
@@ -27,6 +27,7 @@ def test_match_handler_routes_asset_prefix_paths() -> None:
         "/v1/assets/share/token-123",
         "/v1/assets/public/abc/download",
         "/v1/media-request",
+        "/www/v1/media-request",
     )
     for path in routes:
         handler = _match_handler(event=event, method="GET", path=path)
@@ -38,9 +39,17 @@ def test_match_handler_treats_exact_public_post_routes_as_exact_path_only() -> N
     assert _match_handler(event=event, method="POST", path="/v1/reservations") is not None
     assert _match_handler(event=event, method="POST", path="/v1/media-request") is not None
     assert (
+        _match_handler(event=event, method="POST", path="/www/v1/media-request")
+        is not None
+    )
+    assert (
         _match_handler(event=event, method="POST", path="/v1/reservations/extra") is None
     )
     assert (
         _match_handler(event=event, method="POST", path="/v1/media-request/extra")
+        is None
+    )
+    assert (
+        _match_handler(event=event, method="POST", path="/www/v1/media-request/extra")
         is None
     )


### PR DESCRIPTION
The CloudFront viewer-request function was rewriting /www/v1/media-request to /v1/media-request before forwarding to the API origin. Every other public endpoint (reservations, contact-us, etc.) keeps the /www prefix intact and relies on the Lambda route table having a /www/v1/… entry.

The rewrite stripped the prefix that the origin routing depends on, causing the request to fail before reaching the Lambda handler.

Remove the rewrite and add a /www/v1/media-request route to the Lambda route table, matching the pattern used by reservations.