### PR TITLE
fix(public_www): style newsletter checkbox like booking form

### DIFF
--- a/apps/public_www/src/components/shared/marketing-opt-in-checkbox.tsx
+++ b/apps/public_www/src/components/shared/marketing-opt-in-checkbox.tsx
@@ -10,16 +10,16 @@ export function MarketingOptInCheckbox({
   onChange,
 }: MarketingOptInCheckboxProps) {
   return (
-    <label className='flex cursor-pointer items-start gap-2 text-sm es-text-heading'>
+    <label className='flex cursor-pointer items-start gap-2.5 py-1'>
       <input
         type='checkbox'
         checked={checked}
         onChange={(event) => {
           onChange(event.target.checked);
         }}
-        className='es-focus-ring mt-0.5 h-4 w-4 shrink-0 rounded border es-border-input'
+        className='es-focus-ring es-accent-brand mt-1 h-4 w-4 shrink-0'
       />
-      <span className='leading-snug'>{label}</span>
+      <span className='text-sm leading-[1.45] es-text-heading'>{label}</span>
     </label>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Contact us and resource download flows use `MarketingOptInCheckbox`, while the booking modal inlined its own newsletter checkbox with `es-accent-brand` and tighter layout tokens. The shared component still used a bordered native checkbox, so it looked unstyled by comparison.

## Changes

- Update `MarketingOptInCheckbox` to match booking acknowledgements: `es-accent-brand`, `gap-2.5`, `py-1`, `mt-1` on the input, and `text-sm leading-[1.45] es-text-heading` on the label text.

## Testing

- `npm run test -- tests/components/sections/contact-us-form-fields.test.tsx tests/components/sections/media-form.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8833803e-3228-4dce-96e4-9efaf9169656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8833803e-3228-4dce-96e4-9efaf9169656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

