### PR TITLE
fix(infra): eliminate all cross-stack grant calls to break circular d…

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1631,6 +1631,11 @@ export class ApiStack extends cdk.Stack {
     // -------------------------------------------------------------------------
     // Messaging pipelines + SES templates (nested stack to reduce root stack size)
     // -------------------------------------------------------------------------
+    sqsEncryptionKey.grant(
+      new iam.ServicePrincipal("sns.amazonaws.com"),
+      "kms:GenerateDataKey*",
+      "kms:Decrypt"
+    );
     const messaging = new MessagingNestedStack(this, "Messaging", {
       resourcePrefix,
       vpc,
@@ -1648,7 +1653,9 @@ export class ApiStack extends cdk.Stack {
       sesAuthEmailDomainIdentityArn,
       mailchimpApiSecretArn: mailchimpApiSecret.secretArn,
       assetsBucketName: assetsBucket.bucketName,
+      assetsBucketArn: assetsBucket.bucketArn,
       openrouterApiSecretArn: openrouterApiSecret.secretArn,
+      databaseProxyArn: database.proxy.dbProxyArn,
       sesSenderEmail: sesSenderEmail.valueAsString,
       supportEmail: supportEmail.valueAsString,
       authEmailFromAddress: authEmailFromAddress.valueAsString,
@@ -1672,9 +1679,22 @@ export class ApiStack extends cdk.Stack {
       openrouterMaxFileBytes: openrouterMaxFileBytes.valueAsString,
     });
 
-    messaging.bookingRequestTopic.grantPublish(adminFunction);
-    messaging.mediaTopic.grantPublish(adminFunction);
-    messaging.expenseParserTopic.grantPublish(adminFunction);
+    adminFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["sns:Publish"],
+        resources: [
+          messaging.bookingRequestTopic.topicArn,
+          messaging.mediaTopic.topicArn,
+          messaging.expenseParserTopic.topicArn,
+        ],
+      })
+    );
+    adminFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["kms:GenerateDataKey*", "kms:Decrypt"],
+        resources: [sqsEncryptionKey.keyArn],
+      })
+    );
     adminFunction.addEnvironment(
       "MEDIA_REQUEST_TOPIC_ARN",
       messaging.mediaTopic.topicArn
@@ -1683,18 +1703,6 @@ export class ApiStack extends cdk.Stack {
       "EXPENSE_PARSE_TOPIC_ARN",
       messaging.expenseParserTopic.topicArn
     );
-
-    database.grantAdminUserSecretRead(messaging.bookingRequestProcessor);
-    database.grantConnect(messaging.bookingRequestProcessor, "evolvesprouts_admin");
-    database.grantAdminUserSecretRead(messaging.mediaRequestProcessor);
-    database.grantConnect(messaging.mediaRequestProcessor, "evolvesprouts_admin");
-    database.grantAdminUserSecretRead(messaging.expenseParserFunction);
-    database.grantConnect(messaging.expenseParserFunction, "evolvesprouts_admin");
-    mailchimpApiSecret.grantRead(messaging.mediaRequestProcessor);
-    awsProxyFunction.grantInvoke(messaging.mediaRequestProcessor);
-    assetsBucket.grantRead(messaging.expenseParserFunction);
-    openrouterApiSecret.grantRead(messaging.expenseParserFunction);
-    awsProxyFunction.grantInvoke(messaging.expenseParserFunction);
 
     // -------------------------------------------------------------------------
     // Eventbrite sync messaging (nested stack to reduce root stack size)
@@ -1778,7 +1786,18 @@ export class ApiStack extends cdk.Stack {
     database.grantAdminUserSecretRead(inboundInvoiceProcessor);
     database.grantConnect(inboundInvoiceProcessor, "evolvesprouts_admin");
     assetsBucket.grantReadWrite(inboundInvoiceProcessor);
-    messaging.expenseParserTopic.grantPublish(inboundInvoiceProcessor);
+    inboundInvoiceProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["sns:Publish"],
+        resources: [messaging.expenseParserTopic.topicArn],
+      })
+    );
+    inboundInvoiceProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["kms:GenerateDataKey*", "kms:Decrypt"],
+        resources: [sqsEncryptionKey.keyArn],
+      })
+    );
     inboundInvoiceProcessor.addEventSource(
       new lambdaEventSources.SqsEventSource(inboundInvoiceQueue, {
         batchSize: 1,

--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -29,7 +29,9 @@ export interface MessagingNestedStackProps extends cdk.NestedStackProps {
   sesAuthEmailDomainIdentityArn: string;
   mailchimpApiSecretArn: string;
   assetsBucketName: string;
+  assetsBucketArn: string;
   openrouterApiSecretArn: string;
+  databaseProxyArn: string;
   sesSenderEmail: string;
   supportEmail: string;
   authEmailFromAddress: string;
@@ -169,11 +171,6 @@ export class MessagingNestedStack extends cdk.NestedStack {
       masterKey: props.sqsEncryptionKey,
     });
 
-    props.sqsEncryptionKey.grant(
-      new iam.ServicePrincipal("sns.amazonaws.com"),
-      "kms:GenerateDataKey*",
-      "kms:Decrypt"
-    );
 
     this.bookingRequestTopic.addSubscription(
       new snsSubscriptions.SqsSubscription(this.bookingRequestQueue)
@@ -197,6 +194,24 @@ export class MessagingNestedStack extends cdk.NestedStack {
       new iam.PolicyStatement({
         actions: ["ses:SendEmail", "ses:SendRawEmail"],
         resources: [props.sesSenderIdentityArn, props.sesSenderDomainIdentityArn],
+      })
+    );
+    this.bookingRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue"],
+        resources: [props.databaseSecretArn],
+      })
+    );
+    this.bookingRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["rds-db:connect"],
+        resources: [
+          cdk.Fn.join("", [
+            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
+            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
+            "/evolvesprouts_admin",
+          ]),
+        ],
       })
     );
 
@@ -290,6 +305,30 @@ export class MessagingNestedStack extends cdk.NestedStack {
         ],
       })
     );
+    this.mediaRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue"],
+        resources: [props.databaseSecretArn, props.mailchimpApiSecretArn],
+      })
+    );
+    this.mediaRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["rds-db:connect"],
+        resources: [
+          cdk.Fn.join("", [
+            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
+            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
+            "/evolvesprouts_admin",
+          ]),
+        ],
+      })
+    );
+    this.mediaRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["lambda:InvokeFunction"],
+        resources: [props.awsProxyFunctionArn],
+      })
+    );
 
     this.mediaRequestProcessor.addEventSource(
       new lambdaEventSources.SqsEventSource(this.mediaQueue, {
@@ -356,6 +395,37 @@ export class MessagingNestedStack extends cdk.NestedStack {
           AWS_PROXY_FUNCTION_ARN: props.awsProxyFunctionArn,
         },
       });
+
+    this.expenseParserFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue"],
+        resources: [props.databaseSecretArn, props.openrouterApiSecretArn],
+      })
+    );
+    this.expenseParserFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["rds-db:connect"],
+        resources: [
+          cdk.Fn.join("", [
+            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
+            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
+            "/evolvesprouts_admin",
+          ]),
+        ],
+      })
+    );
+    this.expenseParserFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["s3:GetObject", "s3:GetBucketLocation", "s3:ListBucket"],
+        resources: [props.assetsBucketArn, `${props.assetsBucketArn}/*`],
+      })
+    );
+    this.expenseParserFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["lambda:InvokeFunction"],
+        resources: [props.awsProxyFunctionArn],
+      })
+    );
 
     this.expenseParserFunction.addEventSource(
       new lambdaEventSources.SqsEventSource(this.expenseParserQueue, {


### PR DESCRIPTION
…ependency

The root cause was bidirectional IAM modifications between the parent and nested stack. CDK high-level grant methods (grantPublish, grantConnect, grantRead, grantInvoke) modify IAM policies on both the grantor and grantee, creating CloudFormation export/import cycles.

Fix: replace ALL cross-stack grants with explicit addToRolePolicy calls using string ARNs:

- Parent → nested stack topics: adminFunction.addToRolePolicy with sns:Publish on topic ARNs (read-only reference, no backward dep)
- Nested stack processors → parent resources (DB, secrets, S3, proxy): addToRolePolicy inside the nested stack using string ARN props
- KMS SNS grant: moved to parent (before nested stack instantiation)
- inboundInvoiceProcessor → expense parser topic: explicit sns:Publish
  + kms policy instead of grantPublish

The nested stack now only receives string ARN props from the parent, never IFunction/ISecret/IBucket objects. All IAM policy modifications happen within the stack that owns the IAM role being modified.