### PR TITLE
Public WWW: shorter service cards + arrow pulse on hover

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -535,6 +535,14 @@
     animation: es-service-arrow-pulse 1.4s ease-out infinite;
   }
 
+  /* Pulse ring on card hover (desktop); tap path uses .es-service-arrow-ring from TSX */
+  @media (min-width: 1024px) and (hover: hover) {
+    .group:hover .es-service-arrow-ring-target--brand {
+      opacity: 1;
+      animation: es-service-arrow-pulse 1.4s ease-out infinite;
+    }
+  }
+
   .es-section-brand-overlay {
     background: radial-gradient(
         circle at 16% 22%,

--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -137,7 +137,7 @@ export function ServiceCard({
       aria-expanded={isActive}
       onClick={handleCardSurfaceClick}
       onKeyDown={handleCardSurfaceKeyDown}
-      className={`group relative isolate flex min-h-[320px] overflow-hidden rounded-card p-5 sm:min-h-[345px] sm:p-7 lg:min-h-[457px] lg:p-8 ${toneClassName}`}
+      className={`group relative isolate flex min-h-[240px] overflow-hidden rounded-card p-5 sm:min-h-[259px] sm:p-7 lg:min-h-[343px] lg:p-8 ${toneClassName}`}
     >
       {/* Dark overlay - activated by pointer hover or tap */}
       <div

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -42,7 +42,7 @@ const serviceCardMeta: ServiceCardMeta[] = [
     imageSrc: '/images/services/course-card-1.webp',
     imageWidth: 344,
     imageHeight: 309,
-    imageClassName: 'h-[235px] sm:h-[265px] lg:h-[305px]',
+    imageClassName: 'h-[176px] sm:h-[199px] lg:h-[229px]',
   },
   {
     id: 'family-consultations',
@@ -50,7 +50,7 @@ const serviceCardMeta: ServiceCardMeta[] = [
     imageSrc: '/images/services/course-card-2.webp',
     imageWidth: 433,
     imageHeight: 424,
-    imageClassName: 'h-[250px] sm:h-[285px] lg:h-[328px]',
+    imageClassName: 'h-[188px] sm:h-[214px] lg:h-[246px]',
   },
   {
     id: 'free-guides',
@@ -58,7 +58,7 @@ const serviceCardMeta: ServiceCardMeta[] = [
     imageSrc: '/images/services/course-card-3.webp',
     imageWidth: 282,
     imageHeight: 335,
-    imageClassName: 'h-[230px] sm:h-[265px] lg:h-[305px]',
+    imageClassName: 'h-[173px] sm:h-[199px] lg:h-[229px]',
   },
 ];
 

--- a/apps/public_www/tests/components/sections/service-card.test.tsx
+++ b/apps/public_www/tests/components/sections/service-card.test.tsx
@@ -24,7 +24,7 @@ const BASE_PROPS = {
   imageSrc: '/images/services/course-card-1.webp',
   imageWidth: 344,
   imageHeight: 309,
-  imageClassName: 'h-[235px]',
+  imageClassName: 'h-[176px]',
   description: 'Practical scripts and examples',
   tone: 'green' as const,
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Reduces service card vertical footprint by ~25% by lowering `min-h` on the card container and scaling down the three service illustration height utilities in `services.tsx`.
- Fixes the arrow **pulse ring** so it animates when hovering anywhere on the card on desktop (`(min-width: 1024px) and (hover: hover)`), not only after tap. Previously, desktop hover showed overlay/description via Tailwind `group-hover`, but the pulse class `es-service-arrow-ring` was only applied from React state (tap on non-hover devices).

## Testing

- `npm run test -- tests/components/sections/service-card.test.tsx tests/components/sections/services.test.tsx`
- `npm run lint` (public_www)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-504ae549-38bd-4d1a-aa4b-38d6276b42a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-504ae549-38bd-4d1a-aa4b-38d6276b42a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

