### PR TITLE
fix(public_www): remove vertical margins on resource library description spacer

### DIFF
--- a/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
+++ b/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
@@ -399,7 +399,7 @@ export function FreeGuidesAndResourcesLibrary({
                     {item.description}
                   </p>
                 ) : item.description && hideDescription ? (
-                  <div className='mb-3 mt-3 flex-1' aria-hidden />
+                  <div className='flex-1' aria-hidden />
                 ) : null}
                 {item.resourceKey ? (
                   <MediaForm


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When the gated form opens on a resource card, the description is hidden and replaced with an empty flex spacer. This change removes the spacer's `mt-3` and `mb-3` so vertical spacing between the title and form matches the desired layout.

Tests: `npm test -- --run tests/components/sections/free-guides-and-resources-library.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e52ec5e1-b3c8-493e-ba1b-e4dcb36c5949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e52ec5e1-b3c8-493e-ba1b-e4dcb36c5949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

