### PR TITLE
feat(public_www): loading gear on submit during API calls

### DIFF
--- a/apps/public_www/src/components/pages/about-us.tsx
+++ b/apps/public_www/src/components/pages/about-us.tsx
@@ -32,6 +32,7 @@ export function AboutUsPage({ locale, content }: AboutUsPageProps) {
       <SproutsSquadCommunity
         content={content.sproutsSquadCommunity}
         commonCaptchaContent={content.common.captcha}
+        commonFormActionsContent={content.common.formActions}
         locale={locale}
         marketingOptInLabel={content.contactUs.form.marketingOptInLabel}
       />

--- a/apps/public_www/src/components/pages/events.tsx
+++ b/apps/public_www/src/components/pages/events.tsx
@@ -42,6 +42,7 @@ export function EventsPage({ content }: EventsPageProps) {
       <EventNotification
         content={content.events.notification}
         commonCaptchaContent={content.common.captcha}
+        commonFormActionsContent={content.common.formActions}
         locale={resolvedLocale}
         marketingOptInLabel={content.contactUs.form.marketingOptInLabel}
       />

--- a/apps/public_www/src/components/pages/free-guides-and-resources.tsx
+++ b/apps/public_www/src/components/pages/free-guides-and-resources.tsx
@@ -31,6 +31,7 @@ export function FreeGuidesAndResourcesPage({
       <SproutsSquadCommunity
         content={content.sproutsSquadCommunity}
         commonCaptchaContent={content.common.captcha}
+        commonFormActionsContent={content.common.formActions}
         locale={locale}
         marketingOptInLabel={content.contactUs.form.marketingOptInLabel}
       />

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -22,6 +22,7 @@ import type {
 } from '@/components/sections/booking-modal/types';
 import { useFormSubmission } from '@/components/sections/shared/use-form-submission';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { SubmitButtonLoadingContent } from '@/components/shared/submit-button-loading-content';
 import { SmartLink } from '@/components/shared/smart-link';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { trackAnalyticsEvent, trackEcommerceEvent } from '@/lib/analytics';
@@ -58,6 +59,7 @@ import {
   type ReservationSubmissionPayload,
 } from '@/lib/reservations-data';
 import { ServerSubmissionResult } from '@/lib/server-submission-result';
+import { mergeClassNames } from '@/lib/class-name-utils';
 import { isValidEmail, sanitizeSingleLineValue } from '@/lib/validation';
 
 interface BookingReservationFormProps {
@@ -518,6 +520,9 @@ export function BookingReservationForm({
     };
   }, [stripePaymentIntent]);
   const isStripePaymentMethodSelected = selectedPaymentMethod === PAYMENT_METHOD_STRIPE;
+  const reservationSubmitIdleLabel = isStripePaymentMethodSelected
+    ? content.submitStripeLabel
+    : content.submitLabel;
   const isStripeUnavailable = stripePromise === null;
   const isStripeReady = Boolean(
     stripeElementsOptions &&
@@ -1332,9 +1337,17 @@ export function BookingReservationForm({
                   ? SUBMIT_ERROR_MESSAGE_ID
                   : undefined
             }
-            className='mt-1 w-full'
+            className={mergeClassNames(
+              'mt-1 w-full',
+              isSubmitting ? 'inline-flex items-center justify-center gap-2' : undefined,
+            )}
           >
-            {isStripePaymentMethodSelected ? content.submitStripeLabel : content.submitLabel}
+            <SubmitButtonLoadingContent
+              isSubmitting={isSubmitting}
+              submittingLabel={content.submittingLabel}
+              idleLabel={reservationSubmitIdleLabel}
+              loadingGearTestId='booking-reservation-submit-loading-gear'
+            />
           </ButtonPrimitive>
         </form>
       </section>

--- a/apps/public_www/src/components/sections/contact-us-form-fields.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form-fields.tsx
@@ -1,7 +1,7 @@
 import type { FormEvent } from 'react';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
-import { LoadingGearIcon } from '@/components/shared/loading-gear-icon';
+import { SubmitButtonLoadingContent } from '@/components/shared/submit-button-loading-content';
 import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import type { ContactUsContent } from '@/content';
@@ -218,17 +218,12 @@ export function ContactFormFields({
               : undefined
         }
       >
-        {isSubmitting ? (
-          <>
-            <span className='sr-only'>{content.submittingLabel}</span>
-            <LoadingGearIcon
-              className='h-5 w-5 animate-spin'
-              testId='contact-us-form-submit-loading-gear'
-            />
-          </>
-        ) : (
-          content.submitLabel
-        )}
+        <SubmitButtonLoadingContent
+          isSubmitting={isSubmitting}
+          submittingLabel={content.submittingLabel}
+          idleLabel={content.submitLabel}
+          loadingGearTestId='contact-us-form-submit-loading-gear'
+        />
       </ButtonPrimitive>
       <p className='text-base leading-7 text-[color:var(--site-primary-text)]'>
         {content.formDescription}

--- a/apps/public_www/src/components/sections/event-notification.tsx
+++ b/apps/public_www/src/components/sections/event-notification.tsx
@@ -4,6 +4,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { SubmitButtonLoadingContent } from '@/components/shared/submit-button-loading-content';
 import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { SectionContainer } from '@/components/sections/shared/section-container';
@@ -31,6 +32,7 @@ import {
 interface EventNotificationProps {
   content: EventNotificationContent;
   commonCaptchaContent: CommonContent['captcha'];
+  commonFormActionsContent: CommonContent['formActions'];
   locale: Locale;
   marketingOptInLabel: string;
 }
@@ -42,6 +44,7 @@ const SUBMIT_ERROR_MESSAGE_ID = 'event-notification-submit-error';
 export function EventNotification({
   content,
   commonCaptchaContent,
+  commonFormActionsContent,
   locale,
   marketingOptInLabel,
 }: EventNotificationProps) {
@@ -74,6 +77,7 @@ export function EventNotification({
   });
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const submitCtaLabel = content.formSubmitLabel ?? content.ctaLabel;
+  const submitLoadingLabel = commonFormActionsContent.submittingLabel;
 
   const captchaErrorMessage = (() => {
     if (hasCaptchaValidationError) {
@@ -297,8 +301,18 @@ export function EventNotification({
                         variant='primary'
                         type='submit'
                         disabled={isSubmitting || hasSuccessfulSubmission || isCaptchaUnavailable}
+                        className={
+                          isSubmitting
+                            ? 'inline-flex w-full items-center justify-center gap-2'
+                            : undefined
+                        }
                       >
-                        {isSubmitting ? `${submitCtaLabel}...` : submitCtaLabel}
+                        <SubmitButtonLoadingContent
+                          isSubmitting={isSubmitting}
+                          submittingLabel={submitLoadingLabel}
+                          idleLabel={submitCtaLabel}
+                          loadingGearTestId='event-notification-submit-loading-gear'
+                        />
                       </ButtonPrimitive>
                       {submitErrorMessage ? (
                         <p

--- a/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
+++ b/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
@@ -293,6 +293,7 @@ export function FreeGuidesAndResourcesLibrary({
   const mediaFormFirstNameLabel = mediaFormContent.formFirstNameLabel;
   const mediaFormEmailLabel = mediaFormContent.formEmailLabel;
   const mediaFormSubmitLabel = mediaFormContent.formSubmitLabel;
+  const mediaFormSubmittingLabel = mediaFormContent.formSubmittingLabel;
   const mediaFormSuccessTitle = mediaFormContent.formSuccessTitle;
   const mediaFormSuccessBody = mediaFormContent.formSuccessBody;
   const mediaFormErrorMessage = mediaFormContent.formErrorMessage;
@@ -411,6 +412,7 @@ export function FreeGuidesAndResourcesLibrary({
                     formFirstNameLabel={mediaFormFirstNameLabel}
                     formEmailLabel={mediaFormEmailLabel}
                     formSubmitLabel={mediaFormSubmitLabel}
+                    formSubmittingLabel={mediaFormSubmittingLabel}
                     formSuccessTitle={mediaFormSuccessTitle}
                     formSuccessBody={mediaFormSuccessBody}
                     formErrorMessage={mediaFormErrorMessage}

--- a/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
+++ b/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
@@ -47,6 +47,7 @@ interface ResourceCardContentProps {
   formFirstNameLabel: string;
   formEmailLabel: string;
   formSubmitLabel: string;
+  formSubmittingLabel: string;
   formSuccessTitle: string;
   formSuccessBody: string;
   formErrorMessage: string;
@@ -189,6 +190,7 @@ function ResourceCardContent({
   formFirstNameLabel,
   formEmailLabel,
   formSubmitLabel,
+  formSubmittingLabel,
   formSuccessTitle,
   formSuccessBody,
   formErrorMessage,
@@ -241,6 +243,7 @@ function ResourceCardContent({
         formFirstNameLabel={formFirstNameLabel}
         formEmailLabel={formEmailLabel}
         formSubmitLabel={formSubmitLabel}
+        formSubmittingLabel={formSubmittingLabel}
         formSuccessTitle={formSuccessTitle}
         formSuccessBody={formSuccessBody}
         formErrorMessage={formErrorMessage}
@@ -274,6 +277,9 @@ export function FreeResourcesForGentleParenting({
   const formSubmitLabel =
     readOptionalText(content.formSubmitLabel)
     ?? fallbackResourcesContent.formSubmitLabel;
+  const formSubmittingLabel =
+    readOptionalText(content.formSubmittingLabel)
+    ?? fallbackResourcesContent.formSubmittingLabel;
   const formSuccessTitle =
     readOptionalText(content.formSuccessTitle)
     ?? fallbackResourcesContent.formSuccessTitle;
@@ -320,6 +326,7 @@ export function FreeResourcesForGentleParenting({
       formFirstNameLabel={formFirstNameLabel}
       formEmailLabel={formEmailLabel}
       formSubmitLabel={formSubmitLabel}
+      formSubmittingLabel={formSubmittingLabel}
       formSuccessTitle={formSuccessTitle}
       formSuccessBody={formSuccessBody}
       formErrorMessage={formErrorMessage}

--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -4,6 +4,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useId, useMemo, useState } from 'react';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { SubmitButtonLoadingContent } from '@/components/shared/submit-button-loading-content';
 import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { useFormSubmission } from '@/components/sections/shared/use-form-submission';
@@ -23,6 +24,7 @@ interface MediaFormProps {
   formFirstNameLabel: string;
   formEmailLabel: string;
   formSubmitLabel: string;
+  formSubmittingLabel: string;
   formSuccessTitle: string;
   formSuccessBody: string;
   formErrorMessage: string;
@@ -54,6 +56,7 @@ export function MediaForm({
   formFirstNameLabel,
   formEmailLabel,
   formSubmitLabel,
+  formSubmittingLabel,
   formSuccessTitle,
   formSuccessBody,
   formErrorMessage,
@@ -297,11 +300,20 @@ export function MediaForm({
       <ButtonPrimitive
         variant='primary'
         type='submit'
-        className='w-full'
+        className={
+          isSubmitting
+            ? 'inline-flex w-full items-center justify-center gap-2'
+            : 'w-full'
+        }
         disabled={isSubmitDisabled}
         aria-describedby={shouldShowSubmitError ? formErrorId : undefined}
       >
-        {isSubmitting ? `${formSubmitLabel}...` : formSubmitLabel}
+        <SubmitButtonLoadingContent
+          isSubmitting={isSubmitting}
+          submittingLabel={formSubmittingLabel}
+          idleLabel={formSubmitLabel}
+          loadingGearTestId='media-form-submit-loading-gear'
+        />
       </ButtonPrimitive>
 
       {shouldShowSubmitError ? (

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { SubmitButtonLoadingContent } from '@/components/shared/submit-button-loading-content';
 import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { SectionContainer } from '@/components/sections/shared/section-container';
@@ -32,6 +33,7 @@ import {
 interface SproutsSquadCommunityProps {
   content: SproutsSquadCommunityContent;
   commonCaptchaContent: CommonContent['captcha'];
+  commonFormActionsContent: CommonContent['formActions'];
   locale: Locale;
   marketingOptInLabel: string;
 }
@@ -43,6 +45,7 @@ const SUBMIT_ERROR_MESSAGE_ID = 'sprouts-community-submit-error';
 export function SproutsSquadCommunity({
   content,
   commonCaptchaContent,
+  commonFormActionsContent,
   locale,
   marketingOptInLabel,
 }: SproutsSquadCommunityProps) {
@@ -75,6 +78,7 @@ export function SproutsSquadCommunity({
   });
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const submitCtaLabel = content.formSubmitLabel ?? content.ctaLabel;
+  const submitLoadingLabel = commonFormActionsContent.submittingLabel;
 
   const captchaErrorMessage = (() => {
     if (hasCaptchaValidationError) {
@@ -305,8 +309,18 @@ export function SproutsSquadCommunity({
                         variant='primary'
                         type='submit'
                         disabled={isSubmitting || hasSuccessfulSubmission || isCaptchaUnavailable}
+                        className={
+                          isSubmitting
+                            ? 'inline-flex w-full items-center justify-center gap-2'
+                            : undefined
+                        }
                       >
-                        {isSubmitting ? `${submitCtaLabel}...` : submitCtaLabel}
+                        <SubmitButtonLoadingContent
+                          isSubmitting={isSubmitting}
+                          submittingLabel={submitLoadingLabel}
+                          idleLabel={submitCtaLabel}
+                          loadingGearTestId='sprouts-squad-community-submit-loading-gear'
+                        />
                       </ButtonPrimitive>
                       {submitErrorMessage ? (
                         <p

--- a/apps/public_www/src/components/shared/submit-button-loading-content.tsx
+++ b/apps/public_www/src/components/shared/submit-button-loading-content.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+
+import { LoadingGearIcon } from '@/components/shared/loading-gear-icon';
+
+interface SubmitButtonLoadingContentProps {
+  isSubmitting: boolean;
+  submittingLabel: string;
+  idleLabel: ReactNode;
+  loadingGearTestId?: string;
+}
+
+/**
+ * Submit button body: visible idle label, or spinning gear with screen-reader
+ * status text while a request is in flight (matches Contact Us behavior).
+ */
+export function SubmitButtonLoadingContent({
+  isSubmitting,
+  submittingLabel,
+  idleLabel,
+  loadingGearTestId,
+}: SubmitButtonLoadingContentProps) {
+  if (isSubmitting) {
+    return (
+      <>
+        <span className='sr-only'>{submittingLabel}</span>
+        <LoadingGearIcon
+          className='h-5 w-5 animate-spin'
+          testId={loadingGearTestId}
+        />
+      </>
+    );
+  }
+
+  return idleLabel;
+}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -179,6 +179,7 @@
     "formFirstNameLabel": "First Name",
     "formEmailLabel": "Email",
     "formSubmitLabel": "Send Me the Free Guide",
+    "formSubmittingLabel": "Submitting…",
     "formSuccessTitle": "Check Your Email!",
     "formSuccessBody": "The download link is in there.",
     "formErrorMessage": "Unable to submit right now. Please check your details and try again.",
@@ -1015,6 +1016,9 @@
       "loadError": "CAPTCHA failed to load. Please refresh and try again.",
       "unavailableError": "CAPTCHA is temporarily unavailable. Please try again later."
     },
+    "formActions": {
+      "submittingLabel": "Submitting…"
+    },
     "mediaDownload": {
       "invalidTitle": "Invalid download link",
       "invalidDescription": "This media link is missing a valid token. Please request the media again.",
@@ -1445,6 +1449,7 @@
       "termsHref": "/terms",
       "submitLabel": "Reserve My Spot",
       "submitStripeLabel": "Pay & Reserve My Spot",
+      "submittingLabel": "Submitting…",
       "captchaLabel": "Please complete CAPTCHA verification",
       "captchaRequiredError": "Please complete CAPTCHA verification before submitting.",
       "captchaLoadError": "CAPTCHA failed to load. Please refresh and try again.",

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -179,6 +179,7 @@
     "formFirstNameLabel": "名字",
     "formEmailLabel": "邮箱",
     "formSubmitLabel": "发送免费指南给我",
+    "formSubmittingLabel": "提交中…",
     "formSuccessTitle": "请查收你的邮箱！",
     "formSuccessBody": "下载链接就在里面。",
     "formErrorMessage": "暂时无法提交，请检查信息后重试。",
@@ -1015,6 +1016,9 @@
       "loadError": "CAPTCHA 加载失败，请刷新页面后重试。",
       "unavailableError": "CAPTCHA 暂时不可用，请稍后再试。"
     },
+    "formActions": {
+      "submittingLabel": "提交中…"
+    },
     "mediaDownload": {
       "invalidTitle": "下载链接无效",
       "invalidDescription": "此媒体链接缺少有效令牌。请重新申请媒体下载。",
@@ -1445,6 +1449,7 @@
       "termsHref": "/terms",
       "submitLabel": "立即预留我的名额",
       "submitStripeLabel": "立即付款并预留名额",
+      "submittingLabel": "提交中…",
       "captchaLabel": "请完成 CAPTCHA 验证",
       "captchaRequiredError": "提交前请先完成 CAPTCHA 验证。",
       "captchaLoadError": "CAPTCHA 加载失败，请刷新后重试。",

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -179,6 +179,7 @@
     "formFirstNameLabel": "名字",
     "formEmailLabel": "電郵",
     "formSubmitLabel": "把免費指南寄給我",
+    "formSubmittingLabel": "提交中…",
     "formSuccessTitle": "請查收你的電郵！",
     "formSuccessBody": "下載連結就在裡面。",
     "formErrorMessage": "暫時未能提交，請檢查資料後再試。",
@@ -1015,6 +1016,9 @@
       "loadError": "CAPTCHA 載入失敗，請重新整理頁面後再試。",
       "unavailableError": "CAPTCHA 暫時不可用，請稍後再試。"
     },
+    "formActions": {
+      "submittingLabel": "提交中…"
+    },
     "mediaDownload": {
       "invalidTitle": "下載連結無效",
       "invalidDescription": "此媒體連結缺少有效權杖。請重新申請媒體下載。",
@@ -1445,6 +1449,7 @@
       "termsHref": "/terms",
       "submitLabel": "立即付款並預留名額",
       "submitStripeLabel": "立即付款並預留名額",
+      "submittingLabel": "提交中…",
       "captchaLabel": "請完成 CAPTCHA 驗證",
       "captchaRequiredError": "提交前請先完成 CAPTCHA 驗證。",
       "captchaLoadError": "CAPTCHA 載入失敗，請重新整理後再試。",

--- a/apps/public_www/tests/components/sections/event-notification.test.tsx
+++ b/apps/public_www/tests/components/sections/event-notification.test.tsx
@@ -85,6 +85,7 @@ describe('EventNotification section', () => {
       <EventNotification
         content={enContent.events.notification}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -110,6 +111,7 @@ describe('EventNotification section', () => {
       <EventNotification
         content={enContent.events.notification}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -132,6 +134,66 @@ describe('EventNotification section', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows the loading gear on the submit button while the request is in flight', async () => {
+    let releaseRequest: (() => void) | undefined;
+    const request = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          releaseRequest = () => {
+            reject(new Error('deferred failure'));
+          };
+        }),
+    );
+    mockedCreateCrmApiClient.mockReturnValue({ request });
+
+    render(
+      <EventNotification
+        content={enContent.events.notification}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.events.notification.ctaLabel,
+      }),
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(enContent.events.notification.emailPlaceholder),
+      { target: { value: 'events@example.com' } },
+    );
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.events.notification.formSubmitLabel,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole('button', {
+      name: enContent.common.formActions.submittingLabel,
+    });
+    expect(submitButton).toBeDisabled();
+    expect(screen.getByTestId('event-notification-submit-loading-gear')).toHaveClass(
+      'animate-spin',
+    );
+
+    releaseRequest?.();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: enContent.events.notification.formSubmitLabel,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it('submits payload with turnstile token and shows success state', async () => {
     const request = vi.fn().mockResolvedValue(null);
     mockedCreateCrmApiClient.mockReturnValue({ request });
@@ -140,6 +202,7 @@ describe('EventNotification section', () => {
       <EventNotification
         content={enContent.events.notification}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -190,6 +253,7 @@ describe('EventNotification section', () => {
       <EventNotification
         content={enContent.events.notification}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -67,6 +67,7 @@ function mediaFormProps() {
     formFirstNameLabel: resourcesContent.formFirstNameLabel,
     formEmailLabel: resourcesContent.formEmailLabel,
     formSubmitLabel: resourcesContent.formSubmitLabel,
+    formSubmittingLabel: resourcesContent.formSubmittingLabel,
     formSuccessTitle: resourcesContent.formSuccessTitle,
     formSuccessBody: resourcesContent.formSuccessBody,
     formErrorMessage: resourcesContent.formErrorMessage,
@@ -140,6 +141,50 @@ describe('MediaForm', () => {
 
     await waitFor(() => {
       expect(form).toHaveClass('opacity-100');
+    });
+  });
+
+  it('shows the loading gear on the submit button while the request is in flight', async () => {
+    let releaseRequest: (() => void) | undefined;
+    const request = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          releaseRequest = () => {
+            reject(new Error('deferred failure'));
+          };
+        }),
+    );
+    mockedCreateCrmApiClient.mockReturnValue({ request });
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+    fireEvent.change(
+      screen.getByPlaceholderText(enContent.resources.formFirstNameLabel),
+      { target: { value: 'Ida' } },
+    );
+    fireEvent.change(screen.getByPlaceholderText(enContent.resources.formEmailLabel), {
+      target: { value: 'ida@example.com' },
+    });
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(
+      screen.getByRole('button', { name: enContent.resources.formSubmitLabel }),
+    );
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole('button', {
+      name: enContent.resources.formSubmittingLabel,
+    });
+    expect(submitButton).toBeDisabled();
+    expect(screen.getByTestId('media-form-submit-loading-gear')).toHaveClass('animate-spin');
+
+    releaseRequest?.();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: enContent.resources.formSubmitLabel }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -793,6 +793,64 @@ describe('my-best-auntie booking modals footer content', () => {
     expect(screen.queryByTestId('booking-discount-apply-loading-gear')).toBeNull();
   });
 
+  it('shows the loading gear on the reservation submit button while the request is in flight', async () => {
+    const requestSpy = vi.fn(
+      () =>
+        new Promise<unknown>(() => {
+          /* intentionally pending until test ends */
+        }),
+    );
+    mockedCreateCrmApiClient.mockReturnValue({
+      request: requestSpy,
+    });
+    mockedCreatePublicApiClient.mockReturnValue({
+      request: vi.fn(),
+    });
+
+    renderBookingModal({
+      selectedAgeGroupLabel: '18-24 months',
+    });
+
+    fireEvent.change(screen.getByLabelText(new RegExp(bookingModalContent.fullNameLabel)), {
+      target: { value: 'Test User' },
+    });
+    fireEvent.change(screen.getByLabelText(new RegExp(bookingModalContent.emailLabel)), {
+      target: { value: 'ida@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(new RegExp(bookingModalContent.phoneLabel)), {
+      target: { value: '85212345678' },
+    });
+    fireEvent.change(screen.getByLabelText(bookingModalContent.topicsInterestLabel), {
+      target: { value: 'Need details' },
+    });
+    fireEvent.click(
+      screen.getByRole('checkbox', {
+        name: new RegExp(bookingModalContent.pendingReservationAcknowledgementLabel),
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole('checkbox', {
+        name: new RegExp(bookingModalContent.termsLinkLabel),
+      }),
+    );
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: bookingModalContent.submitLabel,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole('button', {
+      name: bookingModalContent.submittingLabel,
+    });
+    expect(submitButton).toBeDisabled();
+    expect(screen.getByTestId('booking-reservation-submit-loading-gear')).toHaveClass('animate-spin');
+  });
+
   it('submits reservation payload with required snake_case fields', async () => {
     const requestSpy = vi.fn().mockResolvedValue({ message: 'Reservation submitted' });
     const onSubmitReservation = vi.fn();

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -85,6 +85,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -151,6 +152,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -178,6 +180,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -209,6 +212,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -240,6 +244,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -273,6 +278,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -300,6 +306,66 @@ describe('SproutsSquadCommunity section', () => {
     });
   });
 
+  it('shows the loading gear on the submit button while the request is in flight', async () => {
+    let releaseRequest: (() => void) | undefined;
+    const request = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          releaseRequest = () => {
+            reject(new Error('deferred failure'));
+          };
+        }),
+    );
+    mockedCreateCrmApiClient.mockReturnValue({ request });
+
+    render(
+      <SproutsSquadCommunity
+        content={enContent.sproutsSquadCommunity}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+        marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.ctaLabel,
+      }),
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(enContent.sproutsSquadCommunity.emailPlaceholder),
+      { target: { value: 'community@example.com' } },
+    );
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.formSubmitLabel,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    const submitButton = screen.getByRole('button', {
+      name: enContent.common.formActions.submittingLabel,
+    });
+    expect(submitButton).toBeDisabled();
+    expect(screen.getByTestId('sprouts-squad-community-submit-loading-gear')).toHaveClass(
+      'animate-spin',
+    );
+
+    releaseRequest?.();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: enContent.sproutsSquadCommunity.formSubmitLabel,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it('submits payload with turnstile token and shows success state', async () => {
     const request = vi.fn().mockResolvedValue(null);
     mockedCreateCrmApiClient.mockReturnValue({ request });
@@ -308,6 +374,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -358,6 +425,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,
@@ -409,6 +477,7 @@ describe('SproutsSquadCommunity section', () => {
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
         commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
         locale='en'
         marketingOptInLabel={enContent.contactUs.form.marketingOptInLabel}
       />,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unifies submit-button loading UX across the public site: when a POST-backed form submit runs, the visible CTA label is replaced by the same spinning gear pattern used on Contact Us.

## Merge note (origin/main)

Merged latest `main`, which removed the marketing opt-in checkbox from event notification and Sprouts Squad flows and always sends `marketing_opt_in: true`. Conflicts were resolved by keeping that behavior and the loading-gear work.

## Changes

- Added `SubmitButtonLoadingContent` in `apps/public_www/src/components/shared/submit-button-loading-content.tsx` (sr-only status + `LoadingGearIcon`).
- Refactored `contact-us-form-fields.tsx` to use the shared helper.
- **Event notification** and **Sprouts Squad** submit buttons use the gear; pages pass `content.common.formActions` for the submitting label.
- **MediaForm** takes `formSubmittingLabel` (from `resources.formSubmittingLabel` in locale JSON); wired from free resources section and library.
- **Booking reservation** main submit uses `paymentModal.submittingLabel` for both FPS and Stripe labels while `isSubmitting`.
- Locale updates: `common.formActions.submittingLabel`, `resources.formSubmittingLabel`, `bookingModal.paymentModal.submittingLabel` in `en`, `zh-CN`, `zh-HK`.

## Tests

Focused Vitest for updated sections; ESLint on touched files.

## Notes

Discount "Apply" in the booking modal already had its own loading gear and was left unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07664172-6838-4296-9be1-a0298b57b52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07664172-6838-4296-9be1-a0298b57b52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

