### PR TITLE
chore: remove legacy wording from code and tests

### DIFF
--- a/apps/admin_web/src/components/admin/assets/asset-editor-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-editor-panel.tsx
@@ -62,7 +62,7 @@ interface AssetFormState {
   description: string;
   resourceKey: string;
   visibility: AssetVisibility;
-  /** BCP 47 tag or empty when unset / unknown legacy value */
+  /** BCP 47 tag or empty when unset / unknown */
   contentLanguage: string;
   /** Select value: empty string = no client tag; client_document = Client */
   clientTag: '' | typeof CLIENT_DOCUMENT_ASSET_TAG;

--- a/apps/admin_web/src/lib/api-payload.ts
+++ b/apps/admin_web/src/lib/api-payload.ts
@@ -19,7 +19,7 @@ export function asNumber(value: unknown, fallback = 0): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }
 
-/** Parse optional lat/lng from API (number or legacy string-encoded decimal). */
+/** Parse optional lat/lng from API (number or string-encoded decimal). */
 export function asNullableFiniteNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;

--- a/apps/admin_web/src/types/crm-relationship.ts
+++ b/apps/admin_web/src/types/crm-relationship.ts
@@ -16,7 +16,7 @@ export const CRM_ENTITY_RELATIONSHIP_TYPES: readonly CrmEntityRelationshipType[]
 
 /**
  * Map a stored CRM relationship to a dropdown value. Vendor is not editable here
- * (Finance / vendor orgs); legacy rows map to `other` so the select stays valid.
+ * (Finance / vendor orgs); unknown values map to `other` so the select stays valid.
  */
 export function relationshipTypeForCrmEditor(
   stored: components['schemas']['CrmRelationshipType']

--- a/apps/admin_web/tests/lib/services-api.test.ts
+++ b/apps/admin_web/tests/lib/services-api.test.ts
@@ -123,7 +123,7 @@ describe('services-api', () => {
     );
   });
 
-  it('parses venue coordinates from number or legacy string response', async () => {
+  it('parses venue coordinates from number or string response', async () => {
     mockAdminApiRequest.mockResolvedValueOnce({
       data: {
         items: [

--- a/apps/public_www/scripts/validate-content.mjs
+++ b/apps/public_www/scripts/validate-content.mjs
@@ -27,7 +27,7 @@ const MAILTO_PROTOCOL_REGEX = /^mailto:/i;
 const TEL_PROTOCOL_REGEX = /^tel:/i;
 const GENERIC_SOCIAL_PROFILE_ROOT_REGEX =
   /^https:\/\/(?:www\.)?(linkedin\.com|instagram\.com)\/?$/i;
-const LEGACY_SECTION_ROOT_KEYS = {
+const DISALLOWED_SECTION_ROOT_KEYS = {
   hero: ['headline', 'subheadline', 'supportingParagraph'],
   'aboutUs.intro': ['heading', 'body'],
   'myBestAuntie.hero': ['body'],
@@ -418,18 +418,18 @@ function validateSemanticRules(value, keyPath, errors, routePaths) {
   }
 }
 
-function validateNoLegacySectionRootKeys(content, locale, errors) {
-  for (const [sectionPath, legacyKeys] of Object.entries(LEGACY_SECTION_ROOT_KEYS)) {
+function validateNoDisallowedSectionRootKeys(content, locale, errors) {
+  for (const [sectionPath, disallowedKeys] of Object.entries(DISALLOWED_SECTION_ROOT_KEYS)) {
     const sectionValue = readObjectAtPath(content, sectionPath);
     if (!sectionValue) {
       errors.push(`${locale}: missing or invalid section "${sectionPath}"`);
       continue;
     }
 
-    for (const legacyKey of legacyKeys) {
-      if (legacyKey in sectionValue) {
+    for (const disallowedKey of disallowedKeys) {
+      if (disallowedKey in sectionValue) {
         errors.push(
-          `${locale}.${sectionPath}: legacy key "${legacyKey}" is not allowed; use canonical copy keys`,
+          `${locale}.${sectionPath}: key "${disallowedKey}" is not allowed; use canonical copy keys`,
         );
       }
     }
@@ -463,7 +463,7 @@ async function main() {
     validateShape(englishContent, localeContent, locale, errors);
     assertLocaleMetadata(localeContent, locale, errors);
     validateSemanticRules(localeContent, locale, errors, localeRoutePaths);
-    validateNoLegacySectionRootKeys(localeContent, locale, errors);
+    validateNoDisallowedSectionRootKeys(localeContent, locale, errors);
   }
 
   if (errors.length > 0) {

--- a/apps/public_www/src/components/sections/testimonials.tsx
+++ b/apps/public_www/src/components/sections/testimonials.tsx
@@ -44,7 +44,7 @@ const TESTIMONIAL_CONTROL_BUTTON_CLASSNAME = 'es-btn--control';
 const CLONE_SETTLE_DELAY_MS = 120;
 const AUTHOR_ANIM_DURATION_MS = 300;
 
-/** Legacy / CMS keys accepted alongside canonical locale JSON keys (`quote`, `author`, …). */
+/** Alternate CMS / import keys accepted alongside canonical locale JSON keys (`quote`, `author`, …). */
 const TESTIMONIAL_QUOTE_CANDIDATE_KEYS = [
   'quote',
   'testimonial',

--- a/apps/public_www/src/content/index.ts
+++ b/apps/public_www/src/content/index.ts
@@ -22,14 +22,14 @@ export const DEFAULT_LOCALE: Locale = 'en';
  */
 type BaseSiteContent = typeof enContent;
 type CourseCohort = typeof myBestAuntieTrainingCourseContent.data[number];
-type LegacyCompatibleTestimonials = Omit<BaseSiteContent['testimonials'], 'items'> & {
+type TestimonialsContentShape = Omit<BaseSiteContent['testimonials'], 'items'> & {
   items: Array<BaseSiteContent['testimonials']['items'][number] & { role?: string }>;
 };
 type SharedCourseBookingContent = BaseSiteContent['myBestAuntie']['booking'] & {
   cohorts: CourseCohort[];
 };
 export type SiteContent = Omit<BaseSiteContent, 'testimonials' | 'myBestAuntie'> & {
-  testimonials: LegacyCompatibleTestimonials;
+  testimonials: TestimonialsContentShape;
   myBestAuntie: Omit<BaseSiteContent['myBestAuntie'], 'booking'> & {
     booking: SharedCourseBookingContent;
   };

--- a/apps/public_www/src/lib/validation.ts
+++ b/apps/public_www/src/lib/validation.ts
@@ -8,7 +8,7 @@ export function isValidEmail(value: string): boolean {
   return EMAIL_PATTERN.test(value.trim());
 }
 
-/** First segment of the email local-part for legacy contact-us `first_name` when no name field exists. */
+/** First segment of the email local-part when synthesizing `first_name` from email only. */
 export function deriveFirstNameFromEmailLocalPart(email: string): string {
   const trimmed = email.trim();
   const atIndex = trimmed.indexOf('@');

--- a/apps/public_www/tests/components/sections/booking-modal/event-details.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-modal/event-details.test.tsx
@@ -26,11 +26,11 @@ describe('BookingEventDetails (event variant)', () => {
         activePartRows={[
           {
             date: '21 May 2026 · 10:00 AM - 12:00 PM',
-            description: 'Legacy schedule description one',
+            description: 'Old-format schedule description one',
           },
           {
             date: '28 May 2026 · 10:00 AM - 12:00 PM',
-            description: 'Legacy schedule description two',
+            description: 'Old-format schedule description two',
           },
         ]}
         originalAmount={1280}
@@ -53,8 +53,8 @@ describe('BookingEventDetails (event variant)', () => {
     expect(screen.getByText('28 May 2026 · 10:00 AM - 12:00 PM')).toBeInTheDocument();
 
     expect(container.querySelectorAll('span[data-course-part-chip="true"]')).toHaveLength(0);
-    expect(screen.queryByText('Legacy schedule description one')).not.toBeInTheDocument();
-    expect(screen.queryByText('Legacy schedule description two')).not.toBeInTheDocument();
+    expect(screen.queryByText('Old-format schedule description one')).not.toBeInTheDocument();
+    expect(screen.queryByText('Old-format schedule description two')).not.toBeInTheDocument();
 
     expect(screen.getByText('HK$1,280')).toBeInTheDocument();
     expect(container.querySelector('span.es-mask-dollar-danger')).not.toBeNull();

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -493,7 +493,7 @@ describe('my-best-auntie booking modals footer content', () => {
     expect(emailField).toHaveAttribute('aria-invalid', 'true');
   });
 
-  it('does not render legacy month/package selector controls in booking modal', () => {
+  it('does not render removed month/package selector controls in booking modal', () => {
     const { container } = renderBookingModal();
     expect(container.querySelectorAll('button[aria-pressed="true"]')).toHaveLength(0);
     expect(container.querySelectorAll('button[aria-pressed="false"]')).toHaveLength(0);

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -357,11 +357,11 @@ describe('events-data', () => {
     });
   });
 
-  it('does not use legacy CTA candidate keys without external_url', () => {
+  it('does not use alternate CTA candidate keys without external_url', () => {
     const payload = {
       data: [
         {
-          title: 'Legacy CTA fields event',
+          title: 'Alternate CTA fields event',
           ctaUrl: 'https://booking.example.com/from-cta-url',
           bookingUrl: 'https://booking.example.com/from-booking-url',
           href: 'https://booking.example.com/from-href',

--- a/backend/db/alembic/versions/0002_drop_unused_domain.py
+++ b/backend/db/alembic/versions/0002_drop_unused_domain.py
@@ -19,7 +19,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Drop legacy domain tables and related columns."""
+    """Drop unused domain tables and related columns."""
     op.execute(
         """
         ALTER TABLE IF EXISTS assets

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -944,8 +944,8 @@ export class ApiStack extends cdk.Stack {
       selfSignUpEnabled: true,
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       customAttributes: {
-        // Legacy custom attribute retained to avoid immutable Cognito schema
-        // update failures on existing user pools.
+        // Custom attribute retained to avoid immutable Cognito schema update failures
+        // on existing user pools.
         feedback_stars: new cognito.StringAttribute({ mutable: true }),
         last_auth_time: new cognito.StringAttribute({ mutable: true }),
       },

--- a/backend/src/app/api/public_discount_validate.py
+++ b/backend/src/app/api/public_discount_validate.py
@@ -27,7 +27,7 @@ def handle_public_discount_validate(
     event: Mapping[str, Any],
     method: str,
 ) -> dict[str, Any]:
-    """Validate a discount code; response shape matches legacy DiscountRule."""
+    """Validate a discount code; response shape matches the public booking contract."""
     logger.info(
         "Handling public discount validate request",
         extra={"method": method},

--- a/backend/src/app/api/public_form_hooks.py
+++ b/backend/src/app/api/public_form_hooks.py
@@ -54,7 +54,7 @@ TAG_PUBLIC_WWW_EVENT_NOTIFICATION = "public-www-event-notification"
 TAG_BOOKING_PREFIX = "public-www-booking-customer-"
 
 # Mailchimp FNAME fallback when first_name is empty for community/event tags.
-# Public forms normally send deriveFirstNameFromEmailLocalPart + locale fallback;
+# Public forms normally send email-derived first_name + locale fallback;
 # this is defensive only (English placeholder if an edge-case request omits FNAME).
 _MAILCHIMP_EMAIL_ONLY_FIRST_NAME = "Friend"
 

--- a/backend/src/app/services/aws_proxy.py
+++ b/backend/src/app/services/aws_proxy.py
@@ -6,7 +6,7 @@ inside the VPC.
 
 Two request types are supported:
 
-**AWS API calls** (``type: "aws"`` or legacy format without ``type``):
+**AWS API calls** (``type: "aws"`` or implicit format without ``type``):
     Executes a boto3 call.  Gated by ``ALLOWED_ACTIONS`` (comma-separated
     ``service:action`` pairs).
 

--- a/backend/src/app/services/public_form_internal_notifications.py
+++ b/backend/src/app/services/public_form_internal_notifications.py
@@ -1,6 +1,6 @@
 """Internal SES notifications for public website form submissions.
 
-Includes **sales recaps** (contact, media lead, reservation, legacy booking) to
+Includes **sales recaps** (contact, media lead, reservation / booking) to
 verified emails on the Cognito group named by ``ADMIN_GROUP`` (default ``admin``),
 and **contact_inquiry** notifications to ``SUPPORT_EMAIL``. Module name avoids
 implying that recaps are an "admin product" concept.

--- a/backend/src/app/utils/logging.py
+++ b/backend/src/app/utils/logging.py
@@ -160,10 +160,10 @@ class StructuredLogFormatter(logging.Formatter):
                 continue
             log_data[key] = value
 
-        # Legacy: some code may attach a dict as record.extra
-        legacy_extra = getattr(record, "extra", None)
-        if isinstance(legacy_extra, dict):
-            for key, value in legacy_extra.items():
+        # Some code may attach a dict as record.extra
+        record_extra = getattr(record, "extra", None)
+        if isinstance(record_extra, dict):
+            for key, value in record_extra.items():
                 if key not in log_data:
                     log_data[key] = value
 

--- a/backend/src/app/utils/responses.py
+++ b/backend/src/app/utils/responses.py
@@ -75,7 +75,7 @@ def get_security_headers() -> dict[str, str]:
     SECURITY: These headers protect against common web vulnerabilities:
     - X-Content-Type-Options: Prevents MIME type sniffing
     - X-Frame-Options: Prevents clickjacking
-    - X-XSS-Protection: Enables browser XSS filter (legacy)
+    - X-XSS-Protection: Enables browser XSS filter (older browsers)
     - Cache-Control: Prevents caching of sensitive data
 
     Returns:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes or rewords all `legacy` references in application source (Python, TypeScript, TSX, and the public content validation script) so comments, docstrings, identifiers, and test titles no longer describe a separate legacy stack.

## Changes

- **Backend:** Docstrings/comments in logging, responses, Alembic migration, aws proxy, public discount validate, form hooks, internal notifications, CDK user pool; variable rename `legacy_extra` → `record_extra` in logging.
- **Admin web:** Comments in api-payload, crm-relationship, asset editor panel; test description in services-api.
- **Public www:** Comments in validation and testimonials; `LegacyCompatibleTestimonials` → `TestimonialsContentShape`; validate-content script renames `LEGACY_*` to `DISALLOWED_*` / `validateNoDisallowedSectionRootKeys` and adjusts validation error text; test strings/titles updated.

## Notes

- Architecture docs (e.g. retired `/v1/legacy/*` decision), `.cursorrules`, and `.github/workflows/verify-rulesets.yml` still use the word *legacy* where it documents GitHub/Git history or historical API decisions; not changed in this PR.

## Validation

- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
- Vitest: `apps/admin_web/tests/lib/services-api.test.ts`; `apps/public_www` affected test files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01f7295d-f9fe-4e79-a896-0e253702f335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01f7295d-f9fe-4e79-a896-0e253702f335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

