### PR TITLE
Expand free-guide (media download) SES email content

### DIFF
--- a/backend/src/app/templates/ses/email_shell.py
+++ b/backend/src/app/templates/ses/email_shell.py
@@ -6,7 +6,8 @@ optional repeated sign-off lines (already kept minimal in each template).
 
 The HTML shell expects ``template_data`` to include keys from
 ``build_transactional_template_shell_data`` (``logo_url``, ``site_home_url``,
-``footer_block_html``, ``faq_url``) plus per-template fields. ``footer_block_html``
+``footer_block_html``, ``faq_url``, ``my_best_auntie_url``, ``free_intro_call_url``
+where used) plus per-template fields. ``footer_block_html``
 is pre-rendered HTML and must be bound with triple-brace Handlebars in the stored
 template (``{{{footer_block_html}}}``) so SES does not escape markup.
 """

--- a/backend/src/app/templates/ses/media_download_link.py
+++ b/backend/src/app/templates/ses/media_download_link.py
@@ -10,6 +10,18 @@ _BUTTON = (
     "display:inline-block;padding:12px 24px;background:#C84A16;"
     "color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;"
 )
+_LINK = "color:#C84A16;font-weight:600;text-decoration:none;"
+_HR = '<hr style="border:none;border-top:1px solid #eeeeee;margin:24px 0;"/>'
+_SECTION_H2 = "margin:24px 0 10px 0;font-size:18px;line-height:1.35;font-weight:700;color:#333333;"
+_BOX = (
+    "margin:24px 0 0 0;padding:18px 20px;background-color:#FDF5EF;"
+    "border:1px solid #C84A16;border-radius:10px;"
+)
+_BOX_H3 = (
+    "margin:0 0 12px 0;font-size:17px;line-height:1.35;font-weight:700;color:#333333;"
+)
+_OL = "margin:0 0 16px;padding-left:22px;"
+_LI = "margin:0 0 8px;"
 
 
 def get_ses_template_definitions() -> list[dict[str, Any]]:
@@ -32,61 +44,171 @@ _LOCALE_ROWS: list[tuple[str, str, str, str, str]] = [
     (
         "en",
         "Your free guide is ready — Evolve Sprouts",
-        "Your free guide is here",
+        "YOUR FREE GUIDE IS HERE!",
         (
             '<p style="margin:0 0 12px;">Hi {{first_name}},</p>'
             '<p style="margin:0 0 20px;">Here is your download link for <strong>{{media_name}}</strong>.</p>'
-            '<p style="margin:0 0 16px;text-align:center;">'
-            f'<a href="{{{{download_url}}}}" style="{_BUTTON}">Download</a>'
+            '<p style="margin:0 0 16px;">'
+            f'<a href="{{{{download_url}}}}" style="{_BUTTON}">Download your free guide</a>'
             "</p>"
             '<p style="margin:0 0 8px;font-size:13px;color:#555555;">If the button does not work, '
             "copy this URL:</p>"
-            '<p style="margin:0;word-break:break-all;font-size:13px;color:#C84A16;">{{download_url}}</p>'
+            '<p style="margin:0 0 0 0;word-break:break-all;font-size:13px;color:#C84A16;">'
+            "{{download_url}}</p>"
+            f"{_HR}"
+            f'<h2 style="{_SECTION_H2}">What you\'ll find inside</h2>'
+            '<p style="margin:0 0 12px 0;">Gentle, Montessori-inspired strategies you can start using '
+            "today, whether it's you or your helper spending time with your child.</p>"
+            "<p style=\"margin:0 0 16px 0;\">These aren't abstract theories. They're practical, everyday "
+            "tools that work in real Hong Kong family life.</p>"
+            f"<h2 style=\"{_SECTION_H2}\">Here's what I'd suggest</h2>"
+            f'<ol style="{_OL}">'
+            f'<li style="{_LI}">Read through the guide, it\'s short and practical</li>'
+            f'<li style="{_LI}">Pick one strategy to try this week</li>'
+            f'<li style="{_LI}">Notice what changes, even small shifts matter</li>'
+            "</ol>"
+            '<p style="margin:0 0 0 0;">And if you have questions or want to go deeper, '
+            "I'm always happy to chat.</p>"
+            f'<div style="{_BOX}">'
+            f'<h3 style="{_BOX_H3}">Want hands-on support?</h3>'
+            '<p style="margin:0 0 14px 0;">'
+            f'<a href="{{{{my_best_auntie_url}}}}" style="{_LINK}">My Best Auntie</a> '
+            "is a 9-week Montessori training programme for domestic helpers — so your child gets "
+            "consistent, confident care every day.</p>"
+            '<p style="margin:0;">Or '
+            f'<a href="{{{{free_intro_call_url}}}}" style="{_LINK}">book a free intro call</a> '
+            "to see what's right for your family.</p>"
+            "</div>"
         ),
         (
             "Hi {{first_name}},\n\n"
             "Here is your download link for {{media_name}}.\n\n"
             "{{download_url}}\n\n"
+            "---\n\n"
+            "What you'll find inside\n\n"
+            "Gentle, Montessori-inspired strategies you can start using today, whether it's you or "
+            "your helper spending time with your child.\n\n"
+            "These aren't abstract theories. They're practical, everyday tools that work in real Hong "
+            "Kong family life.\n\n"
+            "Here's what I'd suggest\n\n"
+            "1. Read through the guide, it's short and practical\n"
+            "2. Pick one strategy to try this week\n"
+            "3. Notice what changes, even small shifts matter\n\n"
+            "And if you have questions or want to go deeper, I'm always happy to chat.\n\n"
+            "Want hands-on support?\n\n"
+            "My Best Auntie ({{my_best_auntie_url}}) is a 9-week Montessori training programme for "
+            "domestic helpers — so your child gets consistent, confident care every day.\n\n"
+            "Or book a free intro call ({{free_intro_call_url}}) to see what's right for your family.\n\n"
             "Thank you,\nEvolve Sprouts"
         ),
     ),
     (
         "zh-CN",
         "您的免费资料已准备好 — Evolve Sprouts",
-        "您的免费资料已准备好",
+        "您的免费指南就在这里！",
         (
             '<p style="margin:0 0 12px;">您好 {{first_name}}，</p>'
             '<p style="margin:0 0 20px;">这是 <strong>{{media_name}}</strong> 的下载链接。</p>'
-            '<p style="margin:0 0 16px;text-align:center;">'
-            f'<a href="{{{{download_url}}}}" style="{_BUTTON}">下载</a>'
+            '<p style="margin:0 0 16px;">'
+            f'<a href="{{{{download_url}}}}" style="{_BUTTON}">下载您的免费指南</a>'
             "</p>"
             '<p style="margin:0 0 8px;font-size:13px;color:#555555;">若按钮无法使用，请复制以下网址：</p>'
-            '<p style="margin:0;word-break:break-all;font-size:13px;color:#C84A16;">{{download_url}}</p>'
+            '<p style="margin:0 0 0 0;word-break:break-all;font-size:13px;color:#C84A16;">'
+            "{{download_url}}</p>"
+            f"{_HR}"
+            f'<h2 style="{_SECTION_H2}">您将了解到</h2>'
+            '<p style="margin:0 0 12px 0;">温和、受蒙特梭利启发的实用方法，您今天就可以开始运用——无论陪伴孩子的'
+            "是您本人还是家政助手。</p>"
+            '<p style="margin:0 0 16px 0;">这些不是抽象理论，而是融入香港家庭日常生活的具体工具。</p>'
+            f'<h2 style="{_SECTION_H2}">我的建议</h2>'
+            f'<ol style="{_OL}">'
+            f'<li style="{_LI}">先通读指南，内容简短、重在实操</li>'
+            f'<li style="{_LI}">本周先选一项策略尝试</li>'
+            f'<li style="{_LI}">留意变化，哪怕是很小的转变也值得肯定</li>'
+            "</ol>"
+            '<p style="margin:0 0 0 0;">若您有疑问或想更深入交流，欢迎随时与我联系。</p>'
+            f'<div style="{_BOX}">'
+            f'<h3 style="{_BOX_H3}">需要实操支持？</h3>'
+            '<p style="margin:0 0 14px 0;">'
+            f'<a href="{{{{my_best_auntie_url}}}}" style="{_LINK}">My Best Auntie</a> '
+            "是一门为期 9 周、面向家政助手的蒙特梭利培训课程，帮助孩子每天获得稳定而自信的照护。</p>"
+            '<p style="margin:0;">或 '
+            f'<a href="{{{{free_intro_call_url}}}}" style="{_LINK}">预约免费咨询通话</a>，'
+            "一起看看哪种方式最适合您的家庭。</p>"
+            "</div>"
         ),
         (
             "您好 {{first_name}}，\n\n"
             "这是 {{media_name}} 的下载链接：\n\n"
             "{{download_url}}\n\n"
+            "---\n\n"
+            "您将了解到\n\n"
+            "温和、受蒙特梭利启发的实用方法，您今天就可以开始运用——无论陪伴孩子的是您本人还是家政助手。\n\n"
+            "这些不是抽象理论，而是融入香港家庭日常生活的具体工具。\n\n"
+            "我的建议\n\n"
+            "1. 先通读指南，内容简短、重在实操\n"
+            "2. 本周先选一项策略尝试\n"
+            "3. 留意变化，哪怕是很小的转变也值得肯定\n\n"
+            "若您有疑问或想更深入交流，欢迎随时与我联系。\n\n"
+            "需要实操支持？\n\n"
+            "My Best Auntie（{{my_best_auntie_url}}）是一门为期 9 周、面向家政助手的蒙特梭利培训课程，"
+            "帮助孩子每天获得稳定而自信的照护。\n\n"
+            "或预约免费咨询通话（{{free_intro_call_url}}），一起看看哪种方式最适合您的家庭。\n\n"
             "谢谢，\nEvolve Sprouts"
         ),
     ),
     (
         "zh-HK",
         "您的免費資料已準備好 — Evolve Sprouts",
-        "您的免費資料已準備好",
+        "您的免費指南就在這裡！",
         (
             '<p style="margin:0 0 12px;">您好 {{first_name}}，</p>'
             '<p style="margin:0 0 20px;">這是 <strong>{{media_name}}</strong> 的下載連結。</p>'
-            '<p style="margin:0 0 16px;text-align:center;">'
-            f'<a href="{{{{download_url}}}}" style="{_BUTTON}">下載</a>'
+            '<p style="margin:0 0 16px;">'
+            f'<a href="{{{{download_url}}}}" style="{_BUTTON}">下載您的免費指南</a>'
             "</p>"
             '<p style="margin:0 0 8px;font-size:13px;color:#555555;">若按鈕無法使用，請複製以下網址：</p>'
-            '<p style="margin:0;word-break:break-all;font-size:13px;color:#C84A16;">{{download_url}}</p>'
+            '<p style="margin:0 0 0 0;word-break:break-all;font-size:13px;color:#C84A16;">'
+            "{{download_url}}</p>"
+            f"{_HR}"
+            f'<h2 style="{_SECTION_H2}">您將了解到</h2>'
+            '<p style="margin:0 0 12px 0;">溫和、受蒙特梭利啟發的實用方法，您今天就可以開始運用——無論陪伴孩子的是'
+            "您本人還是家傭。</p>"
+            '<p style="margin:0 0 16px 0;">這些不是抽象理論，而是融入香港家庭日常生活的具體工具。</p>'
+            f'<h2 style="{_SECTION_H2}">我的建議</h2>'
+            f'<ol style="{_OL}">'
+            f'<li style="{_LI}">先通讀指南，內容簡短、重在實操</li>'
+            f'<li style="{_LI}">本週先選一項策略嘗試</li>'
+            f'<li style="{_LI}">留意變化，哪怕是很小的轉變也值得肯定</li>'
+            "</ol>"
+            '<p style="margin:0 0 0 0;">若您有疑問或想更深入交流，歡迎隨時與我聯絡。</p>'
+            f'<div style="{_BOX}">'
+            f'<h3 style="{_BOX_H3}">需要實操支援？</h3>'
+            '<p style="margin:0 0 14px 0;">'
+            f'<a href="{{{{my_best_auntie_url}}}}" style="{_LINK}">My Best Auntie</a> '
+            "是一門為期 9 週、面向家傭的蒙特梭利培訓課程，讓孩子每天獲得穩定而自信的照顧。</p>"
+            '<p style="margin:0;">或 '
+            f'<a href="{{{{free_intro_call_url}}}}" style="{_LINK}">預約免費諮詢通話</a>，'
+            "一起看看哪種方式最適合您的家庭。</p>"
+            "</div>"
         ),
         (
             "您好 {{first_name}}，\n\n"
             "這是 {{media_name}} 的下載連結：\n\n"
             "{{download_url}}\n\n"
+            "---\n\n"
+            "您將了解到\n\n"
+            "溫和、受蒙特梭利啟發的實用方法，您今天就可以開始運用——無論陪伴孩子的是您本人還是家傭。\n\n"
+            "這些不是抽象理論，而是融入香港家庭日常生活的具體工具。\n\n"
+            "我的建議\n\n"
+            "1. 先通讀指南，內容簡短、重在實操\n"
+            "2. 本週先選一項策略嘗試\n"
+            "3. 留意變化，哪怕是很小的轉變也值得肯定\n\n"
+            "若您有疑問或想更深入交流，歡迎隨時與我聯絡。\n\n"
+            "需要實操支援？\n\n"
+            "My Best Auntie（{{my_best_auntie_url}}）是一門為期 9 週、面向家傭的蒙特梭利培訓課程，"
+            "讓孩子每天獲得穩定而自信的照顧。\n\n"
+            "或預約免費諮詢通話（{{free_intro_call_url}}），一起看看哪種方式最適合您的家庭。\n\n"
             "謝謝，\nEvolve Sprouts"
         ),
     ),

--- a/backend/src/app/templates/transactional_shell_data.py
+++ b/backend/src/app/templates/transactional_shell_data.py
@@ -14,7 +14,7 @@ import html
 import os
 import re
 from typing import Any
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import parse_qsl, quote, urlparse, urlencode, urlunparse
 
 from app.templates.constants import (
     build_faq_url,
@@ -30,6 +30,12 @@ _THANK_YOU_HTML = {
     "en": '<p style="margin:0 0 16px;">Thank you,<br/>Evolve Sprouts</p>',
     "zh-CN": '<p style="margin:0 0 16px;">谢谢，<br/>Evolve Sprouts</p>',
     "zh-HK": '<p style="margin:0 0 16px;">謝謝，<br/>Evolve Sprouts</p>',
+}
+
+_FREE_INTRO_WHATSAPP_PREFILL = {
+    "en": "Hi, I'd like to book a free intro call!",
+    "zh-CN": "您好，我想预约免费咨询通话！",
+    "zh-HK": "您好，我想預約免費諮詢通話！",
 }
 
 _SOCIAL_LABELS = {
@@ -152,6 +158,36 @@ def _build_contact_us_page_url(*, locale: str) -> str:
     return f"{base}/{loc}/contact-us"
 
 
+def build_my_best_auntie_training_page_url(*, locale: str) -> str:
+    """Public WWW URL for the My Best Auntie training course page."""
+    base = resolve_public_www_base_url()
+    if not base:
+        return ""
+    loc = locale if locale in _ALLOWED_LOCALES else "en"
+    return f"{base}/{loc}/services/my-best-auntie-training-course"
+
+
+def build_free_intro_call_url(*, locale: str) -> str:
+    """WhatsApp deep link with intro-call prefill, or contact page if WhatsApp is unavailable."""
+    loc = locale if locale in _ALLOWED_LOCALES else "en"
+    prefill = _FREE_INTRO_WHATSAPP_PREFILL[loc]
+    base_wa = resolve_whatsapp_url_for_template()
+    if not base_wa:
+        return _build_contact_us_page_url(locale=loc)
+    try:
+        parsed = urlparse(base_wa)
+    except ValueError:
+        return _build_contact_us_page_url(locale=loc)
+    pairs = [
+        (k, v)
+        for k, v in parse_qsl(parsed.query, keep_blank_values=True)
+        if k != "text"
+    ]
+    pairs.append(("text", prefill))
+    new_query = urlencode(pairs, safe="", quote_via=quote)
+    return urlunparse(parsed._replace(query=new_query))
+
+
 def _social_link_segment(*, href: str, label: str) -> str:
     safe_href = html.escape(href, quote=True)
     safe_label = html.escape(label)
@@ -209,6 +245,8 @@ def build_transactional_template_shell_data(*, locale: str) -> dict[str, str]:
         "site_home_url": site_home_url,
         "faq_url": build_faq_url(locale=loc),
         "footer_block_html": build_footer_block_html(locale=loc),
+        "my_best_auntie_url": build_my_best_auntie_training_page_url(locale=loc),
+        "free_intro_call_url": build_free_intro_call_url(locale=loc),
     }
 
 

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -140,6 +140,9 @@ responsive while decoupling downstream processing.
 - Applies a resource-specific tag (`public-www-media-<resource_key>`) to the contact.
 - Sends the **download link** to the submitter via **SES templated email**
   (`evolvesprouts-media-download-{locale}`) using `CONFIRMATION_EMAIL_FROM_ADDRESS`.
+  The template includes follow-on guidance plus a highlighted “hands-on support”
+  box; shell data supplies `my_best_auntie_url` (training course page) and
+  `free_intro_call_url` (WhatsApp prefill when configured, else contact page).
 - Syncs subscriber/tag to Mailchimp through `AwsApiProxyFunction` (during a
   **transition** period this may still run for all submissions; when
   `MailchimpRequireMarketingConsent` is `true`, subscribe + free-resource journey

--- a/docs/plans/confirmation-email-and-marketing-optin.md
+++ b/docs/plans/confirmation-email-and-marketing-optin.md
@@ -339,13 +339,17 @@ Template data variables:
 - `{{first_name}}`
 - `{{media_name}}`
 - `{{download_url}}`
+- Plus shared shell keys (logo, footer, `my_best_auntie_url`, `free_intro_call_url`).
 
 Content:
 - Subject: "Your free guide is ready — Evolve Sprouts"
+- Banner title: "YOUR FREE GUIDE IS HERE!" (localized for `zh-CN` / `zh-HK`).
 - Body: Greeting with first name. "Here is your download link for
-  {{media_name}}." Prominent download button/link. "If the button doesn't
-  work, copy this URL: {{download_url}}." Closing.
-- HTML: Branded template. Prominent CTA button for the download URL.
+  {{media_name}}." Left-aligned CTA: "Download your free guide". Fallback URL
+  copy. Horizontal rule, then "What you'll find inside", numbered suggestions,
+  and a bordered callout linking My Best Auntie (`{{my_best_auntie_url}}`) and
+  a free intro call (`{{free_intro_call_url}}`).
+- HTML: Branded template with inline CSS.
 
 **New file:** `backend/src/app/templates/ses/booking_confirmation.py`
 

--- a/tests/test_ses_media_download_templates.py
+++ b/tests/test_ses_media_download_templates.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from app.templates.ses.media_download_link import get_ses_template_definitions
+
+
+def test_media_download_ses_templates_preserve_handlebars_placeholders() -> None:
+    definitions = get_ses_template_definitions()
+    assert len(definitions) == 3
+    en = next(t for t in definitions if t["TemplateName"].endswith("-en"))
+    assert "YOUR FREE GUIDE IS HERE!" in en["HtmlPart"]
+    assert "Download your free guide" in en["HtmlPart"]
+    btn_para_start = en["HtmlPart"].index("Download your free guide")
+    btn_para_snippet = en["HtmlPart"][max(0, btn_para_start - 120) : btn_para_start]
+    assert "text-align:center" not in btn_para_snippet
+    assert "{{first_name}}" in en["HtmlPart"]
+    assert "{{download_url}}" in en["HtmlPart"]
+    assert "{{my_best_auntie_url}}" in en["HtmlPart"]
+    assert "{{free_intro_call_url}}" in en["HtmlPart"]
+    assert "What you'll find inside" in en["HtmlPart"]
+    assert "Want hands-on support?" in en["HtmlPart"]
+    assert "{{my_best_auntie_url}}" in en["TextPart"]
+    assert "{{free_intro_call_url}}" in en["TextPart"]

--- a/tests/test_transactional_shell_data.py
+++ b/tests/test_transactional_shell_data.py
@@ -105,9 +105,26 @@ def test_build_transactional_template_shell_data_footer(
         "https://www.example.com/images/seo/evolvesprouts-og-default.png"
     )
     assert data["site_home_url"] == f"https://www.example.com/{locale}/"
+    assert data["my_best_auntie_url"] == (
+        f"https://www.example.com/{locale}/services/my-best-auntie-training-course"
+    )
+    assert data["free_intro_call_url"].startswith("https://wa.me/")
+    assert "text=" in data["free_intro_call_url"]
     assert expect_fragment in data["footer_block_html"]
     assert "Instagram" in data["footer_block_html"]
     assert "https://www.instagram.com/evolvesprouts" in data["footer_block_html"]
+
+
+def test_build_free_intro_call_url_falls_back_to_contact_without_whatsapp(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("PUBLIC_WWW_BASE_URL", "https://www.example.com")
+    monkeypatch.delenv("PUBLIC_WWW_WHATSAPP_URL", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_WHATSAPP_URL", raising=False)
+    monkeypatch.delenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_BUSINESS_PHONE_NUMBER", raising=False)
+    data = build_transactional_template_shell_data(locale="zh-CN")
+    assert data["free_intro_call_url"] == "https://www.example.com/zh-CN/contact-us"
 
 
 def test_merge_transactional_shell_template_data_order(monkeypatch: Any) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the SES stored templates for `evolvesprouts-media-download-{locale}` to match the new marketing copy: louder banner headline, left-aligned “Download your free guide” CTA, horizontal rule plus guidance sections, and a light-orange bordered callout for My Best Auntie and a free intro call.

## Implementation notes

- **Shell template data** now includes `my_best_auntie_url` (localized training course page under `PUBLIC_WWW_BASE_URL`) and `free_intro_call_url` (WhatsApp `wa.me` with intro-call prefill when WhatsApp URL/phone is configured; otherwise falls back to the localized contact page).
- **zh-CN** and **zh-HK** receive equivalent translated body/CTA/callout text aligned with the English intent.
- Plain-text parts mirror the new sections with `{{my_best_auntie_url}}` and `{{free_intro_call_url}}` placeholders.

## Tests

- `pytest tests/test_ses_media_download_templates.py tests/test_transactional_shell_data.py`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`

## Deploy note

SES templates are upserted by the existing `SesEmailTemplates` custom resource on deploy; no CDK route changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96c2be8b-406c-48fd-8dec-311bde1a1b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96c2be8b-406c-48fd-8dec-311bde1a1b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

