### PR TITLE
fix(infra): skip managed log group for SesTemplateManagerFunction

### DIFF
--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -121,6 +121,7 @@ export class MessagingNestedStack extends cdk.NestedStack {
         memorySize: 256,
         timeout: cdk.Duration.seconds(60),
         noVpc: true,
+        manageLogGroup: false,
         reservedConcurrentExecutions: -1,
       });
     sesTemplateManagerFunction.addToRolePolicy(


### PR DESCRIPTION
Same issue as the three processors — the log group already exists from Phase 1 and cannot be recreated in the nested stack.