### PR TITLE
Public WWW: restore service card height below lg breakpoint

### DIFF
--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -137,7 +137,7 @@ export function ServiceCard({
       aria-expanded={isActive}
       onClick={handleCardSurfaceClick}
       onKeyDown={handleCardSurfaceKeyDown}
-      className={`group relative isolate flex min-h-[240px] overflow-hidden rounded-card p-5 sm:min-h-[259px] sm:p-7 lg:min-h-[343px] lg:p-8 ${toneClassName}`}
+      className={`group relative isolate flex min-h-[320px] overflow-hidden rounded-card p-5 sm:min-h-[345px] sm:p-7 lg:min-h-[343px] lg:p-8 ${toneClassName}`}
     >
       {/* Dark overlay - activated by pointer hover or tap */}
       <div

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -42,7 +42,7 @@ const serviceCardMeta: ServiceCardMeta[] = [
     imageSrc: '/images/hero/my-best-auntie-hero.webp',
     imageWidth: 1200,
     imageHeight: 900,
-    imageClassName: 'h-[176px] sm:h-[199px] lg:h-[229px]',
+    imageClassName: 'h-[235px] sm:h-[265px] lg:h-[229px]',
   },
   {
     id: 'family-consultations',
@@ -50,7 +50,7 @@ const serviceCardMeta: ServiceCardMeta[] = [
     imageSrc: '/images/hero/consultations-hero.webp',
     imageWidth: 1200,
     imageHeight: 800,
-    imageClassName: 'h-[188px] sm:h-[214px] lg:h-[246px]',
+    imageClassName: 'h-[250px] sm:h-[285px] lg:h-[246px]',
   },
   {
     id: 'free-guides',
@@ -58,7 +58,7 @@ const serviceCardMeta: ServiceCardMeta[] = [
     imageSrc: '/images/hero/free-guides-and-resources-hero.webp',
     imageWidth: 433,
     imageHeight: 424,
-    imageClassName: 'h-[188px] sm:h-[214px] lg:h-[246px]',
+    imageClassName: 'h-[230px] sm:h-[265px] lg:h-[246px]',
   },
 ];
 

--- a/apps/public_www/tests/components/sections/service-card.test.tsx
+++ b/apps/public_www/tests/components/sections/service-card.test.tsx
@@ -24,7 +24,7 @@ const BASE_PROPS = {
   imageSrc: '/images/hero/my-best-auntie-hero.webp',
   imageWidth: 1200,
   imageHeight: 900,
-  imageClassName: 'h-[176px]',
+  imageClassName: 'h-[235px]',
   description: 'Practical scripts and examples',
   tone: 'green' as const,
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the **pre-shrink** service card layout for viewports **below `lg` (<1024px)**:

- `ServiceCard` container: `min-h-[320px]` / `sm:min-h-[345px]` again; **`lg:min-h-[343px]`** unchanged (compact large screens).
- Hero image height ladders in `services.tsx`: original default/sm values; **`lg:`** heights unchanged.

## Testing

- `npm run test -- tests/components/sections/service-card.test.tsx tests/components/sections/services.test.tsx`
- `npm run lint` (public_www)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-504ae549-38bd-4d1a-aa4b-38d6276b42a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-504ae549-38bd-4d1a-aa4b-38d6276b42a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

