### PR TITLE
feat(public_www): contact form submit shows loading gear

### DIFF
--- a/apps/public_www/src/components/sections/contact-us-form-fields.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form-fields.tsx
@@ -1,6 +1,7 @@
 import type { FormEvent } from 'react';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { LoadingGearIcon } from '@/components/shared/loading-gear-icon';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import type { ContactUsContent } from '@/content';
 
@@ -25,6 +26,7 @@ interface ContactFormFieldsProps {
   captchaErrorMessage: string;
   submitErrorMessage: string;
   turnstileSiteKey: string;
+  isSubmitting: boolean;
   isSubmitDisabled: boolean;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onUpdateField: (field: keyof ContactUsFormState, value: string) => void;
@@ -42,6 +44,7 @@ export function ContactFormFields({
   captchaErrorMessage,
   submitErrorMessage,
   turnstileSiteKey,
+  isSubmitting,
   isSubmitDisabled,
   onSubmit,
   onUpdateField,
@@ -170,7 +173,11 @@ export function ContactFormFields({
         variant='primary'
         type='submit'
         disabled={isSubmitDisabled}
-        className='mt-2 w-full'
+        className={
+          isSubmitting
+            ? 'mt-2 inline-flex w-full items-center justify-center gap-2'
+            : 'mt-2 w-full'
+        }
         aria-describedby={
           captchaErrorMessage
             ? CAPTCHA_ERROR_MESSAGE_ID
@@ -179,7 +186,17 @@ export function ContactFormFields({
               : undefined
         }
       >
-        {content.submitLabel}
+        {isSubmitting ? (
+          <>
+            <span className='sr-only'>{content.submittingLabel}</span>
+            <LoadingGearIcon
+              className='h-5 w-5 animate-spin'
+              testId='contact-us-form-submit-loading-gear'
+            />
+          </>
+        ) : (
+          content.submitLabel
+        )}
       </ButtonPrimitive>
       <p className='text-base leading-7 text-[color:var(--site-primary-text)]'>
         {content.formDescription}

--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -279,6 +279,7 @@ export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
                 captchaErrorMessage={captchaErrorMessage}
                 submitErrorMessage={submitErrorMessage}
                 turnstileSiteKey={turnstileSiteKey}
+                isSubmitting={isSubmitting}
                 isSubmitDisabled={isSubmitDisabled}
                 onSubmit={handleSubmit}
                 onUpdateField={updateField}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -345,6 +345,7 @@
       "messageLabel": "Your message",
       "messagePlaceholder": "Your message",
       "submitLabel": "Launch the Message!",
+      "submittingLabel": "Sending message…",
       "formDescription": "I reply personally within 24-48 hours. No bots, no templates — just me.",
       "successTitle": "Thank you for your message!",
       "successDescription": "We have received your message and will answer shortly.",

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -345,6 +345,7 @@
       "messageLabel": "你的留言",
       "messagePlaceholder": "你的留言",
       "submitLabel": "发送留言！",
+      "submittingLabel": "正在发送留言…",
       "formDescription": "想用“漂流瓶”方式留言？填写下方联系表单，我们会像小芽发芽一样尽快回复你。",
       "successTitle": "感谢你的留言！",
       "successDescription": "我们已经收到你的留言，会尽快回复你。",

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -345,6 +345,7 @@
       "messageLabel": "你的留言",
       "messagePlaceholder": "你的留言",
       "submitLabel": "送出留言！",
+      "submittingLabel": "正在傳送留言…",
       "formDescription": "想用「漂流瓶」方式留言？填寫下方聯絡表單，我們會像小芽發芽一樣盡快回覆你。",
       "successTitle": "多謝你的留言！",
       "successDescription": "我們已經收到你的留言，會盡快回覆你。",

--- a/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
@@ -63,6 +63,7 @@ describe('ContactFormFields', () => {
         captchaErrorMessage='captcha failed'
         submitErrorMessage='submit failed'
         turnstileSiteKey='site-key'
+        isSubmitting={false}
         isSubmitDisabled={false}
         onSubmit={onSubmit}
         onUpdateField={onUpdateField}

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -324,6 +324,61 @@ describe('ContactUsForm section', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows the loading gear on the submit button while the request is in flight', async () => {
+    let releaseRequest: (() => void) | undefined;
+    const request = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          releaseRequest = () => {
+            reject(new Error('deferred failure'));
+          };
+        }),
+    );
+    mockedCreateCrmApiClient.mockReturnValue({
+      request,
+    });
+
+    renderContactUsForm();
+
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(enContent.contactUs.form.emailFieldLabel)),
+      { target: { value: 'parent@example.com' } },
+    );
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(enContent.contactUs.form.messageLabel)),
+      { target: { value: 'Tell me more about your course.' } },
+    );
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.contactUs.form.submitLabel,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole('button', {
+      name: enContent.contactUs.form.submittingLabel,
+    });
+    expect(submitButton).toBeDisabled();
+    const loadingGear = screen.getByTestId('contact-us-form-submit-loading-gear');
+    expect(loadingGear).toHaveClass('animate-spin');
+
+    releaseRequest?.();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: enContent.contactUs.form.submitLabel,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(enContent.contactUs.form.submitErrorMessage),
+      ).toBeInTheDocument();
+    });
+  });
+
   it('submits the validated form payload to the contact-us API endpoint', async () => {
     const request = vi.fn().mockResolvedValue(null);
     mockedCreateCrmApiClient.mockReturnValue({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While the contact form POST is in flight, the primary submit button now shows the same spinning gear icon used elsewhere on the public site (events, resources library, booking discount) instead of the "Launch the Message!" label.

## Details

- `ContactFormFields` accepts `isSubmitting` and swaps button content for `LoadingGearIcon` with `animate-spin`.
- Added `contactUs.form.submittingLabel` to `en.json`, `zh-CN.json`, and `zh-HK.json` for accessible accessible name (sr-only) while loading.
- Extended Vitest to assert the loading gear appears during a deferred API call.

## Testing

- `npm test -- --run tests/components/sections/contact-us-form.test.tsx tests/components/sections/contact-us-form-fields.test.tsx`
- `npx eslint` on touched files
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4d2c58b-d35f-4721-8ee0-2f529400bd2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4d2c58b-d35f-4721-8ee0-2f529400bd2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

