### PR TITLE
fix(email): derive WhatsApp wa.me link from business phone env var

### DIFF
--- a/apps/public_www/tests/components/pages/homepage.test.tsx
+++ b/apps/public_www/tests/components/pages/homepage.test.tsx
@@ -167,7 +167,7 @@ describe('HomePage', () => {
 
   it('uses locale navbar prefill message when business phone is configured', () => {
     process.env[WHATSAPP_URL_ENV_KEY] = 'https://wa.me/message/ZQHVW4DEORD5A1?src=qr';
-    process.env[BUSINESS_PHONE_ENV_KEY] = '+852 9447 9843';
+    process.env[BUSINESS_PHONE_ENV_KEY] = '+1 555 000 1234';
     heroBannerPropsSpy.mockClear();
     pageLayoutPropsSpy.mockClear();
     freeIntroSessionPropsSpy.mockClear();
@@ -184,14 +184,14 @@ describe('HomePage', () => {
     const parsedNavbarHref = new URL(pageLayoutProps.navbarContent.bookNow.href);
     const parsedFreeIntroHref = new URL(freeIntroProps.content.ctaHref);
 
-    expect(parsedNavbarHref.pathname).toBe('/85294479843');
+    expect(parsedNavbarHref.pathname).toBe('/15550001234');
     expect(parsedNavbarHref.searchParams.get('text')).toBe(
       localizedContent.navbar.bookNow.prefillMessage,
     );
     expect(pageLayoutProps.navbarContent.bookNow.label).toBe(
       localizedContent.navbar.bookNow.label,
     );
-    expect(parsedFreeIntroHref.pathname).toBe('/85294479843');
+    expect(parsedFreeIntroHref.pathname).toBe('/15550001234');
     expect(parsedFreeIntroHref.searchParams.get('text')).toBe(
       localizedContent.freeIntroSession.prefillMessage,
     );

--- a/apps/public_www/tests/components/sections/footer.test.tsx
+++ b/apps/public_www/tests/components/sections/footer.test.tsx
@@ -45,7 +45,7 @@ describe('Footer external links', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_LINKEDIN_URL = 'https://www.linkedin.com/company/evolve-sprouts';
     process.env.NEXT_PUBLIC_INSTAGRAM_URL = 'https://www.instagram.com/evolvesprouts';
-    process.env.NEXT_PUBLIC_WHATSAPP_URL = 'https://wa.me/85294479843';
+    process.env.NEXT_PUBLIC_WHATSAPP_URL = 'https://wa.me/15550001234';
   });
 
   afterEach(() => {

--- a/apps/public_www/tests/components/sections/links-hub.test.tsx
+++ b/apps/public_www/tests/components/sections/links-hub.test.tsx
@@ -31,7 +31,7 @@ const DEFAULT_PROPS = {
   localizedCourseHref: '/en/services/my-best-auntie-training-course',
   localizedContactHref: '/en/contact-us',
   localizedEventsHref: '/en/events',
-  whatsappHref: 'https://wa.me/85294479843',
+  whatsappHref: 'https://wa.me/15550001234',
   instagramHref: 'https://www.instagram.com/evolvesprouts',
 };
 

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -1624,7 +1624,7 @@ describe('my-best-auntie booking modals footer content', () => {
         locale='en'
         content={thankYouModalContent}
         summary={reservationSummary}
-        whatsappHref='https://wa.me/85294479843'
+        whatsappHref='https://wa.me/15550001234'
         whatsappCtaLabel={enContent.contactUs.form.contactMethodLinks.whatsapp}
         onClose={() => {}}
       />,
@@ -1634,7 +1634,7 @@ describe('my-best-auntie booking modals footer content', () => {
     const whatsappLink = screen.getByRole('link', {
       name: enContent.contactUs.form.contactMethodLinks.whatsapp,
     });
-    expect(whatsappLink).toHaveAttribute('href', 'https://wa.me/85294479843');
+    expect(whatsappLink).toHaveAttribute('href', 'https://wa.me/15550001234');
   });
 
   it('tracks thank-you calendar download clicks', () => {

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking.test.tsx
@@ -619,7 +619,7 @@ describe('MyBestAuntieBooking section', () => {
   });
 
   it('renders private programme CTA as outline link with dedicated WhatsApp message', () => {
-    const privateProgrammeWhatsappHref = 'https://wa.me/85294479843?text=private-programme';
+    const privateProgrammeWhatsappHref = 'https://wa.me/15550001234?text=private-programme';
     render(
       <MyBestAuntieBooking
         locale='en'

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -928,7 +928,7 @@ export class ApiStack extends cdk.Stack {
         type: "String",
         default: "",
         description:
-          "Business phone number in international format (e.g. +852 9447 9843) used to build wa.me links in transactional emails. Align with NEXT_PUBLIC_BUSINESS_PHONE_NUMBER.",
+          "Business phone number in international format used to build wa.me links in transactional emails. Align with NEXT_PUBLIC_BUSINESS_PHONE_NUMBER.",
       }
     );
     const adminWebDomainName = new cdk.CfnParameter(this, "AdminWebDomainName", {

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -921,6 +921,16 @@ export class ApiStack extends cdk.Stack {
           "Optional WhatsApp URL for transactional emails; when empty, code falls back to app default. Align with NEXT_PUBLIC_WHATSAPP_URL.",
       }
     );
+    const publicWwwBusinessPhoneNumber = new cdk.CfnParameter(
+      this,
+      "PublicWwwBusinessPhoneNumber",
+      {
+        type: "String",
+        default: "",
+        description:
+          "Business phone number in international format (e.g. +852 9447 9843) used to build wa.me links in transactional emails. Align with NEXT_PUBLIC_BUSINESS_PHONE_NUMBER.",
+      }
+    );
     const adminWebDomainName = new cdk.CfnParameter(this, "AdminWebDomainName", {
       type: "String",
       description: "Admin website domain used for backend CORS allowlisting.",
@@ -1699,6 +1709,7 @@ export class ApiStack extends cdk.Stack {
       publicWwwInstagramUrl: publicWwwInstagramUrl.valueAsString,
       publicWwwLinkedinUrl: publicWwwLinkedinUrl.valueAsString,
       publicWwwWhatsappUrl: publicWwwWhatsappUrl.valueAsString,
+      publicWwwBusinessPhoneNumber: publicWwwBusinessPhoneNumber.valueAsString,
       mailchimpMediaDownloadMergeTag: mailchimpMediaDownloadMergeTag.valueAsString,
       mailchimpFreeResourceJourneyId: mailchimpFreeResourceJourneyId.valueAsString,
       mailchimpFreeResourceJourneyStepId:
@@ -2628,6 +2639,10 @@ export class ApiStack extends cdk.Stack {
     adminFunction.addEnvironment(
       "PUBLIC_WWW_WHATSAPP_URL",
       publicWwwWhatsappUrl.valueAsString
+    );
+    adminFunction.addEnvironment(
+      "PUBLIC_WWW_BUSINESS_PHONE_NUMBER",
+      publicWwwBusinessPhoneNumber.valueAsString
     );
 
     const calendar = v1.addResource("calendar");

--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -45,6 +45,7 @@ export interface MessagingNestedStackProps extends cdk.NestedStackProps {
   publicWwwInstagramUrl: string;
   publicWwwLinkedinUrl: string;
   publicWwwWhatsappUrl: string;
+  publicWwwBusinessPhoneNumber: string;
   mailchimpMediaDownloadMergeTag: string;
   mailchimpFreeResourceJourneyId: string;
   mailchimpFreeResourceJourneyStepId: string;
@@ -211,6 +212,7 @@ export class MessagingNestedStack extends cdk.NestedStack {
           PUBLIC_WWW_INSTAGRAM_URL: props.publicWwwInstagramUrl,
           PUBLIC_WWW_LINKEDIN_URL: props.publicWwwLinkedinUrl,
           PUBLIC_WWW_WHATSAPP_URL: props.publicWwwWhatsappUrl,
+          PUBLIC_WWW_BUSINESS_PHONE_NUMBER: props.publicWwwBusinessPhoneNumber,
         },
       });
 

--- a/backend/infrastructure/params/production.json
+++ b/backend/infrastructure/params/production.json
@@ -35,6 +35,7 @@
   "PublicWwwInstagramUrl": "<FROM_GITHUB_VAR: NEXT_PUBLIC_INSTAGRAM_URL>",
   "PublicWwwLinkedinUrl": "<FROM_GITHUB_VAR: NEXT_PUBLIC_LINKEDIN_URL>",
   "PublicWwwWhatsappUrl": "<FROM_GITHUB_VAR: NEXT_PUBLIC_WHATSAPP_URL>",
+  "PublicWwwBusinessPhoneNumber": "<FROM_GITHUB_VAR: NEXT_PUBLIC_BUSINESS_PHONE_NUMBER>",
   "PublicWwwApiBaseUrl": "<FROM_GITHUB_VAR: NEXT_PUBLIC_API_BASE_URL>",
   "PublicWwwMediaRequestApiBaseUrl": "<FROM_GITHUB_VAR: NEXT_PUBLIC_API_BASE_URL>",
   "WafWebAclArn": "",

--- a/backend/src/app/templates/constants.py
+++ b/backend/src/app/templates/constants.py
@@ -1,17 +1,37 @@
 """Shared constants for transactional email templates.
 
 WhatsApp links in email use ``https://wa.me/<full phone number in international
-format without + or spaces>`` so they open reliably in mail clients. The public
-site may still use ``wa.me/message/...`` for QR flows; see
-``whatsappContact.href`` in ``apps/public_www/src/content/en.json``.
+format without + or spaces>`` so they open reliably in mail clients. The phone
+number is read from ``PUBLIC_WWW_BUSINESS_PHONE_NUMBER`` (or
+``NEXT_PUBLIC_BUSINESS_PHONE_NUMBER``) at runtime — the same env var the public
+website uses. The public site may still use ``wa.me/message/...`` for QR flows;
+see ``whatsappContact.href`` in ``apps/public_www/src/content/en.json``.
 """
 
 from __future__ import annotations
 
 import os
+import re
 
-# +852 9447 9843 (see docs/architecture/marketing-stack.md)
-WHATSAPP_URL = "https://wa.me/85294479843"
+
+def resolve_business_phone_digits() -> str:
+    """Return digits-only business phone from env, or empty string."""
+    for name in (
+        "PUBLIC_WWW_BUSINESS_PHONE_NUMBER",
+        "NEXT_PUBLIC_BUSINESS_PHONE_NUMBER",
+    ):
+        raw = os.getenv(name, "")
+        if isinstance(raw, str) and raw.strip():
+            return re.sub(r"\D", "", raw.strip())
+    return ""
+
+
+def build_whatsapp_phone_url() -> str:
+    """Build ``https://wa.me/<digits>`` from the business phone env var."""
+    digits = resolve_business_phone_digits()
+    if not digits:
+        return ""
+    return f"https://wa.me/{digits}"
 
 
 def resolve_public_www_base_url() -> str:

--- a/backend/src/app/templates/constants.py
+++ b/backend/src/app/templates/constants.py
@@ -1,14 +1,17 @@
 """Shared constants for transactional email templates.
 
-Keep WHATSAPP_URL aligned with ``whatsappContact.href`` in
-``apps/public_www/src/content/en.json``.
+WhatsApp links in email use ``https://wa.me/<full phone number in international
+format without + or spaces>`` so they open reliably in mail clients. The public
+site may still use ``wa.me/message/...`` for QR flows; see
+``whatsappContact.href`` in ``apps/public_www/src/content/en.json``.
 """
 
 from __future__ import annotations
 
 import os
 
-WHATSAPP_URL = "https://wa.me/message/ZQHVW4DEORD5A1?src=qr"
+# +852 9447 9843 (see docs/architecture/marketing-stack.md)
+WHATSAPP_URL = "https://wa.me/85294479843"
 
 
 def resolve_public_www_base_url() -> str:

--- a/backend/src/app/templates/transactional_shell_data.py
+++ b/backend/src/app/templates/transactional_shell_data.py
@@ -17,8 +17,8 @@ from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 from app.templates.constants import (
-    WHATSAPP_URL,
     build_faq_url,
+    build_whatsapp_phone_url,
     resolve_public_www_base_url,
 )
 
@@ -61,7 +61,8 @@ def _coerce_whatsapp_url_for_email(url: str) -> str:
         return url
     path = parsed.path.strip("/")
     if path.lower().startswith("message/"):
-        return WHATSAPP_URL
+        phone_url = build_whatsapp_phone_url()
+        return phone_url if phone_url else url
     return url
 
 
@@ -99,7 +100,7 @@ def resolve_whatsapp_url_for_template() -> str:
     )
     if resolved:
         return _coerce_whatsapp_url_for_email(resolved)
-    return WHATSAPP_URL
+    return build_whatsapp_phone_url()
 
 
 def _resolve_instagram_url() -> str | None:

--- a/backend/src/app/templates/transactional_shell_data.py
+++ b/backend/src/app/templates/transactional_shell_data.py
@@ -50,6 +50,21 @@ def _read_env_url(*names: str) -> str | None:
     return None
 
 
+def _coerce_whatsapp_url_for_email(url: str) -> str:
+    """Prefer ``https://wa.me/<digits>``; ``/message/...`` short links often fail in email."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return url
+    host = (parsed.hostname or "").lower()
+    if host not in ("wa.me", "www.wa.me"):
+        return url
+    path = parsed.path.strip("/")
+    if path.lower().startswith("message/"):
+        return WHATSAPP_URL
+    return url
+
+
 def normalize_optional_absolute_url(value: str | None) -> str | None:
     """Return https URL string, or None if invalid (aligned with public site-config)."""
     if not value or not value.strip():
@@ -83,7 +98,7 @@ def resolve_whatsapp_url_for_template() -> str:
         _read_env_url("PUBLIC_WWW_WHATSAPP_URL", "NEXT_PUBLIC_WHATSAPP_URL")
     )
     if resolved:
-        return resolved
+        return _coerce_whatsapp_url_for_email(resolved)
     return WHATSAPP_URL
 
 

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -348,7 +348,7 @@ For each function above, the following resources are created:
 
 | Function | Additional Permissions |
 |----------|------------------------|
-| `EvolvesproutsAdminFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, invoke `AwsApiProxyFunction`, SNS publish to media, expense parser, and Eventbrite sync topics, SES send email + **SendTemplatedEmail** (internal + `AuthEmailFromAddress` identities), Secrets Manager read for Mailchimp secret (marketing hooks on legacy routes), S3 read/write for the assets bucket; `PUBLIC_WWW_BASE_URL` plus optional `PUBLIC_WWW_INSTAGRAM_URL` / `PUBLIC_WWW_LINKEDIN_URL` / `PUBLIC_WWW_WHATSAPP_URL` for transactional HTML shell data |
+| `EvolvesproutsAdminFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, invoke `AwsApiProxyFunction`, SNS publish to media, expense parser, and Eventbrite sync topics, SES send email + **SendTemplatedEmail** (internal + `AuthEmailFromAddress` identities), Secrets Manager read for Mailchimp secret (marketing hooks on legacy routes), S3 read/write for the assets bucket; `PUBLIC_WWW_BASE_URL` plus optional `PUBLIC_WWW_INSTAGRAM_URL` / `PUBLIC_WWW_LINKEDIN_URL` / `PUBLIC_WWW_WHATSAPP_URL` / `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` for transactional HTML shell data |
 | `AwsApiProxyFunction` | Cognito admin operations (`ListUsers`, `ListUsersInGroup`, `AdminGetUser`, `AdminDeleteUser`, `AdminAddUserToGroup`, `AdminRemoveUserFromGroup`, `AdminListGroupsForUser`, `AdminUserGlobalSignOut`, `AdminUpdateUserAttributes`) |
 | `EvolvesproutsMigrationFunction` | Read DB secret, direct connect to Aurora as `postgres`, Cognito user management, CloudFormation invoke permission |
 | `HealthCheckFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_app` |

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -73,7 +73,8 @@ their primary responsibilities.
 - Environment (selected): `SES_SENDER_EMAIL`, `CONFIRMATION_EMAIL_FROM_ADDRESS`,
   `PUBLIC_WWW_BASE_URL`, optional `PUBLIC_WWW_INSTAGRAM_URL`,
   `PUBLIC_WWW_LINKEDIN_URL`, `PUBLIC_WWW_WHATSAPP_URL` (transactional email shell;
-  align with public site `NEXT_PUBLIC_*` URLs), `SUPPORT_EMAIL`, `MAILCHIMP_*`
+  align with public site `NEXT_PUBLIC_*` URLs; `wa.me/message/...` values are
+  rewritten to `https://wa.me/<phone>` for reliable email clients), `SUPPORT_EMAIL`, `MAILCHIMP_*`
   welcome journey vars (see `aws-messaging.md`)
 - Purpose:   asset metadata CRUD (admin asset list returns `linked_tag_names` for tag
   filters and accepts `tag_name` for any tag linked to assets in the requested
@@ -264,7 +265,7 @@ their primary responsibilities.
   - `PUBLIC_WWW_BASE_URL` (logo and footer links in SES HTML shell)
   - optional `PUBLIC_WWW_INSTAGRAM_URL`, `PUBLIC_WWW_LINKEDIN_URL`,
     `PUBLIC_WWW_WHATSAPP_URL` (same semantics as public site env; empty falls back
-    in application code)
+    in application code; `wa.me/message/...` is coerced to `wa.me/<digits>` for email)
 
 ### Expense parser processor
 - Function: ExpenseParserFunction

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -74,7 +74,9 @@ their primary responsibilities.
   `PUBLIC_WWW_BASE_URL`, optional `PUBLIC_WWW_INSTAGRAM_URL`,
   `PUBLIC_WWW_LINKEDIN_URL`, `PUBLIC_WWW_WHATSAPP_URL` (transactional email shell;
   align with public site `NEXT_PUBLIC_*` URLs; `wa.me/message/...` values are
-  rewritten to `https://wa.me/<phone>` for reliable email clients), `SUPPORT_EMAIL`, `MAILCHIMP_*`
+  rewritten to `https://wa.me/<phone>` for reliable email clients),
+  `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` (used to build `wa.me/<digits>` links;
+  align with `NEXT_PUBLIC_BUSINESS_PHONE_NUMBER`), `SUPPORT_EMAIL`, `MAILCHIMP_*`
   welcome journey vars (see `aws-messaging.md`)
 - Purpose:   asset metadata CRUD (admin asset list returns `linked_tag_names` for tag
   filters and accepts `tag_name` for any tag linked to assets in the requested
@@ -266,6 +268,8 @@ their primary responsibilities.
   - optional `PUBLIC_WWW_INSTAGRAM_URL`, `PUBLIC_WWW_LINKEDIN_URL`,
     `PUBLIC_WWW_WHATSAPP_URL` (same semantics as public site env; empty falls back
     in application code; `wa.me/message/...` is coerced to `wa.me/<digits>` for email)
+  - `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` (used to build `wa.me/<digits>` links;
+    align with `NEXT_PUBLIC_BUSINESS_PHONE_NUMBER`)
 
 ### Expense parser processor
 - Function: ExpenseParserFunction

--- a/docs/architecture/marketing-stack.md
+++ b/docs/architecture/marketing-stack.md
@@ -638,7 +638,7 @@ Audited via Meta Graph API using cursor-bot system user on 2026-03-17.
 |---|---|---|
 | Account name | Evolve Sprouts | OK |
 | Account status | APPROVED | OK |
-| Phone | +852 9447 9843 | OK |
+| Phone | *(set via `NEXT_PUBLIC_BUSINESS_PHONE_NUMBER` env var)* | OK |
 | Phone API status | **CONNECTED** (coexistence mode, updated 2026-03-17) | Cloud API active alongside WhatsApp Business App |
 | Platform type | CLOUD_API | Coexistence with Business App |
 | Quality rating | UNKNOWN | Will update as messages are sent |

--- a/docs/plans/confirmation-email-and-marketing-optin.md
+++ b/docs/plans/confirmation-email-and-marketing-optin.md
@@ -295,16 +295,19 @@ suffix (default `en`).
 
 **New file:** `backend/src/app/templates/constants.py`
 
-Module-level constants shared across email templates:
+Module-level helpers shared across email templates:
 
 ```python
-WHATSAPP_URL = "https://wa.me/85294479843"
+def build_whatsapp_phone_url() -> str:
+    """Build ``https://wa.me/<digits>`` from the business phone env var."""
 ```
 
+The phone number is read from `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` (or
+`NEXT_PUBLIC_BUSINESS_PHONE_NUMBER`), matching the public website env var.
 Transactional email uses the numeric `wa.me` form for reliable link handling;
 `whatsappContact.href` on the public site may still use a `wa.me/message/...` QR
 link. Env-provided `wa.me/message/...` URLs are coerced to the numeric form when
-building template data.
+building template data using this phone number.
 
 Also defines a `resolve_public_www_base_url()` helper that reads
 `PUBLIC_WWW_BASE_URL` env var (set on Lambda from CDK

--- a/docs/plans/confirmation-email-and-marketing-optin.md
+++ b/docs/plans/confirmation-email-and-marketing-optin.md
@@ -298,12 +298,13 @@ suffix (default `en`).
 Module-level constants shared across email templates:
 
 ```python
-WHATSAPP_URL = "https://wa.me/message/ZQHVW4DEORD5A1?src=qr"
+WHATSAPP_URL = "https://wa.me/85294479843"
 ```
 
-This matches the hardcoded fallback in
-`apps/public_www/src/content/en.json` → `whatsappContact.href`. Must stay
-in sync with that value.
+Transactional email uses the numeric `wa.me` form for reliable link handling;
+`whatsappContact.href` on the public site may still use a `wa.me/message/...` QR
+link. Env-provided `wa.me/message/...` URLs are coerced to the numeric form when
+building template data.
 
 Also defines a `resolve_public_www_base_url()` helper that reads
 `PUBLIC_WWW_BASE_URL` env var (set on Lambda from CDK

--- a/tests/test_transactional_shell_data.py
+++ b/tests/test_transactional_shell_data.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pytest
 
-from app.templates.constants import WHATSAPP_URL
 from app.templates.transactional_shell_data import (
     build_footer_social_html,
     build_transactional_template_shell_data,
@@ -12,6 +11,10 @@ from app.templates.transactional_shell_data import (
     normalize_optional_absolute_url,
     resolve_whatsapp_url_for_template,
 )
+
+_TEST_PHONE = "+852 9447 9843"
+_TEST_PHONE_DIGITS = "85294479843"
+_TEST_PHONE_WA_URL = f"https://wa.me/{_TEST_PHONE_DIGITS}"
 
 
 def test_normalize_optional_absolute_url() -> None:
@@ -38,13 +41,44 @@ def test_resolve_whatsapp_url_coerces_message_short_link(monkeypatch: Any) -> No
         "PUBLIC_WWW_WHATSAPP_URL",
         "https://wa.me/message/ZQHVW4DEORD5A1?src=qr",
     )
-    assert resolve_whatsapp_url_for_template() == WHATSAPP_URL
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", _TEST_PHONE)
+    assert resolve_whatsapp_url_for_template() == _TEST_PHONE_WA_URL
 
 
-def test_resolve_whatsapp_url_for_template_falls_back(monkeypatch: Any) -> None:
+def test_resolve_whatsapp_url_coerce_without_phone_keeps_original(
+    monkeypatch: Any,
+) -> None:
+    """When phone env var is missing, coercion cannot rewrite; keep original URL."""
+    monkeypatch.setenv(
+        "PUBLIC_WWW_WHATSAPP_URL",
+        "https://wa.me/message/ZQHVW4DEORD5A1?src=qr",
+    )
+    monkeypatch.delenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_BUSINESS_PHONE_NUMBER", raising=False)
+    assert (
+        resolve_whatsapp_url_for_template()
+        == "https://wa.me/message/ZQHVW4DEORD5A1?src=qr"
+    )
+
+
+def test_resolve_whatsapp_url_for_template_falls_back_to_phone(
+    monkeypatch: Any,
+) -> None:
     monkeypatch.delenv("PUBLIC_WWW_WHATSAPP_URL", raising=False)
     monkeypatch.delenv("NEXT_PUBLIC_WHATSAPP_URL", raising=False)
-    assert resolve_whatsapp_url_for_template() == WHATSAPP_URL
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", _TEST_PHONE)
+    assert resolve_whatsapp_url_for_template() == _TEST_PHONE_WA_URL
+
+
+def test_resolve_whatsapp_url_for_template_empty_without_env(
+    monkeypatch: Any,
+) -> None:
+    """Without any WhatsApp or phone env vars, return empty string."""
+    monkeypatch.delenv("PUBLIC_WWW_WHATSAPP_URL", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_WHATSAPP_URL", raising=False)
+    monkeypatch.delenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_BUSINESS_PHONE_NUMBER", raising=False)
+    assert resolve_whatsapp_url_for_template() == ""
 
 
 @pytest.mark.parametrize(
@@ -59,6 +93,7 @@ def test_build_transactional_template_shell_data_footer(
     monkeypatch: Any, locale: str, expect_fragment: str
 ) -> None:
     monkeypatch.setenv("PUBLIC_WWW_BASE_URL", "https://www.example.com")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", _TEST_PHONE)
     monkeypatch.setenv(
         "PUBLIC_WWW_INSTAGRAM_URL", "https://www.instagram.com/evolvesprouts"
     )
@@ -90,16 +125,17 @@ def test_build_footer_social_html_omits_instagram_linkedin_without_env(
 ) -> None:
     """Without PUBLIC_WWW_* social URLs, do not link IG/LI to the site (matches www footer)."""
     monkeypatch.setenv("PUBLIC_WWW_BASE_URL", "https://www.example.com")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", _TEST_PHONE)
     monkeypatch.delenv("PUBLIC_WWW_INSTAGRAM_URL", raising=False)
     monkeypatch.delenv("NEXT_PUBLIC_INSTAGRAM_URL", raising=False)
     monkeypatch.delenv("PUBLIC_WWW_LINKEDIN_URL", raising=False)
     monkeypatch.delenv("NEXT_PUBLIC_LINKEDIN_URL", raising=False)
-    html = build_footer_social_html(locale="en")
-    assert "Instagram" not in html
-    assert "LinkedIn" not in html
-    assert "https://www.example.com/en/contact-us" not in html
-    assert "WhatsApp" in html
-    assert "Website" in html
+    result = build_footer_social_html(locale="en")
+    assert "Instagram" not in result
+    assert "LinkedIn" not in result
+    assert "https://www.example.com/en/contact-us" not in result
+    assert "WhatsApp" in result
+    assert "Website" in result
 
 
 def test_build_footer_social_html_omits_social_when_env_points_at_own_site(
@@ -107,13 +143,14 @@ def test_build_footer_social_html_omits_social_when_env_points_at_own_site(
 ) -> None:
     """CDK params sometimes copy the site URL; those must not appear as Instagram/LinkedIn."""
     monkeypatch.setenv("PUBLIC_WWW_BASE_URL", "https://www.example.com")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", _TEST_PHONE)
     monkeypatch.setenv(
         "PUBLIC_WWW_INSTAGRAM_URL", "https://www.example.com/en/contact-us"
     )
     monkeypatch.setenv(
         "PUBLIC_WWW_LINKEDIN_URL", "https://www.example.com/zh-HK/contact-us"
     )
-    html = build_footer_social_html(locale="en")
-    assert "Instagram" not in html
-    assert "LinkedIn" not in html
-    assert "WhatsApp" in html
+    result = build_footer_social_html(locale="en")
+    assert "Instagram" not in result
+    assert "LinkedIn" not in result
+    assert "WhatsApp" in result

--- a/tests/test_transactional_shell_data.py
+++ b/tests/test_transactional_shell_data.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from app.templates.constants import WHATSAPP_URL
 from app.templates.transactional_shell_data import (
     build_footer_social_html,
     build_transactional_template_shell_data,
@@ -32,10 +33,18 @@ def test_resolve_whatsapp_url_for_template_env_override(monkeypatch: Any) -> Non
     assert resolve_whatsapp_url_for_template() == "https://wa.me/custom"
 
 
+def test_resolve_whatsapp_url_coerces_message_short_link(monkeypatch: Any) -> None:
+    monkeypatch.setenv(
+        "PUBLIC_WWW_WHATSAPP_URL",
+        "https://wa.me/message/ZQHVW4DEORD5A1?src=qr",
+    )
+    assert resolve_whatsapp_url_for_template() == WHATSAPP_URL
+
+
 def test_resolve_whatsapp_url_for_template_falls_back(monkeypatch: Any) -> None:
     monkeypatch.delenv("PUBLIC_WWW_WHATSAPP_URL", raising=False)
     monkeypatch.delenv("NEXT_PUBLIC_WHATSAPP_URL", raising=False)
-    assert resolve_whatsapp_url_for_template().startswith("https://wa.me/")
+    assert resolve_whatsapp_url_for_template() == WHATSAPP_URL
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transactional_shell_data.py
+++ b/tests/test_transactional_shell_data.py
@@ -12,8 +12,8 @@ from app.templates.transactional_shell_data import (
     resolve_whatsapp_url_for_template,
 )
 
-_TEST_PHONE = "+852 9447 9843"
-_TEST_PHONE_DIGITS = "85294479843"
+_TEST_PHONE = "+1 555 000 1234"
+_TEST_PHONE_DIGITS = "15550001234"
 _TEST_PHONE_WA_URL = f"https://wa.me/{_TEST_PHONE_DIGITS}"
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Transactional email WhatsApp links now derive the phone number from the `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` environment variable (the same one the public website uses as `NEXT_PUBLIC_BUSINESS_PHONE_NUMBER`) instead of hardcoding it in source code. The link is built as `https://wa.me/<digits>` for reliable rendering in mail clients.

The real business phone number has been removed from all source files in the repo — test files use the generic `+1 555 000 1234` number, and docs reference the env var instead.

## Changes

### Backend Python (`backend/src/app/templates/`)
- **`constants.py`**: Removed the hardcoded `WHATSAPP_URL = "https://wa.me/..."` constant. Added `resolve_business_phone_digits()` (reads `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` / `NEXT_PUBLIC_BUSINESS_PHONE_NUMBER`, strips non-digits) and `build_whatsapp_phone_url()` (builds `https://wa.me/<digits>`).
- **`transactional_shell_data.py`**: Updated `_coerce_whatsapp_url_for_email()` to use `build_whatsapp_phone_url()` when rewriting `wa.me/message/...` URLs; gracefully keeps the original URL if the phone env var is not set. Updated `resolve_whatsapp_url_for_template()` fallback to use `build_whatsapp_phone_url()`.

### CDK Infrastructure
- **`api-stack.ts`**: Added `PublicWwwBusinessPhoneNumber` CloudFormation parameter (description no longer contains any real number); passes it as `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` env var to the admin Lambda.
- **`messaging-stack.ts`**: Added `publicWwwBusinessPhoneNumber` to the nested stack props; passes it as `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` env var to the media-request processor Lambda.
- **`production.json`**: Wired new param from `NEXT_PUBLIC_BUSINESS_PHONE_NUMBER` GitHub variable.

### Tests
- Backend: Added 3 new test cases (coerce-with-phone, coerce-without-phone, empty-without-env). All tests use generic `+1 555 000 1234`.
- Public WWW: Replaced real phone number with `+1 555 000 1234` / `15550001234` across 5 test files (footer, links-hub, homepage, booking, booking-modal).

### Docs
- `lambdas.md`, `aws-assets-map.md`: Documented the new `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` env var.
- `marketing-stack.md`: Replaced hardcoded phone with env var reference.
- `confirmation-email-and-marketing-optin.md`: Updated plan to reflect env-var-driven approach.

## Validation
- `python3 -m pytest tests/test_transactional_shell_data.py -v` — 12/12 passed
- `npm test` (public_www, 5 touched files) — 57/57 passed
- `pre-commit run ruff-format --all-files` — clean
- `bash scripts/validate-cursorrules.sh` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76e41ad7-78be-4427-ba73-5343ea346a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76e41ad7-78be-4427-ba73-5343ea346a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

