### PR TITLE
fix(public_www): stretch Cloudflare Turnstile iframe to container width

### DIFF
--- a/apps/public_www/src/app/styles/original/components-core.css
+++ b/apps/public_www/src/app/styles/original/components-core.css
@@ -311,6 +311,12 @@
     color: var(--es-color-brand-orange);
   }
 
+  .es-turnstile-captcha {
+    display: block;
+    width: 100%;
+    min-height: 65px;
+  }
+
   .es-turnstile-captcha,
   .es-turnstile-captcha > div,
   .es-turnstile-captcha iframe {
@@ -318,7 +324,13 @@
     background-color: transparent !important;
   }
 
+  .es-turnstile-captcha > div {
+    width: 100% !important;
+    max-width: none !important;
+  }
+
   .es-turnstile-captcha iframe {
+    width: 100% !important;
     max-width: none !important;
   }
 

--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -238,13 +238,10 @@ export function MediaForm({
 
   if (hasSuccessfulSubmission) {
     return (
-      <div
-        className={mergeClassNames(
-          'mt-auto w-full max-w-[420px] min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4',
-          className,
-        )}
-      >
-        <p className='text-base leading-7 es-text-success'>{formSuccessMessage}</p>
+      <div className={className}>
+        <div className='mt-3 w-full max-w-[420px] min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4'>
+          <p className='text-base leading-7 es-text-success'>{formSuccessMessage}</p>
+        </div>
       </div>
     );
   }

--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -324,7 +324,6 @@ export function MediaForm({
       <TurnstileCaptcha
         siteKey={turnstileSiteKey}
         widgetAction='media_submit'
-        size='normal'
         onTokenChange={handleCaptchaTokenChange}
         onLoadError={handleCaptchaLoadError}
       />

--- a/apps/public_www/src/components/shared/turnstile-captcha.tsx
+++ b/apps/public_www/src/components/shared/turnstile-captcha.tsx
@@ -240,7 +240,7 @@ export function TurnstileCaptcha({
   return (
     <div
       ref={widgetContainerRef}
-      className={mergeClassNames('es-turnstile-captcha min-h-[65px]', className)}
+      className={mergeClassNames('es-turnstile-captcha', className)}
       data-testid='turnstile-captcha'
     />
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Media form (resource library):** Stop forcing Turnstile `size="normal"` so the widget uses the default **flexible** sizing, which responds to container width.
- **Shared styling:** Extend `.es-turnstile-captcha` rules so the host `div`, Turnstile’s inner wrapper, and the `iframe` use full width (`width: 100%` with `!important` where Cloudflare sets inline dimensions). Move minimum height into CSS (`min-height: 65px`) and drop the duplicate Tailwind `min-h` on the component.
- **MediaForm success state:** Wrap the green success box in an outer `div` that receives the optional `className` (e.g. `mt-6 w-full`), and put `mt-3` on the inner success panel so top spacing is applied even when the parent passes margin utilities that would otherwise override a single merged class list.

## Tests
- `npm test -- --run tests/components/shared/turnstile-captcha.test.tsx tests/components/sections/media-form.test.tsx`
- `bash scripts/validate-cursorrules.sh`

## Note
Other forms already used flexible Turnstile by default; they also get the full-width iframe styling where the parent provides width.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e52ec5e1-b3c8-493e-ba1b-e4dcb36c5949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e52ec5e1-b3c8-493e-ba1b-e4dcb36c5949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

