### PR TITLE
style(public_www): form success boxes + media download preparing UI

### DIFF
--- a/apps/public_www/src/app/[locale]/media/download/page.tsx
+++ b/apps/public_www/src/app/[locale]/media/download/page.tsx
@@ -24,9 +24,9 @@ export async function generateMetadata({
 }
 
 function LocalizedDownloadPageFallback({
-  title,
+  message,
 }: {
-  title: string;
+  message: string;
 }) {
   return (
     <main
@@ -34,7 +34,12 @@ function LocalizedDownloadPageFallback({
       tabIndex={-1}
       className='mx-auto flex min-h-[60vh] w-full max-w-2xl flex-col items-center justify-center px-6 py-16 text-center'
     >
-      <h1 className='text-3xl font-semibold es-text-heading'>{title}</h1>
+      <div className='flex w-full max-w-lg flex-col items-center'>
+        <div className='h-10 w-10 animate-spin rounded-full border-4 border-[color:var(--site-primary-soft,#EAD5C4)] border-t-[color:var(--site-primary,#D19253)]' />
+        <div className='mt-6 w-full min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4 text-left'>
+          <p className='text-base leading-7 es-text-success'>{message}</p>
+        </div>
+      </div>
     </main>
   );
 }
@@ -44,7 +49,11 @@ export default async function LocalizedMediaDownloadPage({ params }: LocaleRoute
   const mediaDownloadContent = content.common.mediaDownload;
 
   return (
-    <Suspense fallback={<LocalizedDownloadPageFallback title={mediaDownloadContent.preparingTitle} />}>
+    <Suspense
+      fallback={
+        <LocalizedDownloadPageFallback message={mediaDownloadContent.preparingMessage} />
+      }
+    >
       <MediaDownloadRedirectPage content={mediaDownloadContent} />
     </Suspense>
   );

--- a/apps/public_www/src/components/pages/media-download-redirect.tsx
+++ b/apps/public_www/src/components/pages/media-download-redirect.tsx
@@ -110,17 +110,18 @@ export function MediaDownloadRedirectPage({
       tabIndex={-1}
       className='mx-auto flex min-h-[60vh] w-full max-w-2xl flex-col items-center justify-center px-6 py-16 text-center'
     >
-      <div className='h-10 w-10 animate-spin rounded-full border-4 border-[color:var(--site-primary-soft,#EAD5C4)] border-t-[color:var(--site-primary,#D19253)]' />
-      <h1 className='mt-6 text-3xl font-semibold es-text-heading'>{copy.preparingTitle}</h1>
-      <p className='mt-4 text-base leading-7 es-text-body'>
-        {copy.preparingDescription}
-      </p>
-      <a
-        href={destinationUrl}
-        className='mt-5 text-base font-semibold underline underline-offset-4 es-text-brand'
-      >
-        {copy.manualDownloadLabel}
-      </a>
+      <div className='flex w-full max-w-lg flex-col items-center'>
+        <div className='h-10 w-10 animate-spin rounded-full border-4 border-[color:var(--site-primary-soft,#EAD5C4)] border-t-[color:var(--site-primary,#D19253)]' />
+        <div className='mt-6 w-full min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4 text-left'>
+          <p className='text-base leading-7 es-text-success'>{copy.preparingMessage}</p>
+        </div>
+        <a
+          href={destinationUrl}
+          className='mt-5 text-base font-semibold underline underline-offset-4 es-text-brand'
+        >
+          {copy.manualDownloadLabel}
+        </a>
+      </div>
     </main>
   );
 }

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1024,8 +1024,7 @@
       "invalidDescription": "This media link is missing a valid token. Please request the media again.",
       "unavailableTitle": "Download temporarily unavailable",
       "unavailableDescription": "We could not prepare your download link. Please try again in a moment.",
-      "preparingTitle": "Preparing your download",
-      "preparingDescription": "If your download does not start automatically, use the link below.",
+      "preparingMessage": "Preparing your download. If your download does not start automatically, use the link below.",
       "manualDownloadLabel": "Download the media manually"
     },
     "placeholder": {

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1024,8 +1024,7 @@
       "invalidDescription": "此媒体链接缺少有效令牌。请重新申请媒体下载。",
       "unavailableTitle": "下载暂时不可用",
       "unavailableDescription": "我们暂时无法准备下载链接。请稍后再试。",
-      "preparingTitle": "正在准备您的下载",
-      "preparingDescription": "如果下载未自动开始，请使用下方链接。",
+      "preparingMessage": "正在准备您的下载。如果下载未自动开始，请使用下方链接。",
       "manualDownloadLabel": "手动下载媒体"
     },
     "placeholder": {

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1024,8 +1024,7 @@
       "invalidDescription": "此媒體連結缺少有效權杖。請重新申請媒體下載。",
       "unavailableTitle": "下載暫時不可用",
       "unavailableDescription": "我們暫時未能準備下載連結。請稍後再試。",
-      "preparingTitle": "正在準備你的下載",
-      "preparingDescription": "如果下載未有自動開始，請使用下方連結。",
+      "preparingMessage": "正在準備你的下載。如果下載未有自動開始，請使用下方連結。",
       "manualDownloadLabel": "手動下載媒體"
     },
     "placeholder": {

--- a/apps/public_www/tests/components/pages/media-download-redirect.test.tsx
+++ b/apps/public_www/tests/components/pages/media-download-redirect.test.tsx
@@ -59,7 +59,11 @@ describe('MediaDownloadRedirectPage', () => {
 
     render(<MediaDownloadRedirectPage />);
 
-    expect(screen.getByText('Preparing your download')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Preparing your download. If your download does not start automatically, use the link below.',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Download the media manually' })).toHaveAttribute(
       'href',
       `https://media.evolvesprouts.com/v1/assets/share/${token}`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Event / newsletter success**: bordered rounded success boxes (`rounded-inner`, `es-border-success`, `es-bg-surface-success-pale`) without the checkmark icon; removed unused `form-success-check-icon.svg`.
- **Media download (free guide redirect)**: preparing state uses the **same** success-box styling. **Title + description** merged into `common.mediaDownload.preparingMessage` in en / zh-CN / zh-HK. Suspense fallback matches (spinner + same box).

## Validation

- Vitest: event-notification, sprouts-squad-community, media-download-redirect tests
- ESLint on touched public_www files
- `bash scripts/validate-cursorrules.sh`

Note: Full `npm run validate:content` may require env vars (`NEXT_PUBLIC_EMAIL`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cccdfa4-4872-46b6-a67a-3e4ccbf87ba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cccdfa4-4872-46b6-a67a-3e4ccbf87ba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

