### PR TITLE
Match consultation booking modal feature list to section styling

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -1126,6 +1126,24 @@
     }
   }
 
+  .es-consultation-booking-modal-subtitle-slot .es-consultations-booking-level-features {
+    list-style-type: disc;
+  }
+
+  .es-consultation-booking-modal-subtitle-slot .es-consultations-booking-level-features li::marker {
+    color: var(--es-color-brand-orange);
+  }
+
+  .es-consultation-booking-modal-subtitle-slot .es-consultations-booking-level-description-enter {
+    animation: es-consultations-booking-fade-in 300ms ease-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .es-consultation-booking-modal-subtitle-slot .es-consultations-booking-level-description-enter {
+      animation: none;
+    }
+  }
+
   .es-landing-page-cta-section {
     background-color: var(--figma-colors-frame-2147235259, #FFEEE3);
   }

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -41,6 +41,11 @@ import { useModalFocusManagement } from '@/lib/hooks/use-modal-focus-management'
 import { mergeClassNames } from '@/lib/class-name-utils';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
 
+/** Matches `consultations-booking` level feature list (discs + orange markers via CSS). */
+const CONSULTATION_MODAL_LEVEL_FEATURES_LIST_CLASSNAME =
+  'es-consultations-booking-level-features mt-3 w-full min-w-0 list-disc space-y-2 ps-5 text-left';
+const CONSULTATION_MODAL_LEVEL_FEATURE_LINE_CLASSNAME = 'es-type-body es-text-dim';
+
 export interface ConsultationBookingModalSelectionInfo {
   focusLabel: string;
   levelId: string;
@@ -61,6 +66,12 @@ interface ConsultationBookingModalProps {
   calendarAvailability: CalendarAvailabilityPayload;
   /** Selection context: focus label, level features, upgrade label. */
   selectionInfo?: ConsultationBookingModalSelectionInfo;
+  /**
+   * Increment when the user upgrades from essentials to deep-dive (e.g. parent
+   * `setState` in the upgrade handler) so the feature list can play the same
+   * enter animation as the booking section. Reset when the modal closes.
+   */
+  levelFeaturesEnterAnimationNonce?: number;
   analyticsSectionId?: string;
   metaPixelContentName?: MetaPixelContentName;
   captchaWidgetAction?: string;
@@ -302,6 +313,7 @@ export function ConsultationBookingModal({
   pickerContent,
   calendarAvailability,
   selectionInfo,
+  levelFeaturesEnterAnimationNonce = 0,
   analyticsSectionId = 'consultations-booking',
   metaPixelContentName = PIXEL_CONTENT_NAME.consultation_booking,
   captchaWidgetAction = 'consultation_reservation_submit',
@@ -331,6 +343,11 @@ export function ConsultationBookingModal({
     ymd: string;
     period: ConsultationDayPeriod;
   } | null>(null);
+
+  const featuresListAnimationClass =
+    selectionInfo?.levelId === 'deep-dive' && levelFeaturesEnterAnimationNonce > 0
+      ? 'es-consultations-booking-level-description-enter'
+      : undefined;
 
   const selectedYmd = pickerSelection?.ymd ?? defaultSelection?.ymd ?? '';
   const dayPeriod = pickerSelection?.period ?? defaultSelection?.period ?? 'am';
@@ -390,20 +407,25 @@ export function ConsultationBookingModal({
   );
 
   const subtitleSlot = selectionInfo ? (
-    <div className='mt-3'>
+    <div className='es-consultation-booking-modal-subtitle-slot mt-3'>
       <p className='text-xl font-semibold leading-7 es-text-heading'>
         {selectionInfo.focusLabelFormatted}
       </p>
-      <ul className='mt-3 list-none space-y-2 ps-0'>
-        {selectionInfo.levelFeatures.map((feature, index) => (
-          <li
-            key={`modal-feature-${index}`}
-            className='block ps-0 text-base es-type-body es-text-dim'
-          >
-            {feature}
-          </li>
-        ))}
-      </ul>
+      <div
+        key={`${selectionInfo.levelId}-${levelFeaturesEnterAnimationNonce}`}
+        className={featuresListAnimationClass}
+      >
+        <ul className={CONSULTATION_MODAL_LEVEL_FEATURES_LIST_CLASSNAME}>
+          {selectionInfo.levelFeatures.map((feature, index) => (
+            <li
+              key={`modal-feature-${selectionInfo.levelId}-${index}`}
+              className={CONSULTATION_MODAL_LEVEL_FEATURE_LINE_CLASSNAME}
+            >
+              {feature}
+            </li>
+          ))}
+        </ul>
+      </div>
       {selectionInfo.levelId === 'essentials' && onUpgradeToDeepDive ? (
         <div className='mt-5'>
           <ButtonPrimitive

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -167,6 +167,8 @@ export function ConsultationsBooking({
   );
   const [hasUserChangedLevelSelection, setHasUserChangedLevelSelection] =
     useState(false);
+  const [consultationModalLevelFeaturesAnimNonce, setConsultationModalLevelFeaturesAnimNonce] =
+    useState(0);
 
   useEffect(() => {
     if (!isThankYouOpen || !thankYouSummary) {
@@ -224,6 +226,7 @@ export function ConsultationsBooking({
     }, [content.focusAreas, content.levels, content.reservation, selectedFocusId, selectedLevelId]);
 
   function handleUpgradeToDeepDive() {
+    setConsultationModalLevelFeaturesAnimNonce((n) => n + 1);
     setSelectedLevelId('deep-dive');
   }
 
@@ -537,12 +540,14 @@ export function ConsultationsBooking({
           calendarAvailability={calendarAvailability}
           pickerContent={consultationPickerContent}
           selectionInfo={modalSelectionInfo}
+          levelFeaturesEnterAnimationNonce={consultationModalLevelFeaturesAnimNonce}
           analyticsSectionId='consultations-booking'
           metaPixelContentName={PIXEL_CONTENT_NAME.consultation_booking}
           captchaWidgetAction='consultation_reservation_submit'
           thankYouRecapLabels={buildThankYouRecapLabels(bookingModalContent.thankYouModal)}
           onClose={() => {
             setIsBookingModalOpen(false);
+            setConsultationModalLevelFeaturesAnimNonce(0);
           }}
           onSubmitReservation={(summary) => {
             setIsBookingModalOpen(false);

--- a/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
@@ -254,6 +254,73 @@ describe('ConsultationBookingModal', () => {
     expect(onUpgrade).toHaveBeenCalledOnce();
   });
 
+  it('applies level-features list class and fade-in when selection upgrades to deep-dive', () => {
+    const upgradeLabel = enContent.consultations.booking.reservation.upgradeToDeepDiveLabel;
+    const essentialsInfo: ConsultationBookingModalSelectionInfo = {
+      focusLabel: 'Home Assessment',
+      levelId: 'essentials',
+      levelLabel: enContent.consultations.booking.levels[0].title,
+      levelFeatures: enContent.consultations.booking.levels[0].features,
+      focusLabelFormatted: 'Home Assessment focus',
+      upgradeToDeepDiveLabel: upgradeLabel,
+    };
+
+    const bookingPayload = buildConsultationsBookingModalPayload(
+      enContent.consultations.booking.reservation,
+      'en',
+    );
+
+    const { rerender } = render(
+      <ConsultationBookingModal
+        locale='en'
+        paymentModalContent={enContent.bookingModal.paymentModal}
+        bookingPayload={bookingPayload}
+        pickerContent={buildPickerContent(enContent.bookingModal.paymentModal)}
+        calendarAvailability={{ unavailable_slots: [] }}
+        selectionInfo={essentialsInfo}
+        onClose={() => {}}
+        onSubmitReservation={() => {}}
+        onUpgradeToDeepDive={() => {}}
+      />,
+    );
+
+    const subtitleSlot = document.body.querySelector(
+      '.es-consultation-booking-modal-subtitle-slot',
+    );
+    const list = subtitleSlot?.querySelector('.es-consultations-booking-level-features');
+    expect(list).toBeTruthy();
+    expect(list?.className).toContain('list-disc');
+
+    const deepDiveInfo: ConsultationBookingModalSelectionInfo = {
+      focusLabel: 'Home Assessment',
+      levelId: 'deep-dive',
+      levelLabel: enContent.consultations.booking.levels[1].title,
+      levelFeatures: enContent.consultations.booking.levels[1].features,
+      focusLabelFormatted: 'Home Assessment focus',
+      upgradeToDeepDiveLabel: upgradeLabel,
+    };
+
+    rerender(
+      <ConsultationBookingModal
+        locale='en'
+        paymentModalContent={enContent.bookingModal.paymentModal}
+        bookingPayload={bookingPayload}
+        pickerContent={buildPickerContent(enContent.bookingModal.paymentModal)}
+        calendarAvailability={{ unavailable_slots: [] }}
+        selectionInfo={deepDiveInfo}
+        levelFeaturesEnterAnimationNonce={1}
+        onClose={() => {}}
+        onSubmitReservation={() => {}}
+        onUpgradeToDeepDive={() => {}}
+      />,
+    );
+
+    const animWrap = document.body.querySelector(
+      '.es-consultation-booking-modal-subtitle-slot .es-consultations-booking-level-description-enter',
+    );
+    expect(animWrap).toBeTruthy();
+  });
+
   it('keeps PM selected when changing date if afternoon is available on the new day', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The consultation booking modal subtitle feature list now matches the consultations booking section: disc bullets with brand-orange markers, same spacing and body typography, and the same fade-in animation when the user upgrades from Essentials to Deep Dive via the modal CTA.

## Changes

- **Modal markup** (`consultation-booking-modal.tsx`): Wrap subtitle content in `es-consultation-booking-modal-subtitle-slot`; use `es-consultations-booking-level-features` + `es-type-body es-text-dim` on list items (aligned with `consultations-booking.tsx`).
- **CSS** (`components-sections.css`): Scope disc marker color and `es-consultations-booking-fade-in` animation for the modal wrapper (mirrors `#consultations-booking` rules without affecting other modals).
- **Parent** (`consultations-booking.tsx`): Increment `levelFeaturesEnterAnimationNonce` on upgrade and reset on modal close so the enter animation runs reliably; pass nonce into the modal.
- **Tests**: Assert list classes and animation wrapper when deep-dive is shown with nonce.

## Verification

- `npm run lint` (apps/public_www)
- `npm run test -- --run tests/components/sections/consultation-booking-modal.test.tsx tests/components/sections/consultations-booking.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9acc60b-8dff-483f-a484-fcfbacc3ed7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9acc60b-8dff-483f-a484-fcfbacc3ed7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

