### PR TITLE
Enrich booking sales recaps: telephone, question label, consultation focus/level

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -998,9 +998,13 @@ export function BookingReservationForm({
       ...(() => {
         const focus = sanitizeSingleLineValue(consultationWritingFocusLabel);
         const level = sanitizeSingleLineValue(consultationLevelLabel);
+        const questionLabel = sanitizeSingleLineValue(
+          topicsFieldConfig?.label ?? content.topicsInterestLabel,
+        );
         return {
           ...(focus ? { consultation_writing_focus_label: focus } : {}),
           ...(level ? { consultation_level_label: level } : {}),
+          ...(questionLabel ? { comments_field_label: questionLabel } : {}),
         };
       })(),
     };

--- a/apps/public_www/src/lib/reservations-data.ts
+++ b/apps/public_www/src/lib/reservations-data.ts
@@ -31,6 +31,10 @@ export interface ReservationSubmissionPayload {
   consultation_writing_focus_label?: string;
   /** Consultation booking: level title for confirmation email Details row. */
   consultation_level_label?: string;
+  /**
+   * Label for the free-text question field (topics / notes). Sent for internal sales recap.
+   */
+  comments_field_label?: string;
   location_name?: string;
   /** Venue address line for confirmation email (combined with location_name). */
   location_address?: string;

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -154,6 +154,22 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         "interestedTopics",
         _MAX_TOPICS_LENGTH,
     )
+    consultation_writing_focus_label = _optional_text(
+        body.get("consultationWritingFocusLabel")
+        or body.get("consultation_writing_focus_label"),
+        "consultationWritingFocusLabel",
+        _MAX_LABEL_LENGTH,
+    )
+    consultation_level_label = _optional_text(
+        body.get("consultationLevelLabel") or body.get("consultation_level_label"),
+        "consultationLevelLabel",
+        _MAX_LABEL_LENGTH,
+    )
+    comments_field_label = _optional_text(
+        body.get("commentsFieldLabel") or body.get("comments_field_label"),
+        "commentsFieldLabel",
+        _MAX_LABEL_LENGTH,
+    )
 
     return {
         "attendee_name": attendee_name,
@@ -169,6 +185,9 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         "schedule_time_label": schedule_time_label,
         "interested_topics": interested_topics,
         "stripe_payment_intent_id": stripe_payment_intent_id,
+        "consultation_writing_focus_label": consultation_writing_focus_label,
+        "consultation_level_label": consultation_level_label,
+        "comments_field_label": comments_field_label,
     }
 
 

--- a/backend/src/app/services/public_form_internal_notifications.py
+++ b/backend/src/app/services/public_form_internal_notifications.py
@@ -301,12 +301,20 @@ def build_media_lead_recap_lines(
 
 
 def build_reservation_recap_lines(*, payload: Mapping[str, Any]) -> list[str]:
+    phone = str(payload.get("attendee_phone") or "").strip()
+    focus = str(payload.get("consultation_writing_focus_label") or "").strip()
+    level = str(payload.get("consultation_level_label") or "").strip()
+    topics = str(payload.get("interested_topics") or "").strip()
+    question_label = str(payload.get("comments_field_label") or "").strip()
+    question_heading = (
+        f"Question ({question_label})" if question_label else "Interested topics"
+    )
     lines = [
         "Form: Reservation / booking",
         "",
         f"Attendee name: {payload.get('attendee_name', '')}",
         f"Attendee email: {payload.get('attendee_email', '')}",
-        f"Attendee phone: {payload.get('attendee_phone', '')}",
+        f"Telephone: {phone or '(not provided)'}",
         f"Child age group: {payload.get('child_age_group', '')}",
         f"Package: {payload.get('package_label', '')}",
         f"Month: {payload.get('month_label', '')}",
@@ -314,6 +322,9 @@ def build_reservation_recap_lines(*, payload: Mapping[str, Any]) -> list[str]:
         f"Payment method: {payload.get('payment_method', '')}",
         f"Total amount: {payload.get('total_amount', '')}",
     ]
+    if focus or level:
+        lines.append(f"Focus: {focus or '(not set)'}")
+        lines.append(f"Level: {level or '(not set)'}")
     stripe_pi = payload.get("stripe_payment_intent_id")
     if stripe_pi:
         lines.append(f"Stripe PaymentIntent ID: {stripe_pi}")
@@ -321,9 +332,7 @@ def build_reservation_recap_lines(*, payload: Mapping[str, Any]) -> list[str]:
         lines.append(f"Schedule date: {payload['schedule_date_label']}")
     if payload.get("schedule_time_label"):
         lines.append(f"Schedule time: {payload['schedule_time_label']}")
-    topics = payload.get("interested_topics")
-    if topics:
-        lines.extend(["", "Interested topics:", str(topics)])
+    lines.extend(["", f"{question_heading}:", topics or "(not provided)"])
     return lines
 
 
@@ -331,20 +340,32 @@ def build_booking_legacy_recap_lines(*, payload: Mapping[str, Any]) -> list[str]
     """Recap lines for legacy reservation JSON (post-upstream success)."""
     full_name = str(payload.get("full_name") or "").strip()
     email = str(payload.get("email") or "").strip()
+    phone = str(payload.get("phone_number") or "").strip()
     course = str(payload.get("course_label") or "").strip() or "(not set)"
     payment = str(payload.get("payment_method") or "").strip() or "(not set)"
     price = payload.get("price")
     locale = str(payload.get("locale") or "").strip() or "(not set)"
+    focus = str(payload.get("consultation_writing_focus_label") or "").strip()
+    level = str(payload.get("consultation_level_label") or "").strip()
+    comments = str(payload.get("comments") or "").strip()
+    question_label = str(payload.get("comments_field_label") or "").strip()
+    question_heading = (
+        f"Question ({question_label})" if question_label else "Notes / question"
+    )
     lines = [
         "Form: Booking (legacy API)",
         "",
         f"Name: {full_name}",
         f"Email: {email}",
+        f"Telephone: {phone or '(not provided)'}",
         f"Course: {course}",
         f"Payment method: {payment}",
         f"Price: {price}",
         f"Locale: {locale}",
     ]
+    if focus or level:
+        lines.append(f"Focus: {focus or '(not set)'}")
+        lines.append(f"Level: {level or '(not set)'}")
     if payload.get("schedule_date_label"):
         lines.append(f"Schedule date: {payload['schedule_date_label']}")
     if payload.get("schedule_time_label"):
@@ -352,4 +373,5 @@ def build_booking_legacy_recap_lines(*, payload: Mapping[str, Any]) -> list[str]
     stripe_pi = payload.get("stripe_payment_intent_id")
     if stripe_pi:
         lines.append(f"Stripe PaymentIntent ID: {stripe_pi}")
+    lines.extend(["", f"{question_heading}:", comments or "(not provided)"])
     return lines

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -446,7 +446,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ReservationSubmissionRequest"
+              $ref: "#/components/schemas/PublicReservationSubmissionRequest"
       responses:
         "202":
           description: Reservation submitted.
@@ -473,7 +473,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ReservationSubmissionRequest"
+              $ref: "#/components/schemas/PublicReservationSubmissionRequest"
       responses:
         "202":
           description: Reservation submitted.
@@ -1017,6 +1017,13 @@ components:
         comments:
           type: string
           maxLength: 1000
+        comments_field_label:
+          type: string
+          maxLength: 200
+          description: >
+            Optional label for the free-text question field (e.g. topics interest).
+            Included in the internal sales recap email so the answer is attributed to
+            the correct form prompt.
         discount_code:
           type: string
           maxLength: 100
@@ -1110,6 +1117,77 @@ components:
             FPS QR shown in the public booking modal. When payment is pending and
             payment_method is fps_qr, the API may embed this image in the booking
             confirmation email.
+    PublicReservationSubmissionRequest:
+      type: object
+      required:
+        - attendeeName
+        - attendeeEmail
+        - attendeePhone
+        - childAgeGroup
+        - packageLabel
+        - monthLabel
+        - paymentMethod
+        - totalAmount
+        - courseLabel
+      properties:
+        attendeeName:
+          type: string
+          maxLength: 200
+        attendeeEmail:
+          type: string
+          format: email
+        attendeePhone:
+          type: string
+          maxLength: 40
+        childAgeGroup:
+          type: string
+          maxLength: 200
+        packageLabel:
+          type: string
+          maxLength: 200
+        monthLabel:
+          type: string
+          maxLength: 200
+        paymentMethod:
+          type: string
+          maxLength: 100
+        totalAmount:
+          type: number
+          minimum: 0
+          maximum: 1000000
+        courseLabel:
+          type: string
+          maxLength: 200
+        stripe_payment_intent_id:
+          type: string
+          maxLength: 200
+          description: Required when payment method implies Stripe; PaymentIntent id.
+          pattern: '^pi_[A-Za-z0-9]+$'
+        scheduleDateLabel:
+          type: string
+          maxLength: 200
+        scheduleTimeLabel:
+          type: string
+          maxLength: 200
+        interestedTopics:
+          type: string
+          maxLength: 1000
+        commentsFieldLabel:
+          type: string
+          maxLength: 200
+          description: >
+            Label for the free-text question field as shown to the user. Included in the
+            internal sales recap email next to their answer.
+        consultationWritingFocusLabel:
+          type: string
+          maxLength: 200
+          description: >
+            Consultation booking: writing focus title for confirmation and sales recap.
+        consultationLevelLabel:
+          type: string
+          maxLength: 200
+          description: >
+            Consultation booking: level title for confirmation and sales recap.
     ReservationPaymentIntentRequest:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -120,6 +120,9 @@ their primary responsibilities.
   are set, requests whose `Origin` or `Referer` matches that staging site use
   the staging Stripe secret; otherwise the live `EVOLVESPROUTS_STRIPE_SECRET_KEY`
   is used (reservation submission uses the same selection for PaymentIntent retrieval).
+  `POST /v1/reservations` (and `/www/v1/reservations`) accepts camelCase booking-modal
+  fields and sends a plain-text **sales recap** that includes telephone, optional
+  consultation focus/level, and the free-text question label plus answer when provided.
   (via `AwsApiProxyFunction`), and signed upload/download URL generation in
   `backend/src/app/api/admin.py`.
 

--- a/tests/test_public_form_internal_notifications.py
+++ b/tests/test_public_form_internal_notifications.py
@@ -242,10 +242,34 @@ def test_build_reservation_recap_lines_optional_fields() -> None:
             "schedule_date_label": "D",
             "schedule_time_label": "T",
             "interested_topics": "sleep",
+            "comments_field_label": "What should we know?",
         }
     )
     body = "\n".join(lines)
     assert "pi_x" in body and "sleep" in body
+    assert "Telephone: 1" in body
+    assert "Question (What should we know?):" in body
+
+
+def test_build_reservation_recap_lines_consultation_focus_and_level() -> None:
+    lines = n.build_reservation_recap_lines(
+        payload={
+            "attendee_name": "N",
+            "attendee_email": "n@example.com",
+            "attendee_phone": "999",
+            "child_age_group": "2",
+            "package_label": "P",
+            "month_label": "M",
+            "course_label": "C",
+            "payment_method": "fps",
+            "total_amount": "100",
+            "consultation_writing_focus_label": "Home routines",
+            "consultation_level_label": "Essentials",
+        }
+    )
+    body = "\n".join(lines)
+    assert "Focus: Home routines" in body
+    assert "Level: Essentials" in body
 
 
 def test_build_booking_legacy_recap_lines() -> None:
@@ -253,12 +277,20 @@ def test_build_booking_legacy_recap_lines() -> None:
         payload={
             "full_name": "Jane Doe",
             "email": "j@example.com",
+            "phone_number": "+852 9000 0000",
             "course_label": "Course",
             "payment_method": "stripe",
             "price": 10,
             "locale": "zh-HK",
             "stripe_payment_intent_id": "pi_y",
+            "comments": "Need evening slot",
+            "comments_field_label": "Notes",
+            "consultation_writing_focus_label": "Focus A",
+            "consultation_level_label": "Deep dive",
         }
     )
     body = "\n".join(lines)
     assert "j@example.com" in body and "pi_y" in body
+    assert "Telephone: +852 9000 0000" in body
+    assert "Question (Notes):" in body and "Need evening slot" in body
+    assert "Focus: Focus A" in body and "Level: Deep dive" in body


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Internal **sales recap** emails for bookings now surface:

- **Telephone** on legacy booking recaps (from `phone_number`) and clearer **Telephone** labeling on public reservation recaps.
- **Consultation focus and level** when present (`consultation_writing_focus_label` / `consultation_level_label` on legacy; same keys plus optional camelCase on `POST /v1/reservations`).
- The **free-text answer** together with the **question label** as shown in the booking modal (`comments_field_label` on legacy; optional `commentsFieldLabel` or `comments_field_label` on public reservations; the modal sends the topics field label when set).

## Docs / API

- OpenAPI: new `PublicReservationSubmissionRequest` for `/v1/reservations` and `/www/v1/reservations`; `comments_field_label` on `ReservationSubmissionRequest` (legacy path).
- `docs/architecture/lambdas.md` updated to mention recap field coverage.

## Tests

- `pytest tests/test_public_form_internal_notifications.py`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
- ESLint on touched `public_www` files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33c4ee84-06f2-49eb-bc92-d3b17dec9200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33c4ee84-06f2-49eb-bc92-d3b17dec9200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

