### PR TITLE
feat(public_www): one-time staggered service card reveal on viewport entry

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -544,6 +544,12 @@
     animation: es-service-arrow-pulse 1.4s ease-out infinite;
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    .es-service-arrow-ring {
+      animation: none;
+    }
+  }
+
   /* Pulse ring on card hover (desktop); tap path uses .es-service-arrow-ring from TSX */
   @media (min-width: 1024px) and (hover: hover) {
     .group:hover .es-service-arrow-ring-target--brand {

--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -19,6 +19,30 @@ import { useOutsideClickClose } from '@/lib/hooks/use-outside-click-close';
 const DESKTOP_HOVER_QUERY = '(min-width: 1024px) and (hover: hover)';
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 const AUTO_REVEAL_HOLD_MS = 1800;
+const AUTO_REVEAL_SESSION_STORAGE_KEY_PREFIX = 'es-service-card-auto-reveal:';
+
+function markServiceCardAutoRevealConsumedInSession(cardId: string): void {
+  try {
+    window.sessionStorage.setItem(
+      `${AUTO_REVEAL_SESSION_STORAGE_KEY_PREFIX}${cardId}`,
+      '1',
+    );
+  } catch {
+    /* sessionStorage may be unavailable */
+  }
+}
+
+function hasServiceCardAutoRevealBeenConsumedInSession(cardId: string): boolean {
+  try {
+    return (
+      window.sessionStorage.getItem(
+        `${AUTO_REVEAL_SESSION_STORAGE_KEY_PREFIX}${cardId}`,
+      ) !== null
+    );
+  } catch {
+    return false;
+  }
+}
 
 export type ServiceCardTone = 'gold' | 'green' | 'blue';
 
@@ -71,7 +95,20 @@ export function ServiceCard({
   const [isActive, setIsActive] = useState(false);
   const [isRevealing, setIsRevealing] = useState(false);
   const hasRevealedRef = useRef(false);
+  const autoRevealRevealTimerRef = useRef<number | undefined>(undefined);
+  const autoRevealCollapseTimerRef = useRef<number | undefined>(undefined);
   const cardRef = useRef<HTMLDivElement>(null);
+
+  const clearAutoRevealTimers = useCallback(() => {
+    if (autoRevealRevealTimerRef.current !== undefined) {
+      window.clearTimeout(autoRevealRevealTimerRef.current);
+      autoRevealRevealTimerRef.current = undefined;
+    }
+    if (autoRevealCollapseTimerRef.current !== undefined) {
+      window.clearTimeout(autoRevealCollapseTimerRef.current);
+      autoRevealCollapseTimerRef.current = undefined;
+    }
+  }, []);
   const toneClassMap: Record<ServiceCardTone, string> = {
     gold: 'es-service-card--gold',
     green: 'es-service-card--green',
@@ -102,12 +139,14 @@ export function ServiceCard({
 
       setIsActive((wasActive) => {
         if (!wasActive) {
+          clearAutoRevealTimers();
           setIsRevealing(false);
+          markServiceCardAutoRevealConsumedInSession(id);
         }
         return !wasActive;
       });
     },
-    [],
+    [clearAutoRevealTimers, id],
   );
 
   const handleCardSurfaceKeyDown = useCallback(
@@ -128,16 +167,22 @@ export function ServiceCard({
       event.preventDefault();
       setIsActive((wasActive) => {
         if (!wasActive) {
+          clearAutoRevealTimers();
           setIsRevealing(false);
+          markServiceCardAutoRevealConsumedInSession(id);
         }
         return !wasActive;
       });
     },
-    [],
+    [clearAutoRevealTimers, id],
   );
 
   useEffect(() => {
     if (autoRevealDelayMs === undefined) {
+      return;
+    }
+
+    if (hasServiceCardAutoRevealBeenConsumedInSession(id)) {
       return;
     }
 
@@ -147,24 +192,27 @@ export function ServiceCard({
 
     if (prefersReducedMotion()) {
       hasRevealedRef.current = true;
+      markServiceCardAutoRevealConsumedInSession(id);
       return;
     }
 
     hasRevealedRef.current = true;
 
-    const revealTimeoutId = window.setTimeout(() => {
+    autoRevealRevealTimerRef.current = window.setTimeout(() => {
+      autoRevealRevealTimerRef.current = undefined;
       setIsRevealing(true);
     }, autoRevealDelayMs);
 
-    const collapseTimeoutId = window.setTimeout(() => {
+    autoRevealCollapseTimerRef.current = window.setTimeout(() => {
+      autoRevealCollapseTimerRef.current = undefined;
       setIsRevealing(false);
+      markServiceCardAutoRevealConsumedInSession(id);
     }, autoRevealDelayMs + AUTO_REVEAL_HOLD_MS);
 
     return () => {
-      window.clearTimeout(revealTimeoutId);
-      window.clearTimeout(collapseTimeoutId);
+      clearAutoRevealTimers();
     };
-  }, [autoRevealDelayMs]);
+  }, [autoRevealDelayMs, clearAutoRevealTimers, id]);
 
   const showExpanded = isActive || isRevealing;
 
@@ -195,7 +243,6 @@ export function ServiceCard({
       role='button'
       tabIndex={0}
       aria-expanded={isActive}
-      data-auto-reveal-delay={autoRevealDelayMs}
       onClick={handleCardSurfaceClick}
       onKeyDown={handleCardSurfaceKeyDown}
       className={`group relative isolate flex min-h-[320px] overflow-hidden rounded-card p-5 sm:min-h-[345px] sm:p-7 lg:min-h-[343px] lg:p-8 ${toneClassName}`}

--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -4,6 +4,7 @@ import {
   type KeyboardEvent,
   type MouseEvent,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -16,6 +17,8 @@ import { formatContentTemplate } from '@/content/content-field-utils';
 import { useOutsideClickClose } from '@/lib/hooks/use-outside-click-close';
 
 const DESKTOP_HOVER_QUERY = '(min-width: 1024px) and (hover: hover)';
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+const AUTO_REVEAL_HOLD_MS = 1800;
 
 export type ServiceCardTone = 'gold' | 'green' | 'blue';
 
@@ -30,6 +33,7 @@ export interface ServiceCardProps {
   description?: string;
   tone: ServiceCardTone;
   goToServiceAriaLabelTemplate?: string;
+  autoRevealDelayMs?: number;
 }
 
 const INTERACTIVE_ELEMENT_SELECTOR =
@@ -43,6 +47,14 @@ function isDesktopHoverMode(): boolean {
   return window.matchMedia(DESKTOP_HOVER_QUERY).matches;
 }
 
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
 export function ServiceCard({
   id,
   title,
@@ -54,8 +66,11 @@ export function ServiceCard({
   description,
   tone,
   goToServiceAriaLabelTemplate = enContent.services.goToServiceAriaLabelTemplate,
+  autoRevealDelayMs,
 }: ServiceCardProps) {
   const [isActive, setIsActive] = useState(false);
+  const [isRevealing, setIsRevealing] = useState(false);
+  const hasRevealedRef = useRef(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const toneClassMap: Record<ServiceCardTone, string> = {
     gold: 'es-service-card--gold',
@@ -85,7 +100,12 @@ export function ServiceCard({
         return;
       }
 
-      setIsActive((prev) => !prev);
+      setIsActive((wasActive) => {
+        if (!wasActive) {
+          setIsRevealing(false);
+        }
+        return !wasActive;
+      });
     },
     [],
   );
@@ -106,28 +126,65 @@ export function ServiceCard({
       }
 
       event.preventDefault();
-      setIsActive((prev) => !prev);
+      setIsActive((wasActive) => {
+        if (!wasActive) {
+          setIsRevealing(false);
+        }
+        return !wasActive;
+      });
     },
     [],
   );
 
+  useEffect(() => {
+    if (autoRevealDelayMs === undefined) {
+      return;
+    }
+
+    if (hasRevealedRef.current) {
+      return;
+    }
+
+    if (prefersReducedMotion()) {
+      hasRevealedRef.current = true;
+      return;
+    }
+
+    hasRevealedRef.current = true;
+
+    const revealTimeoutId = window.setTimeout(() => {
+      setIsRevealing(true);
+    }, autoRevealDelayMs);
+
+    const collapseTimeoutId = window.setTimeout(() => {
+      setIsRevealing(false);
+    }, autoRevealDelayMs + AUTO_REVEAL_HOLD_MS);
+
+    return () => {
+      window.clearTimeout(revealTimeoutId);
+      window.clearTimeout(collapseTimeoutId);
+    };
+  }, [autoRevealDelayMs]);
+
+  const showExpanded = isActive || isRevealing;
+
   // Build conditional class fragments for the active (tapped) state.
   // Pointer hover continues to work independently via group-hover:*.
-  const overlayActive = isActive
+  const overlayActive = showExpanded
     ? 'bg-black/70 backdrop-blur-[4px]'
     : '';
-  const arrowActive = isActive
+  const arrowActive = showExpanded
     ? 'h-[70px] w-[70px]'
     : '';
-  const shouldAnimateFromActiveState =
-    isActive && !isDesktopHoverMode();
-  const arrowRingActive = shouldAnimateFromActiveState
+  const shouldAnimatePulseRing =
+    isRevealing || (isActive && !isDesktopHoverMode());
+  const arrowRingActive = shouldAnimatePulseRing
     ? 'opacity-100 es-service-arrow-ring'
     : 'opacity-0';
-  const descriptionVisibilityClassName = isActive
+  const descriptionVisibilityClassName = showExpanded
     ? 'opacity-100 transition-opacity duration-300'
     : 'opacity-0 transition-none';
-  const previewVisibilityClassName = isActive
+  const previewVisibilityClassName = showExpanded
     ? 'opacity-0'
     : 'opacity-70';
 
@@ -138,6 +195,7 @@ export function ServiceCard({
       role='button'
       tabIndex={0}
       aria-expanded={isActive}
+      data-auto-reveal-delay={autoRevealDelayMs}
       onClick={handleCardSurfaceClick}
       onKeyDown={handleCardSurfaceKeyDown}
       className={`group relative isolate flex min-h-[320px] overflow-hidden rounded-card p-5 sm:min-h-[345px] sm:p-7 lg:min-h-[343px] lg:p-8 ${toneClassName}`}
@@ -145,7 +203,7 @@ export function ServiceCard({
       {/* Dark overlay - activated by pointer hover or tap */}
       <div
         aria-hidden='true'
-        className={`pointer-events-none absolute inset-0 z-[1] transition-all duration-300 ${isActive ? '' : 'bg-black/0'} group-hover:bg-black/70 group-hover:backdrop-blur-[4px] ${overlayActive}`}
+        className={`pointer-events-none absolute inset-0 z-[1] transition-all duration-300 ${showExpanded ? '' : 'bg-black/0'} group-hover:bg-black/70 group-hover:backdrop-blur-[4px] ${overlayActive}`}
       />
 
       {/* Card illustration */}
@@ -168,7 +226,7 @@ export function ServiceCard({
         variant='icon'
         href={href}
         aria-label={formatContentTemplate(goToServiceAriaLabelTemplate, { title })}
-        className={`absolute bottom-5 left-5 z-10 appearance-none rounded-full border-0 bg-white/15 p-0 ring-1 ring-white/35 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 lg:bottom-7 lg:left-7 ${isActive ? 'h-[70px] w-[70px]' : 'h-[54px] w-[54px]'} group-hover:h-[70px] group-hover:w-[70px] ${arrowActive}`}
+        className={`absolute bottom-5 left-5 z-10 appearance-none rounded-full border-0 bg-white/15 p-0 ring-1 ring-white/35 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 lg:bottom-7 lg:left-7 ${showExpanded ? 'h-[70px] w-[70px]' : 'h-[54px] w-[54px]'} group-hover:h-[70px] group-hover:w-[70px] ${arrowActive}`}
       >
         <span
           aria-hidden

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useRef } from 'react';
+
 import { ServiceCard } from '@/components/sections/service-card';
 import { SectionContainer } from '@/components/sections/shared/section-container';
 import { SectionHeader } from '@/components/sections/shared/section-header';
 import { SectionShell } from '@/components/sections/shared/section-shell';
 import type { ServicesContent } from '@/content';
 import enContent from '@/content/en.json';
+import { useViewportEntered } from '@/lib/hooks/use-viewport-entered';
 
 interface ServicesProps {
   content: ServicesContent;
@@ -103,6 +106,8 @@ function getServiceCards(content: ServicesContent): ServiceCardData[] {
 export function Services({
   content,
 }: ServicesProps) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  const hasEnteredViewport = useViewportEntered(gridRef, { threshold: 0.3 });
   const sectionTitle = content.title || fallbackServicesCopy.title;
   const sectionEyebrow =
     content.eyebrow || fallbackServicesCopy.eyebrow;
@@ -126,10 +131,16 @@ export function Services({
           title={sectionTitle}
         />
 
-        <div className='relative mt-12 sm:mt-14 xl:mt-16'>
+        <div
+          ref={gridRef}
+          className='relative mt-12 sm:mt-14 xl:mt-16'
+        >
           <ul className='grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3'>
             {serviceCards.map((card, index) => {
               const tone = CARD_TONES[index % CARD_TONES.length];
+              const autoRevealDelayMs = hasEnteredViewport
+                ? 400 + index * 150
+                : undefined;
 
               return (
                 <li key={card.id}>
@@ -144,6 +155,7 @@ export function Services({
                     description={card.description}
                     tone={tone}
                     goToServiceAriaLabelTemplate={content.goToServiceAriaLabelTemplate}
+                    autoRevealDelayMs={autoRevealDelayMs}
                   />
                 </li>
               );

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -36,6 +36,11 @@ interface ServiceCardMeta {
 
 const CARD_TONES = ['green', 'blue'] as const;
 
+/** First card reveal starts this many ms after the grid enters the viewport. */
+const REVEAL_INITIAL_DELAY_MS = 400;
+/** Extra delay per card index for left-to-right stagger. */
+const REVEAL_STAGGER_MS = 150;
+
 const fallbackServicesCopy = enContent.services;
 
 const serviceCardMeta: ServiceCardMeta[] = [
@@ -139,7 +144,7 @@ export function Services({
             {serviceCards.map((card, index) => {
               const tone = CARD_TONES[index % CARD_TONES.length];
               const autoRevealDelayMs = hasEnteredViewport
-                ? 400 + index * 150
+                ? REVEAL_INITIAL_DELAY_MS + index * REVEAL_STAGGER_MS
                 : undefined;
 
               return (

--- a/apps/public_www/src/lib/hooks/use-viewport-entered.ts
+++ b/apps/public_www/src/lib/hooks/use-viewport-entered.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { type RefObject, useEffect, useState } from 'react';
+
+export function useViewportEntered(
+  ref: RefObject<HTMLElement | null>,
+  options?: { threshold?: number; rootMargin?: string },
+): boolean {
+  const [hasEntered, setHasEntered] = useState(false);
+  const threshold = options?.threshold ?? 0;
+  const rootMargin = options?.rootMargin;
+
+  useEffect(() => {
+    if (hasEntered) {
+      return;
+    }
+
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    if (typeof IntersectionObserver === 'undefined') {
+      const timeoutId = window.setTimeout(() => {
+        setHasEntered(true);
+      }, 0);
+      return () => {
+        window.clearTimeout(timeoutId);
+      };
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (!entry || !entry.isIntersecting) {
+          return;
+        }
+
+        setHasEntered(true);
+        observer.disconnect();
+      },
+      {
+        threshold,
+        rootMargin,
+      },
+    );
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasEntered, ref, threshold, rootMargin]);
+
+  return hasEntered;
+}

--- a/apps/public_www/tests/components/sections/service-card.test.tsx
+++ b/apps/public_www/tests/components/sections/service-card.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ServiceCard } from '@/components/sections/service-card';
 
@@ -293,13 +293,20 @@ describe('ServiceCard description visibility transition', () => {
   });
 });
 
+const AUTO_REVEAL_SESSION_KEY = `es-service-card-auto-reveal:${BASE_PROPS.id}`;
+
 describe('ServiceCard auto-reveal demo', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    sessionStorage.removeItem(AUTO_REVEAL_SESSION_KEY);
     mockInteractionCapabilities({
       isDesktopViewport: false,
       canHover: true,
     });
+  });
+
+  afterEach(() => {
+    sessionStorage.removeItem(AUTO_REVEAL_SESSION_KEY);
   });
 
   it('expands visually after delay and collapses after hold while aria-expanded stays false', () => {
@@ -416,6 +423,34 @@ describe('ServiceCard auto-reveal demo', () => {
 
     act(() => {
       vi.advanceTimersByTime(10000);
+    });
+    expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
+    expect(card).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('does not replay auto-reveal after unmount and remount in the same session', () => {
+    const { unmount } = render(
+      <ServiceCard {...BASE_PROPS} autoRevealDelayMs={400} />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2200);
+    });
+
+    expect(sessionStorage.getItem(AUTO_REVEAL_SESSION_KEY)).toBe('1');
+
+    unmount();
+
+    render(<ServiceCard {...BASE_PROPS} autoRevealDelayMs={400} />);
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('[role="button"]');
+    const overlay = getCardOverlay(card);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
     });
     expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
     expect(card).toHaveAttribute('aria-expanded', 'false');

--- a/apps/public_www/tests/components/sections/service-card.test.tsx
+++ b/apps/public_www/tests/components/sections/service-card.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ServiceCard } from '@/components/sections/service-card';
@@ -58,6 +58,8 @@ function mockInteractionCapabilities({
 }
 
 afterEach(() => {
+  vi.useRealTimers();
+
   if (originalMatchMedia) {
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
@@ -76,6 +78,38 @@ function getCardDescriptionParagraph(card: HTMLElement | null): HTMLElement | nu
 
 function getCardDescriptionPreview(card: HTMLElement | null): HTMLElement | null {
   return card?.querySelector('.es-service-card-description-preview') ?? null;
+}
+
+function getCardOverlay(card: HTMLElement | null): HTMLElement | null {
+  if (!card || card.children.length === 0) {
+    return null;
+  }
+
+  return card.children[0] as HTMLElement;
+}
+
+function overlayShowsExpanded(overlay: HTMLElement): boolean {
+  return (
+    hasClassToken(overlay.className, 'bg-black/70') &&
+    !hasClassToken(overlay.className, 'bg-black/0')
+  );
+}
+
+function mockReducedMotion(): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
 }
 
 describe('ServiceCard description visibility transition', () => {
@@ -256,5 +290,134 @@ describe('ServiceCard description visibility transition', () => {
     fireEvent.click(serviceLink);
     expect(card).toHaveAttribute('aria-expanded', 'false');
     expect(serviceLink).toHaveAttribute('href', BASE_PROPS.href);
+  });
+});
+
+describe('ServiceCard auto-reveal demo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockInteractionCapabilities({
+      isDesktopViewport: false,
+      canHover: true,
+    });
+  });
+
+  it('expands visually after delay and collapses after hold while aria-expanded stays false', () => {
+    render(<ServiceCard {...BASE_PROPS} autoRevealDelayMs={400} />);
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('[role="button"]');
+    const overlay = getCardOverlay(card);
+    const serviceLink = screen.getByRole('link', {
+      name: 'Go to Age Specific Strategies',
+    });
+
+    expect(card).not.toBeNull();
+    expect(overlay).not.toBeNull();
+    expect(card).toHaveAttribute('aria-expanded', 'false');
+    expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
+    expect(hasClassToken(serviceLink.className, 'h-[54px]')).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(399);
+    });
+    expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(overlayShowsExpanded(overlay!)).toBe(true);
+    expect(hasClassToken(serviceLink.className, 'h-[70px]')).toBe(true);
+    expect(card).toHaveAttribute('aria-expanded', 'false');
+
+    act(() => {
+      vi.advanceTimersByTime(1800);
+    });
+    expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
+    expect(hasClassToken(serviceLink.className, 'h-[54px]')).toBe(true);
+  });
+
+  it('does not run a second reveal after the prop changes following the first cycle', () => {
+    const { rerender } = render(
+      <ServiceCard {...BASE_PROPS} autoRevealDelayMs={400} />,
+    );
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('[role="button"]');
+    const overlay = getCardOverlay(card);
+
+    act(() => {
+      vi.advanceTimersByTime(2200);
+    });
+    expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
+
+    rerender(<ServiceCard {...BASE_PROPS} autoRevealDelayMs={800} />);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
+  });
+
+  it('cancels reveal when the user activates the card and keeps expanded visuals from isActive', () => {
+    render(<ServiceCard {...BASE_PROPS} autoRevealDelayMs={400} />);
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('[role="button"]');
+    const overlay = getCardOverlay(card);
+    const serviceLink = screen.getByRole('link', {
+      name: 'Go to Age Specific Strategies',
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(overlayShowsExpanded(overlay!)).toBe(true);
+
+    fireEvent.click(card as HTMLElement);
+
+    expect(card).toHaveAttribute('aria-expanded', 'true');
+    expect(overlayShowsExpanded(overlay!)).toBe(true);
+    expect(hasClassToken(serviceLink.className, 'h-[70px]')).toBe(true);
+  });
+
+  it('skips the reveal when prefers-reduced-motion is reduce', () => {
+    mockReducedMotion();
+
+    render(<ServiceCard {...BASE_PROPS} autoRevealDelayMs={400} />);
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('[role="button"]');
+    const overlay = getCardOverlay(card);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
+    expect(card).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('does not auto-expand when autoRevealDelayMs is undefined', () => {
+    render(<ServiceCard {...BASE_PROPS} />);
+
+    const heading = screen.getByRole('heading', {
+      name: 'Age Specific Strategies',
+    });
+    const card = heading.closest('[role="button"]');
+    const overlay = getCardOverlay(card);
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(hasClassToken(overlay!.className, 'bg-black/0')).toBe(true);
+    expect(card).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/apps/public_www/tests/components/sections/services.test.tsx
+++ b/apps/public_www/tests/components/sections/services.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Services } from '@/components/sections/services';
 import enContent from '@/content/en.json';
@@ -13,6 +13,17 @@ vi.mock('next/image', () => ({
     alt?: string;
   } & Record<string, unknown>) => <img alt={alt ?? ''} {...props} />,
 }));
+
+const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+afterEach(() => {
+  globalThis.IntersectionObserver = originalIntersectionObserver;
+});
+
+function getCardRevealDelay(id: string): string | null {
+  const el = document.querySelector(`[data-service-card-id="${id}"]`);
+  return el?.getAttribute('data-auto-reveal-delay') ?? null;
+}
 
 describe('Services', () => {
   it('falls back to default copy and metadata when section content is sparse and renders three service link cards', () => {
@@ -53,5 +64,68 @@ describe('Services', () => {
       0,
     );
     expect(document.querySelectorAll('.es-service-card--gold')).toHaveLength(0);
+  });
+
+  it('passes staggered autoRevealDelayMs after the grid intersects the viewport', async () => {
+    let captured: {
+      observe: ReturnType<typeof vi.fn>;
+      disconnect: ReturnType<typeof vi.fn>;
+      callback: IntersectionObserverCallback;
+    } | null = null;
+
+    class MockIntersectionObserver {
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+      takeRecords = vi.fn();
+      root: Element | null = null;
+      rootMargin = '';
+      thresholds: ReadonlyArray<number> = [];
+
+      constructor(public callback: IntersectionObserverCallback) {
+        captured = this;
+      }
+    }
+
+    globalThis.IntersectionObserver =
+      MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+    const sparseContent = {
+      ...enContent.services,
+      eyebrow: '',
+      title: '',
+      items: [],
+    };
+
+    render(<Services content={sparseContent} />);
+
+    await waitFor(() => {
+      expect(captured).not.toBeNull();
+      expect(captured!.observe).toHaveBeenCalled();
+    });
+
+    const observedTarget = captured!.observe.mock.calls[0][0] as Element;
+
+    expect(getCardRevealDelay('my-best-auntie')).toBeNull();
+    expect(getCardRevealDelay('family-consultations')).toBeNull();
+    expect(getCardRevealDelay('free-guides')).toBeNull();
+
+    captured!.callback(
+      [
+        {
+          isIntersecting: true,
+          target: observedTarget,
+        } as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    );
+
+    await waitFor(() => {
+      expect(getCardRevealDelay('my-best-auntie')).toBe('400');
+    });
+
+    expect(getCardRevealDelay('family-consultations')).toBe('550');
+    expect(getCardRevealDelay('free-guides')).toBe('700');
+    expect(captured!.disconnect).toHaveBeenCalled();
   });
 });

--- a/apps/public_www/tests/components/sections/services.test.tsx
+++ b/apps/public_www/tests/components/sections/services.test.tsx
@@ -1,9 +1,15 @@
 /* eslint-disable @next/next/no-img-element */
+import type { ComponentProps } from 'react';
+import { createElement } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Services } from '@/components/sections/services';
 import enContent from '@/content/en.json';
+
+const { serviceCardSpy } = vi.hoisted(() => ({
+  serviceCardSpy: vi.fn(),
+}));
 
 vi.mock('next/image', () => ({
   default: ({
@@ -14,15 +20,46 @@ vi.mock('next/image', () => ({
   } & Record<string, unknown>) => <img alt={alt ?? ''} {...props} />,
 }));
 
+vi.mock('@/components/sections/service-card', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/components/sections/service-card')
+  >('@/components/sections/service-card');
+
+  return {
+    ...actual,
+    ServiceCard: (props: ComponentProps<typeof actual.ServiceCard>) => {
+      serviceCardSpy(props);
+      return createElement(actual.ServiceCard, props);
+    },
+  };
+});
+
 const originalIntersectionObserver = globalThis.IntersectionObserver;
 
 afterEach(() => {
   globalThis.IntersectionObserver = originalIntersectionObserver;
+  serviceCardSpy.mockClear();
 });
 
-function getCardRevealDelay(id: string): string | null {
-  const el = document.querySelector(`[data-service-card-id="${id}"]`);
-  return el?.getAttribute('data-auto-reveal-delay') ?? null;
+function getLastServiceCardPropsForId(
+  id: string,
+): ComponentProps<
+  typeof import('@/components/sections/service-card').ServiceCard
+> | undefined {
+  let last:
+    | ComponentProps<
+        typeof import('@/components/sections/service-card').ServiceCard
+      >
+    | undefined;
+
+  for (const call of serviceCardSpy.mock.calls) {
+    const props = call[0];
+    if (props.id === id) {
+      last = props;
+    }
+  }
+
+  return last;
 }
 
 describe('Services', () => {
@@ -106,9 +143,11 @@ describe('Services', () => {
 
     const observedTarget = captured!.observe.mock.calls[0][0] as Element;
 
-    expect(getCardRevealDelay('my-best-auntie')).toBeNull();
-    expect(getCardRevealDelay('family-consultations')).toBeNull();
-    expect(getCardRevealDelay('free-guides')).toBeNull();
+    expect(getLastServiceCardPropsForId('my-best-auntie')?.autoRevealDelayMs).toBeUndefined();
+    expect(
+      getLastServiceCardPropsForId('family-consultations')?.autoRevealDelayMs,
+    ).toBeUndefined();
+    expect(getLastServiceCardPropsForId('free-guides')?.autoRevealDelayMs).toBeUndefined();
 
     captured!.callback(
       [
@@ -121,11 +160,13 @@ describe('Services', () => {
     );
 
     await waitFor(() => {
-      expect(getCardRevealDelay('my-best-auntie')).toBe('400');
+      expect(getLastServiceCardPropsForId('my-best-auntie')?.autoRevealDelayMs).toBe(400);
     });
 
-    expect(getCardRevealDelay('family-consultations')).toBe('550');
-    expect(getCardRevealDelay('free-guides')).toBe('700');
+    expect(getLastServiceCardPropsForId('family-consultations')?.autoRevealDelayMs).toBe(
+      550,
+    );
+    expect(getLastServiceCardPropsForId('free-guides')?.autoRevealDelayMs).toBe(700);
     expect(captured!.disconnect).toHaveBeenCalled();
   });
 });

--- a/apps/public_www/tests/lib/hooks/use-viewport-entered.test.ts
+++ b/apps/public_www/tests/lib/hooks/use-viewport-entered.test.ts
@@ -1,0 +1,123 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useRef } from 'react';
+
+import { useViewportEntered } from '@/lib/hooks/use-viewport-entered';
+
+const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+afterEach(() => {
+  globalThis.IntersectionObserver = originalIntersectionObserver;
+});
+
+function installIntersectionObserverMock(
+  onConstruct: (observer: {
+    observe: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    callback: IntersectionObserverCallback;
+  }) => void,
+): void {
+  class MockIntersectionObserver {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+    takeRecords = vi.fn();
+    root: Element | null = null;
+    rootMargin = '';
+    thresholds: ReadonlyArray<number> = [];
+
+    constructor(public callback: IntersectionObserverCallback) {
+      onConstruct(this);
+    }
+  }
+
+  globalThis.IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+}
+
+describe('useViewportEntered', () => {
+  it('returns false before intersection', () => {
+    let instance: {
+      observe: ReturnType<typeof vi.fn>;
+      disconnect: ReturnType<typeof vi.fn>;
+    } | null = null;
+
+    installIntersectionObserverMock((observer) => {
+      instance = observer;
+    });
+
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(null);
+      ref.current = element;
+      return useViewportEntered(ref, { threshold: 0.3 });
+    });
+
+    expect(result.current).toBe(false);
+    expect(instance).not.toBeNull();
+    expect(instance!.observe).toHaveBeenCalledWith(element);
+    expect(instance!.disconnect).not.toHaveBeenCalled();
+
+    document.body.removeChild(element);
+  });
+
+  it('returns true after intersection and disconnects the observer', async () => {
+    let captured: {
+      observe: ReturnType<typeof vi.fn>;
+      disconnect: ReturnType<typeof vi.fn>;
+      callback: IntersectionObserverCallback;
+    } | null = null;
+
+    installIntersectionObserverMock((observer) => {
+      captured = observer;
+    });
+
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(null);
+      ref.current = element;
+      return useViewportEntered(ref, { threshold: 0.3 });
+    });
+
+    expect(captured).not.toBeNull();
+    expect(captured!.observe).toHaveBeenCalledWith(element);
+
+    act(() => {
+      captured!.callback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+
+    expect(captured!.disconnect).toHaveBeenCalled();
+
+    document.body.removeChild(element);
+  });
+
+  it('returns true when IntersectionObserver is unavailable (fallback)', async () => {
+    Reflect.deleteProperty(globalThis, 'IntersectionObserver');
+
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(null);
+      ref.current = element;
+      return useViewportEntered(ref);
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+
+    document.body.removeChild(element);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

One-time demo when the services grid crosses 30% visibility: staggered expand/hold/collapse per card. Rebased onto `main` (includes the description preview work from #1218 as part of the base branch).

## Follow-up fixes (review feedback)

- Import `beforeEach` in `service-card.test.tsx`.
- Named `REVEAL_INITIAL_DELAY_MS` / `REVEAL_STAGGER_MS` in `services.tsx`.
- Clear auto-reveal timers when the user opens the card during reveal; session key marked consumed on collapse, reduced-motion skip, or user takeover.
- `sessionStorage` per card id (`es-service-card-auto-reveal:<id>`) so the demo does not replay on remount within the same browser session.
- Removed `data-auto-reveal-delay` from production DOM; `services.test.tsx` wraps the real `ServiceCard` and asserts props via a spy.

## Testing

- `npm run test -- tests/lib/hooks/use-viewport-entered.test.ts tests/components/sections/service-card.test.tsx tests/components/sections/services.test.tsx`
- `npm run lint` (public_www)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d3eb5c8-578b-4940-acfa-255e3ec5f255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d3eb5c8-578b-4940-acfa-255e3ec5f255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

