### PR TITLE
Adjust services card illustration positions (first + second)

### DIFF
--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -27,6 +27,8 @@ export interface ServiceCardProps {
   imageWidth: number;
   imageHeight: number;
   imageClassName: string;
+  /** Optional classes for the illustration wrapper (e.g. positional nudge). */
+  imageWrapperClassName?: string;
   description?: string;
   tone: ServiceCardTone;
   goToServiceAriaLabelTemplate?: string;
@@ -51,6 +53,7 @@ export function ServiceCard({
   imageWidth,
   imageHeight,
   imageClassName,
+  imageWrapperClassName = '',
   description,
   tone,
   goToServiceAriaLabelTemplate = enContent.services.goToServiceAriaLabelTemplate,
@@ -151,7 +154,7 @@ export function ServiceCard({
       {/* Card illustration */}
       <div
         aria-hidden='true'
-        className='pointer-events-none absolute bottom-0 right-0 z-0'
+        className={`pointer-events-none absolute bottom-0 right-0 z-0 ${imageWrapperClassName}`}
       >
         <Image
           src={imageSrc}

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -137,7 +137,11 @@ export function Services({
                     imageHeight={card.imageHeight}
                     imageClassName={card.imageClassName}
                     imageWrapperClassName={
-                      index === 0 ? 'translate-x-[30px]' : undefined
+                      index === 0
+                        ? 'translate-x-[30px]'
+                        : index === 1
+                          ? 'translate-y-[15px]'
+                          : undefined
                     }
                     description={card.description}
                     tone={tone}

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -136,6 +136,9 @@ export function Services({
                     imageWidth={card.imageWidth}
                     imageHeight={card.imageHeight}
                     imageClassName={card.imageClassName}
+                    imageWrapperClassName={
+                      index === 0 ? 'translate-x-[30px]' : undefined
+                    }
                     description={card.description}
                     tone={tone}
                     goToServiceAriaLabelTemplate={content.goToServiceAriaLabelTemplate}

--- a/apps/public_www/tests/components/sections/services.test.tsx
+++ b/apps/public_www/tests/components/sections/services.test.tsx
@@ -53,5 +53,19 @@ describe('Services', () => {
       0,
     );
     expect(document.querySelectorAll('.es-service-card--gold')).toHaveLength(0);
+
+    const firstCard = document.querySelector(
+      '[data-service-card-id="my-best-auntie"]',
+    );
+    expect(firstCard).not.toBeNull();
+    const firstIllustration = firstCard?.querySelector('div.z-0');
+    expect(firstIllustration?.className).toContain('translate-x-[30px]');
+
+    const secondCard = document.querySelector(
+      '[data-service-card-id="family-consultations"]',
+    );
+    expect(secondCard?.querySelector('div.z-0')?.className).not.toContain(
+      'translate-x-[30px]',
+    );
   });
 });

--- a/apps/public_www/tests/components/sections/services.test.tsx
+++ b/apps/public_www/tests/components/sections/services.test.tsx
@@ -64,8 +64,8 @@ describe('Services', () => {
     const secondCard = document.querySelector(
       '[data-service-card-id="family-consultations"]',
     );
-    expect(secondCard?.querySelector('div.z-0')?.className).not.toContain(
-      'translate-x-[30px]',
-    );
+    const secondIllustration = secondCard?.querySelector('div.z-0');
+    expect(secondIllustration?.className).toContain('translate-y-[15px]');
+    expect(secondIllustration?.className).not.toContain('translate-x-[30px]');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **First** service card (My Best Auntie): illustration **30px to the right** (`translate-x-[30px]`).
- **Second** service card (Family Consultations): illustration **15px down** (`translate-y-[15px]`).

## Implementation

- `ServiceCard` accepts optional `imageWrapperClassName` on the illustration wrapper.
- `Services` applies wrapper classes by grid index (`0` vs `1`).

## Testing

- `npx vitest run tests/components/sections/services.test.tsx tests/components/sections/service-card.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-251e834a-bcf6-4ae7-8be1-5d229ed1ca52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-251e834a-bcf6-4ae7-8be1-5d229ed1ca52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

