### PR TITLE
Consultation booking modal: Deep Dive icon on upgrade CTA, persist AM/PM across date changes

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react';
+
 import type { BookingPaymentModalContent } from '@/content';
 import type { BookingTopicsFieldConfig } from '@/components/sections/booking-modal/types';
 
@@ -51,6 +53,17 @@ export function ReservationFormFields({
   const topicsFieldPlaceholder =
     topicsFieldConfig?.placeholder ?? content.topicsInterestPlaceholder;
   const isTopicsFieldRequired = topicsFieldConfig?.required ?? false;
+  const labelTooltip = topicsFieldConfig?.labelTooltip?.trim() ?? '';
+  const placeholderTooltip = topicsFieldConfig?.placeholderTooltip?.trim() ?? '';
+  const hasVisiblePlaceholder = topicsFieldPlaceholder.trim().length > 0;
+  const topicsFieldId = useId();
+  const topicsPlaceholderHintId = useId();
+  const topicsTextareaDescribedBy = [
+    hasTopicsError ? BOOKING_TOPICS_ERROR_MESSAGE_ID : null,
+    placeholderTooltip ? topicsPlaceholderHintId : null,
+  ]
+    .filter((id): id is string => Boolean(id))
+    .join(' ') || undefined;
 
   return (
     <>
@@ -144,27 +157,50 @@ export function ReservationFormFields({
           </p>
         ) : null}
       </label>
-      <label className='block'>
-        <span className='mb-1 block text-sm font-semibold es-text-heading'>
-          {topicsFieldLabel}
-          {isTopicsFieldRequired ? (
-            <span className='es-form-required-marker ml-0.5' aria-hidden='true'>
-              *
-            </span>
+      <div className='block'>
+        {placeholderTooltip ? (
+          <p id={topicsPlaceholderHintId} className='sr-only'>
+            {placeholderTooltip}
+          </p>
+        ) : null}
+        <label
+          htmlFor={topicsFieldId}
+          className='mb-1 flex flex-wrap items-center gap-1.5 text-sm font-semibold es-text-heading'
+        >
+          <span>
+            {topicsFieldLabel}
+            {isTopicsFieldRequired ? (
+              <span className='es-form-required-marker ml-0.5' aria-hidden='true'>
+                *
+              </span>
+            ) : null}
+          </span>
+          {labelTooltip ? (
+            <button
+              type='button'
+              tabIndex={-1}
+              title={labelTooltip}
+              aria-label={labelTooltip}
+              className='inline-flex h-5 min-w-5 cursor-default items-center justify-center rounded-full border border-black/25 px-1 text-[11px] font-bold leading-none es-text-dim'
+            >
+              i
+            </button>
           ) : null}
-        </span>
+        </label>
         <textarea
+          id={topicsFieldId}
           required={isTopicsFieldRequired}
           value={interestedTopics}
           onChange={(event) => {
             onTopicsChange(event.target.value);
           }}
           onBlur={onTopicsBlur}
-          placeholder={topicsFieldPlaceholder}
+          placeholder={hasVisiblePlaceholder ? topicsFieldPlaceholder : undefined}
+          title={placeholderTooltip || undefined}
           rows={3}
           className={`es-focus-ring es-form-input resize-y ${hasTopicsError ? 'es-form-input-error' : ''}`}
           aria-invalid={hasTopicsError}
-          aria-describedby={hasTopicsError ? BOOKING_TOPICS_ERROR_MESSAGE_ID : undefined}
+          aria-describedby={topicsTextareaDescribedBy}
         />
         {hasTopicsError ? (
           <p
@@ -175,7 +211,7 @@ export function ReservationFormFields({
             {content.topicsRequiredError}
           </p>
         ) : null}
-      </label>
+      </div>
     </>
   );
 }

--- a/apps/public_www/src/components/sections/booking-modal/types.ts
+++ b/apps/public_www/src/components/sections/booking-modal/types.ts
@@ -28,4 +28,8 @@ export interface BookingTopicsFieldConfig {
   label?: string;
   placeholder?: string;
   required?: boolean;
+  /** Native `title` tooltip on an info control beside the label (optional). */
+  labelTooltip?: string;
+  /** Native `title` tooltip on the textarea (e.g. when `placeholder` is empty). */
+  placeholderTooltip?: string;
 }

--- a/apps/public_www/src/components/sections/booking-modal/types.ts
+++ b/apps/public_www/src/components/sections/booking-modal/types.ts
@@ -28,8 +28,6 @@ export interface BookingTopicsFieldConfig {
   label?: string;
   placeholder?: string;
   required?: boolean;
-  /** Native `title` tooltip on an info control beside the label (optional). */
   labelTooltip?: string;
-  /** Native `title` tooltip on the textarea (e.g. when `placeholder` is empty). */
   placeholderTooltip?: string;
 }

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element -- static SVG from /public/images in upgrade CTA */
 'use client';
 
 import {
@@ -44,6 +45,8 @@ export interface ConsultationBookingModalSelectionInfo {
   levelFeatures: string[];
   focusLabelFormatted: string;
   upgradeToDeepDiveLabel: string;
+  /** Shown above the upgrade label inside the CTA (e.g. Deep Dive tier icon). */
+  upgradeToDeepDiveIconSrc?: string;
 }
 
 interface ConsultationBookingModalProps {
@@ -322,10 +325,15 @@ export function ConsultationBookingModal({
   const dayPeriod = pickerSelection?.period ?? defaultSelection?.period ?? 'am';
 
   function handleSelectYmd(ymd: string) {
-    const period = firstSelectableConsultationPeriod(ymd, unavailableByYmd);
-    if (period) {
-      setPickerSelection({ ymd, period });
-    }
+    setPickerSelection((prev) => {
+      const preferredPeriod =
+        prev?.period ?? defaultSelection?.period ?? 'am';
+      if (!isConsultationPeriodBlocked(ymd, preferredPeriod, unavailableByYmd)) {
+        return { ymd, period: preferredPeriod };
+      }
+      const period = firstSelectableConsultationPeriod(ymd, unavailableByYmd);
+      return period ? { ymd, period } : prev;
+    });
   }
 
   function handleSelectPeriod(period: ConsultationDayPeriod) {
@@ -390,10 +398,19 @@ export function ConsultationBookingModal({
           <ButtonPrimitive
             type='button'
             variant='primary'
-            className='max-w-[360px] es-btn--outline'
+            className='max-w-[360px] es-btn--outline flex flex-col items-center gap-2 py-3'
             onClick={onUpgradeToDeepDive}
           >
-            {selectionInfo.upgradeToDeepDiveLabel}
+            {selectionInfo.upgradeToDeepDiveIconSrc ? (
+              <img
+                src={selectionInfo.upgradeToDeepDiveIconSrc}
+                alt=''
+                width={44}
+                height={44}
+                className='h-11 w-11 shrink-0 object-contain'
+              />
+            ) : null}
+            <span className='text-center'>{selectionInfo.upgradeToDeepDiveLabel}</span>
           </ButtonPrimitive>
         </div>
       ) : null}

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -1,6 +1,6 @@
-/* eslint-disable @next/next/no-img-element -- static SVG from /public/images in upgrade CTA */
 'use client';
 
+import Image from 'next/image';
 import {
   useId,
   useMemo,
@@ -45,7 +45,6 @@ export interface ConsultationBookingModalSelectionInfo {
   levelFeatures: string[];
   focusLabelFormatted: string;
   upgradeToDeepDiveLabel: string;
-  /** Shown above the upgrade label inside the CTA (e.g. Deep Dive tier icon). */
   upgradeToDeepDiveIconSrc?: string;
 }
 
@@ -402,7 +401,7 @@ export function ConsultationBookingModal({
             onClick={onUpgradeToDeepDive}
           >
             {selectionInfo.upgradeToDeepDiveIconSrc ? (
-              <img
+              <Image
                 src={selectionInfo.upgradeToDeepDiveIconSrc}
                 alt=''
                 width={44}

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -196,11 +196,7 @@ export function ConsultationsBooking({
   }, [content.focusAreas, content.levels, selectedFocusId, selectedLevelId]);
 
   const bookingPayload = isBookingModalOpen
-    ? buildConsultationsBookingModalPayload(
-        reservationForModal,
-        locale,
-        selectionLabels,
-      )
+    ? buildConsultationsBookingModalPayload(reservationForModal, locale)
     : null;
 
   const modalSelectionInfo: ConsultationBookingModalSelectionInfo | undefined =

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -208,6 +208,7 @@ export function ConsultationsBooking({
       const focus = content.focusAreas.find((a) => a.id === selectedFocusId);
       const level = content.levels.find((l) => l.id === selectedLevelId);
       if (!focus || !level) return undefined;
+      const deepDiveLevel = content.levels.find((l) => l.id === 'deep-dive');
       return {
         focusLabel: focus.title,
         levelId: level.id,
@@ -217,6 +218,7 @@ export function ConsultationsBooking({
           { focus: focus.title },
         ),
         upgradeToDeepDiveLabel: content.reservation.upgradeToDeepDiveLabel,
+        upgradeToDeepDiveIconSrc: deepDiveLevel?.iconSrc,
       };
     }, [content.focusAreas, content.levels, content.reservation, selectedFocusId, selectedLevelId]);
 

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1272,8 +1272,10 @@
         "locationName": "Your Home",
         "locationAddress": "Hong Kong",
         "topicsField": {
-          "label": "Focus, level, and anything we should know",
-          "placeholder": "e.g. Home Assessment, Essentials — child is 3, helper has been with us 2 years",
+          "label": "Anything we should know",
+          "placeholder": "",
+          "labelTooltip": "Your consultation focus and Essentials or Deep Dive level are already selected above.",
+          "placeholderTooltip": "For example: child is 3, helper has been with us 2 years, or any context for the visit.",
           "required": true
         },
         "essentials": {

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1275,7 +1275,7 @@
           "label": "Anything we should know",
           "placeholder": "",
           "labelTooltip": "Your consultation focus and Essentials or Deep Dive level are already selected above.",
-          "placeholderTooltip": "For example: child is 3, helper has been with us 2 years, or any context for the visit.",
+          "placeholderTooltip": "i.e. child is 3, helper has been with us 2 years, or any context for the visit.",
           "required": true
         },
         "essentials": {

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1272,8 +1272,10 @@
         "locationName": "您的家",
         "locationAddress": "香港",
         "topicsField": {
-          "label": "咨询方向、级别及其他需要说明的信息",
-          "placeholder": "例如：家居评估、基础版 — 孩子3岁，阿姨已工作2年",
+          "label": "其他需要说明的信息",
+          "placeholder": "",
+          "labelTooltip": "您的咨询方向和基础版或深入版已在上方选择。",
+          "placeholderTooltip": "例如：孩子3岁、阿姨已工作2年，或上门前希望我们知道的背景。",
           "required": true
         },
         "essentials": {

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1272,8 +1272,10 @@
         "locationName": "你屋企",
         "locationAddress": "香港",
         "topicsField": {
-          "label": "諮詢方向、級別及其他需要說明的資訊",
-          "placeholder": "例如：家居評估、基礎版 — 孩子3歲，姨姨已工作2年",
+          "label": "其他需要說明的資訊",
+          "placeholder": "",
+          "labelTooltip": "您的諮詢方向和基礎版或深入版已經喺上面揀好。",
+          "placeholderTooltip": "例如：孩子3歲、姨姨已工作2年，或者上門前想我哋知嘅背景。",
           "required": true
         },
         "essentials": {

--- a/apps/public_www/src/lib/consultations-booking-modal-payload.ts
+++ b/apps/public_www/src/lib/consultations-booking-modal-payload.ts
@@ -5,24 +5,14 @@ import { formatCurrencyHkd } from '@/lib/format';
 
 export type ConsultationsBookingModalTierId = 'essentials' | 'deepDive';
 
-export interface ConsultationsBookingModalSelectionLabels {
-  focusLabel: string;
-  levelLabel: string;
-}
-
 export function buildConsultationsBookingModalPayload(
   reservation: ConsultationsBookingReservationContent,
   locale: Locale,
-  selection?: ConsultationsBookingModalSelectionLabels,
 ): ConsultationEventBookingModalPayload {
   const tierId = reservation.bookingTier;
   const tier = tierId === 'essentials' ? reservation.essentials : reservation.deepDive;
   const firstPart = tier.dateParts[0];
   const selectedDateStartTime = firstPart?.startDateTime?.trim() ?? '';
-  const topicsPrefill =
-    selection && selection.focusLabel.trim() && selection.levelLabel.trim()
-      ? `${selection.focusLabel.trim()} — ${selection.levelLabel.trim()}`
-      : undefined;
   const payload: ConsultationEventBookingModalPayload = {
     variant: 'event',
     bookingSystem: CONSULTATION_BOOKING_SYSTEM,
@@ -47,8 +37,9 @@ export function buildConsultationsBookingModalPayload(
       label: reservation.topicsField.label,
       placeholder: reservation.topicsField.placeholder,
       required: reservation.topicsField.required,
+      labelTooltip: reservation.topicsField.labelTooltip,
+      placeholderTooltip: reservation.topicsField.placeholderTooltip,
     },
-    topicsPrefill,
   };
   return payload;
 }

--- a/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
@@ -92,4 +92,44 @@ describe('ReservationFormFields', () => {
       'This will help me better personalise your experience',
     );
   });
+
+  it('omits placeholder and exposes native title tooltips when configured', () => {
+    render(
+      <ReservationFormFields
+        content={enContent.bookingModal.paymentModal}
+        fullName=''
+        email=''
+        phone=''
+        interestedTopics=''
+        hasFullNameError={false}
+        hasEmailError={false}
+        hasPhoneError={false}
+        hasTopicsError={false}
+        topicsFieldConfig={{
+          label: 'Anything we should know',
+          placeholder: '',
+          labelTooltip: 'Focus and level are selected above.',
+          placeholderTooltip: 'Add context for the visit.',
+          required: true,
+        }}
+        onFullNameChange={() => {}}
+        onFullNameBlur={() => {}}
+        onEmailChange={() => {}}
+        onEmailBlur={() => {}}
+        onPhoneChange={() => {}}
+        onPhoneBlur={() => {}}
+        onTopicsChange={() => {}}
+        onTopicsBlur={() => {}}
+      />,
+    );
+
+    const topicsInput = screen.getByRole('textbox', {
+      name: /Anything we should know/i,
+    });
+    expect(topicsInput).not.toHaveAttribute('placeholder');
+    expect(topicsInput).toHaveAttribute('title', 'Add context for the visit.');
+    expect(
+      screen.getByRole('button', { name: 'Focus and level are selected above.' }),
+    ).toHaveAttribute('title', 'Focus and level are selected above.');
+  });
 });

--- a/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
@@ -249,4 +249,81 @@ describe('ConsultationBookingModal', () => {
     fireEvent.click(screen.getByRole('button', { name: upgradeLabel }));
     expect(onUpgrade).toHaveBeenCalledOnce();
   });
+
+  it('keeps PM selected when changing date if afternoon is available on the new day', () => {
+    const bookingPayload = buildConsultationsBookingModalPayload(
+      enContent.consultations.booking.reservation,
+      'en',
+      { focusLabel: 'Home', levelLabel: 'Essentials' },
+    );
+
+    render(
+      <ConsultationBookingModal
+        locale='en'
+        paymentModalContent={enContent.bookingModal.paymentModal}
+        bookingPayload={bookingPayload}
+        pickerContent={buildPickerContent(enContent.bookingModal.paymentModal)}
+        calendarAvailability={{ unavailable_slots: [] }}
+        onClose={() => {}}
+        onSubmitReservation={() => {}}
+      />,
+    );
+
+    const pmLabel = enContent.bookingModal.paymentModal.consultationPicker.pmLabel;
+    const amLabel = enContent.bookingModal.paymentModal.consultationPicker.amLabel;
+    const pmButton = screen.getByRole('button', { name: pmLabel });
+    fireEvent.click(pmButton);
+    expect(pmButton).toHaveAttribute('aria-pressed', 'true');
+
+    const day10 = screen.getByRole('button', { name: 'Select day 10' });
+    fireEvent.click(day10);
+
+    expect(screen.getByRole('button', { name: pmLabel })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: amLabel })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('renders deep dive icon in upgrade button when selectionInfo includes icon src', () => {
+    const upgradeLabel = enContent.consultations.booking.reservation.upgradeToDeepDiveLabel;
+    const deepDiveLevel = enContent.consultations.booking.levels.find((l) => l.id === 'deep-dive');
+    expect(deepDiveLevel).toBeDefined();
+
+    const selectionInfo: ConsultationBookingModalSelectionInfo = {
+      focusLabel: 'Home Assessment',
+      levelId: 'essentials',
+      levelFeatures: enContent.consultations.booking.levels[0].features,
+      focusLabelFormatted: 'Home Assessment focus',
+      upgradeToDeepDiveLabel: upgradeLabel,
+      upgradeToDeepDiveIconSrc: deepDiveLevel!.iconSrc,
+    };
+
+    const bookingPayload = buildConsultationsBookingModalPayload(
+      enContent.consultations.booking.reservation,
+      'en',
+      { focusLabel: 'Home Assessment', levelLabel: 'Essentials' },
+    );
+
+    render(
+      <ConsultationBookingModal
+        locale='en'
+        paymentModalContent={enContent.bookingModal.paymentModal}
+        bookingPayload={bookingPayload}
+        pickerContent={buildPickerContent(enContent.bookingModal.paymentModal)}
+        calendarAvailability={{ unavailable_slots: [] }}
+        selectionInfo={selectionInfo}
+        onClose={() => {}}
+        onSubmitReservation={() => {}}
+        onUpgradeToDeepDive={() => {}}
+      />,
+    );
+
+    const upgradeButton = screen.getByRole('button', { name: upgradeLabel });
+    const icon = upgradeButton.querySelector(`img[src="${deepDiveLevel!.iconSrc}"]`);
+    expect(icon).not.toBeNull();
+  });
 });

--- a/apps/public_www/tests/lib/consultations-booking-modal-payload.test.ts
+++ b/apps/public_www/tests/lib/consultations-booking-modal-payload.test.ts
@@ -22,17 +22,6 @@ describe('buildConsultationsBookingModalPayload', () => {
     expect(payload.topicsPrefill).toBeUndefined();
   });
 
-  it('includes topicsPrefill when focus and level labels are provided', () => {
-    const content = getContent('en');
-    const reservation = content.consultations.booking.reservation;
-    const payload = buildConsultationsBookingModalPayload(reservation, 'en', {
-      focusLabel: 'Home Assessment',
-      levelLabel: 'Deep Dive',
-    });
-
-    expect(payload.topicsPrefill).toBe('Home Assessment — Deep Dive');
-  });
-
   it('uses deep dive tier when bookingTier is deepDive', () => {
     const content = getContent('en');
     const reservation: ConsultationsBookingReservationContent = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Upgrade CTA**: Deep Dive tier icon above the upgrade label (centered column layout), rendered with `next/image`.
- **Date picker**: Keeps the selected **AM/PM** when changing dates if that period is still available; otherwise falls back to the first open slot.
- **Consultation topics field**: Label is **Anything we should know** (en / zh-CN / zh-HK). No auto-prefill of focus/level text. Empty placeholder; guidance uses **native `title` tooltips** (textarea + small “i” hint beside the label), matching the event flow pattern of placeholder-as-hint.
- **Shared form**: `BookingTopicsFieldConfig` supports optional `labelTooltip` and `placeholderTooltip`; topics field uses explicit `label`/`htmlFor` so screen readers keep the correct field name.

## Tests

- `npx vitest run tests/components/sections/consultation-booking-modal.test.tsx`
- `npx vitest run tests/lib/consultations-booking-modal-payload.test.ts`
- `npx vitest run tests/components/sections/booking-modal/reservation-form-fields.test.tsx`
- `bash scripts/validate-cursorrules.sh`

## Notes

- `buildConsultationsBookingModalPayload` no longer accepts selection labels or sets `topicsPrefill` for consultations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ad90656-7c83-4e6d-acbd-549b66a4064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ad90656-7c83-4e6d-acbd-549b66a4064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

