### PR TITLE
fix(infra): fully self-contained IAM grants in nested stack (no cross…

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1655,6 +1655,8 @@ export class ApiStack extends cdk.Stack {
       assetsBucketName: assetsBucket.bucketName,
       assetsBucketArn: assetsBucket.bucketArn,
       openrouterApiSecretArn: openrouterApiSecret.secretArn,
+      databaseProxyArn: database.proxy.dbProxyArn,
+      databaseSecretKmsKeyArn: database.adminUserSecretKmsKey?.keyArn ?? "",
       sesSenderEmail: sesSenderEmail.valueAsString,
       supportEmail: supportEmail.valueAsString,
       authEmailFromAddress: authEmailFromAddress.valueAsString,
@@ -1703,17 +1705,6 @@ export class ApiStack extends cdk.Stack {
       messaging.expenseParserTopic.topicArn
     );
 
-    database.grantAdminUserSecretRead(messaging.bookingRequestProcessor);
-    database.grantConnect(messaging.bookingRequestProcessor, "evolvesprouts_admin");
-    database.grantAdminUserSecretRead(messaging.mediaRequestProcessor);
-    database.grantConnect(messaging.mediaRequestProcessor, "evolvesprouts_admin");
-    database.grantAdminUserSecretRead(messaging.expenseParserFunction);
-    database.grantConnect(messaging.expenseParserFunction, "evolvesprouts_admin");
-    mailchimpApiSecret.grantRead(messaging.mediaRequestProcessor);
-    awsProxyFunction.grantInvoke(messaging.mediaRequestProcessor);
-    assetsBucket.grantRead(messaging.expenseParserFunction);
-    openrouterApiSecret.grantRead(messaging.expenseParserFunction);
-    awsProxyFunction.grantInvoke(messaging.expenseParserFunction);
 
     // -------------------------------------------------------------------------
     // Eventbrite sync messaging (nested stack to reduce root stack size)

--- a/backend/infrastructure/lib/constructs/database.ts
+++ b/backend/infrastructure/lib/constructs/database.ts
@@ -95,7 +95,7 @@ export class DatabaseConstruct extends Construct {
   /** KMS key used to encrypt the app user secret. */
   private readonly appUserSecretKmsKey?: kms.IKey;
   /** KMS key used to encrypt the admin user secret. */
-  private readonly adminUserSecretKmsKey?: kms.IKey;
+  public readonly adminUserSecretKmsKey?: kms.IKey;
 
   constructor(scope: Construct, id: string, props: DatabaseConstructProps) {
     super(scope, id);

--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -31,6 +31,8 @@ export interface MessagingNestedStackProps extends cdk.NestedStackProps {
   assetsBucketName: string;
   assetsBucketArn: string;
   openrouterApiSecretArn: string;
+  databaseProxyArn: string;
+  databaseSecretKmsKeyArn: string;
   sesSenderEmail: string;
   supportEmail: string;
   authEmailFromAddress: string;
@@ -201,6 +203,32 @@ export class MessagingNestedStack extends cdk.NestedStack {
         resources: [props.sesSenderIdentityArn, props.sesSenderDomainIdentityArn],
       })
     );
+    this.bookingRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+        resources: [props.databaseSecretArn],
+      })
+    );
+    if (props.databaseSecretKmsKeyArn) {
+      this.bookingRequestProcessor.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ["kms:Decrypt"],
+          resources: [props.databaseSecretKmsKeyArn],
+        })
+      );
+    }
+    this.bookingRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["rds-db:connect"],
+        resources: [
+          cdk.Fn.join("", [
+            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
+            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
+            "/evolvesprouts_admin",
+          ]),
+        ],
+      })
+    );
     this.bookingRequestProcessor.addEventSource(
       new lambdaEventSources.SqsEventSource(this.bookingRequestQueue, {
         batchSize: 1,
@@ -302,6 +330,32 @@ export class MessagingNestedStack extends cdk.NestedStack {
         resources: [props.awsProxyFunctionArn],
       })
     );
+    this.mediaRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+        resources: [props.databaseSecretArn, props.mailchimpApiSecretArn],
+      })
+    );
+    if (props.databaseSecretKmsKeyArn) {
+      this.mediaRequestProcessor.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ["kms:Decrypt"],
+          resources: [props.databaseSecretKmsKeyArn],
+        })
+      );
+    }
+    this.mediaRequestProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["rds-db:connect"],
+        resources: [
+          cdk.Fn.join("", [
+            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
+            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
+            "/evolvesprouts_admin",
+          ]),
+        ],
+      })
+    );
 
     this.mediaRequestProcessor.addEventSource(
       new lambdaEventSources.SqsEventSource(this.mediaQueue, {
@@ -370,6 +424,32 @@ export class MessagingNestedStack extends cdk.NestedStack {
         },
       });
 
+    this.expenseParserFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+        resources: [props.databaseSecretArn, props.openrouterApiSecretArn],
+      })
+    );
+    if (props.databaseSecretKmsKeyArn) {
+      this.expenseParserFunction.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ["kms:Decrypt"],
+          resources: [props.databaseSecretKmsKeyArn],
+        })
+      );
+    }
+    this.expenseParserFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["rds-db:connect"],
+        resources: [
+          cdk.Fn.join("", [
+            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
+            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
+            "/evolvesprouts_admin",
+          ]),
+        ],
+      })
+    );
     this.expenseParserFunction.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["s3:GetObject", "s3:GetBucketLocation", "s3:ListBucket"],


### PR DESCRIPTION
…-stack grants)

The database.grantAdminUserSecretRead() calls from the parent caused circular dependencies because CDK's grantRead on a KMS-encrypted secret modifies the parent's KMS key policy (backward reference).

Fix: all IAM grants for nested stack processors are now explicit addToRolePolicy calls inside the nested stack using string ARN props:
- secretsmanager:GetSecretValue + DescribeSecret for DB and other secrets
- kms:Decrypt on the DB secret's KMS key (ARN exposed from DatabaseConstruct)
- rds-db:connect on the RDS Proxy resource
- lambda:InvokeFunction for the AWS proxy
- s3:GetObject/ListBucket for the assets bucket
- ses:Send* for email identities + templates

Zero CDK high-level grant calls cross the stack boundary. The parent only reads nested stack outputs (topic ARNs, queue URLs) — no IAM modifications in either direction.