### PR TITLE
Default admin assets tag filter to Client

### DIFF
--- a/apps/admin_web/src/hooks/use-asset-list.ts
+++ b/apps/admin_web/src/hooks/use-asset-list.ts
@@ -3,7 +3,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { listAdminAssets } from '@/lib/assets-api';
-import type { AdminAsset, AssetVisibility, ListAdminAssetsInput } from '@/types/assets';
+import {
+  CLIENT_DOCUMENT_ASSET_TAG,
+  type AdminAsset,
+  type AssetVisibility,
+  type ListAdminAssetsInput,
+} from '@/types/assets';
 
 import { toErrorMessage } from './hook-errors';
 import { useDebouncedCallback } from './use-debounced-callback';
@@ -13,7 +18,7 @@ type Filters = Pick<ListAdminAssetsInput, 'query' | 'visibility' | 'tagName'>;
 const DEFAULT_FILTERS: Filters = {
   query: '',
   visibility: '',
-  tagName: '',
+  tagName: CLIENT_DOCUMENT_ASSET_TAG,
 };
 
 const ASSET_LIST_TYPE_FILTER = 'document' as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The admin Assets table now initializes the Tags filter to **Client** (`client_document`) instead of **All tags**, so the first list request and the select control match that default.

## Changes

- `use-asset-list.ts`: set `DEFAULT_FILTERS.tagName` to `CLIENT_DOCUMENT_ASSET_TAG`.

## Testing

- `npm run test -- tests/components/admin/assets/asset-list-panel.test.tsx tests/hooks/use-admin-assets.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0487b27d-64b4-4003-a102-1df46f5dd6d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0487b27d-64b4-4003-a102-1df46f5dd6d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

