### PR TITLE
Nudge first services card illustration 30px right

### DIFF
--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -27,6 +27,8 @@ export interface ServiceCardProps {
   imageWidth: number;
   imageHeight: number;
   imageClassName: string;
+  /** Optional classes for the illustration wrapper (e.g. positional nudge). */
+  imageWrapperClassName?: string;
   description?: string;
   tone: ServiceCardTone;
   goToServiceAriaLabelTemplate?: string;
@@ -51,6 +53,7 @@ export function ServiceCard({
   imageWidth,
   imageHeight,
   imageClassName,
+  imageWrapperClassName = '',
   description,
   tone,
   goToServiceAriaLabelTemplate = enContent.services.goToServiceAriaLabelTemplate,
@@ -151,7 +154,7 @@ export function ServiceCard({
       {/* Card illustration */}
       <div
         aria-hidden='true'
-        className='pointer-events-none absolute bottom-0 right-0 z-0'
+        className={`pointer-events-none absolute bottom-0 right-0 z-0 ${imageWrapperClassName}`}
       >
         <Image
           src={imageSrc}

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -136,6 +136,9 @@ export function Services({
                     imageWidth={card.imageWidth}
                     imageHeight={card.imageHeight}
                     imageClassName={card.imageClassName}
+                    imageWrapperClassName={
+                      index === 0 ? 'translate-x-[30px]' : undefined
+                    }
                     description={card.description}
                     tone={tone}
                     goToServiceAriaLabelTemplate={content.goToServiceAriaLabelTemplate}

--- a/apps/public_www/tests/components/sections/services.test.tsx
+++ b/apps/public_www/tests/components/sections/services.test.tsx
@@ -53,5 +53,19 @@ describe('Services', () => {
       0,
     );
     expect(document.querySelectorAll('.es-service-card--gold')).toHaveLength(0);
+
+    const firstCard = document.querySelector(
+      '[data-service-card-id="my-best-auntie"]',
+    );
+    expect(firstCard).not.toBeNull();
+    const firstIllustration = firstCard?.querySelector('div.z-0');
+    expect(firstIllustration?.className).toContain('translate-x-[30px]');
+
+    const secondCard = document.querySelector(
+      '[data-service-card-id="family-consultations"]',
+    );
+    expect(secondCard?.querySelector('div.z-0')?.className).not.toContain(
+      'translate-x-[30px]',
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The first service card on the homepage services section (My Best Auntie) had its bottom-right illustration shifted 30px to the right using a Tailwind translate on the illustration wrapper only.

## Changes

- Add optional `imageWrapperClassName` to `ServiceCard` for layout tweaks without duplicating card markup.
- Pass `translate-x-[30px]` for the first card in `Services` (`index === 0`).
- Extend `services.test.tsx` to assert the first card has the offset class and the second does not.

## Testing

- `npx vitest run tests/components/sections/services.test.tsx tests/components/sections/service-card.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-251e834a-bcf6-4ae7-8be1-5d229ed1ca52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-251e834a-bcf6-4ae7-8be1-5d229ed1ca52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

