### PR TITLE
Consultation booking: 2-day lead time and date confirmation copy

### DIFF
--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -82,6 +82,8 @@ export interface ConsultationBookingPickerContent {
   datePickerDayTemplate: string;
   /** Interpolate `{day}`; use when the day is unavailable (past or fully blocked). */
   datePickerUnavailableDayTemplate: string;
+  /** Shown under the selected date summary; same tone as payment modal refund hint. */
+  dateConfirmationNote: string;
 }
 
 function ConsultationDatePickerGrid({
@@ -268,19 +270,21 @@ function ConsultationDatePickerGrid({
       </div>
 
       {selectedSlotSummary ? (
-        <div
-          className='flex items-center gap-4'
-          data-testid='consultation-modal-selected-slot'
-        >
-          <span className='es-icon-circle-lg shrink-0'>
-            <span
-              data-testid='consultation-modal-selected-slot-calendar-icon'
-              className='es-mask-calendar-danger h-[37px] w-[37px] shrink-0'
-              aria-hidden='true'
-            />
-          </span>
-          <p className='min-w-0 flex-1 text-[17px] font-semibold leading-6 es-text-heading'>
-            {selectedSlotSummary}
+        <div className='flex flex-col gap-4' data-testid='consultation-modal-selected-slot'>
+          <div className='flex items-center gap-4'>
+            <span className='es-icon-circle-lg shrink-0'>
+              <span
+                data-testid='consultation-modal-selected-slot-calendar-icon'
+                className='es-mask-calendar-danger h-[37px] w-[37px] shrink-0'
+                aria-hidden='true'
+              />
+            </span>
+            <p className='min-w-0 flex-1 text-[17px] font-semibold leading-6 es-text-heading'>
+              {selectedSlotSummary}
+            </p>
+          </div>
+          <p className='text-base font-semibold leading-6 es-text-heading'>
+            {content.dateConfirmationNote}
           </p>
         </div>
       ) : null}

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -126,6 +126,7 @@ function buildConsultationPickerContent(
     datePickerLegend: p.datePickerLegend,
     datePickerDayTemplate: p.datePickerDayTemplate,
     datePickerUnavailableDayTemplate: p.datePickerUnavailableDayTemplate,
+    dateConfirmationNote: p.dateConfirmationNote,
   };
 }
 

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1482,7 +1482,8 @@
         "weekdayShortFri": "Fri",
         "datePickerLegend": "Preferred home visit date and time of day",
         "datePickerDayTemplate": "Select day {day}",
-        "datePickerUnavailableDayTemplate": "Day {day} unavailable"
+        "datePickerUnavailableDayTemplate": "Day {day} unavailable",
+        "dateConfirmationNote": "Date confirmed once booking is complete."
       }
     },
     "thankYouModal": {

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1483,7 +1483,7 @@
         "datePickerLegend": "Preferred home visit date and time of day",
         "datePickerDayTemplate": "Select day {day}",
         "datePickerUnavailableDayTemplate": "Day {day} unavailable",
-        "dateConfirmationNote": "Date confirmed once booking is complete."
+        "dateConfirmationNote": "Date/time confirmed once booking is complete."
       }
     },
     "thankYouModal": {

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1482,7 +1482,8 @@
         "weekdayShortFri": "五",
         "datePickerLegend": "首选上门评估日期与时段",
         "datePickerDayTemplate": "选择 {day} 日",
-        "datePickerUnavailableDayTemplate": "{day} 日不可选"
+        "datePickerUnavailableDayTemplate": "{day} 日不可选",
+        "dateConfirmationNote": "完成预约后才会最终确认日期。"
       }
     },
     "thankYouModal": {

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1483,7 +1483,7 @@
         "datePickerLegend": "首选上门评估日期与时段",
         "datePickerDayTemplate": "选择 {day} 日",
         "datePickerUnavailableDayTemplate": "{day} 日不可选",
-        "dateConfirmationNote": "完成预约后才会最终确认日期。"
+        "dateConfirmationNote": "完成预约后才会最终确认日期与时间。"
       }
     },
     "thankYouModal": {

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1482,7 +1482,8 @@
         "weekdayShortFri": "五",
         "datePickerLegend": "首選上門評估日期與時段",
         "datePickerDayTemplate": "選擇 {day} 日",
-        "datePickerUnavailableDayTemplate": "{day} 日不可選"
+        "datePickerUnavailableDayTemplate": "{day} 日不可選",
+        "dateConfirmationNote": "完成預約後先會最終確認日期。"
       }
     },
     "thankYouModal": {

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1483,7 +1483,7 @@
         "datePickerLegend": "首選上門評估日期與時段",
         "datePickerDayTemplate": "選擇 {day} 日",
         "datePickerUnavailableDayTemplate": "{day} 日不可選",
-        "dateConfirmationNote": "完成預約後先會最終確認日期。"
+        "dateConfirmationNote": "完成預約後先會最終確認日期同時間。"
       }
     },
     "thankYouModal": {

--- a/apps/public_www/src/lib/consultation-booking-slot.ts
+++ b/apps/public_www/src/lib/consultation-booking-slot.ts
@@ -8,6 +8,12 @@ export type ConsultationDayPeriod = 'am' | 'pm';
 export const CONSULTATION_SLOT_AM_HOUR_LOCAL = 9;
 export const CONSULTATION_SLOT_PM_HOUR_LOCAL = 14;
 
+/**
+ * Earliest selectable calendar day is this many whole days after "today" in the picker timezone
+ * (e.g. when today is the 14th, the first bookable day is the 16th).
+ */
+export const CONSULTATION_BOOKING_MIN_LEAD_CALENDAR_DAYS = 2;
+
 const WEEKDAY_LONG_MONDAY_FIRST = [
   'Monday',
   'Tuesday',
@@ -87,13 +93,22 @@ export function isConsultationPeriodBlocked(
   return period === 'am' ? row.am : row.pm;
 }
 
-/** True when both AM and PM are blocked, or the calendar date is in the past (caller passes `todayYmd`). */
+/** First calendar day that can be selected (inclusive), in the same YYYY-MM-DD space as `todayYmd`. */
+export function earliestConsultationBookableYmd(todayYmd: string, timeZone: string): string {
+  return addCalendarDaysInZone(todayYmd, CONSULTATION_BOOKING_MIN_LEAD_CALENDAR_DAYS, timeZone);
+}
+
+/** True when the day is before today, before the minimum lead time, or both AM and PM are blocked. */
 export function isConsultationPickerDayFullyBlocked(
   ymd: string,
   todayYmd: string,
   unavailableByYmd: ConsultationUnavailableByYmd,
+  timeZone: string,
 ): boolean {
   if (ymd < todayYmd) {
+    return true;
+  }
+  if (ymd < earliestConsultationBookableYmd(todayYmd, timeZone)) {
     return true;
   }
   const row = unavailableByYmd.get(ymd);
@@ -147,7 +162,7 @@ export function buildConsultationPickerWeeks(
         ymd,
         dayOfMonth: ymdToDayOfMonth(ymd),
         isPast,
-        isDisabled: isConsultationPickerDayFullyBlocked(ymd, todayYmd, unavailableByYmd),
+        isDisabled: isConsultationPickerDayFullyBlocked(ymd, todayYmd, unavailableByYmd, timeZone),
       });
     }
     weeks.push({ days });

--- a/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
@@ -36,6 +36,7 @@ function buildPickerContent(
     datePickerLegend: p.datePickerLegend,
     datePickerDayTemplate: p.datePickerDayTemplate,
     datePickerUnavailableDayTemplate: p.datePickerUnavailableDayTemplate,
+    dateConfirmationNote: p.dateConfirmationNote,
   };
 }
 
@@ -74,6 +75,11 @@ describe('ConsultationBookingModal', () => {
     expect(screen.getByTestId('consultation-modal-selected-slot')).toBeInTheDocument();
     const icon = screen.getByTestId('consultation-modal-selected-slot-calendar-icon');
     expect(icon.className).toContain('es-mask-calendar-danger');
+    expect(
+      screen.getByText(
+        enContent.bookingModal.paymentModal.consultationPicker.dateConfirmationNote,
+      ),
+    ).toBeInTheDocument();
   });
 
   it('selects PM when only the afternoon slot is available for that day', () => {

--- a/apps/public_www/tests/lib/consultation-booking-slot.test.ts
+++ b/apps/public_www/tests/lib/consultation-booking-slot.test.ts
@@ -14,6 +14,7 @@ import {
   collectDistinctYearMonthsFromYmds,
   CONSULTATION_SLOT_AM_HOUR_LOCAL,
   CONSULTATION_SLOT_PM_HOUR_LOCAL,
+  earliestConsultationBookableYmd,
   firstSelectableConsultationPeriod,
   formatConsultationPickerMonthHeading,
   formatConsultationSelectedSlotSummary,
@@ -61,7 +62,14 @@ describe('consultation-booking-slot', () => {
 
     expect(weeks[0]?.days[0]?.isPast).toBe(true);
     expect(weeks[0]?.days[0]?.isDisabled).toBe(true);
-    expect(weeks[0]?.days[1]?.isDisabled).toBe(false);
+    expect(weeks[0]?.days[1]?.isPast).toBe(false);
+    expect(weeks[0]?.days[1]?.isDisabled).toBe(true);
+    expect(weeks[0]?.days[2]?.isDisabled).toBe(true);
+    expect(weeks[0]?.days[3]?.isDisabled).toBe(false);
+  });
+
+  it('earliestConsultationBookableYmd is two calendar days after today in zone', () => {
+    expect(earliestConsultationBookableYmd('2026-04-14', HK)).toBe('2026-04-16');
   });
 
   it('disables a day when both am and pm are unavailable', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Consultation date picker now treats the first bookable calendar day as **two full days after “today”** in the user’s timezone (e.g. 14th → earliest 16th), in addition to existing past-day and unavailability rules.
- Added **locale-driven** note under the selected date line (same visual weight as the payment modal refund hint): English uses “Date confirmed once booking is complete.” with aligned zh-CN / zh-HK strings.

## Tests

- `npm run test -- --run tests/lib/consultation-booking-slot.test.ts tests/components/sections/consultation-booking-modal.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e3dbb8c-531d-4666-be62-1b00de2104ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e3dbb8c-531d-4666-be62-1b00de2104ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

