### PR TITLE
fix(public_www): disable submit when CRM API client is unavailable

### DIFF
--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -61,16 +61,17 @@ export function MediaForm({
 
   const isCaptchaConfigured = turnstileSiteKey.trim() !== '';
   const isCaptchaUnavailable = !isCaptchaConfigured || hasCaptchaLoadError;
+  const isServiceUnavailable = !crmApiClient || isCaptchaUnavailable;
   const hasFirstNameError = isFirstNameTouched && !sanitizeSingleLineValue(firstName);
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const hasCaptchaError = isCaptchaTouched && !captchaToken;
-  const isSubmitDisabled = isSubmitting || isCaptchaUnavailable;
+  const isSubmitDisabled = isSubmitting || isServiceUnavailable;
   const shouldShowSubmitError =
     !!submitErrorMessage ||
     hasCaptchaError ||
     hasFirstNameError ||
     hasEmailError ||
-    isCaptchaUnavailable;
+    isServiceUnavailable;
 
   useEffect(() => {
     if (!isFormVisible) {
@@ -104,7 +105,7 @@ export function MediaForm({
     if (!normalizedFirstName || !isValidEmail(normalizedEmail) || !captchaToken) {
       return;
     }
-    if (!crmApiClient || isCaptchaUnavailable) {
+    if (isServiceUnavailable) {
       setSubmitErrorMessage(formErrorMessage);
       return;
     }

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -186,4 +186,15 @@ describe('MediaForm', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('disables submit and shows error when CRM API client is unavailable', () => {
+    mockedCreateCrmApiClient.mockReturnValue(null);
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+
+    const submitButton = screen.getByRole('button', { name: enContent.resources.formSubmitLabel });
+    expect(submitButton).toBeDisabled();
+    expect(screen.getByText(enContent.resources.formErrorMessage)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
The submit button was only gated on isSubmitting and isCaptchaUnavailable, ignoring a null crmApiClient. When NEXT_PUBLIC_WWW_CRM_API_BASE_URL or NEXT_PUBLIC_WWW_CRM_API_KEY is missing or invalid at build time, createPublicCrmApiClient() returns null. The form still rendered with an enabled submit button, and clicking it fell through to a guard clause that set the same generic error message — giving no indication that the API client itself was the problem.

Introduce isServiceUnavailable (= !crmApiClient || isCaptchaUnavailable) and wire it into isSubmitDisabled and shouldShowSubmitError so the button is disabled and the error is visible as soon as the form opens.