### PR TITLE
Add GBP to admin web currency selector

### DIFF
--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -18,9 +18,9 @@ describe('format helpers', () => {
     expect(formatEnumLabel('in_person')).toBe('In Person');
   });
 
-  it('exposes only HKD, USD, EUR, CNY, and SGD in currency options with expected labels', () => {
+  it('exposes HKD, USD, EUR, GBP, CNY, and SGD in currency options with expected labels', () => {
     const options = getCurrencyOptions();
-    expect(options.map((o) => o.value)).toEqual(['HKD', 'USD', 'EUR', 'CNY', 'SGD']);
+    expect(options.map((o) => o.value)).toEqual(['HKD', 'USD', 'EUR', 'GBP', 'CNY', 'SGD']);
     expect(options.some((option) => option.value === 'HKD' && option.label === 'HKD Hong Kong Dollar')).toBe(true);
   });
 

--- a/shared/config/admin-selectable-currency-codes.json
+++ b/shared/config/admin-selectable-currency-codes.json
@@ -1,9 +1,10 @@
 {
-  "codes": ["HKD", "USD", "EUR", "CNY", "SGD"],
+  "codes": ["HKD", "USD", "EUR", "GBP", "CNY", "SGD"],
   "currencySymbols": {
     "HKD": "HK$",
     "USD": "$",
     "EUR": "€",
+    "GBP": "£",
     "CNY": "¥",
     "SGD": "S$"
   }

--- a/tests/test_currency_config.py
+++ b/tests/test_currency_config.py
@@ -8,10 +8,11 @@ def test_currency_symbol_for_iso_code_uses_shared_config() -> None:
     assert currency_symbol_for_iso_code("hkd") == "HK$"
     assert currency_symbol_for_iso_code("USD") == "$"
     assert currency_symbol_for_iso_code("  EUR ") == "€"
+    assert currency_symbol_for_iso_code("GBP") == "£"
 
 
 def test_currency_symbol_for_iso_code_unknown_returns_none() -> None:
-    assert currency_symbol_for_iso_code("GBP") is None
+    assert currency_symbol_for_iso_code("AUD") is None
     assert currency_symbol_for_iso_code("") is None
     assert currency_symbol_for_iso_code(None) is None
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin currency dropdowns use `getCurrencyOptions()` in `apps/admin_web/src/lib/format.ts`, which reads ISO codes from `shared/config/admin-selectable-currency-codes.json`. This change adds **GBP** to that list (after EUR) and registers **£** in `currencySymbols` for consistency with other codes.

Python tests in `tests/test_currency_config.py` were updated so GBP expects **£** (no longer treated as unknown) and **AUD** is used as the unknown-code example.

## Testing

- `npm run test -- --run tests/lib/format.test.ts` (admin web)
- `python3 -m pytest tests/test_currency_config.py`
- `bash scripts/validate-cursorrules.sh`
- `pre-commit run ruff-format --all-files`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb89e78e-20dc-442f-96f2-64c3d5fcd940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb89e78e-20dc-442f-96f2-64c3d5fcd940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

