### PR TITLE
fix(admin_web): highlight correct sidebar item across navigation

### DIFF
--- a/apps/admin_web/src/lib/admin-nav.ts
+++ b/apps/admin_web/src/lib/admin-nav.ts
@@ -10,7 +10,31 @@ export type AdminSectionKey = (typeof ADMIN_NAV_ITEMS)[number]['key'];
 
 export const DEFAULT_ADMIN_SECTION_PATH = '/finance' as const;
 
-export function adminSectionKeyFromPathname(pathname: string): AdminSectionKey {
-  const match = ADMIN_NAV_ITEMS.find((item) => item.href === pathname);
-  return match?.key ?? 'finance';
+export const DEFAULT_ADMIN_SECTION_KEY: AdminSectionKey = 'finance';
+
+function normalizePathname(pathname: string | null | undefined): string {
+  if (!pathname) {
+    return '/';
+  }
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}
+
+export function adminSectionKeyFromPathname(
+  pathname: string | null | undefined
+): AdminSectionKey {
+  const normalized = normalizePathname(pathname);
+  const exact = ADMIN_NAV_ITEMS.find((item) => item.href === normalized);
+  if (exact) {
+    return exact.key;
+  }
+  const prefix = ADMIN_NAV_ITEMS.find((item) =>
+    normalized.startsWith(`${item.href}/`)
+  );
+  if (prefix) {
+    return prefix.key;
+  }
+  return DEFAULT_ADMIN_SECTION_KEY;
 }

--- a/apps/admin_web/tests/lib/admin-nav.test.ts
+++ b/apps/admin_web/tests/lib/admin-nav.test.ts
@@ -6,9 +6,37 @@ describe('adminSectionKeyFromPathname', () => {
   it('maps known dashboard paths to section keys', () => {
     expect(adminSectionKeyFromPathname('/sales')).toBe('sales');
     expect(adminSectionKeyFromPathname('/assets')).toBe('assets');
+    expect(adminSectionKeyFromPathname('/contacts')).toBe('contacts');
+    expect(adminSectionKeyFromPathname('/finance')).toBe('finance');
+    expect(adminSectionKeyFromPathname('/services')).toBe('services');
+  });
+
+  it('matches paths served with a trailing slash (next.config trailingSlash: true)', () => {
+    expect(adminSectionKeyFromPathname('/sales/')).toBe('sales');
+    expect(adminSectionKeyFromPathname('/assets/')).toBe('assets');
+    expect(adminSectionKeyFromPathname('/contacts/')).toBe('contacts');
+    expect(adminSectionKeyFromPathname('/finance/')).toBe('finance');
+    expect(adminSectionKeyFromPathname('/services/')).toBe('services');
+  });
+
+  it('matches nested paths under a section as that section', () => {
+    expect(adminSectionKeyFromPathname('/sales/leads/abc-123')).toBe('sales');
+    expect(adminSectionKeyFromPathname('/services/instances/')).toBe(
+      'services'
+    );
+    expect(adminSectionKeyFromPathname('/finance/expenses/')).toBe('finance');
   });
 
   it('defaults to finance for unknown paths', () => {
     expect(adminSectionKeyFromPathname('/unknown')).toBe('finance');
+    expect(adminSectionKeyFromPathname('/')).toBe('finance');
+    expect(adminSectionKeyFromPathname('')).toBe('finance');
+    expect(adminSectionKeyFromPathname(null)).toBe('finance');
+    expect(adminSectionKeyFromPathname(undefined)).toBe('finance');
+  });
+
+  it('does not match a path that merely starts with a section name', () => {
+    expect(adminSectionKeyFromPathname('/salesish')).toBe('finance');
+    expect(adminSectionKeyFromPathname('/assets-archive')).toBe('finance');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Jumping between admin areas (Assets, Contacts, Finance, Sales, Services) left the sidebar always showing **Finance** as the active item, regardless of which page was actually rendered. This PR fixes that.

## Root cause

`AdminAuthenticatedShell` derives the active nav item from `usePathname()`:

```11:16:apps/admin_web/src/lib/admin-nav.ts
export type AdminSectionKey = (typeof ADMIN_NAV_ITEMS)[number]['key'];

export const DEFAULT_ADMIN_SECTION_PATH = '/finance' as const;

export function adminSectionKeyFromPathname(pathname: string): AdminSectionKey {
  const match = ADMIN_NAV_ITEMS.find((item) => item.href === pathname);
```

`apps/admin_web/next.config.js` sets both `output: 'export'` and `trailingSlash: true`. With that configuration, Next.js reports pathnames with a trailing slash, i.e. `/finance/` instead of `/finance`. The previous strict-equality match (`item.href === pathname`) therefore never hit for any section, and the fallback `'finance'` was always returned, pinning the Finance entry as active.

## Fix

`adminSectionKeyFromPathname` now:

1. Accepts `string | null | undefined` (aligning with `usePathname()`'s real return type) and treats empty / nullish values as "unknown".
2. Strips a trailing slash before matching, so `/sales/` maps to `sales`.
3. Falls through to a prefix match (`/<section>/...`) so nested routes under a section continue to highlight that section (e.g. future `/sales/leads/abc-123` highlights Sales).
4. Only then falls back to the Finance default for genuinely unknown paths.

Negative cases like `/salesish` intentionally do not match `/sales` because the prefix check requires a `/` separator.

## Tests

`apps/admin_web/tests/lib/admin-nav.test.ts` expanded from 2 to 5 grouped cases covering:

- exact matches for all five sections
- trailing-slash matches for all five sections
- nested paths under a section (`/sales/leads/abc-123`, `/services/instances/`, `/finance/expenses/`)
- defaults for `/unknown`, `/`, `''`, `null`, `undefined`
- negative matches: `/salesish`, `/assets-archive` fall back to `finance`

## Verification

- `npm run lint` passes in `apps/admin_web`.
- `npm test`: 183/183 pass across 45 files.
- `npm run build`: static export succeeds; all routes remain `(Static)` (`/`, `/_not-found`, `/assets`, `/auth/callback`, `/contacts`, `/finance`, `/sales`, `/services`).
- `bash scripts/validate-cursorrules.sh` passes.

## Notes

- No route, CDK, OpenAPI, or DB changes.
- Does not touch inner-tab persistence (#1238) or the CloudFront refresh fix (#1237); this is a standalone, minimal fix that applies regardless of those.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4232b0f2-9c27-4568-8fd5-cc4398668333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4232b0f2-9c27-4568-8fd5-cc4398668333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

