### PR TITLE
Phase 1: SES confirmations, marketing opt-in, and messaging name migration

### DIFF
--- a/apps/public_www/src/app/[locale]/contact-us/page.tsx
+++ b/apps/public_www/src/app/[locale]/contact-us/page.tsx
@@ -34,7 +34,7 @@ export default async function ContactUsRoutePage({ params }: LocaleRouteProps) {
 
   return (
     <>
-      <ContactUsPage content={content} />
+      <ContactUsPage content={content} locale={locale} />
       <StructuredDataScript
         id={`contact-us-breadcrumb-jsonld-${locale}`}
         data={buildBreadcrumbSchema({

--- a/apps/public_www/src/app/[locale]/services/free-guides-and-resources/page.tsx
+++ b/apps/public_www/src/app/[locale]/services/free-guides-and-resources/page.tsx
@@ -43,7 +43,7 @@ export default async function FreeGuidesAndResourcesRoutePage({
 
   return (
     <>
-      <FreeGuidesAndResourcesPage content={content} />
+      <FreeGuidesAndResourcesPage content={content} locale={locale} />
       <StructuredDataScript
         id={`free-guides-and-resources-breadcrumb-jsonld-${locale}`}
         data={buildBreadcrumbSchema({

--- a/apps/public_www/src/components/pages/contact-us.tsx
+++ b/apps/public_www/src/components/pages/contact-us.tsx
@@ -1,4 +1,4 @@
-import type { SiteContent } from '@/content';
+import type { Locale, SiteContent } from '@/content';
 import { PageLayout } from '@/components/shared/page-layout';
 import { ContactUsForm } from '@/components/sections/contact-us-form';
 import { FreeIntroSession } from '@/components/sections/free-intro-session';
@@ -7,9 +7,10 @@ import { resolvePublicSiteConfig } from '@/lib/site-config';
 
 interface ContactUsPageProps {
   content: SiteContent;
+  locale: Locale;
 }
 
-export function ContactUsPage({ content }: ContactUsPageProps) {
+export function ContactUsPage({ content, locale }: ContactUsPageProps) {
   const publicSiteConfig = resolvePublicSiteConfig();
 
   return (
@@ -19,6 +20,7 @@ export function ContactUsPage({ content }: ContactUsPageProps) {
     >
       <ContactUsForm
         content={content.contactUs.form}
+        locale={locale}
         contactConfig={{
           contactEmail: publicSiteConfig.contactEmail,
           whatsappUrl: publicSiteConfig.whatsappUrl,

--- a/apps/public_www/src/components/pages/free-guides-and-resources.tsx
+++ b/apps/public_www/src/components/pages/free-guides-and-resources.tsx
@@ -4,14 +4,16 @@ import { FreeGuidesAndResourcesHero } from '@/components/sections/free-guides-an
 import { FreeGuidesAndResourcesLibrary } from '@/components/sections/free-guides-and-resources-library';
 import { FreeResourcesForGentleParenting } from '@/components/sections/free-resources-for-gentle-parenting';
 import { SproutsSquadCommunity } from '@/components/sections/sprouts-squad-community';
-import type { SiteContent } from '@/content';
+import type { Locale, SiteContent } from '@/content';
 
 interface FreeGuidesAndResourcesPageProps {
   content: SiteContent;
+  locale: Locale;
 }
 
 export function FreeGuidesAndResourcesPage({
   content,
+  locale,
 }: FreeGuidesAndResourcesPageProps) {
   return (
     <PageLayout
@@ -19,10 +21,11 @@ export function FreeGuidesAndResourcesPage({
       footerContent={content.footer}
     >
       <FreeGuidesAndResourcesHero content={content.freeGuidesAndResources.hero} />
-      <FreeResourcesForGentleParenting content={content.resources} />
+      <FreeResourcesForGentleParenting content={content.resources} locale={locale} />
       <FreeGuidesAndResourcesLibrary
         content={content.freeGuidesAndResources.library}
         mediaFormContent={content.resources}
+        locale={locale}
       />
       <FreeGuidesAndResourcesFaq content={content.freeGuidesAndResources.faq} />
       <SproutsSquadCommunity

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
@@ -1,3 +1,4 @@
+import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import type { BookingPaymentModalContent } from '@/content';
 import type { BookingTopicsFieldConfig } from '@/components/sections/booking-modal/types';
 
@@ -8,12 +9,14 @@ interface ReservationFormFieldsProps {
   phone: string;
   interestedTopics: string;
   hasEmailError: boolean;
+  marketingOptIn: boolean;
   topicsFieldConfig?: BookingTopicsFieldConfig;
   onFullNameChange: (value: string) => void;
   onEmailChange: (value: string) => void;
   onEmailBlur: () => void;
   onPhoneChange: (value: string) => void;
   onTopicsChange: (value: string) => void;
+  onMarketingOptInChange: (checked: boolean) => void;
 }
 
 const EMAIL_ERROR_MESSAGE_ID = 'booking-modal-email-error-message';
@@ -25,12 +28,14 @@ export function ReservationFormFields({
   phone,
   interestedTopics,
   hasEmailError,
+  marketingOptIn,
   topicsFieldConfig,
   onFullNameChange,
   onEmailChange,
   onEmailBlur,
   onPhoneChange,
   onTopicsChange,
+  onMarketingOptInChange,
 }: ReservationFormFieldsProps) {
   const topicsFieldLabel = topicsFieldConfig?.label ?? content.topicsInterestLabel;
   const topicsFieldPlaceholder =
@@ -125,6 +130,12 @@ export function ReservationFormFields({
           className='es-focus-ring es-form-input resize-y'
         />
       </label>
+
+      <MarketingOptInCheckbox
+        label={content.marketingOptInLabel}
+        checked={marketingOptIn}
+        onChange={onMarketingOptInChange}
+      />
     </>
   );
 }

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -22,6 +22,7 @@ import type {
 } from '@/components/sections/booking-modal/types';
 import { useFormSubmission } from '@/components/sections/shared/use-form-submission';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { SmartLink } from '@/components/shared/smart-link';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { trackAnalyticsEvent, trackEcommerceEvent } from '@/lib/analytics';
@@ -423,6 +424,7 @@ export function BookingReservationForm({
   const [hasPendingReservationAcknowledgement, setHasPendingReservationAcknowledgement] =
     useState(false);
   const [hasTermsAgreement, setHasTermsAgreement] = useState(false);
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
   const {
     captchaToken,
     clearSubmissionError,
@@ -790,6 +792,18 @@ export function BookingReservationForm({
       setSubmissionError(content.submitErrorMessage);
       return;
     }
+    const scheduleTimeLabel = (() => {
+      if (!primarySession) {
+        return sanitizeSingleLineValue(selectedDateStartTime) || undefined;
+      }
+      const start = sanitizeSingleLineValue(primarySession.dateStartTime);
+      const end = sanitizeSingleLineValue(primarySession.dateEndTime ?? '');
+      if (!start) {
+        return undefined;
+      }
+      return end ? `${start} – ${end}` : start;
+    })();
+
     const reservationPayload: ReservationSubmissionPayload = {
       full_name: reservationSummary.attendeeName,
       email: reservationSummary.attendeeEmail,
@@ -804,6 +818,12 @@ export function BookingReservationForm({
       agreed_to_terms_and_conditions: hasTermsAgreement,
       payment_method: selectedPaymentMethod,
       stripe_payment_intent_id: undefined,
+      marketing_opt_in: marketingOptIn,
+      locale,
+      course_label: sanitizeSingleLineValue(eventTitle) || undefined,
+      schedule_date_label: sanitizeSingleLineValue(selectedCohortDateLabel) || undefined,
+      schedule_time_label: scheduleTimeLabel,
+      location_name: sanitizeSingleLineValue(venueName) || undefined,
     };
 
     await withSubmitting(async () => {
@@ -941,6 +961,12 @@ export function BookingReservationForm({
             originalAmount={originalAmount}
             discountAmount={discountAmount}
             totalAmount={totalAmount}
+          />
+
+          <MarketingOptInCheckbox
+            label={content.marketingOptInLabel}
+            checked={marketingOptIn}
+            onChange={setMarketingOptIn}
           />
 
           <div data-booking-payment='true' className='w-full space-y-2 py-1'>

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -22,7 +22,6 @@ import type {
 } from '@/components/sections/booking-modal/types';
 import { useFormSubmission } from '@/components/sections/shared/use-form-submission';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
-import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { SmartLink } from '@/components/shared/smart-link';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { trackAnalyticsEvent, trackEcommerceEvent } from '@/lib/analytics';
@@ -930,6 +929,7 @@ export function BookingReservationForm({
             phone={phone}
             interestedTopics={interestedTopics}
             hasEmailError={hasEmailError}
+            marketingOptIn={marketingOptIn}
             topicsFieldConfig={topicsFieldConfig}
             onFullNameChange={setFullName}
             onEmailChange={setEmail}
@@ -938,6 +938,7 @@ export function BookingReservationForm({
             }}
             onPhoneChange={setPhone}
             onTopicsChange={setInterestedTopics}
+            onMarketingOptInChange={setMarketingOptIn}
           />
 
           <ReservationFormDiscountCodeInput
@@ -961,12 +962,6 @@ export function BookingReservationForm({
             originalAmount={originalAmount}
             discountAmount={discountAmount}
             totalAmount={totalAmount}
-          />
-
-          <MarketingOptInCheckbox
-            label={content.marketingOptInLabel}
-            checked={marketingOptIn}
-            onChange={setMarketingOptIn}
           />
 
           <div data-booking-payment='true' className='w-full space-y-2 py-1'>

--- a/apps/public_www/src/components/sections/contact-us-form-fields.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form-fields.tsx
@@ -2,6 +2,7 @@ import type { FormEvent } from 'react';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import { LoadingGearIcon } from '@/components/shared/loading-gear-icon';
+import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import type { ContactUsContent } from '@/content';
 
@@ -15,6 +16,7 @@ export interface ContactUsFormState {
 const MESSAGE_MAX_LENGTH = 5000;
 const EMAIL_ERROR_MESSAGE_ID = 'contact-us-form-email-error';
 const PHONE_ERROR_MESSAGE_ID = 'contact-us-form-phone-error';
+const FIRST_NAME_ERROR_MESSAGE_ID = 'contact-us-form-first-name-error';
 const CAPTCHA_ERROR_MESSAGE_ID = 'contact-us-form-captcha-error';
 const SUBMIT_ERROR_MESSAGE_ID = 'contact-us-form-submit-error';
 
@@ -23,6 +25,8 @@ interface ContactFormFieldsProps {
   formState: ContactUsFormState;
   hasEmailError: boolean;
   hasPhoneError: boolean;
+  hasFirstNameError: boolean;
+  marketingOptIn: boolean;
   captchaErrorMessage: string;
   submitErrorMessage: string;
   turnstileSiteKey: string;
@@ -32,6 +36,8 @@ interface ContactFormFieldsProps {
   onUpdateField: (field: keyof ContactUsFormState, value: string) => void;
   onEmailBlur: () => void;
   onPhoneBlur: () => void;
+  onFirstNameBlur: () => void;
+  onMarketingOptInChange: (checked: boolean) => void;
   onCaptchaTokenChange: (token: string | null) => void;
   onCaptchaLoadError: () => void;
 }
@@ -41,6 +47,8 @@ export function ContactFormFields({
   formState,
   hasEmailError,
   hasPhoneError,
+  hasFirstNameError,
+  marketingOptIn,
   captchaErrorMessage,
   submitErrorMessage,
   turnstileSiteKey,
@@ -50,6 +58,8 @@ export function ContactFormFields({
   onUpdateField,
   onEmailBlur,
   onPhoneBlur,
+  onFirstNameBlur,
+  onMarketingOptInChange,
   onCaptchaTokenChange,
   onCaptchaLoadError,
 }: ContactFormFieldsProps) {
@@ -58,16 +68,32 @@ export function ContactFormFields({
       <label className='block'>
         <span className='mb-1 block text-sm font-semibold es-text-heading'>
           {content.firstNameLabel}
+          <span className='es-form-required-marker ml-0.5' aria-hidden='true'>
+            *
+          </span>
         </span>
         <input
           type='text'
+          required
           autoComplete='given-name'
           value={formState.firstName}
           onChange={(event) => {
             onUpdateField('firstName', event.target.value);
           }}
-          className='es-focus-ring es-form-input'
+          onBlur={onFirstNameBlur}
+          className={`es-focus-ring es-form-input ${hasFirstNameError ? 'es-form-input-error' : ''}`}
+          aria-invalid={hasFirstNameError}
+          aria-describedby={hasFirstNameError ? FIRST_NAME_ERROR_MESSAGE_ID : undefined}
         />
+        {hasFirstNameError ? (
+          <p
+            id={FIRST_NAME_ERROR_MESSAGE_ID}
+            className='text-sm es-text-danger'
+            role='alert'
+          >
+            {content.firstNameRequiredError}
+          </p>
+        ) : null}
       </label>
 
       <label className='block'>
@@ -147,6 +173,12 @@ export function ContactFormFields({
           className='es-focus-ring es-form-input min-h-[152px] resize-y'
         />
       </label>
+
+      <MarketingOptInCheckbox
+        label={content.marketingOptInLabel}
+        checked={marketingOptIn}
+        onChange={onMarketingOptInChange}
+      />
 
       <label className='block'>
         <span className='mb-1 block text-sm font-semibold es-text-heading'>

--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/sections/shared/section-container';
 import { SectionHeader } from '@/components/sections/shared/section-header';
 import { SectionShell } from '@/components/sections/shared/section-shell';
-import type { ContactUsContent } from '@/content';
+import type { ContactUsContent, Locale } from '@/content';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
 import { trackAnalyticsEvent } from '@/lib/analytics';
 import { CONTACT_US_API_PATH } from '@/lib/api-paths';
@@ -35,6 +35,7 @@ export type ContactUsFormContactConfig = Pick<
 
 interface ContactUsFormProps {
   content: ContactUsContent['form'];
+  locale: Locale;
   contactConfig: ContactUsFormContactConfig;
 }
 
@@ -54,7 +55,7 @@ function sanitizeMultilineValue(value: string): string {
   return value.replaceAll(/\r\n/g, '\n').replaceAll(/\r/g, '\n').trim();
 }
 
-export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
+export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormProps) {
   const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '';
   const crmApiClient = useMemo(() => createPublicCrmApiClient(), []);
   const [formState, setFormState] = useState<ContactUsFormState>({
@@ -149,11 +150,13 @@ export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
       phone_number?: string;
       message: string;
       marketing_opt_in: boolean;
+      locale: Locale;
     } = {
       email_address: normalizedEmail,
       message: normalizedMessage,
       first_name: normalizedFirstName,
       marketing_opt_in: marketingOptIn,
+      locale,
     };
     if (normalizedPhone) {
       requestBody.phone_number = normalizedPhone;

--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -65,6 +65,8 @@ export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
   });
   const [isEmailTouched, setIsEmailTouched] = useState(false);
   const [isPhoneTouched, setIsPhoneTouched] = useState(false);
+  const [isFirstNameTouched, setIsFirstNameTouched] = useState(false);
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
   const {
     captchaToken,
     clearSubmissionError,
@@ -87,6 +89,8 @@ export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
 
   const hasEmailError = isEmailTouched && !isValidEmail(formState.email);
   const hasPhoneError = isPhoneTouched && !isValidPhone(formState.phone);
+  const hasFirstNameError =
+    isFirstNameTouched && !sanitizeSingleLineValue(formState.firstName);
   const captchaErrorMessage = !isCaptchaConfigured
     ? content.captchaUnavailableError
     : hasCaptchaLoadError
@@ -115,9 +119,14 @@ export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
     clearSubmissionError();
     setIsEmailTouched(true);
     setIsPhoneTouched(true);
+    setIsFirstNameTouched(true);
     markCaptchaTouched();
 
-    if (!isValidEmail(formState.email) || !isValidPhone(formState.phone)) {
+    if (
+      !sanitizeSingleLineValue(formState.firstName) ||
+      !isValidEmail(formState.email) ||
+      !isValidPhone(formState.phone)
+    ) {
       return;
     }
     if (!captchaToken || isCaptchaUnavailable) {
@@ -135,17 +144,17 @@ export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
     const normalizedFirstName = sanitizeSingleLineValue(formState.firstName);
     const normalizedPhone = sanitizeSingleLineValue(formState.phone);
     const requestBody: {
-      first_name?: string;
+      first_name: string;
       email_address: string;
       phone_number?: string;
       message: string;
+      marketing_opt_in: boolean;
     } = {
       email_address: normalizedEmail,
       message: normalizedMessage,
+      first_name: normalizedFirstName,
+      marketing_opt_in: marketingOptIn,
     };
-    if (normalizedFirstName) {
-      requestBody.first_name = normalizedFirstName;
-    }
     if (normalizedPhone) {
       requestBody.phone_number = normalizedPhone;
     }
@@ -276,6 +285,8 @@ export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
                 formState={formState}
                 hasEmailError={hasEmailError}
                 hasPhoneError={hasPhoneError}
+                hasFirstNameError={hasFirstNameError}
+                marketingOptIn={marketingOptIn}
                 captchaErrorMessage={captchaErrorMessage}
                 submitErrorMessage={submitErrorMessage}
                 turnstileSiteKey={turnstileSiteKey}
@@ -289,6 +300,10 @@ export function ContactUsForm({ content, contactConfig }: ContactUsFormProps) {
                 onPhoneBlur={() => {
                   setIsPhoneTouched(true);
                 }}
+                onFirstNameBlur={() => {
+                  setIsFirstNameTouched(true);
+                }}
+                onMarketingOptInChange={setMarketingOptIn}
                 onCaptchaTokenChange={handleCaptchaTokenChange}
                 onCaptchaLoadError={handleCaptchaLoadError}
               />

--- a/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
+++ b/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
@@ -12,6 +12,7 @@ import { SectionShell } from '@/components/sections/shared/section-shell';
 import { formatContentTemplate } from '@/content/content-field-utils';
 import type {
   FreeGuidesAndResourcesLibraryContent,
+  Locale,
   ResourcesContent,
 } from '@/content';
 import {
@@ -23,6 +24,7 @@ import {
 interface FreeGuidesAndResourcesLibraryProps {
   content: FreeGuidesAndResourcesLibraryContent;
   mediaFormContent: ResourcesContent;
+  locale: Locale;
 }
 
 const ASSET_TYPES = ['guide', 'video', 'pdf', 'document'] as const;
@@ -222,6 +224,7 @@ function LibraryLensIcon() {
 export function FreeGuidesAndResourcesLibrary({
   content,
   mediaFormContent,
+  locale,
 }: FreeGuidesAndResourcesLibraryProps) {
   const [searchValue, setSearchValue] = useState('');
   const [formOpenedByListKey, setFormOpenedByListKey] = useState<
@@ -293,6 +296,7 @@ export function FreeGuidesAndResourcesLibrary({
   const mediaFormSuccessTitle = mediaFormContent.formSuccessTitle;
   const mediaFormSuccessBody = mediaFormContent.formSuccessBody;
   const mediaFormErrorMessage = mediaFormContent.formErrorMessage;
+  const mediaFormMarketingOptInLabel = mediaFormContent.formMarketingOptInLabel;
 
   const listBody = (() => {
     if (loadState === 'loading') {
@@ -402,6 +406,8 @@ export function FreeGuidesAndResourcesLibrary({
                     ctaLabel={gatedCtaLabel}
                     resourceKey={item.resourceKey}
                     analyticsSectionId='free-guides-library'
+                    locale={locale}
+                    formMarketingOptInLabel={mediaFormMarketingOptInLabel}
                     formFirstNameLabel={mediaFormFirstNameLabel}
                     formEmailLabel={mediaFormEmailLabel}
                     formSubmitLabel={mediaFormSubmitLabel}

--- a/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
+++ b/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
@@ -15,10 +15,11 @@ import {
   readStringUnion,
   toRecord,
 } from '@/content/content-field-utils';
-import type { ResourcesContent } from '@/content';
+import type { Locale, ResourcesContent } from '@/content';
 
 interface FreeResourcesForGentleParentingProps {
   content: ResourcesContent;
+  locale: Locale;
 }
 
 interface ChecklistEntry {
@@ -49,6 +50,8 @@ interface ResourceCardContentProps {
   formSuccessTitle: string;
   formSuccessBody: string;
   formErrorMessage: string;
+  formMarketingOptInLabel: string;
+  locale: Locale;
   showChecklist: boolean;
   onFormOpened: () => void;
 }
@@ -189,6 +192,8 @@ function ResourceCardContent({
   formSuccessTitle,
   formSuccessBody,
   formErrorMessage,
+  formMarketingOptInLabel,
+  locale,
   showChecklist,
   onFormOpened,
 }: ResourceCardContentProps) {
@@ -231,6 +236,8 @@ function ResourceCardContent({
         ctaLabel={ctaLabel}
         resourceKey={resourceKey}
         analyticsSectionId='resources'
+        locale={locale}
+        formMarketingOptInLabel={formMarketingOptInLabel}
         formFirstNameLabel={formFirstNameLabel}
         formEmailLabel={formEmailLabel}
         formSubmitLabel={formSubmitLabel}
@@ -245,6 +252,7 @@ function ResourceCardContent({
 
 export function FreeResourcesForGentleParenting({
   content,
+  locale,
 }: FreeResourcesForGentleParentingProps) {
   const [hasOpenedMediaForm, setHasOpenedMediaForm] = useState(false);
 
@@ -275,6 +283,9 @@ export function FreeResourcesForGentleParenting({
   const formErrorMessage =
     readOptionalText(content.formErrorMessage) ??
     fallbackResourcesContent.formErrorMessage;
+  const formMarketingOptInLabel =
+    readOptionalText(content.formMarketingOptInLabel) ??
+    fallbackResourcesContent.formMarketingOptInLabel;
   const checklistItems = resolveChecklistItems(content.items);
   const mediaTitleLine1 =
     readOptionalText(content.mediaTitleLine1) ??
@@ -312,6 +323,8 @@ export function FreeResourcesForGentleParenting({
       formSuccessTitle={formSuccessTitle}
       formSuccessBody={formSuccessBody}
       formErrorMessage={formErrorMessage}
+      formMarketingOptInLabel={formMarketingOptInLabel}
+      locale={locale}
       showChecklist={!hasOpenedMediaForm}
       onFormOpened={() => {
         setHasOpenedMediaForm(true);

--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -4,6 +4,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useId, useMemo, useState } from 'react';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { useFormSubmission } from '@/components/sections/shared/use-form-submission';
 import { trackAnalyticsEvent } from '@/lib/analytics';
@@ -13,9 +14,12 @@ import { mergeClassNames } from '@/lib/class-name-utils';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
 import { ServerSubmissionResult } from '@/lib/server-submission-result';
 import { isValidEmail, sanitizeSingleLineValue } from '@/lib/validation';
+import type { Locale } from '@/content';
 
 interface MediaFormProps {
   ctaLabel: string;
+  locale: Locale;
+  formMarketingOptInLabel: string;
   formFirstNameLabel: string;
   formEmailLabel: string;
   formSubmitLabel: string;
@@ -45,6 +49,8 @@ function normalizeResourceKey(value: string): string {
 
 export function MediaForm({
   ctaLabel,
+  locale,
+  formMarketingOptInLabel,
   formFirstNameLabel,
   formEmailLabel,
   formSubmitLabel,
@@ -70,6 +76,7 @@ export function MediaForm({
   const [email, setEmail] = useState('');
   const [isEmailTouched, setIsEmailTouched] = useState(false);
   const [isFirstNameTouched, setIsFirstNameTouched] = useState(false);
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
   const {
     captchaToken,
     clearSubmissionError,
@@ -151,9 +158,11 @@ export function MediaForm({
     }
 
     await withSubmitting(async () => {
-      const requestBody: Record<string, string> = {
+      const requestBody: Record<string, string | boolean> = {
         first_name: normalizedFirstName,
         email: normalizedEmail,
+        marketing_opt_in: marketingOptIn,
+        locale,
       };
       const normalizedResourceKey = normalizeResourceKey(resourceKey ?? '');
       if (normalizedResourceKey) {
@@ -269,6 +278,12 @@ export function MediaForm({
         aria-describedby={shouldShowSubmitError ? formErrorId : undefined}
         required
         disabled={isSubmitting}
+      />
+
+      <MarketingOptInCheckbox
+        label={formMarketingOptInLabel}
+        checked={marketingOptIn}
+        onChange={setMarketingOptIn}
       />
 
       <TurnstileCaptcha

--- a/apps/public_www/src/components/shared/marketing-opt-in-checkbox.tsx
+++ b/apps/public_www/src/components/shared/marketing-opt-in-checkbox.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+interface MarketingOptInCheckboxProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function MarketingOptInCheckbox({
+  label,
+  checked,
+  onChange,
+}: MarketingOptInCheckboxProps) {
+  return (
+    <label className='flex cursor-pointer items-start gap-2 text-sm es-text-heading'>
+      <input
+        type='checkbox'
+        checked={checked}
+        onChange={(event) => {
+          onChange(event.target.checked);
+        }}
+        className='es-focus-ring mt-0.5 h-4 w-4 shrink-0 rounded border es-border-input'
+      />
+      <span className='leading-snug'>{label}</span>
+    </label>
+  );
+}

--- a/apps/public_www/src/components/shared/marketing-opt-in-checkbox.tsx
+++ b/apps/public_www/src/components/shared/marketing-opt-in-checkbox.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 interface MarketingOptInCheckboxProps {
   label: string;
   checked: boolean;

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -182,6 +182,7 @@
     "formSuccessTitle": "Check Your Email!",
     "formSuccessBody": "The download link is in there.",
     "formErrorMessage": "Unable to submit right now. Please check your details and try again.",
+    "formMarketingOptInLabel": "Keep me updated with parenting tips and resources",
     "sectionConfig": {
       "_comment": "Template config for free resources section layout.",
       "_valueCombinations": [
@@ -355,7 +356,9 @@
       "captchaLoadError": "CAPTCHA failed to load. Please refresh and try again.",
       "captchaUnavailableError": "CAPTCHA is temporarily unavailable. Please try again later.",
       "emailValidationError": "Please enter a valid email address.",
-      "phoneValidationError": "Please enter a valid phone number."
+      "phoneValidationError": "Please enter a valid phone number.",
+      "firstNameRequiredError": "Please enter your name",
+      "marketingOptInLabel": "Keep me updated with parenting tips and resources"
     },
     "faq": {
       "title": "Frequently Asked Questions",
@@ -1434,6 +1437,7 @@
       "priceBreakdownConfirmedPriceLabel": "Confirmed Price",
       "paymentConfirmationNote": "Your spot is confirmed once payment is received",
       "pendingReservationAcknowledgementLabel": "I understand that my reservation is pending until payment is confirmed",
+      "marketingOptInLabel": "Keep me updated with parenting tips and resources",
       "termsAgreementLabel": "I agree with the",
       "termsLinkLabel": "Terms & Conditions",
       "termsHref": "/terms",

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -182,6 +182,7 @@
     "formSuccessTitle": "请查收你的邮箱！",
     "formSuccessBody": "下载链接就在里面。",
     "formErrorMessage": "暂时无法提交，请检查信息后重试。",
+    "formMarketingOptInLabel": "订阅育儿技巧与资源更新",
     "sectionConfig": {
       "_comment": "Template config for free resources section layout.",
       "_valueCombinations": [
@@ -355,7 +356,9 @@
       "captchaLoadError": "CAPTCHA 加载失败，请刷新后重试。",
       "captchaUnavailableError": "CAPTCHA 暂时不可用，请稍后再试。",
       "emailValidationError": "请输入有效的邮箱地址。",
-      "phoneValidationError": "请输入有效的电话号码。"
+      "phoneValidationError": "请输入有效的电话号码。",
+      "firstNameRequiredError": "请输入您的姓名",
+      "marketingOptInLabel": "订阅育儿技巧与资源更新"
     },
     "faq": {
       "title": "常见问题",
@@ -1434,6 +1437,7 @@
       "priceBreakdownConfirmedPriceLabel": "确认价格",
       "paymentConfirmationNote": "收到付款后，你的名额才会确认",
       "pendingReservationAcknowledgementLabel": "我明白在付款确认前，我的预约仍处于待确认状态",
+      "marketingOptInLabel": "订阅育儿技巧与资源更新",
       "termsAgreementLabel": "我同意",
       "termsLinkLabel": "条款与细则",
       "termsHref": "/terms",

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -182,6 +182,7 @@
     "formSuccessTitle": "請查收你的電郵！",
     "formSuccessBody": "下載連結就在裡面。",
     "formErrorMessage": "暫時未能提交，請檢查資料後再試。",
+    "formMarketingOptInLabel": "訂閱育兒貼士與資源更新",
     "sectionConfig": {
       "_comment": "Template config for free resources section layout.",
       "_valueCombinations": [
@@ -355,7 +356,9 @@
       "captchaLoadError": "CAPTCHA 載入失敗，請重新整理後再試。",
       "captchaUnavailableError": "CAPTCHA 暫時未能使用，請稍後再試。",
       "emailValidationError": "請輸入有效的電郵地址。",
-      "phoneValidationError": "請輸入有效的電話號碼。"
+      "phoneValidationError": "請輸入有效的電話號碼。",
+      "firstNameRequiredError": "請輸入你的姓名",
+      "marketingOptInLabel": "訂閱育兒貼士與資源更新"
     },
     "faq": {
       "title": "常見問題",
@@ -1434,6 +1437,7 @@
       "priceBreakdownConfirmedPriceLabel": "確認價格",
       "paymentConfirmationNote": "收到付款後，你的名額才會確認",
       "pendingReservationAcknowledgementLabel": "我明白在付款確認前，我的預約仍屬待確認狀態",
+      "marketingOptInLabel": "訂閱育兒貼士與資源更新",
       "termsAgreementLabel": "我同意",
       "termsLinkLabel": "條款及細則",
       "termsHref": "/terms",

--- a/apps/public_www/src/lib/reservations-data.ts
+++ b/apps/public_www/src/lib/reservations-data.ts
@@ -18,6 +18,12 @@ export interface ReservationSubmissionPayload {
   agreed_to_terms_and_conditions: boolean;
   payment_method: ReservationPaymentMethodCode;
   stripe_payment_intent_id?: string;
+  marketing_opt_in?: boolean;
+  locale?: string;
+  course_label?: string;
+  schedule_date_label?: string;
+  schedule_time_label?: string;
+  location_name?: string;
 }
 
 interface SubmitReservationOptions {

--- a/apps/public_www/tests/components/pages/contact-us.test.tsx
+++ b/apps/public_www/tests/components/pages/contact-us.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@/components/sections/free-intro-session', () => ({
 
 describe('ContactUsPage', () => {
   it('composes contact page sections with scoped content props', () => {
-    render(<ContactUsPage content={enContent} />);
+    render(<ContactUsPage content={enContent} locale='en' />);
 
     expect(screen.getByTestId('page-layout')).toBeInTheDocument();
     expect(screen.getByTestId('contact-us-form')).toBeInTheDocument();

--- a/apps/public_www/tests/components/pages/free-guides-and-resources.test.tsx
+++ b/apps/public_www/tests/components/pages/free-guides-and-resources.test.tsx
@@ -42,7 +42,7 @@ vi.mock('@/components/sections/free-guides-and-resources-faq', () => ({
 
 describe('FreeGuidesAndResourcesPage', () => {
   it('composes all page sections with scoped content', () => {
-    render(<FreeGuidesAndResourcesPage content={enContent} />);
+    render(<FreeGuidesAndResourcesPage content={enContent} locale='en' />);
 
     expect(screen.getByTestId('page-layout')).toBeInTheDocument();
     expect(screen.getByTestId('free-guides-hero')).toHaveTextContent(

--- a/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
@@ -20,11 +20,13 @@ describe('ReservationFormFields', () => {
         phone='12345678'
         interestedTopics='Boundaries'
         hasEmailError
+        marketingOptIn={false}
         onFullNameChange={onFullNameChange}
         onEmailChange={onEmailChange}
         onEmailBlur={onEmailBlur}
         onPhoneChange={onPhoneChange}
         onTopicsChange={onTopicsChange}
+        onMarketingOptInChange={vi.fn()}
       />,
     );
 
@@ -60,6 +62,7 @@ describe('ReservationFormFields', () => {
         phone=''
         interestedTopics=''
         hasEmailError={false}
+        marketingOptIn={false}
         topicsFieldConfig={{
           label: "What's your child's age?",
           placeholder: 'This will help me better personalise your experience',
@@ -70,6 +73,7 @@ describe('ReservationFormFields', () => {
         onEmailBlur={() => {}}
         onPhoneChange={() => {}}
         onTopicsChange={() => {}}
+        onMarketingOptInChange={() => {}}
       />,
     );
 

--- a/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
@@ -60,6 +60,8 @@ describe('ContactFormFields', () => {
         formState={formState}
         hasEmailError
         hasPhoneError
+        hasFirstNameError={false}
+        marketingOptIn={false}
         captchaErrorMessage='captcha failed'
         submitErrorMessage='submit failed'
         turnstileSiteKey='site-key'
@@ -69,6 +71,8 @@ describe('ContactFormFields', () => {
         onUpdateField={onUpdateField}
         onEmailBlur={onEmailBlur}
         onPhoneBlur={onPhoneBlur}
+        onFirstNameBlur={vi.fn()}
+        onMarketingOptInChange={vi.fn()}
         onCaptchaTokenChange={onCaptchaTokenChange}
         onCaptchaLoadError={onCaptchaLoadError}
       />,

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -83,6 +83,7 @@ function renderContactUsForm(
   return render(
     <ContactUsForm
       content={enContent.contactUs.form}
+      locale='en'
       contactConfig={contactConfig}
     />,
   );
@@ -428,6 +429,7 @@ describe('ContactUsForm section', () => {
           phone_number: '+852 1234 5678',
           message: 'Tell me more about your courses.',
           marketing_opt_in: false,
+          locale: 'en',
         },
         expectedSuccessStatuses: [200, 202],
       });

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -198,7 +198,7 @@ describe('ContactUsForm section', () => {
     renderContactUsForm();
 
     const firstNameInput = screen.getByLabelText(
-      enContent.contactUs.form.firstNameLabel,
+      new RegExp(`^${enContent.contactUs.form.firstNameLabel}`),
     );
     const emailInput = screen.getByLabelText(
       new RegExp(enContent.contactUs.form.emailFieldLabel),
@@ -309,6 +309,10 @@ describe('ContactUsForm section', () => {
       name: enContent.contactUs.form.submitLabel,
     });
 
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(`^${enContent.contactUs.form.firstNameLabel}`)),
+      { target: { value: 'Pat' } },
+    );
     fireEvent.change(emailInput, { target: { value: 'parent@example.com' } });
     fireEvent.change(messageInput, { target: { value: 'Tell me more about your course.' } });
     fireEvent.click(submitButton);
@@ -340,6 +344,10 @@ describe('ContactUsForm section', () => {
 
     renderContactUsForm();
 
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(`^${enContent.contactUs.form.firstNameLabel}`)),
+      { target: { value: 'Pat' } },
+    );
     fireEvent.change(
       screen.getByLabelText(new RegExp(enContent.contactUs.form.emailFieldLabel)),
       { target: { value: 'parent@example.com' } },
@@ -388,7 +396,7 @@ describe('ContactUsForm section', () => {
     renderContactUsForm();
 
     const firstNameInput = screen.getByLabelText(
-      enContent.contactUs.form.firstNameLabel,
+      new RegExp(`^${enContent.contactUs.form.firstNameLabel}`),
     );
     const emailInput = screen.getByLabelText(
       new RegExp(enContent.contactUs.form.emailFieldLabel),
@@ -419,6 +427,7 @@ describe('ContactUsForm section', () => {
           email_address: 'parent@example.com',
           phone_number: '+852 1234 5678',
           message: 'Tell me more about your courses.',
+          marketing_opt_in: false,
         },
         expectedSuccessStatuses: [200, 202],
       });
@@ -476,6 +485,10 @@ describe('ContactUsForm section', () => {
 
     renderContactUsForm();
 
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(`^${enContent.contactUs.form.firstNameLabel}`)),
+      { target: { value: 'Pat' } },
+    );
     fireEvent.change(
       screen.getByLabelText(new RegExp(enContent.contactUs.form.emailFieldLabel)),
       { target: { value: 'parent@example.com' } },

--- a/apps/public_www/tests/components/sections/free-guides-and-resources-library.test.tsx
+++ b/apps/public_www/tests/components/sections/free-guides-and-resources-library.test.tsx
@@ -87,6 +87,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -142,6 +143,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -171,6 +173,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -200,6 +203,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -223,6 +227,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -243,6 +248,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -273,6 +279,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -344,6 +351,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -376,6 +384,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -397,6 +406,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -449,6 +459,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -474,6 +485,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -489,6 +501,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 
@@ -502,6 +515,7 @@ describe('FreeGuidesAndResourcesLibrary', () => {
       <FreeGuidesAndResourcesLibrary
         content={content}
         mediaFormContent={mediaFormContent}
+        locale='en'
       />,
     );
 

--- a/apps/public_www/tests/components/sections/free-resources-for-gentle-parenting.test.tsx
+++ b/apps/public_www/tests/components/sections/free-resources-for-gentle-parenting.test.tsx
@@ -35,7 +35,8 @@ function createResourcesContent(
 describe('Free resources for gentle parenting section', () => {
   it('uses center heading and split layout defaults', () => {
     const { container } = render(
-      <FreeResourcesForGentleParenting content={enContent.resources} />,
+      <FreeResourcesForGentleParenting content={enContent.resources}
+        locale='en' />,
     );
 
     const section = container.querySelector('section[data-figma-node="resources"]');
@@ -65,7 +66,8 @@ describe('Free resources for gentle parenting section', () => {
 
   it('applies the orange tile background pattern to the card container', () => {
     const { container, rerender } = render(
-      <FreeResourcesForGentleParenting content={enContent.resources} />,
+      <FreeResourcesForGentleParenting content={enContent.resources}
+        locale='en' />,
     );
 
     const layout = screen.getByTestId('free-resource-layout');
@@ -83,7 +85,8 @@ describe('Free resources for gentle parenting section', () => {
       imagePosition: 'right',
       cardPosition: 'right',
     });
-    rerender(<FreeResourcesForGentleParenting content={overlayContent} />);
+    rerender(<FreeResourcesForGentleParenting content={overlayContent}
+        locale='en' />);
 
     const overlayLayout = screen.getByTestId('free-resource-layout');
     const overlayMediaPane = screen.getByTestId('free-resource-media-pane');
@@ -98,7 +101,8 @@ describe('Free resources for gentle parenting section', () => {
   it('does not render the circular play-arrow overlay on the media image', () => {
     const playIconPathSelector = 'path[d="M12 9.8L23 16L12 22.2V9.8Z"]';
     const { container, rerender } = render(
-      <FreeResourcesForGentleParenting content={enContent.resources} />,
+      <FreeResourcesForGentleParenting content={enContent.resources}
+        locale='en' />,
     );
 
     expect(container.querySelector(playIconPathSelector)).toBeNull();
@@ -109,14 +113,16 @@ describe('Free resources for gentle parenting section', () => {
       imagePosition: 'right',
       cardPosition: 'right',
     });
-    rerender(<FreeResourcesForGentleParenting content={overlayContent} />);
+    rerender(<FreeResourcesForGentleParenting content={overlayContent}
+        locale='en' />);
 
     expect(container.querySelector(playIconPathSelector)).toBeNull();
   });
 
   it('renders checklist list items with white rounded backgrounds', () => {
     const { container } = render(
-      <FreeResourcesForGentleParenting content={enContent.resources} />,
+      <FreeResourcesForGentleParenting content={enContent.resources}
+        locale='en' />,
     );
 
     const checklistList = container.querySelector('ul');
@@ -132,7 +138,8 @@ describe('Free resources for gentle parenting section', () => {
 
   it('hides the checklist after the first CTA reveals the form', () => {
     const { container } = render(
-      <FreeResourcesForGentleParenting content={enContent.resources} />,
+      <FreeResourcesForGentleParenting content={enContent.resources}
+        locale='en' />,
     );
 
     expect(container.querySelector('ul')).not.toBeNull();
@@ -148,7 +155,8 @@ describe('Free resources for gentle parenting section', () => {
       cardPosition: 'left',
     });
 
-    render(<FreeResourcesForGentleParenting content={content} />);
+    render(<FreeResourcesForGentleParenting content={content}
+        locale='en' />);
 
     const header = screen.getByTestId('free-resource-header');
     expect(header.className).toContain('text-left');
@@ -163,7 +171,8 @@ describe('Free resources for gentle parenting section', () => {
       cardPosition: 'left',
     });
 
-    render(<FreeResourcesForGentleParenting content={content} />);
+    render(<FreeResourcesForGentleParenting content={content}
+        locale='en' />);
 
     const layout = screen.getByTestId('free-resource-layout');
     const textPane = screen.getByTestId('free-resource-text-pane');
@@ -185,7 +194,8 @@ describe('Free resources for gentle parenting section', () => {
       cardPosition: 'right',
     });
 
-    render(<FreeResourcesForGentleParenting content={content} />);
+    render(<FreeResourcesForGentleParenting content={content}
+        locale='en' />);
 
     const layout = screen.getByTestId('free-resource-layout');
     const overlayWrapper = screen.getByTestId(
@@ -204,7 +214,8 @@ describe('Free resources for gentle parenting section', () => {
       cardPosition: 'middle',
     });
 
-    render(<FreeResourcesForGentleParenting content={content} />);
+    render(<FreeResourcesForGentleParenting content={content}
+        locale='en' />);
 
     const header = screen.getByTestId('free-resource-header');
     const layout = screen.getByTestId('free-resource-layout');

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -61,7 +61,9 @@ function mediaFormProps() {
   const resourcesContent = enContent.resources;
   return {
     ctaLabel: resourcesContent.ctaLabel,
+    locale: 'en' as const,
     resourceKey: resourcesContent.resourceKey,
+    formMarketingOptInLabel: resourcesContent.formMarketingOptInLabel,
     formFirstNameLabel: resourcesContent.formFirstNameLabel,
     formEmailLabel: resourcesContent.formEmailLabel,
     formSubmitLabel: resourcesContent.formSubmitLabel,
@@ -167,6 +169,8 @@ describe('MediaForm', () => {
           first_name: 'Ida',
           email: 'ida@example.com',
           resource_key: 'patience-free-guide',
+          marketing_opt_in: false,
+          locale: 'en',
         },
         turnstileToken: 'mock-turnstile-token',
         expectedSuccessStatuses: [202],

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -229,6 +229,21 @@ if (!selectedCohortDate) {
   throw new Error('Selected cohort must include a valid primary session date.');
 }
 
+const primarySessionPart = selectedCohort.dates[0];
+const expectedMbaScheduleTimeLabel =
+  primarySessionPart !== undefined && primarySessionPart.end_datetime
+    ? `${primarySessionPart.start_datetime} – ${primarySessionPart.end_datetime}`
+    : primarySessionPart?.start_datetime;
+
+const expectedMbaMarketingFields = {
+  marketing_opt_in: false,
+  locale: 'en' as const,
+  course_label: myBestAuntieModalContent.title,
+  schedule_date_label: 'Apr, 2026',
+  schedule_time_label: expectedMbaScheduleTimeLabel,
+  location_name: selectedCohort.location_name,
+};
+
 function renderWithPortalContainer(ui: ReactNode) {
   const renderView = render(ui);
   return {
@@ -823,26 +838,28 @@ describe('my-best-auntie booking modals footer content', () => {
     );
 
     await waitFor(() => {
-      expect(requestSpy).toHaveBeenCalledWith({
-        endpointPath: '/v1/legacy/reservations',
-        method: 'POST',
-        body: {
-          full_name: 'Test User',
-          email: 'ida@example.com',
-          phone_number: '85212345678',
-          cohort_age: '18-24 months',
-          cohort_date: selectedCohortDate,
-          comments: 'Need details',
-          discount_code: undefined,
-          price: 9000,
-          reservation_pending_until_payment_confirmed: true,
-          agreed_to_terms_and_conditions: true,
-          payment_method: 'fps_qr',
-          stripe_payment_intent_id: undefined,
-        },
-        turnstileToken: 'mock-turnstile-token',
-        expectedSuccessStatuses: [200, 202],
-      });
+      expect(requestSpy).toHaveBeenCalled();
+    });
+    expect(requestSpy).toHaveBeenCalledWith({
+      endpointPath: '/v1/legacy/reservations',
+      method: 'POST',
+      body: expect.objectContaining({
+        full_name: 'Test User',
+        email: 'ida@example.com',
+        phone_number: '85212345678',
+        cohort_age: '18-24 months',
+        cohort_date: selectedCohortDate,
+        comments: 'Need details',
+        discount_code: undefined,
+        price: 9000,
+        reservation_pending_until_payment_confirmed: true,
+        agreed_to_terms_and_conditions: true,
+        payment_method: 'fps_qr',
+        stripe_payment_intent_id: undefined,
+        ...expectedMbaMarketingFields,
+      }),
+      turnstileToken: 'mock-turnstile-token',
+      expectedSuccessStatuses: [200, 202],
     });
     await waitFor(() => {
       expect(onSubmitReservation).toHaveBeenCalledWith(
@@ -1039,26 +1056,28 @@ describe('my-best-auntie booking modals footer content', () => {
     );
 
     await waitFor(() => {
-      expect(requestSpy).toHaveBeenCalledWith({
-        endpointPath: '/v1/legacy/reservations',
-        method: 'POST',
-        body: {
-          full_name: 'Test User',
-          email: 'ida@example.com',
-          phone_number: '85212345678',
-          cohort_age: '18-24 months',
-          cohort_date: selectedCohortDate,
-          comments: 'Need details',
-          discount_code: undefined,
-          price: 9000,
-          reservation_pending_until_payment_confirmed: true,
-          agreed_to_terms_and_conditions: true,
-          payment_method: 'stripe',
-          stripe_payment_intent_id: 'pi_test_booking_modal',
-        },
-        turnstileToken: 'mock-turnstile-token',
-        expectedSuccessStatuses: [200, 202],
-      });
+      expect(requestSpy).toHaveBeenCalled();
+    });
+    expect(requestSpy).toHaveBeenCalledWith({
+      endpointPath: '/v1/legacy/reservations',
+      method: 'POST',
+      body: expect.objectContaining({
+        full_name: 'Test User',
+        email: 'ida@example.com',
+        phone_number: '85212345678',
+        cohort_age: '18-24 months',
+        cohort_date: selectedCohortDate,
+        comments: 'Need details',
+        discount_code: undefined,
+        price: 9000,
+        reservation_pending_until_payment_confirmed: true,
+        agreed_to_terms_and_conditions: true,
+        payment_method: 'stripe',
+        stripe_payment_intent_id: 'pi_test_booking_modal',
+        ...expectedMbaMarketingFields,
+      }),
+      turnstileToken: 'mock-turnstile-token',
+      expectedSuccessStatuses: [200, 202],
     });
     await waitFor(() => {
       expect(onSubmitReservation).toHaveBeenCalledWith(

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1526,6 +1526,7 @@ export class ApiStack extends cdk.Stack {
         LEGACY_PUBLIC_API_KEY: legacyPublicApiKey.valueAsString,
         NOMINATIM_USER_AGENT: nominatimUserAgent.valueAsString,
         NOMINATIM_REFERER: nominatimReferer.valueAsString,
+        SES_SENDER_EMAIL: sesSenderEmail.valueAsString,
       },
     });
     database.grantAdminUserSecretRead(adminFunction);
@@ -1620,11 +1621,6 @@ export class ApiStack extends cdk.Stack {
         noVpc: true,
       }
     );
-    sesTemplateManagerFunction.addPermission("SesTemplateManagerCfnPermission", {
-      principal: new iam.ServicePrincipal("cloudformation.amazonaws.com"),
-      sourceArn: cdk.Stack.of(this).stackId,
-      sourceAccount: cdk.Stack.of(this).account,
-    });
     sesTemplateManagerFunction.addToRolePolicy(
       new iam.PolicyStatement({
         actions: [

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1228,19 +1228,27 @@ export class ApiStack extends cdk.Stack {
         // access (e.g., authorizers that fetch JWKS from Cognito)
         noVpc?: boolean;
         manageLogGroup?: boolean;
+        /** When true, omit physical functionName so CloudFormation can replace the function during two-phase nested-stack migration. */
+        omitFunctionName?: boolean;
       }
     ) => {
       const factory = props.noVpc ? noVpcLambdaFactory : lambdaFactory;
-      const pythonLambda = factory.create(id, {
-        functionName: name(id),
+      const baseProps = {
         handler: props.handler,
         environment: props.environment,
         timeout: props.timeout,
         extraCopyPaths: props.extraCopyPaths,
         securityGroups: props.noVpc ? undefined : (props.securityGroups ?? [lambdaSecurityGroup]),
         memorySize: props.memorySize,
-        manageLogGroup: props.manageLogGroup,
-      });
+        // Omitting physical functionName requires AWS-managed default log groups
+        // (PythonLambda cannot create a fixed /aws/lambda/{name} log group without a name).
+        manageLogGroup: props.omitFunctionName
+          ? false
+          : (props.manageLogGroup ?? true),
+      };
+      const pythonLambda = props.omitFunctionName
+        ? factory.create(id, baseProps)
+        : factory.create(id, { ...baseProps, functionName: name(id) });
       return pythonLambda.function;
     };
 
@@ -1619,6 +1627,7 @@ export class ApiStack extends cdk.Stack {
         memorySize: 256,
         timeout: cdk.Duration.seconds(60),
         noVpc: true,
+        omitFunctionName: true,
       }
     );
     sesTemplateManagerFunction.addToRolePolicy(
@@ -1676,14 +1685,12 @@ export class ApiStack extends cdk.Stack {
     ]);
 
     const bookingRequestDLQ = new sqs.Queue(this, "BookingRequestDLQ", {
-      queueName: name("booking-request-dlq"),
       retentionPeriod: cdk.Duration.days(14),
       encryption: sqs.QueueEncryption.KMS,
       encryptionMasterKey: sqsEncryptionKey,
     });
 
     const bookingRequestQueue = new sqs.Queue(this, "BookingRequestQueue", {
-      queueName: name("booking-request-queue"),
       visibilityTimeout: cdk.Duration.seconds(60),
       deadLetterQueue: {
         queue: bookingRequestDLQ,
@@ -1694,7 +1701,6 @@ export class ApiStack extends cdk.Stack {
     });
 
     const bookingRequestTopic = new sns.Topic(this, "BookingRequestTopic", {
-      topicName: name("booking-request-events"),
       masterKey: sqsEncryptionKey,
     });
 
@@ -1713,6 +1719,7 @@ export class ApiStack extends cdk.Stack {
       {
         handler: "lambda/manager_request_processor/handler.lambda_handler",
         timeout: cdk.Duration.seconds(10),
+        omitFunctionName: true,
         environment: {
           DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
           DATABASE_NAME: "evolvesprouts",
@@ -1742,7 +1749,6 @@ export class ApiStack extends cdk.Stack {
     );
 
     const dlqAlarm = new cdk.aws_cloudwatch.Alarm(this, "BookingRequestDLQAlarm", {
-      alarmName: name("booking-request-dlq-alarm"),
       alarmDescription: "Booking request messages failed processing and landed in DLQ",
       metric: bookingRequestDLQ.metricApproximateNumberOfMessagesVisible({
         period: cdk.Duration.minutes(5),
@@ -1757,14 +1763,12 @@ export class ApiStack extends cdk.Stack {
     // -------------------------------------------------------------------------
 
     const mediaDLQ = new sqs.Queue(this, "MediaDLQ", {
-      queueName: name("media-dlq"),
       retentionPeriod: cdk.Duration.days(14),
       encryption: sqs.QueueEncryption.KMS,
       encryptionMasterKey: sqsEncryptionKey,
     });
 
     const mediaQueue = new sqs.Queue(this, "MediaQueue", {
-      queueName: name("media-queue"),
       visibilityTimeout: cdk.Duration.seconds(60),
       deadLetterQueue: {
         queue: mediaDLQ,
@@ -1775,7 +1779,6 @@ export class ApiStack extends cdk.Stack {
     });
 
     const mediaTopic = new sns.Topic(this, "MediaTopic", {
-      topicName: name("media-events"),
       masterKey: sqsEncryptionKey,
     });
 
@@ -1790,6 +1793,7 @@ export class ApiStack extends cdk.Stack {
       {
         handler: "lambda/media_processor/handler.lambda_handler",
         timeout: cdk.Duration.seconds(30),
+        omitFunctionName: true,
         environment: {
           DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
           DATABASE_NAME: "evolvesprouts",
@@ -1850,7 +1854,6 @@ export class ApiStack extends cdk.Stack {
     );
 
     const mediaDlqAlarm = new cdk.aws_cloudwatch.Alarm(this, "MediaDLQAlarm", {
-      alarmName: name("media-dlq-alarm"),
       alarmDescription:
         "Media request messages failed processing and landed in DLQ",
       metric: mediaDLQ.metricApproximateNumberOfMessagesVisible({
@@ -1866,14 +1869,12 @@ export class ApiStack extends cdk.Stack {
     // -------------------------------------------------------------------------
 
     const expenseParserDLQ = new sqs.Queue(this, "ExpenseParserDLQ", {
-      queueName: name("expense-parser-dlq"),
       retentionPeriod: cdk.Duration.days(14),
       encryption: sqs.QueueEncryption.KMS,
       encryptionMasterKey: sqsEncryptionKey,
     });
 
     const expenseParserQueue = new sqs.Queue(this, "ExpenseParserQueue", {
-      queueName: name("expense-parser-queue"),
       visibilityTimeout: cdk.Duration.seconds(180),
       deadLetterQueue: {
         queue: expenseParserDLQ,
@@ -1884,7 +1885,6 @@ export class ApiStack extends cdk.Stack {
     });
 
     const expenseParserTopic = new sns.Topic(this, "ExpenseParserTopic", {
-      topicName: name("expense-parser-events"),
       masterKey: sqsEncryptionKey,
     });
     expenseParserTopic.addSubscription(
@@ -1899,6 +1899,7 @@ export class ApiStack extends cdk.Stack {
     const expenseParserFunction = createPythonFunction("ExpenseParserFunction", {
       handler: "lambda/expense_parser/handler.lambda_handler",
       timeout: cdk.Duration.seconds(90),
+      omitFunctionName: true,
       environment: {
         DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
         DATABASE_NAME: "evolvesprouts",
@@ -1930,7 +1931,6 @@ export class ApiStack extends cdk.Stack {
       this,
       "ExpenseParserDLQAlarm",
       {
-        alarmName: name("expense-parser-dlq-alarm"),
         alarmDescription:
           "Expense parser messages failed processing and landed in DLQ",
         metric: expenseParserDLQ.metricApproximateNumberOfMessagesVisible({

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -781,6 +781,42 @@ export class ApiStack extends cdk.Stack {
           "(empty disables journey trigger)",
       }
     );
+    const mailchimpWelcomeJourneyId = new cdk.CfnParameter(
+      this,
+      "MailchimpWelcomeJourneyId",
+      {
+        type: "String",
+        default: "",
+        description:
+          "Mailchimp Customer Journey ID for the shared welcome flow " +
+          "(triggered for opted-in contacts from contact/media/booking forms). " +
+          "Empty disables the trigger.",
+      }
+    );
+    const mailchimpWelcomeJourneyStepId = new cdk.CfnParameter(
+      this,
+      "MailchimpWelcomeJourneyStepId",
+      {
+        type: "String",
+        default: "",
+        description:
+          "Mailchimp Customer Journey step ID for the welcome flow entry point. " +
+          "Empty disables the trigger.",
+      }
+    );
+    const mailchimpRequireMarketingConsent = new cdk.CfnParameter(
+      this,
+      "MailchimpRequireMarketingConsent",
+      {
+        type: "String",
+        default: "false",
+        allowedValues: ["true", "false"],
+        description:
+          "When true, the media processor only subscribes to Mailchimp when " +
+          "marketing_opt_in is set. Set to false during SES download link " +
+          "transition to preserve existing behavior.",
+      }
+    );
     const openrouterApiKey = new cdk.CfnParameter(
       this,
       "OpenRouterApiKey",
@@ -1567,11 +1603,48 @@ export class ApiStack extends cdk.Stack {
 
     const [sesSenderIdentityArn, sesSenderDomainIdentityArn] =
       sesVerifiedAddressAndDomainIdentityArns(this, sesSenderEmail.valueAsString);
+    const [sesAuthEmailIdentityArn, sesAuthEmailDomainIdentityArn] =
+      sesVerifiedAddressAndDomainIdentityArns(this, authEmailFromAddress.valueAsString);
     const mailchimpApiSecret = secretsmanager.Secret.fromSecretCompleteArn(
       this,
       "MailchimpApiSecret",
       mailchimpApiSecretArn.valueAsString
     );
+
+    const sesTemplateManagerFunction = createPythonFunction(
+      "SesTemplateManagerFunction",
+      {
+        handler: "lambda/ses_template_manager/handler.lambda_handler",
+        memorySize: 256,
+        timeout: cdk.Duration.seconds(60),
+        noVpc: true,
+      }
+    );
+    sesTemplateManagerFunction.addPermission("SesTemplateManagerCfnPermission", {
+      principal: new iam.ServicePrincipal("cloudformation.amazonaws.com"),
+      sourceArn: cdk.Stack.of(this).stackId,
+      sourceAccount: cdk.Stack.of(this).account,
+    });
+    sesTemplateManagerFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "ses:CreateTemplate",
+          "ses:UpdateTemplate",
+          "ses:DeleteTemplate",
+          "ses:GetTemplate",
+        ],
+        resources: ["*"],
+      })
+    );
+    const sesTemplatesHash = hashDirectory(
+      path.join(__dirname, "../../src/app/templates/ses")
+    );
+    new cdk.CustomResource(this, "SesEmailTemplates", {
+      serviceToken: sesTemplateManagerFunction.functionArn,
+      properties: {
+        TemplatesHash: sesTemplatesHash,
+      },
+    });
     // SECURITY: Use customer-managed KMS key for Secrets Manager (Checkov CKV_AWS_149)
     const secretsEncryptionKey = new kms.Key(this, "SecretsEncryptionKey", {
       enableKeyRotation: true,
@@ -1744,6 +1817,15 @@ export class ApiStack extends cdk.Stack {
             mailchimpFreeResourceJourneyId.valueAsString,
           MAILCHIMP_FREE_RESOURCE_JOURNEY_STEP_ID:
             mailchimpFreeResourceJourneyStepId.valueAsString,
+          CONFIRMATION_EMAIL_FROM_ADDRESS:
+            authEmailFromAddress.valueAsString,
+          MAILCHIMP_REQUIRE_MARKETING_CONSENT:
+            mailchimpRequireMarketingConsent.valueAsString,
+          MAILCHIMP_WELCOME_JOURNEY_ID: mailchimpWelcomeJourneyId.valueAsString,
+          MAILCHIMP_WELCOME_JOURNEY_STEP_ID:
+            mailchimpWelcomeJourneyStepId.valueAsString,
+          PUBLIC_WWW_BASE_URL:
+            `https://${publicWwwDomainName.valueAsString}`,
         },
       }
     );
@@ -1753,8 +1835,13 @@ export class ApiStack extends cdk.Stack {
 
     mediaRequestProcessor.addToRolePolicy(
       new iam.PolicyStatement({
-        actions: ["ses:SendEmail", "ses:SendRawEmail"],
-        resources: [sesSenderIdentityArn, sesSenderDomainIdentityArn],
+        actions: ["ses:SendEmail", "ses:SendRawEmail", "ses:SendTemplatedEmail"],
+        resources: [
+          sesSenderIdentityArn,
+          sesSenderDomainIdentityArn,
+          sesAuthEmailIdentityArn,
+          sesAuthEmailDomainIdentityArn,
+        ],
       })
     );
     mailchimpApiSecret.grantRead(mediaRequestProcessor);
@@ -2684,6 +2771,45 @@ export class ApiStack extends cdk.Stack {
       principal: new iam.ServicePrincipal("apigateway.amazonaws.com"),
       sourceArn: api.arnForExecuteApi(),
     });
+
+    adminFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["ses:SendEmail", "ses:SendRawEmail", "ses:SendTemplatedEmail"],
+        resources: [
+          sesSenderIdentityArn,
+          sesSenderDomainIdentityArn,
+          sesAuthEmailIdentityArn,
+          sesAuthEmailDomainIdentityArn,
+        ],
+      })
+    );
+    mailchimpApiSecret.grantRead(adminFunction);
+    adminFunction.addEnvironment(
+      "CONFIRMATION_EMAIL_FROM_ADDRESS",
+      authEmailFromAddress.valueAsString
+    );
+    adminFunction.addEnvironment("SUPPORT_EMAIL", supportEmail.valueAsString);
+    adminFunction.addEnvironment(
+      "MAILCHIMP_API_SECRET_ARN",
+      mailchimpApiSecret.secretArn
+    );
+    adminFunction.addEnvironment("MAILCHIMP_LIST_ID", mailchimpListId.valueAsString);
+    adminFunction.addEnvironment(
+      "MAILCHIMP_SERVER_PREFIX",
+      mailchimpServerPrefix.valueAsString
+    );
+    adminFunction.addEnvironment(
+      "MAILCHIMP_WELCOME_JOURNEY_ID",
+      mailchimpWelcomeJourneyId.valueAsString
+    );
+    adminFunction.addEnvironment(
+      "MAILCHIMP_WELCOME_JOURNEY_STEP_ID",
+      mailchimpWelcomeJourneyStepId.valueAsString
+    );
+    adminFunction.addEnvironment(
+      "PUBLIC_WWW_BASE_URL",
+      `https://${publicWwwDomainName.valueAsString}`
+    );
 
     const calendar = v1.addResource("calendar");
     calendar.addResource("public").addMethod("GET", adminIntegration, {

--- a/backend/infrastructure/lib/constructs/python-lambda.ts
+++ b/backend/infrastructure/lib/constructs/python-lambda.ts
@@ -26,8 +26,13 @@ export function selectPrivateSubnets(_vpc: ec2.IVpc): ec2.SubnetSelection {
  * Properties for the PythonLambda construct.
  */
 export interface PythonLambdaProps {
-  /** Function name (required for standard /aws/lambda/ log group naming). */
-  functionName: string;
+  /**
+   * Physical Lambda function name. When omitted, CloudFormation assigns a unique
+   * generated name (useful for brief migration windows). A managed log group with
+   * KMS encryption requires an explicit name; omitting `functionName` while
+   * `manageLogGroup` is true is invalid.
+   */
+  functionName?: string;
   /** Handler path (e.g., "lambda/handler.lambda_handler"). */
   handler: string;
   /** Optional function description. */
@@ -154,6 +159,11 @@ export class PythonLambda extends Construct {
       });
 
     const manageLogGroup = props.manageLogGroup ?? true;
+    if (manageLogGroup && !props.functionName) {
+      throw new Error(
+        "PythonLambda: manageLogGroup requires functionName (fixed log group path /aws/lambda/{functionName})."
+      );
+    }
     const logEncryptionKey = manageLogGroup
       ? props.logEncryptionKey ?? this.createLogEncryptionKey()
       : undefined;
@@ -170,7 +180,7 @@ export class PythonLambda extends Construct {
     // COST OPTIMIZATION: Use ARM64 architecture for 20% cost savings
     // Graviton2 processors offer better price-performance ratio
     this.function = new lambda.Function(this, "Function", {
-      functionName: props.functionName,
+      ...(props.functionName ? { functionName: props.functionName } : {}),
       runtime: lambda.Runtime.PYTHON_3_12,
       architecture: lambda.Architecture.ARM_64,
       handler: props.handler,

--- a/backend/lambda/media_processor/handler.py
+++ b/backend/lambda/media_processor/handler.py
@@ -170,6 +170,7 @@ def _process_message(message: dict[str, Any]) -> bool:
                     tag_name=tag_name,
                     merge_fields=None,
                     logger=logger,
+                    subscribe_member=not was_mailchimp_synced,
                 )
             logger.info(
                 "Skipping duplicate media lead",
@@ -254,6 +255,7 @@ def _process_message(message: dict[str, Any]) -> bool:
                 tag_name=tag_name,
                 merge_fields=None,
                 logger=logger,
+                subscribe_member=not was_mailchimp_synced,
             )
 
         _send_sales_notification(

--- a/backend/lambda/media_processor/handler.py
+++ b/backend/lambda/media_processor/handler.py
@@ -34,12 +34,13 @@ from app.api.assets.share_links import (
 from app.db.repositories.asset import AssetRepository
 from app.db.repositories.contact import ContactRepository
 from app.db.repositories.sales_lead import SalesLeadRepository
-from app.services.email import send_email
+from app.services.email import send_email, send_templated_email
 from app.services.mailchimp import (
     MailchimpApiError,
     add_subscriber_with_tag,
     trigger_customer_journey,
 )
+from app.services.marketing_subscribe import subscribe_to_marketing
 from app.templates.media_lead import render_sales_notification_email
 from app.utils.logging import configure_logging, get_logger, mask_email
 from app.utils.retry import run_with_retry
@@ -107,6 +108,8 @@ def _process_message(message: dict[str, Any]) -> bool:
     email = _required_email(message.get("email"))
     submitted_at = _normalize_submitted_at(message.get("submitted_at"))
     request_id = _optional_text(message.get("request_id"))
+    marketing_opt_in = _parse_marketing_opt_in(message.get("marketing_opt_in"))
+    locale = _normalize_email_locale(message.get("locale"))
 
     with Session(get_engine()) as session:
         resource_key, asset_id, tag_name, media_name = _resolve_media_resource(
@@ -137,19 +140,37 @@ def _process_message(message: dict[str, Any]) -> bool:
             download_url = _ensure_share_link_url_for_asset(
                 session=session, asset_id=asset_id
             )
-            # Refresh Mailchimp member (merge fields + tag) on every submit so
-            # MMDLURL stays current; then re-fire Customer Journey for duplicates.
-            was_mailchimp_synced = _sync_contact_to_mailchimp(
-                contact=contact,
+            _send_user_download_email(
                 first_name=first_name,
-                tag_name=tag_name,
-                merge_fields=_mailchimp_merge_fields_with_download_url(download_url),
+                email=email,
+                media_name=media_name,
+                download_url=download_url,
+                locale=locale,
             )
-            journey_triggered = (
-                _trigger_mailchimp_journey(email=email)
-                if was_mailchimp_synced
-                else False
-            )
+            was_mailchimp_synced = False
+            journey_triggered = False
+            if _should_sync_mailchimp_for_media(marketing_opt_in=marketing_opt_in):
+                was_mailchimp_synced = _sync_contact_to_mailchimp(
+                    contact=contact,
+                    first_name=first_name,
+                    tag_name=tag_name,
+                    merge_fields=_mailchimp_merge_fields_with_download_url(
+                        download_url
+                    ),
+                )
+                journey_triggered = (
+                    _trigger_mailchimp_journey(email=email)
+                    if was_mailchimp_synced
+                    else False
+                )
+            if marketing_opt_in:
+                subscribe_to_marketing(
+                    email=email,
+                    first_name=first_name,
+                    tag_name=tag_name,
+                    merge_fields=None,
+                    logger=logger,
+                )
             logger.info(
                 "Skipping duplicate media lead",
                 extra={
@@ -193,29 +214,46 @@ def _process_message(message: dict[str, Any]) -> bool:
         download_url = _ensure_share_link_url_for_asset(
             session=session, asset_id=asset_id
         )
-        was_mailchimp_synced = _sync_contact_to_mailchimp(
-            contact=contact,
+        _send_user_download_email(
             first_name=first_name,
-            tag_name=tag_name,
-            merge_fields=_mailchimp_merge_fields_with_download_url(download_url),
+            email=email,
+            media_name=media_name,
+            download_url=download_url,
+            locale=locale,
         )
+        was_mailchimp_synced = False
         journey_triggered = False
-        if was_mailchimp_synced:
-            journey_triggered = _trigger_mailchimp_journey(email=email)
-            mailchimp_meta: dict[str, object] = {
-                "provider": "mailchimp",
-                "resource_key": resource_key,
-                "tag_name": tag_name,
-                "journey_triggered": journey_triggered,
-            }
-            if download_url:
-                mailchimp_meta["mailchimp_download_url"] = download_url
-            _create_sales_lead_event(
-                session=session,
-                lead_id=lead.id,
-                event_type=LeadEventType.EMAIL_SENT,
-                metadata=mailchimp_meta,
-                created_by=_SYSTEM_ACTOR,
+        if _should_sync_mailchimp_for_media(marketing_opt_in=marketing_opt_in):
+            was_mailchimp_synced = _sync_contact_to_mailchimp(
+                contact=contact,
+                first_name=first_name,
+                tag_name=tag_name,
+                merge_fields=_mailchimp_merge_fields_with_download_url(download_url),
+            )
+            if was_mailchimp_synced:
+                journey_triggered = _trigger_mailchimp_journey(email=email)
+                mailchimp_meta: dict[str, object] = {
+                    "provider": "mailchimp",
+                    "resource_key": resource_key,
+                    "tag_name": tag_name,
+                    "journey_triggered": journey_triggered,
+                }
+                if download_url:
+                    mailchimp_meta["mailchimp_download_url"] = download_url
+                _create_sales_lead_event(
+                    session=session,
+                    lead_id=lead.id,
+                    event_type=LeadEventType.EMAIL_SENT,
+                    metadata=mailchimp_meta,
+                    created_by=_SYSTEM_ACTOR,
+                )
+        if marketing_opt_in:
+            subscribe_to_marketing(
+                email=email,
+                first_name=first_name,
+                tag_name=tag_name,
+                merge_fields=None,
+                logger=logger,
             )
 
         _send_sales_notification(
@@ -236,6 +274,73 @@ def _process_message(message: dict[str, Any]) -> bool:
             },
         )
         return True
+
+
+def _parse_marketing_opt_in(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return False
+
+
+def _normalize_email_locale(value: Any) -> str:
+    if not isinstance(value, str):
+        return "en"
+    s = value.strip()
+    return s if s in {"en", "zh-CN", "zh-HK"} else "en"
+
+
+def _should_sync_mailchimp_for_media(*, marketing_opt_in: bool) -> bool:
+    flag = os.getenv("MAILCHIMP_REQUIRE_MARKETING_CONSENT", "false").strip().lower()
+    if flag == "true":
+        return marketing_opt_in
+    return True
+
+
+def _send_user_download_email(
+    *,
+    first_name: str,
+    email: str,
+    media_name: str,
+    download_url: str | None,
+    locale: str,
+) -> None:
+    from_addr = os.getenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "").strip()
+    if not from_addr:
+        logger.warning(
+            "Skipping user download email: CONFIRMATION_EMAIL_FROM_ADDRESS not set"
+        )
+        return
+    if not download_url:
+        logger.warning(
+            "Skipping user download email: download URL missing",
+            extra={"lead_email": mask_email(email)},
+        )
+        return
+    template = f"evolvesprouts-media-download-{locale}"
+    data = {
+        "first_name": first_name,
+        "media_name": media_name,
+        "download_url": download_url,
+    }
+    try:
+        run_with_retry(
+            send_templated_email,
+            source=from_addr,
+            to_addresses=[email],
+            template_name=template,
+            template_data=data,
+            logger=logger,
+            operation_name="ses.send_templated_email.media_download",
+        )
+    except Exception:
+        logger.exception(
+            "Failed to send media download email",
+            extra={"lead_email": mask_email(email), "template": template},
+        )
 
 
 def _mailchimp_merge_fields_with_download_url(

--- a/backend/lambda/ses_template_manager/handler.py
+++ b/backend/lambda/ses_template_manager/handler.py
@@ -1,0 +1,79 @@
+"""CloudFormation custom resource: upsert SES email templates from code."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from botocore.exceptions import ClientError
+
+from app.services.aws_clients import get_ses_client
+from app.templates.ses.booking_confirmation import get_ses_template_definitions as booking_templates
+from app.templates.ses.contact_confirmation import get_ses_template_definitions as contact_templates
+from app.templates.ses.media_download_link import get_ses_template_definitions as media_templates
+from app.utils.cfn_response import send_cfn_response
+from app.utils.logging import configure_logging, get_logger
+
+configure_logging()
+logger = get_logger(__name__)
+
+
+def lambda_handler(event: Mapping[str, Any], context: Any) -> dict[str, Any]:
+    """Create, update, or delete SES templates based on bundled definitions."""
+    request_type = str(event.get("RequestType", ""))
+    physical_id = str(event.get("PhysicalResourceId") or "ses-templates")
+
+    all_defs = contact_templates() + media_templates() + booking_templates()
+    names = [t["TemplateName"] for t in all_defs]
+
+    if request_type == "Delete":
+        client = get_ses_client()
+        for name in names:
+            try:
+                client.delete_template(TemplateName=name)
+            except ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code", "")
+                if code != "TemplateDoesNotExist":
+                    logger.warning(
+                        "SES delete template failed",
+                        extra={"template": name, "error_code": code},
+                    )
+        data = {"templates": ",".join(names)}
+        send_cfn_response(event, context, "SUCCESS", data, physical_id)
+        return {"PhysicalResourceId": physical_id, "Data": data}
+
+    try:
+        client = get_ses_client()
+        for tpl in all_defs:
+            name = tpl["TemplateName"]
+            payload = {
+                "TemplateName": name,
+                "SubjectPart": tpl["SubjectPart"],
+                "HtmlPart": tpl["HtmlPart"],
+                "TextPart": tpl["TextPart"],
+            }
+            try:
+                client.create_template(Template=payload)
+                logger.info("SES template created", extra={"template": name})
+            except ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code", "")
+                if code == "AlreadyExists":
+                    client.update_template(Template=payload)
+                    logger.info("SES template updated", extra={"template": name})
+                else:
+                    raise
+
+        data = {"templates": ",".join(names)}
+        physical_id = str(event.get("PhysicalResourceId") or "ses-templates")
+        send_cfn_response(event, context, "SUCCESS", data, physical_id)
+        return {"PhysicalResourceId": physical_id, "Data": data}
+    except Exception:
+        logger.exception("SES template manager failed")
+        send_cfn_response(
+            event,
+            context,
+            "FAILED",
+            {"templates": ""},
+            physical_id,
+            "SES template manager failed",
+        )
+        return {"PhysicalResourceId": physical_id, "Data": {"templates": ""}}

--- a/backend/lambda/ses_template_manager/handler.py
+++ b/backend/lambda/ses_template_manager/handler.py
@@ -7,9 +7,15 @@ from typing import Any, Mapping
 from botocore.exceptions import ClientError
 
 from app.services.aws_clients import get_ses_client
-from app.templates.ses.booking_confirmation import get_ses_template_definitions as booking_templates
-from app.templates.ses.contact_confirmation import get_ses_template_definitions as contact_templates
-from app.templates.ses.media_download_link import get_ses_template_definitions as media_templates
+from app.templates.ses.booking_confirmation import (
+    get_ses_template_definitions as booking_templates,
+)
+from app.templates.ses.contact_confirmation import (
+    get_ses_template_definitions as contact_templates,
+)
+from app.templates.ses.media_download_link import (
+    get_ses_template_definitions as media_templates,
+)
 from app.utils.cfn_response import send_cfn_response
 from app.utils.logging import configure_logging, get_logger
 

--- a/backend/src/app/api/public_legacy_confirmation.py
+++ b/backend/src/app/api/public_legacy_confirmation.py
@@ -1,0 +1,290 @@
+"""Post-success transactional email + marketing hooks for legacy public proxy."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Mapping
+
+from app.services.email import send_templated_email
+from app.services.marketing_subscribe import subscribe_to_marketing
+from app.templates.constants import WHATSAPP_URL, build_faq_url
+from app.utils.logging import get_logger, mask_email
+
+logger = get_logger(__name__)
+
+_ALLOWED_LOCALES = frozenset({"en", "zh-CN", "zh-HK"})
+_LOCALE_HEADER_PATTERN = re.compile(
+    r"^(?P<loc>[a-z]{2}(?:-[A-Za-z]{2,4})?)", re.IGNORECASE
+)
+
+
+def resolve_email_locale_from_accept_language(header_value: str) -> str:
+    """Pick best locale from Accept-Language; default en."""
+    if not header_value or not isinstance(header_value, str):
+        return "en"
+    for part in header_value.split(","):
+        token = part.split(";")[0].strip()
+        if not token:
+            continue
+        match = _LOCALE_HEADER_PATTERN.match(token)
+        if not match:
+            continue
+        raw = match.group("loc")
+        normalized = raw.lower()
+        if normalized == "zh-cn":
+            return "zh-CN"
+        if normalized in {"zh-hk", "zh-tw"}:
+            return "zh-HK"
+        if normalized.startswith("zh"):
+            return "zh-HK"
+        if normalized.startswith("en"):
+            return "en"
+    return "en"
+
+
+def normalize_body_locale(value: Any) -> str:
+    """Validate locale from JSON body."""
+    if not isinstance(value, str):
+        return "en"
+    s = value.strip()
+    return s if s in _ALLOWED_LOCALES else "en"
+
+
+def first_name_from_full_name(full_name: str) -> str:
+    """Mailchimp FNAME: first whitespace-separated segment, or whole string."""
+    normalized = " ".join(str(full_name).split()).strip()
+    if not normalized:
+        return ""
+    return normalized.split(maxsplit=1)[0]
+
+
+def send_contact_confirmation_email(
+    *,
+    to_email: str,
+    first_name: str,
+    locale: str,
+) -> None:
+    from_addr = os.getenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "").strip()
+    if not from_addr:
+        logger.warning("CONFIRMATION_EMAIL_FROM_ADDRESS not set; skipping contact confirmation")
+        return
+    loc = normalize_body_locale(locale)
+    template = f"evolvesprouts-contact-confirmation-{loc}"
+    faq = build_faq_url(locale=loc)
+    data = {
+        "first_name": first_name.strip(),
+        "whatsapp_url": WHATSAPP_URL,
+        "faq_url": faq,
+    }
+    try:
+        send_templated_email(
+            source=from_addr,
+            to_addresses=[to_email.strip().lower()],
+            template_name=template,
+            template_data=data,
+        )
+    except Exception:
+        logger.exception(
+            "Contact confirmation email failed",
+            extra={"lead_email": mask_email(to_email), "template": template},
+        )
+
+
+def send_booking_confirmation_email(
+    *,
+    to_email: str,
+    full_name: str,
+    course_label: str,
+    schedule_date_label: str | None,
+    schedule_time_label: str | None,
+    payment_method: str,
+    total_amount: str,
+    is_pending_payment: bool,
+    locale: str,
+) -> None:
+    from_addr = os.getenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "").strip()
+    if not from_addr:
+        logger.warning("CONFIRMATION_EMAIL_FROM_ADDRESS not set; skipping booking confirmation")
+        return
+    loc = normalize_body_locale(locale)
+    template = f"evolvesprouts-booking-confirmation-{loc}"
+    data: dict[str, Any] = {
+        "full_name": full_name.strip(),
+        "course_label": course_label.strip(),
+        "payment_method": payment_method.strip(),
+        "total_amount": total_amount,
+        "is_pending_payment": is_pending_payment,
+        "whatsapp_url": WHATSAPP_URL,
+    }
+    if schedule_date_label and schedule_date_label.strip():
+        data["schedule_date_label"] = schedule_date_label.strip()
+    if schedule_time_label and schedule_time_label.strip():
+        data["schedule_time_label"] = schedule_time_label.strip()
+    try:
+        send_templated_email(
+            source=from_addr,
+            to_addresses=[to_email.strip().lower()],
+            template_name=template,
+            template_data=data,
+        )
+    except Exception:
+        logger.exception(
+            "Booking confirmation email failed",
+            extra={"lead_email": mask_email(to_email), "template": template},
+        )
+
+
+def maybe_subscribe_contact_us_marketing(
+    *,
+    marketing_opt_in: Any,
+    email: str,
+    first_name: str,
+) -> None:
+    if not _truthy_opt_in(marketing_opt_in):
+        return
+    fn = " ".join(str(first_name).split()).strip()
+    if not fn:
+        return
+    subscribe_to_marketing(
+        email=email,
+        first_name=fn,
+        tag_name="contact-us-inquiry",
+        merge_fields=None,
+        logger=logger,
+    )
+
+
+def maybe_subscribe_booking_marketing(
+    *,
+    marketing_opt_in: Any,
+    email: str,
+    full_name: str,
+) -> None:
+    if not _truthy_opt_in(marketing_opt_in):
+        return
+    fn = first_name_from_full_name(full_name)
+    if not fn:
+        return
+    subscribe_to_marketing(
+        email=email,
+        first_name=fn,
+        tag_name="booking-customer",
+        merge_fields=None,
+        logger=logger,
+    )
+
+
+def _truthy_opt_in(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return False
+
+
+def run_contact_us_post_success(*, event: Mapping[str, Any], payload: Mapping[str, Any]) -> None:
+    accept_lang = _get_header_case_insensitive(event, "accept-language")
+    locale = resolve_email_locale_from_accept_language(accept_lang)
+    email = str(payload.get("email_address") or "").strip()
+    first_name = str(payload.get("first_name") or "").strip()
+    if email and first_name:
+        try:
+            send_contact_confirmation_email(
+                to_email=email,
+                first_name=first_name,
+                locale=locale,
+            )
+        except Exception:
+            logger.exception(
+                "Unexpected error sending contact confirmation",
+                extra={"lead_email": mask_email(email)},
+            )
+    try:
+        maybe_subscribe_contact_us_marketing(
+            marketing_opt_in=payload.get("marketing_opt_in"),
+            email=email,
+            first_name=first_name,
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected error in contact marketing subscribe",
+            extra={"lead_email": mask_email(email)},
+        )
+
+
+def run_reservation_post_success(*, payload: Mapping[str, Any]) -> None:
+    email = str(payload.get("email") or "").strip()
+    full_name = str(payload.get("full_name") or "").strip()
+    locale = normalize_body_locale(payload.get("locale"))
+    course_label = str(payload.get("course_label") or "").strip()
+    if not course_label:
+        course_label = "Your booking"
+    schedule_date = _optional_str(payload.get("schedule_date_label"))
+    schedule_time = _optional_str(payload.get("schedule_time_label"))
+    payment_method = str(payload.get("payment_method") or "").strip() or "unknown"
+    price = payload.get("price")
+    total_amount = _format_hkd_amount(price)
+    stripe_pi = _optional_str(payload.get("stripe_payment_intent_id"))
+    pm_lower = payment_method.lower()
+    is_pending = pm_lower != "stripe" and not stripe_pi
+    if email and full_name:
+        try:
+            send_booking_confirmation_email(
+                to_email=email,
+                full_name=full_name,
+                course_label=course_label,
+                schedule_date_label=schedule_date,
+                schedule_time_label=schedule_time,
+                payment_method=payment_method,
+                total_amount=total_amount,
+                is_pending_payment=is_pending,
+                locale=locale,
+            )
+        except Exception:
+            logger.exception(
+                "Unexpected error sending booking confirmation",
+                extra={"lead_email": mask_email(email)},
+            )
+    try:
+        maybe_subscribe_booking_marketing(
+            marketing_opt_in=payload.get("marketing_opt_in"),
+            email=email,
+            full_name=full_name,
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected error in booking marketing subscribe",
+            extra={"lead_email": mask_email(email)},
+        )
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _format_hkd_amount(price: Any) -> str:
+    try:
+        n = float(price)
+    except (TypeError, ValueError):
+        return "0.00"
+    return f"{n:.2f}"
+
+
+def _get_header_case_insensitive(event: Mapping[str, Any], name: str) -> str:
+    headers = event.get("headers") or {}
+    if not isinstance(headers, Mapping):
+        return ""
+    target_name = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == target_name:
+            normalized_value = str(value).strip()
+            if normalized_value:
+                return normalized_value
+            return ""
+    return ""

--- a/backend/src/app/api/public_legacy_confirmation.py
+++ b/backend/src/app/api/public_legacy_confirmation.py
@@ -51,6 +51,18 @@ def normalize_body_locale(value: Any) -> str:
     return s if s in _ALLOWED_LOCALES else "en"
 
 
+def resolve_contact_confirmation_locale(
+    *,
+    payload: Mapping[str, Any],
+    accept_language_header: str,
+) -> str:
+    """Prefer explicit ``locale`` from the JSON body; fall back to Accept-Language."""
+    raw = payload.get("locale")
+    if isinstance(raw, str) and raw.strip() in _ALLOWED_LOCALES:
+        return raw.strip()
+    return resolve_email_locale_from_accept_language(accept_language_header)
+
+
 def first_name_from_full_name(full_name: str) -> str:
     """Mailchimp FNAME: first whitespace-separated segment, or whole string."""
     normalized = " ".join(str(full_name).split()).strip()
@@ -193,7 +205,10 @@ def run_contact_us_post_success(
     *, event: Mapping[str, Any], payload: Mapping[str, Any]
 ) -> None:
     accept_lang = _get_header_case_insensitive(event, "accept-language")
-    locale = resolve_email_locale_from_accept_language(accept_lang)
+    locale = resolve_contact_confirmation_locale(
+        payload=payload,
+        accept_language_header=accept_lang,
+    )
     email = str(payload.get("email_address") or "").strip()
     first_name = str(payload.get("first_name") or "").strip()
     if email and first_name:
@@ -278,8 +293,8 @@ def _format_hkd_amount(price: Any) -> str:
     try:
         n = float(price)
     except (TypeError, ValueError):
-        return "0.00"
-    return f"{n:.2f}"
+        return "HK$0.00"
+    return f"HK${n:.2f}"
 
 
 def _get_header_case_insensitive(event: Mapping[str, Any], name: str) -> str:

--- a/backend/src/app/api/public_legacy_confirmation.py
+++ b/backend/src/app/api/public_legacy_confirmation.py
@@ -67,7 +67,9 @@ def send_contact_confirmation_email(
 ) -> None:
     from_addr = os.getenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "").strip()
     if not from_addr:
-        logger.warning("CONFIRMATION_EMAIL_FROM_ADDRESS not set; skipping contact confirmation")
+        logger.warning(
+            "CONFIRMATION_EMAIL_FROM_ADDRESS not set; skipping contact confirmation"
+        )
         return
     loc = normalize_body_locale(locale)
     template = f"evolvesprouts-contact-confirmation-{loc}"
@@ -105,7 +107,9 @@ def send_booking_confirmation_email(
 ) -> None:
     from_addr = os.getenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "").strip()
     if not from_addr:
-        logger.warning("CONFIRMATION_EMAIL_FROM_ADDRESS not set; skipping booking confirmation")
+        logger.warning(
+            "CONFIRMATION_EMAIL_FROM_ADDRESS not set; skipping booking confirmation"
+        )
         return
     loc = normalize_body_locale(locale)
     template = f"evolvesprouts-booking-confirmation-{loc}"
@@ -185,7 +189,9 @@ def _truthy_opt_in(value: Any) -> bool:
     return False
 
 
-def run_contact_us_post_success(*, event: Mapping[str, Any], payload: Mapping[str, Any]) -> None:
+def run_contact_us_post_success(
+    *, event: Mapping[str, Any], payload: Mapping[str, Any]
+) -> None:
     accept_lang = _get_header_case_insensitive(event, "accept-language")
     locale = resolve_email_locale_from_accept_language(accept_lang)
     email = str(payload.get("email_address") or "").strip()

--- a/backend/src/app/api/public_legacy_proxy.py
+++ b/backend/src/app/api/public_legacy_proxy.py
@@ -8,11 +8,15 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any
+from typing import Any, Callable
 from collections.abc import Mapping
 from urllib.parse import urljoin
 
 from app.api.admin_request import parse_body
+from app.api.public_legacy_confirmation import (
+    run_contact_us_post_success,
+    run_reservation_post_success,
+)
 from app.services.aws_proxy import AwsProxyError, http_invoke
 from app.services.turnstile import extract_turnstile_token
 from app.utils import json_response
@@ -42,11 +46,12 @@ def handle_legacy_reservations(
     method: str,
 ) -> dict[str, Any]:
     """Proxy reservation submissions to legacy public API."""
-    return _handle_legacy_proxy(
+    return _handle_legacy_proxy_with_hooks(
         event=event,
         method=method,
         target_path=_LEGACY_RESERVATIONS_PATH,
         include_turnstile=True,
+        on_proxy_success=lambda payload: run_reservation_post_success(payload=payload),
     )
 
 
@@ -55,11 +60,14 @@ def handle_legacy_contact_us(
     method: str,
 ) -> dict[str, Any]:
     """Proxy contact-us submissions to legacy public API."""
-    return _handle_legacy_proxy(
+    return _handle_legacy_proxy_with_hooks(
         event=event,
         method=method,
         target_path=_LEGACY_CONTACT_US_PATH,
         include_turnstile=False,
+        on_proxy_success=lambda payload: run_contact_us_post_success(
+            event=event, payload=payload
+        ),
     )
 
 
@@ -76,12 +84,13 @@ def handle_legacy_discount_validate(
     )
 
 
-def _handle_legacy_proxy(
+def _handle_legacy_proxy_with_hooks(
     *,
     event: Mapping[str, Any],
     method: str,
     target_path: str,
     include_turnstile: bool,
+    on_proxy_success: Callable[[Mapping[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     if method != "POST":
         return json_response(405, {"error": "Method not allowed"}, event=event)
@@ -128,11 +137,46 @@ def _handle_legacy_proxy(
         headers=request_headers,
         body=request_body,
     )
-    return _normalize_proxy_response(
+    response = _normalize_proxy_response(
         proxy_result=proxy_result,
         target_path=target_path,
         event=event,
     )
+    if on_proxy_success is not None:
+        status = _response_status_code(response)
+        if status in _SUCCESS_STATUS_BY_LEGACY_PATH.get(target_path, ()):
+            try:
+                on_proxy_success(payload)
+            except Exception:
+                logger.exception(
+                    "Legacy proxy post-success hook failed",
+                    extra={"path": target_path},
+                )
+    return response
+
+
+def _handle_legacy_proxy(
+    *,
+    event: Mapping[str, Any],
+    method: str,
+    target_path: str,
+    include_turnstile: bool,
+) -> dict[str, Any]:
+    return _handle_legacy_proxy_with_hooks(
+        event=event,
+        method=method,
+        target_path=target_path,
+        include_turnstile=include_turnstile,
+        on_proxy_success=None,
+    )
+
+
+def _response_status_code(response: Mapping[str, Any]) -> int:
+    status = response.get("statusCode")
+    try:
+        return int(status)
+    except (TypeError, ValueError):
+        return 0
 
 
 def _legacy_base_url() -> str:

--- a/backend/src/app/api/public_legacy_proxy.py
+++ b/backend/src/app/api/public_legacy_proxy.py
@@ -172,11 +172,15 @@ def _handle_legacy_proxy(
 
 
 def _response_status_code(response: Mapping[str, Any]) -> int:
-    status = response.get("statusCode")
-    try:
-        return int(status)
-    except (TypeError, ValueError):
-        return 0
+    raw = response.get("statusCode")
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return int(raw.strip())
+        except ValueError:
+            return 0
+    return 0
 
 
 def _legacy_base_url() -> str:

--- a/backend/src/app/api/public_media.py
+++ b/backend/src/app/api/public_media.py
@@ -57,6 +57,8 @@ def handle_media_request(
     first_name = _validate_first_name(body.get("first_name"))
     email = _validate_required_email(body.get("email"))
     resource_key = _validate_optional_resource_key(body.get("resource_key"))
+    marketing_opt_in = _parse_marketing_opt_in(body.get("marketing_opt_in"))
+    locale = _normalize_locale(body.get("locale"))
 
     topic_arn = os.getenv("MEDIA_REQUEST_TOPIC_ARN", "").strip()
     if not topic_arn:
@@ -74,6 +76,8 @@ def handle_media_request(
         "email": email,
         "submitted_at": datetime.now(timezone.utc).isoformat(),
         "request_id": request_id,
+        "marketing_opt_in": marketing_opt_in,
+        "locale": locale,
     }
     if resource_key is not None:
         message_payload["resource_key"] = resource_key
@@ -136,6 +140,23 @@ def _validate_required_email(value: Any) -> str:
 def _slugify_resource_key(value: str) -> str:
     slug = _RESOURCE_KEY_SANITIZE_PATTERN.sub("-", value.lower()).strip("-")
     return slug[:_MAX_RESOURCE_KEY_LENGTH].strip("-")
+
+
+def _parse_marketing_opt_in(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return False
+
+
+def _normalize_locale(value: Any) -> str:
+    if not isinstance(value, str):
+        return "en"
+    s = value.strip()
+    return s if s in {"en", "zh-CN", "zh-HK"} else "en"
 
 
 def _validate_optional_resource_key(value: Any) -> str | None:

--- a/backend/src/app/services/marketing_subscribe.py
+++ b/backend/src/app/services/marketing_subscribe.py
@@ -27,10 +27,14 @@ def subscribe_to_marketing(
     tag_name: str,
     merge_fields: dict[str, str] | None = None,
     logger: Logger | ContextLogger,
+    subscribe_member: bool = True,
 ) -> bool:
     """Add a contact to the Mailchimp audience with a tag and trigger the welcome journey.
 
-    Returns True if the subscribe succeeded. Logs errors and never raises.
+    When ``subscribe_member`` is False, skip ``add_subscriber_with_tag`` (member already
+    synced elsewhere) and only attempt the welcome journey trigger.
+
+    Returns True if the subscribe succeeded (or was skipped). Logs errors and never raises.
     """
     normalized_email = email.strip().lower()
     normalized_first = " ".join(first_name.split()).strip()
@@ -41,34 +45,35 @@ def subscribe_to_marketing(
         )
         return False
 
-    try:
-        run_with_retry(
-            add_subscriber_with_tag,
-            email=normalized_email,
-            first_name=normalized_first,
-            tag_name=tag_name,
-            merge_fields=merge_fields,
-            max_attempts=3,
-            base_delay_seconds=1.0,
-            should_retry=_is_retryable_mailchimp_exception,
-            logger=logger,
-            operation_name="marketing.add_subscriber_with_tag",
-        )
-    except MailchimpApiError as exc:
-        logger.warning(
-            "Marketing subscribe failed",
-            extra={
-                "status": exc.status,
-                "lead_email": mask_email(normalized_email),
-            },
-        )
-        return False
-    except Exception:
-        logger.exception(
-            "Marketing subscribe failed unexpectedly",
-            extra={"lead_email": mask_email(normalized_email)},
-        )
-        return False
+    if subscribe_member:
+        try:
+            run_with_retry(
+                add_subscriber_with_tag,
+                email=normalized_email,
+                first_name=normalized_first,
+                tag_name=tag_name,
+                merge_fields=merge_fields,
+                max_attempts=3,
+                base_delay_seconds=1.0,
+                should_retry=_is_retryable_mailchimp_exception,
+                logger=logger,
+                operation_name="marketing.add_subscriber_with_tag",
+            )
+        except MailchimpApiError as exc:
+            logger.warning(
+                "Marketing subscribe failed",
+                extra={
+                    "status": exc.status,
+                    "lead_email": mask_email(normalized_email),
+                },
+            )
+            return False
+        except Exception:
+            logger.exception(
+                "Marketing subscribe failed unexpectedly",
+                extra={"lead_email": mask_email(normalized_email)},
+            )
+            return False
 
     journey_id = os.getenv("MAILCHIMP_WELCOME_JOURNEY_ID", "").strip()
     step_id = os.getenv("MAILCHIMP_WELCOME_JOURNEY_STEP_ID", "").strip()

--- a/backend/src/app/services/marketing_subscribe.py
+++ b/backend/src/app/services/marketing_subscribe.py
@@ -1,0 +1,100 @@
+"""Non-blocking Mailchimp marketing subscribe + welcome journey trigger."""
+
+from __future__ import annotations
+
+import os
+from logging import Logger
+
+from app.services.mailchimp import MailchimpApiError, add_subscriber_with_tag, trigger_customer_journey
+from app.utils.logging import mask_email
+from app.utils.retry import run_with_retry
+
+
+def _is_retryable_mailchimp_exception(exc: Exception) -> bool:
+    if isinstance(exc, MailchimpApiError):
+        return exc.status == 429 or exc.status >= 500
+    return isinstance(exc, (ConnectionError, TimeoutError))
+
+
+def subscribe_to_marketing(
+    *,
+    email: str,
+    first_name: str,
+    tag_name: str,
+    merge_fields: dict[str, str] | None = None,
+    logger: Logger,
+) -> bool:
+    """Add a contact to the Mailchimp audience with a tag and trigger the welcome journey.
+
+    Returns True if the subscribe succeeded. Logs errors and never raises.
+    """
+    normalized_email = email.strip().lower()
+    normalized_first = " ".join(first_name.split()).strip()
+    if not normalized_email or not normalized_first:
+        logger.warning(
+            "Skipping marketing subscribe: missing email or first name",
+            extra={"lead_email": mask_email(normalized_email)},
+        )
+        return False
+
+    try:
+        run_with_retry(
+            add_subscriber_with_tag,
+            email=normalized_email,
+            first_name=normalized_first,
+            tag_name=tag_name,
+            merge_fields=merge_fields,
+            max_attempts=3,
+            base_delay_seconds=1.0,
+            should_retry=_is_retryable_mailchimp_exception,
+            logger=logger,
+            operation_name="marketing.add_subscriber_with_tag",
+        )
+    except MailchimpApiError as exc:
+        logger.warning(
+            "Marketing subscribe failed",
+            extra={
+                "status": exc.status,
+                "lead_email": mask_email(normalized_email),
+            },
+        )
+        return False
+    except Exception:
+        logger.exception(
+            "Marketing subscribe failed unexpectedly",
+            extra={"lead_email": mask_email(normalized_email)},
+        )
+        return False
+
+    journey_id = os.getenv("MAILCHIMP_WELCOME_JOURNEY_ID", "").strip()
+    step_id = os.getenv("MAILCHIMP_WELCOME_JOURNEY_STEP_ID", "").strip()
+    if not journey_id or not step_id:
+        return True
+
+    try:
+        run_with_retry(
+            trigger_customer_journey,
+            email=normalized_email,
+            journey_id=journey_id,
+            step_id=step_id,
+            max_attempts=3,
+            base_delay_seconds=1.0,
+            should_retry=_is_retryable_mailchimp_exception,
+            logger=logger,
+            operation_name="marketing.trigger_welcome_journey",
+        )
+    except MailchimpApiError as exc:
+        logger.warning(
+            "Welcome journey trigger failed",
+            extra={
+                "status": exc.status,
+                "lead_email": mask_email(normalized_email),
+            },
+        )
+    except Exception:
+        logger.exception(
+            "Welcome journey trigger failed unexpectedly",
+            extra={"lead_email": mask_email(normalized_email)},
+        )
+
+    return True

--- a/backend/src/app/services/marketing_subscribe.py
+++ b/backend/src/app/services/marketing_subscribe.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import os
 from logging import Logger
 
-from app.services.mailchimp import MailchimpApiError, add_subscriber_with_tag, trigger_customer_journey
-from app.utils.logging import mask_email
+from app.services.mailchimp import (
+    MailchimpApiError,
+    add_subscriber_with_tag,
+    trigger_customer_journey,
+)
+from app.utils.logging import ContextLogger, mask_email
 from app.utils.retry import run_with_retry
 
 
@@ -22,7 +26,7 @@ def subscribe_to_marketing(
     first_name: str,
     tag_name: str,
     merge_fields: dict[str, str] | None = None,
-    logger: Logger,
+    logger: Logger | ContextLogger,
 ) -> bool:
     """Add a contact to the Mailchimp audience with a tag and trigger the welcome journey.
 

--- a/backend/src/app/templates/constants.py
+++ b/backend/src/app/templates/constants.py
@@ -18,9 +18,9 @@ def resolve_public_www_base_url() -> str:
 
 
 def build_faq_url(*, locale: str) -> str:
-    """Build a locale-prefixed FAQ page URL under the public site."""
+    """Build URL to the Contact Us page FAQ block (matches ``contact-us-faq`` section)."""
     base = resolve_public_www_base_url()
     if not base:
         return ""
     loc = locale.strip() if locale.strip() else "en"
-    return f"{base}/{loc}/about-us"
+    return f"{base}/{loc}/contact-us#contact-us-faq"

--- a/backend/src/app/templates/constants.py
+++ b/backend/src/app/templates/constants.py
@@ -1,0 +1,26 @@
+"""Shared constants for transactional email templates.
+
+Keep WHATSAPP_URL aligned with ``whatsappContact.href`` in
+``apps/public_www/src/content/en.json``.
+"""
+
+from __future__ import annotations
+
+import os
+
+WHATSAPP_URL = "https://wa.me/message/ZQHVW4DEORD5A1?src=qr"
+
+
+def resolve_public_www_base_url() -> str:
+    """Return configured public website origin (no trailing slash)."""
+    raw = os.getenv("PUBLIC_WWW_BASE_URL", "").strip().rstrip("/")
+    return raw
+
+
+def build_faq_url(*, locale: str) -> str:
+    """Build a locale-prefixed FAQ page URL under the public site."""
+    base = resolve_public_www_base_url()
+    if not base:
+        return ""
+    loc = locale.strip() if locale.strip() else "en"
+    return f"{base}/{loc}/about-us"

--- a/backend/src/app/templates/ses/__init__.py
+++ b/backend/src/app/templates/ses/__init__.py
@@ -1,0 +1,1 @@
+"""SES stored email template definitions."""

--- a/backend/src/app/templates/ses/booking_confirmation.py
+++ b/backend/src/app/templates/ses/booking_confirmation.py
@@ -29,10 +29,15 @@ style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow
 
 def get_ses_template_definitions() -> list[dict[str, Any]]:
     """Return SES CreateTemplate payloads (Template key for boto3)."""
+    subjects = {
+        "en": "Booking confirmed — {{course_label}} — Evolve Sprouts",
+        "zh-CN": "预约确认 — {{course_label}} — Evolve Sprouts",
+        "zh-HK": "預約確認 — {{course_label}} — Evolve Sprouts",
+    }
     return [
         {
             "TemplateName": f"evolvesprouts-booking-confirmation-{loc}",
-            "SubjectPart": "Booking confirmed — {{course_label}} — Evolve Sprouts",
+            "SubjectPart": subjects[loc],
             "HtmlPart": _wrap_html(inner_html=inner_html),
             "TextPart": text_part,
         }
@@ -60,7 +65,7 @@ _HTML_EN = (
     "{{/if}}"
     '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Payment method</strong></td>'
     '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
-    '<tr><td style="padding:8px 0;"><strong>Total (HKD)</strong></td>'
+    '<tr><td style="padding:8px 0;"><strong>Total</strong></td>'
     '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
     "</table>"
     "{{#if is_pending_payment}}"
@@ -82,7 +87,7 @@ _TEXT_EN = (
     "{{#if schedule_date_label}}Date: {{schedule_date_label}}\n{{/if}}"
     "{{#if schedule_time_label}}Time: {{schedule_time_label}}\n{{/if}}"
     "Payment method: {{payment_method}}\n"
-    "Total (HKD): {{total_amount}}\n\n"
+    "Total: {{total_amount}}\n\n"
     "{{#if is_pending_payment}}"
     "Your reservation is pending until payment is confirmed.\n\n"
     "{{/if}}"
@@ -109,7 +114,7 @@ _HTML_ZH_CN = (
     "{{/if}}"
     '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>付款方式</strong></td>'
     '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
-    '<tr><td style="padding:8px 0;"><strong>总额（港币）</strong></td>'
+    '<tr><td style="padding:8px 0;"><strong>总额</strong></td>'
     '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
     "</table>"
     "{{#if is_pending_payment}}"
@@ -131,7 +136,7 @@ _TEXT_ZH_CN = (
     "{{#if schedule_date_label}}日期：{{schedule_date_label}}\n{{/if}}"
     "{{#if schedule_time_label}}时间：{{schedule_time_label}}\n{{/if}}"
     "付款方式：{{payment_method}}\n"
-    "总额（港币）：{{total_amount}}\n\n"
+    "总额：{{total_amount}}\n\n"
     "{{#if is_pending_payment}}"
     "在付款确认前，您的预订仍为待处理状态。\n\n"
     "{{/if}}"
@@ -158,7 +163,7 @@ _HTML_ZH_HK = (
     "{{/if}}"
     '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>付款方式</strong></td>'
     '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
-    '<tr><td style="padding:8px 0;"><strong>總額（港幣）</strong></td>'
+    '<tr><td style="padding:8px 0;"><strong>總額</strong></td>'
     '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
     "</table>"
     "{{#if is_pending_payment}}"
@@ -180,7 +185,7 @@ _TEXT_ZH_HK = (
     "{{#if schedule_date_label}}日期：{{schedule_date_label}}\n{{/if}}"
     "{{#if schedule_time_label}}時間：{{schedule_time_label}}\n{{/if}}"
     "付款方式：{{payment_method}}\n"
-    "總額（港幣）：{{total_amount}}\n\n"
+    "總額：{{total_amount}}\n\n"
     "{{#if is_pending_payment}}"
     "在付款確認前，您的預訂仍為待處理狀態。\n\n"
     "{{/if}}"

--- a/backend/src/app/templates/ses/booking_confirmation.py
+++ b/backend/src/app/templates/ses/booking_confirmation.py
@@ -1,0 +1,195 @@
+"""SES templates: booking confirmation (per locale)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _wrap_html(*, inner_html: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/></head>
+<body style="margin:0;padding:0;background-color:#f6f6f6;font-family:Arial,Helvetica,sans-serif;">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f6f6f6;">
+<tr><td align="center" style="padding:24px 12px;">
+<table role="presentation" width="600" cellspacing="0" cellpadding="0"
+style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;">
+<tr><td style="padding:24px 28px;background:#1a5f4a;color:#ffffff;">
+<h1 style="margin:0;font-size:22px;line-height:1.3;">Evolve Sprouts</h1>
+<p style="margin:8px 0 0;font-size:14px;opacity:0.95;">Booking confirmed</p>
+</td></tr>
+<tr><td style="padding:28px;color:#333333;font-size:15px;line-height:1.6;">
+{inner_html}
+</td></tr>
+<tr><td style="padding:16px 28px 24px;color:#666666;font-size:12px;line-height:1.5;">
+<p style="margin:0;">Evolve Sprouts</p>
+</td></tr>
+</table></td></tr></table></body></html>"""
+
+
+def get_ses_template_definitions() -> list[dict[str, Any]]:
+    """Return SES CreateTemplate payloads (Template key for boto3)."""
+    return [
+        {
+            "TemplateName": f"evolvesprouts-booking-confirmation-{loc}",
+            "SubjectPart": "Booking confirmed — {{course_label}} — Evolve Sprouts",
+            "HtmlPart": _wrap_html(inner_html=inner_html),
+            "TextPart": text_part,
+        }
+        for loc, inner_html, text_part in _LOCALE_ROWS
+    ]
+
+
+# Handlebars: optional rows and pending-payment note.
+_HTML_EN = (
+    '<p style="margin:0 0 12px;">Hi {{full_name}},</p>'
+    '<p style="margin:0 0 16px;">Thank you for your booking!</p>'
+    '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
+    'style="border-collapse:collapse;margin:0 0 16px;">'
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Course / event</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{course_label}}</td></tr>'
+    "{{#if schedule_date_label}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Date</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+    "{{schedule_date_label}}</td></tr>"
+    "{{/if}}"
+    "{{#if schedule_time_label}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Time</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+    "{{schedule_time_label}}</td></tr>"
+    "{{/if}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Payment method</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
+    '<tr><td style="padding:8px 0;"><strong>Total (HKD)</strong></td>'
+    '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
+    "</table>"
+    "{{#if is_pending_payment}}"
+    '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;border-radius:8px;color:#5c4a00;">'
+    "Your reservation is pending until payment is confirmed."
+    "</p>"
+    "{{/if}}"
+    '<p style="margin:0 0 12px;">Questions? Message us on WhatsApp:</p>'
+    '<p style="margin:0;">'
+    '<a href="{{whatsapp_url}}" style="color:#1a5f4a;font-weight:600;">WhatsApp</a>'
+    "</p>"
+    '<p style="margin:20px 0 0;">Thank you,<br/>Evolve Sprouts</p>'
+)
+
+_TEXT_EN = (
+    "Hi {{full_name}},\n\n"
+    "Thank you for your booking!\n\n"
+    "Course / event: {{course_label}}\n"
+    "{{#if schedule_date_label}}Date: {{schedule_date_label}}\n{{/if}}"
+    "{{#if schedule_time_label}}Time: {{schedule_time_label}}\n{{/if}}"
+    "Payment method: {{payment_method}}\n"
+    "Total (HKD): {{total_amount}}\n\n"
+    "{{#if is_pending_payment}}"
+    "Your reservation is pending until payment is confirmed.\n\n"
+    "{{/if}}"
+    "WhatsApp: {{whatsapp_url}}\n\n"
+    "Thank you,\nEvolve Sprouts"
+)
+
+_HTML_ZH_CN = (
+    '<p style="margin:0 0 12px;">您好 {{full_name}}，</p>'
+    '<p style="margin:0 0 16px;">感谢您的预订！</p>'
+    '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
+    'style="border-collapse:collapse;margin:0 0 16px;">'
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>课程 / 活动</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{course_label}}</td></tr>'
+    "{{#if schedule_date_label}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>日期</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+    "{{schedule_date_label}}</td></tr>"
+    "{{/if}}"
+    "{{#if schedule_time_label}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>时间</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+    "{{schedule_time_label}}</td></tr>"
+    "{{/if}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>付款方式</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
+    '<tr><td style="padding:8px 0;"><strong>总额（港币）</strong></td>'
+    '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
+    "</table>"
+    "{{#if is_pending_payment}}"
+    '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;border-radius:8px;color:#5c4a00;">'
+    "在付款确认前，您的预订仍为待处理状态。"
+    "</p>"
+    "{{/if}}"
+    '<p style="margin:0 0 12px;">有疑问？请通过 WhatsApp 联系我们：</p>'
+    '<p style="margin:0;">'
+    '<a href="{{whatsapp_url}}" style="color:#1a5f4a;font-weight:600;">WhatsApp</a>'
+    "</p>"
+    '<p style="margin:20px 0 0;">谢谢，<br/>Evolve Sprouts</p>'
+)
+
+_TEXT_ZH_CN = (
+    "您好 {{full_name}}，\n\n"
+    "感谢您的预订！\n\n"
+    "课程 / 活动：{{course_label}}\n"
+    "{{#if schedule_date_label}}日期：{{schedule_date_label}}\n{{/if}}"
+    "{{#if schedule_time_label}}时间：{{schedule_time_label}}\n{{/if}}"
+    "付款方式：{{payment_method}}\n"
+    "总额（港币）：{{total_amount}}\n\n"
+    "{{#if is_pending_payment}}"
+    "在付款确认前，您的预订仍为待处理状态。\n\n"
+    "{{/if}}"
+    "WhatsApp：{{whatsapp_url}}\n\n"
+    "谢谢，\nEvolve Sprouts"
+)
+
+_HTML_ZH_HK = (
+    '<p style="margin:0 0 12px;">您好 {{full_name}}，</p>'
+    '<p style="margin:0 0 16px;">多謝您的預訂！</p>'
+    '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
+    'style="border-collapse:collapse;margin:0 0 16px;">'
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>課程 / 活動</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{course_label}}</td></tr>'
+    "{{#if schedule_date_label}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>日期</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+    "{{schedule_date_label}}</td></tr>"
+    "{{/if}}"
+    "{{#if schedule_time_label}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>時間</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+    "{{schedule_time_label}}</td></tr>"
+    "{{/if}}"
+    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>付款方式</strong></td>'
+    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
+    '<tr><td style="padding:8px 0;"><strong>總額（港幣）</strong></td>'
+    '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
+    "</table>"
+    "{{#if is_pending_payment}}"
+    '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;border-radius:8px;color:#5c4a00;">'
+    "在付款確認前，您的預訂仍為待處理狀態。"
+    "</p>"
+    "{{/if}}"
+    '<p style="margin:0 0 12px;">有疑問？請透過 WhatsApp 聯絡我們：</p>'
+    '<p style="margin:0;">'
+    '<a href="{{whatsapp_url}}" style="color:#1a5f4a;font-weight:600;">WhatsApp</a>'
+    "</p>"
+    '<p style="margin:20px 0 0;">謝謝，<br/>Evolve Sprouts</p>'
+)
+
+_TEXT_ZH_HK = (
+    "您好 {{full_name}}，\n\n"
+    "多謝您的預訂！\n\n"
+    "課程 / 活動：{{course_label}}\n"
+    "{{#if schedule_date_label}}日期：{{schedule_date_label}}\n{{/if}}"
+    "{{#if schedule_time_label}}時間：{{schedule_time_label}}\n{{/if}}"
+    "付款方式：{{payment_method}}\n"
+    "總額（港幣）：{{total_amount}}\n\n"
+    "{{#if is_pending_payment}}"
+    "在付款確認前，您的預訂仍為待處理狀態。\n\n"
+    "{{/if}}"
+    "WhatsApp：{{whatsapp_url}}\n\n"
+    "謝謝，\nEvolve Sprouts"
+)
+
+_LOCALE_ROWS: list[tuple[str, str, str]] = [
+    ("en", _HTML_EN, _TEXT_EN),
+    ("zh-CN", _HTML_ZH_CN, _TEXT_ZH_CN),
+    ("zh-HK", _HTML_ZH_HK, _TEXT_ZH_HK),
+]

--- a/backend/src/app/templates/ses/contact_confirmation.py
+++ b/backend/src/app/templates/ses/contact_confirmation.py
@@ -1,0 +1,112 @@
+"""SES templates: contact form confirmation (per locale)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _wrap_html(*, header_subtitle: str, inner_html: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/></head>
+<body style="margin:0;padding:0;background-color:#f6f6f6;font-family:Arial,Helvetica,sans-serif;">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f6f6f6;">
+<tr><td align="center" style="padding:24px 12px;">
+<table role="presentation" width="600" cellspacing="0" cellpadding="0"
+style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;">
+<tr><td style="padding:24px 28px;background:#1a5f4a;color:#ffffff;">
+<h1 style="margin:0;font-size:22px;line-height:1.3;">Evolve Sprouts</h1>
+<p style="margin:8px 0 0;font-size:14px;opacity:0.95;">{header_subtitle}</p>
+</td></tr>
+<tr><td style="padding:28px;color:#333333;font-size:15px;line-height:1.6;">
+{inner_html}
+</td></tr>
+<tr><td style="padding:16px 28px 24px;color:#666666;font-size:12px;line-height:1.5;">
+<p style="margin:0;">Evolve Sprouts</p>
+</td></tr>
+</table></td></tr></table></body></html>"""
+
+
+def get_ses_template_definitions() -> list[dict[str, Any]]:
+    """Return SES CreateTemplate payloads (Template key for boto3)."""
+    return [
+        {
+            "TemplateName": f"evolvesprouts-contact-confirmation-{loc}",
+            "SubjectPart": subject,
+            "HtmlPart": _wrap_html(header_subtitle=subject, inner_html=inner_html),
+            "TextPart": text_part,
+        }
+        for loc, subject, inner_html, text_part in _LOCALE_ROWS
+    ]
+
+
+_LOCALE_ROWS: list[tuple[str, str, str, str]] = [
+    (
+        "en",
+        "We received your message — Evolve Sprouts",
+        (
+            '<p style="margin:0 0 12px;">Hi {{first_name}},</p>'
+            '<p style="margin:0 0 16px;">We received your message and will get back to you '
+            "within 24–48 hours.</p>"
+            '<p style="margin:0 0 12px;">'
+            '<a href="{{faq_url}}" style="color:#1a5f4a;font-weight:600;">Visit our FAQ</a>'
+            "</p>"
+            '<p style="margin:0 0 12px;">'
+            '<a href="{{whatsapp_url}}" style="color:#1a5f4a;font-weight:600;">'
+            "Message us on WhatsApp</a>"
+            "</p>"
+            '<p style="margin:16px 0 0;">Thank you,<br/>Evolve Sprouts</p>'
+        ),
+        (
+            "Hi {{first_name}},\n\n"
+            "We received your message and will get back to you within 24–48 hours.\n\n"
+            "FAQ: {{faq_url}}\n"
+            "WhatsApp: {{whatsapp_url}}\n\n"
+            "Thank you,\nEvolve Sprouts"
+        ),
+    ),
+    (
+        "zh-CN",
+        "我们已收到您的留言 — Evolve Sprouts",
+        (
+            '<p style="margin:0 0 12px;">您好 {{first_name}}，</p>'
+            '<p style="margin:0 0 16px;">我们已收到您的留言，并会在 24–48 小时内回复。</p>'
+            '<p style="margin:0 0 12px;">'
+            '<a href="{{faq_url}}" style="color:#1a5f4a;font-weight:600;">查看常见问题</a>'
+            "</p>"
+            '<p style="margin:0 0 12px;">'
+            '<a href="{{whatsapp_url}}" style="color:#1a5f4a;font-weight:600;">通过 WhatsApp 联系我们</a>'
+            "</p>"
+            '<p style="margin:16px 0 0;">谢谢，<br/>Evolve Sprouts</p>'
+        ),
+        (
+            "您好 {{first_name}}，\n\n"
+            "我们已收到您的留言，并会在 24–48 小时内回复。\n\n"
+            "常见问题：{{faq_url}}\n"
+            "WhatsApp：{{whatsapp_url}}\n\n"
+            "谢谢，\nEvolve Sprouts"
+        ),
+    ),
+    (
+        "zh-HK",
+        "我們已收到您的留言 — Evolve Sprouts",
+        (
+            '<p style="margin:0 0 12px;">您好 {{first_name}}，</p>'
+            '<p style="margin:0 0 16px;">我們已收到您的留言，並會在 24–48 小時內回覆。</p>'
+            '<p style="margin:0 0 12px;">'
+            '<a href="{{faq_url}}" style="color:#1a5f4a;font-weight:600;">查看常見問題</a>'
+            "</p>"
+            '<p style="margin:0 0 12px;">'
+            '<a href="{{whatsapp_url}}" style="color:#1a5f4a;font-weight:600;">透過 WhatsApp 聯絡我們</a>'
+            "</p>"
+            '<p style="margin:16px 0 0;">謝謝，<br/>Evolve Sprouts</p>'
+        ),
+        (
+            "您好 {{first_name}}，\n\n"
+            "我們已收到您的留言，並會在 24–48 小時內回覆。\n\n"
+            "常見問題：{{faq_url}}\n"
+            "WhatsApp：{{whatsapp_url}}\n\n"
+            "謝謝，\nEvolve Sprouts"
+        ),
+    ),
+]

--- a/backend/src/app/templates/ses/media_download_link.py
+++ b/backend/src/app/templates/ses/media_download_link.py
@@ -1,0 +1,108 @@
+"""SES templates: media download link (per locale)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _wrap_html(*, header_subtitle: str, inner_html: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/></head>
+<body style="margin:0;padding:0;background-color:#f6f6f6;font-family:Arial,Helvetica,sans-serif;">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f6f6f6;">
+<tr><td align="center" style="padding:24px 12px;">
+<table role="presentation" width="600" cellspacing="0" cellpadding="0"
+style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;">
+<tr><td style="padding:24px 28px;background:#1a5f4a;color:#ffffff;">
+<h1 style="margin:0;font-size:22px;line-height:1.3;">Evolve Sprouts</h1>
+<p style="margin:8px 0 0;font-size:14px;opacity:0.95;">{header_subtitle}</p>
+</td></tr>
+<tr><td style="padding:28px;color:#333333;font-size:15px;line-height:1.6;">
+{inner_html}
+</td></tr>
+<tr><td style="padding:16px 28px 24px;color:#666666;font-size:12px;line-height:1.5;">
+<p style="margin:0;">Evolve Sprouts</p>
+</td></tr>
+</table></td></tr></table></body></html>"""
+
+
+def get_ses_template_definitions() -> list[dict[str, Any]]:
+    """Return SES CreateTemplate payloads (Template key for boto3)."""
+    return [
+        {
+            "TemplateName": f"evolvesprouts-media-download-{loc}",
+            "SubjectPart": subject,
+            "HtmlPart": _wrap_html(header_subtitle=subject, inner_html=inner_html),
+            "TextPart": text_part,
+        }
+        for loc, subject, inner_html, text_part in _LOCALE_ROWS
+    ]
+
+
+_LOCALE_ROWS: list[tuple[str, str, str, str]] = [
+    (
+        "en",
+        "Your free guide is ready — Evolve Sprouts",
+        (
+            '<p style="margin:0 0 12px;">Hi {{first_name}},</p>'
+            '<p style="margin:0 0 20px;">Here is your download link for <strong>{{media_name}}</strong>.</p>'
+            '<p style="margin:0 0 16px;text-align:center;">'
+            '<a href="{{download_url}}" style="display:inline-block;padding:12px 24px;background:#1a5f4a;'
+            'color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;">Download</a>'
+            "</p>"
+            '<p style="margin:0 0 8px;font-size:13px;color:#555555;">If the button does not work, '
+            "copy this URL:</p>"
+            '<p style="margin:0;word-break:break-all;font-size:13px;color:#1a5f4a;">{{download_url}}</p>'
+            '<p style="margin:20px 0 0;">Thank you,<br/>Evolve Sprouts</p>'
+        ),
+        (
+            "Hi {{first_name}},\n\n"
+            "Here is your download link for {{media_name}}.\n\n"
+            "{{download_url}}\n\n"
+            "Thank you,\nEvolve Sprouts"
+        ),
+    ),
+    (
+        "zh-CN",
+        "您的免费资料已准备好 — Evolve Sprouts",
+        (
+            '<p style="margin:0 0 12px;">您好 {{first_name}}，</p>'
+            '<p style="margin:0 0 20px;">这是 <strong>{{media_name}}</strong> 的下载链接。</p>'
+            '<p style="margin:0 0 16px;text-align:center;">'
+            '<a href="{{download_url}}" style="display:inline-block;padding:12px 24px;background:#1a5f4a;'
+            'color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;">下载</a>'
+            "</p>"
+            '<p style="margin:0 0 8px;font-size:13px;color:#555555;">若按钮无法使用，请复制以下网址：</p>'
+            '<p style="margin:0;word-break:break-all;font-size:13px;color:#1a5f4a;">{{download_url}}</p>'
+            '<p style="margin:20px 0 0;">谢谢，<br/>Evolve Sprouts</p>'
+        ),
+        (
+            "您好 {{first_name}}，\n\n"
+            "这是 {{media_name}} 的下载链接：\n\n"
+            "{{download_url}}\n\n"
+            "谢谢，\nEvolve Sprouts"
+        ),
+    ),
+    (
+        "zh-HK",
+        "您的免費資料已準備好 — Evolve Sprouts",
+        (
+            '<p style="margin:0 0 12px;">您好 {{first_name}}，</p>'
+            '<p style="margin:0 0 20px;">這是 <strong>{{media_name}}</strong> 的下載連結。</p>'
+            '<p style="margin:0 0 16px;text-align:center;">'
+            '<a href="{{download_url}}" style="display:inline-block;padding:12px 24px;background:#1a5f4a;'
+            'color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;">下載</a>'
+            "</p>"
+            '<p style="margin:0 0 8px;font-size:13px;color:#555555;">若按鈕無法使用，請複製以下網址：</p>'
+            '<p style="margin:0;word-break:break-all;font-size:13px;color:#1a5f4a;">{{download_url}}</p>'
+            '<p style="margin:20px 0 0;">謝謝，<br/>Evolve Sprouts</p>'
+        ),
+        (
+            "您好 {{first_name}}，\n\n"
+            "這是 {{media_name}} 的下載連結：\n\n"
+            "{{download_url}}\n\n"
+            "謝謝，\nEvolve Sprouts"
+        ),
+    ),
+]

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -388,7 +388,13 @@ paths:
   /www/v1/legacy/reservations:
     post:
       summary: Submit reservation
-      description: Submit a public reservation request from `public_www`.
+      description: |
+        Submit a public reservation request from `public_www`.
+
+        On successful upstream acceptance (HTTP 200/202), the API also sends a
+        transactional booking confirmation email via SES to the attendee when
+        configured. Optional marketing opt-in may enqueue a Mailchimp audience
+        update; marketing failures do not change the HTTP response.
       security:
         - ApiKeyAuth: []
           TurnstileToken: []
@@ -451,7 +457,14 @@ paths:
   /www/v1/legacy/contact-us:
     post:
       summary: Submit contact-us form
-      description: Submit a contact-us message from `public_www`.
+      description: |
+        Submit a contact-us message from `public_www`.
+
+        On successful upstream acceptance (HTTP 200/202), the API also sends a
+        transactional confirmation email via SES when configured. Optional
+        marketing opt-in may enqueue a Mailchimp audience update; marketing
+        failures do not change the HTTP response. Locale for the confirmation
+        email is derived from the `Accept-Language` header when possible.
       security:
         - ApiKeyAuth: []
       requestBody:
@@ -484,6 +497,10 @@ paths:
       description: |
         Submit a media lead form. Routed on the public website via CloudFront
         as `POST /www/v1/assets/free/request` (execute-api origin).
+
+        The download link is delivered by SES (templated email). During a
+        transition period, Mailchimp may still mirror legacy journey delivery
+        unless consent gating is enabled in deployment configuration.
       security:
         - ApiKeyAuth: []
           TurnstileToken: []
@@ -952,6 +969,30 @@ components:
           type: string
           description: Required when payment method is Stripe/card-wallet flow.
           pattern: '^pi_[A-Za-z0-9]+$'
+        marketing_opt_in:
+          type: boolean
+          default: false
+          description: When true, subscribe the attendee to marketing (Mailchimp) with a booking tag.
+        locale:
+          type: string
+          description: Public website locale for SES booking confirmation template selection.
+          enum:
+            - en
+            - zh-CN
+            - zh-HK
+        course_label:
+          type: string
+          maxLength: 500
+          description: Human-readable course or event title for confirmation email context.
+        schedule_date_label:
+          type: string
+          maxLength: 500
+        schedule_time_label:
+          type: string
+          maxLength: 500
+        location_name:
+          type: string
+          maxLength: 500
     ReservationPaymentIntentRequest:
       type: object
       required:
@@ -985,6 +1026,7 @@ components:
     ContactUsSubmissionRequest:
       type: object
       required:
+        - first_name
         - email_address
         - message
       properties:
@@ -1001,6 +1043,10 @@ components:
         message:
           type: string
           maxLength: 5000
+        marketing_opt_in:
+          type: boolean
+          default: false
+          description: When true, subscribe the contact to marketing (Mailchimp) with a flow-specific tag.
     MediaRequestSubmissionRequest:
       type: object
       required:
@@ -1018,6 +1064,17 @@ components:
           type: string
           maxLength: 200
           description: Optional free-resource identifier used for downstream CRM tagging.
+        marketing_opt_in:
+          type: boolean
+          default: false
+          description: When true, trigger the shared welcome marketing journey after subscribe (when configured).
+        locale:
+          type: string
+          description: Public website locale for SES template selection.
+          enum:
+            - en
+            - zh-CN
+            - zh-HK
     MailchimpWebhookRequest:
       type: object
       required:

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1047,6 +1047,13 @@ components:
           type: boolean
           default: false
           description: When true, subscribe the contact to marketing (Mailchimp) with a flow-specific tag.
+        locale:
+          type: string
+          description: Public website route locale for SES confirmation template selection (falls back to Accept-Language when omitted).
+          enum:
+            - en
+            - zh-CN
+            - zh-HK
     MediaRequestSubmissionRequest:
       type: object
       required:

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -348,7 +348,7 @@ For each function above, the following resources are created:
 
 | Function | Additional Permissions |
 |----------|------------------------|
-| `EvolvesproutsAdminFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, invoke `AwsApiProxyFunction`, SNS publish to booking, media, expense parser, and Eventbrite sync topics, SES send email, S3 read/write for the assets bucket |
+| `EvolvesproutsAdminFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, invoke `AwsApiProxyFunction`, SNS publish to booking, media, expense parser, and Eventbrite sync topics, SES send email + **SendTemplatedEmail** (internal + `AuthEmailFromAddress` identities), Secrets Manager read for Mailchimp secret (marketing hooks on legacy routes), S3 read/write for the assets bucket |
 | `AwsApiProxyFunction` | Cognito admin operations (`ListUsers`, `ListUsersInGroup`, `AdminGetUser`, `AdminDeleteUser`, `AdminAddUserToGroup`, `AdminRemoveUserFromGroup`, `AdminListGroupsForUser`, `AdminUserGlobalSignOut`, `AdminUpdateUserAttributes`) |
 | `EvolvesproutsMigrationFunction` | Read DB secret, direct connect to Aurora as `postgres`, Cognito user management, CloudFormation invoke permission |
 | `HealthCheckFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_app` |
@@ -356,7 +356,8 @@ For each function above, the following resources are created:
 | `AdminBootstrapFunction` | Cognito `AdminCreateUser`, `AdminUpdateUserAttributes`, `AdminSetUserPassword`, `AdminAddUserToGroup`, CloudFormation invoke permission |
 | `ApiKeyRotationFunction` | API Gateway key management, Secrets Manager read/write |
 | `BookingRequestProcessor` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, SES send email |
-| `MediaRequestProcessor` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, SES send email, read Mailchimp secret, invoke `AwsApiProxyFunction`; `ASSET_SHARE_LINK_BASE_URL`, `ASSET_SHARE_LINK_DEFAULT_ALLOWED_DOMAINS`, `MAILCHIMP_MEDIA_DOWNLOAD_MERGE_TAG` for Mailchimp download URL merge field; optional `MAILCHIMP_FREE_RESOURCE_JOURNEY_ID` / `MAILCHIMP_FREE_RESOURCE_JOURNEY_STEP_ID` for Customer Journey trigger |
+| `MediaRequestProcessor` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, SES send email + **SendTemplatedEmail** (internal + `AuthEmailFromAddress` identities), read Mailchimp secret, invoke `AwsApiProxyFunction`; `ASSET_SHARE_LINK_BASE_URL`, `ASSET_SHARE_LINK_DEFAULT_ALLOWED_DOMAINS`, `MAILCHIMP_MEDIA_DOWNLOAD_MERGE_TAG` for Mailchimp download URL merge field; optional `MAILCHIMP_FREE_RESOURCE_JOURNEY_ID` / `MAILCHIMP_FREE_RESOURCE_JOURNEY_STEP_ID` for free-resource Customer Journey trigger; `MAILCHIMP_REQUIRE_MARKETING_CONSENT` + welcome journey env vars (see `aws-messaging.md`) |
+| `SesTemplateManagerFunction` | SES template CRUD (`CreateTemplate`, `UpdateTemplate`, `DeleteTemplate`, `GetTemplate`) for CloudFormation custom resource `SesEmailTemplates` |
 | `ExpenseParserFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, S3 read for the assets bucket, read OpenRouter API secret, invoke `AwsApiProxyFunction` |
 | `InboundInvoiceEmailProcessor` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, S3 read/write for the assets bucket (including the `inbound-email/raw/` prefix), publish to the expense parser SNS topic |
 | `EventbriteSyncProcessor` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, read Eventbrite token secret, invoke `AwsApiProxyFunction` |
@@ -498,6 +499,7 @@ configured by stack custom resources (including retention and KMS association).
 | Resource Type | Logical ID | Handler | Notes |
 |--------------|------------|---------|-------|
 | Custom Resource | `AdminBootstrapResource` | `AdminBootstrapFunction` | Creates admin user in Cognito |
+| `SesEmailTemplates` | `SesTemplateManagerFunction` | Upserts SES stored templates for public transactional email |
 
 **Properties:**
 - `UserPoolId`: Cognito User Pool ID
@@ -544,6 +546,9 @@ configured by stack custom resources (including retention and KMS association).
 | `MailchimpMediaDownloadMergeTag` | String | No | No | Mailchimp audience merge field tag for media download URL (`/v1/assets/email-download/{token}`; empty default; set e.g. `MMDLURL` after creating the field) |
 | `MailchimpFreeResourceJourneyId` | String | No | No | Mailchimp Customer Journey ID for free-resource journey trigger API (empty disables) |
 | `MailchimpFreeResourceJourneyStepId` | String | No | No | Journey step ID paired with `MailchimpFreeResourceJourneyId` (empty disables) |
+| `MailchimpWelcomeJourneyId` | String | No | No | Shared welcome journey ID for opted-in public form contacts (empty disables) |
+| `MailchimpWelcomeJourneyStepId` | String | No | No | Welcome journey entry step ID paired with `MailchimpWelcomeJourneyId` (empty disables) |
+| `MailchimpRequireMarketingConsent` | String | No | No | When `true`, media processor gates legacy Mailchimp subscribe + free-resource journey on `marketing_opt_in` (default: `false`) |
 | `ApiCustomDomainName` | String | No | No | Custom domain for the API (default: empty) |
 | `ApiCustomDomainCertificateArn` | String | No | No | ACM certificate ARN for API custom domain |
 | `NominatimUserAgent` | String | No | No | User-Agent for Nominatim geocoding requests |

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -311,7 +311,7 @@ SQS retries or mailbox forwarding duplicates.
 | `EXPENSE_PARSE_TOPIC_ARN` | SNS topic ARN for expense parser events (required) |
 | `EVENTBRITE_SYNC_TOPIC_ARN` | SNS topic ARN for Eventbrite sync events (required for Eventbrite DB-sync) |
 | `CONFIRMATION_EMAIL_FROM_ADDRESS` | SES-verified from address for customer-facing templated emails on legacy public routes (`EvolvesproutsAdminFunction`) |
-| `PUBLIC_WWW_BASE_URL` | HTTPS origin of the public website (FAQ links in contact confirmation templates) |
+| `PUBLIC_WWW_BASE_URL` | HTTPS origin of the public website (Contact Us FAQ anchor in contact confirmation templates: `/{locale}/contact-us#contact-us-faq`) |
 | `MAILCHIMP_API_SECRET_ARN` | Mailchimp API key secret (marketing subscribe after opt-in on legacy routes) |
 | `MAILCHIMP_LIST_ID` | Mailchimp audience ID |
 | `MAILCHIMP_SERVER_PREFIX` | Mailchimp API host prefix |

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -24,6 +24,24 @@ Ticket submissions are processed asynchronously using SNS + SQS messaging. This 
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
+## Public website transactional confirmations (SES)
+
+The public website contact form, booking modal (`/www/v1/legacy/*`), and media
+download flow send **customer-facing** confirmation or download-link emails
+through **Amazon SES templated send** (`SendTemplatedEmail`). Templates are
+stored in SES and upserted at deploy time by a **CloudFormation custom
+resource** (`SesTemplateManagerFunction`) so runtime Lambdas only reference
+template names.
+
+- **From address**: `CONFIRMATION_EMAIL_FROM_ADDRESS` on the relevant Lambdas,
+  sourced from the stack `AuthEmailFromAddress` parameter (SES-verified
+  customer-facing mailbox, for example `hello@`).
+- **Internal notifications** (for example media lead alerts to the team)
+  continue to use `SES_SENDER_EMAIL` / `SupportEmail` where applicable.
+- **Mailchimp** remains separate: optional marketing subscribe + journey
+  triggers run only when the user opts in; failures are logged and do not
+  change the HTTP response for legacy bridge routes.
+
 ## Components
 
 ### SNS Topic: `evolvesprouts-booking-request-events`
@@ -145,8 +163,14 @@ responsive while decoupling downstream processing.
 - Upserts contact and inserts idempotent lead rows.
 - Resolves media asset IDs by matching `resource_key` against `assets.resource_key`.
 - Applies a resource-specific tag (`public-www-media-<resource_key>-requested`) to the contact.
-- Syncs subscriber/tag to Mailchimp through `AwsApiProxyFunction`.
-- Sends an SES notification to sales/support.
+- Sends the **download link** to the submitter via **SES templated email**
+  (`evolvesprouts-media-download-{locale}`) using `CONFIRMATION_EMAIL_FROM_ADDRESS`.
+- Syncs subscriber/tag to Mailchimp through `AwsApiProxyFunction` (during a
+  **transition** period this may still run for all submissions; when
+  `MailchimpRequireMarketingConsent` is `true`, subscribe + free-resource journey
+  run only when `marketing_opt_in` is true). When users opt in, a **separate**
+  shared welcome journey may be triggered (empty journey env vars disable it).
+- Sends an SES notification to sales/support (internal sender).
 
 ## Expense parsing flow
 
@@ -271,6 +295,7 @@ SQS retries or mailbox forwarding duplicates.
 | `backend/src/app/api/admin.py` | API handler with SNS publish and public calendar feed routing |
 | `backend/lambda/manager_request_processor/handler.py` | SQS booking request processor |
 | `backend/lambda/media_processor/handler.py` | SQS media request processor |
+| `backend/lambda/ses_template_manager/handler.py` | CloudFormation custom resource — upsert SES email templates |
 | `backend/lambda/inbound_invoice_email/handler.py` | SQS inbound invoice email processor |
 | `backend/src/app/services/inbound_invoice_ingest.py` | Expense + asset creation from inbound email |
 | `backend/src/app/db/repositories/ticket.py` | Repository with `find_by_ticket_id` |
@@ -285,6 +310,13 @@ SQS retries or mailbox forwarding duplicates.
 | `MEDIA_REQUEST_TOPIC_ARN` | SNS topic ARN for media events (required) |
 | `EXPENSE_PARSE_TOPIC_ARN` | SNS topic ARN for expense parser events (required) |
 | `EVENTBRITE_SYNC_TOPIC_ARN` | SNS topic ARN for Eventbrite sync events (required for Eventbrite DB-sync) |
+| `CONFIRMATION_EMAIL_FROM_ADDRESS` | SES-verified from address for customer-facing templated emails on legacy public routes (`EvolvesproutsAdminFunction`) |
+| `PUBLIC_WWW_BASE_URL` | HTTPS origin of the public website (FAQ links in contact confirmation templates) |
+| `MAILCHIMP_API_SECRET_ARN` | Mailchimp API key secret (marketing subscribe after opt-in on legacy routes) |
+| `MAILCHIMP_LIST_ID` | Mailchimp audience ID |
+| `MAILCHIMP_SERVER_PREFIX` | Mailchimp API host prefix |
+| `MAILCHIMP_WELCOME_JOURNEY_ID` | Optional shared welcome journey ID (empty disables) |
+| `MAILCHIMP_WELCOME_JOURNEY_STEP_ID` | Optional welcome journey entry step ID (empty disables) |
 
 ### Processor Lambda
 
@@ -305,6 +337,11 @@ SQS retries or mailbox forwarding duplicates.
 | `MAILCHIMP_MEDIA_DOWNLOAD_MERGE_TAG` | Mailchimp merge field tag for that email-download URL (e.g. `MMDLURL`; empty disables) |
 | `MAILCHIMP_FREE_RESOURCE_JOURNEY_ID` | Mailchimp Customer Journey ID for `.../journeys/{id}/steps/.../actions/trigger` (empty disables) |
 | `MAILCHIMP_FREE_RESOURCE_JOURNEY_STEP_ID` | Journey step ID paired with `MAILCHIMP_FREE_RESOURCE_JOURNEY_ID` (empty disables) |
+| `CONFIRMATION_EMAIL_FROM_ADDRESS` | SES-verified from address for media download link email to the submitter |
+| `MAILCHIMP_REQUIRE_MARKETING_CONSENT` | When `true`, gate legacy Mailchimp subscribe + free-resource journey on `marketing_opt_in` |
+| `MAILCHIMP_WELCOME_JOURNEY_ID` | Optional shared welcome journey ID for opted-in media leads (empty disables) |
+| `MAILCHIMP_WELCOME_JOURNEY_STEP_ID` | Optional welcome journey entry step ID (empty disables) |
+| `PUBLIC_WWW_BASE_URL` | HTTPS origin of the public website (reserved for template helpers) |
 | `AWS_PROXY_FUNCTION_ARN` | Lambda ARN for HTTP proxy calls |
 | `OPENROUTER_API_KEY_SECRET_ARN` | Existing secret ARN for OpenRouter API key |
 | `OPENROUTER_CHAT_COMPLETIONS_URL` | OpenRouter chat completion URL |

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -70,8 +70,9 @@ their primary responsibilities.
   verified `SesSenderEmail` identity **and** the `AuthEmailFromAddress` identity
   (plus derived domain identity ARNs), Secrets Manager read for the Mailchimp API
   secret when marketing hooks run on legacy routes
-- Environment (selected): `CONFIRMATION_EMAIL_FROM_ADDRESS`, `PUBLIC_WWW_BASE_URL`,
-  `SUPPORT_EMAIL`, `MAILCHIMP_*` welcome journey vars (see `aws-messaging.md`)
+- Environment (selected): `SES_SENDER_EMAIL`, `CONFIRMATION_EMAIL_FROM_ADDRESS`,
+  `PUBLIC_WWW_BASE_URL`, `SUPPORT_EMAIL`, `MAILCHIMP_*` welcome journey vars
+  (see `aws-messaging.md`)
 - Purpose:   asset metadata CRUD (admin asset list returns `linked_tag_names` for tag
   filters and accepts `tag_name` for any tag linked to assets in the requested
   `asset_type` scope; create/update accept optional `client_tag` for the

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -66,6 +66,12 @@ their primary responsibilities.
   device attestation + API key for `/v1/assets/public/*`,
   API key for `/v1/assets/share/*` and `/v1/assets/email-download/*` (injected by
   media CloudFront at origin) and `GET /v1/assets/free`
+- Permissions: SES `SendEmail` / `SendRawEmail` / `SendTemplatedEmail` on the
+  verified `SesSenderEmail` identity **and** the `AuthEmailFromAddress` identity
+  (plus derived domain identity ARNs), Secrets Manager read for the Mailchimp API
+  secret when marketing hooks run on legacy routes
+- Environment (selected): `CONFIRMATION_EMAIL_FROM_ADDRESS`, `PUBLIC_WWW_BASE_URL`,
+  `SUPPORT_EMAIL`, `MAILCHIMP_*` welcome journey vars (see `aws-messaging.md`)
 - Purpose:   asset metadata CRUD (admin asset list returns `linked_tag_names` for tag
   filters and accepts `tag_name` for any tag linked to assets in the requested
   `asset_type` scope; create/update accept optional `client_tag` for the
@@ -91,7 +97,10 @@ their primary responsibilities.
   `/v1/assets/free/request`, Mailchimp webhook ingestion and contact sync-status
   reconciliation on `/v1/mailchimp/webhook`, legacy public API bridge routing
   on `/v1/legacy/*` (proxying to upstream legacy endpoints via
-  `AwsApiProxyFunction`), Stripe PaymentIntent creation for
+  `AwsApiProxyFunction`; after successful upstream acceptance, sends SES
+  **templated** confirmation emails for contact-us and reservations and may
+  subscribe opted-in contacts to Mailchimp + optional welcome journey),
+  Stripe PaymentIntent creation for
   inline public booking modal payments on `/v1/reservations/payment-intent`
   (card-only `payment_method_types[]=card`; wallet buttons are disabled in the
   public Payment Element; `STRIPE_PAYMENT_METHOD_CONFIGURATION_ID` is not used).
@@ -109,6 +118,15 @@ their primary responsibilities.
 - Auth: IAM
 - Purpose: service health and configuration checks
 - DB access: RDS Proxy with IAM auth (`evolvesprouts_app`)
+
+### SES template manager (custom resource)
+- Function: SesTemplateManagerFunction
+- Handler: backend/lambda/ses_template_manager/handler.py
+- Trigger: CloudFormation custom resource `SesEmailTemplates`
+- Purpose: create/update/delete SES stored email templates used by public
+  transactional flows (contact, media download link, booking confirmation)
+- VPC: **No**
+- Permissions: SES `CreateTemplate`, `UpdateTemplate`, `DeleteTemplate`, `GetTemplate`
 
 ## Auth and security Lambdas
 
@@ -218,19 +236,23 @@ their primary responsibilities.
 - Handler: backend/lambda/media_processor/handler.py
 - Trigger: SQS queue (`evolvesprouts-media-queue`)
 - Purpose: process media lead captures and fan out actions (including Mailchimp
-  journey re-trigger on repeat requests for the same contact + asset)
-- Actions: contact upsert in DB, idempotent sales lead creation, Mailchimp sync
-  (merge fields + tag + optional Customer Journey trigger), and SES notification
-  to sales/support
+  free-resource journey re-trigger on repeat requests during the transition
+  period, and optional welcome journey for opted-in contacts)
+- Actions: contact upsert in DB, idempotent sales lead creation, SES templated
+  download-link email to the submitter, Mailchimp sync (merge fields + tag +
+  optional free-resource Customer Journey trigger; consent-gated when
+  `MAILCHIMP_REQUIRE_MARKETING_CONSENT=true`), optional welcome journey for
+  `marketing_opt_in`, and SES notification to sales/support
 - DB access: RDS Proxy with IAM auth (`evolvesprouts_admin`)
 - VPC: Yes
-- Permissions: SES send email (verified sender address and derived domain identity
-  ARNs), Secrets Manager read for Mailchimp API key,
+- Permissions: SES `SendEmail`, `SendRawEmail`, and `SendTemplatedEmail` (verified
+  internal sender + `AuthEmailFromAddress` identities and derived domain ARNs),
+  Secrets Manager read for Mailchimp API key,
   Lambda invoke permission for `AwsApiProxyFunction`
 - Environment:
   - `DATABASE_SECRET_ARN`, `DATABASE_NAME`, `DATABASE_USERNAME`,
     `DATABASE_PROXY_ENDPOINT`, `DATABASE_IAM_AUTH`
-  - `SES_SENDER_EMAIL`, `SUPPORT_EMAIL`
+  - `SES_SENDER_EMAIL`, `SUPPORT_EMAIL`, `CONFIRMATION_EMAIL_FROM_ADDRESS`
   - `MAILCHIMP_API_SECRET_ARN`, `MAILCHIMP_LIST_ID`,
     `MAILCHIMP_SERVER_PREFIX`
   - `MEDIA_DEFAULT_RESOURCE_KEY`, `AWS_PROXY_FUNCTION_ARN`
@@ -240,6 +262,11 @@ their primary responsibilities.
     `/v1/assets/email-download/{token}` download URL)
   - `MAILCHIMP_FREE_RESOURCE_JOURNEY_ID`, `MAILCHIMP_FREE_RESOURCE_JOURNEY_STEP_ID` (optional;
     Customer Journey API trigger after successful member sync; empty disables)
+  - `MAILCHIMP_REQUIRE_MARKETING_CONSENT` (when `true`, gate legacy Mailchimp
+    subscribe + free-resource journey on `marketing_opt_in`)
+  - `MAILCHIMP_WELCOME_JOURNEY_ID`, `MAILCHIMP_WELCOME_JOURNEY_STEP_ID` (optional;
+    shared welcome journey for opted-in contacts; empty disables)
+  - `PUBLIC_WWW_BASE_URL` (reserved for shared template helpers)
 
 ### Expense parser processor
 - Function: ExpenseParserFunction

--- a/docs/plans/confirmation-email-and-marketing-optin.md
+++ b/docs/plans/confirmation-email-and-marketing-optin.md
@@ -1,0 +1,812 @@
+# Plan: Transactional Confirmation Emails and Marketing Opt-In
+
+**Status**: Draft — awaiting owner approval before implementation.
+
+---
+
+## 1. Goal
+
+Add two capabilities to every public form submission flow (Contact Us, Media
+Download, Booking):
+
+1. **Transactional confirmation email** — always sent to the submitter via
+   AWS SES immediately after a successful submission.
+2. **Marketing opt-in** — an optional, unchecked-by-default checkbox on each
+   form. When checked, the submitter is added to the Mailchimp audience with a
+   flow-specific tag, and a shared welcome Customer Journey is triggered.
+
+Additionally, the media download link delivery is migrated from a Mailchimp
+Customer Journey to a direct SES email. The Mailchimp journey is kept active
+during a transition period (both send), then removed in a follow-up.
+
+---
+
+## 2. Scope
+
+### In scope
+
+| Flow | Frontend form | Backend handler |
+|------|--------------|----------------|
+| Contact Us | `contact-us-form.tsx` / `contact-us-form-fields.tsx` | `public_legacy_proxy.py` → `handle_legacy_contact_us` |
+| Media download | `media-form.tsx` | `public_media.py` → SNS → `media_processor/handler.py` |
+| Booking (events, consultations, MBA) | `reservation-form.tsx` / `reservation-form-fields.tsx` | `public_legacy_proxy.py` → `handle_legacy_reservations` |
+
+### Out of scope
+
+- **Event notification form** (`event-notification.tsx`) — collects email only
+  (no name), serves a different purpose (event alerts). Address in a follow-up.
+- **Native reservation handler** (`public_reservations.py` at
+  `/v1/reservations`) — not used by any frontend client today. Do not modify.
+- **Re-consent campaign** for existing Mailchimp audience members who were
+  subscribed without explicit opt-in — business/legal decision, separate from
+  this work.
+- **Mailchimp journey removal** for media download — planned for removal in a
+  follow-up after the transition period. See §10.
+
+---
+
+## 3. Architecture principles
+
+1. **Transactional and marketing are separate concerns.** SES handles promised
+   content (confirmations, download links). Mailchimp handles audience
+   membership and marketing journeys.
+2. **Marketing subscribe requires explicit consent.** No Mailchimp audience
+   add without the user checking the opt-in box.
+3. **Transactional email must not depend on marketing.** If Mailchimp is down
+   or the user did not opt in, the confirmation email still arrives.
+4. **Marketing failures are non-blocking.** Mailchimp errors are logged but
+   never fail the user response. The primary action (proxy / SNS publish)
+   already succeeded.
+
+---
+
+## 4. Design decisions (resolved)
+
+These decisions were confirmed by the product owner and are binding for
+implementation.
+
+| # | Decision | Detail |
+|---|----------|--------|
+| D1 | Legacy APIs tolerate unknown fields | The new fields (`marketing_opt_in`, `locale`, `course_label`, etc.) can be forwarded to the legacy API without stripping. |
+| D2 | Welcome journey not yet created | Deploy with empty placeholder values for `MAILCHIMP_WELCOME_JOURNEY_ID` and `MAILCHIMP_WELCOME_JOURNEY_STEP_ID` (empty disables the trigger). The existing `MAILCHIMP_FREE_RESOURCE_JOURNEY_ID` and `MAILCHIMP_FREE_RESOURCE_JOURNEY_STEP_ID` GitHub vars and CDK parameters stay unchanged — they serve the media download delivery during the transition period and are a separate journey. |
+| D3 | WhatsApp URL — no new CDK parameter | Use the same hardcoded fallback URL as the website content JSON (`whatsappContact.href` in `en.json`): `https://wa.me/message/ZQHVW4DEORD5A1?src=qr`. Define this as a module constant in a shared email template utilities module (`backend/src/app/templates/constants.py`). Keep it in sync with `apps/public_www/src/content/en.json` → `whatsappContact.href`. This mirrors how the website treats it as a brand-level fallback constant. |
+| D4 | Email sender: `hello@evolvesprouts.com` | Customer-facing confirmation emails use the `AuthEmailFromAddress` parameter (`hello@evolvesprouts.com`). Internal notifications continue using `SesSenderEmail` (`no-reply@`). The SES domain identity ARN (`identity/evolvesprouts.com`) already covers both addresses. |
+| D5 | Legacy APIs accept `first_name` | Making `first_name` required on the Contact Us form and forwarding it in the body is safe. |
+| D6 | Booking display fields tolerated | Adding `course_label`, `schedule_date_label`, `schedule_time_label`, and `location_name` to the reservation POST body is safe. |
+| D7 | Email templates: SES native templates (Handlebars) | Use SES stored templates with Handlebars syntax (`{{variable}}`, `{{#if}}`, `{{#each}}`). The `send_templated_email` function already exists in `backend/src/app/services/email.py`. Templates are created/updated via a CDK custom resource at deploy time. This is the AWS-native approach and avoids maintaining complex HTML in Python string-format templates. See §6.6 for details. |
+| D8 | SES is in production mode | No sending limit concerns. |
+| D9 | Marketing opt-in checkbox: unchecked by default | True opt-in across all three forms. |
+
+---
+
+## 5. Current state
+
+| Flow | Email to user | Email to team | Mailchimp | Consent |
+|------|--------------|--------------|-----------|---------|
+| Contact Us | None | None (legacy handles) | None | None |
+| Media download | Mailchimp journey (download link) | SES (sales notification) | Subscribe + tag + journey | **None** |
+| Booking | None | None (legacy handles) | None | None |
+
+### Problems
+
+- **Media**: Download link delivery is coupled to Mailchimp subscribe. Users
+  are added to the marketing audience without consent.
+- **Contact Us**: No confirmation email. No marketing capability.
+- **Booking**: No confirmation email for paying customers. No marketing
+  capability.
+
+---
+
+## 6. Target state
+
+| Flow | Email to user | Email to team | Mailchimp | Consent |
+|------|--------------|--------------|-----------|---------|
+| Contact Us | SES confirmation (always) | Unchanged (legacy) | Subscribe + tag + journey (if opted in) | Checkbox (unchecked) |
+| Media download | SES download link (always) | SES sales notification (unchanged) | Subscribe + tag + journey (if opted in) | Checkbox (unchecked) |
+| Booking | SES booking confirmation (always) | Unchanged (legacy) | Subscribe + tag + journey (if opted in) | Checkbox (unchecked) |
+
+### Media transition period
+
+During the transition the media flow sends the download link via **both** SES
+and the existing Mailchimp Customer Journey. The Mailchimp journey continues to
+fire for **all** media submissions (opted in or not) until the removal
+follow-up. This ensures no user misses their download link if SES delivery has
+issues in the initial rollout. See §10 for the removal checklist.
+
+---
+
+## 7. Detailed changes
+
+### 7.1 Frontend — Contact Us form
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `apps/public_www/src/components/sections/contact-us-form-fields.tsx` | 1. Make `firstName` field required: add required marker (`*`), add `required` attribute, add `aria-invalid` + error message (same pattern as email field). 2. Add marketing opt-in checkbox below the captcha field, above submit. Unchecked by default. Use locale content for label. |
+| `apps/public_www/src/components/sections/contact-us-form.tsx` | 1. Add `isFirstNameTouched` state + blur handler. 2. Validate `firstName` is non-empty after sanitize in `handleSubmit`. 3. Add `marketingOptIn` boolean state (default `false`). 4. Include `first_name` (always) and `marketing_opt_in` in the POST body. |
+| `apps/public_www/src/content/en.json` | Add under `contactUs.form`: `firstNameRequiredError` ("Please enter your name"), `marketingOptInLabel` ("Keep me updated with parenting tips and resources"). |
+| `apps/public_www/src/content/zh-CN.json` | Chinese Simplified translations for the two new keys. |
+| `apps/public_www/src/content/zh-HK.json` | Chinese Traditional translations for the two new keys. |
+| `apps/public_www/tests/components/sections/contact-us-form.test.tsx` | Update: required first name validation, marketing checkbox presence and default state, payload includes `first_name` and `marketing_opt_in`. |
+| `apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx` | Update: first name required marker, error state, checkbox rendering. |
+
+**Props changes to `ContactFormFields`:**
+
+Add to the component interface:
+
+- `hasFirstNameError: boolean`
+- `marketingOptIn: boolean`
+- `onFirstNameBlur: () => void`
+- `onMarketingOptInChange: (checked: boolean) => void`
+
+The content type (`ContactUsContent['form']`) will need the two new keys added
+to the TypeScript type in `apps/public_www/src/content/index.ts` (or wherever
+the content types are defined).
+
+**Request body change:**
+
+```
+Before: { email_address, message, first_name?, phone_number? }
+After:  { email_address, message, first_name, phone_number?, marketing_opt_in }
+```
+
+`first_name` becomes always-present (required). `marketing_opt_in` is a boolean
+(default `false` if omitted).
+
+### 7.2 Frontend — Media download form
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `apps/public_www/src/components/sections/media-form.tsx` | Add `marketingOptIn` boolean state (default `false`). Add checkbox below email field, before captcha. Include `marketing_opt_in` in the POST body. |
+| `apps/public_www/src/content/en.json` | Add under `resources`: `formMarketingOptInLabel` ("Keep me updated with parenting tips and resources"). |
+| `apps/public_www/src/content/zh-CN.json` | Chinese Simplified translation. |
+| `apps/public_www/src/content/zh-HK.json` | Chinese Traditional translation. |
+| `apps/public_www/tests/components/sections/media-form.test.tsx` | Update: checkbox rendering, default state, payload includes `marketing_opt_in`. |
+
+**Request body change:**
+
+```
+Before: { first_name, email, resource_key? }
+After:  { first_name, email, resource_key?, marketing_opt_in }
+```
+
+### 7.3 Frontend — Booking reservation form
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx` | Add marketing opt-in checkbox. Place it after the topics textarea and before the payment section. Visually distinguish from the required terms checkbox (terms has `*`, marketing does not). Pass `marketingOptIn` and `onMarketingOptInChange` as new props. |
+| `apps/public_www/src/components/sections/booking-modal/reservation-form.tsx` | Add `marketingOptIn` boolean state (default `false`). Include `marketing_opt_in` in the reservation payload. Pass the `locale` prop value into the POST body as `locale` (string, e.g. `"en"`, `"zh-CN"`, `"zh-HK"`). Include display fields from `reservationSummary`: `course_label`, `schedule_date_label`, `schedule_time_label`, `location_name`. |
+| `apps/public_www/src/lib/reservations-data.ts` | Add to `ReservationSubmissionPayload`: `marketing_opt_in?: boolean`, `locale?: string`, `course_label?: string`, `schedule_date_label?: string`, `schedule_time_label?: string`, `location_name?: string`. |
+| `apps/public_www/src/content/en.json` | Add under `bookingModal.paymentModal`: `marketingOptInLabel` ("Keep me updated with parenting tips and resources"). |
+| `apps/public_www/src/content/zh-CN.json` | Chinese Simplified translation. |
+| `apps/public_www/src/content/zh-HK.json` | Chinese Traditional translation. |
+| Tests for the reservation form components. | Update: checkbox rendering, default state, payload includes new fields. |
+
+**Request body change:**
+
+```
+Before: { full_name, email, phone_number, cohort_age, cohort_date, ... }
+After:  { full_name, email, phone_number, cohort_age, cohort_date, ...,
+          marketing_opt_in, locale, course_label, schedule_date_label,
+          schedule_time_label, location_name }
+```
+
+`locale` is passed from the frontend so the backend can select the correct
+email template language. Display fields are sourced from `reservationSummary`
+in `reservation-form.tsx`.
+
+### 7.4 Frontend — Shared checkbox component
+
+All three forms need an identical marketing opt-in checkbox. To avoid
+duplication, extract a shared component:
+
+**New file:**
+`apps/public_www/src/components/shared/marketing-opt-in-checkbox.tsx`
+
+Props: `label: string`, `checked: boolean`, `onChange: (checked: boolean) => void`.
+
+Renders a styled `<label>` with `<input type="checkbox">` using existing
+`es-form-*` CSS classes. No required marker. Accessible (`aria-*` attributes
+not needed beyond the label association).
+
+### 7.5 Backend — Shared marketing subscribe helper
+
+**New file:** `backend/src/app/services/marketing_subscribe.py`
+
+Purpose: reusable, non-blocking wrapper for Mailchimp audience subscribe +
+tag + welcome journey trigger. Called from all three flows.
+
+```python
+def subscribe_to_marketing(
+    *,
+    email: str,
+    first_name: str,
+    tag_name: str,
+    merge_fields: dict[str, str] | None = None,
+    logger: Logger,
+) -> bool:
+    """Add a contact to the Mailchimp audience with a tag and trigger the
+    welcome journey. Returns True if the subscribe succeeded.
+
+    Non-blocking: logs errors but never raises.
+    """
+```
+
+Implementation:
+
+1. Call `add_subscriber_with_tag(email=email, first_name=first_name,
+   tag_name=tag_name, merge_fields=merge_fields)` with `run_with_retry`
+   (3 attempts, 1s base delay, `_is_retryable_mailchimp_exception`).
+2. On success, read `MAILCHIMP_WELCOME_JOURNEY_ID` and
+   `MAILCHIMP_WELCOME_JOURNEY_STEP_ID` from env. If both non-empty, call
+   `trigger_customer_journey(email=email, journey_id=..., step_id=...)`
+   with `run_with_retry`. If either is empty, skip (journey not configured).
+3. Catch and log all exceptions. Return `False` on failure.
+
+Environment variables consumed:
+- `MAILCHIMP_API_SECRET_ARN` (existing)
+- `MAILCHIMP_LIST_ID` (existing)
+- `MAILCHIMP_SERVER_PREFIX` (existing)
+- `MAILCHIMP_WELCOME_JOURNEY_ID` (new — deploy with empty string initially)
+- `MAILCHIMP_WELCOME_JOURNEY_STEP_ID` (new — deploy with empty string initially)
+
+These are the **shared** welcome journey IDs — all three flows trigger the same
+journey. They are **separate** from the existing
+`MAILCHIMP_FREE_RESOURCE_JOURNEY_ID` / `MAILCHIMP_FREE_RESOURCE_JOURNEY_STEP_ID`
+which serve the media download delivery Mailchimp journey and remain unchanged
+during the transition period.
+
+### 7.6 Backend — Email templates
+
+#### 7.6.0 Template approach: SES stored templates with Handlebars
+
+AWS SES natively supports stored email templates with Handlebars syntax
+(`{{variable}}`, `{{#if condition}}`, `{{#each list}}`). The
+`send_templated_email` function already exists in
+`backend/src/app/services/email.py` and calls
+`ses:SendTemplatedEmail`.
+
+**Template management:** Templates will be created/updated at deploy time via
+a CDK custom resource (Lambda-backed) that calls `ses:CreateTemplate` /
+`ses:UpdateTemplate`. Template source lives in Python modules under
+`backend/src/app/templates/ses/` as dictionaries (template name → subject/HTML/text).
+The custom resource Lambda reads these and upserts them into SES.
+
+Each template is **locale-suffixed** to support three languages:
+
+- `evolvesprouts-contact-confirmation-en`
+- `evolvesprouts-contact-confirmation-zh-CN`
+- `evolvesprouts-contact-confirmation-zh-HK`
+- `evolvesprouts-media-download-en` / `zh-CN` / `zh-HK`
+- `evolvesprouts-booking-confirmation-en` / `zh-CN` / `zh-HK`
+
+The handler selects the correct template by appending the validated locale
+suffix (default `en`).
+
+**Template data** is passed as a JSON object via `send_templated_email`'s
+`template_data` parameter.
+
+#### 7.6.1 Shared template constants
+
+**New file:** `backend/src/app/templates/constants.py`
+
+Module-level constants shared across email templates:
+
+```python
+WHATSAPP_URL = "https://wa.me/message/ZQHVW4DEORD5A1?src=qr"
+```
+
+This matches the hardcoded fallback in
+`apps/public_www/src/content/en.json` → `whatsappContact.href`. Must stay
+in sync with that value.
+
+Also defines a `resolve_public_www_base_url()` helper that reads
+`PUBLIC_WWW_BASE_URL` env var (set on Lambda from CDK
+`publicWwwDomainName`).
+
+#### 7.6.2 SES template definitions
+
+**New file:** `backend/src/app/templates/ses/contact_confirmation.py`
+
+Template name pattern: `evolvesprouts-contact-confirmation-{locale}`
+
+Template data variables:
+- `{{first_name}}`
+- `{{whatsapp_url}}`
+- `{{faq_url}}`
+
+Content:
+- Subject: "We received your message — Evolve Sprouts"
+- Body: Greeting with first name. "We received your message and will get back
+  to you within 24–48 hours." Links: FAQ page URL, WhatsApp URL. Closing.
+- HTML: Branded template (inline CSS, 600px max-width, Evolve Sprouts header).
+  Handlebars variables for dynamic content.
+
+**New file:** `backend/src/app/templates/ses/media_download_link.py`
+
+Template name pattern: `evolvesprouts-media-download-{locale}`
+
+Template data variables:
+- `{{first_name}}`
+- `{{media_name}}`
+- `{{download_url}}`
+
+Content:
+- Subject: "Your free guide is ready — Evolve Sprouts"
+- Body: Greeting with first name. "Here is your download link for
+  {{media_name}}." Prominent download button/link. "If the button doesn't
+  work, copy this URL: {{download_url}}." Closing.
+- HTML: Branded template. Prominent CTA button for the download URL.
+
+**New file:** `backend/src/app/templates/ses/booking_confirmation.py`
+
+Template name pattern: `evolvesprouts-booking-confirmation-{locale}`
+
+Template data variables:
+- `{{full_name}}`
+- `{{course_label}}`
+- `{{schedule_date_label}}` (optional — use `{{#if}}`)
+- `{{schedule_time_label}}` (optional)
+- `{{payment_method}}`
+- `{{total_amount}}`
+- `{{is_pending_payment}}` (boolean — for non-Stripe note)
+- `{{whatsapp_url}}`
+
+Content:
+- Subject: "Booking confirmed — {{course_label}} — Evolve Sprouts"
+- Body: Greeting with full name. "Thank you for your booking!" Details table:
+  course/event name, date/time, payment amount (HKD), payment method.
+  `{{#if is_pending_payment}}` block: "Your reservation is pending until
+  payment is confirmed." WhatsApp link for questions. Closing.
+- HTML: Branded template. Details table. WhatsApp CTA.
+
+#### 7.6.3 SES template deployment custom resource
+
+**New file:** `backend/lambda/ses_template_manager/handler.py`
+
+A simple CloudFormation custom resource Lambda that:
+- On CREATE/UPDATE: reads template definitions, calls
+  `ses:CreateTemplate` or `ses:UpdateTemplate` for each.
+- On DELETE: calls `ses:DeleteTemplate` for each.
+- Returns template names as outputs.
+
+**CDK wiring** in `api-stack.ts`: a `CustomResource` backed by this Lambda,
+triggered on every deploy. The Lambda is granted `ses:CreateTemplate`,
+`ses:UpdateTemplate`, `ses:DeleteTemplate`, `ses:GetTemplate` permissions.
+It runs outside the VPC (SES API is public). Template source is bundled with
+the Lambda code.
+
+### 7.7 Backend — Contact Us handler changes
+
+**File:** `backend/src/app/api/public_legacy_proxy.py`
+
+Modify `handle_legacy_contact_us`:
+
+```
+Current flow:
+  1. Validate method → parse body → proxy to legacy API → return response
+
+New flow:
+  1. Validate method → parse body → proxy to legacy API
+  2. If proxy returned a success status (200 or 202):
+     a. Extract email_address, first_name, marketing_opt_in from the
+        ORIGINAL parsed body (not the proxy response).
+     b. Determine locale: read Accept-Language header from the original
+        event, or default to "en".
+     c. Send SES confirmation email via send_templated_email using
+        template evolvesprouts-contact-confirmation-{locale}
+        (fire-and-forget with error logging).
+     d. If marketing_opt_in is truthy AND first_name is non-empty:
+        call subscribe_to_marketing (fire-and-forget).
+  3. Return the proxy response (unchanged).
+```
+
+The SES send and Mailchimp calls MUST NOT delay or alter the response. Wrap
+each in a try/except that logs and swallows errors.
+
+**Refactoring the proxy:** The legacy proxy handler currently does not parse the
+body for its own use — it forwards it opaquely. For the post-success hooks, the
+parsed body must be accessible. The body is already parsed via `parse_body(event)`
+in `_handle_legacy_proxy`.
+
+**Recommended approach:** Have `handle_legacy_contact_us` call `parse_body`
+first, then pass the result to a slightly refactored `_handle_legacy_proxy`
+that accepts an already-parsed payload. This avoids double-parsing and keeps
+the generic proxy clean.
+
+**From address:** Use `CONFIRMATION_EMAIL_FROM_ADDRESS` env var
+(`hello@evolvesprouts.com`).
+
+### 7.8 Backend — Booking handler changes
+
+**File:** `backend/src/app/api/public_legacy_proxy.py`
+
+Modify `handle_legacy_reservations`:
+
+Same pattern as Contact Us. After successful proxy response:
+
+1. Extract `full_name`, `email`, `course_label`, `schedule_date_label`,
+   `schedule_time_label`, `payment_method`, `price`,
+   `stripe_payment_intent_id`, `marketing_opt_in`, `locale` from the
+   original parsed body.
+2. Derive first name from `full_name` by splitting on first whitespace.
+3. Determine locale: use `locale` from the body (passed by the frontend),
+   validate against `["en", "zh-CN", "zh-HK"]`, fall back to `"en"`.
+4. Determine `is_pending_payment`: `True` when `payment_method` is not
+   a Stripe variant (not `"stripe"`) and `stripe_payment_intent_id` is empty.
+5. Send SES booking confirmation email via `send_templated_email` using
+   template `evolvesprouts-booking-confirmation-{locale}`
+   (fire-and-forget).
+6. If `marketing_opt_in` is truthy AND derived first name is non-empty:
+   call `subscribe_to_marketing` with tag `booking-customer`
+   (fire-and-forget).
+
+**From address:** Use `CONFIRMATION_EMAIL_FROM_ADDRESS` env var
+(`hello@evolvesprouts.com`).
+
+**Note on `full_name` → `first_name`:** The booking form collects `full_name`
+(e.g., "Jane Smith"). Mailchimp's `FNAME` merge field expects a first name.
+Split `full_name` on the first whitespace and use the first segment. If the
+name has no spaces, use the entire string.
+
+### 7.9 Backend — Media processor changes
+
+**File:** `backend/src/app/api/public_media.py`
+
+Add `marketing_opt_in` to the SNS message payload:
+
+```python
+message_payload = {
+    "event_type": _EVENT_TYPE,
+    "first_name": first_name,
+    "email": email,
+    "submitted_at": ...,
+    "request_id": ...,
+    "marketing_opt_in": body.get("marketing_opt_in", False),
+}
+```
+
+**File:** `backend/lambda/media_processor/handler.py`
+
+Modify `_process_message`:
+
+```
+Current flow:
+  1. Upsert contact in DB            (always)
+  2. add_subscriber_with_tag()        (always)
+  3. trigger_customer_journey()       (always, if step 2 succeeded)
+  4. SES to sales team                (always)
+
+New flow:
+  1. Upsert contact in DB            (always)
+  2. SES download link to user        (always — NEW, via send_templated_email
+     using evolvesprouts-media-download-{locale})
+  3. SES to sales team                (always — unchanged)
+  4. add_subscriber_with_tag()        (TRANSITION: always;
+                                       POST-TRANSITION: only if marketing_opt_in)
+  5. trigger_customer_journey()       (TRANSITION: always if step 4 succeeded;
+     [free resource journey]           POST-TRANSITION: only if marketing_opt_in)
+  6. subscribe_to_marketing()         (only if marketing_opt_in — NEW;
+     [welcome journey]                 uses shared helper from §7.5)
+```
+
+**Step 2 detail:** After `_ensure_share_link_url_for_asset` returns the
+download URL, call `send_templated_email` with the media download template.
+Use `CONFIRMATION_EMAIL_FROM_ADDRESS` (`hello@evolvesprouts.com`) as the
+source, send to the user's email.
+
+**Locale for media:** The media form does not currently pass a `locale` field.
+Add `locale` to the media form frontend payload (§7.2) and pass it through
+the SNS message. Default to `"en"` if missing.
+
+**Transition behavior:** During the transition period, steps 4 and 5 remain
+unconditional (matching current behavior), controlled by the env var
+`MAILCHIMP_REQUIRE_MARKETING_CONSENT`. When `"false"` (default during
+transition), Mailchimp subscribe + free resource journey fire unconditionally.
+When `"true"` (post-transition), they are gated behind `marketing_opt_in`.
+
+Step 6 (welcome journey via shared helper) **always** requires
+`marketing_opt_in` regardless of the transition flag — it is a new behavior
+that only fires for opted-in users.
+
+**From address:** Use `CONFIRMATION_EMAIL_FROM_ADDRESS` env var
+(`hello@evolvesprouts.com`). Add this env var to the media processor.
+
+### 7.10 Backend — Infrastructure (CDK) changes
+
+**File:** `backend/infrastructure/lib/api-stack.ts`
+
+#### 7.10.1 Admin Lambda SES permissions
+
+Add `ses:SendEmail`, `ses:SendRawEmail`, and `ses:SendTemplatedEmail` IAM
+policy to `adminFunction`. Use the existing `sesSenderDomainIdentityArn`
+which covers all `@evolvesprouts.com` addresses (including `hello@`):
+
+```typescript
+adminFunction.addToRolePolicy(
+  new iam.PolicyStatement({
+    actions: ["ses:SendEmail", "ses:SendRawEmail", "ses:SendTemplatedEmail"],
+    resources: [sesSenderIdentityArn, sesSenderDomainIdentityArn],
+  })
+);
+```
+
+#### 7.10.2 Admin Lambda environment variables
+
+Add the following to `adminFunction` via `addEnvironment`:
+
+| Env var | Value source | Purpose |
+|---------|-------------|---------|
+| `SES_SENDER_EMAIL` | `sesSenderEmail.valueAsString` | Internal notifications (existing pattern) |
+| `CONFIRMATION_EMAIL_FROM_ADDRESS` | `authEmailFromAddress.valueAsString` | Customer-facing emails (`hello@`) |
+| `SUPPORT_EMAIL` | `supportEmail.valueAsString` | Support email reference |
+| `MAILCHIMP_API_SECRET_ARN` | `mailchimpApiSecret.secretArn` | Mailchimp API key access |
+| `MAILCHIMP_LIST_ID` | `mailchimpListId.valueAsString` | Audience ID |
+| `MAILCHIMP_SERVER_PREFIX` | `mailchimpServerPrefix.valueAsString` | Mailchimp API host |
+| `MAILCHIMP_WELCOME_JOURNEY_ID` | `mailchimpWelcomeJourneyId.valueAsString` | Shared welcome journey |
+| `MAILCHIMP_WELCOME_JOURNEY_STEP_ID` | `mailchimpWelcomeJourneyStepId.valueAsString` | Welcome journey entry step |
+| `PUBLIC_WWW_BASE_URL` | `` `https://${publicWwwDomainName.valueAsString}` `` | For FAQ link in emails |
+
+#### 7.10.3 New CfnParameters
+
+```typescript
+const mailchimpWelcomeJourneyId = new cdk.CfnParameter(
+  this, "MailchimpWelcomeJourneyId", {
+    type: "String",
+    default: "",
+    description:
+      "Mailchimp Customer Journey ID for the shared welcome flow " +
+      "(triggered for opted-in contacts from contact/media/booking forms). " +
+      "Empty disables the trigger.",
+  }
+);
+
+const mailchimpWelcomeJourneyStepId = new cdk.CfnParameter(
+  this, "MailchimpWelcomeJourneyStepId", {
+    type: "String",
+    default: "",
+    description:
+      "Mailchimp Customer Journey step ID for the welcome flow entry point. " +
+      "Empty disables the trigger.",
+  }
+);
+
+const mailchimpRequireMarketingConsent = new cdk.CfnParameter(
+  this, "MailchimpRequireMarketingConsent", {
+    type: "String",
+    default: "false",
+    allowedValues: ["true", "false"],
+    description:
+      "When true, the media processor only subscribes to Mailchimp when " +
+      "marketing_opt_in is set. Set to false during SES download link " +
+      "transition to preserve existing behavior.",
+  }
+);
+```
+
+No `WhatsappUrl` parameter — see decision D3.
+
+#### 7.10.4 Admin Lambda Secrets Manager read
+
+```typescript
+mailchimpApiSecret.grantRead(adminFunction);
+```
+
+#### 7.10.5 Media processor additional environment variables
+
+Add to `mediaRequestProcessor` environment:
+
+| Env var | Value source | Purpose |
+|---------|-------------|---------|
+| `CONFIRMATION_EMAIL_FROM_ADDRESS` | `authEmailFromAddress.valueAsString` | Customer-facing download link email |
+| `MAILCHIMP_REQUIRE_MARKETING_CONSENT` | `mailchimpRequireMarketingConsent.valueAsString` | Transition flag |
+| `MAILCHIMP_WELCOME_JOURNEY_ID` | `mailchimpWelcomeJourneyId.valueAsString` | Shared welcome journey (new, separate from free resource journey) |
+| `MAILCHIMP_WELCOME_JOURNEY_STEP_ID` | `mailchimpWelcomeJourneyStepId.valueAsString` | Welcome journey entry step |
+
+Add `ses:SendTemplatedEmail` to the media processor SES IAM policy (it already
+has `ses:SendEmail` and `ses:SendRawEmail`).
+
+#### 7.10.6 SES template deployment custom resource
+
+Add a `CustomResource` backed by the SES template manager Lambda (§7.6.3).
+Grant it `ses:CreateTemplate`, `ses:UpdateTemplate`, `ses:DeleteTemplate`,
+`ses:GetTemplate` on `*`. Run outside VPC. Trigger on every deploy by
+including a hash of the template source as a property.
+
+### 7.11 Documentation updates
+
+| File | Change |
+|------|--------|
+| `docs/api/public.yaml` | Add `marketing_opt_in` (boolean, optional, default false) to `ContactUsSubmissionRequest` and `MediaRequestSubmissionRequest`. Mark `first_name` as required on Contact Us. Add `marketing_opt_in`, `locale`, `course_label`, `schedule_date_label`, `schedule_time_label`, `location_name` to the reservation body description. Add `locale` to `MediaRequestSubmissionRequest`. Document confirmation email behavior in endpoint descriptions. |
+| `docs/architecture/aws-messaging.md` | Add section for contact-us and booking transactional emails (SES, synchronous from Admin Lambda). Update media flow: SES sends download link directly, Mailchimp conditional on consent (with transition note). Document the SES template management custom resource. |
+| `docs/architecture/lambdas.md` | Update Admin Lambda: add SES permissions, new env vars. Update Media Processor: add `CONFIRMATION_EMAIL_FROM_ADDRESS`, `MAILCHIMP_REQUIRE_MARKETING_CONSENT`, welcome journey vars, `ses:SendTemplatedEmail`. Add SES template manager Lambda entry. |
+| `docs/architecture/aws-assets-map.md` | Add new CfnParameters: `MailchimpWelcomeJourneyId`, `MailchimpWelcomeJourneyStepId`, `MailchimpRequireMarketingConsent`. Add SES template custom resource. |
+
+---
+
+## 8. Mailchimp tags
+
+| Flow | Tag name | Applied when |
+|------|----------|-------------|
+| Contact Us | `contact-us-inquiry` | User opts in |
+| Media download | `public-www-media-{resource_key}-requested` (existing) | Transition: always. Post-transition: user opts in |
+| Booking | `booking-customer` | User opts in |
+
+---
+
+## 9. Execution order
+
+Implementation should proceed in this order to minimize risk and allow
+incremental testing:
+
+### Phase 1: Backend infrastructure and shared code
+
+1. CDK changes (§7.10): Admin Lambda SES grant, env vars, new parameters,
+   media processor env updates.
+2. SES template definitions (§7.6): all three template sets (9 templates
+   total: 3 flows × 3 locales).
+3. SES template deployment custom resource (§7.6.3).
+4. Shared marketing subscribe helper (§7.5): `marketing_subscribe.py`.
+5. Shared template constants (§7.6.1): `constants.py`.
+6. Run `pre-commit run ruff-format --all-files` after all Python changes.
+7. Run `bash scripts/validate-cursorrules.sh`.
+
+### Phase 2: Backend handler changes
+
+8. Contact Us handler (§7.7): post-success SES + Mailchimp hook.
+9. Booking handler (§7.8): post-success SES + Mailchimp hook.
+10. Media API (§7.9): pass `marketing_opt_in` and `locale` through SNS payload.
+11. Media processor (§7.9): add SES download link, transition flag for
+    Mailchimp, welcome journey for opt-in.
+
+### Phase 3: Frontend changes
+
+12. Shared checkbox component (§7.4).
+13. Contact Us form (§7.1): required first name + checkbox + payload.
+14. Media form (§7.2): checkbox + payload + locale.
+15. Booking form (§7.3): checkbox + payload + locale + display fields.
+16. Update all affected tests.
+17. Update locale content in all three JSON files.
+
+### Phase 4: Documentation
+
+18. OpenAPI spec updates (§7.11).
+19. Architecture docs updates (§7.11).
+
+---
+
+## 10. Testing checklist
+
+### Backend unit tests
+
+- [ ] `marketing_subscribe.py`: success path, Mailchimp API error (non-blocking),
+  missing env vars, empty email/name, empty journey IDs (skip trigger).
+- [ ] SES template definitions: validate Handlebars syntax, all variables present,
+  all three locales defined for each template.
+- [ ] `public_legacy_proxy.py` (contact-us): successful proxy triggers SES +
+  Mailchimp when opted in; failed proxy triggers neither; Mailchimp failure
+  does not affect response; missing first_name skips Mailchimp.
+- [ ] `public_legacy_proxy.py` (booking): same as above, plus locale
+  passthrough, full_name → first_name extraction, is_pending_payment logic.
+- [ ] `public_media.py`: `marketing_opt_in` and `locale` included in SNS payload.
+- [ ] `media_processor/handler.py`: SES download link sent on success;
+  Mailchimp gated by transition flag + opt-in; SES failure logged but
+  processing continues; welcome journey fires only for opted-in users.
+
+### Frontend component tests
+
+- [ ] Contact Us form: first name required validation, checkbox unchecked by
+  default, payload shape, success/error paths unchanged.
+- [ ] Media form: checkbox unchecked by default, payload shape includes
+  `marketing_opt_in`.
+- [ ] Booking form: checkbox unchecked by default, checkbox visually distinct
+  from terms, payload includes `marketing_opt_in`, `locale`, and display fields.
+- [ ] Shared checkbox component: renders label, toggles state, accessible.
+
+### Integration / manual testing
+
+- [ ] Submit Contact Us with opt-in → receive SES confirmation from
+  `hello@evolvesprouts.com` + appear in Mailchimp audience with
+  `contact-us-inquiry` tag.
+- [ ] Submit Contact Us without opt-in → receive SES confirmation only, not
+  added to Mailchimp.
+- [ ] Submit media form with opt-in → receive SES download link + Mailchimp
+  journey email (transition). Appear in audience with tag and welcome journey.
+- [ ] Submit media form without opt-in → receive SES download link + Mailchimp
+  journey email (transition). Appear in audience (transition — legacy behavior
+  preserved). No welcome journey.
+- [ ] Submit booking with opt-in → receive SES booking confirmation with
+  correct details + appear in Mailchimp audience with `booking-customer` tag.
+- [ ] Submit booking without opt-in → receive SES booking confirmation only.
+- [ ] Verify emails render correctly in Gmail, Outlook, Apple Mail.
+- [ ] Verify Chinese locale emails render correctly (zh-CN and zh-HK).
+- [ ] Verify non-Stripe booking shows pending-payment note in email.
+- [ ] Verify Mailchimp welcome journey triggers (once journey is configured).
+
+---
+
+## 11. Media Mailchimp transition → removal checklist
+
+After the SES download link has been confirmed working in production for a
+sufficient period (recommended: 2 weeks of monitoring):
+
+1. Set `MailchimpRequireMarketingConsent` parameter to `"true"` in production
+   deploy.
+2. Verify: media submissions without opt-in no longer appear in Mailchimp
+   audience. Media submissions with opt-in still appear.
+3. Verify: all users still receive their download link via SES regardless of
+   opt-in.
+4. Disable the Mailchimp "Free Resource" Customer Journey in the Mailchimp
+   dashboard (so it stops sending the download link email on its own).
+5. Remove `MAILCHIMP_FREE_RESOURCE_JOURNEY_ID` and
+   `MAILCHIMP_FREE_RESOURCE_JOURNEY_STEP_ID` env vars from the media
+   processor CDK config. **Do not remove** the corresponding GitHub vars /
+   CDK parameters until any other consumer is confirmed to not use them.
+6. Remove `MAILCHIMP_REQUIRE_MARKETING_CONSENT` env var and the conditional
+   logic in `media_processor/handler.py` — Mailchimp subscribe is now always
+   gated by `marketing_opt_in`.
+7. Remove `MAILCHIMP_MEDIA_DOWNLOAD_MERGE_TAG` env var from the media
+   processor (the download URL merge field is no longer needed since SES
+   sends the link directly).
+8. Update `docs/architecture/aws-messaging.md` to remove transition notes.
+
+---
+
+## 12. Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| SES send failure on contact-us / booking | User does not receive confirmation email | Log error. Return success to user (primary action succeeded). Monitor CloudWatch for SES errors. Consider DLQ retry in a follow-up. |
+| SES send failure on media download link | User does not receive download link | During transition: Mailchimp journey is backup. Post-transition: monitor closely; add DLQ retry. |
+| SES template not found (deployment issue) | `send_templated_email` fails with `TemplateDoesNotExist` | Custom resource creates templates before handler code runs. If missing, falls back to error logging (non-blocking for contact-us/booking; critical for media download link). |
+| Mailchimp API failure after opt-in | User not added to audience | Non-blocking. Log warning. User still gets SES email. Can reconcile via admin tools later. |
+| Added latency on contact-us / booking responses | Slower form submission | SES via VPC endpoint: sub-second. Mailchimp via HTTP proxy: 1-3s but fire-and-forget (non-blocking). Total added latency to response: ~200-500ms (SES only; Mailchimp does not block response). |
+| `full_name` → `first_name` extraction is lossy | Mailchimp FNAME may be imprecise for non-Western names | Acceptable for a merge field. If the user has a single-word name, the entire name is used. |
+| Contact Us `first_name` now required | Existing form users may have muscle memory to skip it | Field was already visually present; only validation changes. Low risk. |
+| Booking form locale accuracy | Email sent in wrong language | Frontend passes current route locale. Backend validates against `["en", "zh-CN", "zh-HK"]` and defaults to `"en"`. |
+| WhatsApp URL drift between backend constant and content JSON | Email links point to stale URL | Document sync requirement in `constants.py`. Both values are brand-level constants that change rarely. |
+
+---
+
+## 13. File inventory (complete)
+
+### New files
+
+| Path | Purpose |
+|------|---------|
+| `apps/public_www/src/components/shared/marketing-opt-in-checkbox.tsx` | Shared checkbox component |
+| `backend/src/app/services/marketing_subscribe.py` | Shared Mailchimp subscribe helper |
+| `backend/src/app/templates/constants.py` | Shared email template constants (WhatsApp URL, public WWW base URL helper) |
+| `backend/src/app/templates/ses/__init__.py` | Package init |
+| `backend/src/app/templates/ses/contact_confirmation.py` | Contact Us SES template definitions (3 locales) |
+| `backend/src/app/templates/ses/media_download_link.py` | Media download SES template definitions (3 locales) |
+| `backend/src/app/templates/ses/booking_confirmation.py` | Booking confirmation SES template definitions (3 locales) |
+| `backend/lambda/ses_template_manager/handler.py` | CDK custom resource for SES template upsert |
+
+### Modified files
+
+| Path | Summary of change |
+|------|------------------|
+| `apps/public_www/src/components/sections/contact-us-form.tsx` | Required first name, marketing opt-in state, updated payload |
+| `apps/public_www/src/components/sections/contact-us-form-fields.tsx` | Required first name validation, marketing checkbox |
+| `apps/public_www/src/components/sections/media-form.tsx` | Marketing opt-in state, checkbox, locale in payload |
+| `apps/public_www/src/components/sections/booking-modal/reservation-form.tsx` | Marketing opt-in state, locale + display fields in payload |
+| `apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx` | Marketing checkbox |
+| `apps/public_www/src/lib/reservations-data.ts` | Add `marketing_opt_in`, `locale`, display fields to payload type |
+| `apps/public_www/src/content/en.json` | New locale keys for all three forms |
+| `apps/public_www/src/content/zh-CN.json` | Chinese Simplified translations |
+| `apps/public_www/src/content/zh-HK.json` | Chinese Traditional translations |
+| `backend/src/app/api/public_legacy_proxy.py` | Post-success hooks for contact-us and booking |
+| `backend/src/app/api/public_media.py` | Pass `marketing_opt_in` and `locale` in SNS payload |
+| `backend/lambda/media_processor/handler.py` | SES download link, transition-gated Mailchimp, welcome journey for opt-in |
+| `backend/infrastructure/lib/api-stack.ts` | Admin Lambda SES grant + env vars, media processor env updates, new parameters, SES template custom resource |
+| `docs/api/public.yaml` | Schema updates for all three endpoints |
+| `docs/architecture/aws-messaging.md` | New transactional email flows, updated media flow |
+| `docs/architecture/lambdas.md` | Updated Admin Lambda and Media Processor descriptions, new SES template manager entry |
+| `docs/architecture/aws-assets-map.md` | New parameters and custom resource |
+| Tests (multiple files) | Updated for new fields, checkbox, payload shapes |

--- a/tests/test_marketing_subscribe.py
+++ b/tests/test_marketing_subscribe.py
@@ -44,3 +44,32 @@ def test_subscribe_to_marketing_skips_journey_when_ids_empty(
         is True
     )
     assert calls == ["add_subscriber_with_tag"]
+
+
+def test_subscribe_to_marketing_skips_member_when_subscribe_member_false(
+    monkeypatch: Any,
+) -> None:
+    logger = MagicMock()
+    monkeypatch.setenv("MAILCHIMP_WELCOME_JOURNEY_ID", "j1")
+    monkeypatch.setenv("MAILCHIMP_WELCOME_JOURNEY_STEP_ID", "s1")
+    calls: list[Any] = []
+
+    def _fake_run_with_retry(fn: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(fn)
+        if fn.__name__ == "trigger_customer_journey":
+            return None
+        raise AssertionError(f"unexpected fn {fn}")
+
+    monkeypatch.setattr(ms, "run_with_retry", _fake_run_with_retry)
+    assert (
+        ms.subscribe_to_marketing(
+            email="a@example.com",
+            first_name="Ada",
+            tag_name="t",
+            logger=logger,
+            subscribe_member=False,
+        )
+        is True
+    )
+    assert len(calls) == 1
+    assert calls[0].__name__ == "trigger_customer_journey"

--- a/tests/test_marketing_subscribe.py
+++ b/tests/test_marketing_subscribe.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.services import marketing_subscribe as ms
+from app.services.mailchimp import add_subscriber_with_tag
+
+
+def test_subscribe_to_marketing_skips_empty_email(monkeypatch: Any) -> None:
+    logger = MagicMock()
+    monkeypatch.setattr(ms, "run_with_retry", MagicMock())
+    assert ms.subscribe_to_marketing(
+        email="",
+        first_name="A",
+        tag_name="t",
+        logger=logger,
+    ) is False
+    ms.run_with_retry.assert_not_called()
+
+
+def test_subscribe_to_marketing_skips_journey_when_ids_empty(
+    monkeypatch: Any,
+) -> None:
+    logger = MagicMock()
+    monkeypatch.setenv("MAILCHIMP_WELCOME_JOURNEY_ID", "")
+    monkeypatch.setenv("MAILCHIMP_WELCOME_JOURNEY_STEP_ID", "")
+    calls: list[str] = []
+
+    def _fake_run_with_retry(fn: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(getattr(fn, "__name__", "op"))
+        if fn is add_subscriber_with_tag:
+            return {"id": "m1"}
+        raise AssertionError("unexpected call")
+
+    monkeypatch.setattr(ms, "run_with_retry", _fake_run_with_retry)
+    assert (
+        ms.subscribe_to_marketing(
+            email="a@example.com",
+            first_name="Ada",
+            tag_name="contact-us-inquiry",
+            logger=logger,
+        )
+        is True
+    )
+    assert calls == ["add_subscriber_with_tag"]

--- a/tests/test_media_processor_handler.py
+++ b/tests/test_media_processor_handler.py
@@ -229,3 +229,200 @@ def test_process_message_uses_keyword_session_for_contact_tag(
     assert isinstance(session_arg, _FakeSession)
     assert contact_id_arg == contact.id
     assert tag_name_arg == "public-www-media-sleep-routines-requested"
+
+
+def test_process_message_opt_in_skips_second_subscribe_when_mailchimp_synced(
+    monkeypatch: Any,
+) -> None:
+    handler = _load_handler_module()
+    contact = SimpleNamespace(
+        id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        email="parent@example.com",
+        mailchimp_status=MailchimpSyncStatus.SYNCED,
+        mailchimp_subscriber_id="subscriber-123",
+    )
+    existing_lead = SimpleNamespace(id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+    subscribe_calls: list[dict[str, Any]] = []
+
+    class _FakeSession:
+        def __init__(self, _engine: Any):
+            self.committed = False
+
+        def __enter__(self) -> _FakeSession:
+            return self
+
+        def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+            return None
+
+        def commit(self) -> None:
+            self.committed = True
+
+    class _FakeContactRepository:
+        def __init__(self, _session: Any):
+            pass
+
+        def upsert_by_email(
+            self,
+            _email: str,
+            *,
+            first_name: str,
+            source: Any,
+            source_detail: str,
+            contact_type: Any,
+        ) -> tuple[Any, bool]:
+            _ = (first_name, source, source_detail, contact_type)
+            return contact, False
+
+    class _FakeSalesLeadRepository:
+        def __init__(self, _session: Any):
+            pass
+
+        def find_by_contact_and_asset(
+            self,
+            _contact_id: UUID,
+            _lead_type: Any,
+            _asset_id: UUID,
+        ) -> Any:
+            return existing_lead
+
+    def _fake_subscribe(**kwargs: Any) -> bool:
+        subscribe_calls.append(dict(kwargs))
+        return True
+
+    monkeypatch.setenv("MAILCHIMP_REQUIRE_MARKETING_CONSENT", "false")
+    monkeypatch.setattr(handler, "get_engine", lambda: object())
+    monkeypatch.setattr(handler, "Session", _FakeSession)
+    monkeypatch.setattr(handler, "ContactRepository", _FakeContactRepository)
+    monkeypatch.setattr(handler, "SalesLeadRepository", _FakeSalesLeadRepository)
+    monkeypatch.setattr(
+        handler,
+        "_resolve_media_resource",
+        lambda *, session, message: (
+            "sleep-routines",
+            UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            "public-www-media-sleep-routines-requested",
+            "Sleep Routines Guide",
+        ),
+    )
+    monkeypatch.setattr(handler, "_ensure_contact_tag", lambda **_: None)
+    monkeypatch.setattr(
+        handler,
+        "_ensure_share_link_url_for_asset",
+        lambda **_: "https://media.example.com/v1/assets/share/TOKEN",
+    )
+    monkeypatch.setattr(handler, "_send_user_download_email", lambda **_: None)
+    monkeypatch.setattr(handler, "_sync_contact_to_mailchimp", lambda **_: True)
+    monkeypatch.setattr(handler, "_trigger_mailchimp_journey", lambda **_: True)
+    monkeypatch.setattr(handler, "subscribe_to_marketing", _fake_subscribe)
+
+    handler._process_message(
+        {
+            "first_name": "Parent",
+            "email": "parent@example.com",
+            "submitted_at": "2026-03-03T03:14:00+00:00",
+            "marketing_opt_in": True,
+        }
+    )
+
+    assert len(subscribe_calls) == 1
+    assert subscribe_calls[0]["subscribe_member"] is False
+
+
+def test_process_message_require_consent_skips_mailchimp_without_opt_in(
+    monkeypatch: Any,
+) -> None:
+    handler = _load_handler_module()
+    contact = SimpleNamespace(
+        id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        email="parent@example.com",
+        mailchimp_status=MailchimpSyncStatus.SYNCED,
+        mailchimp_subscriber_id="subscriber-123",
+    )
+    sync_calls: list[Any] = []
+
+    class _FakeSession:
+        def __init__(self, _engine: Any):
+            pass
+
+        def __enter__(self) -> _FakeSession:
+            return self
+
+        def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+            return None
+
+        def commit(self) -> None:
+            return None
+
+    class _FakeContactRepository:
+        def __init__(self, _session: Any):
+            pass
+
+        def upsert_by_email(
+            self,
+            _email: str,
+            *,
+            first_name: str,
+            source: Any,
+            source_detail: str,
+            contact_type: Any,
+        ) -> tuple[Any, bool]:
+            _ = (first_name, source, source_detail, contact_type)
+            return contact, True
+
+    class _FakeSalesLeadRepository:
+        def __init__(self, _session: Any):
+            pass
+
+        def find_by_contact_and_asset(
+            self,
+            _contact_id: UUID,
+            _lead_type: Any,
+            _asset_id: UUID,
+        ) -> None:
+            return None
+
+        def create_with_event(self, *args: Any, **kwargs: Any) -> Any:
+            return SimpleNamespace(id=UUID("dddddddd-dddd-dddd-dddd-dddddddddddd"))
+
+    def _fake_sync(**kwargs: Any) -> bool:
+        sync_calls.append(kwargs)
+        return True
+
+    monkeypatch.setenv("MAILCHIMP_REQUIRE_MARKETING_CONSENT", "true")
+    monkeypatch.setattr(handler, "get_engine", lambda: object())
+    monkeypatch.setattr(handler, "Session", _FakeSession)
+    monkeypatch.setattr(handler, "ContactRepository", _FakeContactRepository)
+    monkeypatch.setattr(handler, "SalesLeadRepository", _FakeSalesLeadRepository)
+    monkeypatch.setattr(
+        handler,
+        "_resolve_media_resource",
+        lambda *, session, message: (
+            "sleep-routines",
+            UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            "public-www-media-sleep-routines-requested",
+            "Sleep Routines Guide",
+        ),
+    )
+    monkeypatch.setattr(handler, "_ensure_contact_tag", lambda **_: None)
+    monkeypatch.setattr(
+        handler,
+        "_ensure_share_link_url_for_asset",
+        lambda **_: "https://media.example.com/v1/assets/share/TOKEN",
+    )
+    monkeypatch.setattr(handler, "_send_user_download_email", lambda **_: None)
+    monkeypatch.setattr(handler, "_sync_contact_to_mailchimp", _fake_sync)
+    monkeypatch.setattr(handler, "_trigger_mailchimp_journey", lambda **_: True)
+    monkeypatch.setattr(handler, "_send_sales_notification", lambda **_: None)
+    monkeypatch.setattr(handler, "_create_sales_lead_event", lambda **_: None)
+    monkeypatch.setattr(handler, "subscribe_to_marketing", lambda **_: True)
+
+    handler._process_message(
+        {
+            "first_name": "Parent",
+            "email": "parent@example.com",
+            "submitted_at": "2026-03-03T03:14:00+00:00",
+            "marketing_opt_in": False,
+        }
+    )
+
+    assert sync_calls == []

--- a/tests/test_public_legacy_confirmation.py
+++ b/tests/test_public_legacy_confirmation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from app.api.public_legacy_confirmation import (
+    first_name_from_full_name,
+    normalize_body_locale,
+    resolve_email_locale_from_accept_language,
+)
+
+
+def test_resolve_email_locale_from_accept_language() -> None:
+    assert resolve_email_locale_from_accept_language("en-US,en;q=0.9") == "en"
+    assert resolve_email_locale_from_accept_language("zh-CN,en;q=0.8") == "zh-CN"
+    assert resolve_email_locale_from_accept_language("zh-HK") == "zh-HK"
+    assert resolve_email_locale_from_accept_language("zh-TW,en;q=0.5") == "zh-HK"
+    assert resolve_email_locale_from_accept_language("") == "en"
+
+
+def test_normalize_body_locale() -> None:
+    assert normalize_body_locale("zh-CN") == "zh-CN"
+    assert normalize_body_locale("xx") == "en"
+
+
+def test_first_name_from_full_name() -> None:
+    assert first_name_from_full_name("Jane Smith") == "Jane"
+    assert first_name_from_full_name("Single") == "Single"
+    assert first_name_from_full_name("  Pat  Lee  ") == "Pat"

--- a/tests/test_public_legacy_confirmation.py
+++ b/tests/test_public_legacy_confirmation.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from typing import Any
+from unittest.mock import MagicMock
+
 from app.api.public_legacy_confirmation import (
     first_name_from_full_name,
     normalize_body_locale,
+    resolve_contact_confirmation_locale,
     resolve_email_locale_from_accept_language,
+    run_reservation_post_success,
 )
 
 
@@ -24,3 +29,58 @@ def test_first_name_from_full_name() -> None:
     assert first_name_from_full_name("Jane Smith") == "Jane"
     assert first_name_from_full_name("Single") == "Single"
     assert first_name_from_full_name("  Pat  Lee  ") == "Pat"
+
+
+def test_resolve_contact_confirmation_locale_prefers_body() -> None:
+    payload = {"locale": "zh-CN"}
+    assert (
+        resolve_contact_confirmation_locale(
+            payload=payload,
+            accept_language_header="en-US,en;q=0.9",
+        )
+        == "zh-CN"
+    )
+
+
+def test_resolve_contact_confirmation_locale_falls_back_to_accept_language() -> None:
+    payload = {"locale": "invalid"}
+    assert (
+        resolve_contact_confirmation_locale(
+            payload=payload,
+            accept_language_header="zh-HK",
+        )
+        == "zh-HK"
+    )
+
+
+def test_run_reservation_post_success_sets_pending_without_stripe(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_send(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "hello@example.com")
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_booking_confirmation_email",
+        _fake_send,
+    )
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.maybe_subscribe_booking_marketing",
+        MagicMock(),
+    )
+
+    run_reservation_post_success(
+        payload={
+            "full_name": "Jane Doe",
+            "email": "j@example.com",
+            "course_label": "Course",
+            "payment_method": "fps_qr",
+            "price": 150,
+            "locale": "en",
+        }
+    )
+
+    assert captured["is_pending_payment"] is True
+    assert captured["total_amount"] == "HK$150.00"

--- a/tests/test_public_legacy_proxy_api.py
+++ b/tests/test_public_legacy_proxy_api.py
@@ -125,6 +125,68 @@ def test_legacy_proxy_maps_proxy_error_to_bad_gateway(
     }
 
 
+def test_legacy_contact_us_success_triggers_confirmation_hook(
+    api_gateway_event: Any,
+    monkeypatch: Any,
+) -> None:
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/legacy/contact-us",
+        body=json.dumps(
+            {
+                "email_address": "parent@example.com",
+                "first_name": "Pat",
+                "message": "hello",
+                "marketing_opt_in": True,
+            }
+        ),
+        headers={"Accept-Language": "en-GB"},
+    )
+    monkeypatch.setenv("LEGACY_PUBLIC_API_BASE_URL", "https://legacy.example.com")
+    monkeypatch.setattr(
+        "app.api.public_legacy_proxy.http_invoke",
+        lambda **_: {"status": 202, "body": json.dumps({"message": "Accepted"})},
+    )
+    calls: list[str] = []
+
+    def _hook(**kwargs: Any) -> None:
+        calls.append("hook")
+
+    monkeypatch.setattr("app.api.public_legacy_proxy.run_contact_us_post_success", _hook)
+
+    response = handle_legacy_contact_us(event, "POST")
+
+    assert response["statusCode"] == 202
+    assert calls == ["hook"]
+
+
+def test_legacy_proxy_skips_hook_on_upstream_failure(
+    api_gateway_event: Any,
+    monkeypatch: Any,
+) -> None:
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/legacy/contact-us",
+        body=json.dumps({"email_address": "parent@example.com", "message": "hello"}),
+    )
+    monkeypatch.setenv("LEGACY_PUBLIC_API_BASE_URL", "https://legacy.example.com")
+    monkeypatch.setattr(
+        "app.api.public_legacy_proxy.http_invoke",
+        lambda **_: {"status": 400, "body": json.dumps({"error": "bad"})},
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "app.api.public_legacy_proxy.run_contact_us_post_success",
+        lambda **_kwargs: calls.append("hook"),
+    )
+
+    response = handle_legacy_contact_us(event, "POST")
+
+    assert response["statusCode"] == 400
+    assert calls == []
+
+
 def test_legacy_proxy_normalizes_retryable_upstream_failures(
     api_gateway_event: Any,
     monkeypatch: Any,

--- a/tests/test_public_media_api.py
+++ b/tests/test_public_media_api.py
@@ -121,3 +121,5 @@ def test_media_request_publishes_to_sns(
     assert published_message["first_name"] == "Ida"
     assert published_message["email"] == "ida@example.com"
     assert published_message["resource_key"] == "public-website-" + "patience-free-guide"
+    assert published_message["marketing_opt_in"] is False
+    assert published_message["locale"] == "en"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase 1 of 2 — Deploy this PR first, then Phase 2

This PR contains the full confirmation-email and marketing opt-in feature **plus** the Phase 1 infrastructure preparation for the nested-stack migration.

### Feature (commits e0474863 through d84900a4)

- **Transactional SES confirmation emails** for Contact Us, Media Download, and Booking forms (always sent on successful submission)
- **Marketing opt-in checkbox** (unchecked by default) on all three forms — Mailchimp audience subscribe + welcome journey trigger only when user consents
- **Media download link via SES** (replacing Mailchimp journey as delivery mechanism, with transition period where both send)
- SES stored templates (Handlebars, 3 locales each) deployed via CDK custom resource
- Admin Lambda: SES send permissions, Mailchimp env vars, `CONFIRMATION_EMAIL_FROM_ADDRESS`
- Frontend: shared `MarketingOptInCheckbox`, required `first_name` on Contact Us, `locale` in all payloads
- OpenAPI, architecture docs, and tests updated

### Infrastructure: Phase 1 name migration (commit 3ba9cabf)

Strips explicit `queueName`, `topicName`, `functionName`, and `alarmName` from the messaging resources (booking, media, expense parser pipelines + SES template manager). CloudFormation replaces them with auto-generated names, freeing the original names for Phase 2.

`PythonLambdaProps.functionName` is made optional with a runtime guard; `omitFunctionName` flag on `createPythonFunction` disables managed log groups for the four migrating Lambdas.

### Deploy notes

- **Merge and deploy this PR first.** Wait for the `deploy-backend` workflow to succeed.
- During deployment, expect brief disruption (~1-2 min) to media form submissions and expense parser as SNS topics are recreated with auto-generated names.
- Contact-us and booking confirmation emails are unaffected (they run synchronously in the Admin Lambda).
- After this deploy succeeds, merge **Phase 2** (PR #1116) which moves the messaging resources into a `MessagingNestedStack` with the original explicit names.

### Phase 2 (PR #1116)

Extracts messaging pipelines into `MessagingNestedStack` to keep the root stack under CloudFormation's 500-resource limit. Must be deployed **after** this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35d53a85-781d-43fa-aae0-8a5343f46453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35d53a85-781d-43fa-aae0-8a5343f46453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

