### PR TITLE
fix(api): wire admin discount code usage summary route

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2874,6 +2874,14 @@ export class ApiStack extends cdk.Stack {
       authorizer: adminAuthorizer,
     });
 
+    const adminServiceDiscountCodeUsageSummary = adminServiceById.addResource(
+      "discount-code-usage-summary",
+    );
+    adminServiceDiscountCodeUsageSummary.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+
     const adminServiceInstances = adminServiceById.addResource("instances");
     adminServiceInstances.addMethod("GET", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -49,7 +49,8 @@ their primary responsibilities.
   `/v1/admin/leads/*`, `/v1/admin/users`, `/v1/admin/instructors`,
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for
   cross-service instance listing with optional `service_id` / `service_type`
-  filters), `/v1/admin/discount-codes/*`,
+  filters and `GET /v1/admin/services/{id}/discount-code-usage-summary` for
+  aggregate discount usage before service slug changes), `/v1/admin/discount-codes/*`,
   `/v1/admin/vendors/*`,
   `/v1/admin/expenses/*`,
   `/v1/user/assets/*`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The admin Services editor calls `GET /v1/admin/services/{id}/discount-code-usage-summary` to load aggregate discount usage before slug changes. The Python admin handler already implemented this path, but API Gateway did not expose it, so requests failed before the Lambda ran (typically surfaced in the UI as “Could not load discount code usage”).

## Changes

- Register `GET .../discount-code-usage-summary` under `adminServiceById` in `backend/infrastructure/lib/api-stack.ts` with the same Cognito admin authorizer as other `/v1/admin/services/*` routes.
- Note the route in `docs/architecture/lambdas.md`.

## Deployment

After merge, deploy the API stack (CDK) so API Gateway picks up the new resource.

## CloudWatch

This agent environment could not read your production CloudWatch logs (different AWS account). The fix is inferred from the missing CDK route matching the failing client path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a7a1b62-4d3a-4bf8-ba69-2f42b63d75f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a7a1b62-4d3a-4bf8-ba69-2f42b63d75f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

