### PR TITLE
Update SES header logo link target and footer social link styling

### DIFF
--- a/backend/src/app/templates/transactional_shell_data.py
+++ b/backend/src/app/templates/transactional_shell_data.py
@@ -45,7 +45,7 @@ _SOCIAL_LABELS = {
     "zh-HK": ("WhatsApp", "Instagram", "LinkedIn", "網站"),
 }
 
-_LINK_STYLE = "color:#C84A16;font-weight:600;text-decoration:none;"
+_LINK_STYLE = "color:#C84A16;font-weight:600;text-decoration:underline;"
 _SEP = '<span style="color:#EECAB0;"> · </span>'
 
 
@@ -267,7 +267,7 @@ def build_transactional_template_shell_data(*, locale: str) -> dict[str, str]:
     loc = locale if locale in _ALLOWED_LOCALES else "en"
     base = resolve_public_www_base_url()
     logo_url = f"{base}{_DEFAULT_OG_IMAGE_PATH}" if base else ""
-    site_home_url = f"{base}/{loc}/" if base else ""
+    site_home_url = base if base else ""
 
     return {
         "logo_url": logo_url,

--- a/tests/test_transactional_shell_data.py
+++ b/tests/test_transactional_shell_data.py
@@ -116,7 +116,7 @@ def test_build_transactional_template_shell_data_footer(
     assert data["logo_url"] == (
         "https://www.example.com/images/seo/evolvesprouts-og-default.png"
     )
-    assert data["site_home_url"] == f"https://www.example.com/{locale}/"
+    assert data["site_home_url"] == "https://www.example.com"
     assert data["my_best_auntie_url"] == (
         f"https://www.example.com/{locale}/services/my-best-auntie-training-course"
     )
@@ -124,6 +124,7 @@ def test_build_transactional_template_shell_data_footer(
     assert expect_fragment in data["footer_block_html"]
     assert "Instagram" in data["footer_block_html"]
     assert "https://www.instagram.com/evolvesprouts" in data["footer_block_html"]
+    assert "text-decoration:underline" in data["footer_block_html"]
     assert "© 2030 Evolve Sprouts. All rights reserved." in data["footer_block_html"]
     assert "margin:16px 0 0 0;text-align:center" in data["footer_block_html"]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update transactional SES shell data so the header logo link points to the public WWW root URL
- update SES footer social link inline style to render links underlined
- update transactional shell data test assertions for the new link target and underline style

## Validation
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
- `pytest tests/test_transactional_shell_data.py tests/test_ses_contact_confirmation_templates.py tests/test_ses_booking_confirmation_templates.py tests/test_ses_media_download_templates.py tests/test_booking_confirmation_render.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73770e2d-8183-46c5-8fbf-b95086f64728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73770e2d-8183-46c5-8fbf-b95086f64728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

