### PR TITLE
fix(infra): add SES template ARN to SendTemplatedEmail IAM policies

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2549,6 +2549,10 @@ export class ApiStack extends cdk.Stack {
           sesSenderDomainIdentityArn,
           sesAuthEmailIdentityArn,
           sesAuthEmailDomainIdentityArn,
+          cdk.Arn.format(
+            { service: "ses", resource: "template", resourceName: "evolvesprouts-*" },
+            this
+          ),
         ],
       })
     );

--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -309,6 +309,10 @@ export class MessagingNestedStack extends cdk.NestedStack {
           props.sesSenderDomainIdentityArn,
           props.sesAuthEmailIdentityArn,
           props.sesAuthEmailDomainIdentityArn,
+          cdk.Arn.format(
+            { service: "ses", resource: "template", resourceName: "evolvesprouts-*" },
+            cdk.Stack.of(this)
+          ),
         ],
       })
     );


### PR DESCRIPTION
ses:SendTemplatedEmail requires permission on both the identity ARN and the template ARN. The policies only listed identity ARNs, causing AccessDenied on the template resource.

Add arn:aws:ses:*:*:template/evolvesprouts-* to the admin Lambda and media processor SES policies.