### PR TITLE
Consultation booking: align step 2 title (md+), orange bullets, level change animation

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -1098,6 +1098,14 @@
     filter: none;
   }
 
+  #consultations-booking .es-consultations-booking-level-features {
+    list-style-type: disc;
+  }
+
+  #consultations-booking .es-consultations-booking-level-features li::marker {
+    color: var(--es-color-brand-orange);
+  }
+
   @keyframes es-consultations-booking-fade-in {
     from {
       opacity: 0;

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/lib/consultations-booking-modal-payload';
 import { mergeClassNames } from '@/lib/class-name-utils';
 import { useHorizontalCarousel } from '@/lib/hooks/use-horizontal-carousel';
+import { useHeightTransitionOnChange } from '@/lib/hooks/use-height-transition-on-change';
 import { useMatchMedia } from '@/lib/hooks/use-match-media';
 import { trackMetaPixelEvent } from '@/lib/meta-pixel';
 import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
@@ -66,11 +67,11 @@ const LEVEL_COMPACT_SELECTOR_CLASSNAME = mergeClassNames(
 
 /** Step 2 (level picker + description) stays columnar like mobile; width cap keeps it narrower than step 1 / CTA. */
 const CONSULTATIONS_BOOKING_LEVEL_BLOCK_CLASSNAME =
-  'mx-auto w-full max-w-[min(100%,22rem)] sm:max-w-[26rem] md:max-w-[28rem]';
+  'mx-auto w-full max-w-[min(100%,22rem)] sm:max-w-[26rem] md:mx-0 md:max-w-[28rem]';
 
 const LEVEL_FEATURES_LIST_CLASSNAME =
-  'mt-3 w-full min-w-0 list-none space-y-2 ps-0 text-left';
-const LEVEL_FEATURE_LINE_CLASSNAME = 'block ps-0 text-left es-type-body es-text-dim';
+  'es-consultations-booking-level-features mt-3 w-full min-w-0 list-disc space-y-2 ps-5 text-left';
+const LEVEL_FEATURE_LINE_CLASSNAME = 'es-type-body es-text-dim';
 
 const MD_UP_MEDIA_QUERY = '(min-width: 768px)';
 
@@ -231,6 +232,11 @@ export function ConsultationsBooking({
   }, [bookingModalContent.paymentModal]);
 
   const isMdUp = useMatchMedia(MD_UP_MEDIA_QUERY);
+
+  const levelDescriptionShellRef = useHeightTransitionOnChange(
+    isMdUp,
+    selectedLevelId,
+  );
 
   const { carouselRef: focusCarouselRef } =
     useHorizontalCarousel<HTMLDivElement>({
@@ -393,18 +399,24 @@ export function ConsultationsBooking({
           </div>
 
           <div className='mt-12'>
-            <h3 className='text-xl font-semibold es-type-body'>
+            <h3 className='text-xl font-semibold es-type-body md:hidden'>
               {content.step2Title}
             </h3>
-            <div className='relative mt-6'>
+            <div
+              data-testid='consultations-booking-level-block'
+              className={mergeClassNames(
+                'mt-6 flex flex-col gap-6 md:mt-6',
+                CONSULTATIONS_BOOKING_LEVEL_BLOCK_CLASSNAME,
+              )}
+            >
+              <h3 className='hidden text-xl font-semibold es-type-body md:block'>
+                {content.step2Title}
+              </h3>
               <div
                 role='group'
                 aria-label={content.step2Title}
                 data-testid='consultations-booking-level-grid'
-                className={mergeClassNames(
-                  'flex flex-col gap-6',
-                  CONSULTATIONS_BOOKING_LEVEL_BLOCK_CLASSNAME,
-                )}
+                className='flex flex-col gap-6'
               >
                 <ul className='grid list-none grid-cols-2 gap-3 ps-0 sm:gap-4'>
                   {content.levels.map((level) => {
@@ -451,7 +463,8 @@ export function ConsultationsBooking({
                   })}
                 </ul>
                 <div
-                  className='min-w-0'
+                  ref={levelDescriptionShellRef}
+                  className={mergeClassNames('min-w-0', isMdUp && 'overflow-hidden')}
                   aria-live='polite'
                   aria-atomic='true'
                   data-testid='consultations-booking-level-description'

--- a/apps/public_www/src/lib/hooks/use-height-transition-on-change.ts
+++ b/apps/public_www/src/lib/hooks/use-height-transition-on-change.ts
@@ -68,8 +68,12 @@ export function useHeightTransitionOnChange(
       if (ev.propertyName !== 'height') {
         return;
       }
-      el.style.transition = '';
-      el.style.height = '';
+      const target = ev.currentTarget;
+      if (!(target instanceof HTMLDivElement)) {
+        return;
+      }
+      target.style.transition = '';
+      target.style.height = '';
     }
 
     el.addEventListener('transitionend', onTransitionEnd);

--- a/apps/public_www/src/lib/hooks/use-height-transition-on-change.ts
+++ b/apps/public_www/src/lib/hooks/use-height-transition-on-change.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { useLayoutEffect, useRef } from 'react';
+
+const HEIGHT_TRANSITION_MS = 320;
+
+/**
+ * When `enabled` and `changeKey` update, animates a block element's height from
+ * its previous content height to the new height (before paint). Respects
+ * `prefers-reduced-motion: reduce`.
+ */
+export function useHeightTransitionOnChange(
+  enabled: boolean,
+  changeKey: unknown,
+): RefObject<HTMLDivElement | null> {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const prevHeightRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      const el = ref.current;
+      if (el) {
+        el.style.height = '';
+        el.style.transition = '';
+      }
+      prevHeightRef.current = null;
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    const reduceMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const nextHeight = el.scrollHeight;
+    const prevHeight = prevHeightRef.current;
+
+    if (
+      prevHeight != null &&
+      prevHeight !== nextHeight &&
+      !reduceMotion
+    ) {
+      el.style.height = `${prevHeight}px`;
+      void el.offsetHeight;
+      el.style.transition = `height ${HEIGHT_TRANSITION_MS}ms ease-out`;
+      el.style.height = `${nextHeight}px`;
+    }
+
+    prevHeightRef.current = nextHeight;
+  }, [enabled, changeKey]);
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    function onTransitionEnd(ev: TransitionEvent) {
+      if (ev.propertyName !== 'height') {
+        return;
+      }
+      el.style.transition = '';
+      el.style.height = '';
+    }
+
+    el.addEventListener('transitionend', onTransitionEnd);
+    return () => el.removeEventListener('transitionend', onTransitionEnd);
+  }, [enabled]);
+
+  return ref;
+}

--- a/apps/public_www/tests/components/sections/consultations-booking.test.tsx
+++ b/apps/public_www/tests/components/sections/consultations-booking.test.tsx
@@ -100,9 +100,11 @@ describe('ConsultationsBooking', () => {
       ).toBeGreaterThanOrEqual(1);
     }
 
+    const levelBlock = screen.getByTestId('consultations-booking-level-block');
+    expect(levelBlock.className).toContain('max-w-[');
+    expect(levelBlock.className).not.toContain('md:grid');
+
     const levelGrid = screen.getByTestId('consultations-booking-level-grid');
-    expect(levelGrid.className).toContain('max-w-[');
-    expect(levelGrid.className).not.toContain('md:grid');
     const levelSelectorList = levelGrid.querySelector(':scope > ul');
     expect(levelSelectorList).not.toBeNull();
     expect(levelSelectorList!.className).toContain('grid-cols-2');
@@ -198,6 +200,9 @@ describe('ConsultationsBooking', () => {
 
     expect(screen.queryByTestId('consultations-booking-focus-grid')).toBeNull();
     expect(screen.queryByTestId('consultations-booking-level-carousel')).toBeNull();
+
+    const levelBlock = screen.getByTestId('consultations-booking-level-block');
+    expect(levelBlock.className).toContain('max-w-[');
 
     const levelGrid = screen.getByTestId('consultations-booking-level-grid');
     expect(levelGrid.getAttribute('role')).toBe('group');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- On **md and up**, the step 2 heading ("Choose your level" / localized) sits inside the same width-constrained block as the level selector cards so it aligns with the left edge of those cards. Below **md**, the title stays full width above the block (unchanged feel on small screens).
- Level feature lists use **disc bullets** with **brand orange** markers (`::marker` scoped to `#consultations-booking`).
- Switching consultation levels **animates the description panel height** (320ms ease-out) together with the existing fade-in on the inner content; **`prefers-reduced-motion: reduce`** skips the height animation.

## CI fix

- `use-height-transition-on-change`: `transitionend` handler now clears styles via `ev.currentTarget` so production TypeScript (`next build`) does not report `'el' is possibly 'null'`.

## Files

- `apps/public_www/src/components/sections/consultations/consultations-booking.tsx`
- `apps/public_www/src/lib/hooks/use-height-transition-on-change.ts`
- `apps/public_www/src/app/styles/original/components-sections.css`
- `apps/public_www/tests/components/sections/consultations-booking.test.tsx`

## Testing

- `npm run build` (with CI-equivalent `NEXT_PUBLIC_*` env vars)
- `npm run test -- tests/components/sections/consultations-booking.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7545d5f2-ced9-4f48-90ce-5377e793f9f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7545d5f2-ced9-4f48-90ce-5377e793f9f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

