### PR TITLE
fix(infra): retain SES templates on custom resource delete + force re…

### DIFF
--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -138,10 +138,14 @@ export class MessagingNestedStack extends cdk.NestedStack {
     const sesTemplatesHash = hashDirectory(
       path.join(__dirname, "../../src/app/templates/ses")
     );
+    const sesHandlerHash = hashDirectory(
+      path.join(__dirname, "../../lambda/ses_template_manager")
+    );
     new cdk.CustomResource(this, "SesEmailTemplates", {
       serviceToken: sesTemplateManagerFunction.functionArn,
       properties: {
         TemplatesHash: sesTemplatesHash,
+        HandlerHash: sesHandlerHash,
       },
     });
 

--- a/backend/lambda/ses_template_manager/handler.py
+++ b/backend/lambda/ses_template_manager/handler.py
@@ -32,17 +32,10 @@ def lambda_handler(event: Mapping[str, Any], context: Any) -> dict[str, Any]:
     names = [t["TemplateName"] for t in all_defs]
 
     if request_type == "Delete":
-        client = get_ses_client()
-        for name in names:
-            try:
-                client.delete_template(TemplateName=name)
-            except ClientError as exc:
-                code = exc.response.get("Error", {}).get("Code", "")
-                if code != "TemplateDoesNotExist":
-                    logger.warning(
-                        "SES delete template failed",
-                        extra={"template": name, "error_code": code},
-                    )
+        logger.info(
+            "Skipping SES template deletion (templates are retained for reuse)",
+            extra={"templates": ",".join(names)},
+        )
         data = {"templates": ",".join(names)}
         send_cfn_response(event, context, "SUCCESS", data, physical_id)
         return {"PhysicalResourceId": physical_id, "Data": data}


### PR DESCRIPTION
…-create

The DELETE handler was deleting all 9 SES templates during stack rollbacks and resource cleanup. During the Phase 2 deploy, the old auto-named Lambda received the DELETE event AFTER the new named Lambda had already created the templates, leaving them wiped out.

Fix: make the DELETE handler a no-op (templates are retained for reuse). Add HandlerHash to custom resource properties to force CloudFormation to re-invoke and recreate the templates on this deploy.