### PR TITLE
fix(infra): restore database/secret/proxy grants from parent stack

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1655,7 +1655,6 @@ export class ApiStack extends cdk.Stack {
       assetsBucketName: assetsBucket.bucketName,
       assetsBucketArn: assetsBucket.bucketArn,
       openrouterApiSecretArn: openrouterApiSecret.secretArn,
-      databaseProxyArn: database.proxy.dbProxyArn,
       sesSenderEmail: sesSenderEmail.valueAsString,
       supportEmail: supportEmail.valueAsString,
       authEmailFromAddress: authEmailFromAddress.valueAsString,
@@ -1703,6 +1702,18 @@ export class ApiStack extends cdk.Stack {
       "EXPENSE_PARSE_TOPIC_ARN",
       messaging.expenseParserTopic.topicArn
     );
+
+    database.grantAdminUserSecretRead(messaging.bookingRequestProcessor);
+    database.grantConnect(messaging.bookingRequestProcessor, "evolvesprouts_admin");
+    database.grantAdminUserSecretRead(messaging.mediaRequestProcessor);
+    database.grantConnect(messaging.mediaRequestProcessor, "evolvesprouts_admin");
+    database.grantAdminUserSecretRead(messaging.expenseParserFunction);
+    database.grantConnect(messaging.expenseParserFunction, "evolvesprouts_admin");
+    mailchimpApiSecret.grantRead(messaging.mediaRequestProcessor);
+    awsProxyFunction.grantInvoke(messaging.mediaRequestProcessor);
+    assetsBucket.grantRead(messaging.expenseParserFunction);
+    openrouterApiSecret.grantRead(messaging.expenseParserFunction);
+    awsProxyFunction.grantInvoke(messaging.expenseParserFunction);
 
     // -------------------------------------------------------------------------
     // Eventbrite sync messaging (nested stack to reduce root stack size)

--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -31,7 +31,6 @@ export interface MessagingNestedStackProps extends cdk.NestedStackProps {
   assetsBucketName: string;
   assetsBucketArn: string;
   openrouterApiSecretArn: string;
-  databaseProxyArn: string;
   sesSenderEmail: string;
   supportEmail: string;
   authEmailFromAddress: string;
@@ -202,25 +201,6 @@ export class MessagingNestedStack extends cdk.NestedStack {
         resources: [props.sesSenderIdentityArn, props.sesSenderDomainIdentityArn],
       })
     );
-    this.bookingRequestProcessor.addToRolePolicy(
-      new iam.PolicyStatement({
-        actions: ["secretsmanager:GetSecretValue"],
-        resources: [props.databaseSecretArn],
-      })
-    );
-    this.bookingRequestProcessor.addToRolePolicy(
-      new iam.PolicyStatement({
-        actions: ["rds-db:connect"],
-        resources: [
-          cdk.Fn.join("", [
-            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
-            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
-            "/evolvesprouts_admin",
-          ]),
-        ],
-      })
-    );
-
     this.bookingRequestProcessor.addEventSource(
       new lambdaEventSources.SqsEventSource(this.bookingRequestQueue, {
         batchSize: 1,
@@ -318,24 +298,6 @@ export class MessagingNestedStack extends cdk.NestedStack {
     );
     this.mediaRequestProcessor.addToRolePolicy(
       new iam.PolicyStatement({
-        actions: ["secretsmanager:GetSecretValue"],
-        resources: [props.databaseSecretArn, props.mailchimpApiSecretArn],
-      })
-    );
-    this.mediaRequestProcessor.addToRolePolicy(
-      new iam.PolicyStatement({
-        actions: ["rds-db:connect"],
-        resources: [
-          cdk.Fn.join("", [
-            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
-            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
-            "/evolvesprouts_admin",
-          ]),
-        ],
-      })
-    );
-    this.mediaRequestProcessor.addToRolePolicy(
-      new iam.PolicyStatement({
         actions: ["lambda:InvokeFunction"],
         resources: [props.awsProxyFunctionArn],
       })
@@ -408,24 +370,6 @@ export class MessagingNestedStack extends cdk.NestedStack {
         },
       });
 
-    this.expenseParserFunction.addToRolePolicy(
-      new iam.PolicyStatement({
-        actions: ["secretsmanager:GetSecretValue"],
-        resources: [props.databaseSecretArn, props.openrouterApiSecretArn],
-      })
-    );
-    this.expenseParserFunction.addToRolePolicy(
-      new iam.PolicyStatement({
-        actions: ["rds-db:connect"],
-        resources: [
-          cdk.Fn.join("", [
-            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
-            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
-            "/evolvesprouts_admin",
-          ]),
-        ],
-      })
-    );
     this.expenseParserFunction.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["s3:GetObject", "s3:GetBucketLocation", "s3:ListBucket"],


### PR DESCRIPTION
The explicit secretsmanager:GetSecretValue and rds-db:connect policies in the nested stack were missing KMS decrypt permission for the DB secret's encryption key. database.grantAdminUserSecretRead() handles both the secret read AND the KMS key decrypt.

Move database, mailchimp secret, openrouter secret, S3, and proxy grants back to the parent stack (one-way: parent → nested stack Lambda roles, no circular dependency). Keep only S3 read and lambda:Invoke as explicit policies in the nested stack since those don't involve KMS-encrypted secrets.