### PR TITLE
fix(infra): set reservedConcurrentExecutions=1 on all migrating Lambdas

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1721,6 +1721,7 @@ export class ApiStack extends cdk.Stack {
         handler: "lambda/manager_request_processor/handler.lambda_handler",
         timeout: cdk.Duration.seconds(10),
         omitFunctionName: true,
+        reservedConcurrentExecutions: 1,
         environment: {
           DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
           DATABASE_NAME: "evolvesprouts",
@@ -1795,6 +1796,7 @@ export class ApiStack extends cdk.Stack {
         handler: "lambda/media_processor/handler.lambda_handler",
         timeout: cdk.Duration.seconds(30),
         omitFunctionName: true,
+        reservedConcurrentExecutions: 1,
         environment: {
           DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
           DATABASE_NAME: "evolvesprouts",
@@ -1901,6 +1903,7 @@ export class ApiStack extends cdk.Stack {
       handler: "lambda/expense_parser/handler.lambda_handler",
       timeout: cdk.Duration.seconds(90),
       omitFunctionName: true,
+      reservedConcurrentExecutions: 1,
       environment: {
         DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
         DATABASE_NAME: "evolvesprouts",


### PR DESCRIPTION
During Phase 1, CloudFormation creates new auto-named Lambdas before deleting the old named ones. With the default of 25 each, 4 old + 4 new = 200 reserved concurrency temporarily, exhausting the account pool.

Set all four migrating Lambdas (BookingRequestProcessor, MediaRequestProcessor, ExpenseParserFunction, SesTemplateManagerFunction) to reservedConcurrentExecutions=1 during the Phase 1 replacement window. Phase 2 (MessagingNestedStack) restores the default 25 for the processors.