### PR TITLE
refactor(public_www): shared capitalised first_name from email for newsletter and event signup

### DIFF
--- a/apps/public_www/src/components/sections/event-notification.tsx
+++ b/apps/public_www/src/components/sections/event-notification.tsx
@@ -23,10 +23,7 @@ import { trackMetaPixelEvent } from '@/lib/meta-pixel';
 import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
 import { ServerSubmissionResult } from '@/lib/server-submission-result';
-import {
-  deriveFirstNameFromEmailLocalPart,
-  isValidEmail,
-} from '@/lib/validation';
+import { isValidEmail, resolveEmailSignupFirstName } from '@/lib/validation';
 
 interface EventNotificationProps {
   content: EventNotificationContent;
@@ -161,9 +158,10 @@ export function EventNotification({
       });
       return;
     }
-    const derivedFirstName =
-      deriveFirstNameFromEmailLocalPart(normalizedEmail) ||
-      content.emailSignupFirstNameFallback;
+    const derivedFirstName = resolveEmailSignupFirstName(
+      normalizedEmail,
+      content.emailSignupFirstNameFallback,
+    );
 
     await withSubmitting(async () => {
       const submissionResult = await ServerSubmissionResult.resolve({

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -24,10 +24,7 @@ import { trackMetaPixelEvent } from '@/lib/meta-pixel';
 import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
 import { ServerSubmissionResult } from '@/lib/server-submission-result';
-import {
-  deriveFirstNameFromEmailLocalPart,
-  isValidEmail,
-} from '@/lib/validation';
+import { isValidEmail, resolveEmailSignupFirstName } from '@/lib/validation';
 
 interface SproutsSquadCommunityProps {
   content: SproutsSquadCommunityContent;
@@ -162,9 +159,10 @@ export function SproutsSquadCommunity({
       });
       return;
     }
-    const derivedFirstName =
-      deriveFirstNameFromEmailLocalPart(normalizedEmail) ||
-      content.emailSignupFirstNameFallback;
+    const derivedFirstName = resolveEmailSignupFirstName(
+      normalizedEmail,
+      content.emailSignupFirstNameFallback,
+    );
 
     await withSubmitting(async () => {
       const submissionResult = await ServerSubmissionResult.resolve({

--- a/apps/public_www/src/lib/validation.ts
+++ b/apps/public_www/src/lib/validation.ts
@@ -19,3 +19,22 @@ export function deriveFirstNameFromEmailLocalPart(email: string): string {
   const segment = localPart.split(/[.+_-]/)[0] ?? '';
   return sanitizeSingleLineValue(segment);
 }
+
+function capitalizeFirstLetter(value: string): string {
+  if (!value) {
+    return '';
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * `first_name` for email-only public CRM signups (newsletter, event notification):
+ * derived from the email local-part with the first character capitalised, or `fallback` when empty.
+ */
+export function resolveEmailSignupFirstName(email: string, fallback: string): string {
+  const derived = deriveFirstNameFromEmailLocalPart(email);
+  if (derived) {
+    return capitalizeFirstLetter(derived);
+  }
+  return fallback;
+}

--- a/apps/public_www/tests/components/sections/event-notification.test.tsx
+++ b/apps/public_www/tests/components/sections/event-notification.test.tsx
@@ -226,7 +226,7 @@ describe('EventNotification section', () => {
         method: 'POST',
         body: {
           email_address: 'events@example.com',
-          first_name: 'events',
+          first_name: 'Events',
           message: enContent.events.notification.prefilledMessage,
           marketing_opt_in: true,
           locale: 'en',

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -394,7 +394,7 @@ describe('SproutsSquadCommunity section', () => {
         method: 'POST',
         body: {
           email_address: 'community@example.com',
-          first_name: 'community',
+          first_name: 'Community',
           message: enContent.sproutsSquadCommunity.prefilledMessage,
           marketing_opt_in: true,
           locale: 'en',

--- a/apps/public_www/tests/lib/validation.test.ts
+++ b/apps/public_www/tests/lib/validation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   deriveFirstNameFromEmailLocalPart,
   isValidEmail,
+  resolveEmailSignupFirstName,
   sanitizeSingleLineValue,
 } from '@/lib/validation';
 
@@ -20,5 +21,15 @@ describe('validation helpers', () => {
     expect(deriveFirstNameFromEmailLocalPart('pat.smith@example.com')).toBe('pat');
     expect(deriveFirstNameFromEmailLocalPart('user+tag@example.com')).toBe('user');
     expect(deriveFirstNameFromEmailLocalPart('  jane_doe@example.com ')).toBe('jane');
+  });
+
+  it('resolves email signup first name with capitalised first letter or fallback', () => {
+    expect(
+      resolveEmailSignupFirstName('pat.smith@example.com', 'Friend'),
+    ).toBe('Pat');
+    expect(resolveEmailSignupFirstName('user+tag@example.com', 'Friend')).toBe('User');
+    expect(resolveEmailSignupFirstName('  jane_doe@example.com ', 'Friend')).toBe('Jane');
+    expect(resolveEmailSignupFirstName('not-an-email', 'Friend')).toBe('Friend');
+    expect(resolveEmailSignupFirstName('@example.com', 'Friend')).toBe('Friend');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Email-only CRM signups (monthly newsletter in Sprouts Squad community and events notification) both send `first_name` derived from the email local-part. This change introduces a single helper, `resolveEmailSignupFirstName()`, in `apps/public_www/src/lib/validation.ts` that:

- Reuses existing `deriveFirstNameFromEmailLocalPart()` for the token
- Uppercases the first character of the derived token
- Falls back to the existing locale `emailSignupFirstNameFallback` when derivation is empty

Both `event-notification.tsx` and `sprouts-squad-community.tsx` now call this helper instead of duplicating the derive + fallback pattern.

## Tests

- Extended `tests/lib/validation.test.ts` for `resolveEmailSignupFirstName`
- Updated section tests to expect capitalised derived names (`Events`, `Community`)

## Validation

- `npm test` (focused Vitest files)
- `npm run lint` in `apps/public_www`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e390412-1c39-4e22-84b6-e2f5d589db6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e390412-1c39-4e22-84b6-e2f5d589db6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

