### PR TITLE
Admin: remove Copy from referral QR dialog

### DIFF
--- a/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
@@ -96,14 +96,6 @@ export function ReferralLinkQrDialog({
     };
   }, [builtUrl, open]);
 
-  async function copyUrl() {
-    if (!builtUrl || typeof navigator === 'undefined' || !navigator.clipboard) {
-      return;
-    }
-    await navigator.clipboard.writeText(builtUrl);
-    trackAdminAnalyticsEvent('admin_referral_qr_copied', { service_slug: analyticsSlugTag });
-  }
-
   async function downloadPng(size: number) {
     if (!builtUrl) {
       return;
@@ -182,20 +174,9 @@ export function ReferralLinkQrDialog({
         </div>
         <div className='space-y-2'>
           <Label>Preview URL</Label>
-          <div className='flex flex-wrap items-center gap-2'>
-            <code className='max-w-full flex-1 break-all rounded bg-slate-100 px-2 py-1 text-xs text-slate-800'>
-              {builtUrl || '—'}
-            </code>
-            <Button
-              type='button'
-              size='sm'
-              variant='secondary'
-              disabled={!builtUrl}
-              onClick={() => void copyUrl()}
-            >
-              Copy
-            </Button>
-          </div>
+          <code className='block max-w-full break-all rounded bg-slate-100 px-2 py-1 text-xs text-slate-800'>
+            {builtUrl || '—'}
+          </code>
         </div>
         <div className='space-y-2'>
           <Label>QR preview</Label>

--- a/apps/admin_web/src/lib/admin-analytics.ts
+++ b/apps/admin_web/src/lib/admin-analytics.ts
@@ -4,7 +4,6 @@ type AnalyticsPrimitive = string | number | boolean;
 
 export type AdminAnalyticsEventName =
   | 'admin_referral_qr_opened'
-  | 'admin_referral_qr_copied'
   | 'admin_referral_qr_downloaded'
   | 'admin_instance_uuid_copied';
 

--- a/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ReferralLinkQrDialog } from '@/components/admin/services/referral-link-qr-dialog';
@@ -20,14 +20,7 @@ describe('ReferralLinkQrDialog', () => {
     generateSpy.mockClear();
   });
 
-  it('shows URL preview and copy triggers clipboard', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    const clipboardDescriptor = Object.getOwnPropertyDescriptor(Navigator.prototype, 'clipboard');
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    });
-
+  it('shows URL preview and opened analytics when GTM is configured', async () => {
     vi.stubEnv('NEXT_PUBLIC_ADMIN_GTM_CONTAINER_ID', 'GTM-TEST');
     const pushSpy = vi.fn();
     const dataLayerStub: { push: typeof pushSpy } = { push: pushSpy };
@@ -60,24 +53,7 @@ describe('ReferralLinkQrDialog', () => {
       }),
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
-    expect(writeText).toHaveBeenCalledWith(
-      'https://www.example.com/en/services/my-best-auntie-training-course?ref=SAVE10',
-    );
-    await waitFor(() => {
-      expect(pushSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          event: 'admin_referral_qr_copied',
-          service_slug: 'my-best-auntie-training-course',
-        }),
-      );
-    });
-
-    if (clipboardDescriptor) {
-      Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
-    } else {
-      Reflect.deleteProperty(navigator, 'clipboard');
-    }
+    expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
   });
 
   it('download uses createObjectURL', async () => {

--- a/docs/architecture/analytics-ga4-gtm-runbook.md
+++ b/docs/architecture/analytics-ga4-gtm-runbook.md
@@ -26,7 +26,6 @@ Stable **`admin_*` namespace** events used today:
 | Event | Trigger | Notes |
 |---|---|---|
 | `admin_referral_qr_opened` | Referral QR dialog opens | Optional `service_slug` |
-| `admin_referral_qr_copied` | Copy referral URL | Optional `service_slug` |
 | `admin_referral_qr_downloaded` | Download referral PNG | `service_slug`, `png_size_px` |
 | `admin_instance_uuid_copied` | Copy service instance UUID from Instances list | `service_id` |
 
@@ -225,7 +224,7 @@ Both checks run through Public WWW lint/verification workflows.
 
 ## Admin console (optional / not in public taxonomy)
 
-The admin web app may emit **`admin_referral_qr_opened`**, **`admin_referral_qr_copied`**, and **`admin_referral_qr_downloaded`** from the discount referral QR utility (`trackAdminAnalyticsEvent`). These are **not** part of `apps/public_www/src/lib/analytics-taxonomy.json` and are currently **no-ops outside development** unless product wires them to `dataLayer`/GTM on the admin host. If they are enabled later, add GA4/GTM mappings separately from the public-site container.
+The admin web app may emit **`admin_referral_qr_opened`** and **`admin_referral_qr_downloaded`** from the discount referral QR utility (`trackAdminAnalyticsEvent`). These are **not** part of `apps/public_www/src/lib/analytics-taxonomy.json` and are currently **no-ops outside development** unless product wires them to `dataLayer`/GTM on the admin host. If they are enabled later, add GA4/GTM mappings separately from the public-site container.
 
 ## Programmatic setup prerequisites (for service-account automation)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removes the **Copy** button next to the preview URL in `ReferralLinkQrDialog`; the URL remains visible as read-only text for manual selection if needed.
- Removes the unused `admin_referral_qr_copied` analytics event from `AdminAnalyticsEventName` and updates the analytics runbook.
- Updates Vitest coverage: first test now asserts URL display, `admin_referral_qr_opened`, and absence of a Copy button.

## Tests

- `npx vitest run tests/components/admin/services/referral-link-qr-dialog.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-935276e8-fc13-41c6-bc60-a749a774c570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-935276e8-fc13-41c6-bc60-a749a774c570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

