### PR TITLE
Inline FPS QR in pending booking confirmation email

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -53,7 +53,6 @@ import {
   resolvePublicBookingPaymentOptionFlags,
   type PublicBookingPaymentOptionFlags,
 } from '@/lib/booking-payment-options';
-import { generateFpsQrImageDataUrl } from '@/lib/fps-qr-code';
 import {
   submitReservation,
   type ReservationPaymentMethodCode,
@@ -434,6 +433,7 @@ export function BookingReservationForm({
     useState(false);
   const [hasTermsAgreement, setHasTermsAgreement] = useState(false);
   const [marketingOptIn, setMarketingOptIn] = useState(false);
+  const [fpsQrImageDataUrl, setFpsQrImageDataUrl] = useState('');
   const {
     captchaToken,
     clearSubmissionError,
@@ -499,6 +499,9 @@ export function BookingReservationForm({
   const totalAmount = useMemo(() => {
     return applyDiscount(originalAmount, discountRule);
   }, [discountRule, originalAmount]);
+  useEffect(() => {
+    setFpsQrImageDataUrl('');
+  }, [totalAmount, selectedPaymentMethod]);
   const discountAmount = Math.max(0, originalAmount - totalAmount);
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const isTopicsFieldRequired = topicsFieldConfig?.required ?? false;
@@ -949,12 +952,10 @@ export function BookingReservationForm({
 
       if (
         selectedPaymentMethod === PAYMENT_METHOD_FPS &&
-        !reservationPayload.stripe_payment_intent_id
+        !reservationPayload.stripe_payment_intent_id &&
+        fpsQrImageDataUrl.trim()
       ) {
-        const fpsDataUrl = await generateFpsQrImageDataUrl(totalAmount);
-        if (fpsDataUrl) {
-          reservationPayload.fps_qr_image_data_url = fpsDataUrl;
-        }
+        reservationPayload.fps_qr_image_data_url = fpsQrImageDataUrl.trim();
       }
 
       const submissionResult = await ServerSubmissionResult.resolve({
@@ -1261,6 +1262,7 @@ export function BookingReservationForm({
                       <FpsQrCode
                         amount={totalAmount}
                         label={content.fpsQrCodeLabel}
+                        onDataUrlChange={setFpsQrImageDataUrl}
                       />
                       <p
                         data-booking-payment-fps-copy='true'

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -53,6 +53,7 @@ import {
   resolvePublicBookingPaymentOptionFlags,
   type PublicBookingPaymentOptionFlags,
 } from '@/lib/booking-payment-options';
+import { generateFpsQrImageDataUrl } from '@/lib/fps-qr-code';
 import {
   submitReservation,
   type ReservationPaymentMethodCode,
@@ -944,6 +945,16 @@ export function BookingReservationForm({
         }
         stripePaymentIntentId = stripeConfirmation.paymentIntentId;
         reservationPayload.stripe_payment_intent_id = stripePaymentIntentId;
+      }
+
+      if (
+        selectedPaymentMethod === PAYMENT_METHOD_FPS &&
+        !reservationPayload.stripe_payment_intent_id
+      ) {
+        const fpsDataUrl = await generateFpsQrImageDataUrl(totalAmount);
+        if (fpsDataUrl) {
+          reservationPayload.fps_qr_image_data_url = fpsDataUrl;
+        }
       }
 
       const submissionResult = await ServerSubmissionResult.resolve({

--- a/apps/public_www/src/components/sections/booking-modal/shared.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/shared.tsx
@@ -81,9 +81,12 @@ export function CloseButton({
 export function FpsQrCode({
   amount,
   label = enContent.bookingModal.paymentModal.fpsQrCodeLabel,
+  onDataUrlChange,
 }: {
   amount: number;
   label?: string;
+  /** Latest PNG data URL for reuse on submit (avoids regenerating the QR). */
+  onDataUrlChange?: (dataUrl: string) => void;
 }) {
   const [qrCodeImageDataUrl, setQrCodeImageDataUrl] = useState('');
   const qrCodeContainerRef = useRef<HTMLDivElement | null>(null);
@@ -99,13 +102,14 @@ export function FpsQrCode({
     void generateFpsQrImageDataUrl(amount).then((imageDataUrl) => {
       if (!isCancelled && imageDataUrl) {
         setQrCodeImageDataUrl(imageDataUrl);
+        onDataUrlChange?.(imageDataUrl);
       }
     });
 
     return () => {
       isCancelled = true;
     };
-  }, [amount, hasFpsConfiguration]);
+  }, [amount, hasFpsConfiguration, onDataUrlChange]);
 
   if (!hasFpsConfiguration) {
     return null;

--- a/apps/public_www/src/components/sections/booking-modal/shared.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/shared.tsx
@@ -3,7 +3,10 @@
 import Image from 'next/image';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import { OverlayBackdrop } from '@/components/shared/overlay-surface';
-import QRCode from 'qrcode';
+import {
+  generateFpsQrImageDataUrl,
+  hasFpsQrConfiguration,
+} from '@/lib/fps-qr-code';
 import {
   type Ref,
   type ReactNode,
@@ -15,93 +18,7 @@ import { createPortal } from 'react-dom';
 
 import enContent from '@/content/en.json';
 
-const FPS_GENERATOR_SCRIPT_SOURCE = '/scripts/fps-generator.js';
 const CLOSE_ICON_SOURCE = '/images/close.svg';
-const FPS_MERCHANT_NAME = process.env.NEXT_PUBLIC_FPS_MERCHANT_NAME ?? '';
-const FPS_MOBILE_NUMBER = process.env.NEXT_PUBLIC_FPS_MOBILE_NUMBER ?? '';
-const FPS_QR_CODE_SIZE_PX = 128;
-
-interface FpsGenerationResult {
-  data?: string;
-  isError: () => boolean;
-}
-
-interface FpsInstance {
-  merchantName: string;
-  setMobile: (value: string | number) => void;
-  setAmount: (value: string | number) => void;
-  setDynamic: () => void;
-  generate: () => FpsGenerationResult;
-}
-
-interface FpsConstructor {
-  new (): FpsInstance;
-}
-
-declare global {
-  interface Window {
-    FPS?: FpsConstructor;
-  }
-}
-
-const externalScriptLoadMap = new Map<string, Promise<void>>();
-
-function isExternalScriptLoaded(source: string): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  if (source === FPS_GENERATOR_SCRIPT_SOURCE) {
-    return typeof window.FPS === 'function';
-  }
-
-  return false;
-}
-
-function loadExternalScript(source: string): Promise<void> {
-  if (typeof window === 'undefined' || isExternalScriptLoaded(source)) {
-    return Promise.resolve();
-  }
-
-  const cachedPromise = externalScriptLoadMap.get(source);
-  if (cachedPromise) {
-    return cachedPromise;
-  }
-
-  const existingScript = document.querySelector(
-    `script[src="${source}"]`,
-  ) as HTMLScriptElement | null;
-
-  const loadingPromise = new Promise<void>((resolve, reject) => {
-    if (isExternalScriptLoaded(source)) {
-      resolve();
-      return;
-    }
-
-    const handleLoad = () => {
-      resolve();
-    };
-    const handleError = () => {
-      reject(new Error(`Failed to load script: ${source}`));
-    };
-
-    if (existingScript) {
-      existingScript.addEventListener('load', handleLoad, { once: true });
-      existingScript.addEventListener('error', handleError, { once: true });
-      return;
-    }
-
-    const script = document.createElement('script');
-    script.src = source;
-    script.async = true;
-    script.addEventListener('load', handleLoad, { once: true });
-    script.addEventListener('error', handleError, { once: true });
-    document.body.appendChild(script);
-  });
-
-  externalScriptLoadMap.set(source, loadingPromise);
-  return loadingPromise;
-}
 
 export function ModalOverlay({
   onClose,
@@ -170,8 +87,7 @@ export function FpsQrCode({
 }) {
   const [qrCodeImageDataUrl, setQrCodeImageDataUrl] = useState('');
   const qrCodeContainerRef = useRef<HTMLDivElement | null>(null);
-  const hasFpsConfiguration =
-    FPS_MERCHANT_NAME.trim().length > 0 && FPS_MOBILE_NUMBER.trim().length > 0;
+  const hasFpsConfiguration = hasFpsQrConfiguration();
 
   useEffect(() => {
     if (!hasFpsConfiguration) {
@@ -180,41 +96,11 @@ export function FpsQrCode({
 
     let isCancelled = false;
 
-    void loadExternalScript(FPS_GENERATOR_SCRIPT_SOURCE)
-      .then(async () => {
-        const Fps = window.FPS;
-        if (!Fps) {
-          return;
-        }
-
-        const fpsPayloadGenerator = new Fps();
-        fpsPayloadGenerator.merchantName = FPS_MERCHANT_NAME;
-        fpsPayloadGenerator.setMobile(FPS_MOBILE_NUMBER);
-        fpsPayloadGenerator.setAmount(String(amount));
-        fpsPayloadGenerator.setDynamic();
-
-        const payloadResult = fpsPayloadGenerator.generate();
-        if (payloadResult.isError() || !payloadResult.data || isCancelled) {
-          return;
-        }
-
-        const imageDataUrl = await QRCode.toDataURL(payloadResult.data, {
-          width: FPS_QR_CODE_SIZE_PX,
-          margin: 0,
-          errorCorrectionLevel: 'H',
-          color: {
-            dark: '#000000',
-            light: '#FFFFFF',
-          },
-        });
-
-        if (!isCancelled) {
-          setQrCodeImageDataUrl(imageDataUrl);
-        }
-      })
-      .catch(() => {
-        // The QR container remains blank when the payload cannot be generated.
-      });
+    void generateFpsQrImageDataUrl(amount).then((imageDataUrl) => {
+      if (!isCancelled && imageDataUrl) {
+        setQrCodeImageDataUrl(imageDataUrl);
+      }
+    });
 
     return () => {
       isCancelled = true;

--- a/apps/public_www/src/components/sections/shared/use-form-submission.ts
+++ b/apps/public_www/src/components/sections/shared/use-form-submission.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { flushSync } from 'react-dom';
 
 export type FormSubmissionStatus = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -53,7 +54,11 @@ export function useFormSubmission({ turnstileSiteKey }: UseFormSubmissionOptions
   }
 
   async function withSubmitting<T>(request: () => Promise<T>): Promise<T> {
-    setSubmissionStatus('submitting');
+    // Ensure the loading UI (e.g. submit button gear) commits before the async
+    // request runs, so fast responses still produce at least one painted frame.
+    flushSync(() => {
+      setSubmissionStatus('submitting');
+    });
     try {
       return await request();
     } finally {

--- a/apps/public_www/src/lib/fps-qr-code.ts
+++ b/apps/public_www/src/lib/fps-qr-code.ts
@@ -104,6 +104,12 @@ export async function generateFpsQrImageDataUrl(
     return null;
   }
 
+  // jsdom (Vitest) does not complete network loads for injected <script src>;
+  // the load promise would hang forever and block booking submit.
+  if (process.env.NODE_ENV === 'test') {
+    return null;
+  }
+
   try {
     await loadExternalScript(FPS_GENERATOR_SCRIPT_SOURCE);
     const Fps = window.FPS;

--- a/apps/public_www/src/lib/fps-qr-code.ts
+++ b/apps/public_www/src/lib/fps-qr-code.ts
@@ -104,12 +104,6 @@ export async function generateFpsQrImageDataUrl(
     return null;
   }
 
-  // jsdom (Vitest) does not complete network loads for injected <script src>;
-  // the load promise would hang forever and block booking submit.
-  if (process.env.NODE_ENV === 'test') {
-    return null;
-  }
-
   try {
     await loadExternalScript(FPS_GENERATOR_SCRIPT_SOURCE);
     const Fps = window.FPS;

--- a/apps/public_www/src/lib/fps-qr-code.ts
+++ b/apps/public_www/src/lib/fps-qr-code.ts
@@ -1,0 +1,137 @@
+import QRCode from 'qrcode';
+
+const FPS_GENERATOR_SCRIPT_SOURCE = '/scripts/fps-generator.js';
+
+const FPS_MERCHANT_NAME = process.env.NEXT_PUBLIC_FPS_MERCHANT_NAME ?? '';
+const FPS_MOBILE_NUMBER = process.env.NEXT_PUBLIC_FPS_MOBILE_NUMBER ?? '';
+const FPS_QR_CODE_SIZE_PX = 128;
+
+interface FpsGenerationResult {
+  data?: string;
+  isError: () => boolean;
+}
+
+interface FpsInstance {
+  merchantName: string;
+  setMobile: (value: string | number) => void;
+  setAmount: (value: string | number) => void;
+  setDynamic: () => void;
+  generate: () => FpsGenerationResult;
+}
+
+interface FpsConstructor {
+  new (): FpsInstance;
+}
+
+declare global {
+  interface Window {
+    FPS?: FpsConstructor;
+  }
+}
+
+const externalScriptLoadMap = new Map<string, Promise<void>>();
+
+function isExternalScriptLoaded(source: string): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (source === FPS_GENERATOR_SCRIPT_SOURCE) {
+    return typeof window.FPS === 'function';
+  }
+
+  return false;
+}
+
+function loadExternalScript(source: string): Promise<void> {
+  if (typeof window === 'undefined' || isExternalScriptLoaded(source)) {
+    return Promise.resolve();
+  }
+
+  const cachedPromise = externalScriptLoadMap.get(source);
+  if (cachedPromise) {
+    return cachedPromise;
+  }
+
+  const existingScript = document.querySelector(
+    `script[src="${source}"]`,
+  ) as HTMLScriptElement | null;
+
+  const loadingPromise = new Promise<void>((resolve, reject) => {
+    if (isExternalScriptLoaded(source)) {
+      resolve();
+      return;
+    }
+
+    const handleLoad = () => {
+      resolve();
+    };
+    const handleError = () => {
+      reject(new Error(`Failed to load script: ${source}`));
+    };
+
+    if (existingScript) {
+      existingScript.addEventListener('load', handleLoad, { once: true });
+      existingScript.addEventListener('error', handleError, { once: true });
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = source;
+    script.async = true;
+    script.addEventListener('load', handleLoad, { once: true });
+    script.addEventListener('error', handleError, { once: true });
+    document.body.appendChild(script);
+  });
+
+  externalScriptLoadMap.set(source, loadingPromise);
+  return loadingPromise;
+}
+
+export function hasFpsQrConfiguration(): boolean {
+  return (
+    FPS_MERCHANT_NAME.trim().length > 0 && FPS_MOBILE_NUMBER.trim().length > 0
+  );
+}
+
+/**
+ * Same FPS payload + PNG data URL as the booking modal QR (for email attachment fields).
+ */
+export async function generateFpsQrImageDataUrl(
+  amount: number,
+): Promise<string | null> {
+  if (typeof window === 'undefined' || !hasFpsQrConfiguration()) {
+    return null;
+  }
+
+  try {
+    await loadExternalScript(FPS_GENERATOR_SCRIPT_SOURCE);
+    const Fps = window.FPS;
+    if (!Fps) {
+      return null;
+    }
+
+    const fpsPayloadGenerator = new Fps();
+    fpsPayloadGenerator.merchantName = FPS_MERCHANT_NAME;
+    fpsPayloadGenerator.setMobile(FPS_MOBILE_NUMBER);
+    fpsPayloadGenerator.setAmount(String(amount));
+    fpsPayloadGenerator.setDynamic();
+
+    const payloadResult = fpsPayloadGenerator.generate();
+    if (payloadResult.isError() || !payloadResult.data) {
+      return null;
+    }
+
+    return await QRCode.toDataURL(payloadResult.data, {
+      width: FPS_QR_CODE_SIZE_PX,
+      margin: 0,
+      errorCorrectionLevel: 'H',
+      color: {
+        dark: '#000000',
+        light: '#FFFFFF',
+      },
+    });
+  } catch {
+    return null;
+  }
+}

--- a/apps/public_www/src/lib/reservations-data.ts
+++ b/apps/public_www/src/lib/reservations-data.ts
@@ -28,6 +28,11 @@ export interface ReservationSubmissionPayload {
   schedule_date_label?: string;
   schedule_time_label?: string;
   location_name?: string;
+  /**
+   * PNG data URL from the same FPS QR as the booking modal; backend inlines it
+   * in the confirmation email when payment is pending (fps_qr).
+   */
+  fps_qr_image_data_url?: string;
 }
 
 interface SubmitReservationOptions {

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -2,6 +2,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { type AnchorHTMLAttributes, type ComponentProps, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateFpsQrImageDataUrl } from '@/lib/fps-qr-code';
 
 const {
   originalFpsMerchantName,
@@ -119,6 +120,13 @@ vi.mock('@/lib/crm-api-client', async () => {
       error instanceof Error && error.name === 'AbortError',
   };
 });
+
+vi.mock('@/lib/fps-qr-code', () => ({
+  generateFpsQrImageDataUrl: vi.fn(() =>
+    Promise.resolve('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='),
+  ),
+  hasFpsQrConfiguration: vi.fn(() => true),
+}));
 
 vi.mock('@/lib/discounts-data', async () => {
   const actual = await vi.importActual<typeof import('@/lib/discounts-data')>(
@@ -277,6 +285,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.mocked(generateFpsQrImageDataUrl).mockImplementation(() =>
+    Promise.resolve(
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    ),
+  );
   mockedCreateCrmApiClient.mockReturnValue(null);
   mockedCreatePublicApiClient.mockReturnValue(null);
   mockedValidateDiscountCode.mockReset();
@@ -949,6 +962,12 @@ describe('my-best-auntie booking modals footer content', () => {
         name: new RegExp(bookingModalContent.termsLinkLabel),
       }),
     );
+    await waitFor(() => {
+      const qrImg = document.querySelector(
+        '[aria-label="FPS payment QR code"] img',
+      ) as HTMLImageElement | null;
+      expect(qrImg?.getAttribute('src') ?? '').toMatch(/^data:image\/png/);
+    });
     fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
     fireEvent.click(
       screen.getByRole('button', {
@@ -975,6 +994,8 @@ describe('my-best-auntie booking modals footer content', () => {
         agreed_to_terms_and_conditions: true,
         payment_method: 'fps_qr',
         stripe_payment_intent_id: undefined,
+        fps_qr_image_data_url:
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
         ...expectedMbaMarketingFields,
       }),
       turnstileToken: 'mock-turnstile-token',

--- a/backend/src/app/api/public_legacy_confirmation.py
+++ b/backend/src/app/api/public_legacy_confirmation.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import os
 import re
 from typing import Any, Mapping
 
-from app.services.email import send_templated_email
+from app.services.email import (
+    send_mime_email_with_inline_png,
+    send_templated_email,
+)
 from app.services.marketing_subscribe import subscribe_to_marketing
+from app.templates.booking_confirmation_render import (
+    render_booking_confirmation_email,
+    substitute_shell_placeholders,
+)
 from app.templates.constants import build_faq_url
 from app.templates.transactional_shell_data import (
     merge_transactional_shell_template_data,
@@ -33,6 +42,9 @@ TAG_PUBLIC_WWW_CONTACT_INQUIRY = "public-www-contact-inquiry"
 TAG_PUBLIC_WWW_COMMUNITY_NEWSLETTER = "public-www-community-newsletter"
 TAG_PUBLIC_WWW_EVENT_NOTIFICATION = "public-www-event-notification"
 TAG_BOOKING_PREFIX = "public-www-booking-customer-"
+
+_MAX_FPS_QR_DATA_URL_CHARS = 50_000
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
 # Mailchimp FNAME fallback when first_name is empty for community/event tags.
 # Public forms normally send deriveFirstNameFromEmailLocalPart + locale fallback;
@@ -145,6 +157,7 @@ def send_booking_confirmation_email(
     total_amount: str,
     is_pending_payment: bool,
     locale: str,
+    fps_qr_image_data_url: str | None = None,
 ) -> None:
     from_addr = os.getenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "").strip()
     if not from_addr:
@@ -167,6 +180,55 @@ def send_booking_confirmation_email(
     if schedule_time_label and schedule_time_label.strip():
         data["schedule_time_label"] = schedule_time_label.strip()
     merged = merge_transactional_shell_template_data(locale=loc, template_data=data)
+
+    pm_lower = payment_method.lower().strip()
+    png_bytes: bytes | None = None
+    if (
+        is_pending_payment
+        and pm_lower == "fps_qr"
+        and isinstance(fps_qr_image_data_url, str)
+        and fps_qr_image_data_url.strip()
+    ):
+        png_bytes = _decode_png_from_data_url(fps_qr_image_data_url)
+        if png_bytes is None:
+            logger.warning(
+                "Invalid fps_qr_image_data_url for booking confirmation; "
+                "falling back to template without inline QR",
+                extra={"lead_email": mask_email(to_email)},
+            )
+
+    if png_bytes is not None:
+        wa_url = str(merged.get("whatsapp_url") or "").strip()
+        subject, html_doc, plain_text = render_booking_confirmation_email(
+            locale=loc,
+            full_name=full_name,
+            course_label=course_label,
+            schedule_date_label=schedule_date_label,
+            schedule_time_label=schedule_time_label,
+            payment_method=payment_method,
+            total_amount=total_amount,
+            is_pending_payment=is_pending_payment,
+            whatsapp_url=wa_url,
+            include_fps_qr_image=True,
+        )
+        full_html = substitute_shell_placeholders(html_doc, merged)
+        try:
+            send_mime_email_with_inline_png(
+                source=from_addr,
+                to_addresses=[to_email.strip().lower()],
+                subject=subject,
+                body_text=plain_text,
+                body_html=full_html,
+                inline_image_cid="fps_qr",
+                png_bytes=png_bytes,
+            )
+        except Exception:
+            logger.exception(
+                "Booking confirmation email failed (MIME with FPS QR)",
+                extra={"lead_email": mask_email(to_email)},
+            )
+        return
+
     try:
         send_templated_email(
             source=from_addr,
@@ -321,6 +383,12 @@ def run_reservation_post_success(*, payload: Mapping[str, Any]) -> None:
     stripe_pi = _optional_str(payload.get("stripe_payment_intent_id"))
     pm_lower = payment_method.lower()
     is_pending = pm_lower != "stripe" and not stripe_pi
+    fps_qr_raw = payload.get("fps_qr_image_data_url")
+    fps_qr_data_url = (
+        str(fps_qr_raw).strip()
+        if isinstance(fps_qr_raw, str) and fps_qr_raw.strip()
+        else None
+    )
     if email and full_name:
         try:
             send_booking_confirmation_email(
@@ -333,6 +401,7 @@ def run_reservation_post_success(*, payload: Mapping[str, Any]) -> None:
                 total_amount=total_amount,
                 is_pending_payment=is_pending,
                 locale=locale,
+                fps_qr_image_data_url=fps_qr_data_url,
             )
         except Exception:
             logger.exception(
@@ -359,6 +428,26 @@ def _optional_str(value: Any) -> str | None:
         return None
     s = str(value).strip()
     return s or None
+
+
+def _decode_png_from_data_url(raw: str) -> bytes | None:
+    """Accept only ``data:image/png;base64,...`` from the booking modal QR."""
+    s = raw.strip()
+    if len(s) > _MAX_FPS_QR_DATA_URL_CHARS:
+        return None
+    prefix = "data:image/png;base64,"
+    if not s.lower().startswith(prefix):
+        return None
+    b64_part = s[len(prefix) :].strip()
+    if not b64_part or "\n" in b64_part or "\r" in b64_part:
+        return None
+    try:
+        decoded = base64.b64decode(b64_part, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    if len(decoded) > 512_000 or not decoded.startswith(_PNG_MAGIC):
+        return None
+    return decoded
 
 
 def _format_hkd_amount(price: Any) -> str:

--- a/backend/src/app/api/public_legacy_confirmation.py
+++ b/backend/src/app/api/public_legacy_confirmation.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import base64
-import binascii
 import os
 import re
 from typing import Any, Mapping
@@ -21,6 +19,10 @@ from app.templates.constants import build_faq_url
 from app.templates.transactional_shell_data import (
     merge_transactional_shell_template_data,
     resolve_whatsapp_url_for_template,
+)
+from app.utils.fps_qr_png import (
+    decode_fps_qr_png_data_url,
+    optional_fps_qr_data_url_from_payload,
 )
 from app.utils.logging import get_logger, mask_email
 from app.utils.public_slug import normalize_public_slug
@@ -42,9 +44,6 @@ TAG_PUBLIC_WWW_CONTACT_INQUIRY = "public-www-contact-inquiry"
 TAG_PUBLIC_WWW_COMMUNITY_NEWSLETTER = "public-www-community-newsletter"
 TAG_PUBLIC_WWW_EVENT_NOTIFICATION = "public-www-event-notification"
 TAG_BOOKING_PREFIX = "public-www-booking-customer-"
-
-_MAX_FPS_QR_DATA_URL_CHARS = 50_000
-_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
 # Mailchimp FNAME fallback when first_name is empty for community/event tags.
 # Public forms normally send deriveFirstNameFromEmailLocalPart + locale fallback;
@@ -189,7 +188,7 @@ def send_booking_confirmation_email(
         and isinstance(fps_qr_image_data_url, str)
         and fps_qr_image_data_url.strip()
     ):
-        png_bytes = _decode_png_from_data_url(fps_qr_image_data_url)
+        png_bytes = decode_fps_qr_png_data_url(fps_qr_image_data_url)
         if png_bytes is None:
             logger.warning(
                 "Invalid fps_qr_image_data_url for booking confirmation; "
@@ -383,11 +382,8 @@ def run_reservation_post_success(*, payload: Mapping[str, Any]) -> None:
     stripe_pi = _optional_str(payload.get("stripe_payment_intent_id"))
     pm_lower = payment_method.lower()
     is_pending = pm_lower != "stripe" and not stripe_pi
-    fps_qr_raw = payload.get("fps_qr_image_data_url")
-    fps_qr_data_url = (
-        str(fps_qr_raw).strip()
-        if isinstance(fps_qr_raw, str) and fps_qr_raw.strip()
-        else None
+    fps_qr_data_url = optional_fps_qr_data_url_from_payload(
+        payload.get("fps_qr_image_data_url")
     )
     if email and full_name:
         try:
@@ -428,26 +424,6 @@ def _optional_str(value: Any) -> str | None:
         return None
     s = str(value).strip()
     return s or None
-
-
-def _decode_png_from_data_url(raw: str) -> bytes | None:
-    """Accept only ``data:image/png;base64,...`` from the booking modal QR."""
-    s = raw.strip()
-    if len(s) > _MAX_FPS_QR_DATA_URL_CHARS:
-        return None
-    prefix = "data:image/png;base64,"
-    if not s.lower().startswith(prefix):
-        return None
-    b64_part = s[len(prefix) :].strip()
-    if not b64_part or "\n" in b64_part or "\r" in b64_part:
-        return None
-    try:
-        decoded = base64.b64decode(b64_part, validate=True)
-    except (binascii.Error, ValueError):
-        return None
-    if len(decoded) > 512_000 or not decoded.startswith(_PNG_MAGIC):
-        return None
-    return decoded
 
 
 def _format_hkd_amount(price: Any) -> str:

--- a/backend/src/app/api/public_legacy_proxy.py
+++ b/backend/src/app/api/public_legacy_proxy.py
@@ -25,8 +25,9 @@ from app.utils.logging import get_logger
 logger = get_logger(__name__)
 
 _DEFAULT_ERROR_MESSAGE = "Unable to process request. Please try again."
+_MAX_BODY_BYTES_DEFAULT = 20_000
 # Reservation payloads may include a base64 PNG data URL for the FPS QR code.
-_MAX_BODY_BYTES = 120_000
+_MAX_BODY_BYTES_RESERVATIONS = 120_000
 _CONTENT_TYPE_JSON = "application/json"
 
 _LEGACY_RESERVATIONS_PATH = "/v1/reservations"
@@ -53,6 +54,7 @@ def handle_legacy_reservations(
         target_path=_LEGACY_RESERVATIONS_PATH,
         include_turnstile=True,
         on_proxy_success=lambda payload: run_reservation_post_success(payload=payload),
+        max_body_bytes=_MAX_BODY_BYTES_RESERVATIONS,
     )
 
 
@@ -92,6 +94,7 @@ def _handle_legacy_proxy_with_hooks(
     target_path: str,
     include_turnstile: bool,
     on_proxy_success: Callable[[Mapping[str, Any]], None] | None = None,
+    max_body_bytes: int = _MAX_BODY_BYTES_DEFAULT,
 ) -> dict[str, Any]:
     if method != "POST":
         return json_response(405, {"error": "Method not allowed"}, event=event)
@@ -117,7 +120,7 @@ def _handle_legacy_proxy_with_hooks(
         )
 
     request_body = json.dumps(payload, separators=(",", ":"))
-    if len(request_body.encode("utf-8")) > _MAX_BODY_BYTES:
+    if len(request_body.encode("utf-8")) > max_body_bytes:
         return json_response(413, {"error": "Request body too large"}, event=event)
 
     request_headers: dict[str, str] = {"Content-Type": _CONTENT_TYPE_JSON}

--- a/backend/src/app/api/public_legacy_proxy.py
+++ b/backend/src/app/api/public_legacy_proxy.py
@@ -25,7 +25,8 @@ from app.utils.logging import get_logger
 logger = get_logger(__name__)
 
 _DEFAULT_ERROR_MESSAGE = "Unable to process request. Please try again."
-_MAX_BODY_BYTES = 20_000
+# Reservation payloads may include a base64 PNG data URL for the FPS QR code.
+_MAX_BODY_BYTES = 120_000
 _CONTENT_TYPE_JSON = "application/json"
 
 _LEGACY_RESERVATIONS_PATH = "/v1/reservations"

--- a/backend/src/app/services/email.py
+++ b/backend/src/app/services/email.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+from email import policy
+from email.mime.image import MIMEImage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 from typing import Any
 from collections.abc import Iterable
 
@@ -45,4 +49,40 @@ def send_templated_email(
         Destination={"ToAddresses": list(to_addresses)},
         Template=template_name,
         TemplateData=json.dumps(template_data),
+    )
+
+
+def send_mime_email_with_inline_png(
+    *,
+    source: str,
+    to_addresses: Iterable[str],
+    subject: str,
+    body_text: str,
+    body_html: str,
+    inline_image_cid: str,
+    png_bytes: bytes,
+    inline_filename: str = "fps-qr.png",
+) -> None:
+    """Send multipart/related HTML email with one inline PNG (referenced as cid:...)."""
+    to_list = list(to_addresses)
+    root = MIMEMultipart("related", policy=policy.SMTP)
+    root["Subject"] = subject
+    root["From"] = source
+    root["To"] = ", ".join(to_list)
+
+    alt = MIMEMultipart("alternative")
+    alt.attach(MIMEText(body_text, "plain", "utf-8"))
+    alt.attach(MIMEText(body_html, "html", "utf-8"))
+    root.attach(alt)
+
+    image = MIMEImage(png_bytes, _subtype="png")
+    image.add_header("Content-ID", f"<{inline_image_cid}>")
+    image.add_header("Content-Disposition", "inline", filename=inline_filename)
+    root.attach(image)
+
+    raw_bytes = root.as_bytes()
+    get_ses_client().send_raw_email(
+        Source=source,
+        Destinations=to_list,
+        RawMessage={"Data": raw_bytes},
     )

--- a/backend/src/app/templates/booking_confirmation_content.py
+++ b/backend/src/app/templates/booking_confirmation_content.py
@@ -1,0 +1,93 @@
+"""Shared copy and table labels for booking confirmation (SES templates + MIME render)."""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Locales supported by both SES stored templates and the MIME fallback path.
+BOOKING_CONFIRMATION_LOCALES: Final[tuple[str, ...]] = ("en", "zh-CN", "zh-HK")
+
+SUBJECT_PREFIX: dict[str, str] = {
+    "en": "Booking confirmed — ",
+    "zh-CN": "预约确认 — ",
+    "zh-HK": "預約確認 — ",
+}
+SUBJECT_SUFFIX: Final[str] = " — Evolve Sprouts"
+
+HEADER_TITLE: dict[str, str] = {
+    "en": "You're all set — booking confirmed",
+    "zh-CN": "预订已确认",
+    "zh-HK": "預訂已確認",
+}
+
+TABLE_LABELS: dict[str, dict[str, str]] = {
+    "en": {
+        "course": "Course / event",
+        "date": "Date",
+        "time": "Time",
+        "payment": "Payment method",
+        "total": "Total",
+    },
+    "zh-CN": {
+        "course": "课程 / 活动",
+        "date": "日期",
+        "time": "时间",
+        "payment": "付款方式",
+        "total": "总额",
+    },
+    "zh-HK": {
+        "course": "課程 / 活動",
+        "date": "日期",
+        "time": "時間",
+        "payment": "付款方式",
+        "total": "總額",
+    },
+}
+
+PENDING_PAYMENT_NOTE: dict[str, str] = {
+    "en": "Your reservation is pending until payment is confirmed.",
+    "zh-CN": "在付款确认前，您的预订仍为待处理状态。",
+    "zh-HK": "在付款確認前，您的預訂仍為待處理狀態。",
+}
+
+FPS_QR_INTRO: dict[str, str] = {
+    "en": "Use the FPS QR code below with your banking app to pay.",
+    "zh-CN": "请使用下方 FPS 二维码，通过您的银行应用付款。",
+    "zh-HK": "請使用下方 FPS 二維碼，透過您的銀行應用程式付款。",
+}
+
+WHATSAPP_INTRO: dict[str, str] = {
+    "en": "Questions? Message us on WhatsApp:",
+    "zh-CN": "有疑问？请通过 WhatsApp 联系我们：",
+    "zh-HK": "有疑問？請透過 WhatsApp 聯絡我們：",
+}
+
+# Greeting / thank-you HTML fragments (SES Handlebars); same prose as MIME render.
+GREETING_HTML: dict[str, str] = {
+    "en": '<p style="margin:0 0 12px;">Hi {{full_name}},</p>',
+    "zh-CN": '<p style="margin:0 0 12px;">您好 {{full_name}}，</p>',
+    "zh-HK": '<p style="margin:0 0 12px;">您好 {{full_name}}，</p>',
+}
+
+THANK_YOU_HTML: dict[str, str] = {
+    "en": '<p style="margin:0 0 16px;">Thank you for your booking!</p>',
+    "zh-CN": '<p style="margin:0 0 16px;">感谢您的预订！</p>',
+    "zh-HK": '<p style="margin:0 0 16px;">多謝您的預訂！</p>',
+}
+
+# Plain-text thank-you / sign-off (first line after name block, last lines).
+THANK_YOU_PLAIN: dict[str, str] = {
+    "en": "Thank you for your booking!\n",
+    "zh-CN": "感谢您的预订！\n",
+    "zh-HK": "多謝您的預訂！\n",
+}
+
+SIGN_OFF_PLAIN: dict[str, str] = {
+    "en": "Thank you,\nEvolve Sprouts",
+    "zh-CN": "谢谢，\nEvolve Sprouts",
+    "zh-HK": "謝謝，\nEvolve Sprouts",
+}
+
+
+def normalize_booking_locale(locale: str) -> str:
+    return locale if locale in HEADER_TITLE else "en"

--- a/backend/src/app/templates/booking_confirmation_render.py
+++ b/backend/src/app/templates/booking_confirmation_render.py
@@ -1,65 +1,43 @@
-"""Render booking confirmation email bodies (non-SES-template path for inline images)."""
+"""Render booking confirmation email bodies (MIME path with inline FPS QR image)."""
 
 from __future__ import annotations
 
 import html
 from typing import Any
 
+from app.templates.booking_confirmation_content import (
+    FPS_QR_INTRO,
+    HEADER_TITLE,
+    PENDING_PAYMENT_NOTE,
+    SIGN_OFF_PLAIN,
+    SUBJECT_PREFIX,
+    SUBJECT_SUFFIX,
+    TABLE_LABELS,
+    THANK_YOU_HTML,
+    THANK_YOU_PLAIN,
+    WHATSAPP_INTRO,
+    normalize_booking_locale,
+)
 from app.templates.ses.email_shell import wrap_transactional_html
 
 _CTA_LINK = "color:#C84A16;font-weight:600;"
 
-_SUBJECT_PREFIX = {
-    "en": "Booking confirmed — ",
-    "zh-CN": "预约确认 — ",
-    "zh-HK": "預約確認 — ",
-}
-_SUBJECT_SUFFIX = " — Evolve Sprouts"
 
-_HEADER_TITLES = {
-    "en": "You're all set — booking confirmed",
-    "zh-CN": "预订已确认",
-    "zh-HK": "預訂已確認",
-}
-
-_FPS_QR_INTRO = {
-    "en": "Use the FPS QR code below with your banking app to pay.",
-    "zh-CN": "请使用下方 FPS 二维码，通过您的银行应用付款。",
-    "zh-HK": "請使用下方 FPS 二維碼，透過您的銀行應用程式付款。",
-}
-
-_PENDING_NOTE = {
-    "en": "Your reservation is pending until payment is confirmed.",
-    "zh-CN": "在付款确认前，您的预订仍为待处理状态。",
-    "zh-HK": "在付款確認前，您的預訂仍為待處理狀態。",
-}
-
-_WHATSAPP_INTRO = {
-    "en": "Questions? Message us on WhatsApp:",
-    "zh-CN": "有疑问？请通过 WhatsApp 联系我们：",
-    "zh-HK": "有疑問？請透過 WhatsApp 聯絡我們：",
-}
-
-
-def _loc(locale: str) -> str:
-    return locale if locale in _HEADER_TITLES else "en"
-
-
-def _table_row_en(label: str, value: str) -> str:
+def _html_table_row_bordered(label: str, value_html: str) -> str:
     esc_label = html.escape(label)
     return (
         f'<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;">'
         f"<strong>{esc_label}</strong></td>"
         f'<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-        f"{value}</td></tr>"
+        f"{value_html}</td></tr>"
     )
 
 
-def _table_row_final_en(label: str, value: str) -> str:
+def _html_table_row_final(label: str, value_html: str) -> str:
     esc_label = html.escape(label)
     return (
         f'<tr><td style="padding:8px 0;"><strong>{esc_label}</strong></td>'
-        f'<td style="padding:8px 0;text-align:right;">{value}</td></tr>'
+        f'<td style="padding:8px 0;text-align:right;">{value_html}</td></tr>'
     )
 
 
@@ -77,28 +55,39 @@ def render_booking_confirmation_email(
     include_fps_qr_image: bool,
 ) -> tuple[str, str, str]:
     """Return (subject, full_html, plain_text)."""
-    loc = _loc(locale)
+    loc = normalize_booking_locale(locale)
+    labels = TABLE_LABELS[loc]
     esc_name = html.escape(full_name.strip())
     esc_course = html.escape(course_label.strip())
     esc_pm = html.escape(payment_method.strip())
     esc_total = html.escape(total_amount)
     esc_wa = html.escape(whatsapp_url.strip(), quote=True)
 
-    labels = _labels_for_locale(loc)
+    greeting = (
+        f'<p style="margin:0 0 12px;">Hi {esc_name},</p>'
+        if loc == "en"
+        else f'<p style="margin:0 0 12px;">您好 {esc_name}，</p>'
+    )
 
     rows_html: list[str] = [
-        _table_row_en(labels["course"], esc_course),
+        _html_table_row_bordered(labels["course"], esc_course),
     ]
     if schedule_date_label and schedule_date_label.strip():
         rows_html.append(
-            _table_row_en(labels["date"], html.escape(schedule_date_label.strip()))
+            _html_table_row_bordered(
+                labels["date"],
+                html.escape(schedule_date_label.strip()),
+            )
         )
     if schedule_time_label and schedule_time_label.strip():
         rows_html.append(
-            _table_row_en(labels["time"], html.escape(schedule_time_label.strip()))
+            _html_table_row_bordered(
+                labels["time"],
+                html.escape(schedule_time_label.strip()),
+            )
         )
-    rows_html.append(_table_row_en(labels["payment"], esc_pm))
-    rows_html.append(_table_row_final_en(labels["total"], esc_total))
+    rows_html.append(_html_table_row_bordered(labels["payment"], esc_pm))
+    rows_html.append(_html_table_row_final(labels["total"], esc_total))
 
     table_html = (
         '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
@@ -107,22 +96,19 @@ def render_booking_confirmation_email(
         + "</table>"
     )
 
-    thank_you = _thank_you_html(loc)
-    greeting = _greeting_html(loc, esc_name)
-
     pending_block = ""
     if is_pending_payment:
         pending_block = (
             '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;'
             'border-radius:8px;color:#5c4a00;">'
-            f"{html.escape(_PENDING_NOTE[loc])}"
+            f"{html.escape(PENDING_PAYMENT_NOTE[loc])}"
             "</p>"
         )
 
     fps_block = ""
     if include_fps_qr_image:
         fps_block = (
-            f'<p style="margin:0 0 8px;">{html.escape(_FPS_QR_INTRO[loc])}</p>'
+            f'<p style="margin:0 0 8px;">{html.escape(FPS_QR_INTRO[loc])}</p>'
             '<p style="margin:0 0 16px;text-align:center;">'
             '<img src="cid:fps_qr" width="128" height="128" alt="FPS QR code" '
             'style="display:inline-block;border:0;outline:none;"/>'
@@ -130,24 +116,24 @@ def render_booking_confirmation_email(
         )
 
     inner_html = (
-        f'{greeting}<p style="margin:0 0 16px;">{thank_you}</p>'
+        f"{greeting}{THANK_YOU_HTML[loc]}"
         f"{table_html}{pending_block}{fps_block}"
-        f'<p style="margin:0 0 12px;">{html.escape(_WHATSAPP_INTRO[loc])}</p>'
+        f'<p style="margin:0 0 12px;">{html.escape(WHATSAPP_INTRO[loc])}</p>'
         f'<p style="margin:0;">'
         f'<a href="{esc_wa}" style="{_CTA_LINK}">WhatsApp</a>'
         f"</p>"
     )
 
-    header = _HEADER_TITLES[loc]
     full_html_template = wrap_transactional_html(
-        header_title=header,
+        header_title=HEADER_TITLE[loc],
         inner_html=inner_html,
     )
 
-    subject = f"{_SUBJECT_PREFIX[loc]}{course_label.strip()}{_SUBJECT_SUFFIX}"
+    subject = f"{SUBJECT_PREFIX[loc]}{course_label.strip()}{SUBJECT_SUFFIX}"
 
     text_lines = _build_plain_text(
         loc=loc,
+        labels=labels,
         full_name=full_name.strip(),
         course_label=course_label.strip(),
         schedule_date_label=schedule_date_label,
@@ -178,51 +164,10 @@ def substitute_shell_placeholders(
     return out
 
 
-def _labels_for_locale(loc: str) -> dict[str, str]:
-    if loc == "zh-CN":
-        return {
-            "course": "课程 / 活动",
-            "date": "日期",
-            "time": "时间",
-            "payment": "付款方式",
-            "total": "总额",
-        }
-    if loc == "zh-HK":
-        return {
-            "course": "課程 / 活動",
-            "date": "日期",
-            "time": "時間",
-            "payment": "付款方式",
-            "total": "總額",
-        }
-    return {
-        "course": "Course / event",
-        "date": "Date",
-        "time": "Time",
-        "payment": "Payment method",
-        "total": "Total",
-    }
-
-
-def _greeting_html(loc: str, escaped_name: str) -> str:
-    if loc == "zh-CN":
-        return f'<p style="margin:0 0 12px;">您好 {escaped_name}，</p>'
-    if loc == "zh-HK":
-        return f'<p style="margin:0 0 12px;">您好 {escaped_name}，</p>'
-    return f'<p style="margin:0 0 12px;">Hi {escaped_name},</p>'
-
-
-def _thank_you_html(loc: str) -> str:
-    if loc == "zh-CN":
-        return "感谢您的预订！"
-    if loc == "zh-HK":
-        return "多謝您的預訂！"
-    return "Thank you for your booking!"
-
-
 def _build_plain_text(
     *,
     loc: str,
+    labels: dict[str, str],
     full_name: str,
     course_label: str,
     schedule_date_label: str | None,
@@ -233,38 +178,29 @@ def _build_plain_text(
     whatsapp_url: str,
     include_fps_qr_image: bool,
 ) -> list[str]:
-    labels = _labels_for_locale(loc)
+    label_sep = ": " if loc == "en" else "："
     lines: list[str] = []
-    if loc == "zh-CN":
-        lines.append(f"您好 {full_name}，\n")
-        lines.append("感谢您的预订！\n")
-    elif loc == "zh-HK":
-        lines.append(f"您好 {full_name}，\n")
-        lines.append("多謝您的預訂！\n")
-    else:
+    if loc == "en":
         lines.append(f"Hi {full_name},\n")
-        lines.append("Thank you for your booking!\n")
-    lines.append(f"{labels['course']}：{course_label}\n")
+    else:
+        lines.append(f"您好 {full_name}，\n")
+    lines.append(THANK_YOU_PLAIN[loc])
+    lines.append(f"{labels['course']}{label_sep}{course_label}\n")
     if schedule_date_label and schedule_date_label.strip():
-        lines.append(f"{labels['date']}：{schedule_date_label.strip()}\n")
+        lines.append(f"{labels['date']}{label_sep}{schedule_date_label.strip()}\n")
     if schedule_time_label and schedule_time_label.strip():
-        lines.append(f"{labels['time']}：{schedule_time_label.strip()}\n")
-    lines.append(f"{labels['payment']}：{payment_method}\n")
-    lines.append(f"{labels['total']}：{total_amount}\n\n")
+        lines.append(f"{labels['time']}{label_sep}{schedule_time_label.strip()}\n")
+    lines.append(f"{labels['payment']}{label_sep}{payment_method}\n")
+    lines.append(f"{labels['total']}{label_sep}{total_amount}\n\n")
     if is_pending_payment:
-        lines.append(f"{_PENDING_NOTE[loc]}\n\n")
+        lines.append(f"{PENDING_PAYMENT_NOTE[loc]}\n\n")
     if include_fps_qr_image:
-        lines.append(f"{_FPS_QR_INTRO[loc]}\n")
+        lines.append(f"{FPS_QR_INTRO[loc]}\n")
         lines.append("[FPS QR code image is attached as fps-qr.png]\n\n")
-    lines.append(f"{_WHATSAPP_INTRO[loc]}\n")
+    lines.append(f"{WHATSAPP_INTRO[loc]}\n")
     if loc == "en":
         lines.append(f"WhatsApp: {whatsapp_url}\n\n")
     else:
         lines.append(f"WhatsApp：{whatsapp_url}\n\n")
-    if loc == "zh-CN":
-        lines.append("谢谢，\nEvolve Sprouts")
-    elif loc == "zh-HK":
-        lines.append("謝謝，\nEvolve Sprouts")
-    else:
-        lines.append("Thank you,\nEvolve Sprouts")
+    lines.append(SIGN_OFF_PLAIN[loc])
     return lines

--- a/backend/src/app/templates/booking_confirmation_render.py
+++ b/backend/src/app/templates/booking_confirmation_render.py
@@ -144,9 +144,7 @@ def render_booking_confirmation_email(
         inner_html=inner_html,
     )
 
-    subject = (
-        f"{_SUBJECT_PREFIX[loc]}{course_label.strip()}{_SUBJECT_SUFFIX}"
-    )
+    subject = f"{_SUBJECT_PREFIX[loc]}{course_label.strip()}{_SUBJECT_SUFFIX}"
 
     text_lines = _build_plain_text(
         loc=loc,

--- a/backend/src/app/templates/booking_confirmation_render.py
+++ b/backend/src/app/templates/booking_confirmation_render.py
@@ -1,0 +1,272 @@
+"""Render booking confirmation email bodies (non-SES-template path for inline images)."""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+from app.templates.ses.email_shell import wrap_transactional_html
+
+_CTA_LINK = "color:#C84A16;font-weight:600;"
+
+_SUBJECT_PREFIX = {
+    "en": "Booking confirmed — ",
+    "zh-CN": "预约确认 — ",
+    "zh-HK": "預約確認 — ",
+}
+_SUBJECT_SUFFIX = " — Evolve Sprouts"
+
+_HEADER_TITLES = {
+    "en": "You're all set — booking confirmed",
+    "zh-CN": "预订已确认",
+    "zh-HK": "預訂已確認",
+}
+
+_FPS_QR_INTRO = {
+    "en": "Use the FPS QR code below with your banking app to pay.",
+    "zh-CN": "请使用下方 FPS 二维码，通过您的银行应用付款。",
+    "zh-HK": "請使用下方 FPS 二維碼，透過您的銀行應用程式付款。",
+}
+
+_PENDING_NOTE = {
+    "en": "Your reservation is pending until payment is confirmed.",
+    "zh-CN": "在付款确认前，您的预订仍为待处理状态。",
+    "zh-HK": "在付款確認前，您的預訂仍為待處理狀態。",
+}
+
+_WHATSAPP_INTRO = {
+    "en": "Questions? Message us on WhatsApp:",
+    "zh-CN": "有疑问？请通过 WhatsApp 联系我们：",
+    "zh-HK": "有疑問？請透過 WhatsApp 聯絡我們：",
+}
+
+
+def _loc(locale: str) -> str:
+    return locale if locale in _HEADER_TITLES else "en"
+
+
+def _table_row_en(label: str, value: str) -> str:
+    esc_label = html.escape(label)
+    return (
+        f'<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;">'
+        f"<strong>{esc_label}</strong></td>"
+        f'<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+        f"{value}</td></tr>"
+    )
+
+
+def _table_row_final_en(label: str, value: str) -> str:
+    esc_label = html.escape(label)
+    return (
+        f'<tr><td style="padding:8px 0;"><strong>{esc_label}</strong></td>'
+        f'<td style="padding:8px 0;text-align:right;">{value}</td></tr>'
+    )
+
+
+def render_booking_confirmation_email(
+    *,
+    locale: str,
+    full_name: str,
+    course_label: str,
+    schedule_date_label: str | None,
+    schedule_time_label: str | None,
+    payment_method: str,
+    total_amount: str,
+    is_pending_payment: bool,
+    whatsapp_url: str,
+    include_fps_qr_image: bool,
+) -> tuple[str, str, str]:
+    """Return (subject, full_html, plain_text)."""
+    loc = _loc(locale)
+    esc_name = html.escape(full_name.strip())
+    esc_course = html.escape(course_label.strip())
+    esc_pm = html.escape(payment_method.strip())
+    esc_total = html.escape(total_amount)
+    esc_wa = html.escape(whatsapp_url.strip(), quote=True)
+
+    labels = _labels_for_locale(loc)
+
+    rows_html: list[str] = [
+        _table_row_en(labels["course"], esc_course),
+    ]
+    if schedule_date_label and schedule_date_label.strip():
+        rows_html.append(
+            _table_row_en(labels["date"], html.escape(schedule_date_label.strip()))
+        )
+    if schedule_time_label and schedule_time_label.strip():
+        rows_html.append(
+            _table_row_en(labels["time"], html.escape(schedule_time_label.strip()))
+        )
+    rows_html.append(_table_row_en(labels["payment"], esc_pm))
+    rows_html.append(_table_row_final_en(labels["total"], esc_total))
+
+    table_html = (
+        '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
+        'style="border-collapse:collapse;margin:0 0 16px;">'
+        + "".join(rows_html)
+        + "</table>"
+    )
+
+    thank_you = _thank_you_html(loc)
+    greeting = _greeting_html(loc, esc_name)
+
+    pending_block = ""
+    if is_pending_payment:
+        pending_block = (
+            '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;'
+            'border-radius:8px;color:#5c4a00;">'
+            f"{html.escape(_PENDING_NOTE[loc])}"
+            "</p>"
+        )
+
+    fps_block = ""
+    if include_fps_qr_image:
+        fps_block = (
+            f'<p style="margin:0 0 8px;">{html.escape(_FPS_QR_INTRO[loc])}</p>'
+            '<p style="margin:0 0 16px;text-align:center;">'
+            '<img src="cid:fps_qr" width="128" height="128" alt="FPS QR code" '
+            'style="display:inline-block;border:0;outline:none;"/>'
+            "</p>"
+        )
+
+    inner_html = (
+        f'{greeting}<p style="margin:0 0 16px;">{thank_you}</p>'
+        f"{table_html}{pending_block}{fps_block}"
+        f'<p style="margin:0 0 12px;">{html.escape(_WHATSAPP_INTRO[loc])}</p>'
+        f'<p style="margin:0;">'
+        f'<a href="{esc_wa}" style="{_CTA_LINK}">WhatsApp</a>'
+        f"</p>"
+    )
+
+    header = _HEADER_TITLES[loc]
+    full_html_template = wrap_transactional_html(
+        header_title=header,
+        inner_html=inner_html,
+    )
+
+    subject = (
+        f"{_SUBJECT_PREFIX[loc]}{course_label.strip()}{_SUBJECT_SUFFIX}"
+    )
+
+    text_lines = _build_plain_text(
+        loc=loc,
+        full_name=full_name.strip(),
+        course_label=course_label.strip(),
+        schedule_date_label=schedule_date_label,
+        schedule_time_label=schedule_time_label,
+        payment_method=payment_method.strip(),
+        total_amount=total_amount,
+        is_pending_payment=is_pending_payment,
+        whatsapp_url=whatsapp_url.strip(),
+        include_fps_qr_image=include_fps_qr_image,
+    )
+    plain_text = "\n".join(text_lines)
+
+    return subject, full_html_template, plain_text
+
+
+def substitute_shell_placeholders(
+    html_document: str, shell_data: dict[str, Any]
+) -> str:
+    """Fill ``wrap_transactional_html`` placeholders from shell merge data."""
+    out = html_document
+    footer_html = shell_data.get("footer_block_html")
+    if isinstance(footer_html, str):
+        out = out.replace("{{{footer_block_html}}}", footer_html)
+    for key in ("logo_url", "site_home_url", "faq_url"):
+        val = shell_data.get(key)
+        if isinstance(val, str):
+            out = out.replace("{{" + key + "}}", val)
+    return out
+
+
+def _labels_for_locale(loc: str) -> dict[str, str]:
+    if loc == "zh-CN":
+        return {
+            "course": "课程 / 活动",
+            "date": "日期",
+            "time": "时间",
+            "payment": "付款方式",
+            "total": "总额",
+        }
+    if loc == "zh-HK":
+        return {
+            "course": "課程 / 活動",
+            "date": "日期",
+            "time": "時間",
+            "payment": "付款方式",
+            "total": "總額",
+        }
+    return {
+        "course": "Course / event",
+        "date": "Date",
+        "time": "Time",
+        "payment": "Payment method",
+        "total": "Total",
+    }
+
+
+def _greeting_html(loc: str, escaped_name: str) -> str:
+    if loc == "zh-CN":
+        return f'<p style="margin:0 0 12px;">您好 {escaped_name}，</p>'
+    if loc == "zh-HK":
+        return f'<p style="margin:0 0 12px;">您好 {escaped_name}，</p>'
+    return f'<p style="margin:0 0 12px;">Hi {escaped_name},</p>'
+
+
+def _thank_you_html(loc: str) -> str:
+    if loc == "zh-CN":
+        return "感谢您的预订！"
+    if loc == "zh-HK":
+        return "多謝您的預訂！"
+    return "Thank you for your booking!"
+
+
+def _build_plain_text(
+    *,
+    loc: str,
+    full_name: str,
+    course_label: str,
+    schedule_date_label: str | None,
+    schedule_time_label: str | None,
+    payment_method: str,
+    total_amount: str,
+    is_pending_payment: bool,
+    whatsapp_url: str,
+    include_fps_qr_image: bool,
+) -> list[str]:
+    labels = _labels_for_locale(loc)
+    lines: list[str] = []
+    if loc == "zh-CN":
+        lines.append(f"您好 {full_name}，\n")
+        lines.append("感谢您的预订！\n")
+    elif loc == "zh-HK":
+        lines.append(f"您好 {full_name}，\n")
+        lines.append("多謝您的預訂！\n")
+    else:
+        lines.append(f"Hi {full_name},\n")
+        lines.append("Thank you for your booking!\n")
+    lines.append(f"{labels['course']}：{course_label}\n")
+    if schedule_date_label and schedule_date_label.strip():
+        lines.append(f"{labels['date']}：{schedule_date_label.strip()}\n")
+    if schedule_time_label and schedule_time_label.strip():
+        lines.append(f"{labels['time']}：{schedule_time_label.strip()}\n")
+    lines.append(f"{labels['payment']}：{payment_method}\n")
+    lines.append(f"{labels['total']}：{total_amount}\n\n")
+    if is_pending_payment:
+        lines.append(f"{_PENDING_NOTE[loc]}\n\n")
+    if include_fps_qr_image:
+        lines.append(f"{_FPS_QR_INTRO[loc]}\n")
+        lines.append("[FPS QR code image is attached as fps-qr.png]\n\n")
+    lines.append(f"{_WHATSAPP_INTRO[loc]}\n")
+    if loc == "en":
+        lines.append(f"WhatsApp: {whatsapp_url}\n\n")
+    else:
+        lines.append(f"WhatsApp：{whatsapp_url}\n\n")
+    if loc == "zh-CN":
+        lines.append("谢谢，\nEvolve Sprouts")
+    elif loc == "zh-HK":
+        lines.append("謝謝，\nEvolve Sprouts")
+    else:
+        lines.append("Thank you,\nEvolve Sprouts")
+    return lines

--- a/backend/src/app/templates/ses/booking_confirmation.py
+++ b/backend/src/app/templates/ses/booking_confirmation.py
@@ -4,184 +4,132 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.templates.booking_confirmation_content import (
+    BOOKING_CONFIRMATION_LOCALES,
+    GREETING_HTML,
+    HEADER_TITLE,
+    PENDING_PAYMENT_NOTE,
+    SIGN_OFF_PLAIN,
+    SUBJECT_PREFIX,
+    SUBJECT_SUFFIX,
+    TABLE_LABELS,
+    THANK_YOU_HTML,
+    THANK_YOU_PLAIN,
+    WHATSAPP_INTRO,
+)
 from app.templates.ses.email_shell import wrap_transactional_html
 
 _CTA_LINK = "color:#C84A16;font-weight:600;"
 
 
+def _inner_html_and_text_for_locale(loc: str) -> tuple[str, str]:
+    """Handlebars inner HTML and plain text (copy shared with MIME render module)."""
+    labels = TABLE_LABELS[loc]
+    border = "border-bottom:1px solid #eeeeee;"
+    row_course = (
+        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["course"]}</strong></td>'
+        '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+        "{{course_label}}</td></tr>"
+    )
+    row_date = (
+        "{{#if schedule_date_label}}"
+        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["date"]}</strong></td>'
+        '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+        "{{schedule_date_label}}</td></tr>"
+        "{{/if}}"
+    )
+    row_time = (
+        "{{#if schedule_time_label}}"
+        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["time"]}</strong></td>'
+        '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+        "{{schedule_time_label}}</td></tr>"
+        "{{/if}}"
+    )
+    row_payment = (
+        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["payment"]}</strong></td>'
+        '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
+        "{{payment_method}}</td></tr>"
+    )
+    row_total = (
+        f'<tr><td style="padding:8px 0;"><strong>{labels["total"]}</strong></td>'
+        '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
+    )
+    pending = PENDING_PAYMENT_NOTE[loc]
+    inner_html = (
+        GREETING_HTML[loc]
+        + THANK_YOU_HTML[loc]
+        + '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
+        'style="border-collapse:collapse;margin:0 0 16px;">'
+        + row_course
+        + row_date
+        + row_time
+        + row_payment
+        + row_total
+        + "</table>"
+        "{{#if is_pending_payment}}"
+        '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;border-radius:8px;'
+        'color:#5c4a00;">'
+        f"{pending}"
+        "</p>"
+        "{{/if}}"
+        f'<p style="margin:0 0 12px;">{WHATSAPP_INTRO[loc]}</p>'
+        '<p style="margin:0;">'
+        f'<a href="{{{{whatsapp_url}}}}" style="{_CTA_LINK}">WhatsApp</a>'
+        "</p>"
+    )
+
+    label_sep = ": " if loc == "en" else "："
+    greeting_plain = (
+        "Hi {{full_name}},\n\n" if loc == "en" else "您好 {{full_name}}，\n\n"
+    )
+    text_part = (
+        greeting_plain
+        + THANK_YOU_PLAIN[loc]
+        + f"{labels['course']}{label_sep}"
+        + "{{course_label}}\n"
+        + "{{#if schedule_date_label}}"
+        + f"{labels['date']}{label_sep}"
+        + "{{schedule_date_label}}\n"
+        + "{{/if}}"
+        + "{{#if schedule_time_label}}"
+        + f"{labels['time']}{label_sep}"
+        + "{{schedule_time_label}}\n"
+        + "{{/if}}"
+        + f"{labels['payment']}{label_sep}"
+        + "{{payment_method}}\n"
+        + f"{labels['total']}{label_sep}"
+        + "{{total_amount}}\n\n"
+        + "{{#if is_pending_payment}}"
+        + f"{pending}\n\n"
+        + "{{/if}}"
+        + f"{WHATSAPP_INTRO[loc]}\n"
+        + (
+            "WhatsApp: {{whatsapp_url}}\n\n"
+            if loc == "en"
+            else "WhatsApp：{{whatsapp_url}}\n\n"
+        )
+        + SIGN_OFF_PLAIN[loc]
+    )
+
+    return inner_html, text_part
+
+
 def get_ses_template_definitions() -> list[dict[str, Any]]:
     """Return SES CreateTemplate payloads (Template key for boto3)."""
-    subjects = {
-        "en": "Booking confirmed — {{course_label}} — Evolve Sprouts",
-        "zh-CN": "预约确认 — {{course_label}} — Evolve Sprouts",
-        "zh-HK": "預約確認 — {{course_label}} — Evolve Sprouts",
-    }
-    header_titles = {
-        "en": "You're all set — booking confirmed",
-        "zh-CN": "预订已确认",
-        "zh-HK": "預訂已確認",
-    }
-    return [
-        {
-            "TemplateName": f"evolvesprouts-booking-confirmation-{loc}",
-            "SubjectPart": subjects[loc],
-            "HtmlPart": wrap_transactional_html(
-                header_title=header_titles[loc],
-                inner_html=inner_html,
-            ),
-            "TextPart": text_part,
-        }
-        for loc, inner_html, text_part in _LOCALE_ROWS
-    ]
-
-
-# Handlebars: optional rows and pending-payment note.
-_HTML_EN = (
-    '<p style="margin:0 0 12px;">Hi {{full_name}},</p>'
-    '<p style="margin:0 0 16px;">Thank you for your booking!</p>'
-    '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
-    'style="border-collapse:collapse;margin:0 0 16px;">'
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Course / event</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{course_label}}</td></tr>'
-    "{{#if schedule_date_label}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Date</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-    "{{schedule_date_label}}</td></tr>"
-    "{{/if}}"
-    "{{#if schedule_time_label}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Time</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-    "{{schedule_time_label}}</td></tr>"
-    "{{/if}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>Payment method</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
-    '<tr><td style="padding:8px 0;"><strong>Total</strong></td>'
-    '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
-    "</table>"
-    "{{#if is_pending_payment}}"
-    '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;border-radius:8px;color:#5c4a00;">'
-    "Your reservation is pending until payment is confirmed."
-    "</p>"
-    "{{/if}}"
-    '<p style="margin:0 0 12px;">Questions? Message us on WhatsApp:</p>'
-    '<p style="margin:0;">'
-    f'<a href="{{{{whatsapp_url}}}}" style="{_CTA_LINK}">WhatsApp</a>'
-    "</p>"
-)
-
-_TEXT_EN = (
-    "Hi {{full_name}},\n\n"
-    "Thank you for your booking!\n\n"
-    "Course / event: {{course_label}}\n"
-    "{{#if schedule_date_label}}Date: {{schedule_date_label}}\n{{/if}}"
-    "{{#if schedule_time_label}}Time: {{schedule_time_label}}\n{{/if}}"
-    "Payment method: {{payment_method}}\n"
-    "Total: {{total_amount}}\n\n"
-    "{{#if is_pending_payment}}"
-    "Your reservation is pending until payment is confirmed.\n\n"
-    "{{/if}}"
-    "WhatsApp: {{whatsapp_url}}\n\n"
-    "Thank you,\nEvolve Sprouts"
-)
-
-_HTML_ZH_CN = (
-    '<p style="margin:0 0 12px;">您好 {{full_name}}，</p>'
-    '<p style="margin:0 0 16px;">感谢您的预订！</p>'
-    '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
-    'style="border-collapse:collapse;margin:0 0 16px;">'
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>课程 / 活动</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{course_label}}</td></tr>'
-    "{{#if schedule_date_label}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>日期</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-    "{{schedule_date_label}}</td></tr>"
-    "{{/if}}"
-    "{{#if schedule_time_label}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>时间</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-    "{{schedule_time_label}}</td></tr>"
-    "{{/if}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>付款方式</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
-    '<tr><td style="padding:8px 0;"><strong>总额</strong></td>'
-    '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
-    "</table>"
-    "{{#if is_pending_payment}}"
-    '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;border-radius:8px;color:#5c4a00;">'
-    "在付款确认前，您的预订仍为待处理状态。"
-    "</p>"
-    "{{/if}}"
-    '<p style="margin:0 0 12px;">有疑问？请通过 WhatsApp 联系我们：</p>'
-    '<p style="margin:0;">'
-    f'<a href="{{{{whatsapp_url}}}}" style="{_CTA_LINK}">WhatsApp</a>'
-    "</p>"
-)
-
-_TEXT_ZH_CN = (
-    "您好 {{full_name}}，\n\n"
-    "感谢您的预订！\n\n"
-    "课程 / 活动：{{course_label}}\n"
-    "{{#if schedule_date_label}}日期：{{schedule_date_label}}\n{{/if}}"
-    "{{#if schedule_time_label}}时间：{{schedule_time_label}}\n{{/if}}"
-    "付款方式：{{payment_method}}\n"
-    "总额：{{total_amount}}\n\n"
-    "{{#if is_pending_payment}}"
-    "在付款确认前，您的预订仍为待处理状态。\n\n"
-    "{{/if}}"
-    "WhatsApp：{{whatsapp_url}}\n\n"
-    "谢谢，\nEvolve Sprouts"
-)
-
-_HTML_ZH_HK = (
-    '<p style="margin:0 0 12px;">您好 {{full_name}}，</p>'
-    '<p style="margin:0 0 16px;">多謝您的預訂！</p>'
-    '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
-    'style="border-collapse:collapse;margin:0 0 16px;">'
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>課程 / 活動</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{course_label}}</td></tr>'
-    "{{#if schedule_date_label}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>日期</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-    "{{schedule_date_label}}</td></tr>"
-    "{{/if}}"
-    "{{#if schedule_time_label}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>時間</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-    "{{schedule_time_label}}</td></tr>"
-    "{{/if}}"
-    '<tr><td style="padding:8px 0;border-bottom:1px solid #eeeeee;"><strong>付款方式</strong></td>'
-    '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">{{payment_method}}</td></tr>'
-    '<tr><td style="padding:8px 0;"><strong>總額</strong></td>'
-    '<td style="padding:8px 0;text-align:right;">{{total_amount}}</td></tr>'
-    "</table>"
-    "{{#if is_pending_payment}}"
-    '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;border-radius:8px;color:#5c4a00;">'
-    "在付款確認前，您的預訂仍為待處理狀態。"
-    "</p>"
-    "{{/if}}"
-    '<p style="margin:0 0 12px;">有疑問？請透過 WhatsApp 聯絡我們：</p>'
-    '<p style="margin:0;">'
-    f'<a href="{{{{whatsapp_url}}}}" style="{_CTA_LINK}">WhatsApp</a>'
-    "</p>"
-)
-
-_TEXT_ZH_HK = (
-    "您好 {{full_name}}，\n\n"
-    "多謝您的預訂！\n\n"
-    "課程 / 活動：{{course_label}}\n"
-    "{{#if schedule_date_label}}日期：{{schedule_date_label}}\n{{/if}}"
-    "{{#if schedule_time_label}}時間：{{schedule_time_label}}\n{{/if}}"
-    "付款方式：{{payment_method}}\n"
-    "總額：{{total_amount}}\n\n"
-    "{{#if is_pending_payment}}"
-    "在付款確認前，您的預訂仍為待處理狀態。\n\n"
-    "{{/if}}"
-    "WhatsApp：{{whatsapp_url}}\n\n"
-    "謝謝，\nEvolve Sprouts"
-)
-
-_LOCALE_ROWS: list[tuple[str, str, str]] = [
-    ("en", _HTML_EN, _TEXT_EN),
-    ("zh-CN", _HTML_ZH_CN, _TEXT_ZH_CN),
-    ("zh-HK", _HTML_ZH_HK, _TEXT_ZH_HK),
-]
+    definitions: list[dict[str, Any]] = []
+    for loc in BOOKING_CONFIRMATION_LOCALES:
+        inner_html, text_part = _inner_html_and_text_for_locale(loc)
+        definitions.append(
+            {
+                "TemplateName": f"evolvesprouts-booking-confirmation-{loc}",
+                "SubjectPart": SUBJECT_PREFIX[loc]
+                + "{{course_label}}"
+                + SUBJECT_SUFFIX,
+                "HtmlPart": wrap_transactional_html(
+                    header_title=HEADER_TITLE[loc],
+                    inner_html=inner_html,
+                ),
+                "TextPart": text_part,
+            }
+        )
+    return definitions

--- a/backend/src/app/utils/fps_qr_png.py
+++ b/backend/src/app/utils/fps_qr_png.py
@@ -1,0 +1,37 @@
+"""Decode FPS QR PNG data URLs from the public booking modal."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Any
+
+_MAX_FPS_QR_DATA_URL_CHARS = 50_000
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def decode_fps_qr_png_data_url(raw: str) -> bytes | None:
+    """Accept only ``data:image/png;base64,...`` payloads from the booking modal QR."""
+    s = raw.strip()
+    if len(s) > _MAX_FPS_QR_DATA_URL_CHARS:
+        return None
+    prefix = "data:image/png;base64,"
+    if not s.lower().startswith(prefix):
+        return None
+    b64_part = s[len(prefix) :].strip()
+    if not b64_part or "\n" in b64_part or "\r" in b64_part:
+        return None
+    try:
+        decoded = base64.b64decode(b64_part, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    if len(decoded) > 512_000 or not decoded.startswith(_PNG_MAGIC):
+        return None
+    return decoded
+
+
+def optional_fps_qr_data_url_from_payload(value: Any) -> str | None:
+    """Normalize optional ``fps_qr_image_data_url`` from JSON."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1008,6 +1008,14 @@ components:
         location_name:
           type: string
           maxLength: 500
+        fps_qr_image_data_url:
+          type: string
+          maxLength: 50000
+          description: >
+            Optional PNG image as a data URL (data:image/png;base64,...) matching the
+            FPS QR shown in the public booking modal. When payment is pending and
+            payment_method is fps_qr, the API may embed this image in the booking
+            confirmation email.
     ReservationPaymentIntentRequest:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -131,7 +131,10 @@ their primary responsibilities.
 - Trigger: CloudFormation custom resource `SesEmailTemplates`
 - Stack: nested stack `evolvesprouts-Messaging` (`backend/infrastructure/lib/messaging-stack.ts`)
 - Purpose: create/update/delete SES stored email templates used by public
-  transactional flows (contact, media download link, booking confirmation)
+  transactional flows (contact, media download link, booking confirmation).
+  Pending FPS bookings may instead send booking confirmation via
+  `SendRawEmail` (multipart HTML + inline PNG) when the client supplies a valid
+  PNG data URL.
 - VPC: **No**
 - Permissions: SES `CreateTemplate`, `UpdateTemplate`, `DeleteTemplate`, `GetTemplate`
 

--- a/tests/test_booking_confirmation_fps_qr.py
+++ b/tests/test_booking_confirmation_fps_qr.py
@@ -4,10 +4,8 @@ import base64
 from typing import Any
 from unittest.mock import MagicMock
 
-from app.api.public_legacy_confirmation import (
-    _decode_png_from_data_url,
-    send_booking_confirmation_email,
-)
+from app.api.public_legacy_confirmation import send_booking_confirmation_email
+from app.utils.fps_qr_png import decode_fps_qr_png_data_url
 
 # 1×1 PNG (valid magic).
 _TINY_PNG_B64 = (
@@ -16,23 +14,23 @@ _TINY_PNG_B64 = (
 _TINY_PNG_DATA_URL = f"data:image/png;base64,{_TINY_PNG_B64}"
 
 
-def test_decode_png_from_data_url_accepts_booking_modal_shape() -> None:
-    out = _decode_png_from_data_url(_TINY_PNG_DATA_URL)
+def test_decode_fps_qr_png_data_url_accepts_booking_modal_shape() -> None:
+    out = decode_fps_qr_png_data_url(_TINY_PNG_DATA_URL)
     assert out is not None
     assert out.startswith(b"\x89PNG\r\n\x1a\n")
 
 
-def test_decode_png_from_data_url_rejects_non_png_prefix() -> None:
-    assert _decode_png_from_data_url("data:image/jpeg;base64,AAAA") is None
+def test_decode_fps_qr_png_data_url_rejects_non_png_prefix() -> None:
+    assert decode_fps_qr_png_data_url("data:image/jpeg;base64,AAAA") is None
 
 
-def test_decode_png_from_data_url_rejects_invalid_base64() -> None:
-    assert _decode_png_from_data_url("data:image/png;base64,@@@") is None
+def test_decode_fps_qr_png_data_url_rejects_invalid_base64() -> None:
+    assert decode_fps_qr_png_data_url("data:image/png;base64,@@@") is None
 
 
-def test_decode_png_from_data_url_rejects_oversized() -> None:
+def test_decode_fps_qr_png_data_url_rejects_oversized() -> None:
     huge = "data:image/png;base64," + ("A" * 100_000)
-    assert _decode_png_from_data_url(huge) is None
+    assert decode_fps_qr_png_data_url(huge) is None
 
 
 def test_send_booking_confirmation_uses_mime_with_valid_fps_qr(

--- a/tests/test_booking_confirmation_fps_qr.py
+++ b/tests/test_booking_confirmation_fps_qr.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.api.public_legacy_confirmation import (
+    _decode_png_from_data_url,
+    send_booking_confirmation_email,
+)
+
+# 1×1 PNG (valid magic).
+_TINY_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+_TINY_PNG_DATA_URL = f"data:image/png;base64,{_TINY_PNG_B64}"
+
+
+def test_decode_png_from_data_url_accepts_booking_modal_shape() -> None:
+    out = _decode_png_from_data_url(_TINY_PNG_DATA_URL)
+    assert out is not None
+    assert out.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_decode_png_from_data_url_rejects_non_png_prefix() -> None:
+    assert _decode_png_from_data_url("data:image/jpeg;base64,AAAA") is None
+
+
+def test_decode_png_from_data_url_rejects_invalid_base64() -> None:
+    assert _decode_png_from_data_url("data:image/png;base64,@@@") is None
+
+
+def test_decode_png_from_data_url_rejects_oversized() -> None:
+    huge = "data:image/png;base64," + ("A" * 100_000)
+    assert _decode_png_from_data_url(huge) is None
+
+
+def test_send_booking_confirmation_uses_mime_with_valid_fps_qr(
+    monkeypatch: Any,
+) -> None:
+    templated = MagicMock()
+    mime = MagicMock()
+    monkeypatch.setenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "hello@example.com")
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_templated_email",
+        templated,
+    )
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_mime_email_with_inline_png",
+        mime,
+    )
+
+    send_booking_confirmation_email(
+        to_email="u@example.com",
+        full_name="Jane",
+        course_label="Course",
+        schedule_date_label=None,
+        schedule_time_label=None,
+        payment_method="fps_qr",
+        total_amount="HK$1.00",
+        is_pending_payment=True,
+        locale="en",
+        fps_qr_image_data_url=_TINY_PNG_DATA_URL,
+    )
+
+    mime.assert_called_once()
+    kwargs = mime.call_args.kwargs
+    assert kwargs["inline_image_cid"] == "fps_qr"
+    assert kwargs["png_bytes"] == base64.b64decode(_TINY_PNG_B64)
+    assert "cid:fps_qr" in kwargs["body_html"]
+    templated.assert_not_called()
+
+
+def test_send_booking_confirmation_ignores_fps_qr_when_not_pending(
+    monkeypatch: Any,
+) -> None:
+    templated = MagicMock()
+    mime = MagicMock()
+    monkeypatch.setenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "hello@example.com")
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_templated_email",
+        templated,
+    )
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_mime_email_with_inline_png",
+        mime,
+    )
+
+    send_booking_confirmation_email(
+        to_email="u@example.com",
+        full_name="Jane",
+        course_label="Course",
+        schedule_date_label=None,
+        schedule_time_label=None,
+        payment_method="fps_qr",
+        total_amount="HK$1.00",
+        is_pending_payment=False,
+        locale="en",
+        fps_qr_image_data_url=_TINY_PNG_DATA_URL,
+    )
+
+    templated.assert_called_once()
+    mime.assert_not_called()
+
+
+def test_send_booking_confirmation_falls_back_when_fps_qr_invalid(
+    monkeypatch: Any,
+) -> None:
+    templated = MagicMock()
+    mime = MagicMock()
+    monkeypatch.setenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "hello@example.com")
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_templated_email",
+        templated,
+    )
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_mime_email_with_inline_png",
+        mime,
+    )
+
+    send_booking_confirmation_email(
+        to_email="u@example.com",
+        full_name="Jane",
+        course_label="Course",
+        schedule_date_label=None,
+        schedule_time_label=None,
+        payment_method="fps_qr",
+        total_amount="HK$1.00",
+        is_pending_payment=True,
+        locale="en",
+        fps_qr_image_data_url="data:image/png;base64,not-valid-base64!!!",
+    )
+
+    templated.assert_called_once()
+    mime.assert_not_called()

--- a/tests/test_booking_confirmation_render.py
+++ b/tests/test_booking_confirmation_render.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from app.templates.booking_confirmation_render import (
+    render_booking_confirmation_email,
+    substitute_shell_placeholders,
+)
+
+
+def test_render_booking_confirmation_zh_cn_includes_labels_and_fps_block() -> None:
+    subject, html_doc, plain = render_booking_confirmation_email(
+        locale="zh-CN",
+        full_name="王敏",
+        course_label="课程 A",
+        schedule_date_label="4月12日",
+        schedule_time_label=None,
+        payment_method="fps_qr",
+        total_amount="HK$100.00",
+        is_pending_payment=True,
+        whatsapp_url="https://wa.me/123",
+        include_fps_qr_image=True,
+    )
+    assert "预约确认" in subject
+    assert "课程 A" in subject
+    assert "王敏" in html_doc
+    assert "课程 / 活动" in html_doc
+    assert "cid:fps_qr" in html_doc
+    assert "付款确认前" in plain
+    assert "WhatsApp：" in plain
+
+
+def test_render_booking_confirmation_en_omits_optional_schedule_rows() -> None:
+    _subject, html_doc, plain = render_booking_confirmation_email(
+        locale="en",
+        full_name="Pat",
+        course_label="Workshop",
+        schedule_date_label=None,
+        schedule_time_label=None,
+        payment_method="bank_transfer",
+        total_amount="HK$50.00",
+        is_pending_payment=False,
+        whatsapp_url="https://wa.me/x",
+        include_fps_qr_image=False,
+    )
+    assert "Date" not in html_doc
+    assert "Time" not in html_doc
+    assert "cid:fps_qr" not in html_doc
+    assert "Date:" not in plain
+    assert "WhatsApp: https://wa.me/x" in plain
+
+
+def test_substitute_shell_placeholders_replaces_logo_and_footer() -> None:
+    _s, html_doc, _p = render_booking_confirmation_email(
+        locale="en",
+        full_name="A",
+        course_label="B",
+        schedule_date_label=None,
+        schedule_time_label=None,
+        payment_method="m",
+        total_amount="HK$1",
+        is_pending_payment=False,
+        whatsapp_url="https://wa.me/1",
+        include_fps_qr_image=False,
+    )
+    out = substitute_shell_placeholders(
+        html_doc,
+        {
+            "logo_url": "https://cdn.example/logo.png",
+            "site_home_url": "https://site.example/en/",
+            "faq_url": "https://site.example/en/faq",
+            "footer_block_html": "<p>Footer</p>",
+        },
+    )
+    assert "https://cdn.example/logo.png" in out
+    assert "https://site.example/en/" in out
+    assert "<p>Footer</p>" in out

--- a/tests/test_fps_qr_png.py
+++ b/tests/test_fps_qr_png.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from app.utils.fps_qr_png import optional_fps_qr_data_url_from_payload
+
+
+def test_optional_fps_qr_data_url_from_payload() -> None:
+    assert optional_fps_qr_data_url_from_payload("  x  ") == "x"
+    assert optional_fps_qr_data_url_from_payload("") is None
+    assert optional_fps_qr_data_url_from_payload(None) is None
+    assert optional_fps_qr_data_url_from_payload(123) is None

--- a/tests/test_public_legacy_proxy_api.py
+++ b/tests/test_public_legacy_proxy_api.py
@@ -75,6 +75,51 @@ def test_legacy_reservations_forwards_payload_and_headers(
     }
 
 
+def test_legacy_contact_us_rejects_body_over_default_limit(
+    api_gateway_event: Any,
+    monkeypatch: Any,
+) -> None:
+    large = "x" * 25_000
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/legacy/contact-us",
+        body=json.dumps({"email_address": "a@b.com", "message": large}),
+    )
+    monkeypatch.setenv("LEGACY_PUBLIC_API_BASE_URL", "https://legacy.example.com")
+
+    response = handle_legacy_contact_us(event, "POST")
+
+    assert response["statusCode"] == 413
+    assert json.loads(response["body"]) == {"error": "Request body too large"}
+
+
+def test_legacy_reservations_allows_larger_body_than_other_legacy_routes(
+    api_gateway_event: Any,
+    monkeypatch: Any,
+) -> None:
+    payload = {"full_name": "Ida", "email": "ida@example.com", "pad": "y" * 25_000}
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/legacy/reservations",
+        body=json.dumps(payload),
+        headers={"X-Turnstile-Token": "t"},
+    )
+    monkeypatch.setenv("LEGACY_PUBLIC_API_BASE_URL", "https://legacy.example.com")
+
+    def _http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        return {"status": 202, "body": json.dumps({"message": "Accepted"})}
+
+    monkeypatch.setattr("app.api.public_legacy_proxy.http_invoke", _http_invoke)
+    monkeypatch.setattr(
+        "app.api.public_legacy_proxy.run_reservation_post_success",
+        lambda **_kw: None,
+    )
+
+    response = handle_legacy_reservations(event, "POST")
+
+    assert response["statusCode"] == 202
+
+
 def test_legacy_discount_uses_configured_api_key_when_inbound_missing(
     api_gateway_event: Any,
     monkeypatch: Any,

--- a/tests/test_ses_booking_confirmation_templates.py
+++ b/tests/test_ses_booking_confirmation_templates.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from app.templates.ses.booking_confirmation import get_ses_template_definitions
+
+
+def test_booking_ses_templates_preserve_handlebars_placeholders() -> None:
+    definitions = get_ses_template_definitions()
+    assert len(definitions) == 3
+    en = next(t for t in definitions if t["TemplateName"].endswith("-en"))
+    assert "{{course_label}}" in en["SubjectPart"]
+    assert "{{full_name}}" in en["HtmlPart"]
+    assert "{{#if is_pending_payment}}" in en["HtmlPart"]
+    assert "{{whatsapp_url}}" in en["TextPart"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pending FPS bookings can include an inline FPS QR in the booking confirmation email (SES raw MIME). Follow-up commit addresses code review feedback.

## Review follow-ups (latest)

- Restored **`flushSync`** in `use-form-submission.ts` so submit loading UI commits before async work.
- **Per-route body limit**: legacy proxy defaults to **20KB**; **reservations** keep **120KB** for PNG data URLs.
- **Single QR generation**: `FpsQrCode` reports the data URL via `onDataUrlChange`; submit reuses it (no second `generateFpsQrImageDataUrl` call). Removed `NODE_ENV === 'test'` guard; tests **mock** `@/lib/fps-qr-code`.
- **Shared copy**: `booking_confirmation_content.py` holds labels/strings; **SES** `booking_confirmation.py` and **MIME** `booking_confirmation_render.py` both use it. Fixed **Handlebars** placeholders in refactored SES strings (f-string `{{` bug).
- **Public decoder**: `app.utils.fps_qr_png.decode_fps_qr_png_data_url` (tests use this instead of a private API function).
- **Tests**: render/substitute coverage, SES template placeholder smoke test, proxy limit tests, `optional_fps_qr_data_url_from_payload`.

## Validation

- `pre-commit run ruff-format --all-files`
- `python3 -m pytest` (booking confirmation, proxy, SES template, fps_qr_png)
- `apps/public_www`: `npm run test` (606 tests)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-596889e2-5f1e-45b1-b6cb-e2f9e65e00db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-596889e2-5f1e-45b1-b6cb-e2f9e65e00db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

