### PR TITLE
Admin: referral QR dialog — clickable preview, labels, optional logo

### DIFF
--- a/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
@@ -12,6 +12,8 @@ import { generateReferralQrPngDataUrl } from '@/lib/qr-code-image';
 import {
   buildPublicReferralUrlWithSlug,
   MY_BEST_AUNTIE_REFERRAL_LOCALES,
+  REFERRAL_LOCALE_DISPLAY_LABELS,
+  REFERRAL_PARAM_DISPLAY_LABELS,
   type MyBestAuntieReferralLocale,
   type ReferralParamName,
 } from '@/lib/referral-links';
@@ -32,6 +34,7 @@ export function ReferralLinkQrDialog({
 }: ReferralLinkQrDialogProps) {
   const [locale, setLocale] = useState<MyBestAuntieReferralLocale>('en');
   const [paramName, setParamName] = useState<ReferralParamName>('ref');
+  const [includeLogoInQr, setIncludeLogoInQr] = useState(true);
   const [previewDataUrl, setPreviewDataUrl] = useState('');
   const [isRenderingPreview, setIsRenderingPreview] = useState(false);
   const [renderError, setRenderError] = useState('');
@@ -69,10 +72,11 @@ export function ReferralLinkQrDialog({
       }
       setIsRenderingPreview(true);
       setRenderError('');
+      const logoSrc = includeLogoInQr ? `${window.location.origin}/evolvesprouts-logo.svg` : '';
       void generateReferralQrPngDataUrl({
         url: builtUrl,
         size: 220,
-        logoSrc: `${typeof window !== 'undefined' ? window.location.origin : ''}/evolvesprouts-logo.svg`,
+        logoSrc,
       })
         .then((dataUrl) => {
           if (!cancelled) {
@@ -94,16 +98,17 @@ export function ReferralLinkQrDialog({
     return () => {
       cancelled = true;
     };
-  }, [builtUrl, open]);
+  }, [builtUrl, includeLogoInQr, open]);
 
   async function downloadPng(size: number) {
     if (!builtUrl) {
       return;
     }
+    const logoSrc = includeLogoInQr ? `${window.location.origin}/evolvesprouts-logo.svg` : '';
     const dataUrl = await generateReferralQrPngDataUrl({
       url: builtUrl,
       size,
-      logoSrc: `${window.location.origin}/evolvesprouts-logo.svg`,
+      logoSrc,
     });
     const response = await fetch(dataUrl);
     const blob = await response.blob();
@@ -154,7 +159,7 @@ export function ReferralLinkQrDialog({
             >
               {MY_BEST_AUNTIE_REFERRAL_LOCALES.map((entry) => (
                 <option key={entry} value={entry}>
-                  {entry}
+                  {REFERRAL_LOCALE_DISPLAY_LABELS[entry]}
                 </option>
               ))}
             </Select>
@@ -167,16 +172,47 @@ export function ReferralLinkQrDialog({
               onChange={(event) => setParamName(event.target.value as ReferralParamName)}
               disabled={Boolean(configError)}
             >
-              <option value='ref'>ref</option>
-              <option value='discount'>discount</option>
+              {(['ref', 'discount'] as const satisfies readonly ReferralParamName[]).map((name) => (
+                <option key={name} value={name}>
+                  {REFERRAL_PARAM_DISPLAY_LABELS[name]}
+                </option>
+              ))}
             </Select>
           </div>
         </div>
+        <div className='flex items-center gap-2'>
+          <input
+            id='referral-qr-include-logo'
+            type='checkbox'
+            className='h-4 w-4 rounded border-slate-300 text-slate-900'
+            checked={includeLogoInQr}
+            onChange={(event) => setIncludeLogoInQr(event.target.checked)}
+            disabled={Boolean(configError)}
+          />
+          <Label htmlFor='referral-qr-include-logo' className='cursor-pointer font-normal'>
+            Include logo in QR code
+          </Label>
+        </div>
         <div className='space-y-2'>
-          <Label>Preview URL</Label>
-          <code className='block max-w-full break-all rounded bg-slate-100 px-2 py-1 text-xs text-slate-800'>
-            {builtUrl || '—'}
-          </code>
+          <Label htmlFor='referral-preview-url'>Preview URL</Label>
+          {builtUrl ? (
+            <a
+              id='referral-preview-url'
+              href={builtUrl}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='block max-w-full break-all rounded bg-slate-100 px-2 py-1 text-xs text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950'
+            >
+              {builtUrl}
+            </a>
+          ) : (
+            <p
+              id='referral-preview-url'
+              className='block max-w-full break-all rounded bg-slate-100 px-2 py-1 text-xs text-slate-500'
+            >
+              —
+            </p>
+          )}
         </div>
         <div className='space-y-2'>
           <Label>QR preview</Label>

--- a/apps/admin_web/src/lib/qr-code-image.ts
+++ b/apps/admin_web/src/lib/qr-code-image.ts
@@ -3,11 +3,12 @@ import QRCode from 'qrcode';
 export interface GenerateReferralQrPngDataUrlInput {
   url: string;
   size: number;
-  logoSrc: string;
+  /** When omitted or empty, the QR is generated without a centered logo. */
+  logoSrc?: string;
 }
 
 /**
- * Draw a QR code with centered logo overlay (error correction H).
+ * Draw a QR code, optionally with a centered logo overlay (error correction H).
  * Returns a PNG data URL suitable for download.
  */
 export async function generateReferralQrPngDataUrl(
@@ -22,6 +23,11 @@ export async function generateReferralQrPngDataUrl(
     margin: 2,
     width: input.size,
   });
+
+  const logoSrc = input.logoSrc?.trim() ?? '';
+  if (!logoSrc) {
+    return canvas.toDataURL('image/png');
+  }
 
   const ctx = canvas.getContext('2d');
   if (!ctx) {
@@ -51,7 +57,7 @@ export async function generateReferralQrPngDataUrl(
     image.onerror = () => {
       reject(new Error('Failed to load logo image'));
     };
-    image.src = input.logoSrc;
+    image.src = logoSrc;
   });
 
   return canvas.toDataURL('image/png');

--- a/apps/admin_web/src/lib/referral-links.ts
+++ b/apps/admin_web/src/lib/referral-links.ts
@@ -4,7 +4,20 @@ const MBA_PATH = '/services/my-best-auntie-training-course';
 export const MY_BEST_AUNTIE_REFERRAL_LOCALES = ['en', 'zh-CN', 'zh-HK'] as const;
 export type MyBestAuntieReferralLocale = (typeof MY_BEST_AUNTIE_REFERRAL_LOCALES)[number];
 
+/** Human-readable labels for the referral QR locale selector (values stay `en` / `zh-CN` / `zh-HK`). */
+export const REFERRAL_LOCALE_DISPLAY_LABELS: Record<MyBestAuntieReferralLocale, string> = {
+  en: 'English',
+  'zh-CN': 'Chinese Simplified',
+  'zh-HK': 'Chinese Traditional',
+};
+
 export type ReferralParamName = 'ref' | 'discount';
+
+/** Select labels for query param style; URL still uses `ref` or `discount`. */
+export const REFERRAL_PARAM_DISPLAY_LABELS: Record<ReferralParamName, string> = {
+  ref: 'Referral',
+  discount: 'Discount',
+};
 
 export interface BuildMyBestAuntieReferralUrlInput {
   baseUrl: string;

--- a/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
@@ -41,7 +41,9 @@ describe('ReferralLinkQrDialog', () => {
 
     await vi.waitFor(() => {
       expect(
-        screen.getByText('https://www.example.com/en/services/my-best-auntie-training-course?ref=SAVE10'),
+        screen.getByRole('link', {
+          name: 'https://www.example.com/en/services/my-best-auntie-training-course?ref=SAVE10',
+        }),
       ).toBeInTheDocument();
     });
 
@@ -72,6 +74,10 @@ describe('ReferralLinkQrDialog', () => {
       expect(generateSpy).toHaveBeenCalled();
     });
 
+    expect(generateSpy.mock.calls[0]?.[0]).toMatchObject({
+      logoSrc: expect.stringMatching(/\/evolvesprouts-logo\.svg$/),
+    });
+
     fireEvent.click(screen.getByRole('button', { name: 'Download PNG (512)' }));
 
     await vi.waitFor(() => {
@@ -80,6 +86,27 @@ describe('ReferralLinkQrDialog', () => {
 
     createObjectUrlSpy.mockRestore();
     revokeSpy.mockRestore();
+  });
+
+  it('omits logo from QR generation when include-logo is unchecked', async () => {
+    render(
+      <ReferralLinkQrDialog open onClose={() => {}} discountCode='ABC' serviceSlug={null} />,
+    );
+
+    await vi.waitFor(() => {
+      expect(generateSpy).toHaveBeenCalled();
+    });
+
+    generateSpy.mockClear();
+    fireEvent.click(screen.getByRole('checkbox', { name: /include logo in qr code/i }));
+
+    await vi.waitFor(() => {
+      expect(generateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          logoSrc: '',
+        }),
+      );
+    });
   });
 
   it('labels inner content for screen readers', async () => {

--- a/apps/admin_web/tests/lib/qr-code-image.test.ts
+++ b/apps/admin_web/tests/lib/qr-code-image.test.ts
@@ -78,4 +78,43 @@ describe('generateReferralQrPngDataUrl', () => {
     createElementSpy.mockRestore();
     globalThis.Image = OriginalImage;
   });
+
+  it('skips logo pad and drawImage when logoSrc is omitted', async () => {
+    const drawImageSpy = vi.fn();
+    const fillRectSpy = vi.fn();
+    const toDataURLSpy = vi.fn().mockReturnValue('data:image/png;base64,BB');
+
+    const originalCreateElement = Document.prototype.createElement.bind(document);
+    const createElementSpy = vi.spyOn(Document.prototype, 'createElement').mockImplementation(
+      function patchedCreateElement(this: Document, tagName: string, options?: unknown) {
+        if (tagName !== 'canvas') {
+          return originalCreateElement(tagName, options as never);
+        }
+        const canvas = originalCreateElement('canvas', options as never);
+        canvas.getContext = vi.fn(() => {
+          return {
+            fillStyle: '',
+            fillRect: fillRectSpy,
+            drawImage: drawImageSpy,
+          } as unknown as CanvasRenderingContext2D;
+        });
+        canvas.toDataURL = toDataURLSpy;
+        return canvas;
+      },
+    );
+
+    const { generateReferralQrPngDataUrl } = await import('@/lib/qr-code-image');
+
+    await generateReferralQrPngDataUrl({
+      url: 'https://example.com',
+      size: 200,
+    });
+
+    expect(toCanvasMock).toHaveBeenCalled();
+    expect(fillRectSpy).not.toHaveBeenCalled();
+    expect(drawImageSpy).not.toHaveBeenCalled();
+    expect(toDataURLSpy).toHaveBeenCalledWith('image/png');
+
+    createElementSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the discount codes **Referral link and QR** modal in admin web.

## Changes

- **Preview URL** is now a real link that opens in a new tab (`target="_blank"`, `rel="noopener noreferrer"`).
- **Locale** select shows **English**, **Chinese Simplified**, and **Chinese Traditional** (URL segments remain `en`, `zh-CN`, `zh-HK`).
- **URL parameter** select shows **Referral** and **Discount** (query keys remain `ref` and `discount`).
- **Include logo in QR code** checkbox (default on) toggles whether the Evolve Sprouts logo is composited into the QR for both preview and PNG download.
- `generateReferralQrPngDataUrl` accepts optional `logoSrc`; when empty, it returns a plain QR without logo overlay.

## Tests

- Extended `referral-link-qr-dialog` and `qr-code-image` Vitest coverage.
- `npm run lint` (admin_web) passed locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f293ee29-2b94-4263-82be-18c64cbe2eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f293ee29-2b94-4263-82be-18c64cbe2eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

