### PR TITLE
Booking thank-you modal and confirmation email tweaks

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
@@ -39,7 +39,7 @@ import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
 import { getHrefKind } from '@/lib/url-utils';
 
 const THANK_YOU_ICS_DOWNLOAD_CLASSNAME =
-  'es-footer-link mt-3 inline-block cursor-pointer rounded-none border-0 bg-transparent p-0 text-left text-base font-normal underline decoration-1 underline-offset-2 transition-opacity hover:opacity-70 disabled:cursor-not-allowed disabled:opacity-50';
+  'es-footer-link mt-3 inline-block cursor-pointer rounded-none border-0 bg-transparent p-0 text-left text-base font-semibold underline decoration-1 underline-offset-2 transition-opacity hover:opacity-70 disabled:cursor-not-allowed disabled:opacity-50';
 
 export interface BookingThankYouModalProps {
   locale: Locale;
@@ -142,7 +142,7 @@ function buildThankYouDateTimeLines(
     }
 
     const datePart = formatSitePartDate(session.dateStartTime, locale);
-    const amPm = formatSiteAmPmIndicator(session.dateStartTime);
+    const amPm = formatSiteAmPmIndicator(session.dateStartTime, locale);
     if (!datePart || !amPm) {
       return [];
     }
@@ -210,6 +210,9 @@ export function BookingThankYouModal({
   const showDetailsRow = detailLines.length > 0;
   const showDateTimeRow = dateTimeLines.length > 0;
   const showIcsOnlyRow = Boolean(summary) && !showDateTimeRow;
+  const courseSlugNormalized = (summary?.courseSlug ?? '').trim().toLowerCase();
+  const isConsultationBooking = courseSlugNormalized === 'consultation-booking';
+  const showCalendarDownload = !isConsultationBooking;
 
   const messageParts = useMemo(() => {
     return splitMessageTemplate(content.messageTemplate);
@@ -368,19 +371,21 @@ export function BookingThankYouModal({
                           </span>
                         );
                       })}
-                      <button
-                        type='button'
-                        disabled={!canDownloadIcs}
-                        onClick={handleDownloadIcs}
-                        className={THANK_YOU_ICS_DOWNLOAD_CLASSNAME}
-                      >
-                        {content.downloadCalendarInviteLabel}
-                      </button>
+                      {showCalendarDownload ? (
+                        <button
+                          type='button'
+                          disabled={!canDownloadIcs}
+                          onClick={handleDownloadIcs}
+                          className={THANK_YOU_ICS_DOWNLOAD_CLASSNAME}
+                        >
+                          {content.downloadCalendarInviteLabel}
+                        </button>
+                      ) : null}
                     </dd>
                   </div>
                 </div>
               ) : null}
-              {showIcsOnlyRow ? (
+              {showIcsOnlyRow && showCalendarDownload ? (
                 <div className='es-booking-thank-you-recap-row-border py-4'>
                   <div className='grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,140px)_1fr] sm:gap-6'>
                     <dt
@@ -486,7 +491,7 @@ export function BookingThankYouModal({
                             width={128}
                             height={128}
                             unoptimized
-                            className='mx-auto mt-2 block h-32 w-32'
+                            className='mt-2 block h-32 w-32'
                           />
                         ) : null}
                       </>

--- a/apps/public_www/src/lib/site-datetime.ts
+++ b/apps/public_www/src/lib/site-datetime.ts
@@ -106,9 +106,13 @@ export function formatSitePartDate(isoDateTime: string, locale: Locale): string 
 }
 
 /**
- * "AM" or "PM" from the HKT wall-clock hour of the instant (12:00–12:59 → PM).
+ * English consultation slot phrasing from the HKT wall-clock hour (12:00–12:59 → afternoon).
+ * Other locales keep compact "AM"/"PM" markers.
  */
-export function formatSiteAmPmIndicator(isoDateTime: string): 'AM' | 'PM' | '' {
+export function formatSiteAmPmIndicator(
+  isoDateTime: string,
+  locale: Locale = 'en',
+): 'AM' | 'PM' | 'in the morning' | 'in the afternoon' | '' {
   const date = new Date(isoDateTime);
   if (Number.isNaN(date.getTime())) {
     return '';
@@ -121,7 +125,12 @@ export function formatSiteAmPmIndicator(isoDateTime: string): 'AM' | 'PM' | '' {
     return '';
   }
 
-  return hour < 12 ? 'AM' : 'PM';
+  const isMorning = hour < 12;
+  if (locale === 'en') {
+    return isMorning ? 'in the morning' : 'in the afternoon';
+  }
+
+  return isMorning ? 'AM' : 'PM';
 }
 
 export function formatSiteCompactDate(isoDateTime: string, locale: Locale): string {

--- a/apps/public_www/tests/components/sections/booking-thank-you-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-thank-you-modal.test.tsx
@@ -27,7 +27,7 @@ describe('BookingThankYouModal', () => {
   const thankYouEn = enContent.bookingModal.thankYouModal;
   const thankYouZhCn = zhCnContent.bookingModal.thankYouModal;
 
-  it('shows consultation date with AM from HKT hour', () => {
+  it('shows consultation date with morning phrasing from HKT hour', () => {
     const summary: ReservationSummary = {
       attendeeName: 'Pat',
       attendeeEmail: 'pat@example.com',
@@ -51,7 +51,37 @@ describe('BookingThankYouModal', () => {
       />,
     );
 
-    expect(screen.getByText('16 May AM')).toBeInTheDocument();
+    expect(screen.getByText('16 May in the morning')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: thankYouEn.downloadCalendarInviteLabel }),
+    ).toBeNull();
+  });
+
+  it('shows consultation date with AM marker for zh-CN', () => {
+    const summary: ReservationSummary = {
+      attendeeName: 'Pat',
+      attendeeEmail: 'pat@example.com',
+      attendeePhone: '123',
+      paymentMethod: 'Credit Card',
+      paymentMethodCode: 'stripe',
+      totalAmount: 100,
+      eventTitle: '咨询',
+      courseSlug: 'consultation-booking',
+      dateStartTime: '2026-05-16T02:00:00Z',
+      courseSessions: [{ dateStartTime: '2026-05-16T02:00:00Z' }],
+    };
+
+    render(
+      <BookingThankYouModal
+        locale='zh-CN'
+        content={thankYouZhCn}
+        summary={summary}
+        analyticsSectionId='test'
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('5月16日 AM')).toBeInTheDocument();
   });
 
   it('uses zh-CN ordinals for MBA group session lines', () => {

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -1721,6 +1721,7 @@ describe('my-best-auntie booking modals footer content', () => {
     });
     expect(calendarDownload).toBeInTheDocument();
     expect(calendarDownload.className).toContain('es-footer-link');
+    expect(calendarDownload.className).toContain('font-semibold');
     expect(calendarDownload.className).toContain('underline');
     expect(calendarDownload.className).toContain('hover:opacity-70');
     expect(screen.getByText(selectedCohort.location_name)).toBeInTheDocument();

--- a/backend/src/app/api/public_legacy_confirmation.py
+++ b/backend/src/app/api/public_legacy_confirmation.py
@@ -217,6 +217,7 @@ def send_booking_confirmation_email(
         primary_session_iso=primary_session_iso,
         primary_session_end_iso=primary_session_end_iso,
         location_line=loc_line_for_ics,
+        course_slug=course_slug,
     )
     if ics_bytes is not None:
         data["include_calendar_note_after_schedule_html"] = True

--- a/backend/src/app/templates/booking_confirmation_content.py
+++ b/backend/src/app/templates/booking_confirmation_content.py
@@ -189,11 +189,11 @@ SIGN_OFF_PLAIN: dict[str, str] = {
     "zh-HK": "謝謝，\nEvolve Sprouts",
 }
 
-# Shown in MIME-rendered email when an .ics attachment is included.
+# Shown in MIME-rendered email and SES when an .ics attachment is included.
 BOOKING_ICS_ATTACHED_NOTE: dict[str, str] = {
-    "en": "A calendar invite (.ics) is attached — open it to add this booking to your calendar.",
-    "zh-CN": "已附上日历邀请（.ics 文件），打开即可将此预约加入您的日历。",
-    "zh-HK": "已附上日曆邀請（.ics 檔案），開啟即可將此預約加入你的日曆。",
+    "en": "A calendar invite (.ics) is attached.",
+    "zh-CN": "已附上日历邀请（.ics 文件）。",
+    "zh-HK": "已附上日曆邀請（.ics 檔案）。",
 }
 
 # SES template path (no attachment): remind customers to use the date/time row in their calendar app.

--- a/backend/src/app/templates/booking_confirmation_render.py
+++ b/backend/src/app/templates/booking_confirmation_render.py
@@ -158,8 +158,12 @@ def build_booking_confirmation_ics(
     primary_session_iso: str | None,
     primary_session_end_iso: str | None = None,
     location_line: str | None = None,
+    course_slug: str | None = None,
 ) -> bytes | None:
     """Build a single-event UTF-8 .ics for the primary session, or None if no start ISO."""
+    if _normalize_course_slug(course_slug) == "consultation-booking":
+        return None
+
     start_dt = _parse_iso_to_utc_datetime(primary_session_iso)
     if start_dt is None:
         return None
@@ -319,9 +323,13 @@ def _format_hkt_time_email(dt: datetime) -> str:
     return f"{local.hour:02d}:{local.minute:02d}"
 
 
-def _hkt_am_pm_indicator(dt: datetime) -> str:
+def _hkt_consultation_day_part_label(dt: datetime, loc: str) -> str:
+    """Consultation slot wording: English uses phrases; zh locales keep AM/PM."""
     local = dt.astimezone(_EMAIL_HKT_TZ)
-    return "AM" if local.hour < 12 else "PM"
+    is_morning = local.hour < 12
+    if loc == "en":
+        return "in the morning" if is_morning else "in the afternoon"
+    return "AM" if is_morning else "PM"
 
 
 def _format_hkt_email_line_no_tz_suffix(dt: datetime) -> str:
@@ -399,7 +407,7 @@ def format_booking_datetime_display_multi(
         parsed = _parse_iso_datetime(start_raw) if start_raw else None
         if parsed is not None:
             date_part = _format_hkt_part_date_email(parsed)
-            am_pm = _hkt_am_pm_indicator(parsed)
+            am_pm = _hkt_consultation_day_part_label(parsed, loc)
             plain_lines.append(f"{date_part} {am_pm}")
     else:
         # Events and other flows: all course_sessions when present, else primary only

--- a/tests/test_booking_confirmation_fps_qr.py
+++ b/tests/test_booking_confirmation_fps_qr.py
@@ -115,6 +115,44 @@ def test_send_booking_confirmation_mime_ics_without_inline_fps_when_not_pending(
     templated.assert_not_called()
 
 
+def test_send_booking_confirmation_consultation_skips_ics_attachment(
+    monkeypatch: Any,
+) -> None:
+    templated = MagicMock()
+    mime = MagicMock()
+    monkeypatch.setenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "hello@example.com")
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_templated_email",
+        templated,
+    )
+    monkeypatch.setattr(
+        "app.api.public_legacy_confirmation.send_mime_email_with_optional_attachments",
+        mime,
+    )
+
+    send_booking_confirmation_email(
+        to_email="u@example.com",
+        full_name="Jane",
+        course_label="Consultation",
+        schedule_date_label=None,
+        schedule_time_label=None,
+        location_name="Venue",
+        location_address="Hong Kong",
+        primary_session_iso="2026-04-10T14:00:00+08:00",
+        course_slug="consultation-booking",
+        payment_method="stripe",
+        total_amount="HK$1.00",
+        is_pending_payment=False,
+        locale="en",
+    )
+
+    templated.assert_called_once()
+    mime.assert_not_called()
+    merged = templated.call_args.kwargs["template_data"]
+    assert merged.get("include_calendar_note_after_schedule_html") is False
+    assert merged.get("include_calendar_note_after_schedule_plain") is False
+
+
 def test_send_booking_confirmation_falls_back_when_fps_qr_invalid(
     monkeypatch: Any,
 ) -> None:

--- a/tests/test_booking_confirmation_helpers.py
+++ b/tests/test_booking_confirmation_helpers.py
@@ -37,7 +37,7 @@ def test_booking_confirmation_template_merge_data_consultation_details() -> None
         consultation_writing_focus_label="College essays",
         consultation_level_label="Essentials",
     )
-    assert data["schedule_datetime_label_html"] == "12 April AM"
+    assert data["schedule_datetime_label_html"] == "12 April in the morning"
     assert data["payment_method"] == "FPS"
     assert data["include_fps_instructions"] is True
     assert "College essays" in data["details_block_html"]
@@ -62,6 +62,25 @@ def test_booking_confirmation_hkt_schedule_from_iso() -> None:
         whatsapp_url="https://wa.me/1",
     )
     assert data["schedule_datetime_label_html"] == "16 April @ 18:00 HKT"
+
+
+def test_booking_confirmation_merge_consultation_en_uses_morning_afternoon() -> None:
+    data = booking_confirmation_template_merge_data(
+        locale="en",
+        full_name="A",
+        course_label="Consultation",
+        schedule_date_label="Apr 2026",
+        schedule_time_label="ignored",
+        location_name="Venue",
+        location_address="Hong Kong",
+        primary_session_iso="2026-04-12T10:30:00+08:00",
+        course_slug="consultation-booking",
+        payment_method_code="stripe",
+        total_amount="HK$1",
+        is_pending_payment=False,
+        whatsapp_url="https://wa.me/1",
+    )
+    assert data["schedule_datetime_label_html"] == "12 April in the morning"
 
 
 def test_booking_confirmation_template_merge_includes_directions_when_url() -> None:

--- a/tests/test_booking_confirmation_render.py
+++ b/tests/test_booking_confirmation_render.py
@@ -206,6 +206,18 @@ def test_build_booking_confirmation_ics_returns_none_without_iso() -> None:
     )
 
 
+def test_build_booking_confirmation_ics_skips_consultation_bookings() -> None:
+    assert (
+        build_booking_confirmation_ics(
+            course_label="Consultation",
+            primary_session_iso="2026-04-12T10:30:00+08:00",
+            location_line="HK",
+            course_slug="consultation-booking",
+        )
+        is None
+    )
+
+
 def test_booking_confirmation_template_merge_calendar_fallback_hint() -> None:
     data = booking_confirmation_template_merge_data(
         locale="en",
@@ -258,7 +270,9 @@ def test_render_booking_confirmation_includes_ics_note_when_flagged() -> None:
     )
     assert "calendar invite" in html_doc.lower()
     assert "ics" in html_doc.lower()
+    assert "open it" not in html_doc.lower()
     assert "calendar invite" in plain.lower()
+    assert "open it" not in plain.lower()
 
 
 def test_render_booking_confirmation_mba_zh_cn_uses_localized_ordinals() -> None:
@@ -408,8 +422,9 @@ def test_render_booking_confirmation_consultation_am_pm_from_iso() -> None:
         faq_url="https://site.example/faq",
         include_fps_qr_image=False,
     )
-    assert "12 April PM" in html_doc
-    assert "12 April PM" in plain
+    assert "12 April in the afternoon" in html_doc
+    assert "12 April in the afternoon" in plain
+    assert "calendar invite" not in html_doc.lower()
 
 
 def test_render_booking_confirmation_location_includes_directions_link() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Thank-you modal:** Left-align the FPS QR image with recap text; make “Download calendar invite” semibold; hide that control when `courseSlug` is `consultation-booking`. English consultation date lines now use “in the morning” / “in the afternoon” instead of AM/PM (zh-CN/zh-HK thank-you still use AM/PM).
- **Confirmation email:** Consultation schedule lines in English use the same morning/afternoon phrasing; Chinese locales keep AM/PM. Calendar invite copy is shortened to “A calendar invite (.ics) is attached.” (and zh equivalents). For `consultation-booking`, no `.ics` file is generated or attached and the calendar-invite note is not shown (SES path uses existing fallback flags).

## Tests

- `npm run test -- --run` (booking thank-you + MBA booking modal tests)
- `python3 -m pytest` on booking confirmation / SES template tests
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f51e8209-44a4-4ae7-b341-b0eb32f61b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f51e8209-44a4-4ae7-b341-b0eb32f61b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

