### PR TITLE
feat(public_www): service card description preview with vertical fade

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -489,6 +489,15 @@
     );
   }
 
+  .es-service-card-description-preview {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    mask-image: linear-gradient(to bottom, black 40%, transparent 95%);
+    -webkit-mask-image: linear-gradient(to bottom, black 40%, transparent 95%);
+  }
+
   .es-service-card--gold {
     background-color: var(--es-color-accent-gold, #9E6D12);
   }

--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -127,6 +127,9 @@ export function ServiceCard({
   const descriptionVisibilityClassName = isActive
     ? 'opacity-100 transition-opacity duration-300'
     : 'opacity-0 transition-none';
+  const previewVisibilityClassName = isActive
+    ? 'opacity-0'
+    : 'opacity-70';
 
   return (
     <div
@@ -187,11 +190,19 @@ export function ServiceCard({
           </h3>
 
           {description && (
-            <p
-              className={`max-w-[34ch] es-service-card-description group-hover:opacity-100 group-hover:transition-opacity group-hover:duration-300 ${descriptionVisibilityClassName}`}
-            >
-              {renderQuotedDescriptionText(description)}
-            </p>
+            <div className='relative'>
+              <span
+                aria-hidden='true'
+                className={`pointer-events-none absolute inset-x-0 top-0 z-[2] max-w-[34ch] es-service-card-description es-service-card-description-preview transition-opacity duration-150 group-hover:opacity-0 ${previewVisibilityClassName}`}
+              >
+                {renderQuotedDescriptionText(description)}
+              </span>
+              <p
+                className={`relative z-[1] max-w-[34ch] es-service-card-description group-hover:opacity-100 group-hover:transition-opacity group-hover:duration-300 ${descriptionVisibilityClassName}`}
+              >
+                {renderQuotedDescriptionText(description)}
+              </p>
+            </div>
           )}
         </div>
       </div>

--- a/apps/public_www/tests/components/sections/service-card.test.tsx
+++ b/apps/public_www/tests/components/sections/service-card.test.tsx
@@ -70,6 +70,14 @@ afterEach(() => {
   Reflect.deleteProperty(window, 'matchMedia');
 });
 
+function getCardDescriptionParagraph(card: HTMLElement | null): HTMLElement | null {
+  return card?.querySelector('p.es-service-card-description') ?? null;
+}
+
+function getCardDescriptionPreview(card: HTMLElement | null): HTMLElement | null {
+  return card?.querySelector('.es-service-card-description-preview') ?? null;
+}
+
 describe('ServiceCard description visibility transition', () => {
   it('renders arrow as a link CTA with go-to aria label', () => {
     render(<ServiceCard {...BASE_PROPS} />);
@@ -78,21 +86,22 @@ describe('ServiceCard description visibility transition', () => {
       name: 'Age Specific Strategies',
     });
     const card = heading.closest('[role="button"]');
-    const description = screen.getByText('Practical scripts and examples');
+    const description = getCardDescriptionParagraph(card);
     const serviceLink = screen.getByRole('link', {
       name: 'Go to Age Specific Strategies',
     });
     const pulseRing = document.querySelector('.es-service-arrow-ring-target');
 
     expect(card).not.toBeNull();
+    expect(description).not.toBeNull();
     expect(card?.className).toContain('group');
     expect(serviceLink).toHaveAttribute('href', BASE_PROPS.href);
     expect(pulseRing).not.toBeNull();
     expect(
       hasClassToken((pulseRing as HTMLElement).className, 'es-service-arrow-ring-target--brand'),
     ).toBe(true);
-    expect(description.className).toContain('group-hover:opacity-100');
-    expect(description.className).not.toContain('lg:group-hover:opacity-100');
+    expect(description!.className).toContain('group-hover:opacity-100');
+    expect(description!.className).not.toContain('lg:group-hover:opacity-100');
     expect(serviceLink.className).toContain('group-hover:h-[70px]');
     expect(serviceLink.className).not.toContain('lg:group-hover:h-[70px]');
   });
@@ -104,14 +113,15 @@ describe('ServiceCard description visibility transition', () => {
       name: 'Age Specific Strategies',
     });
     const card = heading.closest('[role="button"]');
-    const description = screen.getByText('Practical scripts and examples');
+    const description = getCardDescriptionParagraph(card);
     const pulseRing = document.querySelector('.es-service-arrow-ring-target');
 
     expect(card).not.toBeNull();
+    expect(description).not.toBeNull();
     expect(card).toHaveAttribute('aria-expanded', 'false');
     expect(pulseRing).not.toBeNull();
-    expect(hasClassToken(description.className, 'opacity-0')).toBe(true);
-    expect(hasClassToken(description.className, 'transition-none')).toBe(true);
+    expect(hasClassToken(description!.className, 'opacity-0')).toBe(true);
+    expect(hasClassToken(description!.className, 'transition-none')).toBe(true);
     expect(
       hasClassToken((pulseRing as HTMLElement).className, 'es-service-arrow-ring'),
     ).toBe(false);
@@ -119,9 +129,9 @@ describe('ServiceCard description visibility transition', () => {
     fireEvent.click(card as HTMLElement);
 
     expect(card).toHaveAttribute('aria-expanded', 'true');
-    expect(hasClassToken(description.className, 'opacity-100')).toBe(true);
-    expect(hasClassToken(description.className, 'transition-opacity')).toBe(true);
-    expect(hasClassToken(description.className, 'duration-300')).toBe(true);
+    expect(hasClassToken(description!.className, 'opacity-100')).toBe(true);
+    expect(hasClassToken(description!.className, 'transition-opacity')).toBe(true);
+    expect(hasClassToken(description!.className, 'duration-300')).toBe(true);
     expect(
       hasClassToken((pulseRing as HTMLElement).className, 'es-service-arrow-ring'),
     ).toBe(true);
@@ -132,14 +142,50 @@ describe('ServiceCard description visibility transition', () => {
     fireEvent.click(card as HTMLElement);
 
     expect(card).toHaveAttribute('aria-expanded', 'false');
-    expect(hasClassToken(description.className, 'opacity-0')).toBe(true);
-    expect(hasClassToken(description.className, 'transition-none')).toBe(true);
+    expect(hasClassToken(description!.className, 'opacity-0')).toBe(true);
+    expect(hasClassToken(description!.className, 'transition-none')).toBe(true);
     expect(
       hasClassToken((pulseRing as HTMLElement).className, 'es-service-arrow-ring'),
     ).toBe(false);
     expect(
       hasClassToken((pulseRing as HTMLElement).className, 'opacity-0'),
     ).toBe(true);
+  });
+
+  it('renders a description preview teaser with expected visibility classes', () => {
+    render(<ServiceCard {...BASE_PROPS} />);
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('[role="button"]');
+    const preview = getCardDescriptionPreview(card);
+
+    expect(preview).not.toBeNull();
+    expect(preview).toHaveAttribute('aria-hidden', 'true');
+    expect(preview!.className).toContain('es-service-card-description-preview');
+    expect(hasClassToken(preview!.className, 'opacity-70')).toBe(true);
+    expect(preview!.className).toContain('group-hover:opacity-0');
+    expect(preview!.className).toContain('duration-150');
+    expect(hasClassToken(preview!.className, 'opacity-0')).toBe(false);
+  });
+
+  it('hides the description preview when the card is active', () => {
+    render(<ServiceCard {...BASE_PROPS} />);
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('[role="button"]');
+    const preview = getCardDescriptionPreview(card);
+
+    expect(preview).not.toBeNull();
+    expect(hasClassToken(preview!.className, 'opacity-70')).toBe(true);
+
+    fireEvent.click(card as HTMLElement);
+
+    expect(hasClassToken(preview!.className, 'opacity-0')).toBe(true);
+    expect(hasClassToken(preview!.className, 'opacity-70')).toBe(false);
   });
 
   it('toggles when tapping the card surface below desktop breakpoint', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an absolutely positioned description preview overlay on service cards: ~2-line clamp with a bottom-edge mask fade at 70% opacity. On hover (desktop) or active tap (mobile), the preview fades out in 150ms while the full description fades in over 300ms, with no layout shift. Preview uses `aria-hidden="true"` so screen readers only see the paragraph.

## Changes

- `service-card.tsx`: relative wrapper, preview `<span>` + existing `<p>` with z-index stacking (`pointer-events-none` on preview).
- `components-sections.css`: `.es-service-card-description-preview` with line-clamp and gradient mask (standard + `-webkit-`).

## Testing

- `npm run test -- tests/components/sections/service-card.test.tsx`
- `npm run lint` (public_www)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d3eb5c8-578b-4940-acfa-255e3ec5f255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d3eb5c8-578b-4940-acfa-255e3ec5f255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

