### PR TITLE
feat(public_www): cross-form pre-fill via sessionStorage

### DIFF
--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -19,6 +19,7 @@ import { trackMetaPixelEvent } from '@/lib/meta-pixel';
 import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
 import { mergeClassNames } from '@/lib/class-name-utils';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
+import { readFormPrefill, writeFormPrefill } from '@/lib/form-prefill';
 import { ServerSubmissionResult } from '@/lib/server-submission-result';
 import { isValidEmail, sanitizeSingleLineValue } from '@/lib/validation';
 import type { Locale } from '@/content';
@@ -168,6 +169,9 @@ export function MediaForm({
   const mediaFormAnalyticsId = `media-form__${analyticsSectionId}`;
 
   function handleOpenForm() {
+    const prefill = readFormPrefill();
+    setFirstName(prefill.firstName);
+    setEmail(prefill.email);
     setIsFormFadingIn(false);
     setIsFormVisible(true);
     trackPublicFormOutcome('media_form_open', {
@@ -264,6 +268,7 @@ export function MediaForm({
         });
         trackMetaPixelEvent('Lead', { content_name: PIXEL_CONTENT_NAME.media_download });
         markSubmissionSuccess();
+        writeFormPrefill({ firstName: normalizedFirstName, email: normalizedEmail });
         return;
       }
 

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -31,7 +31,11 @@ import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
 import { readFormPrefill, writeFormPrefill } from '@/lib/form-prefill';
 import { ServerSubmissionResult } from '@/lib/server-submission-result';
-import { isValidEmail, resolveEmailSignupFirstName } from '@/lib/validation';
+import {
+  isValidEmail,
+  resolveEmailSignupFirstName,
+  sanitizeSingleLineValue,
+} from '@/lib/validation';
 
 interface SproutsSquadCommunityProps {
   content: SproutsSquadCommunityContent;
@@ -163,7 +167,7 @@ export function SproutsSquadCommunity({
       return;
     }
 
-    const normalizedEmail = email.trim();
+    const normalizedEmail = sanitizeSingleLineValue(email).toLowerCase();
     if (!normalizedEmail) {
       trackPublicFormOutcome('community_signup_submit_error', {
         formKind: 'community',

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -29,6 +29,7 @@ import { CONTACT_US_API_PATH } from '@/lib/api-paths';
 import { trackMetaPixelEvent } from '@/lib/meta-pixel';
 import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
+import { readFormPrefill, writeFormPrefill } from '@/lib/form-prefill';
 import { ServerSubmissionResult } from '@/lib/server-submission-result';
 import { isValidEmail, resolveEmailSignupFirstName } from '@/lib/validation';
 
@@ -212,6 +213,7 @@ export function SproutsSquadCommunity({
         });
         trackMetaPixelEvent('Lead', { content_name: PIXEL_CONTENT_NAME.community_signup });
         markSubmissionSuccess();
+        writeFormPrefill({ email: normalizedEmail });
         return;
       }
 
@@ -286,6 +288,8 @@ export function SproutsSquadCommunity({
                       variant='primary'
                       type='button'
                       onClick={() => {
+                        const prefill = readFormPrefill();
+                        setEmail(prefill.email);
                         setIsFormFadingIn(false);
                         setIsFormVisible(true);
                       }}

--- a/apps/public_www/src/lib/form-prefill.ts
+++ b/apps/public_www/src/lib/form-prefill.ts
@@ -12,7 +12,7 @@ const EMPTY_PREFILL: FormPrefillData = {
 
 function parseStoredPrefill(raw: string): FormPrefillData {
   const parsed: unknown = JSON.parse(raw);
-  if (!parsed || typeof parsed !== 'object') {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return { ...EMPTY_PREFILL };
   }
   const record = parsed as Record<string, unknown>;
@@ -36,6 +36,11 @@ export function readFormPrefill(): FormPrefillData {
   }
 }
 
+/**
+ * Merges non-empty trimmed `firstName` / `email` into stored prefill.
+ * Empty strings are ignored so partial callers (e.g. email-only) never erase
+ * other fields; use {@link clearFormPrefill} to remove stored data.
+ */
 export function writeFormPrefill(data: Partial<FormPrefillData>): void {
   try {
     if (typeof sessionStorage === 'undefined') {
@@ -57,5 +62,16 @@ export function writeFormPrefill(data: Partial<FormPrefillData>): void {
     sessionStorage.setItem(FORM_PREFILL_STORAGE_KEY, JSON.stringify(merged));
   } catch {
     // Ignore environments where sessionStorage throws (e.g. some private browsing modes).
+  }
+}
+
+export function clearFormPrefill(): void {
+  try {
+    if (typeof sessionStorage === 'undefined') {
+      return;
+    }
+    sessionStorage.removeItem(FORM_PREFILL_STORAGE_KEY);
+  } catch {
+    // Same tolerance as read/write for restricted storage environments.
   }
 }

--- a/apps/public_www/src/lib/form-prefill.ts
+++ b/apps/public_www/src/lib/form-prefill.ts
@@ -1,0 +1,61 @@
+export interface FormPrefillData {
+  firstName: string;
+  email: string;
+}
+
+export const FORM_PREFILL_STORAGE_KEY = 'es_form_prefill';
+
+const EMPTY_PREFILL: FormPrefillData = {
+  firstName: '',
+  email: '',
+};
+
+function parseStoredPrefill(raw: string): FormPrefillData {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object') {
+    return { ...EMPTY_PREFILL };
+  }
+  const record = parsed as Record<string, unknown>;
+  const firstName = typeof record.firstName === 'string' ? record.firstName : '';
+  const email = typeof record.email === 'string' ? record.email : '';
+  return { firstName, email };
+}
+
+export function readFormPrefill(): FormPrefillData {
+  try {
+    if (typeof sessionStorage === 'undefined') {
+      return { ...EMPTY_PREFILL };
+    }
+    const raw = sessionStorage.getItem(FORM_PREFILL_STORAGE_KEY);
+    if (!raw) {
+      return { ...EMPTY_PREFILL };
+    }
+    return parseStoredPrefill(raw);
+  } catch {
+    return { ...EMPTY_PREFILL };
+  }
+}
+
+export function writeFormPrefill(data: Partial<FormPrefillData>): void {
+  try {
+    if (typeof sessionStorage === 'undefined') {
+      return;
+    }
+    const merged: FormPrefillData = { ...readFormPrefill() };
+    if (data.firstName !== undefined) {
+      const trimmedFirstName = data.firstName.trim();
+      if (trimmedFirstName) {
+        merged.firstName = trimmedFirstName;
+      }
+    }
+    if (data.email !== undefined) {
+      const trimmedEmail = data.email.trim();
+      if (trimmedEmail) {
+        merged.email = trimmedEmail;
+      }
+    }
+    sessionStorage.setItem(FORM_PREFILL_STORAGE_KEY, JSON.stringify(merged));
+  } catch {
+    // Ignore environments where sessionStorage throws (e.g. some private browsing modes).
+  }
+}

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MediaForm } from '@/components/sections/media-form';
 import enContent from '@/content/en.json';
+import { FORM_PREFILL_STORAGE_KEY } from '@/lib/form-prefill';
 import { trackPublicFormOutcome } from '@/lib/analytics';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
 
@@ -86,6 +87,7 @@ function renderMediaForm() {
 describe('MediaForm', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = 'test-turnstile-site-key';
+    sessionStorage.clear();
   });
 
   afterEach(() => {
@@ -97,6 +99,7 @@ describe('MediaForm', () => {
     } else {
       process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = originalTurnstileSiteKey;
     }
+    sessionStorage.clear();
   });
 
   it('tracks validation_error when submit runs with invalid fields', () => {
@@ -176,6 +179,77 @@ describe('MediaForm', () => {
     expect(
       screen.queryByLabelText(new RegExp(enContent.resources.formFirstNameLabel)),
     ).not.toBeInTheDocument();
+  });
+
+  it('opens the form with empty fields when sessionStorage has no prefill data', () => {
+    mockedCreateCrmApiClient.mockReturnValue({ request: vi.fn() });
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+
+    expect(screen.getByLabelText(new RegExp(enContent.resources.formFirstNameLabel))).toHaveValue(
+      '',
+    );
+    expect(screen.getByLabelText(new RegExp(enContent.resources.formEmailLabel))).toHaveValue('');
+  });
+
+  it('pre-fills first name and email from sessionStorage when CTA is clicked', () => {
+    mockedCreateCrmApiClient.mockReturnValue({ request: vi.fn() });
+    sessionStorage.setItem(
+      FORM_PREFILL_STORAGE_KEY,
+      JSON.stringify({ firstName: 'Alice', email: 'alice@example.com' }),
+    );
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+
+    expect(screen.getByLabelText(new RegExp(enContent.resources.formFirstNameLabel))).toHaveValue(
+      'Alice',
+    );
+    expect(screen.getByLabelText(new RegExp(enContent.resources.formEmailLabel))).toHaveValue(
+      'alice@example.com',
+    );
+  });
+
+  it('does not pre-fill marketing opt-in from sessionStorage', () => {
+    mockedCreateCrmApiClient.mockReturnValue({ request: vi.fn() });
+    sessionStorage.setItem(
+      FORM_PREFILL_STORAGE_KEY,
+      JSON.stringify({ firstName: 'Alice', email: 'alice@example.com' }),
+    );
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+
+    const optIn = screen.getByRole('checkbox');
+    expect(optIn).not.toBeChecked();
+  });
+
+  it('writes normalized prefill to sessionStorage after successful submit', async () => {
+    const request = vi.fn().mockResolvedValue(null);
+    mockedCreateCrmApiClient.mockReturnValue({ request });
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(enContent.resources.formFirstNameLabel)),
+      { target: { value: ' Ida ' } },
+    );
+    fireEvent.change(screen.getByLabelText(new RegExp(enContent.resources.formEmailLabel)), {
+      target: { value: 'IDA@Example.com' },
+    });
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(
+      screen.getByRole('button', { name: enContent.resources.formSubmitLabel }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(enContent.resources.formSuccessMessage)).toBeInTheDocument();
+    });
+
+    expect(sessionStorage.getItem(FORM_PREFILL_STORAGE_KEY)).toBe(
+      JSON.stringify({ firstName: 'Ida', email: 'ida@example.com' }),
+    );
   });
 
   it('opens the form when CTA is clicked', () => {

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SproutsSquadCommunity } from '@/components/sections/sprouts-squad-community';
 import enContent from '@/content/en.json';
+import { FORM_PREFILL_STORAGE_KEY } from '@/lib/form-prefill';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
 
 const originalTurnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
@@ -68,6 +69,7 @@ const mockedCreateCrmApiClient = vi.mocked(createPublicCrmApiClient);
 describe('SproutsSquadCommunity section', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = 'test-turnstile-site-key';
+    sessionStorage.clear();
   });
 
   afterEach(() => {
@@ -78,6 +80,7 @@ describe('SproutsSquadCommunity section', () => {
     } else {
       process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = originalTurnstileSiteKey;
     }
+    sessionStorage.clear();
   });
 
   it('uses migrated section/overlay/logo classes and renders CTA-first state', () => {
@@ -174,6 +177,138 @@ describe('SproutsSquadCommunity section', () => {
         name: enContent.sproutsSquadCommunity.formSubmitLabel,
       }),
     ).toBeInTheDocument();
+  });
+
+  it('opens with empty email when sessionStorage has no prefill data', () => {
+    mockedCreateCrmApiClient.mockReturnValue({ request: vi.fn() });
+    render(
+      <SproutsSquadCommunity
+        content={enContent.sproutsSquadCommunity}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.ctaLabel,
+      }),
+    );
+
+    expect(
+      screen.getByLabelText(new RegExp(enContent.sproutsSquadCommunity.emailLabel)),
+    ).toHaveValue('');
+  });
+
+  it('pre-fills email from sessionStorage when CTA is clicked', () => {
+    mockedCreateCrmApiClient.mockReturnValue({ request: vi.fn() });
+    sessionStorage.setItem(
+      FORM_PREFILL_STORAGE_KEY,
+      JSON.stringify({ firstName: 'Alice', email: 'alice@example.com' }),
+    );
+    render(
+      <SproutsSquadCommunity
+        content={enContent.sproutsSquadCommunity}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.ctaLabel,
+      }),
+    );
+
+    expect(
+      screen.getByLabelText(new RegExp(enContent.sproutsSquadCommunity.emailLabel)),
+    ).toHaveValue('alice@example.com');
+  });
+
+  it('writes lowercased email to sessionStorage after successful submit', async () => {
+    const request = vi.fn().mockResolvedValue(null);
+    mockedCreateCrmApiClient.mockReturnValue({ request });
+
+    render(
+      <SproutsSquadCommunity
+        content={enContent.sproutsSquadCommunity}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.ctaLabel,
+      }),
+    );
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(enContent.sproutsSquadCommunity.emailLabel)),
+      { target: { value: 'Community@Example.com' } },
+    );
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.formSubmitLabel,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(enContent.sproutsSquadCommunity.successMessage),
+      ).toBeInTheDocument();
+    });
+
+    expect(sessionStorage.getItem(FORM_PREFILL_STORAGE_KEY)).toBe(
+      JSON.stringify({ firstName: '', email: 'community@example.com' }),
+    );
+  });
+
+  it('preserves stored firstName when sprouts squad writes email only', async () => {
+    const request = vi.fn().mockResolvedValue(null);
+    mockedCreateCrmApiClient.mockReturnValue({ request });
+    sessionStorage.setItem(
+      FORM_PREFILL_STORAGE_KEY,
+      JSON.stringify({ firstName: 'Alice', email: 'old@example.com' }),
+    );
+
+    render(
+      <SproutsSquadCommunity
+        content={enContent.sproutsSquadCommunity}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.ctaLabel,
+      }),
+    );
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(enContent.sproutsSquadCommunity.emailLabel)),
+      { target: { value: 'newuser@example.com' } },
+    );
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.formSubmitLabel,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(enContent.sproutsSquadCommunity.successMessage),
+      ).toBeInTheDocument();
+    });
+
+    expect(sessionStorage.getItem(FORM_PREFILL_STORAGE_KEY)).toBe(
+      JSON.stringify({ firstName: 'Alice', email: 'newuser@example.com' }),
+    );
   });
 
   it('fades in revealed fields after the initial CTA click', async () => {

--- a/apps/public_www/tests/lib/form-prefill.test.ts
+++ b/apps/public_www/tests/lib/form-prefill.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  clearFormPrefill,
   FORM_PREFILL_STORAGE_KEY,
   readFormPrefill,
   writeFormPrefill,
@@ -59,6 +60,18 @@ describe('form-prefill', () => {
   it('readFormPrefill returns empty strings for non-string shape fields', () => {
     sessionStorage.setItem(FORM_PREFILL_STORAGE_KEY, JSON.stringify({ firstName: 1, email: null }));
     expect(readFormPrefill()).toEqual({ firstName: '', email: '' });
+  });
+
+  it('readFormPrefill returns defaults when stored value is a JSON array', () => {
+    sessionStorage.setItem(FORM_PREFILL_STORAGE_KEY, JSON.stringify(['a', 'b']));
+    expect(readFormPrefill()).toEqual({ firstName: '', email: '' });
+  });
+
+  it('clearFormPrefill removes the storage key', () => {
+    writeFormPrefill({ firstName: 'A', email: 'a@b.co' });
+    expect(sessionStorage.getItem(FORM_PREFILL_STORAGE_KEY)).not.toBeNull();
+    clearFormPrefill();
+    expect(sessionStorage.getItem(FORM_PREFILL_STORAGE_KEY)).toBeNull();
   });
 
   it('gracefully handles sessionStorage read throwing', () => {

--- a/apps/public_www/tests/lib/form-prefill.test.ts
+++ b/apps/public_www/tests/lib/form-prefill.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  FORM_PREFILL_STORAGE_KEY,
+  readFormPrefill,
+  writeFormPrefill,
+} from '@/lib/form-prefill';
+
+describe('form-prefill', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('readFormPrefill returns defaults when storage is empty', () => {
+    expect(readFormPrefill()).toEqual({ firstName: '', email: '' });
+  });
+
+  it('writeFormPrefill and readFormPrefill round-trip stored data', () => {
+    writeFormPrefill({ firstName: 'Alice', email: 'alice@example.com' });
+    expect(readFormPrefill()).toEqual({
+      firstName: 'Alice',
+      email: 'alice@example.com',
+    });
+    expect(sessionStorage.getItem(FORM_PREFILL_STORAGE_KEY)).toBe(
+      JSON.stringify({ firstName: 'Alice', email: 'alice@example.com' }),
+    );
+  });
+
+  it('partial write merges without erasing other fields', () => {
+    writeFormPrefill({ firstName: 'Alice', email: 'alice@example.com' });
+    writeFormPrefill({ email: 'bob@example.com' });
+    expect(readFormPrefill()).toEqual({
+      firstName: 'Alice',
+      email: 'bob@example.com',
+    });
+  });
+
+  it('partial write with only email preserves existing firstName', () => {
+    writeFormPrefill({ firstName: 'Alice', email: 'alice@example.com' });
+    writeFormPrefill({ email: 'charlie@example.com' });
+    expect(readFormPrefill().firstName).toBe('Alice');
+  });
+
+  it('does not update fields when partial values are empty or whitespace', () => {
+    writeFormPrefill({ firstName: 'Alice', email: 'alice@example.com' });
+    writeFormPrefill({ firstName: '   ', email: '' });
+    expect(readFormPrefill()).toEqual({
+      firstName: 'Alice',
+      email: 'alice@example.com',
+    });
+  });
+
+  it('readFormPrefill returns defaults for malformed JSON', () => {
+    sessionStorage.setItem(FORM_PREFILL_STORAGE_KEY, 'not-json');
+    expect(readFormPrefill()).toEqual({ firstName: '', email: '' });
+  });
+
+  it('readFormPrefill returns empty strings for non-string shape fields', () => {
+    sessionStorage.setItem(FORM_PREFILL_STORAGE_KEY, JSON.stringify({ firstName: 1, email: null }));
+    expect(readFormPrefill()).toEqual({ firstName: '', email: '' });
+  });
+
+  it('gracefully handles sessionStorage read throwing', () => {
+    vi.stubGlobal('sessionStorage', {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn(),
+      length: 0,
+    });
+    expect(readFormPrefill()).toEqual({ firstName: '', email: '' });
+  });
+
+  it('gracefully handles sessionStorage write throwing', () => {
+    const setItem = vi.fn(() => {
+      throw new Error('quota');
+    });
+    vi.stubGlobal('sessionStorage', {
+      getItem: () => null,
+      setItem,
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn(),
+      length: 0,
+    });
+    expect(() => writeFormPrefill({ firstName: 'A', email: 'a@b.co' })).not.toThrow();
+    expect(setItem).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds sessionStorage-backed cross-form prefill (first name + email) for **MediaForm** and email prefill for **SproutsSquadCommunity**, with utilities and tests.

## Changes (this update)

- **SproutsSquadCommunity tests**: empty email on open, prefill from storage, success writes lowercased email to storage, `firstName` preserved when squad submits email only.
- **form-prefill**: JSDoc on merge semantics (non-empty only); `clearFormPrefill()`; `parseStoredPrefill` rejects JSON arrays.
- **SproutsSquadCommunity**: submit path uses `sanitizeSingleLineValue(email).toLowerCase()` for CRM body and prefill write (aligned with MediaForm).

## Tests

- `tests/lib/form-prefill.test.ts` + `tests/components/sections/media-form.test.tsx` + `tests/components/sections/sprouts-squad-community.test.tsx`

## Validation

- Scoped vitest, ESLint on touched files, `scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c88c5ba0-90db-4000-8206-28b4de1a97d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c88c5ba0-90db-4000-8206-28b4de1a97d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

