### PR TITLE
fix(admin-web): repair admin-analytics dataLayer typing

### DIFF
--- a/apps/admin_web/src/lib/admin-analytics.ts
+++ b/apps/admin_web/src/lib/admin-analytics.ts
@@ -95,25 +95,13 @@ function pushAdminDataLayerPayload(
     app_surface: 'admin',
     ...removeUndefinedParams(params),
   };
-  const layer = window.dataLayer;
-  if (Array.isArray(layer)) {
-    layer.push(payload);
+  const existingLayer = window.dataLayer;
+  if (Array.isArray(existingLayer)) {
+    existingLayer.push(payload);
     return;
   }
-  if (layer && typeof layer === 'object' && typeof layer.push === 'function') {
-    (layer as { push: (item: AdminDataLayerEventPayload) => void }).push(payload);
-    return;
-  }
-  try {
-    window.dataLayer = [payload];
-  } catch {
-    Object.defineProperty(window, 'dataLayer', {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: [payload],
-    });
-  }
+
+  window.dataLayer = [payload];
 }
 
 /**

--- a/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
@@ -29,12 +29,12 @@ describe('ReferralLinkQrDialog', () => {
     });
 
     vi.stubEnv('NEXT_PUBLIC_ADMIN_GTM_CONTAINER_ID', 'GTM-TEST');
-    const pushSpy = vi.fn();
-    const dataLayerStub: { push: typeof pushSpy } = { push: pushSpy };
+    const dataLayerArray: Record<string, unknown>[] = [];
+    const pushSpy = vi.spyOn(dataLayerArray, 'push');
     Object.defineProperty(window, 'dataLayer', {
       configurable: true,
       writable: true,
-      value: dataLayerStub,
+      value: dataLayerArray,
     });
 
     render(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

The `Deploy Admin Web` workflow on `main` failed at the TypeScript step
([run 24550443602](https://github.com/lcacchiani/evolvesprouts/actions/runs/24550443602/job/71774932682)):

```
./src/lib/admin-analytics.ts:103:58
Type error: Property 'push' does not exist on type 'never'.

  101 |     return;
  102 |   }
> 103 |   if (layer && typeof layer === 'object' && typeof layer.push === 'function') {
      |                                                          ^
  104 |     (layer as { push: (item: AdminDataLayerEventPayload) => void }).push(payload);
```

`window.dataLayer` is declared as `AdminDataLayerEventPayload[] | undefined`,
so after `Array.isArray(layer)` returns `false` TypeScript narrows `layer` to
`undefined`, making the object-form fallback branch unreachable by type. The
extra branch was over-engineering: GTM's own init snippet (`w[l]=w[l]||[]`)
guarantees `window.dataLayer` is always an array by the time events fire, which
is also why `apps/public_www/src/lib/analytics.ts` only handles the two real
cases (push on existing array, otherwise create a new one).

## Change

- Simplify `pushAdminDataLayerPayload` to match the `public_www` analytics
  pattern: push onto the array when present; otherwise initialize the array
  with the single payload.
- Update `referral-link-qr-dialog.test.tsx` to spy on
  `Array.prototype.push` of a real array stub instead of a non-array object,
  so the assertion reflects runtime behavior.

## Verification

- `npm run build` in `apps/admin_web` now completes the TypeScript step.
- `npm run lint` in `apps/admin_web` passes.
- `npm run test -- --run` in `apps/admin_web`: 174/174 tests green.

No other admin-web files reference the removed code path; `rg dataLayer apps/admin_web` was checked before pushing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e17987f1-3017-4adb-af1f-eef64f1d2cf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e17987f1-3017-4adb-af1f-eef64f1d2cf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

