### PR TITLE
fix(ses): repair Handlebars in media download CTA for SES templates

### DIFF
--- a/backend/src/app/templates/ses/media_download_link.py
+++ b/backend/src/app/templates/ses/media_download_link.py
@@ -11,7 +11,7 @@ _CTA_BTN_OPEN = (
     '<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:0;">'
     '<tr><td bgcolor="#C84A16" align="left" '
     'style="background-color:#C84A16;border-radius:8px;padding:12px 24px;">'
-    '<a href="{{{{download_url}}}}" '
+    '<a href="{{download_url}}" '
     'style="color:#ffffff;text-decoration:none;font-weight:600;'
     'font-size:15px;line-height:1.5;font-family:Arial,Helvetica,sans-serif;">'
 )

--- a/tests/test_ses_media_download_templates.py
+++ b/tests/test_ses_media_download_templates.py
@@ -18,6 +18,7 @@ def test_media_download_ses_templates_preserve_handlebars_placeholders() -> None
     assert "padding:18px 20px" in en["HtmlPart"]
     assert "{{first_name}}" in en["HtmlPart"]
     assert "{{download_url}}" in en["HtmlPart"]
+    assert "{{{{" not in en["HtmlPart"]
     assert "{{my_best_auntie_url}}" in en["HtmlPart"]
     assert "{{free_intro_call_url}}" in en["HtmlPart"]
     assert "What you'll find inside" in en["HtmlPart"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deploy failed on `SesEmailTemplates` with:

`InvalidTemplate: Handlebars compilation failed for input Template Content`

Lambda logs showed the failure when processing `evolvesprouts-media-download-*` right after contact templates succeeded.

## Root cause

`_CTA_BTN_OPEN` is a **plain** string constant. It contained `{{{{download_url}}}}`, which was meant for Python f-string escaping (as elsewhere) but here stayed as **four** opening braces. SES treats that as invalid Handlebars.

## Fix

- Use `{{download_url}}` in `_CTA_BTN_OPEN`, consistent with other SES template placeholders.
- Test: assert `{{{{` does not appear in the English HTML part.

## Testing

- `python3 -m pytest tests/test_ses_media_download_templates.py -q`
- `pre-commit run ruff-format --files ...`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f4bb000-ea8a-4d5a-8bb5-a15ca87c8d5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f4bb000-ea8a-4d5a-8bb5-a15ca87c8d5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

