### PR TITLE
fix: discount code duplicate flow, bump logic, and Ruff on tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,10 @@ repos:
     rev: v0.3.0
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-        files: ^backend/
+        args: [--fix, --exit-non-zero-on-fix, --config=backend/pyproject.toml]
+        files: ^(backend|tests)/
       - id: ruff-format
+        args: [--config=backend/pyproject.toml]
         files: ^backend/
 
   # Python type checking with mypy

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -16,7 +16,11 @@ import { ReferralLinkQrDialog } from '@/components/admin/services/referral-link-
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useServiceInstanceOptions } from '@/hooks/use-service-instance-options';
 import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
-import { bumpDuplicateDiscountCode } from '@/lib/discount-code-duplicate';
+import {
+  bumpDuplicateDiscountCode,
+  DISCOUNT_CODE_ALLOCATION_FAILED_MESSAGE,
+  MAX_DISCOUNT_CODE_DUPLICATE_CREATE_RETRIES,
+} from '@/lib/discount-code-duplicate';
 import {
   DISCOUNT_VALIDITY_RANGE_INVERTED_MESSAGE,
   isDiscountValidityRangeInverted,
@@ -80,12 +84,17 @@ export interface DiscountCodesPanelProps {
     value: DiscountCodeFilters[TKey]
   ) => void;
   onLoadMore: () => Promise<void> | void;
-  onCreate: (payload: ApiSchemas['CreateDiscountCodeRequest']) => Promise<unknown> | void;
+  onCreate: (
+    payload: ApiSchemas['CreateDiscountCodeRequest'],
+    options?: { batchSaving?: boolean },
+  ) => Promise<unknown> | void;
   onUpdate: (
     codeId: string,
     payload: ApiSchemas['UpdateDiscountCodeRequest']
   ) => Promise<unknown> | void;
   onDelete: (codeId: string) => Promise<void> | void;
+  /** Optional refresh after a failed duplicate-retry batch (intermediate attempts skip refetch). */
+  onDiscountCodesRefresh?: () => void | Promise<void>;
 }
 
 export function DiscountCodesPanel({
@@ -106,6 +115,7 @@ export function DiscountCodesPanel({
   onCreate,
   onUpdate,
   onDelete,
+  onDiscountCodesRefresh,
 }: DiscountCodesPanelProps) {
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
   const [scopeConfirmProps, requestScopeConfirm] = useConfirmDialog();
@@ -127,6 +137,7 @@ export function DiscountCodesPanel({
   const [referralOpen, setReferralOpen] = useState(false);
   const [referralCode, setReferralCode] = useState('');
   const [referralServiceSlug, setReferralServiceSlug] = useState<string | null>(null);
+  const [isBatchCreating, setIsBatchCreating] = useState(false);
   const directoryList = serviceDirectoryForDisplay ?? serviceOptions;
   const { instances, isLoading: instancesLoading, error: instancesError, loadForService } =
     useServiceInstanceOptions(instanceOptionsRefreshKey);
@@ -179,6 +190,7 @@ export function DiscountCodesPanel({
     setSaveError('');
     setServiceId('');
     setInstanceId('');
+    setIsBatchCreating(false);
   };
 
   const handleSubmit = async () => {
@@ -213,26 +225,36 @@ export function DiscountCodesPanel({
     try {
       if (editorMode === 'create') {
         let attemptCode = createPayload.code;
-        const maxDuplicateRetries = 64;
-        for (let round = 0; round < maxDuplicateRetries; round += 1) {
-          try {
-            await onCreate({ ...createPayload, code: attemptCode });
-            resetCreateForm();
-            return;
-          } catch (err) {
-            if (!isDuplicateCodeError(err)) {
-              throw err;
+        const maxDuplicateRetries = MAX_DISCOUNT_CODE_DUPLICATE_CREATE_RETRIES;
+        setIsBatchCreating(true);
+        try {
+          for (let round = 0; round < maxDuplicateRetries; round += 1) {
+            try {
+              const isLastAttempt = round === maxDuplicateRetries - 1;
+              await onCreate(
+                { ...createPayload, code: attemptCode },
+                { batchSaving: !isLastAttempt },
+              );
+              resetCreateForm();
+              return;
+            } catch (err) {
+              if (!isDuplicateCodeError(err)) {
+                throw err;
+              }
+              const nextCode = bumpDuplicateDiscountCode(attemptCode);
+              if (nextCode === attemptCode) {
+                throw err;
+              }
+              attemptCode = nextCode;
+              setCode(nextCode);
             }
-            const nextCode = bumpDuplicateDiscountCode(attemptCode);
-            if (nextCode === attemptCode) {
-              throw err;
-            }
-            attemptCode = nextCode;
-            setCode(nextCode);
           }
+          setSaveError(DISCOUNT_CODE_ALLOCATION_FAILED_MESSAGE);
+          void onDiscountCodesRefresh?.();
+          return;
+        } finally {
+          setIsBatchCreating(false);
         }
-        setSaveError('Could not allocate a unique discount code. Try a shorter base code.');
-        return;
       }
       if (!selectedCode) {
         return;
@@ -322,6 +344,8 @@ export function DiscountCodesPanel({
     setReferralOpen(true);
   }
 
+  const editorIsBusy = isSaving || isBatchCreating;
+
   return (
     <div className='space-y-6'>
       <AdminEditorCard
@@ -330,14 +354,14 @@ export function DiscountCodesPanel({
         actions={
           <>
             {editorMode === 'edit' ? (
-              <Button type='button' variant='secondary' onClick={resetCreateForm} disabled={isSaving}>
+              <Button type='button' variant='secondary' onClick={resetCreateForm} disabled={editorIsBusy}>
                 Cancel
               </Button>
             ) : null}
             <Button
               type='button'
               disabled={
-                isSaving ||
+                editorIsBusy ||
                 !code.trim() ||
                 !discountValue.trim() ||
                 isDiscountValidityRangeInverted(validFromLocal, validUntilLocal)

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -246,9 +246,15 @@ export function ServicesPage() {
           onShowArchivedChange={setShowArchivedDiscountServices}
           onFilterChange={state.discountCodes.setFilter}
           onLoadMore={state.discountCodes.loadMore}
-          onCreate={state.discountCodes.createCode}
+          onCreate={(payload, options) =>
+            state.discountCodes.createCode(payload, {
+              suppressSaving: options?.batchSaving,
+              suppressRefetch: options?.batchSaving,
+            })
+          }
           onUpdate={state.discountCodes.updateCode}
           onDelete={state.discountCodes.deleteCode}
+          onDiscountCodesRefresh={state.discountCodes.refetch}
         />
       ) : (
         <VenuesPanel

--- a/apps/admin_web/src/hooks/use-discount-codes.ts
+++ b/apps/admin_web/src/hooks/use-discount-codes.ts
@@ -37,21 +37,43 @@ export function useDiscountCodes() {
   const { refetch } = list;
   const [isSaving, setIsSaving] = useState(false);
 
-  const mutate = useCallback(async <TResult>(work: () => Promise<TResult>): Promise<TResult> => {
-    setIsSaving(true);
-    try {
-      const result = await work();
-      await refetch();
-      return result;
-    } finally {
-      setIsSaving(false);
-    }
-  }, [refetch]);
+  type MutateOptions = {
+    /** When true, skip toggling `isSaving` (caller manages a longer-lived saving state). */
+    suppressSaving?: boolean;
+    /** When true, skip the post-mutation list refetch (caller will refetch once). */
+    suppressRefetch?: boolean;
+  };
+
+  const mutate = useCallback(
+    async <TResult>(
+      work: () => Promise<TResult>,
+      options: MutateOptions = {},
+    ): Promise<TResult> => {
+      const { suppressSaving = false, suppressRefetch = false } = options;
+      if (!suppressSaving) {
+        setIsSaving(true);
+      }
+      try {
+        const result = await work();
+        if (!suppressRefetch) {
+          await refetch();
+        }
+        return result;
+      } finally {
+        if (!suppressSaving) {
+          setIsSaving(false);
+        }
+      }
+    },
+    [refetch],
+  );
 
   const createCode = useCallback(
-    async (payload: ApiSchemas['CreateDiscountCodeRequest']) =>
-      mutate(async () => createDiscountCode(payload)),
-    [mutate]
+    async (
+      payload: ApiSchemas['CreateDiscountCodeRequest'],
+      options: MutateOptions = {},
+    ) => mutate(async () => createDiscountCode(payload), options),
+    [mutate],
   );
 
   const updateCode = useCallback(

--- a/apps/admin_web/src/lib/discount-code-duplicate.ts
+++ b/apps/admin_web/src/lib/discount-code-duplicate.ts
@@ -1,7 +1,13 @@
 /** Matches admin API `parse_create_discount_code_payload` max_length for `code`. */
 export const MAX_DISCOUNT_CODE_LENGTH = 50;
 
-const TRAILING_COPY_RE = /^(.+)(COPY(\d+)?)$/;
+/** Bounded create retries when the server returns duplicate `code` (409). */
+export const MAX_DISCOUNT_CODE_DUPLICATE_CREATE_RETRIES = 16;
+
+export const DISCOUNT_CODE_ALLOCATION_FAILED_MESSAGE =
+  'Could not allocate a unique discount code. Try a shorter base code.';
+
+const TRAILING_COPY_RE = /^(.*?)(COPY(\d+)?)$/;
 
 /**
  * After a duplicate-code (409) response, derive the next candidate: append `COPY`,
@@ -20,6 +26,15 @@ export function bumpDuplicateDiscountCode(current: string): string {
   }
   const root = match[1];
   const digitPart = match[3];
+  if (!root) {
+    if (!digitPart) {
+      return 'COPY2';
+    }
+    const n = Number.parseInt(digitPart, 10);
+    const nextN = n + 1;
+    const suffix = `COPY${nextN}`;
+    return suffix.slice(0, MAX_DISCOUNT_CODE_LENGTH);
+  }
   const n = digitPart ? Number.parseInt(digitPart, 10) : 1;
   const nextN = n + 1;
   const suffix = `COPY${nextN}`;

--- a/apps/admin_web/tests/lib/discount-code-duplicate.test.ts
+++ b/apps/admin_web/tests/lib/discount-code-duplicate.test.ts
@@ -28,4 +28,14 @@ describe('bumpDuplicateDiscountCode', () => {
   it('returns COPY for blank input', () => {
     expect(bumpDuplicateDiscountCode('   ')).toBe('COPY');
   });
+
+  it('bumps bare COPY and COPY<n> as sequence roots', () => {
+    expect(bumpDuplicateDiscountCode('COPY')).toBe('COPY2');
+    expect(bumpDuplicateDiscountCode('COPY2')).toBe('COPY3');
+  });
+
+  it('treats trailing COPY as suffix even when glued to letters (collision bump)', () => {
+    expect(bumpDuplicateDiscountCode('SCALLOPCOPY')).toBe('SCALLOPCOPY2');
+    expect(bumpDuplicateDiscountCode('JOYCOPY9')).toBe('JOYCOPY10');
+  });
 });

--- a/tests/test_admin_discount_codes_api.py
+++ b/tests/test_admin_discount_codes_api.py
@@ -9,8 +9,6 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from sqlalchemy.exc import IntegrityError
-
 from app.api import admin_discount_codes
 from app.api.admin_services_payloads import ensure_discount_validity_window
 from app.exceptions import ValidationError

--- a/tests/test_admin_services_slug_violation.py
+++ b/tests/test_admin_services_slug_violation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
 
 from sqlalchemy.exc import IntegrityError
 

--- a/tests/test_public_discount_validate_api.py
+++ b/tests/test_public_discount_validate_api.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from app.api import public_discount_validate
 from app.db.models.enums import DiscountType

--- a/tests/test_public_free_assets_api.py
+++ b/tests/test_public_free_assets_api.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 import pytest
 
 from app.api import public_free_assets
-from app.db.models import AssetType, AssetVisibility
+from app.db.models import AssetType
 from app.exceptions import ValidationError
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removed duplicate `IntegrityError` import in `tests/test_admin_discount_codes_api.py`.
- Extended the pre-commit **Ruff** hook to `tests/` with `--config=backend/pyproject.toml` so CI catches merge artifacts and lint issues in root tests; left **ruff-format** scoped to `backend/` to avoid mass-reformatting the entire `tests/` tree on every hook run.
- Ruff auto-fixed two small issues uncovered in `tests/` (unused imports) and fixed a real bug: `UUID` was used in a type hint in `tests/test_public_discount_validate_api.py` without importing `UUID`.
- Refined `bumpDuplicateDiscountCode`: non-greedy root + explicit empty-root handling so bare `COPY` / `COPY2` bump to `COPY2` / `COPY3`; documented collision behavior for glued suffixes (`SCALLOPCOPY` → `SCALLOPCOPY2`, `JOYCOPY9` → `JOYCOPY10`) in unit tests.
- Reduced duplicate-create retries from 64 to **16** (`MAX_DISCOUNT_CODE_DUPLICATE_CREATE_RETRIES`).
- Avoided `isSaving` flicker during duplicate retries: `createCode` accepts `suppressSaving` / `suppressRefetch`; the panel passes `batchSaving` for intermediate attempts and triggers a single `refetch` after allocation failure via optional `onDiscountCodesRefresh`.
- Centralized the allocation failure copy in `DISCOUNT_CODE_ALLOCATION_FAILED_MESSAGE`.

## Validation

- `pre-commit run ruff-format --all-files` and `pre-commit run ruff --all-files`
- `pytest tests/test_admin_discount_codes_api.py tests/test_public_discount_validate_api.py`
- `npm run lint` and targeted Vitest in `apps/admin_web` for discount code files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3936b14-b907-4b73-903d-9ca50280794f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3936b14-b907-4b73-903d-9ca50280794f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

