### PR TITLE
Make consultation booking "Anything we should know" optional

### DIFF
--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1274,7 +1274,7 @@
         "topicsField": {
           "label": "Anything we should know",
           "placeholder": "i.e. child is 3, helper has been with us 2 years, or any context for the visit",
-          "required": true
+          "required": false
         },
         "essentials": {
           "priceHkd": 2800,

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1274,7 +1274,7 @@
         "topicsField": {
           "label": "其他需要说明的信息",
           "placeholder": "例如：孩子3岁、阿姨已工作2年，或上门前希望我们知道的背景",
-          "required": true
+          "required": false
         },
         "essentials": {
           "priceHkd": 2800,

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1274,7 +1274,7 @@
         "topicsField": {
           "label": "其他需要說明的資訊",
           "placeholder": "例如：孩子3歲、姨姨已工作2年，或者上門前想我哋知嘅背景",
-          "required": true
+          "required": false
         },
         "essentials": {
           "priceHkd": 2800,

--- a/apps/public_www/tests/lib/consultations-booking-modal-payload.test.ts
+++ b/apps/public_www/tests/lib/consultations-booking-modal-payload.test.ts
@@ -17,7 +17,7 @@ describe('buildConsultationsBookingModalPayload', () => {
     expect(payload.title).toBe(reservation.modalTitle);
     expect(payload.originalAmount).toBe(reservation.essentials.priceHkd);
     expect(payload.dateParts).toHaveLength(reservation.essentials.dateParts.length);
-    expect(payload.topicsFieldConfig?.required).toBe(true);
+    expect(payload.topicsFieldConfig?.required).toBe(false);
     expect(payload.directionHref).toBeUndefined();
     expect(payload.topicsPrefill).toBeUndefined();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The family consultation booking flow read `consultations.booking.reservation.topicsField.required` from locale content and passed it through `buildConsultationsBookingModalPayload` to `ReservationForm`, which treated the topics textarea as required when `true`.

## Changes

- Set `topicsField.required` to `false` in `en.json`, `zh-CN.json`, and `zh-HK.json` under `consultations.booking.reservation`.
- Updated `consultations-booking-modal-payload.test.ts` to expect optional topics.

## Verification

- `npm run test -- --run tests/lib/consultations-booking-modal-payload.test.ts` (Vitest)
- `bash scripts/validate-cursorrules.sh`

Backend reservation handling already treats `interested_topics` as optional; no API or Lambda changes were required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b3d316a-e259-42cc-a534-c6fcc5dcecc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b3d316a-e259-42cc-a534-c6fcc5dcecc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

