### PR TITLE
Unify consultation booking level picker layout on desktop

### DIFF
--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -62,8 +62,11 @@ const CONSULTATIONS_BOOKING_ICON_CIRCLE_CLASSNAME =
 const LEVEL_COMPACT_SELECTOR_CLASSNAME = mergeClassNames(
   'w-full rounded-3xl border es-border-soft es-bg-surface-neutral px-3 py-4 text-center sm:px-4 md:py-5',
   'flex min-h-0 flex-col items-center justify-center gap-3',
-  'md:flex-row md:items-center md:justify-start md:gap-[50px] md:px-8 md:py-8 md:text-left',
 );
+
+/** Step 2 (level picker + description) stays columnar like mobile; width cap keeps it narrower than step 1 / CTA. */
+const CONSULTATIONS_BOOKING_LEVEL_BLOCK_CLASSNAME =
+  'mx-auto w-full max-w-[min(100%,22rem)] sm:max-w-[26rem] md:max-w-[28rem]';
 
 const LEVEL_FEATURES_LIST_CLASSNAME =
   'mt-3 w-full min-w-0 list-none space-y-2 ps-0 text-left';
@@ -398,9 +401,12 @@ export function ConsultationsBooking({
                 role='group'
                 aria-label={content.step2Title}
                 data-testid='consultations-booking-level-grid'
-                className='flex flex-col gap-6 md:grid md:grid-cols-3 md:gap-6'
+                className={mergeClassNames(
+                  'flex flex-col gap-6',
+                  CONSULTATIONS_BOOKING_LEVEL_BLOCK_CLASSNAME,
+                )}
               >
-                <ul className='grid list-none grid-cols-2 gap-3 ps-0 sm:gap-4 md:flex md:flex-col md:gap-4'>
+                <ul className='grid list-none grid-cols-2 gap-3 ps-0 sm:gap-4'>
                   {content.levels.map((level) => {
                     const isSelected = level.id === selectedLevelId;
                     return (
@@ -436,7 +442,7 @@ export function ConsultationsBooking({
                               )}
                             />
                           </span>
-                          <span className='w-full min-w-0 max-w-full break-words text-center text-sm font-bold leading-tight es-text-heading sm:text-base md:w-auto md:max-w-none md:text-left md:text-lg'>
+                          <span className='w-full min-w-0 max-w-full break-words text-center text-sm font-bold leading-tight es-text-heading sm:text-base'>
                             {level.title}
                           </span>
                         </ButtonPrimitive>
@@ -445,7 +451,7 @@ export function ConsultationsBooking({
                   })}
                 </ul>
                 <div
-                  className='min-w-0 md:col-span-2 md:min-h-0'
+                  className='min-w-0'
                   aria-live='polite'
                   aria-atomic='true'
                   data-testid='consultations-booking-level-description'

--- a/apps/public_www/tests/components/sections/consultations-booking.test.tsx
+++ b/apps/public_www/tests/components/sections/consultations-booking.test.tsx
@@ -101,8 +101,12 @@ describe('ConsultationsBooking', () => {
     }
 
     const levelGrid = screen.getByTestId('consultations-booking-level-grid');
+    expect(levelGrid.className).toContain('max-w-[');
+    expect(levelGrid.className).not.toContain('md:grid');
     const levelSelectorList = levelGrid.querySelector(':scope > ul');
     expect(levelSelectorList).not.toBeNull();
+    expect(levelSelectorList!.className).toContain('grid-cols-2');
+    expect(levelSelectorList!.className).not.toContain('md:flex');
     for (const level of booking.levels) {
       expect(
         within(levelGrid).getByRole('button', { name: level.title }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The consultations booking step 2 (level picker + “what you get” description) used a horizontal row layout on `md+` while mobile kept a stacked card layout. This change removes the desktop-only flex row and grid split so **all breakpoints use the same mobile-style column layout**.

The step 2 block is wrapped in a **centered max-width** so the level title/picker/description column reads **narrower** than step 1 focus cards and the full-width CTA below.

## Test plan

- `npm run test -- --run tests/components/sections/consultations-booking.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3fa73d2-aa0a-4895-b13e-fdd17e224e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3fa73d2-aa0a-4895-b13e-fdd17e224e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

