### PR TITLE
Match services spacing and enhance orange arrow ring

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -504,13 +504,31 @@
   @keyframes es-service-arrow-pulse {
     0% {
       transform: scale(1);
-      opacity: 0.45;
+      opacity: 0.85;
     }
 
     100% {
-      transform: scale(1.3);
+      transform: scale(1.42);
       opacity: 0;
     }
+  }
+
+  .es-service-arrow-ring-target--brand {
+    border-color: color-mix(
+      in srgb,
+      var(--es-color-brand-orange, #C84A16) 75%,
+      white 25%
+    );
+    background-color: color-mix(
+      in srgb,
+      var(--es-color-brand-orange, #C84A16) 22%,
+      transparent
+    );
+    box-shadow: 0 0 0 1px color-mix(
+      in srgb,
+      var(--es-color-brand-orange, #C84A16) 45%,
+      transparent
+    );
   }
 
   .es-service-arrow-ring {

--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -169,7 +169,7 @@ export function ServiceCard({
       >
         <span
           aria-hidden
-          className={`es-service-arrow-ring-target pointer-events-none absolute inset-0 rounded-full border border-white/40 bg-white/10 transition-opacity duration-300 ${arrowRingActive}`}
+          className={`es-service-arrow-ring-target es-service-arrow-ring-target--brand pointer-events-none absolute inset-0 rounded-full border transition-opacity duration-300 ${arrowRingActive}`}
         />
         <span className='inline-flex h-[44px] w-[44px] items-center justify-center rounded-full es-bg-brand-strong shadow-[0_4px_10px_rgba(0,0,0,0.18)]'>
           <span

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -126,7 +126,7 @@ export function Services({
           title={sectionTitle}
         />
 
-        <div className='relative'>
+        <div className='relative mt-12 sm:mt-14 xl:mt-16'>
           <ul className='grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3'>
             {serviceCards.map((card, index) => {
               const tone = CARD_TONES[index % CARD_TONES.length];

--- a/apps/public_www/tests/components/sections/service-card.test.tsx
+++ b/apps/public_www/tests/components/sections/service-card.test.tsx
@@ -82,10 +82,15 @@ describe('ServiceCard description visibility transition', () => {
     const serviceLink = screen.getByRole('link', {
       name: 'Go to Age Specific Strategies',
     });
+    const pulseRing = document.querySelector('.es-service-arrow-ring-target');
 
     expect(card).not.toBeNull();
     expect(card?.className).toContain('group');
     expect(serviceLink).toHaveAttribute('href', BASE_PROPS.href);
+    expect(pulseRing).not.toBeNull();
+    expect(
+      hasClassToken((pulseRing as HTMLElement).className, 'es-service-arrow-ring-target--brand'),
+    ).toBe(true);
     expect(description.className).toContain('group-hover:opacity-100');
     expect(description.className).not.toContain('lg:group-hover:opacity-100');
     expect(serviceLink.className).toContain('group-hover:h-[70px]');

--- a/apps/public_www/tests/components/sections/services.test.tsx
+++ b/apps/public_www/tests/components/sections/services.test.tsx
@@ -39,6 +39,14 @@ describe('Services', () => {
       screen.getByRole('link', { name: 'Go to Free Guides & Resources' }),
     ).toHaveAttribute('href', '/services/free-guides-and-resources');
 
+    const cardsGrid = screen
+      .getByRole('link', { name: 'Go to My Best Auntie Programme' })
+      .closest('ul');
+    expect(cardsGrid).not.toBeNull();
+    expect(cardsGrid?.parentElement?.className).toContain('mt-12');
+    expect(cardsGrid?.parentElement?.className).toContain('sm:mt-14');
+    expect(cardsGrid?.parentElement?.className).toContain('xl:mt-16');
+
     const cards = screen.getAllByRole('button');
     expect(cards).toHaveLength(3);
     expect(document.querySelectorAll('.es-service-card--green').length).toBeGreaterThan(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- match the Services section title-to-cards spacing with the Real Talk section (`mt-12 sm:mt-14 xl:mt-16`)
- make the Service card arrow pulse ring more visible by using brand orange styling and a stronger pulse animation
- add focused assertions for spacing and ring styling hooks in section tests

## Testing
- `npm run test -- tests/components/sections/service-card.test.tsx tests/components/sections/services.test.tsx`
- `bash scripts/validate-cursorrules.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2004f5a9-c512-443c-9417-c1919f696b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2004f5a9-c512-443c-9417-c1919f696b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

