### PR TITLE
Public WWW: shared success panel, submit loading bubble, media form field errors

### DIFF
--- a/apps/public_www/src/app/[locale]/media/download/page.tsx
+++ b/apps/public_www/src/app/[locale]/media/download/page.tsx
@@ -36,8 +36,8 @@ function LocalizedDownloadPageFallback({
     >
       <div className='flex w-full max-w-lg flex-col items-center'>
         <div className='h-10 w-10 animate-spin rounded-full border-4 border-[color:var(--site-primary-soft,#EAD5C4)] border-t-[color:var(--site-primary,#D19253)]' />
-        <div className='mt-6 w-full min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4 text-left'>
-          <p className='text-base leading-7 es-text-success'>{message}</p>
+        <div className='es-public-form-success-panel mt-6 w-full text-left'>
+          <p className='es-public-form-success-panel-message'>{message}</p>
         </div>
       </div>
     </main>

--- a/apps/public_www/src/app/styles/original/components-core.css
+++ b/apps/public_www/src/app/styles/original/components-core.css
@@ -157,6 +157,21 @@
     color: var(--es-color-text-success);
   }
 
+  .es-public-form-success-panel {
+    min-height: 0;
+    overflow: hidden;
+    border-radius: var(--radius-inner, 14px);
+    border: 1px solid var(--es-color-text-success);
+    background-color: var(--es-color-surface-success-pale);
+    padding: 1rem;
+  }
+
+  .es-public-form-success-panel-message {
+    font-size: 1rem;
+    line-height: 1.75rem;
+    color: var(--es-color-text-success);
+  }
+
   .es-text-neutral-strong {
     color: var(--es-color-text-neutral-strong);
   }

--- a/apps/public_www/src/components/pages/media-download-redirect.tsx
+++ b/apps/public_www/src/components/pages/media-download-redirect.tsx
@@ -112,8 +112,8 @@ export function MediaDownloadRedirectPage({
     >
       <div className='flex w-full max-w-lg flex-col items-center'>
         <div className='h-10 w-10 animate-spin rounded-full border-4 border-[color:var(--site-primary-soft,#EAD5C4)] border-t-[color:var(--site-primary,#D19253)]' />
-        <div className='mt-6 w-full min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4 text-left'>
-          <p className='text-base leading-7 es-text-success'>{copy.preparingMessage}</p>
+        <div className='es-public-form-success-panel mt-6 w-full text-left'>
+          <p className='es-public-form-success-panel-message'>{copy.preparingMessage}</p>
         </div>
         <a
           href={destinationUrl}

--- a/apps/public_www/src/components/sections/event-notification.tsx
+++ b/apps/public_www/src/components/sections/event-notification.tsx
@@ -361,8 +361,8 @@ export function EventNotification({
                 }`}
                 aria-live='polite'
               >
-                <div className='min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4'>
-                  <p className='text-base leading-7 es-text-success'>
+                <div className='es-public-form-success-panel'>
+                  <p className='es-public-form-success-panel-message'>
                     {content.successMessage}
                   </p>
                 </div>

--- a/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
+++ b/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
@@ -292,6 +292,10 @@ export function FreeGuidesAndResourcesLibrary({
 
   const mediaFormFirstNameLabel = mediaFormContent.formFirstNameLabel;
   const mediaFormEmailLabel = mediaFormContent.formEmailLabel;
+  const mediaFormFirstNameValidationMessage =
+    mediaFormContent.formFirstNameValidationMessage;
+  const mediaFormEmailValidationMessage =
+    mediaFormContent.formEmailValidationMessage;
   const mediaFormSubmitLabel = mediaFormContent.formSubmitLabel;
   const mediaFormSubmittingLabel = mediaFormContent.formSubmittingLabel;
   const mediaFormSuccessMessage = mediaFormContent.formSuccessMessage;
@@ -410,6 +414,8 @@ export function FreeGuidesAndResourcesLibrary({
                     formMarketingOptInLabel={mediaFormMarketingOptInLabel}
                     formFirstNameLabel={mediaFormFirstNameLabel}
                     formEmailLabel={mediaFormEmailLabel}
+                    formFirstNameValidationMessage={mediaFormFirstNameValidationMessage}
+                    formEmailValidationMessage={mediaFormEmailValidationMessage}
                     formSubmitLabel={mediaFormSubmitLabel}
                     formSubmittingLabel={mediaFormSubmittingLabel}
                     formSuccessMessage={mediaFormSuccessMessage}

--- a/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
+++ b/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
@@ -46,6 +46,8 @@ interface ResourceCardContentProps {
   resourceKey: string;
   formFirstNameLabel: string;
   formEmailLabel: string;
+  formFirstNameValidationMessage: string;
+  formEmailValidationMessage: string;
   formSubmitLabel: string;
   formSubmittingLabel: string;
   formSuccessMessage: string;
@@ -188,6 +190,8 @@ function ResourceCardContent({
   resourceKey,
   formFirstNameLabel,
   formEmailLabel,
+  formFirstNameValidationMessage,
+  formEmailValidationMessage,
   formSubmitLabel,
   formSubmittingLabel,
   formSuccessMessage,
@@ -240,6 +244,8 @@ function ResourceCardContent({
         formMarketingOptInLabel={formMarketingOptInLabel}
         formFirstNameLabel={formFirstNameLabel}
         formEmailLabel={formEmailLabel}
+        formFirstNameValidationMessage={formFirstNameValidationMessage}
+        formEmailValidationMessage={formEmailValidationMessage}
         formSubmitLabel={formSubmitLabel}
         formSubmittingLabel={formSubmittingLabel}
         formSuccessMessage={formSuccessMessage}
@@ -271,6 +277,12 @@ export function FreeResourcesForGentleParenting({
   const formEmailLabel =
     readOptionalText(content.formEmailLabel)
     ?? fallbackResourcesContent.formEmailLabel;
+  const formFirstNameValidationMessage =
+    readOptionalText(content.formFirstNameValidationMessage)
+    ?? fallbackResourcesContent.formFirstNameValidationMessage;
+  const formEmailValidationMessage =
+    readOptionalText(content.formEmailValidationMessage)
+    ?? fallbackResourcesContent.formEmailValidationMessage;
   const formSubmitLabel =
     readOptionalText(content.formSubmitLabel)
     ?? fallbackResourcesContent.formSubmitLabel;
@@ -319,6 +331,8 @@ export function FreeResourcesForGentleParenting({
       resourceKey={resourceKey}
       formFirstNameLabel={formFirstNameLabel}
       formEmailLabel={formEmailLabel}
+      formFirstNameValidationMessage={formFirstNameValidationMessage}
+      formEmailValidationMessage={formEmailValidationMessage}
       formSubmitLabel={formSubmitLabel}
       formSubmittingLabel={formSubmittingLabel}
       formSuccessMessage={formSuccessMessage}

--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -23,6 +23,8 @@ interface MediaFormProps {
   formMarketingOptInLabel: string;
   formFirstNameLabel: string;
   formEmailLabel: string;
+  formFirstNameValidationMessage: string;
+  formEmailValidationMessage: string;
   formSubmitLabel: string;
   formSubmittingLabel: string;
   formSuccessMessage: string;
@@ -54,6 +56,8 @@ export function MediaForm({
   formMarketingOptInLabel,
   formFirstNameLabel,
   formEmailLabel,
+  formFirstNameValidationMessage,
+  formEmailValidationMessage,
   formSubmitLabel,
   formSubmittingLabel,
   formSuccessMessage,
@@ -67,6 +71,8 @@ export function MediaForm({
   const mediaFormInstanceId = useId();
   const firstNameInputId = `${mediaFormInstanceId}-media-first-name`;
   const emailInputId = `${mediaFormInstanceId}-media-email`;
+  const firstNameErrorId = `${mediaFormInstanceId}-media-first-name-error`;
+  const emailErrorId = `${mediaFormInstanceId}-media-email-error`;
   const formErrorId = `${mediaFormInstanceId}-media-form-error`;
 
   const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '';
@@ -100,11 +106,19 @@ export function MediaForm({
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const isSubmitDisabled = isSubmitting || isServiceUnavailable;
   const shouldShowSubmitError =
-    !!submitErrorMessage ||
-    hasCaptchaValidationError ||
-    hasFirstNameError ||
-    hasEmailError ||
-    isServiceUnavailable;
+    !!submitErrorMessage || hasCaptchaValidationError || isServiceUnavailable;
+
+  const firstNameDescribedBy = hasFirstNameError ? firstNameErrorId : undefined;
+  const emailDescribedBy = hasEmailError ? emailErrorId : undefined;
+  const submitButtonDescribedByParts = [
+    shouldShowSubmitError ? formErrorId : null,
+    hasFirstNameError ? firstNameErrorId : null,
+    hasEmailError ? emailErrorId : null,
+  ].filter((id): id is string => id !== null);
+  const submitButtonDescribedBy =
+    submitButtonDescribedByParts.length > 0
+      ? submitButtonDescribedByParts.join(' ')
+      : undefined;
 
   useEffect(() => {
     if (!isFormVisible) {
@@ -239,8 +253,8 @@ export function MediaForm({
   if (hasSuccessfulSubmission) {
     return (
       <div className={className}>
-        <div className='mt-3 w-full max-w-[420px] min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4'>
-          <p className='text-base leading-7 es-text-success'>{formSuccessMessage}</p>
+        <div className='es-public-form-success-panel mt-3 w-full max-w-[420px]'>
+          <p className='es-public-form-success-panel-message'>{formSuccessMessage}</p>
         </div>
       </div>
     );
@@ -272,45 +286,59 @@ export function MediaForm({
       )}
       noValidate
     >
-      <input
-        id={firstNameInputId}
-        type='text'
-        autoComplete='given-name'
-        value={firstName}
-        onChange={(event) => {
-          setFirstName(event.target.value);
-        }}
-        onBlur={() => {
-          setIsFirstNameTouched(true);
-        }}
-        placeholder={formFirstNameLabel}
-        className={`es-form-input ${hasFirstNameError ? 'es-form-input-error' : ''}`}
-        aria-label={formFirstNameLabel}
-        aria-invalid={hasFirstNameError}
-        aria-describedby={shouldShowSubmitError ? formErrorId : undefined}
-        required
-        disabled={isSubmitting}
-      />
+      <div className='space-y-0'>
+        <input
+          id={firstNameInputId}
+          type='text'
+          autoComplete='given-name'
+          value={firstName}
+          onChange={(event) => {
+            setFirstName(event.target.value);
+          }}
+          onBlur={() => {
+            setIsFirstNameTouched(true);
+          }}
+          placeholder={formFirstNameLabel}
+          className={`es-form-input ${hasFirstNameError ? 'es-form-input-error' : ''}`}
+          aria-label={formFirstNameLabel}
+          aria-invalid={hasFirstNameError}
+          aria-describedby={firstNameDescribedBy}
+          required
+          disabled={isSubmitting}
+        />
+        {hasFirstNameError ? (
+          <p id={firstNameErrorId} className='mt-1 text-sm es-text-danger' role='alert'>
+            {formFirstNameValidationMessage}
+          </p>
+        ) : null}
+      </div>
 
-      <input
-        id={emailInputId}
-        type='email'
-        autoComplete='email'
-        value={email}
-        onChange={(event) => {
-          setEmail(event.target.value);
-        }}
-        onBlur={() => {
-          setIsEmailTouched(true);
-        }}
-        placeholder={formEmailLabel}
-        className={`es-form-input ${hasEmailError ? 'es-form-input-error' : ''}`}
-        aria-label={formEmailLabel}
-        aria-invalid={hasEmailError}
-        aria-describedby={shouldShowSubmitError ? formErrorId : undefined}
-        required
-        disabled={isSubmitting}
-      />
+      <div className='space-y-0'>
+        <input
+          id={emailInputId}
+          type='email'
+          autoComplete='email'
+          value={email}
+          onChange={(event) => {
+            setEmail(event.target.value);
+          }}
+          onBlur={() => {
+            setIsEmailTouched(true);
+          }}
+          placeholder={formEmailLabel}
+          className={`es-form-input ${hasEmailError ? 'es-form-input-error' : ''}`}
+          aria-label={formEmailLabel}
+          aria-invalid={hasEmailError}
+          aria-describedby={emailDescribedBy}
+          required
+          disabled={isSubmitting}
+        />
+        {hasEmailError ? (
+          <p id={emailErrorId} className='mt-1 text-sm es-text-danger' role='alert'>
+            {formEmailValidationMessage}
+          </p>
+        ) : null}
+      </div>
 
       <MarketingOptInCheckbox
         label={formMarketingOptInLabel}
@@ -334,7 +362,7 @@ export function MediaForm({
             : 'w-full'
         }
         disabled={isSubmitDisabled}
-        aria-describedby={shouldShowSubmitError ? formErrorId : undefined}
+        aria-describedby={submitButtonDescribedBy}
       >
         <SubmitButtonLoadingContent
           isSubmitting={isSubmitting}

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -369,8 +369,8 @@ export function SproutsSquadCommunity({
                 }`}
                 aria-live='polite'
               >
-                <div className='min-h-0 overflow-hidden rounded-inner border es-border-success es-bg-surface-success-pale p-4'>
-                  <p className='text-base leading-7 es-text-success'>
+                <div className='es-public-form-success-panel'>
+                  <p className='es-public-form-success-panel-message'>
                     {content.successMessage}
                   </p>
                 </div>

--- a/apps/public_www/src/components/shared/submit-button-loading-content.tsx
+++ b/apps/public_www/src/components/shared/submit-button-loading-content.tsx
@@ -23,10 +23,15 @@ export function SubmitButtonLoadingContent({
     return (
       <>
         <span className='sr-only'>{submittingLabel}</span>
-        <LoadingGearIcon
-          className='h-5 w-5 animate-spin'
-          testId={loadingGearTestId}
-        />
+        <span
+          className='inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border es-border-soft es-loading-gear-bubble'
+          aria-hidden='true'
+        >
+          <LoadingGearIcon
+            className='h-5 w-5 animate-spin'
+            testId={loadingGearTestId}
+          />
+        </span>
       </>
     );
   }

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -178,6 +178,8 @@
     "resourceKey": "patience-free-guide",
     "formFirstNameLabel": "First Name",
     "formEmailLabel": "Email",
+    "formFirstNameValidationMessage": "Please enter your first name.",
+    "formEmailValidationMessage": "Please enter a valid email address.",
     "formSubmitLabel": "Send Me the Free Guide",
     "formSubmittingLabel": "Submitting…",
     "formSuccessMessage": "Check your email! The download link is in there.",

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -178,6 +178,8 @@
     "resourceKey": "patience-free-guide",
     "formFirstNameLabel": "名字",
     "formEmailLabel": "邮箱",
+    "formFirstNameValidationMessage": "请输入你的名字。",
+    "formEmailValidationMessage": "请输入有效的邮箱地址。",
     "formSubmitLabel": "发送免费指南给我",
     "formSubmittingLabel": "提交中…",
     "formSuccessMessage": "请查收你的邮箱！下载链接就在里面。",

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -178,6 +178,8 @@
     "resourceKey": "patience-free-guide",
     "formFirstNameLabel": "名字",
     "formEmailLabel": "電郵",
+    "formFirstNameValidationMessage": "請輸入你的名字。",
+    "formEmailValidationMessage": "請輸入有效的電郵地址。",
     "formSubmitLabel": "把免費指南寄給我",
     "formSubmittingLabel": "提交中…",
     "formSuccessMessage": "請查收你的電郵！下載連結就在裡面。",

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -396,6 +396,7 @@ describe('ContactUsForm section', () => {
     expect(submitButton).toBeDisabled();
     const loadingGear = screen.getByTestId('contact-us-form-submit-loading-gear');
     expect(loadingGear).toHaveClass('animate-spin');
+    expect(loadingGear.parentElement?.className).toContain('es-loading-gear-bubble');
 
     releaseRequest?.();
     await waitFor(() => {

--- a/apps/public_www/tests/components/sections/event-notification.test.tsx
+++ b/apps/public_www/tests/components/sections/event-notification.test.tsx
@@ -177,9 +177,9 @@ describe('EventNotification section', () => {
       name: enContent.common.formActions.submittingLabel,
     });
     expect(submitButton).toBeDisabled();
-    expect(screen.getByTestId('event-notification-submit-loading-gear')).toHaveClass(
-      'animate-spin',
-    );
+    const loadingGear = screen.getByTestId('event-notification-submit-loading-gear');
+    expect(loadingGear).toHaveClass('animate-spin');
+    expect(loadingGear.parentElement?.className).toContain('es-loading-gear-bubble');
 
     releaseRequest?.();
     await waitFor(() => {

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -66,6 +66,8 @@ function mediaFormProps() {
     formMarketingOptInLabel: resourcesContent.formMarketingOptInLabel,
     formFirstNameLabel: resourcesContent.formFirstNameLabel,
     formEmailLabel: resourcesContent.formEmailLabel,
+    formFirstNameValidationMessage: resourcesContent.formFirstNameValidationMessage,
+    formEmailValidationMessage: resourcesContent.formEmailValidationMessage,
     formSubmitLabel: resourcesContent.formSubmitLabel,
     formSubmittingLabel: resourcesContent.formSubmittingLabel,
     formSuccessMessage: resourcesContent.formSuccessMessage,
@@ -129,6 +131,13 @@ describe('MediaForm', () => {
         error_type: 'validation_error',
       },
     });
+    expect(
+      screen.getByText(enContent.resources.formFirstNameValidationMessage),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(enContent.resources.formEmailValidationMessage),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(enContent.resources.formErrorMessage)).toBeNull();
   });
 
   it('renders the CTA button before the form opens', () => {
@@ -217,7 +226,9 @@ describe('MediaForm', () => {
       name: enContent.resources.formSubmittingLabel,
     });
     expect(submitButton).toBeDisabled();
-    expect(screen.getByTestId('media-form-submit-loading-gear')).toHaveClass('animate-spin');
+    const loadingGear = screen.getByTestId('media-form-submit-loading-gear');
+    expect(loadingGear).toHaveClass('animate-spin');
+    expect(loadingGear.parentElement?.className).toContain('es-loading-gear-bubble');
 
     releaseRequest?.();
     await waitFor(() => {

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -862,7 +862,9 @@ describe('my-best-auntie booking modals footer content', () => {
       name: bookingModalContent.submittingLabel,
     });
     expect(submitButton).toBeDisabled();
-    expect(screen.getByTestId('booking-reservation-submit-loading-gear')).toHaveClass('animate-spin');
+    const loadingGear = screen.getByTestId('booking-reservation-submit-loading-gear');
+    expect(loadingGear).toHaveClass('animate-spin');
+    expect(loadingGear.parentElement?.className).toContain('es-loading-gear-bubble');
   });
 
   it('tracks validation_error when email is invalid on submit', async () => {

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -345,9 +345,9 @@ describe('SproutsSquadCommunity section', () => {
       name: enContent.common.formActions.submittingLabel,
     });
     expect(submitButton).toBeDisabled();
-    expect(screen.getByTestId('sprouts-squad-community-submit-loading-gear')).toHaveClass(
-      'animate-spin',
-    );
+    const loadingGear = screen.getByTestId('sprouts-squad-community-submit-loading-gear');
+    expect(loadingGear).toHaveClass('animate-spin');
+    expect(loadingGear.parentElement?.className).toContain('es-loading-gear-bubble');
 
     releaseRequest?.();
     await waitFor(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Introduces shared CSS classes `es-public-form-success-panel` and `es-public-form-success-panel-message` in `components-core.css` and applies them to event notification, Sprouts Squad community, media download success, and media download redirect preparing states (same visual as before, single definition).
- Wraps the gear in `SubmitButtonLoadingContent` with the same circular `es-loading-gear-bubble` treatment used for events/free guides loading (scaled to `h-8 w-8` for primary buttons).
- **Media / free guide form:** adds `formFirstNameValidationMessage` and `formEmailValidationMessage` to `resources` in all locale JSON files; shows inline errors under each field (event-notification style) and no longer surfaces the generic `formErrorMessage` for empty first name or invalid email. Captcha, service, and API errors still use the bottom alert + `formErrorMessage`.

## Tests

- `npm test -- --run` on: `media-form`, `event-notification`, `sprouts-squad-community`, `contact-us-form`, `my-best-auntie-booking-modal` (Vitest).

## Notes

- Full `npm run validate:content` was not run in this environment (missing `NEXT_PUBLIC_EMAIL` / `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`); JSON shape is aligned across `en`, `zh-CN`, `zh-HK`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ced7f4e-14a0-497c-92ee-d781912b5215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ced7f4e-14a0-497c-92ee-d781912b5215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

