### PR TITLE
fix(admin-web): serve per-route HTML on refresh via CloudFront rewrite

### DIFF
--- a/backend/infrastructure/lib/admin-web-stack.ts
+++ b/backend/infrastructure/lib/admin-web-stack.ts
@@ -115,6 +115,38 @@ export class AdminWebStack extends cdk.Stack {
       originAccessIdentity,
     });
 
+    const pathRewriteFunction = new cloudfront.Function(
+      this,
+      "AdminWebPathRewriteFunction",
+      {
+        comment:
+          "Rewrite extensionless and trailing-slash paths to index.html for Next.js static export.",
+        runtime: cloudfront.FunctionRuntime.JS_2_0,
+        code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  // Never rewrite Next.js static asset requests.
+  if (uri.startsWith('/_next/')) {
+    return request;
+  }
+
+  if (uri.endsWith('/')) {
+    request.uri = uri + 'index.html';
+    return request;
+  }
+
+  if (uri.indexOf('.') === -1) {
+    request.uri = uri + '/index.html';
+  }
+
+  return request;
+}
+`),
+      },
+    );
+
     this.distribution = new cloudfront.Distribution(this, "AdminWebDistribution", {
       defaultRootObject: "index.html",
       domainNames: [domainName.valueAsString],
@@ -128,19 +160,25 @@ export class AdminWebStack extends cdk.Stack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
         cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        functionAssociations: [
+          {
+            function: pathRewriteFunction,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          },
+        ],
       },
       errorResponses: [
         {
           httpStatus: 403,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-          ttl: cdk.Duration.minutes(5),
+          responseHttpStatus: 404,
+          responsePagePath: "/404.html",
+          ttl: cdk.Duration.minutes(1),
         },
         {
           httpStatus: 404,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-          ttl: cdk.Duration.minutes(5),
+          responseHttpStatus: 404,
+          responsePagePath: "/404.html",
+          ttl: cdk.Duration.minutes(1),
         },
       ],
     });

--- a/backend/infrastructure/package.json
+++ b/backend/infrastructure/package.json
@@ -10,6 +10,7 @@
     "synth": "cdk synth",
     "deploy": "cdk deploy",
     "test:infra": "ts-node scripts/assert-existing-db.ts",
+    "test:admin-web-stack": "ts-node --prefer-ts-exts test/admin-web-stack.test.ts",
     "postinstall": "node scripts/patch-bundled-aws-cdk-lib-deps.js"
   },
   "keywords": [],

--- a/backend/infrastructure/test/admin-web-stack.test.ts
+++ b/backend/infrastructure/test/admin-web-stack.test.ts
@@ -1,0 +1,129 @@
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+
+import { AdminWebStack } from "../lib/admin-web-stack";
+
+function synthAdminWebTemplate(): Template {
+  const app = new cdk.App();
+  const stack = new AdminWebStack(app, "TestAdminWeb", {
+    env: { account: "111111111111", region: "ap-southeast-1" },
+  });
+  return Template.fromStack(stack);
+}
+
+function assertPathRewriteFunctionExists(template: Template) {
+  const functions = template.findResources("AWS::CloudFront::Function");
+  const entries = Object.entries(functions);
+  const match = entries.find(([, resource]) => {
+    const code = resource.Properties?.FunctionCode ?? "";
+    return (
+      typeof code === "string" &&
+      code.includes("index.html") &&
+      code.includes("/_next/")
+    );
+  });
+  if (!match) {
+    throw new Error(
+      "Expected AdminWebStack to define a CloudFront Function that rewrites extensionless paths to /index.html.",
+    );
+  }
+  const [logicalId, resource] = match;
+  const runtime = resource.Properties?.FunctionConfig?.Runtime;
+  if (runtime !== "cloudfront-js-2.0") {
+    throw new Error(
+      `Expected admin-web path rewrite function to use runtime cloudfront-js-2.0, found: ${String(runtime)}`,
+    );
+  }
+  return logicalId;
+}
+
+function assertDistributionAttachesRewriteFunction(
+  template: Template,
+  rewriteFunctionLogicalId: string,
+) {
+  template.hasResourceProperties(
+    "AWS::CloudFront::Distribution",
+    Match.objectLike({
+      DistributionConfig: Match.objectLike({
+        DefaultCacheBehavior: Match.objectLike({
+          FunctionAssociations: Match.arrayWith([
+            Match.objectLike({
+              EventType: "viewer-request",
+              FunctionARN: {
+                "Fn::GetAtt": [rewriteFunctionLogicalId, "FunctionARN"],
+              },
+            }),
+          ]),
+        }),
+      }),
+    }),
+  );
+}
+
+function assertErrorResponsesPointAt404Page(template: Template) {
+  template.hasResourceProperties(
+    "AWS::CloudFront::Distribution",
+    Match.objectLike({
+      DistributionConfig: Match.objectLike({
+        CustomErrorResponses: Match.arrayWith([
+          Match.objectLike({
+            ErrorCode: 403,
+            ResponseCode: 404,
+            ResponsePagePath: "/404.html",
+            ErrorCachingMinTTL: 60,
+          }),
+          Match.objectLike({
+            ErrorCode: 404,
+            ResponseCode: 404,
+            ResponsePagePath: "/404.html",
+            ErrorCachingMinTTL: 60,
+          }),
+        ]),
+      }),
+    }),
+  );
+}
+
+function assertNoLegacyIndexHtmlFallback(template: Template) {
+  const distributions = template.findResources(
+    "AWS::CloudFront::Distribution",
+  );
+  for (const [logicalId, resource] of Object.entries(distributions)) {
+    const errorResponses: Array<{ ResponsePagePath?: string; ResponseCode?: number }> =
+      resource.Properties?.DistributionConfig?.CustomErrorResponses ?? [];
+    for (const entry of errorResponses) {
+      if (
+        entry.ResponsePagePath === "/index.html" &&
+        entry.ResponseCode === 200
+      ) {
+        throw new Error(
+          `Distribution ${logicalId} still maps an error response to /index.html with status 200. ` +
+            "This defeats the new per-route static export and must be removed.",
+        );
+      }
+    }
+  }
+}
+
+function main() {
+  const template = synthAdminWebTemplate();
+  const rewriteFunctionLogicalId = assertPathRewriteFunctionExists(template);
+  assertDistributionAttachesRewriteFunction(
+    template,
+    rewriteFunctionLogicalId,
+  );
+  assertErrorResponsesPointAt404Page(template);
+  assertNoLegacyIndexHtmlFallback(template);
+  console.log(
+    "admin-web-stack CloudFront refresh-routing assertions passed.",
+  );
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(
+    err instanceof Error ? err.message : String(err),
+  );
+  process.exit(1);
+}

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -62,6 +62,43 @@ Public WWW CloudFront includes:
       because browsers ignore it outside the response header.
 - Staging distribution adds `X-Robots-Tag: noindex, nofollow, noarchive`.
 
+### Admin Web CloudFront distribution
+
+| Stack Name | Domain Parameter | Certificate Parameter | Notes |
+|-----------|------------------|-----------------------|-------|
+| `evolvesprouts-admin-web` | `AdminWebDomainName` | `AdminWebCertificateArn` | Admin UI (Next.js static export from `apps/admin_web`) |
+
+The stack outputs:
+
+- `AdminWebBucketName`
+- `AdminWebDistributionId`
+- `AdminWebDistributionDomain`
+- `AdminWebLoggingBucketName`
+
+Admin Web CloudFront includes:
+
+- Default behavior: static site content from S3 with a viewer-request
+  CloudFront Function (`AdminWebPathRewriteFunction`, `cloudfront-js-2.0`)
+  that maps extensionless and trailing-slash paths to the matching
+  `index.html` for the Next.js static export (`output: 'export'`,
+  `trailingSlash: true`). This is required so direct navigation and
+  refreshes on `/assets`, `/contacts`, `/finance`, `/sales`, `/services`,
+  and `/auth/callback` resolve to the correct per-route HTML instead of
+  falling back to the root shell.
+  - `/` resolves via CloudFront `defaultRootObject` to `index.html`.
+  - `/foo` → `/foo/index.html`; `/foo/` → `/foo/index.html`.
+  - `/_next/*` and any path containing a `.` (static assets) are passed
+    through untouched.
+- `CustomErrorResponses` map 403 and 404 origin responses to `/404.html`
+  with a `404` status code and a 1-minute TTL. This aligns admin web
+  behavior with `public_www` and avoids the legacy "rewrite every miss to
+  `/index.html` (200)" pattern, which would otherwise replay the root
+  `page.tsx` redirect into `/finance` on every section refresh.
+
+Deploys that change distribution behavior should include a CloudFront
+invalidation (`/*`) so cached 403/404 rewrites produced before the
+function was attached are flushed from all edge POPs.
+
 ---
 
 ## CDK Bootstrap Stack (CDKToolkit)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1235. After that PR, refreshing the admin site on `/assets`, `/contacts`, `/finance`, `/sales`, or `/services` still dropped the user back on Finance. The root cause was in the CloudFront distribution for admin-web, not in the React shell.

The Next.js static export (`output: 'export'` + `trailingSlash: true`) emits per-route `index.html` files (`out/finance/index.html`, `out/assets/index.html`, …). The admin-web CloudFront distribution, however:

1. Had no viewer-request path rewrite, so `/finance` was sent to S3 as the key `finance` (which does not exist) and returned 403.
2. Had `errorResponses` that mapped 403/404 → `/index.html` with status 200. The new root `page.tsx` contains `redirect('/finance')`, which in a static export is baked into the HTML as a `NEXT_REDIRECT;replace;/finance;307;` marker. The fallback therefore pushed every refresh back to Finance.

This change makes admin-web behave like `public_www`:

- Adds `AdminWebPathRewriteFunction` (`cloudfront-js-2.0`) attached as a `VIEWER_REQUEST` function on the default behavior. It:
  - Leaves `/_next/...` and any URI containing a `.` (static assets) untouched.
  - Rewrites `/foo/` → `/foo/index.html`.
  - Rewrites `/foo` → `/foo/index.html`.
- Replaces the `errorResponses` that returned `/index.html` (200) with `/404.html` (404) at a 1-minute TTL, mirroring `public_www`. Next already emits `out/404.html`, and its "Return to the admin dashboard" link points at `/finance`.

## Verification

- Local simulation of the CloudFront Function against the expected paths:

| URI | Rewritten to |
|---|---|
| `/` | `/` (served by `defaultRootObject`) |
| `/finance` | `/finance/index.html` |
| `/finance/` | `/finance/index.html` |
| `/assets` | `/assets/index.html` |
| `/auth/callback` | `/auth/callback/index.html` |
| `/_next/static/chunks/foo.js` | unchanged |
| `/favicon.ico` | unchanged |
| `/evolvesprouts-logo.svg` | unchanged |

- New CDK assertion test `backend/infrastructure/test/admin-web-stack.test.ts` synthesizes the stack and checks that:
  - a CloudFront Function with the rewrite logic exists and uses `cloudfront-js-2.0`;
  - the default behavior attaches it as `viewer-request`;
  - `CustomErrorResponses` map 403 and 404 to `/404.html` with status 404 and a 60s TTL;
  - no distribution still contains `ResponsePagePath: "/index.html"` with `ResponseCode: 200`.
- Runnable via `npm run test:admin-web-stack` in `backend/infrastructure/`.
- `npx tsc --noEmit` passes in `backend/infrastructure/`.
- `bash scripts/validate-cursorrules.sh` passes.
- No application code, no Next.js config, and no OpenAPI/Alembic changes needed.

## Post-deploy action

After deploying the CDK change, run a CloudFront invalidation (`/*`) on the admin-web distribution to flush cached 403/404 rewrites produced before the function was attached.

## Out of scope

- Inner-tab persistence within an area (e.g. Finance Expenses vs Vendors, Sales Pipeline vs Analytics) still lives in component state. That would be a separate change — URL/query-param wiring inside each area page.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4232b0f2-9c27-4568-8fd5-cc4398668333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4232b0f2-9c27-4568-8fd5-cc4398668333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

