### PR TITLE
Booking confirmation email: service row, combined schedule, payment labels, consultation details

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -93,6 +93,9 @@ interface BookingReservationFormProps {
   dateEndTime?: string;
   topicsFieldConfig?: BookingTopicsFieldConfig;
   topicsPrefill?: string;
+  /** Consultation flow: optional labels for confirmation email Details row. */
+  consultationWritingFocusLabel?: string;
+  consultationLevelLabel?: string;
   descriptionId: string;
   analyticsSectionId?: string;
   metaPixelContentName?: MetaPixelContentName;
@@ -423,6 +426,8 @@ export function BookingReservationForm({
   dateEndTime = '',
   topicsFieldConfig,
   topicsPrefill = '',
+  consultationWritingFocusLabel = '',
+  consultationLevelLabel = '',
   descriptionId,
   analyticsSectionId = 'my-best-auntie-booking',
   metaPixelContentName = PIXEL_CONTENT_NAME.my_best_auntie,
@@ -987,6 +992,14 @@ export function BookingReservationForm({
       schedule_date_label: sanitizeSingleLineValue(selectedCohortDateLabel) || undefined,
       schedule_time_label: scheduleTimeLabel,
       location_name: sanitizeSingleLineValue(venueName) || undefined,
+      ...(() => {
+        const focus = sanitizeSingleLineValue(consultationWritingFocusLabel);
+        const level = sanitizeSingleLineValue(consultationLevelLabel);
+        return {
+          ...(focus ? { consultation_writing_focus_label: focus } : {}),
+          ...(level ? { consultation_level_label: level } : {}),
+        };
+      })(),
     };
 
     await withSubmitting(async () => {

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -41,6 +41,8 @@ import { ButtonPrimitive } from '@/components/shared/button-primitive';
 export interface ConsultationBookingModalSelectionInfo {
   focusLabel: string;
   levelId: string;
+  /** Level display title for confirmation email Details row. */
+  levelLabel: string;
   levelFeatures: string[];
   focusLabelFormatted: string;
   upgradeToDeepDiveLabel: string;
@@ -452,6 +454,8 @@ export function ConsultationBookingModal({
         dateEndTime={rebasedParts[0]?.endDateTime ?? ''}
         topicsFieldConfig={topicsFieldConfig}
         topicsPrefill={bookingPayload.topicsPrefill}
+        consultationWritingFocusLabel={selectionInfo?.focusLabel ?? ''}
+        consultationLevelLabel={selectionInfo?.levelLabel ?? ''}
         descriptionId={dialogDescriptionId}
         analyticsSectionId={analyticsSectionId}
         metaPixelContentName={metaPixelContentName}

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -207,6 +207,7 @@ export function ConsultationsBooking({
       return {
         focusLabel: focus.title,
         levelId: level.id,
+        levelLabel: level.title,
         levelFeatures: level.features,
         focusLabelFormatted: formatContentTemplate(
           content.reservation.modalFocusLabelTemplate,

--- a/apps/public_www/src/lib/reservations-data.ts
+++ b/apps/public_www/src/lib/reservations-data.ts
@@ -27,6 +27,10 @@ export interface ReservationSubmissionPayload {
   course_slug?: string;
   schedule_date_label?: string;
   schedule_time_label?: string;
+  /** Consultation booking: writing focus title for confirmation email Details row. */
+  consultation_writing_focus_label?: string;
+  /** Consultation booking: level title for confirmation email Details row. */
+  consultation_level_label?: string;
   location_name?: string;
   /**
    * PNG data URL from the same FPS QR as the booking modal; backend inlines it

--- a/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
@@ -111,6 +111,7 @@ describe('ConsultationBookingModal', () => {
     const selectionInfo: ConsultationBookingModalSelectionInfo = {
       focusLabel: 'Home Assessment',
       levelId: 'essentials',
+      levelLabel: essentialsLevel.title,
       levelFeatures: essentialsLevel.features,
       focusLabelFormatted: 'Home Assessment focus',
       upgradeToDeepDiveLabel: enContent.consultations.booking.reservation.upgradeToDeepDiveLabel,
@@ -146,6 +147,7 @@ describe('ConsultationBookingModal', () => {
     const essentialsInfo: ConsultationBookingModalSelectionInfo = {
       focusLabel: 'Home Assessment',
       levelId: 'essentials',
+      levelLabel: enContent.consultations.booking.levels[0].title,
       levelFeatures: enContent.consultations.booking.levels[0].features,
       focusLabelFormatted: 'Home Assessment focus',
       upgradeToDeepDiveLabel: upgradeLabel,
@@ -178,6 +180,7 @@ describe('ConsultationBookingModal', () => {
     const deepDiveInfo: ConsultationBookingModalSelectionInfo = {
       focusLabel: 'Home Assessment',
       levelId: 'deep-dive',
+      levelLabel: enContent.consultations.booking.levels[1].title,
       levelFeatures: enContent.consultations.booking.levels[1].features,
       focusLabelFormatted: 'Home Assessment focus',
       upgradeToDeepDiveLabel: upgradeLabel,
@@ -216,6 +219,7 @@ describe('ConsultationBookingModal', () => {
     const selectionInfo: ConsultationBookingModalSelectionInfo = {
       focusLabel: 'Home Assessment',
       levelId: 'essentials',
+      levelLabel: enContent.consultations.booking.levels[0].title,
       levelFeatures: enContent.consultations.booking.levels[0].features,
       focusLabelFormatted: 'Home Assessment focus',
       upgradeToDeepDiveLabel: upgradeLabel,

--- a/backend/src/app/api/public_legacy_confirmation.py
+++ b/backend/src/app/api/public_legacy_confirmation.py
@@ -12,6 +12,7 @@ from app.services.email import (
 )
 from app.services.marketing_subscribe import subscribe_to_marketing
 from app.templates.booking_confirmation_render import (
+    booking_confirmation_template_merge_data,
     render_booking_confirmation_email,
     substitute_shell_placeholders,
 )
@@ -157,6 +158,8 @@ def send_booking_confirmation_email(
     is_pending_payment: bool,
     locale: str,
     fps_qr_image_data_url: str | None = None,
+    consultation_writing_focus_label: str | None = None,
+    consultation_level_label: str | None = None,
 ) -> None:
     from_addr = os.getenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "").strip()
     if not from_addr:
@@ -166,18 +169,19 @@ def send_booking_confirmation_email(
         return
     loc = normalize_body_locale(locale)
     template = f"evolvesprouts-booking-confirmation-{loc}"
-    data: dict[str, Any] = {
-        "full_name": full_name.strip(),
-        "course_label": course_label.strip(),
-        "payment_method": payment_method.strip(),
-        "total_amount": total_amount,
-        "is_pending_payment": is_pending_payment,
-        "whatsapp_url": resolve_whatsapp_url_for_template(),
-    }
-    if schedule_date_label and schedule_date_label.strip():
-        data["schedule_date_label"] = schedule_date_label.strip()
-    if schedule_time_label and schedule_time_label.strip():
-        data["schedule_time_label"] = schedule_time_label.strip()
+    data: dict[str, Any] = booking_confirmation_template_merge_data(
+        locale=loc,
+        full_name=full_name,
+        course_label=course_label,
+        schedule_date_label=schedule_date_label,
+        schedule_time_label=schedule_time_label,
+        payment_method_code=payment_method,
+        total_amount=total_amount,
+        is_pending_payment=is_pending_payment,
+        whatsapp_url=resolve_whatsapp_url_for_template(),
+        consultation_writing_focus_label=consultation_writing_focus_label,
+        consultation_level_label=consultation_level_label,
+    )
     merged = merge_transactional_shell_template_data(locale=loc, template_data=data)
 
     pm_lower = payment_method.lower().strip()
@@ -204,11 +208,13 @@ def send_booking_confirmation_email(
             course_label=course_label,
             schedule_date_label=schedule_date_label,
             schedule_time_label=schedule_time_label,
-            payment_method=payment_method,
+            payment_method_code=payment_method,
             total_amount=total_amount,
             is_pending_payment=is_pending_payment,
             whatsapp_url=wa_url,
             include_fps_qr_image=True,
+            consultation_writing_focus_label=consultation_writing_focus_label,
+            consultation_level_label=consultation_level_label,
         )
         full_html = substitute_shell_placeholders(html_doc, merged)
         try:
@@ -376,6 +382,8 @@ def run_reservation_post_success(*, payload: Mapping[str, Any]) -> None:
         course_label = "Your booking"
     schedule_date = _optional_str(payload.get("schedule_date_label"))
     schedule_time = _optional_str(payload.get("schedule_time_label"))
+    consultation_focus = _optional_str(payload.get("consultation_writing_focus_label"))
+    consultation_level = _optional_str(payload.get("consultation_level_label"))
     payment_method = str(payload.get("payment_method") or "").strip() or "unknown"
     price = payload.get("price")
     total_amount = _format_hkd_amount(price)
@@ -398,6 +406,8 @@ def run_reservation_post_success(*, payload: Mapping[str, Any]) -> None:
                 is_pending_payment=is_pending,
                 locale=locale,
                 fps_qr_image_data_url=fps_qr_data_url,
+                consultation_writing_focus_label=consultation_focus,
+                consultation_level_label=consultation_level,
             )
         except Exception:
             logger.exception(
@@ -431,7 +441,7 @@ def _format_hkd_amount(price: Any) -> str:
         n = float(price)
     except (TypeError, ValueError):
         return "HK$0.00"
-    return f"HK${n:.2f}"
+    return f"HK${n:,.2f}"
 
 
 def _get_header_case_insensitive(event: Mapping[str, Any], name: str) -> str:

--- a/backend/src/app/templates/booking_confirmation_content.py
+++ b/backend/src/app/templates/booking_confirmation_content.py
@@ -22,23 +22,23 @@ HEADER_TITLE: dict[str, str] = {
 
 TABLE_LABELS: dict[str, dict[str, str]] = {
     "en": {
-        "course": "Course / event",
-        "date": "Date",
-        "time": "Time",
+        "service": "Service",
+        "datetime": "Date & time",
+        "details": "Details",
         "payment": "Payment method",
         "total": "Total",
     },
     "zh-CN": {
-        "course": "课程 / 活动",
-        "date": "日期",
-        "time": "时间",
+        "service": "服务",
+        "datetime": "日期及时间",
+        "details": "详情",
         "payment": "付款方式",
         "total": "总额",
     },
     "zh-HK": {
-        "course": "課程 / 活動",
-        "date": "日期",
-        "time": "時間",
+        "service": "服務",
+        "datetime": "日期及時間",
+        "details": "詳情",
         "payment": "付款方式",
         "total": "總額",
     },
@@ -54,6 +54,36 @@ FPS_QR_INTRO: dict[str, str] = {
     "en": "Use the FPS QR code below with your banking app to pay.",
     "zh-CN": "请使用下方 FPS 二维码，通过您的银行应用付款。",
     "zh-HK": "請使用下方 FPS 二維碼，透過您的銀行應用程式付款。",
+}
+
+FPS_PAYMENT_DISCLAIMER: dict[str, str] = {
+    "en": "If you have already completed payment, you can ignore the QR code below.",
+    "zh-CN": "若您已完成付款，请忽略下方的二维码。",
+    "zh-HK": "若您已完成付款，請忽略下方的二維碼。",
+}
+
+# Sub-lines inside the HTML "Details" row (consultation bookings).
+DETAILS_CONSULTATION_KIND: dict[str, str] = {
+    "en": "Consultation",
+    "zh-CN": "咨询",
+    "zh-HK": "諮詢",
+}
+DETAILS_WRITING_FOCUS_PREFIX: dict[str, str] = {
+    "en": "Writing focus",
+    "zh-CN": "写作重点",
+    "zh-HK": "寫作重點",
+}
+DETAILS_LEVEL_PREFIX: dict[str, str] = {
+    "en": "Level",
+    "zh-CN": "级别",
+    "zh-HK": "級別",
+}
+
+# Customer-facing payment method line in confirmation (maps reservation payload codes).
+PAYMENT_METHOD_LABELS: dict[str, str] = {
+    "fps_qr": "FPS",
+    "bank_transfer": "Bank Transfer",
+    "stripe": "Credit Card",
 }
 
 WHATSAPP_INTRO: dict[str, str] = {

--- a/backend/src/app/templates/booking_confirmation_render.py
+++ b/backend/src/app/templates/booking_confirmation_render.py
@@ -6,8 +6,13 @@ import html
 from typing import Any
 
 from app.templates.booking_confirmation_content import (
+    DETAILS_CONSULTATION_KIND,
+    DETAILS_LEVEL_PREFIX,
+    DETAILS_WRITING_FOCUS_PREFIX,
+    FPS_PAYMENT_DISCLAIMER,
     FPS_QR_INTRO,
     HEADER_TITLE,
+    PAYMENT_METHOD_LABELS,
     PENDING_PAYMENT_NOTE,
     SIGN_OFF_PLAIN,
     SUBJECT_PREFIX,
@@ -21,6 +26,129 @@ from app.templates.booking_confirmation_content import (
 from app.templates.ses.email_shell import wrap_transactional_html
 
 _CTA_LINK = "color:#C84A16;font-weight:600;"
+
+
+def resolve_payment_method_display(payment_method_code: str) -> str:
+    """Map reservation ``payment_method`` code to the customer-facing email label."""
+    key = (payment_method_code or "").strip().lower()
+    if key in PAYMENT_METHOD_LABELS:
+        return PAYMENT_METHOD_LABELS[key]
+    return (payment_method_code or "").strip() or "unknown"
+
+
+def format_schedule_datetime_line(
+    schedule_date_label: str | None,
+    schedule_time_label: str | None,
+) -> str | None:
+    """Single schedule line: date+time, time-only, or date-only (first session rules)."""
+    date_s = (schedule_date_label or "").strip()
+    time_s = (schedule_time_label or "").strip()
+    if date_s and time_s:
+        return f"{date_s} {time_s}"
+    if time_s:
+        return time_s
+    if date_s:
+        return date_s
+    return None
+
+
+def _consultation_details_segments(
+    *,
+    loc: str,
+    consultation_writing_focus_label: str | None,
+    consultation_level_label: str | None,
+) -> list[str]:
+    focus = (consultation_writing_focus_label or "").strip()
+    level = (consultation_level_label or "").strip()
+    if not focus and not level:
+        return []
+    lines: list[str] = [DETAILS_CONSULTATION_KIND[loc]]
+    if focus:
+        lines.append(f"{DETAILS_WRITING_FOCUS_PREFIX[loc]}: {focus}")
+    if level:
+        lines.append(f"{DETAILS_LEVEL_PREFIX[loc]}: {level}")
+    return lines
+
+
+def format_consultation_details_html_cell(
+    *,
+    loc: str,
+    consultation_writing_focus_label: str | None,
+    consultation_level_label: str | None,
+) -> str:
+    segments = _consultation_details_segments(
+        loc=loc,
+        consultation_writing_focus_label=consultation_writing_focus_label,
+        consultation_level_label=consultation_level_label,
+    )
+    if not segments:
+        return ""
+    inner = "<br/>".join(html.escape(s) for s in segments)
+    return f'<span style="display:block;text-align:right;">{inner}</span>'
+
+
+def format_consultation_details_plain(
+    *,
+    loc: str,
+    consultation_writing_focus_label: str | None,
+    consultation_level_label: str | None,
+) -> str:
+    segments = _consultation_details_segments(
+        loc=loc,
+        consultation_writing_focus_label=consultation_writing_focus_label,
+        consultation_level_label=consultation_level_label,
+    )
+    if not segments:
+        return ""
+    return "\n".join(segments)
+
+
+def booking_confirmation_template_merge_data(
+    *,
+    locale: str,
+    full_name: str,
+    course_label: str,
+    schedule_date_label: str | None,
+    schedule_time_label: str | None,
+    payment_method_code: str,
+    total_amount: str,
+    is_pending_payment: bool,
+    whatsapp_url: str,
+    consultation_writing_focus_label: str | None = None,
+    consultation_level_label: str | None = None,
+) -> dict[str, Any]:
+    """Build SES template_data (before shell merge)."""
+    loc = normalize_booking_locale(locale)
+    pm_display = resolve_payment_method_display(payment_method_code)
+    schedule_line = format_schedule_datetime_line(
+        schedule_date_label, schedule_time_label
+    )
+    details_html = format_consultation_details_html_cell(
+        loc=loc,
+        consultation_writing_focus_label=consultation_writing_focus_label,
+        consultation_level_label=consultation_level_label,
+    )
+    details_plain = format_consultation_details_plain(
+        loc=loc,
+        consultation_writing_focus_label=consultation_writing_focus_label,
+        consultation_level_label=consultation_level_label,
+    )
+    pm_lower = (payment_method_code or "").strip().lower()
+    include_fps_instructions = pm_lower == "fps_qr" and is_pending_payment
+    data: dict[str, Any] = {
+        "full_name": full_name.strip(),
+        "course_label": course_label.strip(),
+        "payment_method": pm_display,
+        "total_amount": total_amount,
+        "is_pending_payment": is_pending_payment,
+        "whatsapp_url": whatsapp_url.strip(),
+        "include_fps_instructions": include_fps_instructions,
+        "details_block_html": details_html,
+        "details_plain": details_plain,
+    }
+    if schedule_line:
+        data["schedule_datetime_label"] = schedule_line
+    return data
 
 
 def _html_table_row_bordered(label: str, value_html: str) -> str:
@@ -48,18 +176,21 @@ def render_booking_confirmation_email(
     course_label: str,
     schedule_date_label: str | None,
     schedule_time_label: str | None,
-    payment_method: str,
+    payment_method_code: str,
     total_amount: str,
     is_pending_payment: bool,
     whatsapp_url: str,
     include_fps_qr_image: bool,
+    consultation_writing_focus_label: str | None = None,
+    consultation_level_label: str | None = None,
 ) -> tuple[str, str, str]:
     """Return (subject, full_html, plain_text)."""
     loc = normalize_booking_locale(locale)
     labels = TABLE_LABELS[loc]
     esc_name = html.escape(full_name.strip())
     esc_course = html.escape(course_label.strip())
-    esc_pm = html.escape(payment_method.strip())
+    pm_display = resolve_payment_method_display(payment_method_code)
+    esc_pm = html.escape(pm_display)
     esc_total = html.escape(total_amount)
     esc_wa = html.escape(whatsapp_url.strip(), quote=True)
 
@@ -70,21 +201,26 @@ def render_booking_confirmation_email(
     )
 
     rows_html: list[str] = [
-        _html_table_row_bordered(labels["course"], esc_course),
+        _html_table_row_bordered(labels["service"], esc_course),
     ]
-    if schedule_date_label and schedule_date_label.strip():
+    schedule_line = format_schedule_datetime_line(
+        schedule_date_label, schedule_time_label
+    )
+    if schedule_line:
         rows_html.append(
             _html_table_row_bordered(
-                labels["date"],
-                html.escape(schedule_date_label.strip()),
+                labels["datetime"],
+                html.escape(schedule_line),
             )
         )
-    if schedule_time_label and schedule_time_label.strip():
+    details_cell = format_consultation_details_html_cell(
+        loc=loc,
+        consultation_writing_focus_label=consultation_writing_focus_label,
+        consultation_level_label=consultation_level_label,
+    )
+    if details_cell:
         rows_html.append(
-            _html_table_row_bordered(
-                labels["time"],
-                html.escape(schedule_time_label.strip()),
-            )
+            _html_table_row_bordered(labels["details"], details_cell),
         )
     rows_html.append(_html_table_row_bordered(labels["payment"], esc_pm))
     rows_html.append(_html_table_row_final(labels["total"], esc_total))
@@ -109,6 +245,9 @@ def render_booking_confirmation_email(
     if include_fps_qr_image:
         fps_block = (
             f'<p style="margin:0 0 8px;">{html.escape(FPS_QR_INTRO[loc])}</p>'
+            f'<p style="margin:0 0 12px;font-size:14px;line-height:1.5;color:#555555;">'
+            f"{html.escape(FPS_PAYMENT_DISCLAIMER[loc])}"
+            "</p>"
             '<p style="margin:0 0 16px;text-align:center;">'
             '<img src="cid:fps_qr" width="128" height="128" alt="FPS QR code" '
             'style="display:inline-block;border:0;outline:none;"/>'
@@ -138,11 +277,13 @@ def render_booking_confirmation_email(
         course_label=course_label.strip(),
         schedule_date_label=schedule_date_label,
         schedule_time_label=schedule_time_label,
-        payment_method=payment_method.strip(),
+        payment_method_display=pm_display,
         total_amount=total_amount,
         is_pending_payment=is_pending_payment,
         whatsapp_url=whatsapp_url.strip(),
         include_fps_qr_image=include_fps_qr_image,
+        consultation_writing_focus_label=consultation_writing_focus_label,
+        consultation_level_label=consultation_level_label,
     )
     plain_text = "\n".join(text_lines)
 
@@ -172,11 +313,13 @@ def _build_plain_text(
     course_label: str,
     schedule_date_label: str | None,
     schedule_time_label: str | None,
-    payment_method: str,
+    payment_method_display: str,
     total_amount: str,
     is_pending_payment: bool,
     whatsapp_url: str,
     include_fps_qr_image: bool,
+    consultation_writing_focus_label: str | None,
+    consultation_level_label: str | None,
 ) -> list[str]:
     label_sep = ": " if loc == "en" else "："
     lines: list[str] = []
@@ -185,17 +328,26 @@ def _build_plain_text(
     else:
         lines.append(f"您好 {full_name}，\n")
     lines.append(THANK_YOU_PLAIN[loc])
-    lines.append(f"{labels['course']}{label_sep}{course_label}\n")
-    if schedule_date_label and schedule_date_label.strip():
-        lines.append(f"{labels['date']}{label_sep}{schedule_date_label.strip()}\n")
-    if schedule_time_label and schedule_time_label.strip():
-        lines.append(f"{labels['time']}{label_sep}{schedule_time_label.strip()}\n")
-    lines.append(f"{labels['payment']}{label_sep}{payment_method}\n")
+    lines.append(f"{labels['service']}{label_sep}{course_label}\n")
+    schedule_line = format_schedule_datetime_line(
+        schedule_date_label, schedule_time_label
+    )
+    if schedule_line:
+        lines.append(f"{labels['datetime']}{label_sep}{schedule_line}\n")
+    details_plain = format_consultation_details_plain(
+        loc=loc,
+        consultation_writing_focus_label=consultation_writing_focus_label,
+        consultation_level_label=consultation_level_label,
+    )
+    if details_plain:
+        lines.append(f"{labels['details']}{label_sep}\n{details_plain}\n")
+    lines.append(f"{labels['payment']}{label_sep}{payment_method_display}\n")
     lines.append(f"{labels['total']}{label_sep}{total_amount}\n\n")
     if is_pending_payment:
         lines.append(f"{PENDING_PAYMENT_NOTE[loc]}\n\n")
     if include_fps_qr_image:
         lines.append(f"{FPS_QR_INTRO[loc]}\n")
+        lines.append(f"{FPS_PAYMENT_DISCLAIMER[loc]}\n")
         lines.append("[FPS QR code image is attached as fps-qr.png]\n\n")
     lines.append(f"{WHATSAPP_INTRO[loc]}\n")
     if loc == "en":

--- a/backend/src/app/templates/ses/booking_confirmation.py
+++ b/backend/src/app/templates/ses/booking_confirmation.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from app.templates.booking_confirmation_content import (
     BOOKING_CONFIRMATION_LOCALES,
+    FPS_PAYMENT_DISCLAIMER,
+    FPS_QR_INTRO,
     GREETING_HTML,
     HEADER_TITLE,
     PENDING_PAYMENT_NOTE,
@@ -26,23 +28,23 @@ def _inner_html_and_text_for_locale(loc: str) -> tuple[str, str]:
     """Handlebars inner HTML and plain text (copy shared with MIME render module)."""
     labels = TABLE_LABELS[loc]
     border = "border-bottom:1px solid #eeeeee;"
-    row_course = (
-        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["course"]}</strong></td>'
+    row_service = (
+        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["service"]}</strong></td>'
         '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
         "{{course_label}}</td></tr>"
     )
-    row_date = (
-        "{{#if schedule_date_label}}"
-        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["date"]}</strong></td>'
+    row_datetime = (
+        "{{#if schedule_datetime_label}}"
+        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["datetime"]}</strong></td>'
         '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-        "{{schedule_date_label}}</td></tr>"
+        "{{schedule_datetime_label}}</td></tr>"
         "{{/if}}"
     )
-    row_time = (
-        "{{#if schedule_time_label}}"
-        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["time"]}</strong></td>'
+    row_details = (
+        "{{#if details_block_html}}"
+        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["details"]}</strong></td>'
         '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-        "{{schedule_time_label}}</td></tr>"
+        "{{{details_block_html}}}</td></tr>"
         "{{/if}}"
     )
     row_payment = (
@@ -60,9 +62,9 @@ def _inner_html_and_text_for_locale(loc: str) -> tuple[str, str]:
         + THANK_YOU_HTML[loc]
         + '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" '
         'style="border-collapse:collapse;margin:0 0 16px;">'
-        + row_course
-        + row_date
-        + row_time
+        + row_service
+        + row_datetime
+        + row_details
         + row_payment
         + row_total
         + "</table>"
@@ -70,6 +72,12 @@ def _inner_html_and_text_for_locale(loc: str) -> tuple[str, str]:
         '<p style="margin:0 0 16px;padding:12px;background:#fff8e6;border-radius:8px;'
         'color:#5c4a00;">'
         f"{pending}"
+        "</p>"
+        "{{/if}}"
+        "{{#if include_fps_instructions}}"
+        f'<p style="margin:0 0 8px;">{FPS_QR_INTRO[loc]}</p>'
+        '<p style="margin:0 0 12px;font-size:14px;line-height:1.5;color:#555555;">'
+        f"{FPS_PAYMENT_DISCLAIMER[loc]}"
         "</p>"
         "{{/if}}"
         f'<p style="margin:0 0 12px;">{WHATSAPP_INTRO[loc]}</p>'
@@ -85,15 +93,15 @@ def _inner_html_and_text_for_locale(loc: str) -> tuple[str, str]:
     text_part = (
         greeting_plain
         + THANK_YOU_PLAIN[loc]
-        + f"{labels['course']}{label_sep}"
+        + f"{labels['service']}{label_sep}"
         + "{{course_label}}\n"
-        + "{{#if schedule_date_label}}"
-        + f"{labels['date']}{label_sep}"
-        + "{{schedule_date_label}}\n"
+        + "{{#if schedule_datetime_label}}"
+        + f"{labels['datetime']}{label_sep}"
+        + "{{schedule_datetime_label}}\n"
         + "{{/if}}"
-        + "{{#if schedule_time_label}}"
-        + f"{labels['time']}{label_sep}"
-        + "{{schedule_time_label}}\n"
+        + "{{#if details_plain}}"
+        + f"{labels['details']}{label_sep}\n"
+        + "{{details_plain}}\n"
         + "{{/if}}"
         + f"{labels['payment']}{label_sep}"
         + "{{payment_method}}\n"
@@ -101,6 +109,10 @@ def _inner_html_and_text_for_locale(loc: str) -> tuple[str, str]:
         + "{{total_amount}}\n\n"
         + "{{#if is_pending_payment}}"
         + f"{pending}\n\n"
+        + "{{/if}}"
+        + "{{#if include_fps_instructions}}"
+        + f"{FPS_QR_INTRO[loc]}\n"
+        + f"{FPS_PAYMENT_DISCLAIMER[loc]}\n\n"
         + "{{/if}}"
         + f"{WHATSAPP_INTRO[loc]}\n"
         + (

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1005,6 +1005,18 @@ components:
         schedule_time_label:
           type: string
           maxLength: 500
+        consultation_writing_focus_label:
+          type: string
+          maxLength: 500
+          description: >
+            Optional consultation booking: writing focus title shown in the booking
+            confirmation email Details row.
+        consultation_level_label:
+          type: string
+          maxLength: 500
+          description: >
+            Optional consultation booking: level title shown in the booking confirmation
+            email Details row.
         location_name:
           type: string
           maxLength: 500

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -50,6 +50,11 @@ template names.
 - **Shared HTML shell footer** (`footer_block_html`): after the thank-you line,
   rule, and optional social links, a centered copyright line is appended using
   the **UTC year at send time** (`© <year> Evolve Sprouts. All rights reserved.`).
+- **Booking confirmation** (`evolvesprouts-booking-confirmation-{locale}`): table
+  shows **Service**, a single **Date & time** line, customer-facing **Payment method**
+  (FPS / Credit Card / Bank Transfer), HKD totals with thousands separators, optional
+  **Details** for consultation payloads, and FPS pay instructions only when payment is
+  pending and `payment_method` is `fps_qr` (plus a short “already paid” disclaimer).
 
 ## Components
 

--- a/tests/test_booking_confirmation_fps_qr.py
+++ b/tests/test_booking_confirmation_fps_qr.py
@@ -99,6 +99,8 @@ def test_send_booking_confirmation_ignores_fps_qr_when_not_pending(
 
     templated.assert_called_once()
     mime.assert_not_called()
+    merged = templated.call_args.kwargs["template_data"]
+    assert merged.get("include_fps_instructions") is False
 
 
 def test_send_booking_confirmation_falls_back_when_fps_qr_invalid(
@@ -131,3 +133,6 @@ def test_send_booking_confirmation_falls_back_when_fps_qr_invalid(
 
     templated.assert_called_once()
     mime.assert_not_called()
+    merged = templated.call_args.kwargs["template_data"]
+    assert merged.get("include_fps_instructions") is True
+    assert merged.get("payment_method") == "FPS"

--- a/tests/test_booking_confirmation_helpers.py
+++ b/tests/test_booking_confirmation_helpers.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from app.templates.booking_confirmation_render import (
+    booking_confirmation_template_merge_data,
+    format_schedule_datetime_line,
+    resolve_payment_method_display,
+)
+
+
+def test_format_schedule_datetime_line_joins_or_prefers_parts() -> None:
+    assert format_schedule_datetime_line("Apr 2026", "10:00 – 11:00") == "Apr 2026 10:00 – 11:00"
+    assert format_schedule_datetime_line("", "Mon, 12 Apr 2026 AM") == "Mon, 12 Apr 2026 AM"
+    assert format_schedule_datetime_line("Apr, 2026", "") == "Apr, 2026"
+    assert format_schedule_datetime_line(None, None) is None
+
+
+def test_resolve_payment_method_display() -> None:
+    assert resolve_payment_method_display("fps_qr") == "FPS"
+    assert resolve_payment_method_display("stripe") == "Credit Card"
+    assert resolve_payment_method_display("bank_transfer") == "Bank Transfer"
+    assert resolve_payment_method_display("other") == "other"
+
+
+def test_booking_confirmation_template_merge_data_consultation_details() -> None:
+    data = booking_confirmation_template_merge_data(
+        locale="en",
+        full_name="A",
+        course_label="Consultation",
+        schedule_date_label="Apr 2026",
+        schedule_time_label="Mon, 12 Apr 2026 AM",
+        payment_method_code="fps_qr",
+        total_amount="HK$1,234.00",
+        is_pending_payment=True,
+        whatsapp_url="https://wa.me/1",
+        consultation_writing_focus_label="College essays",
+        consultation_level_label="Essentials",
+    )
+    assert data["schedule_datetime_label"] == "Apr 2026 Mon, 12 Apr 2026 AM"
+    assert data["payment_method"] == "FPS"
+    assert data["include_fps_instructions"] is True
+    assert "Consultation" in data["details_block_html"]
+    assert "College essays" in data["details_block_html"]
+    assert "Writing focus" in data["details_plain"]

--- a/tests/test_booking_confirmation_render.py
+++ b/tests/test_booking_confirmation_render.py
@@ -13,7 +13,7 @@ def test_render_booking_confirmation_zh_cn_includes_labels_and_fps_block() -> No
         course_label="课程 A",
         schedule_date_label="4月12日",
         schedule_time_label=None,
-        payment_method="fps_qr",
+        payment_method_code="fps_qr",
         total_amount="HK$100.00",
         is_pending_payment=True,
         whatsapp_url="https://wa.me/123",
@@ -22,8 +22,12 @@ def test_render_booking_confirmation_zh_cn_includes_labels_and_fps_block() -> No
     assert "预约确认" in subject
     assert "课程 A" in subject
     assert "王敏" in html_doc
-    assert "课程 / 活动" in html_doc
+    assert "服务" in html_doc
+    assert "日期及时间" in html_doc
+    assert "付款方式" in html_doc
+    assert "FPS" in html_doc
     assert "cid:fps_qr" in html_doc
+    assert "若您已完成付款" in html_doc
     assert "付款确认前" in plain
     assert "WhatsApp：" in plain
 
@@ -35,16 +39,16 @@ def test_render_booking_confirmation_en_omits_optional_schedule_rows() -> None:
         course_label="Workshop",
         schedule_date_label=None,
         schedule_time_label=None,
-        payment_method="bank_transfer",
+        payment_method_code="bank_transfer",
         total_amount="HK$50.00",
         is_pending_payment=False,
         whatsapp_url="https://wa.me/x",
         include_fps_qr_image=False,
     )
-    assert "Date" not in html_doc
-    assert "Time" not in html_doc
+    assert "Date &amp; time" not in html_doc
+    assert "Bank Transfer" in html_doc
     assert "cid:fps_qr" not in html_doc
-    assert "Date:" not in plain
+    assert "Date & time:" not in plain
     assert "WhatsApp: https://wa.me/x" in plain
 
 
@@ -55,7 +59,7 @@ def test_substitute_shell_placeholders_replaces_logo_and_footer() -> None:
         course_label="B",
         schedule_date_label=None,
         schedule_time_label=None,
-        payment_method="m",
+        payment_method_code="m",
         total_amount="HK$1",
         is_pending_payment=False,
         whatsapp_url="https://wa.me/1",

--- a/tests/test_public_legacy_confirmation.py
+++ b/tests/test_public_legacy_confirmation.py
@@ -77,10 +77,10 @@ def test_run_reservation_post_success_sets_pending_without_stripe(
             "email": "j@example.com",
             "course_label": "Course",
             "payment_method": "fps_qr",
-            "price": 150,
+            "price": 15234.5,
             "locale": "en",
         }
     )
 
     assert captured["is_pending_payment"] is True
-    assert captured["total_amount"] == "HK$150.00"
+    assert captured["total_amount"] == "HK$15,234.50"

--- a/tests/test_ses_booking_confirmation_templates.py
+++ b/tests/test_ses_booking_confirmation_templates.py
@@ -10,4 +10,7 @@ def test_booking_ses_templates_preserve_handlebars_placeholders() -> None:
     assert "{{course_label}}" in en["SubjectPart"]
     assert "{{full_name}}" in en["HtmlPart"]
     assert "{{#if is_pending_payment}}" in en["HtmlPart"]
+    assert "{{#if include_fps_instructions}}" in en["HtmlPart"]
+    assert "{{#if schedule_datetime_label}}" in en["HtmlPart"]
+    assert "{{{details_block_html}}}" in en["HtmlPart"]
     assert "{{whatsapp_url}}" in en["TextPart"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the transactional booking confirmation email (SES templates + MIME path with inline FPS QR) and the public reservation payload for consultations.

### Email behavior
- **Total**: HKD amounts use thousands separators (e.g. `HK$15,234.50`).
- **Payment method** shows **FPS**, **Credit Card**, or **Bank Transfer** (mapped from `fps_qr`, `stripe`, `bank_transfer`).
- **Schedule**: one **Date & time** row — `date + time` when both exist, otherwise whichever is present (multi-session flows already send the first session via existing labels).
- **Course / event** label is now **Service** (en/zh-CN/zh-HK).
- **Details** row (consultation only): includes Consultation, writing focus, and level when the reservation sends optional `consultation_writing_focus_label` and `consultation_level_label`.
- **FPS copy**: intro + “already paid” disclaimer render only when payment is **pending** and method is **FPS** (SES `include_fps_instructions`; MIME path unchanged for QR image).

### Public site
- Consultation booking passes focus and level titles into the reservation body for the Details row.

### Ops note
SES stored templates are upserted at deploy via `SesTemplateManagerFunction`; deploy or run the template manager so `evolvesprouts-booking-confirmation-*` matches this repo.

### Docs
- `docs/api/public.yaml`: optional consultation fields on reservation request.
- `docs/architecture/aws-messaging.md`: booking confirmation bullet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c373c55e-29d1-415b-883a-5b168699eac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c373c55e-29d1-415b-883a-5b168699eac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

