### PR TITLE
Admin web: assets tag filter default label "Client default"

### DIFF
--- a/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
@@ -153,7 +153,7 @@ export function AssetListPanel({
                     onTagNameChange(event.target.value === '' ? '' : event.target.value)
                   }
                 >
-                  <option value=''>All tags</option>
+                  <option value=''>Client default</option>
                   {tagFilterOptions.map((name) => (
                     <option key={name} value={name}>
                       {formatAssetTagDisplayName(name)}

--- a/apps/admin_web/tests/components/admin/assets/asset-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/assets/asset-list-panel.test.tsx
@@ -90,6 +90,7 @@ describe('AssetListPanel', () => {
       assets: [createAdminAssetFixture({ ...FIXTURE_ASSET, contentLanguage: 'zh-HK' })],
     });
 
+    expect(screen.getByRole('option', { name: 'Client default' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Language' })).toBeInTheDocument();
     expect(screen.getByText('Cantonese (Hong Kong)')).toBeInTheDocument();
     expect(screen.getByText('Infant Nutrition Guide')).toBeInTheDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The assets list tag filter used "All tags" for the empty value (no specific tag filter). Product copy should read **Client default** instead.

## Changes

- Update the default `<option>` label in `AssetListPanel`.
- Extend the existing panel test to assert the new option text.

## Testing

- `npm run test -- tests/components/admin/assets/asset-list-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27b2cf82-cd32-43c6-8a74-e8c6f098714d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27b2cf82-cd32-43c6-8a74-e8c6f098714d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

