### PR TITLE
feat(admin_web): persist inner area tab across refresh via ?tab= param

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
@@ -13,6 +13,7 @@ import { toErrorMessage } from '@/hooks/hook-errors';
 import { useAdminCrmContacts } from '@/hooks/use-admin-crm-contacts';
 import { useAdminCrmFamilies } from '@/hooks/use-admin-crm-families';
 import { useAdminCrmOrganizations } from '@/hooks/use-admin-crm-organizations';
+import { useQueryTabState } from '@/hooks/use-query-tab-state';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
 
 const TAB_ITEMS = [
@@ -23,8 +24,16 @@ const TAB_ITEMS = [
 
 type ContactsView = (typeof TAB_ITEMS)[number]['key'];
 
+const CONTACTS_TAB_KEYS: readonly ContactsView[] = TAB_ITEMS.map(
+  (item) => item.key
+);
+const DEFAULT_CONTACTS_VIEW: ContactsView = 'contacts';
+
 export function ContactsPage() {
-  const [activeView, setActiveView] = useState<ContactsView>('contacts');
+  const [activeView, setActiveView] = useQueryTabState<ContactsView>(
+    CONTACTS_TAB_KEYS,
+    DEFAULT_CONTACTS_VIEW
+  );
   const [tags, setTags] = useState<CrmTagRef[]>([]);
   const [locations, setLocations] = useState<LocationSummary[]>([]);
   const [geographicAreas, setGeographicAreas] = useState<GeographicAreaSummary[]>([]);

--- a/apps/admin_web/src/components/admin/finance/finance-header.tsx
+++ b/apps/admin_web/src/components/admin/finance/finance-header.tsx
@@ -10,6 +10,12 @@ export const FINANCE_TAB_ITEMS: readonly AdminTabItem<FinanceView>[] = [
   { key: 'client-invoices', label: 'Client Invoices' },
 ] as const;
 
+export const FINANCE_TAB_KEYS: readonly FinanceView[] = FINANCE_TAB_ITEMS.map(
+  (item) => item.key
+);
+
+export const DEFAULT_FINANCE_VIEW: FinanceView = 'expenses';
+
 export interface FinanceHeaderProps {
   activeView: FinanceView;
   onSetView: (view: FinanceView) => void;

--- a/apps/admin_web/src/components/admin/finance/finance-page.tsx
+++ b/apps/admin_web/src/components/admin/finance/finance-page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { toErrorMessage } from '@/hooks/hook-errors';
 import { useExpenses } from '@/hooks/use-expenses';
+import { useQueryTabState } from '@/hooks/use-query-tab-state';
 import { useVendorSpendDefaultCurrency } from '@/hooks/use-vendor-spend-default-currency';
 import { useVendors } from '@/hooks/use-vendors';
 import { listAllAdminExpenses } from '@/lib/expenses-api';
@@ -12,27 +13,38 @@ import type { Expense } from '@/types/expenses';
 
 import { ExpensesEditorPanel } from './expenses-editor-panel';
 import { ExpensesListPanel } from './expenses-list-panel';
-import { FinanceHeader, type FinanceView } from './finance-header';
+import {
+  DEFAULT_FINANCE_VIEW,
+  FINANCE_TAB_KEYS,
+  FinanceHeader,
+  type FinanceView,
+} from './finance-header';
 import { VendorsPanel } from './vendors-panel';
 
 export function FinancePage() {
-  const [activeView, setActiveView] = useState<FinanceView>('expenses');
+  const [activeView, setActiveView] = useQueryTabState<FinanceView>(
+    FINANCE_TAB_KEYS,
+    DEFAULT_FINANCE_VIEW
+  );
   const expenses = useExpenses();
   const vendors = useVendors();
   const [vendorSpendExpenses, setVendorSpendExpenses] = useState<Expense[] | null>(null);
   const [vendorSpendFetchError, setVendorSpendFetchError] = useState('');
   const vendorSpend = useVendorSpendDefaultCurrency(activeView === 'vendors' ? vendorSpendExpenses : null);
 
-  const setFinanceView = useCallback((view: FinanceView) => {
-    setActiveView(view);
-    if (view !== 'vendors') {
+  const setFinanceView = useCallback(
+    (view: FinanceView) => {
+      setActiveView(view);
+      if (view !== 'vendors') {
+        setVendorSpendExpenses(null);
+        setVendorSpendFetchError('');
+        return;
+      }
       setVendorSpendExpenses(null);
       setVendorSpendFetchError('');
-      return;
-    }
-    setVendorSpendExpenses(null);
-    setVendorSpendFetchError('');
-  }, []);
+    },
+    [setActiveView]
+  );
 
   useEffect(() => {
     if (activeView !== 'vendors') {

--- a/apps/admin_web/src/hooks/use-query-tab-state.ts
+++ b/apps/admin_web/src/hooks/use-query-tab-state.ts
@@ -1,0 +1,113 @@
+'use client';
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+
+/**
+ * Persist a tab-style view selection in the page URL as a query parameter
+ * (e.g. `?tab=vendors`).
+ *
+ * Design notes:
+ * - `useSyncExternalStore` is used so the server snapshot (empty) matches
+ *   the statically prerendered HTML (`output: 'export'`) while the client
+ *   snapshot immediately reflects `window.location.search`. React handles
+ *   the cross-over during hydration without tripping a hydration mismatch.
+ * - Tab changes use `history.replaceState` so they do not create back/forward
+ *   history entries. The param is omitted entirely when the active tab is the
+ *   default, keeping URLs clean (e.g. `/finance` rather than
+ *   `/finance?tab=expenses`). Unrelated query parameters are preserved.
+ * - Because `history.replaceState` does not fire `popstate`, each update
+ *   dispatches a synthetic `popstate` event so subscribers re-read the
+ *   search string immediately.
+ * - An effect strips unknown tab values and explicit-default tab values
+ *   from the URL. It only mutates `history`; it never calls `setState`.
+ */
+export function useQueryTabState<T extends string>(
+  validKeys: readonly T[],
+  defaultKey: T,
+  paramName: string = 'tab'
+): [T, (next: T) => void] {
+  const search = useSyncExternalStore(
+    subscribeToLocationSearch,
+    getClientLocationSearch,
+    getServerLocationSearch
+  );
+
+  const rawValue = new URLSearchParams(search).get(paramName);
+  const isKnownKey =
+    rawValue !== null && (validKeys as readonly string[]).includes(rawValue);
+  const activeTab: T =
+    isKnownKey && rawValue !== defaultKey ? (rawValue as T) : defaultKey;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (rawValue === null) {
+      return;
+    }
+    if (isKnownKey && rawValue !== defaultKey) {
+      return;
+    }
+    const url = new URL(window.location.href);
+    url.searchParams.delete(paramName);
+    window.history.replaceState(null, '', formatUrl(url));
+    emitLocationSearchChange();
+  }, [rawValue, isKnownKey, defaultKey, paramName]);
+
+  const setActiveTab = useCallback(
+    (next: T) => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      const url = new URL(window.location.href);
+      if (next === defaultKey) {
+        url.searchParams.delete(paramName);
+      } else {
+        url.searchParams.set(paramName, next);
+      }
+      window.history.replaceState(null, '', formatUrl(url));
+      emitLocationSearchChange();
+    },
+    [defaultKey, paramName]
+  );
+
+  return [activeTab, setActiveTab];
+}
+
+const LOCATION_SEARCH_EVENT = 'cursor:location-search-change';
+
+function subscribeToLocationSearch(onStoreChange: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+  window.addEventListener('popstate', onStoreChange);
+  window.addEventListener(LOCATION_SEARCH_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener('popstate', onStoreChange);
+    window.removeEventListener(LOCATION_SEARCH_EVENT, onStoreChange);
+  };
+}
+
+function getClientLocationSearch(): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  return window.location.search;
+}
+
+function getServerLocationSearch(): string {
+  return '';
+}
+
+function emitLocationSearchChange(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.dispatchEvent(new Event(LOCATION_SEARCH_EVENT));
+}
+
+function formatUrl(url: URL): string {
+  const query = url.searchParams.toString();
+  const suffix = query ? `?${query}` : '';
+  return `${url.pathname}${suffix}${url.hash}`;
+}

--- a/apps/admin_web/src/hooks/use-sales-page.ts
+++ b/apps/admin_web/src/hooks/use-sales-page.ts
@@ -7,11 +7,18 @@ import { useLeadAnalytics } from './use-lead-analytics';
 import { useLeadDetail } from './use-lead-detail';
 import { useLeadList } from './use-lead-list';
 import { useLeadMutations } from './use-lead-mutations';
+import { useQueryTabState } from './use-query-tab-state';
 
 export type SalesView = 'pipeline' | 'analytics';
 
+export const SALES_VIEW_KEYS: readonly SalesView[] = ['pipeline', 'analytics'];
+export const DEFAULT_SALES_VIEW: SalesView = 'pipeline';
+
 export function useSalesPage() {
-  const [activeView, setActiveView] = useState<SalesView>('pipeline');
+  const [activeView, setActiveView] = useQueryTabState<SalesView>(
+    SALES_VIEW_KEYS,
+    DEFAULT_SALES_VIEW
+  );
   const [selectedLeadIdState, setSelectedLeadIdState] = useState<string | null | undefined>(
     undefined
   );

--- a/apps/admin_web/src/hooks/use-services-page.ts
+++ b/apps/admin_web/src/hooks/use-services-page.ts
@@ -9,14 +9,26 @@ import { useEnrollmentMutations } from './use-enrollment-mutations';
 import { useInstanceList } from './use-instance-list';
 import { useInstanceMutations } from './use-instance-mutations';
 import { useLocationList } from './use-location-list';
+import { useQueryTabState } from './use-query-tab-state';
 import { useServiceDetail } from './use-service-detail';
 import { useServiceList } from './use-service-list';
 import { useServiceMutations } from './use-service-mutations';
 
 export type ServicesView = 'catalog' | 'instances' | 'discount-codes' | 'venues';
 
+export const SERVICES_VIEW_KEYS: readonly ServicesView[] = [
+  'catalog',
+  'instances',
+  'discount-codes',
+  'venues',
+];
+export const DEFAULT_SERVICES_VIEW: ServicesView = 'catalog';
+
 export function useServicesPage() {
-  const [activeView, setActiveView] = useState<ServicesView>('catalog');
+  const [activeView, setActiveView] = useQueryTabState<ServicesView>(
+    SERVICES_VIEW_KEYS,
+    DEFAULT_SERVICES_VIEW
+  );
   const [selectedServiceIdState, setSelectedServiceIdState] = useState<string | null>(null);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
   const [instanceOptionsCacheVersion, setInstanceOptionsCacheVersion] = useState(0);

--- a/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ContactsPage } from '@/components/admin/contacts/contacts-page';
 
@@ -91,6 +91,14 @@ vi.mock('@/hooks/use-admin-crm-organizations', () => ({
 }));
 
 describe('ContactsPage', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/contacts');
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, '', '/contacts');
+  });
+
   it('loads tags and locations on mount', async () => {
     listCrmTags.mockResolvedValue([]);
     listAllLocations.mockResolvedValue([]);
@@ -119,8 +127,28 @@ describe('ContactsPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Families' }));
     expect(screen.getByRole('heading', { name: 'Families' })).toBeInTheDocument();
+    expect(window.location.search).toBe('?tab=families');
 
     await user.click(screen.getByRole('button', { name: 'Organisations' }));
     expect(screen.getByRole('heading', { name: 'Organisations' })).toBeInTheDocument();
+    expect(window.location.search).toBe('?tab=organizations');
+
+    await user.click(screen.getByRole('button', { name: 'Contacts' }));
+    expect(window.location.search).toBe('');
+  });
+
+  it('seeds the active sub-view from the URL query parameter on mount', async () => {
+    listCrmTags.mockResolvedValue([]);
+    listAllLocations.mockResolvedValue([]);
+    listGeographicAreas.mockResolvedValue([]);
+
+    window.history.replaceState(null, '', '/contacts?tab=organizations');
+    render(<ContactsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Organisations' })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockUseExpenses, expensesState, mockUseVendors, vendorsState, mockListAllAdminExpenses } = vi.hoisted(() => {
   const state = {
@@ -74,6 +74,14 @@ vi.mock('@/lib/expenses-api', async () => {
 import { FinancePage } from '@/components/admin/finance/finance-page';
 
 describe('FinancePage', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/finance');
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, '', '/finance');
+  });
+
   it('renders finance tabs and switches to scaffold tab', async () => {
     const user = userEvent.setup();
     render(<FinancePage />);
@@ -86,9 +94,24 @@ describe('FinancePage', () => {
     await user.click(screen.getByRole('button', { name: 'Vendors' }));
     expect(screen.getByRole('heading', { name: 'Vendors' })).toBeInTheDocument();
     expect(mockListAllAdminExpenses).toHaveBeenCalled();
+    expect(window.location.search).toBe('?tab=vendors');
 
     await user.click(screen.getByRole('button', { name: 'Client Invoices' }));
     expect(screen.getByRole('heading', { name: 'Client Invoices' })).toBeInTheDocument();
+    expect(window.location.search).toBe('?tab=client-invoices');
+
+    await user.click(screen.getByRole('button', { name: 'Expenses' }));
+    expect(window.location.search).toBe('');
+  });
+
+  it('seeds the active tab from the URL query parameter on mount', async () => {
+    window.history.replaceState(null, '', '/finance?tab=client-invoices');
+    render(<FinancePage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Client Invoices' })
+      ).toBeInTheDocument();
+    });
   });
 
   it('renders expense editor before submitted expenses list', () => {

--- a/apps/admin_web/tests/hooks/use-query-tab-state.test.ts
+++ b/apps/admin_web/tests/hooks/use-query-tab-state.test.ts
@@ -1,0 +1,142 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useQueryTabState } from '@/hooks/use-query-tab-state';
+
+const VALID_KEYS = ['alpha', 'beta', 'gamma'] as const;
+type Key = (typeof VALID_KEYS)[number];
+const DEFAULT_KEY: Key = 'alpha';
+
+function setLocation(pathAndQuery: string) {
+  window.history.replaceState(null, '', pathAndQuery);
+}
+
+describe('useQueryTabState', () => {
+  const originalUrl = 'http://localhost/finance';
+
+  beforeEach(() => {
+    setLocation('/finance');
+  });
+
+  afterEach(() => {
+    setLocation('/finance');
+  });
+
+  it('starts at the default when the URL has no param', () => {
+    setLocation('/finance');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    expect(result.current[0]).toBe('alpha');
+    expect(window.location.pathname + window.location.search).toBe('/finance');
+  });
+
+  it('seeds state from a valid tab param on mount', () => {
+    setLocation('/finance?tab=beta');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    expect(result.current[0]).toBe('beta');
+    expect(window.location.search).toBe('?tab=beta');
+  });
+
+  it('falls back to the default and strips the param when the URL has an unknown tab value', () => {
+    setLocation('/finance?tab=nope');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    expect(result.current[0]).toBe('alpha');
+    expect(window.location.search).toBe('');
+  });
+
+  it('strips the param when the URL explicitly names the default tab', () => {
+    setLocation('/finance?tab=alpha');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    expect(result.current[0]).toBe('alpha');
+    expect(window.location.search).toBe('');
+  });
+
+  it('updates the URL when switching to a non-default tab', () => {
+    setLocation('/finance');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    act(() => {
+      result.current[1]('gamma');
+    });
+    expect(result.current[0]).toBe('gamma');
+    expect(window.location.search).toBe('?tab=gamma');
+  });
+
+  it('removes the param when switching back to the default tab', () => {
+    setLocation('/finance?tab=gamma');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    act(() => {
+      result.current[1]('alpha');
+    });
+    expect(result.current[0]).toBe('alpha');
+    expect(window.location.search).toBe('');
+  });
+
+  it('preserves unrelated query parameters when updating the tab', () => {
+    setLocation('/finance?code=xyz&tab=beta');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    expect(result.current[0]).toBe('beta');
+    act(() => {
+      result.current[1]('gamma');
+    });
+    expect(window.location.search).toContain('code=xyz');
+    expect(window.location.search).toContain('tab=gamma');
+    act(() => {
+      result.current[1]('alpha');
+    });
+    expect(window.location.search).toBe('?code=xyz');
+  });
+
+  it('uses replaceState so tab changes do not create history entries', () => {
+    setLocation('/finance');
+    const before = window.history.length;
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    act(() => {
+      result.current[1]('beta');
+    });
+    act(() => {
+      result.current[1]('gamma');
+    });
+    act(() => {
+      result.current[1]('alpha');
+    });
+    expect(window.history.length).toBe(before);
+    expect(window.location.search).toBe('');
+  });
+
+  it('supports a custom param name', () => {
+    setLocation('/finance?view=beta');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY, 'view')
+    );
+    expect(result.current[0]).toBe('beta');
+    act(() => {
+      result.current[1]('gamma');
+    });
+    expect(window.location.search).toBe('?view=gamma');
+  });
+
+  it('ignores the starting URL when a different pathname is used', () => {
+    setLocation('/services?tab=gamma');
+    const { result } = renderHook(() =>
+      useQueryTabState<Key>(VALID_KEYS, DEFAULT_KEY)
+    );
+    expect(result.current[0]).toBe('gamma');
+    expect(window.location.pathname).toBe('/services');
+    void originalUrl;
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1235 / #1237 ("stay on the screen" after refresh).

The top-level area (Assets / Contacts / Finance / Sales / Services) is already URL-backed. This PR extends that guarantee down one level, to the inner tab inside each area. Refreshing `/finance?tab=vendors` now keeps you on the Vendors view instead of snapping back to Expenses. The same applies to Contacts (`tab=families` / `tab=organizations`), Sales (`tab=analytics`), and Services (`tab=instances` / `tab=discount-codes` / `tab=venues`).

Assets has no inner tabs; unchanged.

## Design

A small client-only hook `useQueryTabState<T extends string>(validKeys, defaultKey, paramName = 'tab')` in `apps/admin_web/src/hooks/use-query-tab-state.ts`:

- Mirrors the active tab to a query parameter.
- Strips the param when the tab equals the default, keeping URLs clean (`/finance`, not `/finance?tab=expenses`).
- Falls back to the default and normalizes the URL if an incoming `?tab=` value is not a known key.
- Preserves unrelated query parameters (e.g. anything carried in from OAuth callback).
- Uses `history.replaceState`, so tab switches do not inflate the browser history stack — Back navigates out of the area, as with the top-level sidebar.
- Reads via `useSyncExternalStore` so the server snapshot matches Next.js static export prerender and hydration stays stable.

No new routes, no CloudFront change, no CDK change, no OpenAPI/Alembic change.

## Files

- `apps/admin_web/src/hooks/use-query-tab-state.ts` — new hook.
- `apps/admin_web/src/components/admin/finance/finance-header.tsx` — export `FINANCE_TAB_KEYS`, `DEFAULT_FINANCE_VIEW`.
- `apps/admin_web/src/components/admin/finance/finance-page.tsx` — replace `useState<FinanceView>('expenses')` with the hook.
- `apps/admin_web/src/components/admin/contacts/contacts-page.tsx` — same swap for `ContactsView`.
- `apps/admin_web/src/hooks/use-sales-page.ts` — same swap for `SalesView`.
- `apps/admin_web/src/hooks/use-services-page.ts` — same swap for `ServicesView`.

## Tests

- New `apps/admin_web/tests/hooks/use-query-tab-state.test.ts` with 10 cases:
  - default when URL has no param
  - seeds from valid param
  - strips and falls back to default for unknown values
  - strips an explicit-default value
  - writes `?tab=` when switching to a non-default tab
  - drops the param when switching back to default
  - preserves unrelated params across updates
  - uses `replaceState` (no `history.length` growth)
  - supports a custom param name
  - works on a non-`/finance` pathname.
- Finance and Contacts page tests now assert URL ↔ panel wiring on click and assert the correct panel renders when the mount URL carries `?tab=<non-default>`.
- Sales/Services page tests still mock the page hook (unchanged); the hook layer itself is fully covered by the unit tests.

## Verification

- `npm run lint` passes in `apps/admin_web`.
- `npm test` in `apps/admin_web`: 192 tests pass (46 files).
- `npm run build` in `apps/admin_web`: static export succeeds, all routes remain `(Static)`.
- `bash scripts/validate-cursorrules.sh` passes.

## Behavior notes for reviewers

- Default tab: URL shows just `/finance` (no `?tab=`). Switching away adds the param; switching back removes it.
- Unknown `?tab=` value: URL is normalized to remove the bogus param; UI renders the default.
- Cross-area navigation via the sidebar is unchanged — `<Link href="/contacts">` navigates to the clean target URL and does not leak the previous area's `?tab=`.
- `history.replaceState` means per-tab Back/Forward history is intentionally not created. This matches the button-group UX of `AdminTabStrip` (not ARIA tabs) and keeps Back predictable. Easy to switch to `pushState` later if product preference changes.

## Out of scope

- Deep state inside tabs (selected lead, selected service/instance, list filter values) still lives in component state. If you want those URL-backed too, that is a separate change per screen.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4232b0f2-9c27-4568-8fd5-cc4398668333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4232b0f2-9c27-4568-8fd5-cc4398668333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

