### PR TITLE
Align public www services section background with My Best Auntie outline

### DIFF
--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -28,6 +28,7 @@
   .es-free-guides-and-resources-hero-section,
   .es-free-resources-section,
   .es-my-best-auntie-outline-section,
+  .es-services-section,
   .es-consultations-comparison-section {
     --es-section-bg-image: url('/images/evolvesprouts-logo.svg');
     --es-section-bg-position: center -150px;
@@ -52,6 +53,7 @@
 
   .es-free-resources-section,
   .es-my-best-auntie-outline-section,
+  .es-services-section,
   .es-consultations-comparison-section {
     background-color: var(--figma-colors-desktop, #FFFFFF);
   }
@@ -367,7 +369,6 @@
   }
 
   .es-why-us-section,
-  .es-services-section,
   .es-free-guides-and-resources-library-section,
   .es-my-best-auntie-description-section,
   .es-consultations-focus-details-section,
@@ -382,7 +383,6 @@
   }
 
   .es-why-us-section,
-  .es-services-section,
   .es-free-guides-and-resources-library-section {
     background-color: var(--figma-colors-frame-2147235259, #FFEEE3);
   }

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -115,12 +115,7 @@ export function Services({
       dataFigmaNode='services'
       className='es-section-bg-overlay es-services-section'
     >
-      <div
-        aria-hidden='true'
-        className='es-section-brand-overlay pointer-events-none absolute inset-0'
-      />
-
-      <SectionContainer>
+      <SectionContainer className='relative z-10'>
         <SectionHeader
           eyebrow={sectionEyebrow}
           title={sectionTitle}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The home page services block now uses the same section background treatment as the My Best Auntie outline section: white surface (`--figma-colors-desktop`), the smaller centered logo watermark, and the same mask/position/size CSS variables. The previous peach base color and brand radial overlay on services were removed so the visual matches the outline section.

## Testing

- `npm test -- --run tests/components/sections/services.test.tsx` (Vitest)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f9adb9d-0b55-4d87-ac7f-df6a0875bac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f9adb9d-0b55-4d87-ac7f-df6a0875bac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

