### PR TITLE
Remove optional SES templated email path for ticket notifications

### DIFF
--- a/backend/lambda/manager_request_processor/handler.py
+++ b/backend/lambda/manager_request_processor/handler.py
@@ -24,13 +24,8 @@ from sqlalchemy.orm import Session
 from app.db.engine import get_engine
 from app.db.models import Ticket, TicketType
 from app.db.repositories import TicketRepository
-from app.services.email import send_email, send_templated_email
-from app.templates import (
-    build_new_request_template_data,
-    build_new_suggestion_template_data,
-    render_new_request_email,
-    render_new_suggestion_email,
-)
+from app.services.email import send_email
+from app.templates import render_new_request_email, render_new_suggestion_email
 from app.utils.logging import configure_logging, get_logger
 from app.utils.retry import run_with_retry
 
@@ -218,14 +213,6 @@ def _send_notification_email(ticket: Ticket) -> None:
         )
 
         if ticket.ticket_type == TicketType.ACCESS_REQUEST:
-            template_name = os.getenv("SES_TEMPLATE_NEW_ACCESS_REQUEST", "")
-            template_data = build_new_request_template_data(
-                ticket_id=ticket.ticket_id,
-                requester_email=ticket.submitter_email,
-                organization_name=ticket.organization_name,
-                request_message=ticket.message,
-                submitted_at=submitted_at,
-            )
             email_content = render_new_request_email(
                 ticket_id=ticket.ticket_id,
                 requester_email=ticket.submitter_email,
@@ -234,17 +221,6 @@ def _send_notification_email(ticket: Ticket) -> None:
                 submitted_at=submitted_at,
             )
         elif ticket.ticket_type == TicketType.ORGANIZATION_SUGGESTION:
-            template_name = os.getenv("SES_TEMPLATE_NEW_SUGGESTION", "")
-            template_data = build_new_suggestion_template_data(
-                ticket_id=ticket.ticket_id,
-                suggester_email=ticket.submitter_email,
-                organization_name=ticket.organization_name,
-                description=ticket.description,
-                district=ticket.suggested_district,
-                address=ticket.suggested_address,
-                additional_notes=ticket.message,
-                submitted_at=submitted_at,
-            )
             email_content = render_new_suggestion_email(
                 ticket_id=ticket.ticket_id,
                 suggester_email=ticket.submitter_email,
@@ -262,27 +238,16 @@ def _send_notification_email(ticket: Ticket) -> None:
             )
             return
 
-        if template_name:
-            run_with_retry(
-                send_templated_email,
-                source=sender_email,
-                to_addresses=[support_email],
-                template_name=template_name,
-                template_data=template_data,
-                logger=logger,
-                operation_name="ses.send_templated_email",
-            )
-        else:
-            run_with_retry(
-                send_email,
-                source=sender_email,
-                to_addresses=[support_email],
-                subject=email_content.subject,
-                body_text=email_content.body_text,
-                body_html=email_content.body_html,
-                logger=logger,
-                operation_name="ses.send_email",
-            )
+        run_with_retry(
+            send_email,
+            source=sender_email,
+            to_addresses=[support_email],
+            subject=email_content.subject,
+            body_text=email_content.body_text,
+            body_html=email_content.body_html,
+            logger=logger,
+            operation_name="ses.send_email",
+        )
         logger.info(f"Notification email sent for {ticket.ticket_id}")
 
     except Exception as e:

--- a/backend/src/app/templates/__init__.py
+++ b/backend/src/app/templates/__init__.py
@@ -1,9 +1,6 @@
 """Email templates for the application."""
 
-from app.templates.access_request import (
-    build_new_request_template_data,
-    render_new_request_email,
-)
+from app.templates.access_request import render_new_request_email
 from app.templates.media_lead import (
     build_sales_notification_template_data,
     render_sales_notification_email,
@@ -12,16 +9,11 @@ from app.templates.request_decision import (
     build_request_decision_template_data,
     render_request_decision_email,
 )
-from app.templates.suggestion import (
-    build_new_suggestion_template_data,
-    render_new_suggestion_email,
-)
+from app.templates.suggestion import render_new_suggestion_email
 from app.templates.types import EmailContent
 
 __all__ = [
     "EmailContent",
-    "build_new_request_template_data",
-    "build_new_suggestion_template_data",
     "build_request_decision_template_data",
     "build_sales_notification_template_data",
     "render_new_request_email",

--- a/backend/src/app/templates/access_request.py
+++ b/backend/src/app/templates/access_request.py
@@ -135,20 +135,3 @@ def render_new_request_email(
         body_text=body_text,
         body_html=body_html,
     )
-
-
-def build_new_request_template_data(
-    ticket_id: str,
-    requester_email: str,
-    organization_name: str,
-    request_message: str | None,
-    submitted_at: str,
-) -> dict[str, str]:
-    """Build template data for a new access request."""
-    return {
-        "ticket_id": ticket_id,
-        "requester_email": requester_email,
-        "organization_name": organization_name,
-        "request_message": request_message or "No message provided",
-        "submitted_at": submitted_at,
-    }

--- a/backend/src/app/templates/suggestion.py
+++ b/backend/src/app/templates/suggestion.py
@@ -174,26 +174,3 @@ def render_new_suggestion_email(
         body_text=body_text,
         body_html=body_html,
     )
-
-
-def build_new_suggestion_template_data(
-    ticket_id: str,
-    suggester_email: str,
-    organization_name: str,
-    description: str | None,
-    district: str | None,
-    address: str | None,
-    additional_notes: str | None,
-    submitted_at: str,
-) -> dict[str, str]:
-    """Build template data for a new organization suggestion."""
-    return {
-        "ticket_id": ticket_id,
-        "suggester_email": suggester_email,
-        "organization_name": organization_name,
-        "description": description or "Not provided",
-        "district": district or "Not provided",
-        "address": address or "Not provided",
-        "additional_notes": additional_notes or "No additional notes",
-        "submitted_at": submitted_at,
-    }

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -337,8 +337,6 @@ SQS retries or mailbox forwarding duplicates.
 | `DATABASE_PROXY_ENDPOINT` | RDS Proxy endpoint |
 | `SUPPORT_EMAIL` | Email to receive notifications |
 | `SES_SENDER_EMAIL` | Verified SES sender address |
-| `SES_TEMPLATE_NEW_ACCESS_REQUEST` | Optional SES template for access requests |
-| `SES_TEMPLATE_NEW_SUGGESTION` | Optional SES template for suggestions |
 | `MAILCHIMP_API_SECRET_ARN` | Existing secret ARN for Mailchimp API key |
 | `MAILCHIMP_LIST_ID` | Mailchimp list ID |
 | `MAILCHIMP_SERVER_PREFIX` | Mailchimp server prefix (for example `us21`) |

--- a/tests/test_manager_request_processor_handler.py
+++ b/tests/test_manager_request_processor_handler.py
@@ -57,7 +57,6 @@ def test_send_notification_email_retries_transient_send_failures(
     handler = _load_handler_module()
     monkeypatch.setenv("SUPPORT_EMAIL", "support@example.com")
     monkeypatch.setenv("SES_SENDER_EMAIL", "sender@example.com")
-    monkeypatch.setenv("SES_TEMPLATE_NEW_ACCESS_REQUEST", "")
 
     monkeypatch.setattr(
         handler,
@@ -67,11 +66,6 @@ def test_send_notification_email_retries_transient_send_failures(
             body_text="body",
             body_html=None,
         ),
-    )
-    monkeypatch.setattr(
-        handler,
-        "build_new_request_template_data",
-        lambda **_: {},
     )
 
     attempts = {"count": 0}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the optional `SES_TEMPLATE_NEW_ACCESS_REQUEST` and `SES_TEMPLATE_NEW_SUGGESTION` code path from `BookingRequestProcessor` (`backend/lambda/manager_request_processor/handler.py`). Ticket notifications for access requests and organization suggestions now always use `send_email` with bodies from `render_new_request_email` / `render_new_suggestion_email`.

## Also

- Deletes `build_new_request_template_data` and `build_new_suggestion_template_data` from `access_request.py` / `suggestion.py` and re-exports in `app.templates`.
- Updates `docs/architecture/aws-messaging.md` (processor env table).
- Adjusts `tests/test_manager_request_processor_handler.py`.

## Validation

- `pre-commit run ruff-format --all-files`
- `pytest tests/test_manager_request_processor_handler.py`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b743eb2-800c-4881-bf07-e19188475e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b743eb2-800c-4881-bf07-e19188475e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

