### PR TITLE
Consultation booking modal: persist AM/PM, topics placeholder, text-only upgrade

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form-fields.tsx
@@ -1,5 +1,3 @@
-import { useId } from 'react';
-
 import type { BookingPaymentModalContent } from '@/content';
 import type { BookingTopicsFieldConfig } from '@/components/sections/booking-modal/types';
 
@@ -53,17 +51,6 @@ export function ReservationFormFields({
   const topicsFieldPlaceholder =
     topicsFieldConfig?.placeholder ?? content.topicsInterestPlaceholder;
   const isTopicsFieldRequired = topicsFieldConfig?.required ?? false;
-  const labelTooltip = topicsFieldConfig?.labelTooltip?.trim() ?? '';
-  const placeholderTooltip = topicsFieldConfig?.placeholderTooltip?.trim() ?? '';
-  const hasVisiblePlaceholder = topicsFieldPlaceholder.trim().length > 0;
-  const topicsFieldId = useId();
-  const topicsPlaceholderHintId = useId();
-  const topicsTextareaDescribedBy = [
-    hasTopicsError ? BOOKING_TOPICS_ERROR_MESSAGE_ID : null,
-    placeholderTooltip ? topicsPlaceholderHintId : null,
-  ]
-    .filter((id): id is string => Boolean(id))
-    .join(' ') || undefined;
 
   return (
     <>
@@ -157,50 +144,27 @@ export function ReservationFormFields({
           </p>
         ) : null}
       </label>
-      <div className='block'>
-        {placeholderTooltip ? (
-          <p id={topicsPlaceholderHintId} className='sr-only'>
-            {placeholderTooltip}
-          </p>
-        ) : null}
-        <label
-          htmlFor={topicsFieldId}
-          className='mb-1 flex flex-wrap items-center gap-1.5 text-sm font-semibold es-text-heading'
-        >
-          <span>
-            {topicsFieldLabel}
-            {isTopicsFieldRequired ? (
-              <span className='es-form-required-marker ml-0.5' aria-hidden='true'>
-                *
-              </span>
-            ) : null}
-          </span>
-          {labelTooltip ? (
-            <button
-              type='button'
-              tabIndex={-1}
-              title={labelTooltip}
-              aria-label={labelTooltip}
-              className='inline-flex h-5 min-w-5 cursor-default items-center justify-center rounded-full border border-black/25 px-1 text-[11px] font-bold leading-none es-text-dim'
-            >
-              i
-            </button>
+      <label className='block'>
+        <span className='mb-1 block text-sm font-semibold es-text-heading'>
+          {topicsFieldLabel}
+          {isTopicsFieldRequired ? (
+            <span className='es-form-required-marker ml-0.5' aria-hidden='true'>
+              *
+            </span>
           ) : null}
-        </label>
+        </span>
         <textarea
-          id={topicsFieldId}
           required={isTopicsFieldRequired}
           value={interestedTopics}
           onChange={(event) => {
             onTopicsChange(event.target.value);
           }}
           onBlur={onTopicsBlur}
-          placeholder={hasVisiblePlaceholder ? topicsFieldPlaceholder : undefined}
-          title={placeholderTooltip || undefined}
+          placeholder={topicsFieldPlaceholder}
           rows={3}
           className={`es-focus-ring es-form-input resize-y ${hasTopicsError ? 'es-form-input-error' : ''}`}
           aria-invalid={hasTopicsError}
-          aria-describedby={topicsTextareaDescribedBy}
+          aria-describedby={hasTopicsError ? BOOKING_TOPICS_ERROR_MESSAGE_ID : undefined}
         />
         {hasTopicsError ? (
           <p
@@ -211,7 +175,7 @@ export function ReservationFormFields({
             {content.topicsRequiredError}
           </p>
         ) : null}
-      </div>
+      </label>
     </>
   );
 }

--- a/apps/public_www/src/components/sections/booking-modal/types.ts
+++ b/apps/public_www/src/components/sections/booking-modal/types.ts
@@ -28,6 +28,4 @@ export interface BookingTopicsFieldConfig {
   label?: string;
   placeholder?: string;
   required?: boolean;
-  labelTooltip?: string;
-  placeholderTooltip?: string;
 }

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Image from 'next/image';
 import {
   useId,
   useMemo,
@@ -45,7 +44,6 @@ export interface ConsultationBookingModalSelectionInfo {
   levelFeatures: string[];
   focusLabelFormatted: string;
   upgradeToDeepDiveLabel: string;
-  upgradeToDeepDiveIconSrc?: string;
 }
 
 interface ConsultationBookingModalProps {
@@ -397,19 +395,10 @@ export function ConsultationBookingModal({
           <ButtonPrimitive
             type='button'
             variant='primary'
-            className='max-w-[360px] es-btn--outline flex flex-col items-center gap-2 py-3'
+            className='max-w-[360px] es-btn--outline'
             onClick={onUpgradeToDeepDive}
           >
-            {selectionInfo.upgradeToDeepDiveIconSrc ? (
-              <Image
-                src={selectionInfo.upgradeToDeepDiveIconSrc}
-                alt=''
-                width={44}
-                height={44}
-                className='h-11 w-11 shrink-0 object-contain'
-              />
-            ) : null}
-            <span className='text-center'>{selectionInfo.upgradeToDeepDiveLabel}</span>
+            {selectionInfo.upgradeToDeepDiveLabel}
           </ButtonPrimitive>
         </div>
       ) : null}

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -204,7 +204,6 @@ export function ConsultationsBooking({
       const focus = content.focusAreas.find((a) => a.id === selectedFocusId);
       const level = content.levels.find((l) => l.id === selectedLevelId);
       if (!focus || !level) return undefined;
-      const deepDiveLevel = content.levels.find((l) => l.id === 'deep-dive');
       return {
         focusLabel: focus.title,
         levelId: level.id,
@@ -214,7 +213,6 @@ export function ConsultationsBooking({
           { focus: focus.title },
         ),
         upgradeToDeepDiveLabel: content.reservation.upgradeToDeepDiveLabel,
-        upgradeToDeepDiveIconSrc: deepDiveLevel?.iconSrc,
       };
     }, [content.focusAreas, content.levels, content.reservation, selectedFocusId, selectedLevelId]);
 

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1273,9 +1273,7 @@
         "locationAddress": "Hong Kong",
         "topicsField": {
           "label": "Anything we should know",
-          "placeholder": "",
-          "labelTooltip": "Your consultation focus and Essentials or Deep Dive level are already selected above.",
-          "placeholderTooltip": "i.e. child is 3, helper has been with us 2 years, or any context for the visit.",
+          "placeholder": "i.e. child is 3, helper has been with us 2 years, or any context for the visit",
           "required": true
         },
         "essentials": {

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1273,9 +1273,7 @@
         "locationAddress": "香港",
         "topicsField": {
           "label": "其他需要说明的信息",
-          "placeholder": "",
-          "labelTooltip": "您的咨询方向和基础版或深入版已在上方选择。",
-          "placeholderTooltip": "例如：孩子3岁、阿姨已工作2年，或上门前希望我们知道的背景。",
+          "placeholder": "例如：孩子3岁、阿姨已工作2年，或上门前希望我们知道的背景",
           "required": true
         },
         "essentials": {

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1273,9 +1273,7 @@
         "locationAddress": "香港",
         "topicsField": {
           "label": "其他需要說明的資訊",
-          "placeholder": "",
-          "labelTooltip": "您的諮詢方向和基礎版或深入版已經喺上面揀好。",
-          "placeholderTooltip": "例如：孩子3歲、姨姨已工作2年，或者上門前想我哋知嘅背景。",
+          "placeholder": "例如：孩子3歲、姨姨已工作2年，或者上門前想我哋知嘅背景",
           "required": true
         },
         "essentials": {

--- a/apps/public_www/src/lib/consultations-booking-modal-payload.ts
+++ b/apps/public_www/src/lib/consultations-booking-modal-payload.ts
@@ -37,8 +37,6 @@ export function buildConsultationsBookingModalPayload(
       label: reservation.topicsField.label,
       placeholder: reservation.topicsField.placeholder,
       required: reservation.topicsField.required,
-      labelTooltip: reservation.topicsField.labelTooltip,
-      placeholderTooltip: reservation.topicsField.placeholderTooltip,
     },
   };
   return payload;

--- a/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-modal/reservation-form-fields.test.tsx
@@ -93,43 +93,4 @@ describe('ReservationFormFields', () => {
     );
   });
 
-  it('omits placeholder and exposes native title tooltips when configured', () => {
-    render(
-      <ReservationFormFields
-        content={enContent.bookingModal.paymentModal}
-        fullName=''
-        email=''
-        phone=''
-        interestedTopics=''
-        hasFullNameError={false}
-        hasEmailError={false}
-        hasPhoneError={false}
-        hasTopicsError={false}
-        topicsFieldConfig={{
-          label: 'Anything we should know',
-          placeholder: '',
-          labelTooltip: 'Focus and level are selected above.',
-          placeholderTooltip: 'Add context for the visit.',
-          required: true,
-        }}
-        onFullNameChange={() => {}}
-        onFullNameBlur={() => {}}
-        onEmailChange={() => {}}
-        onEmailBlur={() => {}}
-        onPhoneChange={() => {}}
-        onPhoneBlur={() => {}}
-        onTopicsChange={() => {}}
-        onTopicsBlur={() => {}}
-      />,
-    );
-
-    const topicsInput = screen.getByRole('textbox', {
-      name: /Anything we should know/i,
-    });
-    expect(topicsInput).not.toHaveAttribute('placeholder');
-    expect(topicsInput).toHaveAttribute('title', 'Add context for the visit.');
-    expect(
-      screen.getByRole('button', { name: 'Focus and level are selected above.' }),
-    ).toHaveAttribute('title', 'Focus and level are selected above.');
-  });
 });

--- a/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
@@ -53,7 +53,6 @@ describe('ConsultationBookingModal', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,
       'en',
-      { focusLabel: 'Home', levelLabel: 'Essentials' },
     );
 
     render(
@@ -81,7 +80,6 @@ describe('ConsultationBookingModal', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,
       'en',
-      { focusLabel: 'Home', levelLabel: 'Essentials' },
     );
 
     render(
@@ -121,7 +119,6 @@ describe('ConsultationBookingModal', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,
       'en',
-      { focusLabel: 'Home Assessment', levelLabel: 'Essentials' },
     );
 
     render(
@@ -157,7 +154,6 @@ describe('ConsultationBookingModal', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,
       'en',
-      { focusLabel: 'Home Assessment', levelLabel: 'Essentials' },
     );
 
     const { unmount } = render(
@@ -195,7 +191,6 @@ describe('ConsultationBookingModal', () => {
     const deepDivePayload = buildConsultationsBookingModalPayload(
       deepDiveReservation,
       'en',
-      { focusLabel: 'Home Assessment', levelLabel: 'Deep Dive' },
     );
 
     render(
@@ -229,7 +224,6 @@ describe('ConsultationBookingModal', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,
       'en',
-      { focusLabel: 'Home Assessment', levelLabel: 'Essentials' },
     );
 
     render(
@@ -254,7 +248,6 @@ describe('ConsultationBookingModal', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,
       'en',
-      { focusLabel: 'Home', levelLabel: 'Essentials' },
     );
 
     render(
@@ -288,42 +281,4 @@ describe('ConsultationBookingModal', () => {
     );
   });
 
-  it('renders deep dive icon in upgrade button when selectionInfo includes icon src', () => {
-    const upgradeLabel = enContent.consultations.booking.reservation.upgradeToDeepDiveLabel;
-    const deepDiveLevel = enContent.consultations.booking.levels.find((l) => l.id === 'deep-dive');
-    expect(deepDiveLevel).toBeDefined();
-
-    const selectionInfo: ConsultationBookingModalSelectionInfo = {
-      focusLabel: 'Home Assessment',
-      levelId: 'essentials',
-      levelFeatures: enContent.consultations.booking.levels[0].features,
-      focusLabelFormatted: 'Home Assessment focus',
-      upgradeToDeepDiveLabel: upgradeLabel,
-      upgradeToDeepDiveIconSrc: deepDiveLevel!.iconSrc,
-    };
-
-    const bookingPayload = buildConsultationsBookingModalPayload(
-      enContent.consultations.booking.reservation,
-      'en',
-      { focusLabel: 'Home Assessment', levelLabel: 'Essentials' },
-    );
-
-    render(
-      <ConsultationBookingModal
-        locale='en'
-        paymentModalContent={enContent.bookingModal.paymentModal}
-        bookingPayload={bookingPayload}
-        pickerContent={buildPickerContent(enContent.bookingModal.paymentModal)}
-        calendarAvailability={{ unavailable_slots: [] }}
-        selectionInfo={selectionInfo}
-        onClose={() => {}}
-        onSubmitReservation={() => {}}
-        onUpgradeToDeepDive={() => {}}
-      />,
-    );
-
-    const upgradeButton = screen.getByRole('button', { name: upgradeLabel });
-    const icon = upgradeButton.querySelector(`img[src="${deepDiveLevel!.iconSrc}"]`);
-    expect(icon).not.toBeNull();
-  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Date picker**: Keeps the selected **AM/PM** when changing dates if that period is still available; otherwise falls back to the first open slot.
- **Consultation topics field**: Label **Anything we should know** (en / zh-CN / zh-HK). Hint text is the **textarea placeholder** only (same pattern as My Best Auntie). No focus/level prefill; no separate tooltip or “i” control.
- **Upgrade CTA**: Text-only button (no Deep Dive icon).

## Tests

- `npx vitest run tests/components/sections/consultation-booking-modal.test.tsx`
- `npx vitest run tests/components/sections/booking-modal/reservation-form-fields.test.tsx`
- `npx vitest run tests/lib/consultations-booking-modal-payload.test.ts`
- `bash scripts/validate-cursorrules.sh`

## Notes

- `BookingTopicsFieldConfig` is `label`, `placeholder`, and `required` only.
- `buildConsultationsBookingModalPayload` takes reservation + locale only (no `topicsPrefill`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ad90656-7c83-4e6d-acbd-549b66a4064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ad90656-7c83-4e6d-acbd-549b66a4064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

