### PR TITLE
Services cards: nudge second illustration; narrow description width

### DIFF
--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -196,12 +196,12 @@ export function ServiceCard({
             <div className='relative'>
               <span
                 aria-hidden='true'
-                className={`pointer-events-none absolute inset-x-0 top-0 z-[2] max-w-[34ch] es-service-card-description es-service-card-description-preview transition-opacity duration-150 group-hover:opacity-0 ${previewVisibilityClassName}`}
+                className={`pointer-events-none absolute inset-x-0 top-0 z-[2] max-w-[calc(34ch-50px)] es-service-card-description es-service-card-description-preview transition-opacity duration-150 group-hover:opacity-0 ${previewVisibilityClassName}`}
               >
                 {renderQuotedDescriptionText(description)}
               </span>
               <p
-                className={`relative z-[1] max-w-[34ch] es-service-card-description group-hover:opacity-100 group-hover:transition-opacity group-hover:duration-300 ${descriptionVisibilityClassName}`}
+                className={`relative z-[1] max-w-[calc(34ch-50px)] es-service-card-description group-hover:opacity-100 group-hover:transition-opacity group-hover:duration-300 ${descriptionVisibilityClassName}`}
               >
                 {renderQuotedDescriptionText(description)}
               </p>

--- a/apps/public_www/src/components/sections/service-card.tsx
+++ b/apps/public_www/src/components/sections/service-card.tsx
@@ -201,7 +201,7 @@ export function ServiceCard({
                 {renderQuotedDescriptionText(description)}
               </span>
               <p
-                className={`relative z-[1] max-w-[calc(34ch-50px)] es-service-card-description group-hover:opacity-100 group-hover:transition-opacity group-hover:duration-300 ${descriptionVisibilityClassName}`}
+                className={`relative z-[1] max-w-[34ch] es-service-card-description group-hover:opacity-100 group-hover:transition-opacity group-hover:duration-300 ${descriptionVisibilityClassName}`}
               >
                 {renderQuotedDescriptionText(description)}
               </p>

--- a/apps/public_www/src/components/sections/services.tsx
+++ b/apps/public_www/src/components/sections/services.tsx
@@ -36,7 +36,7 @@ const CARD_TONES = ['green', 'blue'] as const;
 /** Grid-position nudges for card illustrations (index matches rendered order). */
 const SERVICE_CARD_ILLUSTRATION_WRAPPER_CLASSES: (string | undefined)[] = [
   'translate-x-[30px]',
-  'translate-y-[30px]',
+  'translate-x-[50px] translate-y-[30px]',
 ];
 
 const fallbackServicesCopy = enContent.services;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Shift the second service card illustration 50px to the right by adding `translate-x-[50px]` alongside its existing vertical nudge in `SERVICE_CARD_ILLUSTRATION_WRAPPER_CLASSES`.
- Narrow the description **preview** (two-line clamped state) by 50px using `max-w-[calc(34ch-50px)]` on the preview span only. The full description on hover/tap keeps `max-w-[34ch]`.

## Testing

- `npm test -- tests/components/sections/service-card.test.tsx` (public_www)
- `bash scripts/validate-cursorrules.sh` (on prior revision; unchanged for this commit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-798048ba-aa2a-4e84-ab63-539c68b063ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-798048ba-aa2a-4e84-ab63-539c68b063ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

