### PR TITLE
Align booking modal newsletter checkbox with terms styling

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
@@ -1,4 +1,3 @@
-import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import type { BookingPaymentModalContent } from '@/content';
 import type { BookingTopicsFieldConfig } from '@/components/sections/booking-modal/types';
 
@@ -9,14 +8,12 @@ interface ReservationFormFieldsProps {
   phone: string;
   interestedTopics: string;
   hasEmailError: boolean;
-  marketingOptIn: boolean;
   topicsFieldConfig?: BookingTopicsFieldConfig;
   onFullNameChange: (value: string) => void;
   onEmailChange: (value: string) => void;
   onEmailBlur: () => void;
   onPhoneChange: (value: string) => void;
   onTopicsChange: (value: string) => void;
-  onMarketingOptInChange: (checked: boolean) => void;
 }
 
 const EMAIL_ERROR_MESSAGE_ID = 'booking-modal-email-error-message';
@@ -28,14 +25,12 @@ export function ReservationFormFields({
   phone,
   interestedTopics,
   hasEmailError,
-  marketingOptIn,
   topicsFieldConfig,
   onFullNameChange,
   onEmailChange,
   onEmailBlur,
   onPhoneChange,
   onTopicsChange,
-  onMarketingOptInChange,
 }: ReservationFormFieldsProps) {
   const topicsFieldLabel = topicsFieldConfig?.label ?? content.topicsInterestLabel;
   const topicsFieldPlaceholder =
@@ -130,12 +125,6 @@ export function ReservationFormFields({
           className='es-focus-ring es-form-input resize-y'
         />
       </label>
-
-      <MarketingOptInCheckbox
-        label={content.marketingOptInLabel}
-        checked={marketingOptIn}
-        onChange={onMarketingOptInChange}
-      />
     </>
   );
 }

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -929,7 +929,6 @@ export function BookingReservationForm({
             phone={phone}
             interestedTopics={interestedTopics}
             hasEmailError={hasEmailError}
-            marketingOptIn={marketingOptIn}
             topicsFieldConfig={topicsFieldConfig}
             onFullNameChange={setFullName}
             onEmailChange={setEmail}
@@ -938,7 +937,6 @@ export function BookingReservationForm({
             }}
             onPhoneChange={setPhone}
             onTopicsChange={setInterestedTopics}
-            onMarketingOptInChange={setMarketingOptIn}
           />
 
           <ReservationFormDiscountCodeInput
@@ -1261,6 +1259,20 @@ export function BookingReservationForm({
                 <span className='es-form-required-marker ml-0.5' aria-hidden='true'>
                   *
                 </span>
+              </span>
+            </label>
+
+            <label className='flex items-start gap-2.5 py-1'>
+              <input
+                type='checkbox'
+                checked={marketingOptIn}
+                onChange={(event) => {
+                  setMarketingOptIn(event.target.checked);
+                }}
+                className='es-focus-ring mt-1 h-4 w-4 shrink-0 es-accent-brand'
+              />
+              <span className='text-sm leading-[1.45] es-text-heading'>
+                {content.marketingOptInLabel}
               </span>
             </label>
           </div>

--- a/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
@@ -20,13 +20,11 @@ describe('ReservationFormFields', () => {
         phone='12345678'
         interestedTopics='Boundaries'
         hasEmailError
-        marketingOptIn={false}
         onFullNameChange={onFullNameChange}
         onEmailChange={onEmailChange}
         onEmailBlur={onEmailBlur}
         onPhoneChange={onPhoneChange}
         onTopicsChange={onTopicsChange}
-        onMarketingOptInChange={vi.fn()}
       />,
     );
 
@@ -62,7 +60,6 @@ describe('ReservationFormFields', () => {
         phone=''
         interestedTopics=''
         hasEmailError={false}
-        marketingOptIn={false}
         topicsFieldConfig={{
           label: "What's your child's age?",
           placeholder: 'This will help me better personalise your experience',
@@ -73,7 +70,6 @@ describe('ReservationFormFields', () => {
         onEmailBlur={() => {}}
         onPhoneChange={() => {}}
         onTopicsChange={() => {}}
-        onMarketingOptInChange={() => {}}
       />,
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The booking / reservation modal newsletter opt-in now uses the same acknowledgement row pattern as the pending reservation and terms checkboxes (`flex items-start gap-2.5 py-1`, `es-accent-brand` checkbox, `text-sm leading-[1.45]` label text). It is rendered **after** the terms row inside `data-booking-acknowledgements`.

`ReservationFormFields` no longer includes marketing props or `MarketingOptInCheckbox`; contact and media forms are unchanged.

## Testing

- `npm run test -- --run tests/components/sections/booking-modal/reservation-form-fields.test.tsx tests/components/sections/my-best-auntie-booking-modal.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-539b8fc1-bed2-4041-a7c2-1bada059a5a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-539b8fc1-bed2-4041-a7c2-1bada059a5a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

