### PR TITLE
Add GET calendar and free-assets checks to public www API smoke

### DIFF
--- a/apps/public_www/README.md
+++ b/apps/public_www/README.md
@@ -173,16 +173,18 @@ What the runner validates:
 
 - Page smoke: fetches all pages discovered from `/sitemap.xml` (with URLs
   remapped to the target smoke origin) and fails on broken HTTP responses.
-- CTA API smoke:
+- Public API smoke (same-origin `/www/v1/*` with optional direct `/v1/*` fallback):
+  - `GET /www/v1/calendar/public`
+  - `GET /www/v1/assets/free?limit=100`
   - `POST /www/v1/legacy/contact-us`
   - `POST /www/v1/discounts/validate`
   - `POST /www/v1/assets/free/request`
   - `POST /www/v1/legacy/reservations`
   - `POST /www/v1/reservations/payment-intent`
 
-Status handling for CTA APIs:
+Status handling for API checks:
 
-- `PASS`: endpoint accepted the payload (`200`/`202` depending on endpoint).
+- `PASS`: successful response (`200` for reads and most writes, `202` where applicable).
 - `PASS*`: endpoint was reached but blocked by validation/auth gates
   (for example invalid/missing Turnstile token on staging).
 - `FAIL`: unexpected status, server error (`5xx`), timeout, or transport error.

--- a/apps/public_www/scripts/smoke-staging.mjs
+++ b/apps/public_www/scripts/smoke-staging.mjs
@@ -174,6 +174,18 @@ function buildUrlFromApiBase(apiBaseUrl, endpointPath) {
   return requestUrl.toString();
 }
 
+function applyQueryString(urlString, queryString) {
+  const trimmed = queryString?.trim() ?? '';
+  if (!trimmed) {
+    return urlString;
+  }
+
+  const requestUrl = new URL(urlString);
+  const normalizedQuery = trimmed.startsWith('?') ? trimmed.slice(1) : trimmed;
+  requestUrl.search = normalizedQuery;
+  return requestUrl.toString();
+}
+
 async function fetchWithTimeout(url, init, timeoutMs) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
@@ -385,6 +397,28 @@ function buildApiCases(turnstileToken) {
 
   return [
     {
+      name: 'public calendar feed endpoint',
+      method: 'GET',
+      proxyPath: '/www/v1/calendar/public',
+      directPath: '/v1/calendar/public',
+      apiBaseType: 'crm',
+      queryString: '',
+      allowedStatuses: new Set([200, 400, 403, 404]),
+      expectedStatuses: new Set([200]),
+      includeTurnstileHeader: false,
+    },
+    {
+      name: 'public free assets list endpoint',
+      method: 'GET',
+      proxyPath: '/www/v1/assets/free',
+      directPath: '/v1/assets/free',
+      apiBaseType: 'crm',
+      queryString: 'limit=100',
+      allowedStatuses: new Set([200, 400, 403, 404]),
+      expectedStatuses: new Set([200]),
+      includeTurnstileHeader: false,
+    },
+    {
       name: 'contact-us CTA endpoint',
       method: 'POST',
       proxyPath: '/www/v1/legacy/contact-us',
@@ -476,18 +510,25 @@ function buildApiCandidateUrls({
   crmApiBaseUrl,
   mediaApiBaseUrl,
 }) {
-  const candidateUrls = [new URL(apiCase.proxyPath, baseUrl).toString()];
+  const queryString = apiCase.queryString ?? '';
+  const candidateUrls = [
+    applyQueryString(new URL(apiCase.proxyPath, baseUrl).toString(), queryString),
+  ];
   if (apiCase.apiBaseType === 'crm' && crmApiBaseUrl) {
-    candidateUrls.push(buildUrlFromApiBase(crmApiBaseUrl, apiCase.directPath));
+    candidateUrls.push(
+      applyQueryString(buildUrlFromApiBase(crmApiBaseUrl, apiCase.directPath), queryString),
+    );
   }
   if (apiCase.apiBaseType === 'media' && mediaApiBaseUrl) {
-    candidateUrls.push(buildUrlFromApiBase(mediaApiBaseUrl, apiCase.directPath));
+    candidateUrls.push(
+      applyQueryString(buildUrlFromApiBase(mediaApiBaseUrl, apiCase.directPath), queryString),
+    );
   }
   return [...new Set(candidateUrls)];
 }
 
 async function runApiChecks({ baseUrl, timeoutMs, apiBaseUrl, mediaApiBaseUrl }) {
-  logSection('CTA API smoke checks');
+  logSection('Public API smoke checks');
 
   const apiKey = (process.env[SMOKE_API_KEY_ENV] ?? process.env[FALLBACK_API_KEY_ENV] ?? '').trim();
   if (!apiKey) {
@@ -510,11 +551,22 @@ async function runApiChecks({ baseUrl, timeoutMs, apiBaseUrl, mediaApiBaseUrl })
     });
     const headers = {
       accept: 'application/json',
-      'content-type': 'application/json',
       'x-api-key': apiKey,
     };
+    if (apiCase.method !== 'GET') {
+      headers['content-type'] = 'application/json';
+    }
     if (apiCase.includeTurnstileHeader) {
       headers['X-Turnstile-Token'] = apiCase.turnstileToken;
+    }
+
+    const requestInit = {
+      method: apiCase.method,
+      headers,
+      redirect: 'follow',
+    };
+    if (apiCase.method !== 'GET' && apiCase.body !== undefined) {
+      requestInit.body = JSON.stringify(apiCase.body);
     }
 
     let hasRecordedOutcome = false;
@@ -522,16 +574,7 @@ async function runApiChecks({ baseUrl, timeoutMs, apiBaseUrl, mediaApiBaseUrl })
 
     for (const [candidateIndex, endpointUrl] of endpointUrls.entries()) {
       try {
-        const response = await fetchWithTimeout(
-          endpointUrl,
-          {
-            method: apiCase.method,
-            headers,
-            body: JSON.stringify(apiCase.body),
-            redirect: 'follow',
-          },
-          timeoutMs,
-        );
+        const response = await fetchWithTimeout(endpointUrl, requestInit, timeoutMs);
         const responseBody = trimForLog(await response.text().catch(() => ''));
         const endpointSuffix =
           endpointUrls.length > 1 && candidateIndex > 0 ? ' (fallback endpoint)' : '';

--- a/docs/deployment/public-www.md
+++ b/docs/deployment/public-www.md
@@ -126,7 +126,9 @@ Workflow: `.github/workflows/smoke-public-www-staging.yml`
   - runs `npm run smoke:staging` in `apps/public_www`
   - verifies page health via sitemap-driven URL checks (with staging-origin URL
     remapping)
-  - verifies CTA API endpoints:
+  - verifies public API endpoints:
+    - `GET /www/v1/calendar/public`
+    - `GET /www/v1/assets/free?limit=100`
     - `POST /www/v1/legacy/contact-us`
     - `POST /www/v1/discounts/validate`
     - `POST /www/v1/assets/free/request`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends `apps/public_www/scripts/smoke-staging.mjs` so the **API** smoke mode exercises the same **GET** routes the public site uses for the events feed and free-guides listing:

- `GET /www/v1/calendar/public` (with `/v1/calendar/public` fallback when proxy returns 404)
- `GET /www/v1/assets/free?limit=100` (aligned with the library page size; same fallback pattern)

GET requests no longer send a JSON body or `Content-Type: application/json`. Existing POST CTA checks are unchanged.

## Docs

- `apps/public_www/README.md` — smoke runner endpoint list
- `docs/deployment/public-www.md` — GitHub workflow behavior

## Notes

- `GET /v1/assets/share/{token}` (media download redirect) is still not covered: it needs a valid share token and `NEXT_PUBLIC_ASSET_SHARE_BASE_URL`, which the workflow does not configure today.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-125365ca-ee52-40a9-b311-332ea543a0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-125365ca-ee52-40a9-b311-332ea543a0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

