### PR TITLE
Free guide media request

### DIFF
--- a/docs/deployment/public-www.md
+++ b/docs/deployment/public-www.md
@@ -83,6 +83,7 @@ Workflow: `.github/workflows/deploy-public-www.yml`
   - store immutable snapshot in `releases/<release_id>/`
   - preserve existing `_next/static` hashed assets to avoid stale HTML
     requesting deleted chunks
+  - re-apply `/www/*` CloudFront proxy allowlist behavior
   - invalidate staging CloudFront (including `/_next/static/*` to clear
     stale asset error responses)
 

--- a/scripts/deploy/deploy-public-www.sh
+++ b/scripts/deploy/deploy-public-www.sh
@@ -675,12 +675,10 @@ if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
   enforce_staging_robots_txt "$TARGET_BUCKET_NAME"
 fi
 
-if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
-  apply_www_proxy_mode \
-    "$STACK_NAME" \
-    "$TARGET_DISTRIBUTION_ID" \
-    "$DEPLOY_ENVIRONMENT" \
-    "normal"
-fi
+apply_www_proxy_mode \
+  "$STACK_NAME" \
+  "$TARGET_DISTRIBUTION_ID" \
+  "$DEPLOY_ENVIRONMENT" \
+  "normal"
 
 invalidate_distribution "$TARGET_DISTRIBUTION_ID"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enforce `/www` allowlist reassociation on staging deploys to fix 404 for media-request API calls.

The staging environment was returning a `404` for `POST /www/v1/media-request` because the CloudFront viewer-request function, which proxies `/www/*` paths to the API, was not consistently re-associated during normal staging deployments. This caused routing drift, leading requests for the `media-request` endpoint to hit the static website's 404 page instead of the API. This change ensures the allowlist function is always applied on staging deploys.

---
<p><a href="https://cursor.com/agents/bc-7a2eec83-ec61-4cee-8b3d-883f0265b61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a2eec83-ec61-4cee-8b3d-883f0265b61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->