### PR TITLE
SES transactional email footer: add copyright line

### DIFF
--- a/backend/src/app/templates/ses/email_shell.py
+++ b/backend/src/app/templates/ses/email_shell.py
@@ -7,7 +7,7 @@ optional repeated sign-off lines (already kept minimal in each template).
 The HTML shell expects ``template_data`` to include keys from
 ``build_transactional_template_shell_data`` (``logo_url``, ``site_home_url``,
 ``footer_block_html``, ``faq_url``, ``my_best_auntie_url``, ``free_intro_call_url``
-where used) plus per-template fields. ``footer_block_html``
+where used) plus per-template fields. ``footer_block_html`` (thank-you, rule, optional social links, copyright line)
 is pre-rendered HTML and must be bound with triple-brace Handlebars in the stored
 template (``{{{footer_block_html}}}``) so SES does not escape markup.
 """

--- a/backend/src/app/templates/transactional_shell_data.py
+++ b/backend/src/app/templates/transactional_shell_data.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import html
 import os
 import re
+from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import parse_qsl, quote, urlparse, urlencode, urlunparse
 
@@ -222,15 +223,27 @@ def build_footer_social_html(*, locale: str) -> str:
     return f'<p style="margin:0;text-align:center;font-size:13px;line-height:1.8;">{inner}</p>'
 
 
+def _build_footer_copyright_html() -> str:
+    """Centered copyright line (year at send time, UTC)."""
+    year = datetime.now(UTC).year
+    text = f"© {year} Evolve Sprouts. All rights reserved."
+    return (
+        '<p style="margin:16px 0 0 0;text-align:center;font-size:11px;'
+        'line-height:1.5;color:#888888;">'
+        f"{html.escape(text)}</p>"
+    )
+
+
 def build_footer_block_html(*, locale: str) -> str:
-    """Thank-you line, rule, and social links for the shell footer."""
+    """Thank-you line, rule, social links, and copyright for the shell footer."""
     loc = locale if locale in _ALLOWED_LOCALES else "en"
     thank = _THANK_YOU_HTML[loc]
     hr = '<hr style="border:none;border-top:1px solid #eeeeee;margin:0 0 16px 0;"/>'
     social = build_footer_social_html(locale=loc)
+    copyright_html = _build_footer_copyright_html()
     if social:
-        return thank + hr + social
-    return thank + hr
+        return thank + hr + social + copyright_html
+    return thank + hr + copyright_html
 
 
 def build_transactional_template_shell_data(*, locale: str) -> dict[str, str]:

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -47,6 +47,9 @@ template names.
 - **Mailchimp** remains separate: optional marketing subscribe + journey
   triggers run only when the user opts in; failures are logged and do not
   change the HTTP response for legacy bridge routes.
+- **Shared HTML shell footer** (`footer_block_html`): after the thank-you line,
+  rule, and optional social links, a centered copyright line is appended using
+  the **UTC year at send time** (`© <year> Evolve Sprouts. All rights reserved.`).
 
 ## Components
 

--- a/tests/test_transactional_shell_data.py
+++ b/tests/test_transactional_shell_data.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
 
+import app.templates.transactional_shell_data as transactional_shell_data
 from app.templates.transactional_shell_data import (
+    build_footer_block_html,
     build_footer_social_html,
     build_transactional_template_shell_data,
     merge_transactional_shell_template_data,
@@ -92,6 +95,14 @@ def test_resolve_whatsapp_url_for_template_empty_without_env(
 def test_build_transactional_template_shell_data_footer(
     monkeypatch: Any, locale: str, expect_fragment: str
 ) -> None:
+    fixed_now = datetime(2030, 1, 2, tzinfo=UTC)
+
+    class _DatetimePatch:
+        @staticmethod
+        def now(tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(transactional_shell_data, "datetime", _DatetimePatch)
     monkeypatch.setenv("PUBLIC_WWW_BASE_URL", "https://www.example.com")
     monkeypatch.setenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", _TEST_PHONE)
     monkeypatch.setenv(
@@ -113,6 +124,27 @@ def test_build_transactional_template_shell_data_footer(
     assert expect_fragment in data["footer_block_html"]
     assert "Instagram" in data["footer_block_html"]
     assert "https://www.instagram.com/evolvesprouts" in data["footer_block_html"]
+    assert "© 2030 Evolve Sprouts. All rights reserved." in data["footer_block_html"]
+    assert "margin:16px 0 0 0;text-align:center" in data["footer_block_html"]
+
+
+def test_build_footer_block_html_copyright_when_no_social_links(monkeypatch: Any) -> None:
+    fixed_now = datetime(2027, 6, 1, tzinfo=UTC)
+
+    class _DatetimePatch:
+        @staticmethod
+        def now(tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(transactional_shell_data, "datetime", _DatetimePatch)
+    monkeypatch.delenv("PUBLIC_WWW_BASE_URL", raising=False)
+    monkeypatch.delenv("PUBLIC_WWW_WHATSAPP_URL", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_WHATSAPP_URL", raising=False)
+    monkeypatch.delenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_BUSINESS_PHONE_NUMBER", raising=False)
+    html = build_footer_block_html(locale="en")
+    assert build_footer_social_html(locale="en") == ""
+    assert "© 2027 Evolve Sprouts. All rights reserved." in html
 
 
 def test_build_free_intro_call_url_falls_back_to_contact_without_whatsapp(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Appends a centered line after the social links in the shared SES transactional footer (`footer_block_html`): **© \<UTC year\> Evolve Sprouts. All rights reserved.** Spacing uses `margin-top: 16px` so it sits one line below the social row. The year is taken at **send time** in **UTC** (`datetime.now(UTC).year`).

The copyright appears whether or not social links are present (still after the horizontal rule).

## Docs / tests

- `docs/architecture/aws-messaging.md` — note on shell footer content
- `tests/test_transactional_shell_data.py` — patched `datetime` for stable assertions + no-social case

## Checks

- `pytest tests/test_transactional_shell_data.py`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96c2be8b-406c-48fd-8dec-311bde1a1b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96c2be8b-406c-48fd-8dec-311bde1a1b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

