### PR TITLE
Default first My Best Auntie outline column expanded on desktop

### DIFF
--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-outline.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-outline.tsx
@@ -257,8 +257,10 @@ export function MyBestAuntieOutline({
   ctaHref,
   commonAccessibility = enContent.common.accessibility,
 }: MyBestAuntieOutlineProps) {
+  const firstModuleStep = content.modules[0]?.step ?? null;
+
   const [expandedModuleStep, setExpandedModuleStep] = useState<string | null>(
-    null,
+    firstModuleStep,
   );
 
   const { carouselRef } = useHorizontalCarousel<HTMLDivElement>({

--- a/apps/public_www/tests/components/sections/my-best-auntie-outline.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-outline.test.tsx
@@ -103,7 +103,7 @@ describe('MyBestAuntieOutline section', () => {
     expect(renderedModuleIconCount).toBe(moduleIcons.length * 2);
   });
 
-  it('reveals the desktop card description when clicked', () => {
+  it('defaults the first desktop column expanded and toggles it on click', () => {
     const { container } = render(
       <MyBestAuntieOutline content={enContent.myBestAuntie.outline} />,
     );
@@ -125,6 +125,12 @@ describe('MyBestAuntieOutline section', () => {
     );
     expect(description).not.toBeNull();
     expect(countLine).not.toBeNull();
+    expect(description?.className).not.toContain('max-h-[92px]');
+    expect(description?.className).not.toContain('overflow-hidden');
+    expect(countLine?.className).toContain('h-[74px]');
+    expect(countLine?.className).toContain('-top-[70px]');
+
+    fireEvent.click(firstCard!);
     expect(description?.className).toContain('max-h-[92px]');
     expect(description?.className).toContain('overflow-hidden');
     expect(countLine?.className).toContain('h-[148px]');
@@ -136,12 +142,6 @@ describe('MyBestAuntieOutline section', () => {
     expect(countLine?.className).toContain('h-[74px]');
     expect(countLine?.className).toContain('-top-[70px]');
     expect(countLine?.className).not.toContain('h-[148px]');
-
-    fireEvent.click(firstCard!);
-    expect(description?.className).toContain('max-h-[92px]');
-    expect(description?.className).toContain('overflow-hidden');
-    expect(countLine?.className).toContain('h-[148px]');
-    expect(countLine?.className).toContain('-top-[144px]');
   });
 
   it('renders three key points per module without visible bullet glyphs', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The My Best Auntie **course outline** section uses a 3-column grid on `md+` where each column expands its activity text when selected (or on hover). On first paint, nothing was expanded, so the first column did not match the “hovered first column” state.

## Changes

- Initialize `expandedModuleStep` in `MyBestAuntieOutline` to the first module’s `step` when modules exist, so the first desktop column loads in the same expanded layout as after interaction.
- Mobile carousel cards still use `showFullActivity` and are unchanged.
- Updated `my-best-auntie-outline.test.tsx` to assert the new default and the existing click toggle behavior.

## Testing

- `npx vitest run tests/components/sections/my-best-auntie-outline.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa03d6d9-09a6-42eb-9729-d0cf93596804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa03d6d9-09a6-42eb-9729-d0cf93596804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

