### PR TITLE
Underline media-download CTAs; use wa.me/<digits>?text for intro link

### DIFF
--- a/backend/src/app/templates/ses/media_download_link.py
+++ b/backend/src/app/templates/ses/media_download_link.py
@@ -10,7 +10,7 @@ _BUTTON = (
     "display:inline-block;padding:12px 24px;background:#C84A16;"
     "color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;"
 )
-_LINK = "color:#C84A16;font-weight:600;text-decoration:none;"
+_CALLOUT_LINK = "color:#C84A16;font-weight:600;text-decoration:underline;"
 _HR = '<hr style="border:none;border-top:1px solid #eeeeee;margin:24px 0;"/>'
 _SECTION_H2 = "margin:24px 0 10px 0;font-size:18px;line-height:1.35;font-weight:700;color:#333333;"
 _BOX = (
@@ -72,11 +72,11 @@ _LOCALE_ROWS: list[tuple[str, str, str, str, str]] = [
             f'<div style="{_BOX}">'
             f'<h3 style="{_BOX_H3}">Want hands-on support?</h3>'
             '<p style="margin:0 0 14px 0;">'
-            f'<a href="{{{{my_best_auntie_url}}}}" style="{_LINK}">My Best Auntie</a> '
+            f'<a href="{{{{my_best_auntie_url}}}}" style="{_CALLOUT_LINK}">My Best Auntie</a> '
             "is a 9-week Montessori training programme for domestic helpers — so your child gets "
             "consistent, confident care every day.</p>"
             '<p style="margin:0;">Or '
-            f'<a href="{{{{free_intro_call_url}}}}" style="{_LINK}">book a free intro call</a> '
+            f'<a href="{{{{free_intro_call_url}}}}" style="{_CALLOUT_LINK}">book a free intro call</a> '
             "to see what's right for your family.</p>"
             "</div>"
         ),
@@ -130,10 +130,10 @@ _LOCALE_ROWS: list[tuple[str, str, str, str, str]] = [
             f'<div style="{_BOX}">'
             f'<h3 style="{_BOX_H3}">需要实操支持？</h3>'
             '<p style="margin:0 0 14px 0;">'
-            f'<a href="{{{{my_best_auntie_url}}}}" style="{_LINK}">My Best Auntie</a> '
+            f'<a href="{{{{my_best_auntie_url}}}}" style="{_CALLOUT_LINK}">My Best Auntie</a> '
             "是一门为期 9 周、面向家政助手的蒙特梭利培训课程，帮助孩子每天获得稳定而自信的照护。</p>"
             '<p style="margin:0;">或 '
-            f'<a href="{{{{free_intro_call_url}}}}" style="{_LINK}">预约免费咨询通话</a>，'
+            f'<a href="{{{{free_intro_call_url}}}}" style="{_CALLOUT_LINK}">预约免费咨询通话</a>，'
             "一起看看哪种方式最适合您的家庭。</p>"
             "</div>"
         ),
@@ -185,10 +185,10 @@ _LOCALE_ROWS: list[tuple[str, str, str, str, str]] = [
             f'<div style="{_BOX}">'
             f'<h3 style="{_BOX_H3}">需要實操支援？</h3>'
             '<p style="margin:0 0 14px 0;">'
-            f'<a href="{{{{my_best_auntie_url}}}}" style="{_LINK}">My Best Auntie</a> '
+            f'<a href="{{{{my_best_auntie_url}}}}" style="{_CALLOUT_LINK}">My Best Auntie</a> '
             "是一門為期 9 週、面向家傭的蒙特梭利培訓課程，讓孩子每天獲得穩定而自信的照顧。</p>"
             '<p style="margin:0;">或 '
-            f'<a href="{{{{free_intro_call_url}}}}" style="{_LINK}">預約免費諮詢通話</a>，'
+            f'<a href="{{{{free_intro_call_url}}}}" style="{_CALLOUT_LINK}">預約免費諮詢通話</a>，'
             "一起看看哪種方式最適合您的家庭。</p>"
             "</div>"
         ),

--- a/backend/src/app/templates/transactional_shell_data.py
+++ b/backend/src/app/templates/transactional_shell_data.py
@@ -14,7 +14,7 @@ import html
 import os
 import re
 from typing import Any
-from urllib.parse import parse_qsl, quote, urlparse, urlencode, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 from app.templates.constants import (
     build_faq_url,
@@ -168,9 +168,22 @@ def build_my_best_auntie_training_page_url(*, locale: str) -> str:
 
 
 def build_free_intro_call_url(*, locale: str) -> str:
-    """WhatsApp deep link with intro-call prefill, or contact page if WhatsApp is unavailable."""
+    """WhatsApp ``wa.me/<digits>?text=...`` intro link, or contact page if unavailable.
+
+    Prefer ``build_whatsapp_phone_url()`` so the link matches other transactional
+    WhatsApp CTAs (digits path + ``text`` query). If the phone env var is empty
+    but ``PUBLIC_WWW_WHATSAPP_URL`` is already ``https://wa.me/<digits>``, use
+    that number with ``text``. Otherwise fall back to the contact page when a
+    digits-only ``wa.me`` URL cannot be built.
+    """
     loc = locale if locale in _ALLOWED_LOCALES else "en"
     prefill = _FREE_INTRO_WHATSAPP_PREFILL[loc]
+    encoded_prefill = quote(prefill, safe="")
+
+    phone_url = build_whatsapp_phone_url()
+    if phone_url:
+        return f"{phone_url}?text={encoded_prefill}"
+
     base_wa = resolve_whatsapp_url_for_template()
     if not base_wa:
         return _build_contact_us_page_url(locale=loc)
@@ -178,14 +191,17 @@ def build_free_intro_call_url(*, locale: str) -> str:
         parsed = urlparse(base_wa)
     except ValueError:
         return _build_contact_us_page_url(locale=loc)
-    pairs = [
-        (k, v)
-        for k, v in parse_qsl(parsed.query, keep_blank_values=True)
-        if k != "text"
-    ]
-    pairs.append(("text", prefill))
-    new_query = urlencode(pairs, safe="", quote_via=quote)
-    return urlunparse(parsed._replace(query=new_query))
+
+    host = (parsed.hostname or "").lower()
+    if host in ("wa.me", "www.wa.me"):
+        path = parsed.path.strip("/")
+        first_seg = path.split("/", 1)[0] if path else ""
+        if first_seg and not first_seg.lower().startswith("message"):
+            digits_only = re.sub(r"\D", "", first_seg)
+            if digits_only:
+                return f"https://wa.me/{digits_only}?text={encoded_prefill}"
+
+    return _build_contact_us_page_url(locale=loc)
 
 
 def _social_link_segment(*, href: str, label: str) -> str:

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -142,7 +142,8 @@ responsive while decoupling downstream processing.
   (`evolvesprouts-media-download-{locale}`) using `CONFIRMATION_EMAIL_FROM_ADDRESS`.
   The template includes follow-on guidance plus a highlighted “hands-on support”
   box; shell data supplies `my_best_auntie_url` (training course page) and
-  `free_intro_call_url` (WhatsApp prefill when configured, else contact page).
+  `free_intro_call_url` (`https://wa.me/<digits>?text=...` when a business phone
+  or digit `wa.me` path is configured; otherwise the localized contact page).
 - Syncs subscriber/tag to Mailchimp through `AwsApiProxyFunction` (during a
   **transition** period this may still run for all submissions; when
   `MailchimpRequireMarketingConsent` is `true`, subscribe + free-resource journey

--- a/tests/test_ses_media_download_templates.py
+++ b/tests/test_ses_media_download_templates.py
@@ -18,5 +18,6 @@ def test_media_download_ses_templates_preserve_handlebars_placeholders() -> None
     assert "{{free_intro_call_url}}" in en["HtmlPart"]
     assert "What you'll find inside" in en["HtmlPart"]
     assert "Want hands-on support?" in en["HtmlPart"]
+    assert "text-decoration:underline" in en["HtmlPart"]
     assert "{{my_best_auntie_url}}" in en["TextPart"]
     assert "{{free_intro_call_url}}" in en["TextPart"]

--- a/tests/test_transactional_shell_data.py
+++ b/tests/test_transactional_shell_data.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.templates.transactional_shell_data import (
     build_footer_social_html,
+    build_free_intro_call_url,
     build_transactional_template_shell_data,
     merge_transactional_shell_template_data,
     normalize_optional_absolute_url,
@@ -108,8 +109,7 @@ def test_build_transactional_template_shell_data_footer(
     assert data["my_best_auntie_url"] == (
         f"https://www.example.com/{locale}/services/my-best-auntie-training-course"
     )
-    assert data["free_intro_call_url"].startswith("https://wa.me/")
-    assert "text=" in data["free_intro_call_url"]
+    assert data["free_intro_call_url"].startswith(_TEST_PHONE_WA_URL + "?text=")
     assert expect_fragment in data["footer_block_html"]
     assert "Instagram" in data["footer_block_html"]
     assert "https://www.instagram.com/evolvesprouts" in data["footer_block_html"]
@@ -125,6 +125,38 @@ def test_build_free_intro_call_url_falls_back_to_contact_without_whatsapp(
     monkeypatch.delenv("NEXT_PUBLIC_BUSINESS_PHONE_NUMBER", raising=False)
     data = build_transactional_template_shell_data(locale="zh-CN")
     assert data["free_intro_call_url"] == "https://www.example.com/zh-CN/contact-us"
+
+
+def test_build_free_intro_call_url_prefers_phone_digits_path(monkeypatch: Any) -> None:
+    """Intro link uses ``wa.me/<digits>?text=`` like other WhatsApp CTAs."""
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", _TEST_PHONE)
+    monkeypatch.setenv("PUBLIC_WWW_WHATSAPP_URL", "https://wa.me/custom")
+    url = build_free_intro_call_url(locale="en")
+    assert url.startswith(_TEST_PHONE_WA_URL + "?text=")
+    assert "custom" not in url
+
+
+def test_build_free_intro_call_url_digits_from_wa_me_path_without_phone(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_BUSINESS_PHONE_NUMBER", raising=False)
+    monkeypatch.setenv("PUBLIC_WWW_WHATSAPP_URL", "https://wa.me/85291234567")
+    url = build_free_intro_call_url(locale="en")
+    assert url.startswith("https://wa.me/85291234567?text=")
+
+
+def test_build_free_intro_call_url_message_short_link_without_phone_falls_back(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("PUBLIC_WWW_BASE_URL", "https://www.example.com")
+    monkeypatch.setenv(
+        "PUBLIC_WWW_WHATSAPP_URL",
+        "https://wa.me/message/ZQHVW4DEORD5A1?src=qr",
+    )
+    monkeypatch.delenv("PUBLIC_WWW_BUSINESS_PHONE_NUMBER", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_BUSINESS_PHONE_NUMBER", raising=False)
+    assert build_free_intro_call_url(locale="en") == "https://www.example.com/en/contact-us"
 
 
 def test_merge_transactional_shell_template_data_order(monkeypatch: Any) -> None:


### PR DESCRIPTION
- Callout links use text-decoration:underline
- free_intro_call_url prefers build_whatsapp_phone_url + ?text=; else digits from wa.me path; contact page if no digits URL can be built
- Tests and aws-messaging note updated