### PR TITLE
refactor(ses): single shared HTML shell for SES templates

### DIFF
--- a/backend/src/app/templates/ses/booking_confirmation.py
+++ b/backend/src/app/templates/ses/booking_confirmation.py
@@ -4,27 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-
-def _wrap_html(*, inner_html: str) -> str:
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/></head>
-<body style="margin:0;padding:0;background-color:#f6f6f6;font-family:Arial,Helvetica,sans-serif;">
-<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f6f6f6;">
-<tr><td align="center" style="padding:24px 12px;">
-<table role="presentation" width="600" cellspacing="0" cellpadding="0"
-style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;">
-<tr><td style="padding:24px 28px;background:#1a5f4a;color:#ffffff;">
-<h1 style="margin:0;font-size:22px;line-height:1.3;">Evolve Sprouts</h1>
-<p style="margin:8px 0 0;font-size:14px;opacity:0.95;">Booking confirmed</p>
-</td></tr>
-<tr><td style="padding:28px;color:#333333;font-size:15px;line-height:1.6;">
-{inner_html}
-</td></tr>
-<tr><td style="padding:16px 28px 24px;color:#666666;font-size:12px;line-height:1.5;">
-<p style="margin:0;">Evolve Sprouts</p>
-</td></tr>
-</table></td></tr></table></body></html>"""
+from app.templates.ses.email_shell import wrap_transactional_html
 
 
 def get_ses_template_definitions() -> list[dict[str, Any]]:
@@ -34,11 +14,19 @@ def get_ses_template_definitions() -> list[dict[str, Any]]:
         "zh-CN": "预约确认 — {{course_label}} — Evolve Sprouts",
         "zh-HK": "預約確認 — {{course_label}} — Evolve Sprouts",
     }
+    header_subtitles = {
+        "en": "Booking confirmed",
+        "zh-CN": "预约确认",
+        "zh-HK": "預約確認",
+    }
     return [
         {
             "TemplateName": f"evolvesprouts-booking-confirmation-{loc}",
             "SubjectPart": subjects[loc],
-            "HtmlPart": _wrap_html(inner_html=inner_html),
+            "HtmlPart": wrap_transactional_html(
+                header_subtitle=header_subtitles[loc],
+                inner_html=inner_html,
+            ),
             "TextPart": text_part,
         }
         for loc, inner_html, text_part in _LOCALE_ROWS

--- a/backend/src/app/templates/ses/contact_confirmation.py
+++ b/backend/src/app/templates/ses/contact_confirmation.py
@@ -4,27 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-
-def _wrap_html(*, header_subtitle: str, inner_html: str) -> str:
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/></head>
-<body style="margin:0;padding:0;background-color:#f6f6f6;font-family:Arial,Helvetica,sans-serif;">
-<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f6f6f6;">
-<tr><td align="center" style="padding:24px 12px;">
-<table role="presentation" width="600" cellspacing="0" cellpadding="0"
-style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;">
-<tr><td style="padding:24px 28px;background:#1a5f4a;color:#ffffff;">
-<h1 style="margin:0;font-size:22px;line-height:1.3;">Evolve Sprouts</h1>
-<p style="margin:8px 0 0;font-size:14px;opacity:0.95;">{header_subtitle}</p>
-</td></tr>
-<tr><td style="padding:28px;color:#333333;font-size:15px;line-height:1.6;">
-{inner_html}
-</td></tr>
-<tr><td style="padding:16px 28px 24px;color:#666666;font-size:12px;line-height:1.5;">
-<p style="margin:0;">Evolve Sprouts</p>
-</td></tr>
-</table></td></tr></table></body></html>"""
+from app.templates.ses.email_shell import wrap_transactional_html
 
 
 def get_ses_template_definitions() -> list[dict[str, Any]]:
@@ -33,7 +13,9 @@ def get_ses_template_definitions() -> list[dict[str, Any]]:
         {
             "TemplateName": f"evolvesprouts-contact-confirmation-{loc}",
             "SubjectPart": subject,
-            "HtmlPart": _wrap_html(header_subtitle=subject, inner_html=inner_html),
+            "HtmlPart": wrap_transactional_html(
+                header_subtitle=subject, inner_html=inner_html
+            ),
             "TextPart": text_part,
         }
         for loc, subject, inner_html, text_part in _LOCALE_ROWS

--- a/backend/src/app/templates/ses/email_shell.py
+++ b/backend/src/app/templates/ses/email_shell.py
@@ -1,0 +1,31 @@
+"""Shared HTML shell for SES transactional templates.
+
+Plain-text (`TextPart`) bodies stay defined per template module: copy, placeholders,
+and Handlebars blocks differ, so there is no meaningful shared wrapper beyond
+optional repeated sign-off lines (already kept minimal in each template).
+"""
+
+from __future__ import annotations
+
+
+def wrap_transactional_html(*, header_subtitle: str, inner_html: str) -> str:
+    """Return a full HTML document wrapping `inner_html` in the standard Evolve Sprouts layout."""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/></head>
+<body style="margin:0;padding:0;background-color:#f6f6f6;font-family:Arial,Helvetica,sans-serif;">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f6f6f6;">
+<tr><td align="center" style="padding:24px 12px;">
+<table role="presentation" width="600" cellspacing="0" cellpadding="0"
+style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;">
+<tr><td style="padding:24px 28px;background:#1a5f4a;color:#ffffff;">
+<h1 style="margin:0;font-size:22px;line-height:1.3;">Evolve Sprouts</h1>
+<p style="margin:8px 0 0;font-size:14px;opacity:0.95;">{header_subtitle}</p>
+</td></tr>
+<tr><td style="padding:28px;color:#333333;font-size:15px;line-height:1.6;">
+{inner_html}
+</td></tr>
+<tr><td style="padding:16px 28px 24px;color:#666666;font-size:12px;line-height:1.5;">
+<p style="margin:0;">Evolve Sprouts</p>
+</td></tr>
+</table></td></tr></table></body></html>"""

--- a/backend/src/app/templates/ses/media_download_link.py
+++ b/backend/src/app/templates/ses/media_download_link.py
@@ -4,27 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-
-def _wrap_html(*, header_subtitle: str, inner_html: str) -> str:
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/></head>
-<body style="margin:0;padding:0;background-color:#f6f6f6;font-family:Arial,Helvetica,sans-serif;">
-<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f6f6f6;">
-<tr><td align="center" style="padding:24px 12px;">
-<table role="presentation" width="600" cellspacing="0" cellpadding="0"
-style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;">
-<tr><td style="padding:24px 28px;background:#1a5f4a;color:#ffffff;">
-<h1 style="margin:0;font-size:22px;line-height:1.3;">Evolve Sprouts</h1>
-<p style="margin:8px 0 0;font-size:14px;opacity:0.95;">{header_subtitle}</p>
-</td></tr>
-<tr><td style="padding:28px;color:#333333;font-size:15px;line-height:1.6;">
-{inner_html}
-</td></tr>
-<tr><td style="padding:16px 28px 24px;color:#666666;font-size:12px;line-height:1.5;">
-<p style="margin:0;">Evolve Sprouts</p>
-</td></tr>
-</table></td></tr></table></body></html>"""
+from app.templates.ses.email_shell import wrap_transactional_html
 
 
 def get_ses_template_definitions() -> list[dict[str, Any]]:
@@ -33,7 +13,9 @@ def get_ses_template_definitions() -> list[dict[str, Any]]:
         {
             "TemplateName": f"evolvesprouts-media-download-{loc}",
             "SubjectPart": subject,
-            "HtmlPart": _wrap_html(header_subtitle=subject, inner_html=inner_html),
+            "HtmlPart": wrap_transactional_html(
+                header_subtitle=subject, inner_html=inner_html
+            ),
             "TextPart": text_part,
         }
         for loc, subject, inner_html, text_part in _LOCALE_ROWS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Extracted the duplicated transactional email HTML document wrapper into `backend/src/app/templates/ses/email_shell.py` as `wrap_transactional_html`.
- `contact_confirmation`, `media_download_link`, and `booking_confirmation` now import and use that helper.
- Booking templates: HTML header subtitle is localized per locale (`en` / `zh-CN` / `zh-HK`) to match the subject line prefix, replacing the previous English-only "Booking confirmed" in the banner.

## Text-only (`TextPart`)

There is no shared text wrapper: each template has different body copy, placeholders, and Handlebars blocks. The module docstring in `email_shell.py` documents this. Optional future work would be tiny helpers (e.g. standard sign-off) only if we want to DRY repeated lines.

## Validation

- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
- `python3 -m pytest tests/test_public_legacy_confirmation.py tests/test_public_legacy_confirmation_mailchimp_tags.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a59a0a0-aa57-4b42-b888-c91a838dbe45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a59a0a0-aa57-4b42-b888-c91a838dbe45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

