### PR TITLE
Remove min-height from intro community layout (event notification et al.)

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -380,7 +380,6 @@
 
   .es-intro-community-layout {
     display: flex;
-    min-height: 315px;
     flex-direction: column;
     justify-content: space-between;
   }
@@ -393,12 +392,6 @@
 
   .es-intro-community-layout-cta {
     padding-top: 1.75rem;
-  }
-
-  @media (min-width: 640px) {
-    .es-intro-community-layout {
-      min-height: 400px;
-    }
   }
 
   @media (min-width: 1024px) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the fixed `min-height` on `.es-intro-community-layout` in `apps/public_www/src/app/styles/original/components-sections.css` (previously 315px base, 400px from `sm` up). That layout is shared by the event notification section, sprouts squad community, and free intro session, so all three now grow/shrink with content instead of enforcing a floor height.

## Testing

- `npm run test` in `apps/public_www` for `event-notification`, `sprouts-squad-community`, and `free-intro-session` section tests
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89a1de26-ae22-4b9b-bc01-6f35021a88d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89a1de26-ae22-4b9b-bc01-6f35021a88d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

