### PR TITLE
Booking thank-you: contact-style message plus email-parity confirmation table

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -1447,6 +1447,32 @@
     line-height: 1.5;
   }
 
+  .es-booking-confirmation-table {
+    color: var(--site-primary-text);
+    font-family: var(--figma-fontfamilies-lato, Lato), sans-serif;
+  }
+
+  .es-booking-confirmation-table__row .es-booking-confirmation-table__label,
+  .es-booking-confirmation-table__row .es-booking-confirmation-table__value {
+    padding: 8px 0;
+    border-bottom: 1px solid #eeeeee;
+  }
+
+  .es-booking-confirmation-table__row--last .es-booking-confirmation-table__label,
+  .es-booking-confirmation-table__row--last .es-booking-confirmation-table__value {
+    border-bottom: none;
+  }
+
+  .es-booking-thank-you-pending-note {
+    background: #fff8e6;
+    color: #5c4a00;
+  }
+
+  .es-booking-thank-you-fps-qr {
+    border: 0;
+    outline: none;
+  }
+
   .es-events-section {
     background-color: var(--es-color-surface-white, #FFFFFF);
   }

--- a/apps/public_www/src/components/sections/booking-modal/booking-confirmation-summary-table.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/booking-confirmation-summary-table.tsx
@@ -1,0 +1,54 @@
+import type { BookingConfirmationTableRow } from '@/lib/booking-confirmation-table';
+
+export interface BookingConfirmationSummaryTableProps {
+  rows: BookingConfirmationTableRow[];
+  caption?: string;
+}
+
+export function BookingConfirmationSummaryTable({
+  rows,
+  caption,
+}: BookingConfirmationSummaryTableProps) {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className='w-full overflow-x-auto'>
+      <table className='es-booking-confirmation-table w-full border-collapse text-left'>
+        {caption ? <caption className='sr-only'>{caption}</caption> : null}
+        <tbody>
+          {rows.map((row, index) => {
+            const isLast = index === rows.length - 1;
+            return (
+              <tr
+                key={`${row.label}-${index}`}
+                className={
+                  isLast
+                    ? 'es-booking-confirmation-table__row es-booking-confirmation-table__row--last'
+                    : 'es-booking-confirmation-table__row'
+                }
+              >
+                <th
+                  scope='row'
+                  className='es-booking-confirmation-table__label align-top font-semibold'
+                >
+                  {row.label}
+                </th>
+                <td className='es-booking-confirmation-table__value text-right align-top'>
+                  {row.multiline ? (
+                    <span className='es-booking-confirmation-table__multiline whitespace-pre-line'>
+                      {row.value}
+                    </span>
+                  ) : (
+                    row.value
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -907,15 +907,36 @@ export function BookingReservationForm({
     }
 
     const primarySession = resolvedCourseSessions[0];
+    const scheduleTimeLabel = (() => {
+      if (!primarySession) {
+        return sanitizeSingleLineValue(selectedDateStartTime) || undefined;
+      }
+      const start = sanitizeSingleLineValue(primarySession.dateStartTime);
+      const end = sanitizeSingleLineValue(primarySession.dateEndTime ?? '');
+      if (!start) {
+        return undefined;
+      }
+      return end ? `${start} – ${end}` : start;
+    })();
+    const sanitizedScheduleDateLabel =
+      sanitizeSingleLineValue(selectedCohortDateLabel) || undefined;
+    const sanitizedCourseSlug = sanitizeSingleLineValue(courseSlug ?? '') || undefined;
+    const consultationFocusSanitized =
+      sanitizeSingleLineValue(consultationWritingFocusLabel);
+    const consultationLevelSanitized = sanitizeSingleLineValue(consultationLevelLabel);
+    const primarySessionStartIso =
+      sanitizeSingleLineValue(primarySession?.dateStartTime) || undefined;
+
     const reservationSummary: ReservationSummary = {
       attendeeName: sanitizeSingleLineValue(fullName),
       attendeeEmail: sanitizeSingleLineValue(email),
       attendeePhone: sanitizeSingleLineValue(phone),
       ageGroup: sanitizeSingleLineValue(selectedAgeGroupLabel) || undefined,
-      cohort: sanitizeSingleLineValue(selectedCohortDateLabel) || undefined,
+      cohort: sanitizedScheduleDateLabel,
       paymentMethod: sanitizeSingleLineValue(
         getPaymentMethodLabel(content, selectedPaymentMethod),
       ),
+      paymentMethodCode: selectedPaymentMethod,
       totalAmount,
       eventTitle: sanitizeSingleLineValue(eventTitle),
       dateStartTime: primarySession?.dateStartTime,
@@ -933,6 +954,17 @@ export function BookingReservationForm({
 
         return href;
       })(),
+      scheduleDateLabel: sanitizedScheduleDateLabel,
+      scheduleTimeLabel,
+      primarySessionStartIso,
+      courseSlug: sanitizedCourseSlug,
+      reservationPendingUntilPaymentConfirmed: hasPendingReservationAcknowledgement,
+      ...(consultationFocusSanitized
+        ? { consultationWritingFocusLabel: consultationFocusSanitized }
+        : {}),
+      ...(consultationLevelSanitized
+        ? { consultationLevelLabel: consultationLevelSanitized }
+        : {}),
     };
     const crmApiClient = createPublicCrmApiClient();
     if (!crmApiClient || !captchaToken) {
@@ -952,18 +984,6 @@ export function BookingReservationForm({
       setSubmissionError(content.submitErrorMessage);
       return;
     }
-    const scheduleTimeLabel = (() => {
-      if (!primarySession) {
-        return sanitizeSingleLineValue(selectedDateStartTime) || undefined;
-      }
-      const start = sanitizeSingleLineValue(primarySession.dateStartTime);
-      const end = sanitizeSingleLineValue(primarySession.dateEndTime ?? '');
-      if (!start) {
-        return undefined;
-      }
-      return end ? `${start} – ${end}` : start;
-    })();
-
     const reservationPayload: ReservationSubmissionPayload = {
       full_name: reservationSummary.attendeeName,
       email: reservationSummary.attendeeEmail,
@@ -983,26 +1003,22 @@ export function BookingReservationForm({
       course_label: sanitizeSingleLineValue(eventTitle) || undefined,
       ...(() => {
         const sanitizedServiceKey = sanitizeSingleLineValue(serviceKey ?? '');
-        const sanitizedCourseSlug = sanitizeSingleLineValue(courseSlug ?? '');
         return {
           ...(sanitizedServiceKey ? { service_key: sanitizedServiceKey } : {}),
           ...(sanitizedCourseSlug ? { course_slug: sanitizedCourseSlug } : {}),
         };
       })(),
-      schedule_date_label: sanitizeSingleLineValue(selectedCohortDateLabel) || undefined,
-      schedule_time_label: scheduleTimeLabel,
+      schedule_date_label: reservationSummary.scheduleDateLabel,
+      schedule_time_label: reservationSummary.scheduleTimeLabel,
       location_name: sanitizeSingleLineValue(venueName) || undefined,
       location_address: sanitizeSingleLineValue(venueAddress) || undefined,
-      primary_session_start_iso: sanitizeSingleLineValue(primarySession?.dateStartTime)
-        || undefined,
-      ...(() => {
-        const focus = sanitizeSingleLineValue(consultationWritingFocusLabel);
-        const level = sanitizeSingleLineValue(consultationLevelLabel);
-        return {
-          ...(focus ? { consultation_writing_focus_label: focus } : {}),
-          ...(level ? { consultation_level_label: level } : {}),
-        };
-      })(),
+      primary_session_start_iso: reservationSummary.primarySessionStartIso,
+      ...(consultationFocusSanitized
+        ? { consultation_writing_focus_label: consultationFocusSanitized }
+        : {}),
+      ...(consultationLevelSanitized
+        ? { consultation_level_label: consultationLevelSanitized }
+        : {}),
     };
 
     await withSubmitting(async () => {
@@ -1097,7 +1113,16 @@ export function BookingReservationForm({
             quantity: 1,
           }],
         });
-        onSubmitReservation(reservationSummary);
+        const includeFpsQrDataUrl =
+          selectedPaymentMethod === PAYMENT_METHOD_FPS
+          && !reservationPayload.stripe_payment_intent_id
+          && fpsQrImageDataUrl.trim();
+        onSubmitReservation({
+          ...reservationSummary,
+          ...(includeFpsQrDataUrl
+            ? { fpsQrImageDataUrl: fpsQrImageDataUrl.trim() }
+            : {}),
+        });
         return;
       }
 

--- a/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
@@ -3,41 +3,28 @@
 import Image from 'next/image';
 import { useId, useMemo, useRef } from 'react';
 
-import { ExternalLinkInlineContent } from '@/components/shared/external-link-icon';
-import { ButtonPrimitive } from '@/components/shared/button-primitive';
-import { SmartLink } from '@/components/shared/smart-link';
-import {
-  OverlayDialogPanel,
-  OverlayScrollableBody,
-} from '@/components/shared/overlay-surface';
+import { BookingConfirmationSummaryTable } from '@/components/sections/booking-modal/booking-confirmation-summary-table';
 import {
   CloseButton,
   ModalOverlay,
 } from '@/components/sections/booking-modal/shared';
-import type {
-  ReservationCourseSession,
-  ReservationSummary,
-} from '@/components/sections/booking-modal/types';
+import type { ReservationSummary } from '@/components/sections/booking-modal/types';
+import { renderQuotedDescriptionText } from '@/components/sections/shared/render-highlighted-text';
+import {
+  OverlayDialogPanel,
+  OverlayScrollableBody,
+} from '@/components/shared/overlay-surface';
+import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import type { BookingThankYouModalContent, Locale } from '@/content';
 import { trackAnalyticsEvent } from '@/lib/analytics';
-import {
-  buildBookingIcsCalendarContent,
-  buildEvolveSproutsThankYouIcsFilenameBase,
-  triggerBookingIcsDownload,
-} from '@/lib/booking-calendar-download';
+import { buildBookingConfirmationTableRows } from '@/lib/booking-confirmation-table';
 import { formatCurrencyHkd } from '@/lib/format';
-import {
-  formatSiteCompactDate,
-  formatSiteTimeOfDay,
-} from '@/lib/site-datetime';
 import { useModalLockBody } from '@/lib/hooks/use-modal-lock-body';
 import { useModalFocusManagement } from '@/lib/hooks/use-modal-focus-management';
 import { trackMetaPixelEvent } from '@/lib/meta-pixel';
 import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
-import { getHrefKind } from '@/lib/url-utils';
 
-const THANK_YOU_ICS_OUTLINE_BUTTON_CLASSNAME =
-  'h-[54px] w-full rounded-control px-6 text-[16px] font-semibold sm:h-[60px] sm:text-[18px]';
+const WHATSAPP_ICON_SRC = '/images/contact-whatsapp.svg';
 
 export interface BookingThankYouModalProps {
   locale: Locale;
@@ -49,101 +36,19 @@ export interface BookingThankYouModalProps {
   onClose: () => void;
 }
 
-const WHATSAPP_ICON_SRC = '/images/contact-whatsapp.svg';
-
-type ThankYouCardIconId = 'training' | 'calendar' | 'location' | 'dollar';
-
-function ThankYouDetailCardIcon({ icon }: { icon: ThankYouCardIconId }) {
-  return (
-    <span className='inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-2xl es-booking-thank-you-detail-card-icon-wrap'>
-      <span
-        className={`es-booking-thank-you-detail-icon-mask es-booking-thank-you-detail-icon-mask--${icon}`}
-        aria-hidden='true'
-      />
-    </span>
-  );
-}
-
-function formatSummaryDatePart(dateStartTime: string | undefined, locale: Locale): string {
-  const normalized = dateStartTime?.trim() ?? '';
-  if (!normalized) {
-    return '';
-  }
-
-  return formatSiteCompactDate(normalized, locale);
-}
-
-function formatSummaryTimePart(dateStartTime: string | undefined, locale: Locale): string {
-  const normalized = dateStartTime?.trim() ?? '';
-  if (!normalized) {
-    return '';
-  }
-
-  return formatSiteTimeOfDay(normalized, locale);
-}
-
-function formatSummaryDateTimeLine(
-  dateStartTime: string | undefined,
-  locale: Locale,
-): string {
-  const datePart = formatSummaryDatePart(dateStartTime, locale);
-  const timePart = formatSummaryTimePart(dateStartTime, locale);
-  if (datePart && timePart) {
-    return `${datePart}, ${timePart}`;
-  }
-
-  return datePart || timePart;
-}
-
-function resolveThankYouLocationDisplay(
-  summary: ReservationSummary | null,
-  virtualFallback: string,
-): string {
-  const name = summary?.locationName?.trim() ?? '';
-  const address = summary?.locationAddress?.trim() ?? '';
-  const segments = [name, address].filter(Boolean);
-  if (segments.length > 0) {
-    return segments.join(', ');
-  }
-
-  return virtualFallback;
-}
-
-function resolveThankYouCourseSessions(summary: ReservationSummary | null): ReservationCourseSession[] {
-  if (!summary) {
-    return [];
-  }
-
-  if (summary.courseSessions && summary.courseSessions.length > 0) {
-    return summary.courseSessions;
-  }
-
-  const start = summary.dateStartTime?.trim() ?? '';
-  if (!start) {
-    return [];
-  }
-
-  return [
-    {
-      dateStartTime: start,
-      dateEndTime: summary.dateEndTime?.trim() || undefined,
-    },
-  ];
-}
-
 export function BookingThankYouModal({
   locale,
   content,
   summary,
-  analyticsSectionId,
+  analyticsSectionId: _analyticsSectionId,
   whatsappHref,
   whatsappCtaLabel,
   onClose,
 }: BookingThankYouModalProps) {
+  void _analyticsSectionId;
   const modalPanelRef = useRef<HTMLElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const dialogTitleId = useId();
-  const dialogSuccessId = useId();
   const dialogDescriptionId = useId();
 
   useModalLockBody({ onEscape: onClose });
@@ -154,94 +59,41 @@ export function BookingThankYouModal({
     restoreFocus: true,
   });
 
-  const subtitleText = content.subtitle?.trim() ?? '';
-  const hasSubtitleBlock = subtitleText.length > 0;
-  const attendeeEmail = summary?.attendeeEmail ?? '';
-  const eventTitle = summary?.eventTitle ?? content.courseLabel;
-  const eventSubtitle = summary?.eventSubtitle?.trim() ?? '';
-  const thankYouSessions = useMemo(
-    () => resolveThankYouCourseSessions(summary),
-    [summary],
-  );
-  const dateTimeLines = useMemo(() => {
-    return thankYouSessions
-      .map((session) => formatSummaryDateTimeLine(session.dateStartTime, locale))
-      .filter((line) => line.length > 0);
-  }, [thankYouSessions, locale]);
-
-  const locationLine = resolveThankYouLocationDisplay(
-    summary,
-    content.summaryLocationVirtualFallback,
-  );
-  const amountLine = summary
-    ? formatCurrencyHkd(summary.totalAmount, locale)
-    : content.summaryEmptyValue;
-  const locationNameRaw = summary?.locationName?.trim() ?? '';
-  const locationAddressRaw = summary?.locationAddress?.trim() ?? '';
-  const hasStructuredVenue =
-    locationNameRaw.length > 0 || locationAddressRaw.length > 0;
-  const directionHref = summary?.locationDirectionHref?.trim() ?? '';
-  const showDirectionsLink =
-    hasStructuredVenue && getHrefKind(directionHref) === 'http';
-
-  const describedByIds = hasSubtitleBlock
-    ? `${dialogSuccessId} ${dialogDescriptionId}`
-    : dialogSuccessId;
-
   const normalizedWhatsappHref = whatsappHref?.trim() ?? '';
   const normalizedWhatsappLabel = whatsappCtaLabel?.trim() ?? '';
   const showWhatsappFollowUp =
     normalizedWhatsappHref.length > 0 && normalizedWhatsappLabel.length > 0;
 
-  const icsBody = useMemo(() => {
-    if (thankYouSessions.length === 0) {
-      return null;
+  const confirmationRows = useMemo(() => {
+    if (!summary) {
+      return [];
     }
-
-    return buildBookingIcsCalendarContent({
-      title: eventTitle,
-      location: locationLine,
-      sessions: thankYouSessions.map((session) => {
-        return {
-          dateStartTime: session.dateStartTime,
-          dateEndTime: session.dateEndTime,
-        };
-      }),
+    return buildBookingConfirmationTableRows({
+      courseLabel: summary.eventTitle || content.courseLabel,
+      labels: content.confirmationTable,
+      detailsPrefixes: content.confirmationDetailsPrefixes,
+      courseSlug: summary.courseSlug,
+      scheduleDateLabel: summary.scheduleDateLabel,
+      scheduleTimeLabel: summary.scheduleTimeLabel,
+      primarySessionIso: summary.primarySessionStartIso ?? summary.dateStartTime,
+      ageGroupLabel: summary.ageGroup,
+      consultationWritingFocusLabel: summary.consultationWritingFocusLabel,
+      consultationLevelLabel: summary.consultationLevelLabel,
+      locationName: summary.locationName,
+      locationAddress: summary.locationAddress,
+      paymentMethodCode: summary.paymentMethodCode,
+      totalAmountFormatted: formatCurrencyHkd(summary.totalAmount, locale),
     });
-  }, [thankYouSessions, eventTitle, locationLine]);
+  }, [summary, content.courseLabel, content.confirmationTable, content.confirmationDetailsPrefixes, locale]);
 
-  const canDownloadIcs = Boolean(icsBody);
+  const showPendingPaymentBlock =
+    Boolean(summary?.reservationPendingUntilPaymentConfirmed);
+  const showFpsQrBlock =
+    showPendingPaymentBlock
+    && summary?.paymentMethodCode === 'fps_qr'
+    && Boolean(summary.fpsQrImageDataUrl?.trim());
 
-  function handleDownloadIcs() {
-    if (!icsBody || !summary) {
-      return;
-    }
-
-    const cohortDate =
-      thankYouSessions[0]?.dateStartTime.split('T')[0] ?? '';
-
-    trackAnalyticsEvent('booking_thank_you_ics_download', {
-      sectionId: analyticsSectionId,
-      ctaLocation: 'thank_you_modal',
-      params: {
-        cohort_date: cohortDate,
-        total_amount: summary.totalAmount,
-      },
-    });
-
-    triggerBookingIcsDownload(
-      icsBody,
-      buildEvolveSproutsThankYouIcsFilenameBase(eventTitle),
-    );
-  }
-
-  const locationTitle = hasStructuredVenue
-    ? (locationNameRaw || locationAddressRaw)
-    : locationLine;
-  const showLocationAddressBelow =
-    hasStructuredVenue
-    && locationNameRaw.length > 0
-    && locationAddressRaw.length > 0;
+  const fpsQrSrc = summary?.fpsQrImageDataUrl?.trim() ?? '';
 
   return (
     <ModalOverlay
@@ -251,7 +103,7 @@ export function BookingThankYouModal({
       <OverlayDialogPanel
         panelRef={modalPanelRef}
         ariaLabelledBy={dialogTitleId}
-        ariaDescribedBy={describedByIds}
+        ariaDescribedBy={dialogDescriptionId}
         tabIndex={-1}
         className='es-booking-thank-you-panel es-section-bg-overlay es-booking-thank-you-modal-section-bg'
       >
@@ -264,7 +116,7 @@ export function BookingThankYouModal({
         </header>
 
         <OverlayScrollableBody>
-          <div className='relative z-10 flex flex-col items-center pt-0 text-center sm:pt-6 lg:pt-14'>
+          <div className='relative z-10 flex flex-col items-center px-4 pb-2 pt-0 text-center sm:px-8 sm:pt-2'>
             <div className='flex h-[100px] w-[100px] items-center justify-center rounded-full es-bg-surface-success-soft'>
               <Image
                 src='/images/green-tick-icon.png'
@@ -275,132 +127,61 @@ export function BookingThankYouModal({
                 aria-hidden='true'
               />
             </div>
-            <h3
-              id={dialogSuccessId}
-              className='mt-3 text-[22px] font-normal leading-none es-text-heading sm:text-[28px]'
-            >
-              {content.successLabel}
-            </h3>
             <h2
               id={dialogTitleId}
-              className='es-type-title mt-2 max-w-[610px] leading-[1.1] es-booking-thank-you-heading'
+              className='mt-4 text-2xl font-semibold es-text-heading'
             >
-              {content.title}
+              {content.successTitle}
             </h2>
-            {hasSubtitleBlock ? (
-              <p
-                id={dialogDescriptionId}
-                className='mt-3 text-lg leading-7 es-booking-thank-you-body'
-              >
-                {content.subtitle}
-                {' '}
-                <span className='font-semibold es-text-emphasis'>
-                  {attendeeEmail}
-                </span>
-              </p>
-            ) : null}
+            <p
+              id={dialogDescriptionId}
+              className='mt-3 max-w-[610px] text-base leading-7 text-[color:var(--site-primary-text)]'
+            >
+              {renderQuotedDescriptionText(content.successDescription)}
+            </p>
           </div>
 
-          <section className='relative z-10 mx-auto mt-10 w-full max-w-[713px] px-4 sm:px-0'>
-            <div className='grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-5'>
-              <article className='flex h-full min-h-[200px] flex-col rounded-card-xl p-6 sm:p-8 es-booking-thank-you-detail-card'>
-                <div className='flex items-center justify-between gap-4 es-booking-thank-you-detail-card-title-row'>
-                  <h3 className='min-w-0 flex-1 text-left es-booking-thank-you-detail-card-title'>
-                    {eventTitle}
-                  </h3>
-                  <ThankYouDetailCardIcon icon='training' />
-                </div>
-                {eventSubtitle ? (
-                  <p className='mt-3 text-left es-booking-thank-you-detail-card-description'>
-                    {eventSubtitle}
-                  </p>
-                ) : null}
-              </article>
+          {confirmationRows.length > 0 ? (
+            <section
+              className='relative z-10 mx-auto mt-8 w-full max-w-[713px] px-4 sm:px-8'
+              aria-label={content.confirmationTableSectionLabel}
+            >
+              <BookingConfirmationSummaryTable
+                rows={confirmationRows}
+                caption={content.confirmationTableSectionLabel}
+              />
 
-              <article className='flex h-full min-h-[200px] flex-col rounded-card-xl p-6 sm:p-8 es-booking-thank-you-detail-card'>
-                <div className='flex items-center justify-between gap-4 es-booking-thank-you-detail-card-title-row'>
-                  <h3 className='min-w-0 flex-1 text-left es-booking-thank-you-detail-card-title'>
-                    {amountLine}
-                  </h3>
-                  <ThankYouDetailCardIcon icon='dollar' />
-                </div>
-                <p className='mt-3 text-left es-booking-thank-you-detail-card-description'>
-                  {content.paymentConfirmationNote}
+              {showPendingPaymentBlock ? (
+                <p className='es-booking-thank-you-pending-note mt-4 rounded-card-lg px-4 py-3 text-left text-base leading-7'>
+                  {content.pendingPaymentNote}
                 </p>
-              </article>
+              ) : null}
 
-              <article className='flex h-full min-h-[200px] flex-col rounded-card-xl p-6 sm:p-8 es-booking-thank-you-detail-card'>
-                <div className='flex items-center justify-between gap-4 es-booking-thank-you-detail-card-title-row'>
-                  <h3 className='min-w-0 flex-1 text-left es-booking-thank-you-detail-card-title'>
-                    {locationTitle}
-                  </h3>
-                  <ThankYouDetailCardIcon icon='location' />
+              {showFpsQrBlock ? (
+                <div className='mt-6 text-left'>
+                  <p className='text-base leading-7 text-[color:var(--site-primary-text)]'>
+                    {content.fpsQrIntro}
+                  </p>
+                  <p className='mt-2 text-sm leading-6 es-text-neutral-strong'>
+                    {content.fpsQrDisclaimer}
+                  </p>
+                  <div className='mt-4 flex justify-center sm:justify-start'>
+                    <Image
+                      src={fpsQrSrc}
+                      width={128}
+                      height={128}
+                      alt={content.fpsQrImageAlt}
+                      unoptimized
+                      className='es-booking-thank-you-fps-qr inline-block'
+                    />
+                  </div>
                 </div>
-                <div className='mt-3 flex w-full flex-col text-left'>
-                  {showLocationAddressBelow ? (
-                    <p className='es-booking-thank-you-detail-card-description'>
-                      {locationAddressRaw}
-                    </p>
-                  ) : null}
-                  {showDirectionsLink ? (
-                    <SmartLink
-                      href={directionHref}
-                      className='mt-3 inline-flex items-center text-base font-semibold leading-none es-text-heading'
-                    >
-                      {({ isExternalHttp }) => (
-                        <ExternalLinkInlineContent
-                          isExternalHttp={isExternalHttp}
-                          externalLabelClassName='es-link-external-label--direction'
-                        >
-                          {content.directionLabel}
-                        </ExternalLinkInlineContent>
-                      )}
-                    </SmartLink>
-                  ) : null}
-                </div>
-              </article>
-
-              <article className='flex h-full min-h-[200px] flex-col rounded-card-xl p-6 sm:p-8 es-booking-thank-you-detail-card'>
-                <div className='flex items-center justify-between gap-4 es-booking-thank-you-detail-card-title-row'>
-                  <h3 className='min-w-0 flex-1 text-left es-booking-thank-you-detail-card-title'>
-                    {dateTimeLines.length === 0 ? (
-                      content.summaryEmptyValue
-                    ) : (
-                      dateTimeLines.map((line, index) => {
-                        return (
-                          <span
-                            key={`${line}-${index}`}
-                            className={
-                              index > 0
-                                ? 'mt-1 block'
-                                : 'block'
-                            }
-                          >
-                            {line}
-                          </span>
-                        );
-                      })
-                    )}
-                  </h3>
-                  <ThankYouDetailCardIcon icon='calendar' />
-                </div>
-                <div className='mt-auto flex w-full pt-4 sm:pt-3'>
-                  <ButtonPrimitive
-                    variant='outline'
-                    type='button'
-                    disabled={!canDownloadIcs}
-                    onClick={handleDownloadIcs}
-                    className={THANK_YOU_ICS_OUTLINE_BUTTON_CLASSNAME}
-                  >
-                    {content.downloadCalendarInviteLabel}
-                  </ButtonPrimitive>
-                </div>
-              </article>
-            </div>
-          </section>
+              ) : null}
+            </section>
+          ) : null}
 
           {showWhatsappFollowUp ? (
-            <div className='relative z-10 mx-auto mt-8 max-w-[713px] text-center'>
+            <div className='relative z-10 mx-auto mt-8 max-w-[713px] px-4 pb-8 text-center sm:px-8'>
               <p className='text-lg leading-7 es-booking-thank-you-body'>
                 {content.followUpPrompt}
               </p>
@@ -428,7 +209,9 @@ export function BookingThankYouModal({
                 />
               </ButtonPrimitive>
             </div>
-          ) : null}
+          ) : (
+            <div className='pb-8' aria-hidden='true' />
+          )}
         </OverlayScrollableBody>
       </OverlayDialogPanel>
     </ModalOverlay>

--- a/apps/public_www/src/components/sections/booking-modal/types.ts
+++ b/apps/public_www/src/components/sections/booking-modal/types.ts
@@ -1,3 +1,5 @@
+import type { ReservationPaymentMethodCode } from '@/lib/reservations-data';
+
 export interface ReservationCourseSession {
   dateStartTime: string;
   dateEndTime?: string;
@@ -9,7 +11,10 @@ export interface ReservationSummary {
   attendeePhone: string;
   ageGroup?: string;
   cohort?: string;
+  /** Localized label from the payment form (analytics / legacy). */
   paymentMethod: string;
+  /** Machine code; matches confirmation email payment row. */
+  paymentMethodCode: ReservationPaymentMethodCode;
   totalAmount: number;
   eventTitle: string;
   dateStartTime?: string;
@@ -22,6 +27,19 @@ export interface ReservationSummary {
   locationAddress?: string;
   /** Maps or venue URL for “Get directions” on the thank-you step. */
   locationDirectionHref?: string;
+  /** Same as reservation payload: cohort / event date label for confirmation table Details row. */
+  scheduleDateLabel?: string;
+  /** Same as reservation payload: ISO range or time line for confirmation email. */
+  scheduleTimeLabel?: string;
+  /** First session start ISO (payload `primary_session_start_iso`). */
+  primarySessionStartIso?: string;
+  /** Payload `course_slug` for consultation vs MBA Details formatting. */
+  courseSlug?: string;
+  reservationPendingUntilPaymentConfirmed: boolean;
+  /** FPS PNG data URL when client attached it to the reservation payload. */
+  fpsQrImageDataUrl?: string;
+  consultationWritingFocusLabel?: string;
+  consultationLevelLabel?: string;
 }
 
 export interface BookingTopicsFieldConfig {

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1487,15 +1487,28 @@
     },
     "thankYouModal": {
       "closeLabel": "Close",
-      "title": "We will get in touch shortly.",
-      "subtitle": "",
-      "successLabel": "Thank you!",
       "courseLabel": "My Best Auntie Training Course.",
-      "summaryLocationVirtualFallback": "Virtual Zoom call",
-      "summaryEmptyValue": "—",
-      "downloadCalendarInviteLabel": "Download the invite to your personal calendar",
-      "paymentConfirmationNote": "Your spot is confirmed once payment is received.",
-      "directionLabel": "Get Directions",
+      "successTitle": "Thank you for your booking!",
+      "successDescription": "We've received your booking and a confirmation email with all the details is on its way to your inbox.",
+      "confirmationTableSectionLabel": "Booking details",
+      "confirmationTable": {
+        "service": "Service",
+        "datetime": "Date & time",
+        "location": "Location",
+        "details": "Details",
+        "payment": "Payment method",
+        "total": "Total"
+      },
+      "confirmationDetailsPrefixes": {
+        "cohort": "Cohort",
+        "ageGroup": "Age group",
+        "writingFocus": "Focus",
+        "level": "Level"
+      },
+      "pendingPaymentNote": "Your reservation is pending until payment is confirmed.",
+      "fpsQrIntro": "Use the FPS QR code below with your banking app to pay.",
+      "fpsQrDisclaimer": "If you have already completed payment, you can ignore the QR code below.",
+      "fpsQrImageAlt": "FPS QR code",
       "followUpPrompt": "Any immediate questions?"
     }
   },

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1487,15 +1487,28 @@
     },
     "thankYouModal": {
       "closeLabel": "关闭",
-      "title": "我们会尽快与您联系。",
-      "subtitle": "",
-      "successLabel": "谢谢你！",
       "courseLabel": "我的最佳阿姨培训课程。",
-      "summaryLocationVirtualFallback": "线上 Zoom 会议",
-      "summaryEmptyValue": "—",
-      "downloadCalendarInviteLabel": "下载邀请并添加到你的个人日历",
-      "paymentConfirmationNote": "收到付款后，你的名额才会确认",
-      "directionLabel": "查看路线",
+      "successTitle": "感谢你的预约！",
+      "successDescription": "我们已收到你的预约，包含全部详情的确认邮件正在发送到你的邮箱。",
+      "confirmationTableSectionLabel": "预约详情",
+      "confirmationTable": {
+        "service": "服务",
+        "datetime": "日期及时间",
+        "location": "地点",
+        "details": "详情",
+        "payment": "付款方式",
+        "total": "总额"
+      },
+      "confirmationDetailsPrefixes": {
+        "cohort": "班级",
+        "ageGroup": "年龄组",
+        "writingFocus": "重点",
+        "level": "级别"
+      },
+      "pendingPaymentNote": "在付款确认前，您的预订仍为待处理状态。",
+      "fpsQrIntro": "请使用下方 FPS 二维码，通过您的银行应用付款。",
+      "fpsQrDisclaimer": "若您已完成付款，请忽略下方的二维码。",
+      "fpsQrImageAlt": "FPS 二维码",
       "followUpPrompt": "有任何问题想立即了解？"
     }
   },

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1487,15 +1487,28 @@
     },
     "thankYouModal": {
       "closeLabel": "關閉",
-      "title": "我們會盡快與你聯絡。",
-      "subtitle": "",
-      "successLabel": "多謝你！",
       "courseLabel": "我的最佳姨姨培訓課程。",
-      "summaryLocationVirtualFallback": "網上 Zoom 會議",
-      "summaryEmptyValue": "—",
-      "downloadCalendarInviteLabel": "下載邀請並加入你嘅個人日曆",
-      "paymentConfirmationNote": "收到付款後，你的名額才會確認",
-      "directionLabel": "查看路線",
+      "successTitle": "多謝你的預約！",
+      "successDescription": "我們已收到你的預約，包含全部詳情的確認電郵正在發送到你的收件箱。",
+      "confirmationTableSectionLabel": "預約詳情",
+      "confirmationTable": {
+        "service": "服務",
+        "datetime": "日期及時間",
+        "location": "地點",
+        "details": "詳情",
+        "payment": "付款方式",
+        "total": "總額"
+      },
+      "confirmationDetailsPrefixes": {
+        "cohort": "班級",
+        "ageGroup": "年齡組",
+        "writingFocus": "重點",
+        "level": "級別"
+      },
+      "pendingPaymentNote": "在付款確認前，您的預訂仍為待處理狀態。",
+      "fpsQrIntro": "請使用下方 FPS 二維碼，透過您的銀行應用程式付款。",
+      "fpsQrDisclaimer": "若您已完成付款，請忽略下方的二維碼。",
+      "fpsQrImageAlt": "FPS 二維碼",
       "followUpPrompt": "有任何問題想即時了解？"
     }
   },

--- a/apps/public_www/src/lib/booking-confirmation-table.ts
+++ b/apps/public_www/src/lib/booking-confirmation-table.ts
@@ -1,0 +1,362 @@
+/**
+ * Mirrors booking confirmation email row logic in
+ * `backend/src/app/templates/booking_confirmation_render.py`
+ * so the thank-you modal matches the SES email table.
+ */
+
+import type { ReservationPaymentMethodCode } from '@/lib/reservations-data';
+
+const HK_LOCATION_MARKERS = [
+  'hong kong',
+  'hk',
+  'h.k.',
+  '香港',
+  'kowloon',
+  '九龍',
+  '九龙',
+  'new territories',
+  '新界',
+  'sheung wan',
+  '上環',
+  '上环',
+  'wan chai',
+  '灣仔',
+  '湾仔',
+  'central',
+  '中環',
+  '中环',
+  'admiralty',
+  '金鐘',
+  '金钟',
+  'causeway bay',
+  '銅鑼灣',
+  '铜锣湾',
+  'mid-levels',
+  '半山',
+  'shek tong tsui',
+  '石塘咀',
+  'pacific place',
+  '太古廣場',
+  '太古广场',
+] as const;
+
+const MONTH_NAMES_EN = [
+  '',
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+/** Same values as `PAYMENT_METHOD_LABELS` in booking_confirmation_content.py */
+export const BOOKING_CONFIRMATION_PAYMENT_LABELS: Record<
+  ReservationPaymentMethodCode,
+  string
+> = {
+  fps_qr: 'FPS',
+  bank_transfer: 'Bank Transfer',
+  stripe: 'Credit Card',
+};
+
+export interface BookingConfirmationTableLabels {
+  service: string;
+  datetime: string;
+  location: string;
+  details: string;
+  payment: string;
+  total: string;
+}
+
+export interface BookingConfirmationDetailsPrefixes {
+  cohort: string;
+  ageGroup: string;
+  writingFocus: string;
+  level: string;
+}
+
+function normalizeCourseSlug(courseSlug: string | undefined): string {
+  return (courseSlug ?? '').trim().toLowerCase();
+}
+
+function normalizeLocationMatchText(
+  locationName: string | undefined,
+  locationAddress: string | undefined,
+): string {
+  const parts = [locationName, locationAddress]
+    .map((p) => (p ?? '').trim().toLowerCase())
+    .filter(Boolean);
+  return parts.join(' ');
+}
+
+export function locationSuggestsHongKong(
+  locationName: string | undefined,
+  locationAddress: string | undefined,
+): boolean {
+  const blob = normalizeLocationMatchText(locationName, locationAddress);
+  if (!blob) {
+    return false;
+  }
+  return HK_LOCATION_MARKERS.some((marker) => blob.includes(marker));
+}
+
+export function formatBookingLocationDisplayLine(
+  locationName: string | undefined,
+  locationAddress: string | undefined,
+): string | null {
+  const name = (locationName ?? '').trim();
+  const addr = (locationAddress ?? '').trim();
+  if (name && addr) {
+    if (name.toLowerCase() === addr.toLowerCase()) {
+      return name;
+    }
+    return `${name}, ${addr}`;
+  }
+  if (name) {
+    return name;
+  }
+  if (addr) {
+    return addr;
+  }
+  return null;
+}
+
+function hasExplicitTimezoneOffset(iso: string): boolean {
+  return /Z$/i.test(iso) || /[+-]\d{2}:\d{2}$/.test(iso) || /[+-]\d{4}$/.test(iso);
+}
+
+function parseIsoDatetime(value: string | undefined | null): Date | null {
+  const raw = (value ?? '').trim();
+  if (!raw) {
+    return null;
+  }
+  let normalized = raw.endsWith('Z') ? `${raw.slice(0, -1)}+00:00` : raw;
+  if (!hasExplicitTimezoneOffset(normalized)) {
+    normalized = `${normalized}+08:00`;
+  }
+  const d = new Date(normalized);
+  if (Number.isNaN(d.getTime())) {
+    return null;
+  }
+  return d;
+}
+
+function formatHktEmailLine(iso: string): string | null {
+  const dt = parseIsoDatetime(iso);
+  if (!dt) {
+    return null;
+  }
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Hong_Kong',
+    day: 'numeric',
+    month: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(dt);
+  const dayPart = parts.find((p) => p.type === 'day')?.value;
+  const monthPart = parts.find((p) => p.type === 'month')?.value;
+  const hourPart = parts.find((p) => p.type === 'hour')?.value ?? '00';
+  const minutePart = parts.find((p) => p.type === 'minute')?.value ?? '00';
+  const day = Number(dayPart);
+  const month = Number(monthPart);
+  if (!day || !month || month < 1 || month > 12) {
+    return null;
+  }
+  const monthName = MONTH_NAMES_EN[month];
+  const hm = `${hourPart.padStart(2, '0')}:${minutePart.padStart(2, '0')}`;
+  return `${day} ${monthName} @ ${hm} HKT`;
+}
+
+export function formatScheduleDatetimeLine(
+  scheduleDateLabel: string | undefined | null,
+  scheduleTimeLabel: string | undefined | null,
+): string | null {
+  const dateS = (scheduleDateLabel ?? '').trim();
+  const timeS = (scheduleTimeLabel ?? '').trim();
+  if (dateS && timeS) {
+    return `${dateS} ${timeS}`;
+  }
+  if (timeS) {
+    return timeS;
+  }
+  if (dateS) {
+    return dateS;
+  }
+  return null;
+}
+
+export function formatBookingDatetimeDisplay(input: {
+  primarySessionIso: string | undefined | null;
+  scheduleDateLabel: string | undefined | null;
+  scheduleTimeLabel: string | undefined | null;
+  locationUseHkt: boolean;
+}): string | null {
+  const { primarySessionIso, scheduleDateLabel, scheduleTimeLabel, locationUseHkt } =
+    input;
+  if (locationUseHkt) {
+    const primary = (primarySessionIso ?? '').trim();
+    if (primary) {
+      const hktLine = formatHktEmailLine(primary);
+      if (hktLine) {
+        return hktLine;
+      }
+    }
+    const line = formatScheduleDatetimeLine(scheduleDateLabel, scheduleTimeLabel);
+    if (!line) {
+      return null;
+    }
+    if (!line.toLowerCase().includes('hkt')) {
+      return `${line} HKT`;
+    }
+    return line;
+  }
+  return formatScheduleDatetimeLine(scheduleDateLabel, scheduleTimeLabel);
+}
+
+function cohortLabelForMbaDetails(
+  courseSlug: string | undefined,
+  scheduleDateLabel: string | undefined,
+): string | null {
+  if (normalizeCourseSlug(courseSlug) !== 'my-best-auntie') {
+    return null;
+  }
+  const s = (scheduleDateLabel ?? '').trim();
+  return s || null;
+}
+
+export function formatBookingDetailsLines(input: {
+  courseSlug: string | undefined;
+  scheduleDateLabel: string | undefined;
+  ageGroupLabel: string | undefined;
+  consultationWritingFocusLabel: string | undefined;
+  consultationLevelLabel: string | undefined;
+  prefixes: BookingConfirmationDetailsPrefixes;
+}): string[] {
+  const slug = normalizeCourseSlug(input.courseSlug);
+  const cohortForMba = cohortLabelForMbaDetails(
+    input.courseSlug,
+    input.scheduleDateLabel,
+  );
+
+  if (slug === 'my-best-auntie') {
+    const cohort = (cohortForMba ?? '').trim();
+    const age = (input.ageGroupLabel ?? '').trim();
+    const lines: string[] = [];
+    if (cohort) {
+      lines.push(`${input.prefixes.cohort}: ${cohort}`);
+    }
+    if (age) {
+      lines.push(`${input.prefixes.ageGroup}: ${age}`);
+    }
+    return lines;
+  }
+
+  if (slug === 'consultation-booking') {
+    const focus = (input.consultationWritingFocusLabel ?? '').trim();
+    const level = (input.consultationLevelLabel ?? '').trim();
+    const lines: string[] = [];
+    if (focus) {
+      lines.push(`${input.prefixes.writingFocus}: ${focus}`);
+    }
+    if (level) {
+      lines.push(`${input.prefixes.level}: ${level}`);
+    }
+    return lines;
+  }
+
+  return [];
+}
+
+export function resolvePaymentMethodDisplayForConfirmation(
+  code: string | undefined | null,
+): string {
+  const key = (code ?? '').trim().toLowerCase() as ReservationPaymentMethodCode;
+  if (key in BOOKING_CONFIRMATION_PAYMENT_LABELS) {
+    return BOOKING_CONFIRMATION_PAYMENT_LABELS[key];
+  }
+  const raw = (code ?? '').trim();
+  return raw || 'unknown';
+}
+
+export interface BookingConfirmationTableRow {
+  label: string;
+  value: string;
+  multiline?: boolean;
+}
+
+export function buildBookingConfirmationTableRows(input: {
+  courseLabel: string;
+  labels: BookingConfirmationTableLabels;
+  detailsPrefixes: BookingConfirmationDetailsPrefixes;
+  courseSlug: string | undefined;
+  scheduleDateLabel: string | undefined;
+  scheduleTimeLabel: string | undefined;
+  primarySessionIso: string | undefined;
+  ageGroupLabel: string | undefined;
+  consultationWritingFocusLabel: string | undefined;
+  consultationLevelLabel: string | undefined;
+  locationName: string | undefined;
+  locationAddress: string | undefined;
+  paymentMethodCode: string | undefined;
+  totalAmountFormatted: string;
+}): BookingConfirmationTableRow[] {
+  const useHkt = locationSuggestsHongKong(
+    input.locationName,
+    input.locationAddress,
+  );
+  const scheduleLine = formatBookingDatetimeDisplay({
+    primarySessionIso: input.primarySessionIso,
+    scheduleDateLabel: input.scheduleDateLabel,
+    scheduleTimeLabel: input.scheduleTimeLabel,
+    locationUseHkt: useHkt,
+  });
+  const locLine = formatBookingLocationDisplayLine(
+    input.locationName,
+    input.locationAddress,
+  );
+
+  const detailLines = formatBookingDetailsLines({
+    courseSlug: input.courseSlug,
+    scheduleDateLabel: input.scheduleDateLabel,
+    ageGroupLabel: input.ageGroupLabel,
+    consultationWritingFocusLabel: input.consultationWritingFocusLabel,
+    consultationLevelLabel: input.consultationLevelLabel,
+    prefixes: input.detailsPrefixes,
+  });
+
+  const rows: BookingConfirmationTableRow[] = [
+    { label: input.labels.service, value: input.courseLabel.trim() },
+  ];
+
+  if (detailLines.length > 0) {
+    rows.push({
+      label: input.labels.details,
+      value: detailLines.join('\n'),
+      multiline: true,
+    });
+  }
+
+  if (scheduleLine) {
+    rows.push({ label: input.labels.datetime, value: scheduleLine });
+  }
+
+  if (locLine) {
+    rows.push({ label: input.labels.location, value: locLine });
+  }
+
+  rows.push({
+    label: input.labels.payment,
+    value: resolvePaymentMethodDisplayForConfirmation(input.paymentMethodCode),
+  });
+  rows.push({ label: input.labels.total, value: input.totalAmountFormatted });
+
+  return rows;
+}

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -46,11 +46,8 @@ import trainingCoursesContent from '@/content/my-best-auntie-training-courses.js
 import { trackAnalyticsEvent, trackPublicFormOutcome } from '@/lib/analytics';
 import { createPublicApiClient, createPublicCrmApiClient } from '@/lib/crm-api-client';
 import { validateDiscountCode } from '@/lib/discounts-data';
+import { formatCurrencyHkd } from '@/lib/format';
 import { createReservationPaymentIntent } from '@/lib/reservation-payments-data';
-import {
-  formatSiteCompactDate,
-  formatSiteTimeOfDay,
-} from '@/lib/site-datetime';
 
 vi.mock('next/image', () => ({
   default: ({
@@ -210,28 +207,6 @@ const testBankAccountHolder = 'Test Account Holder';
 const testBankAccountNumber = '123-456-789';
 const originalTurnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
-const reservationSummary: ReservationSummary = {
-  attendeeName: 'Test User',
-  attendeeEmail: 'test@example.com',
-  attendeePhone: '12345678',
-  ageGroup: '1-3',
-  paymentMethod: 'Pay via FPS QR',
-  totalAmount: 9000,
-  eventTitle: 'My Best Auntie',
-  dateStartTime: selectedCohort.dates[0]?.start_datetime,
-  dateEndTime: selectedCohort.dates[0]?.end_datetime,
-  courseSessions: selectedCohort.dates.slice(0, 2).map((part) => {
-    return {
-      dateStartTime: part.start_datetime,
-      dateEndTime: part.end_datetime,
-    };
-  }),
-  eventSubtitle: myBestAuntieModalContent.subtitle,
-  locationName: selectedCohort.location_name,
-  locationAddress: selectedCohort.location_address,
-  locationDirectionHref: selectedCohort.location_url,
-};
-
 const selectedCohortDate = selectedCohort.dates[0]?.start_datetime.slice(0, 10);
 if (!selectedCohortDate) {
   throw new Error('Selected cohort must include a valid primary session date.');
@@ -252,6 +227,34 @@ const expectedMbaMarketingFields = {
   location_name: selectedCohort.location_name,
   location_address: selectedCohort.location_address,
   primary_session_start_iso: primarySessionPart?.start_datetime,
+};
+
+const reservationSummary: ReservationSummary = {
+  attendeeName: 'Test User',
+  attendeeEmail: 'test@example.com',
+  attendeePhone: '12345678',
+  ageGroup: '1-3',
+  paymentMethod: 'Pay via FPS QR',
+  paymentMethodCode: 'fps_qr',
+  totalAmount: 9000,
+  eventTitle: myBestAuntieModalContent.title,
+  dateStartTime: selectedCohort.dates[0]?.start_datetime,
+  dateEndTime: selectedCohort.dates[0]?.end_datetime,
+  courseSessions: selectedCohort.dates.slice(0, 2).map((part) => {
+    return {
+      dateStartTime: part.start_datetime,
+      dateEndTime: part.end_datetime,
+    };
+  }),
+  eventSubtitle: myBestAuntieModalContent.subtitle,
+  locationName: selectedCohort.location_name,
+  locationAddress: selectedCohort.location_address,
+  locationDirectionHref: selectedCohort.location_url,
+  scheduleDateLabel: expectedMbaMarketingFields.schedule_date_label,
+  scheduleTimeLabel: expectedMbaMarketingFields.schedule_time_label,
+  primarySessionStartIso: expectedMbaMarketingFields.primary_session_start_iso,
+  courseSlug: 'my-best-auntie',
+  reservationPendingUntilPaymentConfirmed: true,
 };
 
 function renderWithPortalContainer(ui: ReactNode) {
@@ -370,14 +373,14 @@ describe('my-best-auntie booking modals footer content', () => {
     );
 
     const thankYouDialog = screen.getByRole('dialog', {
-      name: thankYouModalContent.title,
+      name: thankYouModalContent.successTitle,
     });
     const thankYouDescriptionId = thankYouDialog.getAttribute('aria-describedby');
     expect(thankYouDialog).toHaveAttribute('aria-labelledby');
     expect(thankYouDescriptionId).toBeTruthy();
     expect(
       document.getElementById(thankYouDescriptionId ?? '')?.textContent ?? '',
-    ).toContain(thankYouModalContent.successLabel);
+    ).toContain(thankYouModalContent.successDescription);
   });
 
   it('hides child age group and renders icon-based payment option radios in booking modal', () => {
@@ -1647,8 +1650,8 @@ describe('my-best-auntie booking modals footer content', () => {
     expect(container.querySelector('img[src="/images/evolvesprouts-logo.svg"]')).toBeNull();
   });
 
-  it('renders thank-you detail cards and directions link', () => {
-    const { container } = renderWithPortalContainer(
+  it('renders thank-you confirmation table matching email-style rows', () => {
+    renderWithPortalContainer(
       <MyBestAuntieThankYouModal
         locale='en'
         content={thankYouModalContent}
@@ -1657,43 +1660,37 @@ describe('my-best-auntie booking modals footer content', () => {
       />,
     );
 
-    expect(container.querySelectorAll('.es-booking-thank-you-detail-card')).toHaveLength(4);
+    expect(screen.getByRole('table')).toBeInTheDocument();
     expect(
-      container.querySelector('.es-booking-thank-you-detail-icon-mask--training'),
-    ).not.toBeNull();
+      screen.getByRole('rowheader', { name: thankYouModalContent.confirmationTable.service }),
+    ).toBeInTheDocument();
     expect(
-      container.querySelector('.es-booking-thank-you-detail-icon-mask--calendar'),
-    ).not.toBeNull();
+      screen.getByRole('cell', { name: reservationSummary.eventTitle }),
+    ).toBeInTheDocument();
+
+    const cohortLine = `${thankYouModalContent.confirmationDetailsPrefixes.cohort}: ${reservationSummary.scheduleDateLabel}`;
+    const ageLine = `${thankYouModalContent.confirmationDetailsPrefixes.ageGroup}: ${reservationSummary.ageGroup}`;
     expect(
-      container.querySelector('.es-booking-thank-you-detail-icon-mask--location'),
-    ).not.toBeNull();
-    expect(
-      container.querySelector('.es-booking-thank-you-detail-icon-mask--dollar'),
-    ).not.toBeNull();
-    expect(screen.getByText(reservationSummary.eventTitle)).toBeInTheDocument();
-    expect(screen.getByText(myBestAuntieModalContent.subtitle)).toBeInTheDocument();
-    const sessionLines =
-      reservationSummary.courseSessions?.map((session) => {
-        const datePart = formatSiteCompactDate(session.dateStartTime, 'en');
-        const timePart = formatSiteTimeOfDay(session.dateStartTime, 'en');
-        return `${datePart}, ${timePart}`;
-      }) ?? [];
-    expect(sessionLines).toHaveLength(2);
-    for (const line of sessionLines) {
-      expect(screen.getByText(line)).toBeInTheDocument();
-    }
-    expect(screen.getByText(thankYouModalContent.paymentConfirmationNote)).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: thankYouModalContent.downloadCalendarInviteLabel,
+      screen.getByRole('cell', {
+        name: new RegExp(
+          `${cohortLine.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\n]*${ageLine.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+        ),
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText(selectedCohort.location_name)).toBeInTheDocument();
-    expect(screen.getByText(selectedCohort.location_address)).toBeInTheDocument();
-    const directionLink = screen.getByRole('link', {
-      name: thankYouModalContent.directionLabel,
-    });
-    expect(directionLink).toHaveAttribute('href', reservationSummary.locationDirectionHref);
+
+    expect(
+      screen.getByRole('cell', { name: '19 April @ 09:00 HKT' }),
+    ).toBeInTheDocument();
+
+    const locationCell = `${selectedCohort.location_name}, ${selectedCohort.location_address}`;
+    expect(screen.getByRole('cell', { name: locationCell })).toBeInTheDocument();
+
+    expect(screen.getByRole('cell', { name: 'FPS' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', { name: formatCurrencyHkd(reservationSummary.totalAmount, 'en') }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(thankYouModalContent.pendingPaymentNote)).toBeInTheDocument();
   });
 
   it('renders WhatsApp follow-up when href and label are provided', () => {
@@ -1715,37 +1712,22 @@ describe('my-best-auntie booking modals footer content', () => {
     expect(whatsappLink).toHaveAttribute('href', 'https://wa.me/15550001234');
   });
 
-  it('tracks thank-you calendar download clicks', () => {
-    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
-    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
-    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
-
+  it('renders FPS QR block when pending FPS booking includes QR data URL', () => {
+    const tinyPng =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
     render(
       <MyBestAuntieThankYouModal
         locale='en'
         content={thankYouModalContent}
-        summary={reservationSummary}
+        summary={{ ...reservationSummary, fpsQrImageDataUrl: tinyPng }}
         onClose={() => {}}
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: thankYouModalContent.downloadCalendarInviteLabel,
-      }),
-    );
-
-    expect(mockedTrackAnalyticsEvent).toHaveBeenCalledWith(
-      'booking_thank_you_ics_download',
-      expect.objectContaining({
-        sectionId: 'my-best-auntie-booking',
-        ctaLocation: 'thank_you_modal',
-      }),
-    );
-
-    createObjectUrlSpy.mockRestore();
-    revokeSpy.mockRestore();
-    clickSpy.mockRestore();
+    expect(screen.getByText(thankYouModalContent.fpsQrIntro)).toBeInTheDocument();
+    expect(screen.getByText(thankYouModalContent.fpsQrDisclaimer)).toBeInTheDocument();
+    const qrImg = screen.getByRole('img', { name: thankYouModalContent.fpsQrImageAlt });
+    expect(qrImg.getAttribute('src')).toBe(tinyPng);
   });
 
   it('allows only one discount code to be applied at a time', async () => {

--- a/apps/public_www/tests/lib/booking-confirmation-table.test.ts
+++ b/apps/public_www/tests/lib/booking-confirmation-table.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildBookingConfirmationTableRows,
+  formatBookingDatetimeDisplay,
+  locationSuggestsHongKong,
+} from '@/lib/booking-confirmation-table';
+
+const tableLabels = {
+  service: 'Service',
+  datetime: 'Date & time',
+  location: 'Location',
+  details: 'Details',
+  payment: 'Payment method',
+  total: 'Total',
+};
+
+const detailsPrefixes = {
+  cohort: 'Cohort',
+  ageGroup: 'Age group',
+  writingFocus: 'Focus',
+  level: 'Level',
+};
+
+describe('booking-confirmation-table', () => {
+  it('detects Hong Kong from venue text', () => {
+    expect(locationSuggestsHongKong('Evolve Sprouts', "Queen's Road West, Sheung Wan")).toBe(
+      true,
+    );
+    expect(locationSuggestsHongKong('Online', undefined)).toBe(false);
+  });
+
+  it('formats HKT line from primary session ISO when location is HK', () => {
+    const line = formatBookingDatetimeDisplay({
+      primarySessionIso: '2026-04-19T01:00:00Z',
+      scheduleDateLabel: 'Apr, 2026',
+      scheduleTimeLabel: 'ignored when iso parses',
+      locationUseHkt: true,
+    });
+    expect(line).toBe('19 April @ 09:00 HKT');
+  });
+
+  it('builds MBA-style details and rows', () => {
+    const rows = buildBookingConfirmationTableRows({
+      courseLabel: 'My Best Auntie Training Course',
+      labels: tableLabels,
+      detailsPrefixes,
+      courseSlug: 'my-best-auntie',
+      scheduleDateLabel: 'Apr, 2026',
+      scheduleTimeLabel: '2026-04-19T01:00:00Z – 2026-04-19T03:00:00Z',
+      primarySessionIso: '2026-04-19T01:00:00Z',
+      ageGroupLabel: '1-3',
+      consultationWritingFocusLabel: undefined,
+      consultationLevelLabel: undefined,
+      locationName: 'Evolve Sprouts',
+      locationAddress: 'Sheung Wan',
+      paymentMethodCode: 'fps_qr',
+      totalAmountFormatted: 'HK$9,000',
+    });
+
+    expect(rows.map((r) => r.label)).toEqual([
+      'Service',
+      'Details',
+      'Date & time',
+      'Location',
+      'Payment method',
+      'Total',
+    ]);
+    expect(rows[1].multiline).toBe(true);
+    expect(rows[1].value).toContain('Cohort: Apr, 2026');
+    expect(rows[1].value).toContain('Age group: 1-3');
+    expect(rows.find((r) => r.label === 'Date & time')?.value).toBe('19 April @ 09:00 HKT');
+    expect(rows.find((r) => r.label === 'Payment method')?.value).toBe('FPS');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The booking thank-you modal now matches the contact form success pattern (title + body), then shows a confirmation **table** aligned with the transactional booking email (service, optional details, date/time with HKT when the venue looks like Hong Kong, location, payment method using the same FPS/Bank Transfer/Credit Card labels as email, total). When payment is still pending, it shows the same **pending** note as the email; for pending **FPS** bookings it shows the **FPS intro, disclaimer, and QR** (using the PNG data URL only after a successful submit).

## Notes

- `ReservationSummary` carries `paymentMethodCode`, schedule/primary-session fields, `courseSlug`, pending flag, and optional `fpsQrImageDataUrl` for the thank-you step.
- Calendar ICS download was removed from thank-you (not part of the email table).
- Copy for table labels and FPS/pending strings lives in locale JSON and is aligned with `booking_confirmation_content.py` where applicable.

## Tests

- `npm run lint` (public_www)
- `vitest` for `booking-confirmation-table` and `my-best-auntie-booking-modal` tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0120b95f-40c7-42a8-8b36-f34f511a8805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0120b95f-40c7-42a8-8b36-f34f511a8805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

