### PR TITLE
fix(infra): skip managed log groups for migrated processor Lambdas

### DIFF
--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -179,6 +179,7 @@ export class MessagingNestedStack extends cdk.NestedStack {
     this.bookingRequestProcessor = createPythonFunction("BookingRequestProcessor", {
         handler: "lambda/manager_request_processor/handler.lambda_handler",
         timeout: cdk.Duration.seconds(10),
+        manageLogGroup: false,
         environment: {
           DATABASE_SECRET_ARN: props.databaseSecretArn,
           DATABASE_NAME: "evolvesprouts",
@@ -266,6 +267,7 @@ export class MessagingNestedStack extends cdk.NestedStack {
     this.mediaRequestProcessor = createPythonFunction("MediaRequestProcessor", {
         handler: "lambda/media_processor/handler.lambda_handler",
         timeout: cdk.Duration.seconds(30),
+        manageLogGroup: false,
         environment: {
           DATABASE_SECRET_ARN: props.databaseSecretArn,
           DATABASE_NAME: "evolvesprouts",
@@ -381,6 +383,7 @@ export class MessagingNestedStack extends cdk.NestedStack {
     this.expenseParserFunction = createPythonFunction("ExpenseParserFunction", {
         handler: "lambda/expense_parser/handler.lambda_handler",
         timeout: cdk.Duration.seconds(90),
+        manageLogGroup: false,
         environment: {
           DATABASE_SECRET_ARN: props.databaseSecretArn,
           DATABASE_NAME: "evolvesprouts",


### PR DESCRIPTION
The original /aws/lambda/evolvesprouts-{BookingRequestProcessor, MediaRequestProcessor,ExpenseParserFunction} log groups still exist in CloudWatch from before Phase 1. The nested stack cannot recreate them. Set manageLogGroup: false so the Lambdas reuse the existing log groups automatically.