### PR TITLE
Public www: submit-time validation, field errors, captcha labels

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
@@ -7,16 +7,25 @@ interface ReservationFormFieldsProps {
   email: string;
   phone: string;
   interestedTopics: string;
+  hasFullNameError: boolean;
   hasEmailError: boolean;
+  hasPhoneError: boolean;
+  hasTopicsError: boolean;
   topicsFieldConfig?: BookingTopicsFieldConfig;
   onFullNameChange: (value: string) => void;
+  onFullNameBlur: () => void;
   onEmailChange: (value: string) => void;
   onEmailBlur: () => void;
   onPhoneChange: (value: string) => void;
+  onPhoneBlur: () => void;
   onTopicsChange: (value: string) => void;
+  onTopicsBlur: () => void;
 }
 
-const EMAIL_ERROR_MESSAGE_ID = 'booking-modal-email-error-message';
+export const BOOKING_FULL_NAME_ERROR_MESSAGE_ID = 'booking-modal-full-name-error-message';
+export const BOOKING_EMAIL_ERROR_MESSAGE_ID = 'booking-modal-email-error-message';
+export const BOOKING_PHONE_ERROR_MESSAGE_ID = 'booking-modal-phone-error-message';
+export const BOOKING_TOPICS_ERROR_MESSAGE_ID = 'booking-modal-topics-error-message';
 
 export function ReservationFormFields({
   content,
@@ -24,13 +33,19 @@ export function ReservationFormFields({
   email,
   phone,
   interestedTopics,
+  hasFullNameError,
   hasEmailError,
+  hasPhoneError,
+  hasTopicsError,
   topicsFieldConfig,
   onFullNameChange,
+  onFullNameBlur,
   onEmailChange,
   onEmailBlur,
   onPhoneChange,
+  onPhoneBlur,
   onTopicsChange,
+  onTopicsBlur,
 }: ReservationFormFieldsProps) {
   const topicsFieldLabel = topicsFieldConfig?.label ?? content.topicsInterestLabel;
   const topicsFieldPlaceholder =
@@ -54,8 +69,20 @@ export function ReservationFormFields({
           onChange={(event) => {
             onFullNameChange(event.target.value);
           }}
-          className='es-focus-ring es-form-input'
+          onBlur={onFullNameBlur}
+          className={`es-focus-ring es-form-input ${hasFullNameError ? 'es-form-input-error' : ''}`}
+          aria-invalid={hasFullNameError}
+          aria-describedby={hasFullNameError ? BOOKING_FULL_NAME_ERROR_MESSAGE_ID : undefined}
         />
+        {hasFullNameError ? (
+          <p
+            id={BOOKING_FULL_NAME_ERROR_MESSAGE_ID}
+            className='es-form-field-error'
+            role='alert'
+          >
+            {content.fullNameRequiredError}
+          </p>
+        ) : null}
       </label>
       <label className='block'>
         <span className='mb-1 block text-sm font-semibold es-text-heading'>
@@ -75,11 +102,11 @@ export function ReservationFormFields({
           onBlur={onEmailBlur}
           className={`es-focus-ring es-form-input ${hasEmailError ? 'es-form-input-error' : ''}`}
           aria-invalid={hasEmailError}
-          aria-describedby={hasEmailError ? EMAIL_ERROR_MESSAGE_ID : undefined}
+          aria-describedby={hasEmailError ? BOOKING_EMAIL_ERROR_MESSAGE_ID : undefined}
         />
         {hasEmailError ? (
           <p
-            id={EMAIL_ERROR_MESSAGE_ID}
+            id={BOOKING_EMAIL_ERROR_MESSAGE_ID}
             className='es-form-field-error'
             role='alert'
           >
@@ -102,8 +129,20 @@ export function ReservationFormFields({
           onChange={(event) => {
             onPhoneChange(event.target.value);
           }}
-          className='es-focus-ring es-form-input'
+          onBlur={onPhoneBlur}
+          className={`es-focus-ring es-form-input ${hasPhoneError ? 'es-form-input-error' : ''}`}
+          aria-invalid={hasPhoneError}
+          aria-describedby={hasPhoneError ? BOOKING_PHONE_ERROR_MESSAGE_ID : undefined}
         />
+        {hasPhoneError ? (
+          <p
+            id={BOOKING_PHONE_ERROR_MESSAGE_ID}
+            className='es-form-field-error'
+            role='alert'
+          >
+            {content.phoneRequiredError}
+          </p>
+        ) : null}
       </label>
       <label className='block'>
         <span className='mb-1 block text-sm font-semibold es-text-heading'>
@@ -120,10 +159,22 @@ export function ReservationFormFields({
           onChange={(event) => {
             onTopicsChange(event.target.value);
           }}
+          onBlur={onTopicsBlur}
           placeholder={topicsFieldPlaceholder}
           rows={3}
-          className='es-focus-ring es-form-input resize-y'
+          className={`es-focus-ring es-form-input resize-y ${hasTopicsError ? 'es-form-input-error' : ''}`}
+          aria-invalid={hasTopicsError}
+          aria-describedby={hasTopicsError ? BOOKING_TOPICS_ERROR_MESSAGE_ID : undefined}
         />
+        {hasTopicsError ? (
+          <p
+            id={BOOKING_TOPICS_ERROR_MESSAGE_ID}
+            className='es-form-field-error'
+            role='alert'
+          >
+            {content.topicsRequiredError}
+          </p>
+        ) : null}
       </label>
     </>
   );

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -12,7 +12,13 @@ import {
 } from 'react';
 
 import { ReservationFormDiscountCodeInput } from '@/components/sections/booking-modal/reservation-form-discount-code-input';
-import { ReservationFormFields } from '@/components/sections/booking-modal/reservation-form-fields';
+import {
+  BOOKING_EMAIL_ERROR_MESSAGE_ID,
+  BOOKING_FULL_NAME_ERROR_MESSAGE_ID,
+  BOOKING_PHONE_ERROR_MESSAGE_ID,
+  BOOKING_TOPICS_ERROR_MESSAGE_ID,
+  ReservationFormFields,
+} from '@/components/sections/booking-modal/reservation-form-fields';
 import { ReservationFormPriceBreakdown } from '@/components/sections/booking-modal/reservation-form-price-breakdown';
 import { DiscountBadge, FpsQrCode } from '@/components/sections/booking-modal/shared';
 import type {
@@ -96,6 +102,7 @@ interface BookingReservationFormProps {
 
 const CAPTCHA_ERROR_MESSAGE_ID = 'booking-modal-captcha-error-message';
 const SUBMIT_ERROR_MESSAGE_ID = 'booking-modal-submit-error-message';
+const ACKNOWLEDGEMENT_ERROR_MESSAGE_ID = 'booking-modal-acknowledgement-error-message';
 const FPS_ICON_SOURCE = '/images/fps-logo.svg';
 const BANK_ICON_SOURCE = '/images/bank.svg';
 const STRIPE_CARD_ICON_SOURCE = '/images/credit-cards.svg';
@@ -425,8 +432,12 @@ export function BookingReservationForm({
   const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '';
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
+  const [isFullNameTouched, setIsFullNameTouched] = useState(false);
   const [isEmailTouched, setIsEmailTouched] = useState(false);
   const [phone, setPhone] = useState('');
+  const [isPhoneTouched, setIsPhoneTouched] = useState(false);
+  const [isTopicsTouched, setIsTopicsTouched] = useState(false);
+  const [isAcknowledgementsTouched, setIsAcknowledgementsTouched] = useState(false);
   const [interestedTopics, setInterestedTopics] = useState(() => topicsPrefill.trim());
   const lastAppliedTopicsPrefillRef = useRef(topicsPrefill.trim());
   const [discountCode, setDiscountCode] = useState('');
@@ -509,7 +520,14 @@ export function BookingReservationForm({
   }, [totalAmount, selectedPaymentMethod]);
   const discountAmount = Math.max(0, originalAmount - totalAmount);
   const hasEmailError = isEmailTouched && !isValidEmail(email);
+  const hasFullNameError = isFullNameTouched && !sanitizeSingleLineValue(fullName);
+  const hasPhoneError = isPhoneTouched && !sanitizeSingleLineValue(phone);
   const isTopicsFieldRequired = topicsFieldConfig?.required ?? false;
+  const hasTopicsError =
+    isTopicsTouched && isTopicsFieldRequired && !interestedTopics.trim();
+  const hasAcknowledgementsError =
+    isAcknowledgementsTouched &&
+    (!hasPendingReservationAcknowledgement || !hasTermsAgreement);
   const normalizedStartDateTime = sanitizeSingleLineValue(selectedDateStartTime);
   const normalizedCohortDate =
     (normalizedStartDateTime.split('T')[0] ?? '') ||
@@ -552,6 +570,11 @@ export function BookingReservationForm({
     },
   );
   const submitButtonDescribedByParts = [
+    hasFullNameError ? BOOKING_FULL_NAME_ERROR_MESSAGE_ID : null,
+    hasEmailError ? BOOKING_EMAIL_ERROR_MESSAGE_ID : null,
+    hasPhoneError ? BOOKING_PHONE_ERROR_MESSAGE_ID : null,
+    hasTopicsError ? BOOKING_TOPICS_ERROR_MESSAGE_ID : null,
+    hasAcknowledgementsError ? ACKNOWLEDGEMENT_ERROR_MESSAGE_ID : null,
     captchaErrorMessage ? CAPTCHA_ERROR_MESSAGE_ID : null,
     submitErrorMessage ? SUBMIT_ERROR_MESSAGE_ID : null,
   ].filter((id): id is string => id !== null);
@@ -560,14 +583,6 @@ export function BookingReservationForm({
       ? submitButtonDescribedByParts.join(' ')
       : undefined;
   const isSubmitDisabled =
-    !fullName.trim() ||
-    !email.trim() ||
-    hasEmailError ||
-    !phone.trim() ||
-    (isTopicsFieldRequired && !interestedTopics.trim()) ||
-    !hasPendingReservationAcknowledgement ||
-    !hasTermsAgreement ||
-    !captchaToken ||
     isCaptchaUnavailable ||
     (isStripePaymentMethodSelected && (isStripePaymentIntentLoading || !isStripeReady)) ||
     isSubmitting;
@@ -739,7 +754,13 @@ export function BookingReservationForm({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    setIsFullNameTouched(true);
     setIsEmailTouched(true);
+    setIsPhoneTouched(true);
+    if (isTopicsFieldRequired) {
+      setIsTopicsTouched(true);
+    }
+    setIsAcknowledgementsTouched(true);
     markCaptchaTouched();
     clearSubmissionError();
 
@@ -759,7 +780,18 @@ export function BookingReservationForm({
       },
     });
 
-    if (!isValidEmail(email)) {
+    const normalizedFullName = sanitizeSingleLineValue(fullName);
+    const normalizedPhone = sanitizeSingleLineValue(phone);
+    const hasFieldErrors =
+      !normalizedFullName ||
+      !isValidEmail(email) ||
+      !normalizedPhone ||
+      (isTopicsFieldRequired && !interestedTopics.trim()) ||
+      !hasPendingReservationAcknowledgement ||
+      !hasTermsAgreement ||
+      !captchaToken;
+
+    if (hasFieldErrors) {
       trackPublicFormOutcome('booking_submit_error', {
         formKind: 'reservation',
         formId: BOOKING_RESERVATION_FORM_ANALYTICS_ID,
@@ -775,11 +807,45 @@ export function BookingReservationForm({
       });
       return;
     }
-    if (
-      !selectedCohortDateLabel ||
-      (isTopicsFieldRequired && !interestedTopics.trim()) ||
-      isSubmitDisabled
-    ) {
+
+    if (isSubmitting) {
+      return;
+    }
+    if (isCaptchaUnavailable) {
+      trackPublicFormOutcome('booking_submit_error', {
+        formKind: 'reservation',
+        formId: BOOKING_RESERVATION_FORM_ANALYTICS_ID,
+        sectionId: analyticsSectionId,
+        ctaLocation: 'reservation_form',
+        params: {
+          payment_method: selectedPaymentMethod,
+          age_group: selectedAgeGroupLabel,
+          cohort_date: normalizedCohortDate,
+          total_amount: totalAmount,
+          error_type: 'service_unavailable',
+        },
+      });
+      return;
+    }
+    if (isStripePaymentMethodSelected && (isStripePaymentIntentLoading || !isStripeReady)) {
+      trackPublicFormOutcome('booking_submit_error', {
+        formKind: 'reservation',
+        formId: BOOKING_RESERVATION_FORM_ANALYTICS_ID,
+        sectionId: analyticsSectionId,
+        ctaLocation: 'reservation_form',
+        params: {
+          payment_method: selectedPaymentMethod,
+          age_group: selectedAgeGroupLabel,
+          cohort_date: normalizedCohortDate,
+          total_amount: totalAmount,
+          error_type: 'validation_error',
+        },
+      });
+      setSubmissionError(content.submitErrorMessage);
+      return;
+    }
+
+    if (!selectedCohortDateLabel) {
       trackPublicFormOutcome('booking_submit_error', {
         formKind: 'reservation',
         formId: BOOKING_RESERVATION_FORM_ANALYTICS_ID,
@@ -861,23 +927,6 @@ export function BookingReservationForm({
           cohort_date: normalizedCohortDate,
           total_amount: totalAmount,
           error_type: 'service_unavailable',
-        },
-      });
-      setSubmissionError(content.submitErrorMessage);
-      return;
-    }
-    if (isStripePaymentMethodSelected && !isStripeReady) {
-      trackPublicFormOutcome('booking_submit_error', {
-        formKind: 'reservation',
-        formId: BOOKING_RESERVATION_FORM_ANALYTICS_ID,
-        sectionId: analyticsSectionId,
-        ctaLocation: 'reservation_form',
-        params: {
-          payment_method: selectedPaymentMethod,
-          age_group: selectedAgeGroupLabel,
-          cohort_date: normalizedCohortDate,
-          total_amount: totalAmount,
-          error_type: 'validation_error',
         },
       });
       setSubmissionError(content.submitErrorMessage);
@@ -1059,15 +1108,27 @@ export function BookingReservationForm({
             email={email}
             phone={phone}
             interestedTopics={interestedTopics}
+            hasFullNameError={hasFullNameError}
             hasEmailError={hasEmailError}
+            hasPhoneError={hasPhoneError}
+            hasTopicsError={hasTopicsError}
             topicsFieldConfig={topicsFieldConfig}
             onFullNameChange={setFullName}
+            onFullNameBlur={() => {
+              setIsFullNameTouched(true);
+            }}
             onEmailChange={setEmail}
             onEmailBlur={() => {
               setIsEmailTouched(true);
             }}
             onPhoneChange={setPhone}
+            onPhoneBlur={() => {
+              setIsPhoneTouched(true);
+            }}
             onTopicsChange={setInterestedTopics}
+            onTopicsBlur={() => {
+              setIsTopicsTouched(true);
+            }}
           />
 
           <ReservationFormDiscountCodeInput
@@ -1348,7 +1409,7 @@ export function BookingReservationForm({
           </div>
 
           <div data-booking-acknowledgements='true' className='space-y-2'>
-            <label className='flex items-start gap-2.5 py-1'>
+            <label className='flex cursor-pointer items-start gap-2.5 py-1'>
               <input
                 type='checkbox'
                 required
@@ -1366,7 +1427,7 @@ export function BookingReservationForm({
               </span>
             </label>
 
-            <label className='flex items-start gap-2.5 py-1'>
+            <label className='flex cursor-pointer items-start gap-2.5 py-1'>
               <input
                 type='checkbox'
                 required
@@ -1394,7 +1455,7 @@ export function BookingReservationForm({
               </span>
             </label>
 
-            <label className='flex items-start gap-2.5 py-1'>
+            <label className='flex cursor-pointer items-start gap-2.5 py-1'>
               <input
                 type='checkbox'
                 checked={marketingOptIn}
@@ -1407,6 +1468,15 @@ export function BookingReservationForm({
                 {content.marketingOptInLabel}
               </span>
             </label>
+            {hasAcknowledgementsError ? (
+              <p
+                id={ACKNOWLEDGEMENT_ERROR_MESSAGE_ID}
+                className='es-form-field-error'
+                role='alert'
+              >
+                {content.acknowledgementRequiredError}
+              </p>
+            ) : null}
           </div>
 
           <label className='relative z-20 block overflow-visible'>

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -754,6 +754,9 @@ export function BookingReservationForm({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (isSubmitting) {
+      return;
+    }
     setIsFullNameTouched(true);
     setIsEmailTouched(true);
     setIsPhoneTouched(true);
@@ -788,8 +791,7 @@ export function BookingReservationForm({
       !normalizedPhone ||
       (isTopicsFieldRequired && !interestedTopics.trim()) ||
       !hasPendingReservationAcknowledgement ||
-      !hasTermsAgreement ||
-      !captchaToken;
+      !hasTermsAgreement;
 
     if (hasFieldErrors) {
       trackPublicFormOutcome('booking_submit_error', {
@@ -808,9 +810,6 @@ export function BookingReservationForm({
       return;
     }
 
-    if (isSubmitting) {
-      return;
-    }
     if (isCaptchaUnavailable) {
       trackPublicFormOutcome('booking_submit_error', {
         formKind: 'reservation',
@@ -823,6 +822,22 @@ export function BookingReservationForm({
           cohort_date: normalizedCohortDate,
           total_amount: totalAmount,
           error_type: 'service_unavailable',
+        },
+      });
+      return;
+    }
+    if (!captchaToken) {
+      trackPublicFormOutcome('booking_submit_error', {
+        formKind: 'reservation',
+        formId: BOOKING_RESERVATION_FORM_ANALYTICS_ID,
+        sectionId: analyticsSectionId,
+        ctaLocation: 'reservation_form',
+        params: {
+          payment_method: selectedPaymentMethod,
+          age_group: selectedAgeGroupLabel,
+          cohort_date: normalizedCohortDate,
+          total_amount: totalAmount,
+          error_type: 'validation_error',
         },
       });
       return;
@@ -1454,6 +1469,15 @@ export function BookingReservationForm({
                 </span>
               </span>
             </label>
+            {hasAcknowledgementsError ? (
+              <p
+                id={ACKNOWLEDGEMENT_ERROR_MESSAGE_ID}
+                className='es-form-field-error'
+                role='alert'
+              >
+                {content.acknowledgementRequiredError}
+              </p>
+            ) : null}
 
             <label className='flex cursor-pointer items-start gap-2.5 py-1'>
               <input
@@ -1468,15 +1492,6 @@ export function BookingReservationForm({
                 {content.marketingOptInLabel}
               </span>
             </label>
-            {hasAcknowledgementsError ? (
-              <p
-                id={ACKNOWLEDGEMENT_ERROR_MESSAGE_ID}
-                className='es-form-field-error'
-                role='alert'
-              >
-                {content.acknowledgementRequiredError}
-              </p>
-            ) : null}
           </div>
 
           <label className='relative z-20 block overflow-visible'>

--- a/apps/public_www/src/components/sections/contact-us-form-fields.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form-fields.tsx
@@ -20,6 +20,7 @@ const MESSAGE_MAX_LENGTH = 5000;
 const EMAIL_ERROR_MESSAGE_ID = 'contact-us-form-email-error';
 const PHONE_ERROR_MESSAGE_ID = 'contact-us-form-phone-error';
 const FIRST_NAME_ERROR_MESSAGE_ID = 'contact-us-form-first-name-error';
+const MESSAGE_ERROR_MESSAGE_ID = 'contact-us-form-message-error';
 const CAPTCHA_ERROR_MESSAGE_ID = 'contact-us-form-captcha-error';
 const SUBMIT_ERROR_MESSAGE_ID = 'contact-us-form-submit-error';
 
@@ -29,6 +30,7 @@ interface ContactFormFieldsProps {
   hasEmailError: boolean;
   hasPhoneError: boolean;
   hasFirstNameError: boolean;
+  hasMessageError: boolean;
   marketingOptIn: boolean;
   captchaErrorMessage: string;
   submitErrorMessage: string;
@@ -40,6 +42,7 @@ interface ContactFormFieldsProps {
   onEmailBlur: () => void;
   onPhoneBlur: () => void;
   onFirstNameBlur: () => void;
+  onMessageBlur: () => void;
   onMarketingOptInChange: (checked: boolean) => void;
   onCaptchaTokenChange: (token: string | null) => void;
   onCaptchaLoadError: () => void;
@@ -51,6 +54,7 @@ export function ContactFormFields({
   hasEmailError,
   hasPhoneError,
   hasFirstNameError,
+  hasMessageError,
   marketingOptIn,
   captchaErrorMessage,
   submitErrorMessage,
@@ -62,11 +66,16 @@ export function ContactFormFields({
   onEmailBlur,
   onPhoneBlur,
   onFirstNameBlur,
+  onMessageBlur,
   onMarketingOptInChange,
   onCaptchaTokenChange,
   onCaptchaLoadError,
 }: ContactFormFieldsProps) {
   const submitButtonDescribedByParts = [
+    hasFirstNameError ? FIRST_NAME_ERROR_MESSAGE_ID : null,
+    hasEmailError ? EMAIL_ERROR_MESSAGE_ID : null,
+    hasPhoneError ? PHONE_ERROR_MESSAGE_ID : null,
+    hasMessageError ? MESSAGE_ERROR_MESSAGE_ID : null,
     captchaErrorMessage ? CAPTCHA_ERROR_MESSAGE_ID : null,
     submitErrorMessage ? SUBMIT_ERROR_MESSAGE_ID : null,
   ].filter((id): id is string => id !== null);
@@ -151,7 +160,7 @@ export function ContactFormFields({
             onUpdateField('phone', event.target.value);
           }}
           onBlur={onPhoneBlur}
-          className='es-focus-ring es-form-input'
+          className={`es-focus-ring es-form-input ${hasPhoneError ? 'es-form-input-error' : ''}`}
           aria-invalid={hasPhoneError}
           aria-describedby={hasPhoneError ? PHONE_ERROR_MESSAGE_ID : undefined}
         />
@@ -181,9 +190,21 @@ export function ContactFormFields({
           onChange={(event) => {
             onUpdateField('message', event.target.value);
           }}
+          onBlur={onMessageBlur}
           placeholder={content.messagePlaceholder}
-          className='es-focus-ring es-form-input min-h-[152px] resize-y'
+          className={`es-focus-ring es-form-input min-h-[152px] resize-y ${hasMessageError ? 'es-form-input-error' : ''}`}
+          aria-invalid={hasMessageError}
+          aria-describedby={hasMessageError ? MESSAGE_ERROR_MESSAGE_ID : undefined}
         />
+        {hasMessageError ? (
+          <p
+            id={MESSAGE_ERROR_MESSAGE_ID}
+            className='es-form-field-error'
+            role='alert'
+          >
+            {content.messageRequiredError}
+          </p>
+        ) : null}
       </label>
 
       <MarketingOptInCheckbox

--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -70,6 +70,7 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
   const [isEmailTouched, setIsEmailTouched] = useState(false);
   const [isPhoneTouched, setIsPhoneTouched] = useState(false);
   const [isFirstNameTouched, setIsFirstNameTouched] = useState(false);
+  const [isMessageTouched, setIsMessageTouched] = useState(false);
   const [marketingOptIn, setMarketingOptIn] = useState(false);
   const {
     captchaToken,
@@ -95,6 +96,7 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
   const hasPhoneError = isPhoneTouched && !isValidPhone(formState.phone);
   const hasFirstNameError =
     isFirstNameTouched && !sanitizeSingleLineValue(formState.firstName);
+  const hasMessageError = isMessageTouched && !sanitizeMultilineValue(formState.message);
   const captchaErrorMessage = resolveCaptchaErrorMessage(
     {
       isCaptchaConfigured,
@@ -131,12 +133,14 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
     setIsEmailTouched(true);
     setIsPhoneTouched(true);
     setIsFirstNameTouched(true);
+    setIsMessageTouched(true);
     markCaptchaTouched();
 
     if (
       !sanitizeSingleLineValue(formState.firstName) ||
       !isValidEmail(formState.email) ||
-      !isValidPhone(formState.phone)
+      !isValidPhone(formState.phone) ||
+      !sanitizeMultilineValue(formState.message)
     ) {
       trackPublicFormOutcome('contact_form_submit_error', {
         formKind: 'contact',
@@ -358,6 +362,7 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
                 hasEmailError={hasEmailError}
                 hasPhoneError={hasPhoneError}
                 hasFirstNameError={hasFirstNameError}
+                hasMessageError={hasMessageError}
                 marketingOptIn={marketingOptIn}
                 captchaErrorMessage={captchaErrorMessage}
                 submitErrorMessage={submitErrorMessage}
@@ -374,6 +379,9 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
                 }}
                 onFirstNameBlur={() => {
                   setIsFirstNameTouched(true);
+                }}
+                onMessageBlur={() => {
+                  setIsMessageTouched(true);
                 }}
                 onMarketingOptInChange={setMarketingOptIn}
                 onCaptchaTokenChange={handleCaptchaTokenChange}

--- a/apps/public_www/src/components/sections/event-notification.tsx
+++ b/apps/public_www/src/components/sections/event-notification.tsx
@@ -78,6 +78,7 @@ export function EventNotification({
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const submitCtaLabel = content.formSubmitLabel ?? content.ctaLabel;
   const submitLoadingLabel = commonFormActionsContent.submittingLabel;
+  const captchaLabel = commonCaptchaContent.captchaLabel;
 
   const captchaErrorMessage = resolveCaptchaErrorMessage(
     {
@@ -324,17 +325,22 @@ export function EventNotification({
                           {content.emailValidationMessage}
                         </p>
                       ) : null}
-                      <TurnstileCaptcha
-                        siteKey={turnstileSiteKey}
-                        widgetAction='event_notification_submit'
-                        onTokenChange={handleCaptchaTokenChange}
-                        onLoadError={() => {
-                          handleCaptchaLoadError();
-                          setSubmissionError(
-                            content.captchaLoadError ?? commonCaptchaContent.loadError,
-                          );
-                        }}
-                      />
+                      <label className='block'>
+                        <span className='mb-1 block text-sm font-semibold es-text-heading'>
+                          {captchaLabel}
+                        </span>
+                        <TurnstileCaptcha
+                          siteKey={turnstileSiteKey}
+                          widgetAction='event_notification_submit'
+                          onTokenChange={handleCaptchaTokenChange}
+                          onLoadError={() => {
+                            handleCaptchaLoadError();
+                            setSubmissionError(
+                              content.captchaLoadError ?? commonCaptchaContent.loadError,
+                            );
+                          }}
+                        />
+                      </label>
                       {captchaErrorMessage ? (
                         <p
                           id={CAPTCHA_ERROR_MESSAGE_ID}

--- a/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
+++ b/apps/public_www/src/components/sections/free-guides-and-resources-library.tsx
@@ -305,6 +305,7 @@ export function FreeGuidesAndResourcesLibrary({
   const mediaFormCaptchaLoadError = mediaFormContent.formCaptchaLoadError;
   const mediaFormCaptchaUnavailableError =
     mediaFormContent.formCaptchaUnavailableError;
+  const mediaFormCaptchaLabel = mediaFormContent.formCaptchaLabel;
 
   const listBody = (() => {
     if (loadState === 'loading') {
@@ -427,6 +428,7 @@ export function FreeGuidesAndResourcesLibrary({
                     formCaptchaRequiredError={mediaFormCaptchaRequiredError}
                     formCaptchaLoadError={mediaFormCaptchaLoadError}
                     formCaptchaUnavailableError={mediaFormCaptchaUnavailableError}
+                    formCaptchaLabel={mediaFormCaptchaLabel}
                     ctaButtonClassName='es-btn--outline'
                     className='mt-6 w-full sm:w-fit'
                     onFormOpened={() => {

--- a/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
+++ b/apps/public_www/src/components/sections/free-resources-for-gentle-parenting.tsx
@@ -56,6 +56,7 @@ interface ResourceCardContentProps {
   formCaptchaRequiredError: string;
   formCaptchaLoadError: string;
   formCaptchaUnavailableError: string;
+  formCaptchaLabel: string;
   locale: Locale;
   showChecklist: boolean;
   onFormOpened: () => void;
@@ -203,6 +204,7 @@ function ResourceCardContent({
   formCaptchaRequiredError,
   formCaptchaLoadError,
   formCaptchaUnavailableError,
+  formCaptchaLabel,
   locale,
   showChecklist,
   onFormOpened,
@@ -259,6 +261,7 @@ function ResourceCardContent({
         formCaptchaRequiredError={formCaptchaRequiredError}
         formCaptchaLoadError={formCaptchaLoadError}
         formCaptchaUnavailableError={formCaptchaUnavailableError}
+        formCaptchaLabel={formCaptchaLabel}
         onFormOpened={onFormOpened}
       />
     </>
@@ -316,6 +319,9 @@ export function FreeResourcesForGentleParenting({
   const formCaptchaUnavailableError =
     readOptionalText(content.formCaptchaUnavailableError) ??
     fallbackResourcesContent.formCaptchaUnavailableError;
+  const formCaptchaLabel =
+    readOptionalText(content.formCaptchaLabel) ??
+    fallbackResourcesContent.formCaptchaLabel;
   const checklistItems = resolveChecklistItems(content.items);
   const mediaTitleLine1 =
     readOptionalText(content.mediaTitleLine1) ??
@@ -359,6 +365,7 @@ export function FreeResourcesForGentleParenting({
       formCaptchaRequiredError={formCaptchaRequiredError}
       formCaptchaLoadError={formCaptchaLoadError}
       formCaptchaUnavailableError={formCaptchaUnavailableError}
+      formCaptchaLabel={formCaptchaLabel}
       locale={locale}
       showChecklist={!hasOpenedMediaForm}
       onFormOpened={() => {

--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -38,6 +38,7 @@ interface MediaFormProps {
   formCaptchaRequiredError: string;
   formCaptchaLoadError: string;
   formCaptchaUnavailableError: string;
+  formCaptchaLabel: string;
   resourceKey?: string;
   className?: string;
   /** Extra classes for the closed-state CTA (e.g. `es-btn--outline` for primary outline). */
@@ -74,6 +75,7 @@ export function MediaForm({
   formCaptchaRequiredError,
   formCaptchaLoadError,
   formCaptchaUnavailableError,
+  formCaptchaLabel,
   resourceKey,
   className,
   ctaButtonClassName,
@@ -383,12 +385,17 @@ export function MediaForm({
         onChange={setMarketingOptIn}
       />
 
-      <TurnstileCaptcha
-        siteKey={turnstileSiteKey}
-        widgetAction='media_submit'
-        onTokenChange={handleCaptchaTokenChange}
-        onLoadError={handleCaptchaLoadError}
-      />
+      <label className='block'>
+        <span className='mb-1 block text-sm font-semibold es-text-heading'>
+          {formCaptchaLabel}
+        </span>
+        <TurnstileCaptcha
+          siteKey={turnstileSiteKey}
+          widgetAction='media_submit'
+          onTokenChange={handleCaptchaTokenChange}
+          onLoadError={handleCaptchaLoadError}
+        />
+      </label>
 
       {captchaErrorMessage ? (
         <p id={captchaErrorId} className='es-form-submit-error' role='alert'>

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -79,6 +79,7 @@ export function SproutsSquadCommunity({
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const submitCtaLabel = content.formSubmitLabel ?? content.ctaLabel;
   const submitLoadingLabel = commonFormActionsContent.submittingLabel;
+  const captchaLabel = commonCaptchaContent.captchaLabel;
 
   const captchaErrorMessage = resolveCaptchaErrorMessage(
     {
@@ -332,17 +333,22 @@ export function SproutsSquadCommunity({
                           {content.emailValidationMessage}
                         </p>
                       ) : null}
-                      <TurnstileCaptcha
-                        siteKey={turnstileSiteKey}
-                        widgetAction='sprouts_squad_community_submit'
-                        onTokenChange={handleCaptchaTokenChange}
-                        onLoadError={() => {
-                          handleCaptchaLoadError();
-                          setSubmissionError(
-                            content.captchaLoadError ?? commonCaptchaContent.loadError,
-                          );
-                        }}
-                      />
+                      <label className='block'>
+                        <span className='mb-1 block text-sm font-semibold es-text-heading'>
+                          {captchaLabel}
+                        </span>
+                        <TurnstileCaptcha
+                          siteKey={turnstileSiteKey}
+                          widgetAction='sprouts_squad_community_submit'
+                          onTokenChange={handleCaptchaTokenChange}
+                          onLoadError={() => {
+                            handleCaptchaLoadError();
+                            setSubmissionError(
+                              content.captchaLoadError ?? commonCaptchaContent.loadError,
+                            );
+                          }}
+                        />
+                      </label>
                       {captchaErrorMessage ? (
                         <p
                           id={CAPTCHA_ERROR_MESSAGE_ID}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -187,6 +187,7 @@
     "formCaptchaRequiredError": "Please complete CAPTCHA verification before submitting.",
     "formCaptchaLoadError": "CAPTCHA failed to load. Please refresh and try again.",
     "formCaptchaUnavailableError": "CAPTCHA is temporarily unavailable. Please try again later.",
+    "formCaptchaLabel": "Verification",
     "formMarketingOptInLabel": "Keep me updated with parenting tips and resources",
     "sectionConfig": {
       "_comment": "Template config for free resources section layout.",
@@ -363,6 +364,7 @@
       "emailValidationError": "Please enter a valid email address.",
       "phoneValidationError": "Please enter a valid phone number.",
       "firstNameRequiredError": "Please enter your name",
+      "messageRequiredError": "Please enter your message.",
       "marketingOptInLabel": "Keep me updated with parenting tips and resources"
     },
     "faq": {
@@ -1018,6 +1020,7 @@
       "sliderLabelTemplate": "{title} slider"
     },
     "captcha": {
+      "captchaLabel": "Verification",
       "requiredError": "Please complete CAPTCHA verification before submitting.",
       "loadError": "CAPTCHA failed to load. Please refresh and try again.",
       "unavailableError": "CAPTCHA is temporarily unavailable. Please try again later."
@@ -1423,10 +1426,13 @@
       "reservationDescription": "Please complete your details. We will send payment confirmation by email.",
       "selectedAgeGroupLabel": "Child age group",
       "fullNameLabel": "Full Name",
+      "fullNameRequiredError": "Please enter your full name.",
       "emailLabel": "Email",
       "phoneLabel": "Phone Number",
+      "phoneRequiredError": "Please enter your phone number.",
       "topicsInterestLabel": "Anything you'd like me to know about your child or helper before we start?",
       "topicsInterestPlaceholder": "i.e. My daughter is 2, our helper has been with us for a year",
+      "topicsRequiredError": "Please share what you'd like to discuss.",
       "paymentMethodLabel": "Payment options",
       "paymentMethodValue": "Pay via FPS QR",
       "paymentFpsQrInstruction": "Scan this FPS QR code using your preferred banking app.",
@@ -1448,6 +1454,7 @@
       "priceBreakdownConfirmedPriceLabel": "Confirmed Price",
       "paymentConfirmationNote": "Your spot is confirmed once payment is received",
       "pendingReservationAcknowledgementLabel": "I understand that my reservation is pending until payment is confirmed",
+      "acknowledgementRequiredError": "Please review and accept the required agreements.",
       "marketingOptInLabel": "Keep me updated with parenting tips and resources",
       "termsAgreementLabel": "I agree with the",
       "termsLinkLabel": "Terms & Conditions",

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -187,6 +187,7 @@
     "formCaptchaRequiredError": "提交前请先完成 CAPTCHA 验证。",
     "formCaptchaLoadError": "CAPTCHA 加载失败，请刷新页面后重试。",
     "formCaptchaUnavailableError": "CAPTCHA 暂时不可用，请稍后再试。",
+    "formCaptchaLabel": "验证",
     "formMarketingOptInLabel": "订阅育儿技巧与资源更新",
     "sectionConfig": {
       "_comment": "Template config for free resources section layout.",
@@ -363,6 +364,7 @@
       "emailValidationError": "请输入有效的邮箱地址。",
       "phoneValidationError": "请输入有效的电话号码。",
       "firstNameRequiredError": "请输入您的姓名",
+      "messageRequiredError": "请输入你的留言。",
       "marketingOptInLabel": "订阅育儿技巧与资源更新"
     },
     "faq": {
@@ -1018,6 +1020,7 @@
       "sliderLabelTemplate": "{title}滑动内容"
     },
     "captcha": {
+      "captchaLabel": "验证",
       "requiredError": "提交前请先完成 CAPTCHA 验证。",
       "loadError": "CAPTCHA 加载失败，请刷新页面后重试。",
       "unavailableError": "CAPTCHA 暂时不可用，请稍后再试。"
@@ -1423,10 +1426,13 @@
       "reservationDescription": "请填写你的信息，我们会通过邮箱发送付款确认。",
       "selectedAgeGroupLabel": "孩子年龄组",
       "fullNameLabel": "姓名",
+      "fullNameRequiredError": "请输入你的全名。",
       "emailLabel": "邮箱",
       "phoneLabel": "电话号码",
+      "phoneRequiredError": "请输入你的电话号码。",
       "topicsInterestLabel": "开始前，你希望我先了解你家孩子或阿姨的哪些情况？",
       "topicsInterestPlaceholder": "例如：我女儿 2 岁，我们家阿姨已经照顾我们一年了。",
+      "topicsRequiredError": "请告诉我们你想讨论的内容。",
       "paymentMethodLabel": "付款方式",
       "paymentMethodValue": "通过 FPS 二维码付款",
       "paymentFpsQrInstruction": "请使用你常用的银行应用扫描此 FPS 二维码。",
@@ -1448,6 +1454,7 @@
       "priceBreakdownConfirmedPriceLabel": "确认价格",
       "paymentConfirmationNote": "收到付款后，你的名额才会确认",
       "pendingReservationAcknowledgementLabel": "我明白在付款确认前，我的预约仍处于待确认状态",
+      "acknowledgementRequiredError": "请阅读并同意必填条款。",
       "marketingOptInLabel": "订阅育儿技巧与资源更新",
       "termsAgreementLabel": "我同意",
       "termsLinkLabel": "条款与细则",

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -187,6 +187,7 @@
     "formCaptchaRequiredError": "提交前請先完成 CAPTCHA 驗證。",
     "formCaptchaLoadError": "CAPTCHA 載入失敗，請重新整理頁面後再試。",
     "formCaptchaUnavailableError": "CAPTCHA 暫時不可用，請稍後再試。",
+    "formCaptchaLabel": "驗證",
     "formMarketingOptInLabel": "訂閱育兒貼士與資源更新",
     "sectionConfig": {
       "_comment": "Template config for free resources section layout.",
@@ -363,6 +364,7 @@
       "emailValidationError": "請輸入有效的電郵地址。",
       "phoneValidationError": "請輸入有效的電話號碼。",
       "firstNameRequiredError": "請輸入你的姓名",
+      "messageRequiredError": "請輸入你的留言。",
       "marketingOptInLabel": "訂閱育兒貼士與資源更新"
     },
     "faq": {
@@ -1018,6 +1020,7 @@
       "sliderLabelTemplate": "{title}滑動內容"
     },
     "captcha": {
+      "captchaLabel": "驗證",
       "requiredError": "提交前請先完成 CAPTCHA 驗證。",
       "loadError": "CAPTCHA 載入失敗，請重新整理頁面後再試。",
       "unavailableError": "CAPTCHA 暫時不可用，請稍後再試。"
@@ -1423,10 +1426,13 @@
       "reservationDescription": "請填寫你的資料，我們會以電郵發送付款確認。",
       "selectedAgeGroupLabel": "小朋友年齡組別",
       "fullNameLabel": "姓名",
+      "fullNameRequiredError": "請輸入你的全名。",
       "emailLabel": "電郵",
       "phoneLabel": "電話號碼",
+      "phoneRequiredError": "請輸入你的電話號碼。",
       "topicsInterestLabel": "開始前，你想我先了解你的小朋友或姐姐哪些情況？",
       "topicsInterestPlaceholder": "例如：我女兒 2 歲，我們的姐姐已經照顧我們一年。",
+      "topicsRequiredError": "請告訴我們你想討論的內容。",
       "paymentMethodLabel": "付款方式",
       "paymentMethodValue": "以 FPS 二維碼付款",
       "paymentFpsQrInstruction": "使用你常用的銀行應用程式掃描此 FPS 二維碼。",
@@ -1448,6 +1454,7 @@
       "priceBreakdownConfirmedPriceLabel": "確認價格",
       "paymentConfirmationNote": "收到付款後，你的名額才會確認",
       "pendingReservationAcknowledgementLabel": "我明白在付款確認前，我的預約仍屬待確認狀態",
+      "acknowledgementRequiredError": "請閱讀並同意必填條款。",
       "marketingOptInLabel": "訂閱育兒貼士與資源更新",
       "termsAgreementLabel": "我同意",
       "termsLinkLabel": "條款及細則",

--- a/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
@@ -19,12 +19,18 @@ describe('ReservationFormFields', () => {
         email='bad-email'
         phone='12345678'
         interestedTopics='Boundaries'
+        hasFullNameError={false}
         hasEmailError
+        hasPhoneError={false}
+        hasTopicsError={false}
         onFullNameChange={onFullNameChange}
+        onFullNameBlur={vi.fn()}
         onEmailChange={onEmailChange}
         onEmailBlur={onEmailBlur}
         onPhoneChange={onPhoneChange}
+        onPhoneBlur={vi.fn()}
         onTopicsChange={onTopicsChange}
+        onTopicsBlur={vi.fn()}
       />,
     );
 
@@ -59,17 +65,23 @@ describe('ReservationFormFields', () => {
         email=''
         phone=''
         interestedTopics=''
+        hasFullNameError={false}
         hasEmailError={false}
+        hasPhoneError={false}
+        hasTopicsError={false}
         topicsFieldConfig={{
           label: "What's your child's age?",
           placeholder: 'This will help me better personalise your experience',
           required: true,
         }}
         onFullNameChange={() => {}}
+        onFullNameBlur={() => {}}
         onEmailChange={() => {}}
         onEmailBlur={() => {}}
         onPhoneChange={() => {}}
+        onPhoneBlur={() => {}}
         onTopicsChange={() => {}}
+        onTopicsBlur={() => {}}
       />,
     );
 

--- a/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
@@ -61,6 +61,7 @@ describe('ContactFormFields', () => {
         hasEmailError
         hasPhoneError
         hasFirstNameError={false}
+        hasMessageError={false}
         marketingOptIn={false}
         captchaErrorMessage='captcha failed'
         submitErrorMessage='submit failed'
@@ -72,6 +73,7 @@ describe('ContactFormFields', () => {
         onEmailBlur={onEmailBlur}
         onPhoneBlur={onPhoneBlur}
         onFirstNameBlur={vi.fn()}
+        onMessageBlur={vi.fn()}
         onMarketingOptInChange={vi.fn()}
         onCaptchaTokenChange={onCaptchaTokenChange}
         onCaptchaLoadError={onCaptchaLoadError}

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -302,6 +302,40 @@ describe('ContactUsForm section', () => {
     );
   });
 
+  it('shows message required error when message is empty on submit', () => {
+    renderContactUsForm();
+
+    const firstNameInput = screen.getByLabelText(
+      new RegExp(`^${enContent.contactUs.form.firstNameLabel}`),
+    );
+    const emailInput = screen.getByLabelText(
+      new RegExp(enContent.contactUs.form.emailFieldLabel),
+    );
+    const messageInput = screen.getByLabelText(
+      new RegExp(enContent.contactUs.form.messageLabel),
+    );
+    const formElement = screen
+      .getByRole('button', { name: enContent.contactUs.form.submitLabel })
+      .closest('form');
+    if (!formElement) {
+      throw new Error('Expected contact form');
+    }
+
+    fireEvent.change(firstNameInput, { target: { value: 'Pat' } });
+    fireEvent.change(emailInput, { target: { value: 'parent@example.com' } });
+    fireEvent.change(messageInput, { target: { value: '   ' } });
+    fireEvent.submit(formElement);
+
+    expect(
+      screen.getByText(enContent.contactUs.form.messageRequiredError),
+    ).toBeInTheDocument();
+    expect(messageInput).toHaveAttribute('aria-invalid', 'true');
+    expect(messageInput).toHaveAttribute(
+      'aria-describedby',
+      'contact-us-form-message-error',
+    );
+  });
+
   it('validates email only after blur instead of while typing', () => {
     renderContactUsForm();
 

--- a/apps/public_www/tests/components/sections/event-notification.test.tsx
+++ b/apps/public_www/tests/components/sections/event-notification.test.tsx
@@ -124,6 +124,7 @@ describe('EventNotification section', () => {
     expect(
       screen.getByLabelText(new RegExp(enContent.events.notification.emailLabel)),
     ).toBeInTheDocument();
+    expect(screen.getByText(enContent.common.captcha.captchaLabel)).toBeInTheDocument();
     expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -75,6 +75,7 @@ function mediaFormProps() {
     formCaptchaRequiredError: resourcesContent.formCaptchaRequiredError,
     formCaptchaLoadError: resourcesContent.formCaptchaLoadError,
     formCaptchaUnavailableError: resourcesContent.formCaptchaUnavailableError,
+    formCaptchaLabel: resourcesContent.formCaptchaLabel,
   };
 }
 
@@ -186,6 +187,7 @@ describe('MediaForm', () => {
       screen.getByLabelText(new RegExp(enContent.resources.formFirstNameLabel)),
     ).toBeInTheDocument();
     expect(screen.getByLabelText(new RegExp(enContent.resources.formEmailLabel))).toBeInTheDocument();
+    expect(screen.getByText(enContent.resources.formCaptchaLabel)).toBeInTheDocument();
     expect(mockedTrackPublicFormOutcome).toHaveBeenCalledWith('media_form_open', {
       formKind: 'media_request',
       formId: 'media-form__media-form',

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -512,6 +512,8 @@ describe('my-best-auntie booking modals footer content', () => {
     const pendingWrapperClassName =
       pendingAcknowledgement.closest('label')?.className ?? '';
     const termsWrapperClassName = termsAcknowledgement.closest('label')?.className ?? '';
+    expect(pendingWrapperClassName).toContain('cursor-pointer');
+    expect(termsWrapperClassName).toContain('cursor-pointer');
     expect(pendingWrapperClassName).not.toContain('border');
     expect(pendingWrapperClassName).not.toContain('bg-');
     expect(termsWrapperClassName).not.toContain('border');
@@ -634,15 +636,15 @@ describe('my-best-auntie booking modals footer content', () => {
     const submitButton = screen.getByRole('button', {
       name: bookingModalContent.submitLabel,
     });
-    expect(submitButton).toBeDisabled();
+    expect(submitButton).toBeEnabled();
 
     fireEvent.change(fullNameField, { target: { value: 'Test User' } });
     fireEvent.change(emailField, { target: { value: 'ida@example.com' } });
     fireEvent.change(phoneField, { target: { value: '85212345678' } });
     fireEvent.click(pendingAcknowledgement);
-    expect(submitButton).toBeDisabled();
+    expect(submitButton).toBeEnabled();
     fireEvent.click(termsAcknowledgement);
-    expect(submitButton).toBeDisabled();
+    expect(submitButton).toBeEnabled();
 
     fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
     expect(submitButton).toBeEnabled();
@@ -827,6 +829,53 @@ describe('my-best-auntie booking modals footer content', () => {
       throw new Error('Expected reservation form');
     }
     expect(reservationForm).toHaveAttribute('novalidate');
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('shows field-level validation errors when submitting with empty required inputs', async () => {
+    mockedCreateCrmApiClient.mockReturnValue({
+      request: vi.fn(),
+    });
+    mockedCreatePublicApiClient.mockReturnValue({
+      request: vi.fn(),
+    });
+
+    renderBookingModal({
+      selectedAgeGroupLabel: '18-24 months',
+    });
+
+    const submitButton = screen.getByRole('button', {
+      name: bookingModalContent.submitLabel,
+    });
+    const reservationForm = submitButton.closest('form');
+    if (!reservationForm) {
+      throw new Error('Expected reservation form');
+    }
+    fireEvent.submit(reservationForm);
+
+    expect(
+      screen.getByText(bookingModalContent.fullNameRequiredError),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(bookingModalContent.phoneRequiredError),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(bookingModalContent.acknowledgementRequiredError),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(bookingModalContent.captchaRequiredError),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockedTrackPublicFormOutcome).toHaveBeenCalledWith(
+        'booking_submit_error',
+        expect.objectContaining({
+          params: expect.objectContaining({
+            error_type: 'validation_error',
+          }),
+        }),
+      );
+    });
   });
 
   it('shows the loading gear on the reservation submit button while the request is in flight', async () => {

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -857,6 +857,9 @@ describe('my-best-auntie booking modals footer content', () => {
       screen.getByText(bookingModalContent.fullNameRequiredError),
     ).toBeInTheDocument();
     expect(
+      screen.getByText(bookingModalContent.emailValidationError),
+    ).toBeInTheDocument();
+    expect(
       screen.getByText(bookingModalContent.phoneRequiredError),
     ).toBeInTheDocument();
     expect(

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -167,6 +167,7 @@ describe('SproutsSquadCommunity section', () => {
     );
     expect(emailField).toBeInTheDocument();
     expect(emailField.closest('form')).toHaveClass('gap-3');
+    expect(screen.getByText(enContent.common.captcha.captchaLabel)).toBeInTheDocument();
     expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns booking, contact, community signup, and media download forms with the planned UX: submit buttons stay enabled for empty-field validation (except infrastructure gates), custom errors with `noValidate`, and visible CAPTCHA labels on small forms.

## Follow-up (review fixes)

- Booking `handleSubmit`: `isSubmitting` guard runs immediately after `preventDefault` (before touches and `booking_submit_attempt`).
- Captcha: `!captchaToken` removed from `hasFieldErrors`; after field validation, `isCaptchaUnavailable` still returns `service_unavailable`; missing token returns `validation_error` without conflating the two.
- Acknowledgement error paragraph moved between the two required checkboxes and the optional marketing opt-in.
- Test asserts `emailValidationError` on empty submit.

## Changes

- **Booking reservation** (`reservation-form.tsx`, `reservation-form-fields.tsx`): Minimal `disabled` (captcha unavailable, Stripe loading/not ready, submitting). On submit, mark fields touched, validate full name, email, phone, optional topics, acknowledgements, and captcha; show inline errors and combined acknowledgement error; `cursor-pointer` on the three checkbox labels; submit `aria-describedby` includes active field error IDs.
- **Contact us** (`contact-us-form.tsx`, `contact-us-form-fields.tsx`): Message touched/error, phone error border, submit button describes field errors.
- **Event notification / Sprouts Squad** (`event-notification.tsx`, `sprouts-squad-community.tsx`): Wrap Turnstile in a labelled block using `common.captcha.captchaLabel` (short **Verification** text).
- **Media form** (`media-form.tsx` + resource section wiring): `formCaptchaLabel` from locale; captcha label wrapper.
- **Locales** (`en.json`, `zh-CN.json`, `zh-HK.json`): New keys for booking field errors, contact message error, `common.captcha.captchaLabel`, and `resources.formCaptchaLabel`.

## Tests

- Updated booking modal expectations (submit enabled until infra blocks; new validation test; `noValidate` + enabled submit).
- Contact us message error test; community/event captcha label assertions; media form captcha label; reservation/contact field component props.

## Validation

- `npm run lint` (public_www)
- `vitest run` on touched test files (with `NEXT_PUBLIC_EMAIL` / `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` for `validate:content` when run locally)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dd38325-7136-4d88-8f3c-f70d9e79987c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dd38325-7136-4d88-8f3c-f70d9e79987c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

