### PR TITLE
Admin web: persist active section on refresh via URL routes

### DIFF
--- a/apps/admin_web/src/app/(dashboard)/assets/page.tsx
+++ b/apps/admin_web/src/app/(dashboard)/assets/page.tsx
@@ -1,0 +1,5 @@
+import { AssetsPage } from '@/components/admin/assets/assets-page';
+
+export default function AssetsRoutePage() {
+  return <AssetsPage />;
+}

--- a/apps/admin_web/src/app/(dashboard)/contacts/page.tsx
+++ b/apps/admin_web/src/app/(dashboard)/contacts/page.tsx
@@ -1,0 +1,5 @@
+import { ContactsPage } from '@/components/admin/contacts/contacts-page';
+
+export default function ContactsRoutePage() {
+  return <ContactsPage />;
+}

--- a/apps/admin_web/src/app/(dashboard)/finance/page.tsx
+++ b/apps/admin_web/src/app/(dashboard)/finance/page.tsx
@@ -1,0 +1,5 @@
+import { FinancePage } from '@/components/admin/finance/finance-page';
+
+export default function FinanceRoutePage() {
+  return <FinancePage />;
+}

--- a/apps/admin_web/src/app/(dashboard)/layout.tsx
+++ b/apps/admin_web/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,7 @@
+import type { ReactNode } from 'react';
+
+import { AdminAuthenticatedShell } from '@/components/admin-authenticated-shell';
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return <AdminAuthenticatedShell>{children}</AdminAuthenticatedShell>;
+}

--- a/apps/admin_web/src/app/(dashboard)/sales/page.tsx
+++ b/apps/admin_web/src/app/(dashboard)/sales/page.tsx
@@ -1,0 +1,5 @@
+import { SalesPage } from '@/components/admin/sales/sales-page';
+
+export default function SalesRoutePage() {
+  return <SalesPage />;
+}

--- a/apps/admin_web/src/app/(dashboard)/services/page.tsx
+++ b/apps/admin_web/src/app/(dashboard)/services/page.tsx
@@ -1,0 +1,5 @@
+import { ServicesPage } from '@/components/admin/services/services-page';
+
+export default function ServicesRoutePage() {
+  return <ServicesPage />;
+}

--- a/apps/admin_web/src/app/layout.tsx
+++ b/apps/admin_web/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import type { ReactNode } from 'react';
 
+import { AuthProvider } from '@/components/auth-provider';
+
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -40,7 +42,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer',${adminGtmContainerIdJson});`}
           </Script>
         ) : null}
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/apps/admin_web/src/app/not-found.tsx
+++ b/apps/admin_web/src/app/not-found.tsx
@@ -7,7 +7,7 @@ export default function NotFound() {
     <main className='mx-auto flex min-h-screen max-w-lg items-center px-6'>
       <StatusBanner variant='info' title='Page not found'>
         The page you requested does not exist.{' '}
-        <Link href='/' className='font-semibold underline underline-offset-2'>
+        <Link href='/finance' className='font-semibold underline underline-offset-2'>
           Return to the admin dashboard.
         </Link>
       </StatusBanner>

--- a/apps/admin_web/src/app/page.tsx
+++ b/apps/admin_web/src/app/page.tsx
@@ -1,71 +1,7 @@
-'use client';
+import { redirect } from 'next/navigation';
 
-import { useState } from 'react';
-
-import { AssetsPage } from '../components/admin/assets/assets-page';
-import { ContactsPage } from '../components/admin/contacts/contacts-page';
-import { FinancePage } from '../components/admin/finance/finance-page';
-import { SalesPage } from '../components/admin/sales/sales-page';
-import { ServicesPage } from '../components/admin/services/services-page';
-import { AppShell } from '../components/app-shell';
-import { AuthProvider, useAuth } from '../components/auth-provider';
-import { LoginScreen } from '../components/login-screen';
-import { StatusBanner } from '../components/status-banner';
-
-const NAV_ITEMS = [
-  { key: 'assets', label: 'Assets' },
-  { key: 'contacts', label: 'Contacts' },
-  { key: 'finance', label: 'Finance' },
-  { key: 'sales', label: 'Sales' },
-  { key: 'services', label: 'Services' },
-] as const;
-
-function LoginGate() {
-  const { status, user, logout } = useAuth();
-  const [activeSectionKey, setActiveSectionKey] = useState<(typeof NAV_ITEMS)[number]['key']>('finance');
-
-  if (status === 'loading') {
-    return (
-      <main className='mx-auto flex min-h-screen max-w-lg items-center px-6'>
-        <StatusBanner variant='info' title='Loading'>
-          Preparing your admin session.
-        </StatusBanner>
-      </main>
-    );
-  }
-
-  if (status === 'authenticated') {
-    return (
-      <AppShell
-        navItems={NAV_ITEMS.map((item) => ({ ...item }))}
-        activeKey={activeSectionKey}
-        onSelect={(key) => setActiveSectionKey(key as (typeof NAV_ITEMS)[number]['key'])}
-        onLogout={logout}
-        userEmail={user?.email}
-        lastAuthTime={user?.lastAuthTime}
-      >
-        {activeSectionKey === 'assets' ? (
-          <AssetsPage />
-        ) : activeSectionKey === 'contacts' ? (
-          <ContactsPage />
-        ) : activeSectionKey === 'finance' ? (
-          <FinancePage />
-        ) : activeSectionKey === 'sales' ? (
-          <SalesPage />
-        ) : (
-          <ServicesPage />
-        )}
-      </AppShell>
-    );
-  }
-
-  return <LoginScreen />;
-}
+import { DEFAULT_ADMIN_SECTION_PATH } from '@/lib/admin-nav';
 
 export default function HomePage() {
-  return (
-    <AuthProvider>
-      <LoginGate />
-    </AuthProvider>
-  );
+  redirect(DEFAULT_ADMIN_SECTION_PATH);
 }

--- a/apps/admin_web/src/components/admin-authenticated-shell.tsx
+++ b/apps/admin_web/src/components/admin-authenticated-shell.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { usePathname } from 'next/navigation';
+
+import { AppShell } from '@/components/app-shell';
+import { useAuth } from '@/components/auth-provider';
+import { LoginScreen } from '@/components/login-screen';
+import { StatusBanner } from '@/components/status-banner';
+import { ADMIN_NAV_ITEMS, adminSectionKeyFromPathname } from '@/lib/admin-nav';
+
+export function AdminAuthenticatedShell({ children }: { children: ReactNode }) {
+  const { status, user, logout } = useAuth();
+  const pathname = usePathname();
+  const activeSectionKey = adminSectionKeyFromPathname(pathname);
+
+  if (status === 'loading') {
+    return (
+      <main className='mx-auto flex min-h-screen max-w-lg items-center px-6'>
+        <StatusBanner variant='info' title='Loading'>
+          Preparing your admin session.
+        </StatusBanner>
+      </main>
+    );
+  }
+
+  if (status === 'authenticated') {
+    return (
+      <AppShell
+        navItems={ADMIN_NAV_ITEMS.map((item) => ({ ...item }))}
+        activeKey={activeSectionKey}
+        onLogout={logout}
+        userEmail={user?.email}
+        lastAuthTime={user?.lastAuthTime}
+      >
+        {children}
+      </AppShell>
+    );
+  }
+
+  return <LoginScreen />;
+}

--- a/apps/admin_web/src/components/app-shell.tsx
+++ b/apps/admin_web/src/components/app-shell.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, type ReactNode } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 
 import { NAVBAR_LOCAL_DATETIME_OPTIONS } from '@/lib/format';
 
@@ -12,12 +13,12 @@ import { Button } from './ui/button';
 export interface AppShellNavItem {
   key: string;
   label: string;
+  href: string;
 }
 
 export interface AppShellProps {
   navItems: AppShellNavItem[];
   activeKey: string;
-  onSelect: (key: string) => void;
   onLogout: () => void;
   userEmail?: string;
   lastAuthTime?: string;
@@ -53,7 +54,6 @@ function formatTimestamp(value?: string): string | null {
 export function AppShell({
   navItems,
   activeKey,
-  onSelect,
   onLogout,
   userEmail,
   lastAuthTime,
@@ -137,21 +137,21 @@ export function AppShell({
             {navItems.map((item) => {
               const isActive = item.key === activeKey;
               return (
-                <button
+                <Link
                   key={item.key}
-                  type='button'
+                  href={item.href}
                   onClick={() => {
-                    onSelect(item.key);
                     setIsMobileMenuOpen(false);
                   }}
-                  className={`w-full rounded-md px-3 py-2 text-left text-sm font-medium transition ${
+                  aria-current={isActive ? 'page' : undefined}
+                  className={`block w-full rounded-md px-3 py-2 text-left text-sm font-medium transition ${
                     isActive
                       ? 'bg-slate-900 text-white'
                       : 'text-slate-700 hover:bg-slate-100 hover:text-slate-900'
                   }`}
                 >
                   {item.label}
-                </button>
+                </Link>
               );
             })}
           </nav>

--- a/apps/admin_web/src/components/login-screen.tsx
+++ b/apps/admin_web/src/components/login-screen.tsx
@@ -2,6 +2,8 @@
 
 import { useState, type FormEvent } from 'react';
 
+import { DEFAULT_ADMIN_SECTION_PATH } from '@/lib/admin-nav';
+
 import { useAuth } from './auth-provider';
 import { EmailIcon, GoogleIcon } from './icons/action-icons';
 import { StatusBanner } from './status-banner';
@@ -85,7 +87,7 @@ export function LoginScreen() {
   };
 
   const handleGoogleLogin = () => {
-    void login({ provider: 'Google', returnTo: '/' });
+    void login({ provider: 'Google', returnTo: DEFAULT_ADMIN_SECTION_PATH });
   };
 
   return (

--- a/apps/admin_web/src/lib/admin-nav.ts
+++ b/apps/admin_web/src/lib/admin-nav.ts
@@ -1,0 +1,16 @@
+export const ADMIN_NAV_ITEMS = [
+  { key: 'assets', label: 'Assets', href: '/assets' },
+  { key: 'contacts', label: 'Contacts', href: '/contacts' },
+  { key: 'finance', label: 'Finance', href: '/finance' },
+  { key: 'sales', label: 'Sales', href: '/sales' },
+  { key: 'services', label: 'Services', href: '/services' },
+] as const;
+
+export type AdminSectionKey = (typeof ADMIN_NAV_ITEMS)[number]['key'];
+
+export const DEFAULT_ADMIN_SECTION_PATH = '/finance' as const;
+
+export function adminSectionKeyFromPathname(pathname: string): AdminSectionKey {
+  const match = ADMIN_NAV_ITEMS.find((item) => item.href === pathname);
+  return match?.key ?? 'finance';
+}

--- a/apps/admin_web/tests/components/app-shell.test.tsx
+++ b/apps/admin_web/tests/components/app-shell.test.tsx
@@ -2,24 +2,37 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 import { AppShell } from '@/components/app-shell';
 
 const navItems = [
-  { key: 'a', label: 'Section A' },
-  { key: 'b', label: 'Section B' },
+  { key: 'a', label: 'Section A', href: '/a' },
+  { key: 'b', label: 'Section B', href: '/b' },
 ];
 
 describe('AppShell', () => {
-  it('renders navigation and calls onSelect when a nav item is clicked', async () => {
-    const user = userEvent.setup();
-    const onSelect = vi.fn();
+  it('renders navigation links for each section', () => {
     const onLogout = vi.fn();
 
     render(
       <AppShell
         navItems={navItems}
         activeKey='a'
-        onSelect={onSelect}
         onLogout={onLogout}
         userEmail='admin@example.com'
         lastAuthTime='2025-01-15T12:00:00.000Z'
@@ -29,12 +42,10 @@ describe('AppShell', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Section A' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Section B' })).toBeInTheDocument();
+    const sectionBLink = screen.getByRole('link', { name: 'Section B' });
+    expect(sectionBLink).toHaveAttribute('href', '/b');
     expect(screen.getAllByText('admin@example.com').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText(/Last login:/).length).toBeGreaterThanOrEqual(1);
-
-    await user.click(screen.getByRole('button', { name: 'Section B' }));
-    expect(onSelect).toHaveBeenCalledWith('b');
   });
 
   it('calls onLogout from desktop header sign out', async () => {
@@ -45,7 +56,6 @@ describe('AppShell', () => {
       <AppShell
         navItems={navItems}
         activeKey='a'
-        onSelect={vi.fn()}
         onLogout={onLogout}
         userEmail='admin@example.com'
       >

--- a/apps/admin_web/tests/components/login-screen.test.tsx
+++ b/apps/admin_web/tests/components/login-screen.test.tsx
@@ -78,7 +78,7 @@ describe('LoginScreen', () => {
 
     await user.click(screen.getByRole('button', { name: 'Continue with Google' }));
 
-    expect(authContext.login).toHaveBeenCalledWith({ provider: 'Google', returnTo: '/' });
+    expect(authContext.login).toHaveBeenCalledWith({ provider: 'Google', returnTo: '/finance' });
     expect(screen.queryByText('Enter your work email.')).not.toBeInTheDocument();
   });
 
@@ -92,7 +92,7 @@ describe('LoginScreen', () => {
     expect(googleButton).toBeEnabled();
 
     await user.click(googleButton);
-    expect(enabledAuthContext.login).toHaveBeenCalledWith({ provider: 'Google', returnTo: '/' });
+    expect(enabledAuthContext.login).toHaveBeenCalledWith({ provider: 'Google', returnTo: '/finance' });
 
     const disabledAuthContext = createAuthContext({
       configErrors: ['NEXT_PUBLIC_COGNITO_DOMAIN is missing.'],

--- a/apps/admin_web/tests/lib/admin-nav.test.ts
+++ b/apps/admin_web/tests/lib/admin-nav.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { adminSectionKeyFromPathname } from '@/lib/admin-nav';
+
+describe('adminSectionKeyFromPathname', () => {
+  it('maps known dashboard paths to section keys', () => {
+    expect(adminSectionKeyFromPathname('/sales')).toBe('sales');
+    expect(adminSectionKeyFromPathname('/assets')).toBe('assets');
+  });
+
+  it('defaults to finance for unknown paths', () => {
+    expect(adminSectionKeyFromPathname('/unknown')).toBe('finance');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The admin dashboard previously stored the active area (Assets, Contacts, Finance, Sales, Services) only in React state on the home page, so a full browser refresh always reset to Finance.

This change maps each area to its own route (`/assets`, `/contacts`, `/finance`, `/sales`, `/services`). The sidebar uses Next.js `Link` navigation so the URL is the source of truth; refreshing keeps the same section.

## Details

- Root `/` redirects to `/finance` (unchanged product default for first visit).
- `AuthProvider` wraps the entire app from the root layout so `/auth/callback` and all routes share the same auth context.
- Google OAuth `returnTo` now defaults to `/finance` instead of `/`.
- 404 "Return to dashboard" link points to `/finance`.

## Testing

- `npm run lint` and `npm run build` in `apps/admin_web`
- `npm test` (Vitest)

## Notes

Inner tabs within an area (e.g. Finance expenses vs vendors, Sales pipeline vs analytics) still reset on refresh until those are wired to the URL separately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f1739f4-3fff-4531-bf95-ac594c3aff33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f1739f4-3fff-4531-bf95-ac594c3aff33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

