### PR TITLE
feat(public_www): free guide MediaForm success matches event notification

### DIFF
--- a/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
+++ b/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
@@ -294,8 +294,7 @@ export function FreeGuidesAndResourcesLibrary({
   const mediaFormEmailLabel = mediaFormContent.formEmailLabel;
   const mediaFormSubmitLabel = mediaFormContent.formSubmitLabel;
   const mediaFormSubmittingLabel = mediaFormContent.formSubmittingLabel;
-  const mediaFormSuccessTitle = mediaFormContent.formSuccessTitle;
-  const mediaFormSuccessBody = mediaFormContent.formSuccessBody;
+  const mediaFormSuccessMessage = mediaFormContent.formSuccessMessage;
   const mediaFormErrorMessage = mediaFormContent.formErrorMessage;
   const mediaFormMarketingOptInLabel = mediaFormContent.formMarketingOptInLabel;
 
@@ -413,8 +412,7 @@ export function FreeGuidesAndResourcesLibrary({
                     formEmailLabel={mediaFormEmailLabel}
                     formSubmitLabel={mediaFormSubmitLabel}
                     formSubmittingLabel={mediaFormSubmittingLabel}
-                    formSuccessTitle={mediaFormSuccessTitle}
-                    formSuccessBody={mediaFormSuccessBody}
+                    formSuccessMessage={mediaFormSuccessMessage}
                     formErrorMessage={mediaFormErrorMessage}
                     ctaButtonClassName='es-btn--outline'
                     className='mt-6 w-full sm:w-fit'

--- a/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
+++ b/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
@@ -48,8 +48,7 @@ interface ResourceCardContentProps {
   formEmailLabel: string;
   formSubmitLabel: string;
   formSubmittingLabel: string;
-  formSuccessTitle: string;
-  formSuccessBody: string;
+  formSuccessMessage: string;
   formErrorMessage: string;
   formMarketingOptInLabel: string;
   locale: Locale;
@@ -191,8 +190,7 @@ function ResourceCardContent({
   formEmailLabel,
   formSubmitLabel,
   formSubmittingLabel,
-  formSuccessTitle,
-  formSuccessBody,
+  formSuccessMessage,
   formErrorMessage,
   formMarketingOptInLabel,
   locale,
@@ -244,8 +242,7 @@ function ResourceCardContent({
         formEmailLabel={formEmailLabel}
         formSubmitLabel={formSubmitLabel}
         formSubmittingLabel={formSubmittingLabel}
-        formSuccessTitle={formSuccessTitle}
-        formSuccessBody={formSuccessBody}
+        formSuccessMessage={formSuccessMessage}
         formErrorMessage={formErrorMessage}
         onFormOpened={onFormOpened}
       />
@@ -280,12 +277,9 @@ export function FreeResourcesForGentleParenting({
   const formSubmittingLabel =
     readOptionalText(content.formSubmittingLabel)
     ?? fallbackResourcesContent.formSubmittingLabel;
-  const formSuccessTitle =
-    readOptionalText(content.formSuccessTitle)
-    ?? fallbackResourcesContent.formSuccessTitle;
-  const formSuccessBody =
-    readOptionalText(content.formSuccessBody) ??
-    fallbackResourcesContent.formSuccessBody;
+  const formSuccessMessage =
+    readOptionalText(content.formSuccessMessage) ??
+    fallbackResourcesContent.formSuccessMessage;
   const formErrorMessage =
     readOptionalText(content.formErrorMessage) ??
     fallbackResourcesContent.formErrorMessage;
@@ -327,8 +321,7 @@ export function FreeResourcesForGentleParenting({
       formEmailLabel={formEmailLabel}
       formSubmitLabel={formSubmitLabel}
       formSubmittingLabel={formSubmittingLabel}
-      formSuccessTitle={formSuccessTitle}
-      formSuccessBody={formSuccessBody}
+      formSuccessMessage={formSuccessMessage}
       formErrorMessage={formErrorMessage}
       formMarketingOptInLabel={formMarketingOptInLabel}
       locale={locale}

--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -25,8 +25,7 @@ interface MediaFormProps {
   formEmailLabel: string;
   formSubmitLabel: string;
   formSubmittingLabel: string;
-  formSuccessTitle: string;
-  formSuccessBody: string;
+  formSuccessMessage: string;
   formErrorMessage: string;
   resourceKey?: string;
   className?: string;
@@ -57,8 +56,7 @@ export function MediaForm({
   formEmailLabel,
   formSubmitLabel,
   formSubmittingLabel,
-  formSuccessTitle,
-  formSuccessBody,
+  formSuccessMessage,
   formErrorMessage,
   resourceKey,
   className,
@@ -240,9 +238,13 @@ export function MediaForm({
 
   if (hasSuccessfulSubmission) {
     return (
-      <div className={mergeClassNames('mt-auto max-w-[420px] rounded-xl bg-white p-5', className)}>
-        <h4 className='text-xl font-bold es-text-heading'>{formSuccessTitle}</h4>
-        <p className='mt-2 text-base leading-7 es-text-body'>{formSuccessBody}</p>
+      <div
+        className={mergeClassNames(
+          'mt-auto w-full max-w-[420px] min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4',
+          className,
+        )}
+      >
+        <p className='text-base leading-7 es-text-success'>{formSuccessMessage}</p>
       </div>
     );
   }

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -180,8 +180,7 @@
     "formEmailLabel": "Email",
     "formSubmitLabel": "Send Me the Free Guide",
     "formSubmittingLabel": "Submitting…",
-    "formSuccessTitle": "Check Your Email!",
-    "formSuccessBody": "The download link is in there.",
+    "formSuccessMessage": "Check your email! The download link is in there.",
     "formErrorMessage": "Unable to submit right now. Please check your details and try again.",
     "formMarketingOptInLabel": "Keep me updated with parenting tips and resources",
     "sectionConfig": {

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -180,8 +180,7 @@
     "formEmailLabel": "邮箱",
     "formSubmitLabel": "发送免费指南给我",
     "formSubmittingLabel": "提交中…",
-    "formSuccessTitle": "请查收你的邮箱！",
-    "formSuccessBody": "下载链接就在里面。",
+    "formSuccessMessage": "请查收你的邮箱！下载链接就在里面。",
     "formErrorMessage": "暂时无法提交，请检查信息后重试。",
     "formMarketingOptInLabel": "订阅育儿技巧与资源更新",
     "sectionConfig": {

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -180,8 +180,7 @@
     "formEmailLabel": "電郵",
     "formSubmitLabel": "把免費指南寄給我",
     "formSubmittingLabel": "提交中…",
-    "formSuccessTitle": "請查收你的電郵！",
-    "formSuccessBody": "下載連結就在裡面。",
+    "formSuccessMessage": "請查收你的電郵！下載連結就在裡面。",
     "formErrorMessage": "暫時未能提交，請檢查資料後再試。",
     "formMarketingOptInLabel": "訂閱育兒貼士與資源更新",
     "sectionConfig": {

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -68,8 +68,7 @@ function mediaFormProps() {
     formEmailLabel: resourcesContent.formEmailLabel,
     formSubmitLabel: resourcesContent.formSubmitLabel,
     formSubmittingLabel: resourcesContent.formSubmittingLabel,
-    formSuccessTitle: resourcesContent.formSuccessTitle,
-    formSuccessBody: resourcesContent.formSuccessBody,
+    formSuccessMessage: resourcesContent.formSuccessMessage,
     formErrorMessage: resourcesContent.formErrorMessage,
   };
 }
@@ -281,10 +280,7 @@ describe('MediaForm', () => {
     });
 
     expect(
-      screen.getByText(enContent.resources.formSuccessTitle),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(enContent.resources.formSuccessBody),
+      screen.getByText(enContent.resources.formSuccessMessage),
     ).toBeInTheDocument();
   });
 
@@ -368,8 +364,8 @@ describe('MediaForm', () => {
     );
 
     await waitFor(() => {
-      const titles = screen.getAllByText(enContent.resources.formSuccessTitle);
-      expect(titles).toHaveLength(1);
+      const messages = screen.getAllByText(enContent.resources.formSuccessMessage);
+      expect(messages).toHaveLength(1);
     });
 
     expect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The **Free Guides & Resources** library (and the home-page free resources section) use `MediaForm`. Earlier success styling was only applied to event/newsletter flows and `/media/download`, so gated guide success still showed a white card with separate title + body.

## Changes

- **`MediaForm`**: Success state uses the same treatment as event notification: `rounded-inner border es-border-success es-bg-surface-success-pale p-4` with a single `es-text-success` paragraph.
- **`resources` locale** (en / zh-CN / zh-HK): Replace `formSuccessTitle` + `formSuccessBody` with **`formSuccessMessage`** (merged copy).
- **Call sites**: `free-guides-and-resources-library`, `free-resources-for-gentle-parenting`.
- **Tests**: `media-form.test.tsx` updated.

## Validation

- Vitest: `media-form`, `free-resources-for-gentle-parenting`, `free-guides-and-resources-library`
- ESLint on touched files
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cccdfa4-4872-46b6-a67a-3e4ccbf87ba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cccdfa4-4872-46b6-a67a-3e4ccbf87ba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

