### PR TITLE
Duplicate discount codes: append COPY and return 409

### DIFF
--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -15,6 +15,8 @@ import { CopyIcon, DeleteIcon, QrLinkIcon } from '@/components/icons/action-icon
 import { ReferralLinkQrDialog } from '@/components/admin/services/referral-link-qr-dialog';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useServiceInstanceOptions } from '@/hooks/use-service-instance-options';
+import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
+import { buildDuplicateDiscountCodeName } from '@/lib/discount-code-duplicate';
 import {
   DISCOUNT_VALIDITY_RANGE_INVERTED_MESSAGE,
   isDiscountValidityRangeInverted,
@@ -119,6 +121,7 @@ export function DiscountCodesPanel({
   const [validFromLocal, setValidFromLocal] = useState('');
   const [validUntilLocal, setValidUntilLocal] = useState('');
   const [validityRangeError, setValidityRangeError] = useState('');
+  const [saveError, setSaveError] = useState('');
   const [serviceId, setServiceId] = useState('');
   const [instanceId, setInstanceId] = useState('');
   const [referralOpen, setReferralOpen] = useState(false);
@@ -173,6 +176,7 @@ export function DiscountCodesPanel({
     setValidFromLocal('');
     setValidUntilLocal('');
     setValidityRangeError('');
+    setSaveError('');
     setServiceId('');
     setInstanceId('');
   };
@@ -183,6 +187,7 @@ export function DiscountCodesPanel({
       return;
     }
     setValidityRangeError('');
+    setSaveError('');
     const validFromIso = parseDatetimeLocalToIsoUtc(validFromLocal);
     const validUntilIso = parseDatetimeLocalToIsoUtc(validUntilLocal);
     const serviceUuid = serviceId.trim() || null;
@@ -202,7 +207,20 @@ export function DiscountCodesPanel({
     };
     try {
       if (editorMode === 'create') {
-        await onCreate(createPayload);
+        try {
+          await onCreate(createPayload);
+        } catch (firstErr) {
+          const isDuplicateCode =
+            firstErr instanceof AdminApiError &&
+            firstErr.statusCode === 409 &&
+            readAdminApiErrorField(firstErr) === 'code';
+          if (!isDuplicateCode) {
+            throw firstErr;
+          }
+          const retryCode = buildDuplicateDiscountCodeName(code);
+          setCode(retryCode);
+          await onCreate({ ...createPayload, code: retryCode });
+        }
         resetCreateForm();
         return;
       }
@@ -238,8 +256,10 @@ export function DiscountCodesPanel({
         service_id: serviceUuid,
         instance_id: instanceUuid,
       });
-    } catch {
-      // Keep inline form state visible to let users retry.
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        setSaveError(err.message);
+      }
     }
   };
 
@@ -256,6 +276,7 @@ export function DiscountCodesPanel({
     setValidFromLocal(formatIsoForDatetimeLocalInput(entry.validFrom));
     setValidUntilLocal(formatIsoForDatetimeLocalInput(entry.validUntil));
     setValidityRangeError('');
+    setSaveError('');
     setServiceId(entry.serviceId ?? '');
     setInstanceId(entry.instanceId ?? '');
   };
@@ -324,7 +345,10 @@ export function DiscountCodesPanel({
             <Input
               id='discount-code'
               value={code}
-              onChange={(event) => setCode(event.target.value.toUpperCase())}
+              onChange={(event) => {
+                setSaveError('');
+                setCode(event.target.value.toUpperCase());
+              }}
               disabled={editorMode === 'edit'}
             />
           </div>
@@ -368,6 +392,7 @@ export function DiscountCodesPanel({
           </div>
         </div>
         {validityRangeError ? <p className='text-sm text-red-600'>{validityRangeError}</p> : null}
+        {saveError ? <p className='text-sm text-red-600'>{saveError}</p> : null}
         <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
           <div>
             <Label htmlFor='discount-service'>Applies to service</Label>

--- a/apps/admin_web/src/lib/discount-code-duplicate.ts
+++ b/apps/admin_web/src/lib/discount-code-duplicate.ts
@@ -1,0 +1,21 @@
+/** Matches admin API `parse_create_discount_code_payload` max_length for `code`. */
+export const MAX_DISCOUNT_CODE_LENGTH = 50;
+
+const COPY_SUFFIX = 'COPY';
+
+/**
+ * When create fails with duplicate code, append `COPY` (trimming the base if needed
+ * so the result fits `MAX_DISCOUNT_CODE_LENGTH`).
+ */
+export function buildDuplicateDiscountCodeName(base: string): string {
+  const normalized = base.trim().toUpperCase();
+  if (!normalized) {
+    return COPY_SUFFIX;
+  }
+  const suffixLen = COPY_SUFFIX.length;
+  if (normalized.length + suffixLen <= MAX_DISCOUNT_CODE_LENGTH) {
+    return `${normalized}${COPY_SUFFIX}`;
+  }
+  const keep = MAX_DISCOUNT_CODE_LENGTH - suffixLen;
+  return `${normalized.slice(0, keep)}${COPY_SUFFIX}`;
+}

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2016,6 +2016,15 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
+                /** @description Discount code value conflict (duplicate code, case-insensitive). */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
             };
         };
         delete?: never;

--- a/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { DiscountCodesPanel } from '@/components/admin/services/discount-codes-panel';
+import { AdminApiError } from '@/lib/api-admin-client';
 
 vi.mock('@/hooks/use-service-instance-options', () => ({
   useServiceInstanceOptions: () => ({
@@ -221,5 +222,46 @@ describe('DiscountCodesPanel', () => {
       expect(onUpdate).toHaveBeenCalled();
     });
     expect(onUpdate.mock.calls[0][1]).toMatchObject({ service_id: 'svc-2' });
+  });
+
+  it('retries create with COPY suffix when API returns duplicate code conflict', async () => {
+    const onCreate = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new AdminApiError({
+          statusCode: 409,
+          payload: { error: 'duplicate', field: 'code' },
+          message: 'A discount code with this value already exists',
+        }),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    render(
+      <DiscountCodesPanel
+        codes={[]}
+        filters={{ active: '', search: '', scope: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        isSaving={false}
+        hasMore={false}
+        error=''
+        serviceOptions={[{ ...baseService }]}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Code'), { target: { value: 'DUP' } });
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: '10' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create code' }));
+
+    await vi.waitFor(() => {
+      expect(onCreate).toHaveBeenCalledTimes(2);
+    });
+    expect(onCreate.mock.calls[0][0]).toMatchObject({ code: 'DUP' });
+    expect(onCreate.mock.calls[1][0]).toMatchObject({ code: 'DUPCOPY' });
   });
 });

--- a/apps/admin_web/tests/lib/discount-code-duplicate.test.ts
+++ b/apps/admin_web/tests/lib/discount-code-duplicate.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDuplicateDiscountCodeName, MAX_DISCOUNT_CODE_LENGTH } from '@/lib/discount-code-duplicate';
+
+describe('buildDuplicateDiscountCodeName', () => {
+  it('appends COPY when within max length', () => {
+    expect(buildDuplicateDiscountCodeName('SAVE10')).toBe('SAVE10COPY');
+  });
+
+  it('trims base so base plus COPY fits max length', () => {
+    const base = 'A'.repeat(MAX_DISCOUNT_CODE_LENGTH);
+    const out = buildDuplicateDiscountCodeName(base);
+    expect(out.length).toBe(MAX_DISCOUNT_CODE_LENGTH);
+    expect(out.endsWith('COPY')).toBe(true);
+  });
+
+  it('returns COPY for blank input', () => {
+    expect(buildDuplicateDiscountCodeName('   ')).toBe('COPY');
+  });
+});

--- a/backend/src/app/api/admin_discount_codes.py
+++ b/backend/src/app/api/admin_discount_codes.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.admin_request import parse_body, parse_uuid
@@ -160,12 +161,34 @@ def _create_discount_code(
             created_by=actor_sub,
         )
         created = repository.create(entity)
-        session.commit()
+        try:
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            if _is_discount_code_unique_violation(exc):
+                raise ValidationError(
+                    "A discount code with this value already exists",
+                    field="code",
+                    status_code=409,
+                ) from exc
+            raise
         return json_response(
             201,
             {"discount_code": serialize_discount_code(created)},
             event=event,
         )
+
+
+def _is_discount_code_unique_violation(exc: IntegrityError) -> bool:
+    orig = getattr(exc.orig, "__cause__", None) or exc.orig
+    diag = getattr(orig, "diag", None)
+    constraint = getattr(diag, "constraint_name", None) if diag else None
+    if constraint == "discount_codes_code_unique_idx":
+        return True
+    message = str(exc).lower()
+    if "discount_codes_code_unique_idx" not in message:
+        return False
+    return True
 
 
 def _update_discount_code(

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1443,6 +1443,12 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: Discount code value conflict (duplicate code, case-insensitive).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/admin/discount-codes/{id}:
     parameters:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -49,7 +49,8 @@ their primary responsibilities.
   `/v1/admin/leads/*`, `/v1/admin/users`, `/v1/admin/instructors`,
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for
   cross-service instance listing with optional `service_id` / `service_type`
-  filters), `/v1/admin/discount-codes/*`,
+  filters), `/v1/admin/discount-codes/*` (`POST` returns `409` with `field: code` when
+  the code collides with the case-insensitive unique index),
   `/v1/admin/vendors/*`,
   `/v1/admin/expenses/*`,
   `/v1/user/assets/*`,

--- a/tests/test_admin_discount_codes_api.py
+++ b/tests/test_admin_discount_codes_api.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 
 import pytest
 
+from sqlalchemy.exc import IntegrityError
+
 from app.api import admin_discount_codes
 from app.api.admin_services_payloads import ensure_discount_validity_window
 from app.exceptions import ValidationError
@@ -96,3 +98,25 @@ def test_ensure_discount_validity_window_rejects_inverted_range() -> None:
             datetime(2026, 1, 1, tzinfo=UTC),
         )
     assert exc_info.value.field == "valid_until"
+
+
+def test_is_discount_code_unique_violation_matches_constraint_name() -> None:
+    class _FakeDiag:
+        constraint_name = "discount_codes_code_unique_idx"
+
+    class _FakeOrig:
+        diag = _FakeDiag()
+
+    exc = IntegrityError("stmt", {}, _FakeOrig())
+    assert admin_discount_codes._is_discount_code_unique_violation(exc) is True
+
+
+def test_is_discount_code_unique_violation_false_for_other_constraint() -> None:
+    class _FakeDiag:
+        constraint_name = "other_idx"
+
+    class _FakeOrig:
+        diag = _FakeDiag()
+
+    exc = IntegrityError("stmt", {}, _FakeOrig())
+    assert admin_discount_codes._is_discount_code_unique_violation(exc) is False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **API:** `POST /v1/admin/discount-codes` maps the discount code unique-index `IntegrityError` to **409** with `field: "code"` when the code collides (case-insensitive).
- **Admin UI:** On create, if the API returns that duplicate response, the client retries once with `COPY` appended to the uppercase code (trimmed so the value stays within the **50** character limit). Other failures surface via `saveError`.
- **OpenAPI / docs:** Documents the `409` response on discount code create and notes behavior in `docs/architecture/lambdas.md`.
- **CI:** Regenerated `apps/admin_web/src/types/generated/admin-api.generated.ts` so `npm run check:admin-api-types` matches the updated OpenAPI spec (this was causing **Lint React** to fail).

## Tests

- `python3 -m pytest tests/test_admin_discount_codes_api.py -q`
- `npx vitest run tests/lib/discount-code-duplicate.test.ts tests/components/admin/services/discount-codes-panel.test.tsx`
- `npm run lint` in `apps/admin_web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-935276e8-fc13-41c6-bc60-a749a774c570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-935276e8-fc13-41c6-bc60-a749a774c570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

