### PR TITLE
fix: drop hardcoded apiKeyName to avoid replacement collision

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1851,7 +1851,6 @@ export class ApiStack extends cdk.Stack {
     });
 
     const publicWwwApiKey = new apigateway.ApiKey(this, "PublicWwwApiKey", {
-      apiKeyName: name("public-www-key"),
       value: publicApiKeyValue.valueAsString,
     });
     const publicWwwUsagePlan = api.addUsagePlan("PublicWwwUsagePlan", {

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -431,7 +431,7 @@ allowlist (`CORS_ALLOWED_ORIGINS` plus required defaults).
 
 | Resource Type | Logical ID | Physical Name/ID | Notes |
 |--------------|------------|------------------|-------|
-| API Key | `PublicWwwApiKey` | `evolvesprouts-public-www-key` | Value from `PublicApiKeyValue` parameter |
+| API Key | `PublicWwwApiKey` | Auto-generated | Value from `PublicApiKeyValue` parameter |
 | Usage Plan | `PublicWwwUsagePlan` | `evolvesprouts-public-www-plan` | Linked to API key and `prod` stage |
 
 ### API Gateway IAM Roles


### PR DESCRIPTION
CloudFormation replaces the PublicWwwApiKey resource when the PublicApiKeyValue parameter changes. With a fixed apiKeyName the new key cannot be created while the old one still exists, causing the deploy to fail with 'ApiKey with name … already exists'.

Remove apiKeyName so CloudFormation auto-generates unique names, allowing create-before-delete replacements to succeed. The rotation Lambda already uses its own timestamped naming convention and is unaffected.