### PR TITLE
refactor(public_www): domain wrappers for booking thank-you modal

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -1473,11 +1473,11 @@
     -webkit-mask-image: url('/images/virtual-call.svg');
   }
 
-  .es-my-best-auntie-thank-you-panel {
+  .es-booking-thank-you-panel {
     position: relative;
   }
 
-  .es-my-best-auntie-thank-you-heading {
+  .es-booking-thank-you-heading {
     color: var(--site-heading-text);
     font-family: var(--figma-fontfamilies-poppins, Poppins), sans-serif;
     font-weight: 700;
@@ -1485,7 +1485,7 @@
     letter-spacing: 0;
   }
 
-  .es-my-best-auntie-thank-you-body {
+  .es-booking-thank-you-body {
     color: var(--site-primary-text);
     font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
     font-weight: 400;

--- a/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
@@ -39,11 +39,11 @@ import { getHrefKind } from '@/lib/url-utils';
 const THANK_YOU_ICS_OUTLINE_BUTTON_CLASSNAME =
   'h-[54px] w-full rounded-control px-6 text-[16px] font-semibold sm:h-[60px] sm:text-[18px]';
 
-export interface MyBestAuntieThankYouModalProps {
+export interface BookingThankYouModalProps {
   locale: Locale;
   content: BookingThankYouModalContent;
   summary: ReservationSummary | null;
-  analyticsSectionId?: string;
+  analyticsSectionId: string;
   whatsappHref?: string;
   whatsappCtaLabel?: string;
   onClose: () => void;
@@ -131,15 +131,15 @@ function resolveThankYouCourseSessions(summary: ReservationSummary | null): Rese
   ];
 }
 
-export function MyBestAuntieThankYouModal({
+export function BookingThankYouModal({
   locale,
   content,
   summary,
-  analyticsSectionId = 'my-best-auntie-booking',
+  analyticsSectionId,
   whatsappHref,
   whatsappCtaLabel,
   onClose,
-}: MyBestAuntieThankYouModalProps) {
+}: BookingThankYouModalProps) {
   const modalPanelRef = useRef<HTMLElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const dialogTitleId = useId();
@@ -253,7 +253,7 @@ export function MyBestAuntieThankYouModal({
         ariaLabelledBy={dialogTitleId}
         ariaDescribedBy={describedByIds}
         tabIndex={-1}
-        className='es-my-best-auntie-thank-you-panel es-section-bg-overlay es-booking-thank-you-modal-section-bg'
+        className='es-booking-thank-you-panel es-section-bg-overlay es-booking-thank-you-modal-section-bg'
       >
         <header className='flex justify-end px-4 pb-6 pt-6 sm:px-8 sm:pt-7'>
           <CloseButton
@@ -283,14 +283,14 @@ export function MyBestAuntieThankYouModal({
             </h3>
             <h2
               id={dialogTitleId}
-              className='es-type-title mt-2 max-w-[610px] leading-[1.1] es-my-best-auntie-thank-you-heading'
+              className='es-type-title mt-2 max-w-[610px] leading-[1.1] es-booking-thank-you-heading'
             >
               {content.title}
             </h2>
             {hasSubtitleBlock ? (
               <p
                 id={dialogDescriptionId}
-                className='mt-3 text-lg leading-7 es-my-best-auntie-thank-you-body'
+                className='mt-3 text-lg leading-7 es-booking-thank-you-body'
               >
                 {content.subtitle}
                 {' '}
@@ -401,7 +401,7 @@ export function MyBestAuntieThankYouModal({
 
           {showWhatsappFollowUp ? (
             <div className='relative z-10 mx-auto mt-8 max-w-[713px] text-center'>
-              <p className='text-lg leading-7 es-my-best-auntie-thank-you-body'>
+              <p className='text-lg leading-7 es-booking-thank-you-body'>
                 {content.followUpPrompt}
               </p>
               <ButtonPrimitive
@@ -434,7 +434,3 @@ export function MyBestAuntieThankYouModal({
     </ModalOverlay>
   );
 }
-
-/** Alias for generic booking thank-you flows (events, consultations, etc.). */
-export { MyBestAuntieThankYouModal as BookingThankYouModal };
-export type BookingThankYouModalProps = MyBestAuntieThankYouModalProps;

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -44,10 +44,10 @@ const ConsultationBookingModal = dynamic(
   { ssr: false },
 );
 
-const BookingThankYouModal = dynamic(
+const ConsultationsThankYouModal = dynamic(
   () =>
-    import('@/components/sections/booking-modal/thank-you-modal').then(
-      (module) => module.BookingThankYouModal,
+    import('@/components/sections/consultations/consultations-thank-you-modal').then(
+      (module) => module.ConsultationsThankYouModal,
     ),
   { ssr: false },
 );
@@ -535,11 +535,10 @@ export function ConsultationsBooking({
       ) : null}
 
       {isThankYouOpen && (
-        <BookingThankYouModal
+        <ConsultationsThankYouModal
           locale={locale}
           content={bookingModalContent.thankYouModal}
           summary={thankYouSummary}
-          analyticsSectionId='consultations-booking'
           whatsappHref={thankYouWhatsappHref}
           whatsappCtaLabel={thankYouWhatsappCtaLabel}
           onClose={() => {

--- a/apps/public_www/src/components/sections/consultations/consultations-thank-you-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-thank-you-modal.tsx
@@ -5,16 +5,18 @@ import {
   type BookingThankYouModalProps,
 } from '@/components/sections/booking-modal/thank-you-modal';
 
-type EventThankYouModalProps = Omit<
+export type ConsultationsThankYouModalProps = Omit<
   BookingThankYouModalProps,
   'analyticsSectionId'
 >;
 
-export function EventThankYouModal(props: EventThankYouModalProps) {
+export function ConsultationsThankYouModal(
+  props: ConsultationsThankYouModalProps,
+) {
   return (
     <BookingThankYouModal
       {...props}
-      analyticsSectionId='events-booking'
+      analyticsSectionId='consultations-booking'
     />
   );
 }

--- a/apps/public_www/src/components/sections/events.tsx
+++ b/apps/public_www/src/components/sections/events.tsx
@@ -47,14 +47,6 @@ const MyBestAuntieBookingModal = dynamic(
   { ssr: false },
 );
 
-const MyBestAuntieThankYouModal = dynamic(
-  () =>
-    import('@/components/sections/my-best-auntie/my-best-auntie-booking-modal').then(
-      (module) => module.MyBestAuntieThankYouModal,
-    ),
-  { ssr: false },
-);
-
 interface EventsProps {
   content: EventsContent;
   bookingModalContent: BookingModalContent;
@@ -75,9 +67,7 @@ export function Events({
   const [activeBookingEventId, setActiveBookingEventId] = useState('');
   const [reservationSummary, setReservationSummary] =
     useState<ReservationSummary | null>(null);
-  const [activeThankYouModalVariant, setActiveThankYouModalVariant] = useState<
-    'event' | 'my-best-auntie' | ''
-  >('');
+  const [isThankYouModalOpen, setIsThankYouModalOpen] = useState(false);
   const {
     visibleEvents,
     isLoading,
@@ -90,8 +80,6 @@ export function Events({
   const activeBookingEvent = visibleEvents.find((event) => event.id === activeBookingEventId)
     ?? null;
   const activeBookingPayload = activeBookingEvent?.bookingModalPayload;
-  const isThankYouModalOpen = activeThankYouModalVariant !== '';
-
   useEffect(() => {
     if (!isThankYouModalOpen || !reservationSummary) {
       return;
@@ -207,7 +195,7 @@ export function Events({
           onSubmitReservation={(summary) => {
             setReservationSummary(summary);
             setActiveBookingEventId('');
-            setActiveThankYouModalVariant('event');
+            setIsThankYouModalOpen(true);
           }}
         />
       )}
@@ -229,12 +217,12 @@ export function Events({
           onSubmitReservation={(summary) => {
             setReservationSummary(summary);
             setActiveBookingEventId('');
-            setActiveThankYouModalVariant('my-best-auntie');
+            setIsThankYouModalOpen(true);
           }}
         />
       )}
 
-      {isThankYouModalOpen && activeThankYouModalVariant === 'event' && (
+      {isThankYouModalOpen && (
         <EventThankYouModal
           locale={locale}
           content={bookingModalContent.thankYouModal}
@@ -242,21 +230,7 @@ export function Events({
           whatsappHref={thankYouWhatsappHref}
           whatsappCtaLabel={thankYouWhatsappCtaLabel}
           onClose={() => {
-            setActiveThankYouModalVariant('');
-          }}
-        />
-      )}
-
-      {isThankYouModalOpen && activeThankYouModalVariant === 'my-best-auntie' && (
-        <MyBestAuntieThankYouModal
-          locale={locale}
-          content={bookingModalContent.thankYouModal}
-          summary={reservationSummary}
-          analyticsSectionId='events-booking'
-          whatsappHref={thankYouWhatsappHref}
-          whatsappCtaLabel={thankYouWhatsappCtaLabel}
-          onClose={() => {
-            setActiveThankYouModalVariant('');
+            setIsThankYouModalOpen(false);
           }}
         />
       )}

--- a/apps/public_www/src/components/sections/events/event-thank-you-modal.tsx
+++ b/apps/public_www/src/components/sections/events/event-thank-you-modal.tsx
@@ -5,7 +5,7 @@ import {
   type BookingThankYouModalProps,
 } from '@/components/sections/booking-modal/thank-you-modal';
 
-type EventThankYouModalProps = Omit<
+export type EventThankYouModalProps = Omit<
   BookingThankYouModalProps,
   'analyticsSectionId'
 >;

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking-modal.tsx
@@ -192,5 +192,3 @@ export function MyBestAuntieBookingModal({
     </ModalOverlay>
   );
 }
-
-export { MyBestAuntieThankYouModal } from '@/components/sections/booking-modal/thank-you-modal';

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking.tsx
@@ -43,7 +43,7 @@ const MyBestAuntieBookingModal = dynamic(
 
 const MyBestAuntieThankYouModal = dynamic(
   () =>
-    import('@/components/sections/my-best-auntie/my-best-auntie-booking-modal').then(
+    import('@/components/sections/my-best-auntie/my-best-auntie-thank-you-modal').then(
       (module) => module.MyBestAuntieThankYouModal,
     ),
   { ssr: false },

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-thank-you-modal.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-thank-you-modal.tsx
@@ -5,16 +5,16 @@ import {
   type BookingThankYouModalProps,
 } from '@/components/sections/booking-modal/thank-you-modal';
 
-type EventThankYouModalProps = Omit<
+export type MyBestAuntieThankYouModalProps = Omit<
   BookingThankYouModalProps,
   'analyticsSectionId'
 >;
 
-export function EventThankYouModal(props: EventThankYouModalProps) {
+export function MyBestAuntieThankYouModal(props: MyBestAuntieThankYouModalProps) {
   return (
     <BookingThankYouModal
       {...props}
-      analyticsSectionId='events-booking'
+      analyticsSectionId='my-best-auntie-booking'
     />
   );
 }

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -37,10 +37,8 @@ const {
 const mockedStripeElementsProps = vi.hoisted(() => vi.fn());
 const mockedStripePaymentElementProps = vi.hoisted(() => vi.fn());
 
-import {
-  MyBestAuntieBookingModal,
-  MyBestAuntieThankYouModal,
-} from '@/components/sections/my-best-auntie/my-best-auntie-booking-modal';
+import { MyBestAuntieBookingModal } from '@/components/sections/my-best-auntie/my-best-auntie-booking-modal';
+import { MyBestAuntieThankYouModal } from '@/components/sections/my-best-auntie/my-best-auntie-thank-you-modal';
 import type { ReservationSummary } from '@/components/sections/booking-modal/types';
 import enContent from '@/content/en.json';
 import trainingCoursesContent from '@/content/my-best-auntie-training-courses.json';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Renamed the shared thank-you component to `BookingThankYouModal` with `BookingThankYouModalProps`; `analyticsSectionId` is required (no default).
- Renamed panel/heading/body CSS classes to neutral `es-booking-thank-you-*` in `thank-you-modal.tsx` and `components-sections.css`.
- Added thin domain wrappers: `my-best-auntie-thank-you-modal.tsx`, `consultations-thank-you-modal.tsx`; updated `event-thank-you-modal.tsx` to use the shared names.
- Simplified `events.tsx` thank-you state to a boolean and removed the MBA thank-you dynamic import (both flows use `EventThankYouModal`).
- Pointed MBA and consultations consumers at the wrappers; removed the stale re-export from `my-best-auntie-booking-modal.tsx`.
- Updated `my-best-auntie-booking-modal.test.tsx` import path.

## Testing

- `npx eslint` on touched source files
- `npx vitest run tests/components/sections/my-best-auntie-booking-modal.test.tsx`
- `bash scripts/validate-cursorrules.sh`

Analytics section IDs are unchanged: `events-booking`, `my-best-auntie-booking`, `consultations-booking`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-597f1a5b-d400-441f-bc0d-89668e0d2ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-597f1a5b-d400-441f-bc0d-89668e0d2ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

