### PR TITLE
fix(public_www): remove marketing checkbox from community signup forms

### DIFF
--- a/apps/public_www/src/components/pages/about-us.tsx
+++ b/apps/public_www/src/components/pages/about-us.tsx
@@ -33,7 +33,6 @@ export function AboutUsPage({ locale, content }: AboutUsPageProps) {
         content={content.sproutsSquadCommunity}
         commonCaptchaContent={content.common.captcha}
         locale={locale}
-        marketingOptInLabel={content.contactUs.form.marketingOptInLabel}
       />
     </PageLayout>
   );

--- a/apps/public_www/src/components/pages/events.tsx
+++ b/apps/public_www/src/components/pages/events.tsx
@@ -43,7 +43,6 @@ export function EventsPage({ content }: EventsPageProps) {
         content={content.events.notification}
         commonCaptchaContent={content.common.captcha}
         locale={resolvedLocale}
-        marketingOptInLabel={content.contactUs.form.marketingOptInLabel}
       />
     </PageLayout>
   );

--- a/apps/public_www/src/components/pages/free-guides-and-resources.tsx
+++ b/apps/public_www/src/components/pages/free-guides-and-resources.tsx
@@ -32,7 +32,6 @@ export function FreeGuidesAndResourcesPage({
         content={content.sproutsSquadCommunity}
         commonCaptchaContent={content.common.captcha}
         locale={locale}
-        marketingOptInLabel={content.contactUs.form.marketingOptInLabel}
       />
     </PageLayout>
   );

--- a/apps/public_www/src/components/sections/event-notification.tsx
+++ b/apps/public_www/src/components/sections/event-notification.tsx
@@ -4,7 +4,6 @@ import type { FormEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
-import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { SectionContainer } from '@/components/sections/shared/section-container';
 import { renderQuotedDescriptionText } from '@/components/sections/shared/render-highlighted-text';
@@ -32,7 +31,6 @@ interface EventNotificationProps {
   content: EventNotificationContent;
   commonCaptchaContent: CommonContent['captcha'];
   locale: Locale;
-  marketingOptInLabel: string;
 }
 
 const EMAIL_ERROR_MESSAGE_ID = 'event-notification-email-error';
@@ -43,7 +41,6 @@ export function EventNotification({
   content,
   commonCaptchaContent,
   locale,
-  marketingOptInLabel,
 }: EventNotificationProps) {
   const copy = resolveEventNotificationCopy(content);
   const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '';
@@ -52,7 +49,6 @@ export function EventNotification({
   const [isFormFadingIn, setIsFormFadingIn] = useState(false);
   const [email, setEmail] = useState('');
   const [isEmailTouched, setIsEmailTouched] = useState(false);
-  const [marketingOptIn, setMarketingOptIn] = useState(false);
   const {
     captchaToken,
     clearSubmissionError,
@@ -142,7 +138,7 @@ export function EventNotification({
               email_address: normalizedEmail,
               first_name: derivedFirstName,
               message: content.prefilledMessage,
-              marketing_opt_in: marketingOptIn,
+              marketing_opt_in: true,
               locale,
               signup_intent: 'event_notification',
             },
@@ -268,11 +264,6 @@ export function EventNotification({
                           {content.emailValidationMessage}
                         </p>
                       ) : null}
-                      <MarketingOptInCheckbox
-                        label={marketingOptInLabel}
-                        checked={marketingOptIn}
-                        onChange={setMarketingOptIn}
-                      />
                       <TurnstileCaptcha
                         siteKey={turnstileSiteKey}
                         widgetAction='event_notification_submit'

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -5,7 +5,6 @@ import { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
-import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { SectionContainer } from '@/components/sections/shared/section-container';
 import { renderQuotedDescriptionText } from '@/components/sections/shared/render-highlighted-text';
@@ -33,7 +32,6 @@ interface SproutsSquadCommunityProps {
   content: SproutsSquadCommunityContent;
   commonCaptchaContent: CommonContent['captcha'];
   locale: Locale;
-  marketingOptInLabel: string;
 }
 
 const EMAIL_ERROR_MESSAGE_ID = 'sprouts-community-email-error';
@@ -44,7 +42,6 @@ export function SproutsSquadCommunity({
   content,
   commonCaptchaContent,
   locale,
-  marketingOptInLabel,
 }: SproutsSquadCommunityProps) {
   const copy = resolveSproutsSquadCommunityCopy(content);
   const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '';
@@ -53,7 +50,6 @@ export function SproutsSquadCommunity({
   const [isFormFadingIn, setIsFormFadingIn] = useState(false);
   const [email, setEmail] = useState('');
   const [isEmailTouched, setIsEmailTouched] = useState(false);
-  const [marketingOptIn, setMarketingOptIn] = useState(false);
   const {
     captchaToken,
     clearSubmissionError,
@@ -143,7 +139,7 @@ export function SproutsSquadCommunity({
               email_address: normalizedEmail,
               first_name: derivedFirstName,
               message: content.prefilledMessage,
-              marketing_opt_in: marketingOptIn,
+              marketing_opt_in: true,
               locale,
               signup_intent: 'community_newsletter',
             },
@@ -276,11 +272,6 @@ export function SproutsSquadCommunity({
                           {content.emailValidationMessage}
                         </p>
                       ) : null}
-                      <MarketingOptInCheckbox
-                        label={marketingOptInLabel}
-                        checked={marketingOptIn}
-                        onChange={setMarketingOptIn}
-                      />
                       <TurnstileCaptcha
                         siteKey={turnstileSiteKey}
                         widgetAction='sprouts_squad_community_submit'

--- a/apps/public_www/tests/components/sections/event-notification.test.tsx
+++ b/apps/public_www/tests/components/sections/event-notification.test.tsx
@@ -86,7 +86,6 @@ describe('EventNotification section', () => {
         content={enContent.events.notification}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -111,7 +110,6 @@ describe('EventNotification section', () => {
         content={enContent.events.notification}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -141,7 +139,6 @@ describe('EventNotification section', () => {
         content={enContent.events.notification}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -169,7 +166,7 @@ describe('EventNotification section', () => {
           email_address: 'events@example.com',
           first_name: 'events',
           message: enContent.events.notification.prefilledMessage,
-          marketing_opt_in: false,
+          marketing_opt_in: true,
           locale: 'en',
           signup_intent: 'event_notification',
         },
@@ -182,54 +179,4 @@ describe('EventNotification section', () => {
     });
   });
 
-  it('includes marketing opt-in when the newsletter checkbox is checked', async () => {
-    const request = vi.fn().mockResolvedValue(null);
-    mockedCreateCrmApiClient.mockReturnValue({ request });
-
-    render(
-      <EventNotification
-        content={enContent.events.notification}
-        commonCaptchaContent={enContent.common.captcha}
-        locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
-      />,
-    );
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: enContent.events.notification.ctaLabel,
-      }),
-    );
-    fireEvent.change(
-      screen.getByPlaceholderText(enContent.events.notification.emailPlaceholder),
-      { target: { value: 'events@example.com' } },
-    );
-    fireEvent.click(
-      screen.getByRole('checkbox', {
-        name: enContent.contactUs.form.marketingOptInLabel,
-      }),
-    );
-    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: enContent.events.notification.formSubmitLabel,
-      }),
-    );
-
-    await waitFor(() => {
-      expect(request).toHaveBeenCalledWith({
-        endpointPath: '/v1/legacy/contact-us',
-        method: 'POST',
-        body: expect.objectContaining({
-          email_address: 'events@example.com',
-          first_name: 'events',
-          marketing_opt_in: true,
-          locale: 'en',
-          signup_intent: 'event_notification',
-        }),
-        turnstileToken: 'mock-turnstile-token',
-        expectedSuccessStatuses: [200, 202],
-      });
-    });
-  });
 });

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -86,7 +86,6 @@ describe('SproutsSquadCommunity section', () => {
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -152,7 +151,6 @@ describe('SproutsSquadCommunity section', () => {
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -179,7 +177,6 @@ describe('SproutsSquadCommunity section', () => {
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -210,7 +207,6 @@ describe('SproutsSquadCommunity section', () => {
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -241,7 +237,6 @@ describe('SproutsSquadCommunity section', () => {
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -274,7 +269,6 @@ describe('SproutsSquadCommunity section', () => {
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -309,7 +303,6 @@ describe('SproutsSquadCommunity section', () => {
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 
@@ -337,7 +330,7 @@ describe('SproutsSquadCommunity section', () => {
           email_address: 'community@example.com',
           first_name: 'community',
           message: enContent.sproutsSquadCommunity.prefilledMessage,
-          marketing_opt_in: false,
+          marketing_opt_in: true,
           locale: 'en',
           signup_intent: 'community_newsletter',
         },
@@ -350,57 +343,6 @@ describe('SproutsSquadCommunity section', () => {
     });
   });
 
-  it('includes marketing opt-in when the newsletter checkbox is checked', async () => {
-    const request = vi.fn().mockResolvedValue(null);
-    mockedCreateCrmApiClient.mockReturnValue({ request });
-
-    render(
-      <SproutsSquadCommunity
-        content={enContent.sproutsSquadCommunity}
-        commonCaptchaContent={enContent.common.captcha}
-        locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
-      />,
-    );
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: enContent.sproutsSquadCommunity.ctaLabel,
-      }),
-    );
-    fireEvent.change(
-      screen.getByPlaceholderText(enContent.sproutsSquadCommunity.emailPlaceholder),
-      { target: { value: 'community@example.com' } },
-    );
-    fireEvent.click(
-      screen.getByRole('checkbox', {
-        name: enContent.contactUs.form.marketingOptInLabel,
-      }),
-    );
-    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: enContent.sproutsSquadCommunity.formSubmitLabel,
-      }),
-    );
-
-    await waitFor(() => {
-      expect(request).toHaveBeenCalledWith({
-        endpointPath: '/v1/legacy/contact-us',
-        method: 'POST',
-        body: expect.objectContaining({
-          email_address: 'community@example.com',
-          first_name: 'community',
-          marketing_opt_in: true,
-          locale: 'en',
-          signup_intent: 'community_newsletter',
-        }),
-        turnstileToken: 'mock-turnstile-token',
-        expectedSuccessStatuses: [200, 202],
-      });
-    });
-  });
-
   it('shows submit error when API request fails', async () => {
     const request = vi.fn().mockRejectedValue(new Error('request failed'));
     mockedCreateCrmApiClient.mockReturnValue({ request });
@@ -410,7 +352,6 @@ describe('SproutsSquadCommunity section', () => {
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
         locale='en'
-        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Event notification and monthly newsletter (Sprouts Squad community) signup forms no longer show the marketing opt-in checkbox. Submitting either form now always sends `marketing_opt_in: true` to the legacy contact-us API.

## Changes

- Removed `MarketingOptInCheckbox` and related state from `event-notification.tsx` and `sprouts-squad-community.tsx`.
- Dropped the `marketingOptInLabel` prop from those sections; pages no longer pass contact form copy for this control.
- Updated Vitest expectations and removed the redundant checkbox-specific test cases.

## Testing

- `npm test -- tests/components/sections/event-notification.test.tsx tests/components/sections/sprouts-squad-community.test.tsx`
- `npm run lint` (in `apps/public_www`)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22d6b0a9-607a-4c5e-870c-329f7219da82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22d6b0a9-607a-4c5e-870c-329f7219da82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

