### PR TITLE
Move second services card illustration down 15px

### DIFF
--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -137,7 +137,11 @@ export function Services({
                     imageHeight={card.imageHeight}
                     imageClassName={card.imageClassName}
                     imageWrapperClassName={
-                      index === 0 ? 'translate-x-[30px]' : undefined
+                      index === 0
+                        ? 'translate-x-[30px]'
+                        : index === 1
+                          ? 'translate-y-[15px]'
+                          : undefined
                     }
                     description={card.description}
                     tone={tone}

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -33,6 +33,12 @@ interface ServiceCardMeta {
 
 const CARD_TONES = ['green', 'blue'] as const;
 
+/** Grid-position nudges for card illustrations (index matches rendered order). */
+const SERVICE_CARD_ILLUSTRATION_WRAPPER_CLASSES: (string | undefined)[] = [
+  'translate-x-[30px]',
+  'translate-y-[15px]',
+];
+
 const fallbackServicesCopy = enContent.services;
 
 const serviceCardMeta: ServiceCardMeta[] = [
@@ -137,11 +143,7 @@ export function Services({
                     imageHeight={card.imageHeight}
                     imageClassName={card.imageClassName}
                     imageWrapperClassName={
-                      index === 0
-                        ? 'translate-x-[30px]'
-                        : index === 1
-                          ? 'translate-y-[15px]'
-                          : undefined
+                      SERVICE_CARD_ILLUSTRATION_WRAPPER_CLASSES[index]
                     }
                     description={card.description}
                     tone={tone}

--- a/apps/public_www/tests/components/sections/services.test.tsx
+++ b/apps/public_www/tests/components/sections/services.test.tsx
@@ -64,8 +64,10 @@ describe('Services', () => {
     const secondCard = document.querySelector(
       '[data-service-card-id="family-consultations"]',
     );
-    expect(secondCard?.querySelector('div.z-0')?.className).not.toContain(
+    const secondIllustration = secondCard?.querySelector('div.z-0');
+    expect(secondIllustration?.className).not.toContain(
       'translate-x-[30px]',
     );
+    expect(secondIllustration?.className).toContain('translate-y-[15px]');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Moves the Family Consultations (second grid card) illustration down 15px via the existing `imageWrapperClassName` hook on `ServiceCard`.
- Replaces nested index conditionals with a small `SERVICE_CARD_ILLUSTRATION_WRAPPER_CLASSES` lookup keyed by render index so future per-slot nudges stay in one place.

## Testing

- `npm test -- --run tests/components/sections/services.test.tsx` (from `apps/public_www`)
- `bash scripts/validate-cursorrules.sh` (on earlier revision; unchanged contract surface)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c641540-80dc-434d-b0b9-818f31050014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c641540-80dc-434d-b0b9-818f31050014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

