### PR TITLE
fix(infra): remove reserved concurrency on migrating Lambdas during P…

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1628,7 +1628,7 @@ export class ApiStack extends cdk.Stack {
         timeout: cdk.Duration.seconds(60),
         noVpc: true,
         omitFunctionName: true,
-        reservedConcurrentExecutions: 1,
+        reservedConcurrentExecutions: -1,
       }
     );
     sesTemplateManagerFunction.addToRolePolicy(
@@ -1721,7 +1721,7 @@ export class ApiStack extends cdk.Stack {
         handler: "lambda/manager_request_processor/handler.lambda_handler",
         timeout: cdk.Duration.seconds(10),
         omitFunctionName: true,
-        reservedConcurrentExecutions: 1,
+        reservedConcurrentExecutions: -1,
         environment: {
           DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
           DATABASE_NAME: "evolvesprouts",
@@ -1796,7 +1796,7 @@ export class ApiStack extends cdk.Stack {
         handler: "lambda/media_processor/handler.lambda_handler",
         timeout: cdk.Duration.seconds(30),
         omitFunctionName: true,
-        reservedConcurrentExecutions: 1,
+        reservedConcurrentExecutions: -1,
         environment: {
           DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
           DATABASE_NAME: "evolvesprouts",
@@ -1903,7 +1903,7 @@ export class ApiStack extends cdk.Stack {
       handler: "lambda/expense_parser/handler.lambda_handler",
       timeout: cdk.Duration.seconds(90),
       omitFunctionName: true,
-      reservedConcurrentExecutions: 1,
+      reservedConcurrentExecutions: -1,
       environment: {
         DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
         DATABASE_NAME: "evolvesprouts",

--- a/backend/infrastructure/lib/constructs/python-lambda.ts
+++ b/backend/infrastructure/lib/constructs/python-lambda.ts
@@ -51,7 +51,12 @@ export interface PythonLambdaProps {
   extraCopyPaths?: string[];
   /** Custom code asset (overrides default bundling). */
   code?: lambda.Code;
-  /** Reserved concurrency limit. */
+  /**
+   * Reserved concurrency limit. Defaults to 25 when omitted. Set to ``-1``
+   * to omit ``ReservedConcurrentExecutions`` entirely (function draws from
+   * the unreserved account pool — useful during migration windows when the
+   * account concurrency budget is temporarily tight).
+   */
   reservedConcurrentExecutions?: number;
   /** KMS key to encrypt environment variables. */
   environmentEncryptionKey?: kms.IKey;
@@ -231,8 +236,9 @@ export class PythonLambda extends Construct {
       environmentEncryption: environmentEncryptionKey,
       deadLetterQueue,
       deadLetterQueueEnabled: true,
-      reservedConcurrentExecutions:
-        props.reservedConcurrentExecutions ?? 25,
+      ...(props.reservedConcurrentExecutions === -1
+        ? {}
+        : { reservedConcurrentExecutions: props.reservedConcurrentExecutions ?? 25 }),
       logGroup,
       environment: {
         PYTHONPATH: "/var/task/src",


### PR DESCRIPTION
…hase 1

Even reservedConcurrentExecutions=1 fails because the account's total reserved pool is saturated. Use -1 sentinel to omit the property entirely so CloudFormation creates the replacement Lambdas in the unreserved pool.

PythonLambda construct now treats reservedConcurrentExecutions=-1 as 'omit the property' rather than defaulting to 25.