### PR TITLE
Add referral discount type (tracking-only)

### DIFF
--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -21,6 +21,7 @@ import {
   DISCOUNT_VALIDITY_RANGE_INVERTED_MESSAGE,
   isDiscountValidityRangeInverted,
 } from '@/lib/discount-validity';
+import { formatDiscountRowValue } from '@/lib/discount-row-format';
 import {
   formatDate,
   formatEnumLabel,
@@ -30,7 +31,11 @@ import {
 } from '@/lib/format';
 
 import type { components } from '@/types/generated/admin-api.generated';
-import { DISCOUNT_TYPES } from '@/types/services';
+import {
+  DISCOUNT_TYPES,
+  REFERRAL_DEFAULT_CURRENCY,
+  REFERRAL_DEFAULT_DISCOUNT_VALUE,
+} from '@/types/services';
 import type { DiscountCode, DiscountCodeFilters, DiscountType, ServiceSummary } from '@/types/services';
 
 type ApiSchemas = components['schemas'];
@@ -127,10 +132,12 @@ export function DiscountCodesPanel({
   const [referralOpen, setReferralOpen] = useState(false);
   const [referralCode, setReferralCode] = useState('');
   const [referralServiceSlug, setReferralServiceSlug] = useState<string | null>(null);
+  const [referralDiscountType, setReferralDiscountType] = useState<DiscountType>('percentage');
   const directoryList = serviceDirectoryForDisplay ?? serviceOptions;
   const { instances, isLoading: instancesLoading, error: instancesError, loadForService } =
     useServiceInstanceOptions(instanceOptionsRefreshKey);
   const currencyOptions = getCurrencyOptions();
+  const isReferral = discountType === 'referral';
 
   const serviceById = useMemo(() => {
     const map = new Map<string, ServiceSummary>();
@@ -196,8 +203,8 @@ export function DiscountCodesPanel({
       code: code.trim().toUpperCase(),
       description: description.trim() || null,
       discount_type: discountType as DiscountType,
-      discount_value: discountValue.trim(),
-      currency: currency.trim() || null,
+      discount_value: isReferral ? REFERRAL_DEFAULT_DISCOUNT_VALUE : discountValue.trim(),
+      currency: isReferral ? REFERRAL_DEFAULT_CURRENCY : currency.trim() || null,
       valid_from: validFromIso,
       valid_until: validUntilIso,
       max_uses: maxUses ? Number(maxUses) : null,
@@ -257,8 +264,8 @@ export function DiscountCodesPanel({
       await onUpdate(selectedCode.id, {
         description: description.trim() || null,
         discount_type: discountType as DiscountType,
-        discount_value: discountValue.trim(),
-        currency: currency.trim() || null,
+        discount_value: isReferral ? REFERRAL_DEFAULT_DISCOUNT_VALUE : discountValue.trim(),
+        currency: isReferral ? REFERRAL_DEFAULT_CURRENCY : currency.trim() || null,
         valid_from: validFromIso,
         valid_until: validUntilIso,
         max_uses: maxUses ? Number(maxUses) : null,
@@ -317,6 +324,7 @@ export function DiscountCodesPanel({
 
   function openReferralDialog(entry: DiscountCode) {
     setReferralCode(entry.code);
+    setReferralDiscountType(entry.discountType);
     const slug = entry.serviceId ? serviceById.get(entry.serviceId)?.slug?.trim() ?? null : null;
     setReferralServiceSlug(slug && slug.length ? slug : null);
     setReferralOpen(true);
@@ -339,7 +347,7 @@ export function DiscountCodesPanel({
               disabled={
                 isSaving ||
                 !code.trim() ||
-                !discountValue.trim() ||
+                (!isReferral && !discountValue.trim()) ||
                 isDiscountValidityRangeInverted(validFromLocal, validUntilLocal)
               }
               onClick={() => void handleSubmit()}
@@ -367,7 +375,17 @@ export function DiscountCodesPanel({
             <Select
               id='discount-type'
               value={discountType}
-              onChange={(event) => setDiscountType(event.target.value as ApiSchemas['DiscountType'])}
+              onChange={(event) => {
+                const next = event.target.value as ApiSchemas['DiscountType'];
+                const prev = discountType;
+                setDiscountType(next);
+                if (next === 'referral') {
+                  setDiscountValue(REFERRAL_DEFAULT_DISCOUNT_VALUE);
+                  setCurrency(REFERRAL_DEFAULT_CURRENCY);
+                } else if (prev === 'referral') {
+                  setDiscountValue('');
+                }
+              }}
             >
               {DISCOUNT_TYPES.map((entry) => (
                 <option key={entry} value={entry}>
@@ -444,7 +462,12 @@ export function DiscountCodesPanel({
         <div className='grid grid-cols-1 gap-3 sm:grid-cols-4'>
           <div>
             <Label htmlFor='discount-value'>Value</Label>
-            <Input id='discount-value' value={discountValue} onChange={(event) => setDiscountValue(event.target.value)} />
+            <Input
+              id='discount-value'
+              value={discountValue}
+              onChange={(event) => setDiscountValue(event.target.value)}
+              disabled={isReferral}
+            />
           </div>
           <div>
             <Label htmlFor='discount-currency'>Currency</Label>
@@ -452,7 +475,7 @@ export function DiscountCodesPanel({
               id='discount-currency'
               value={currency}
               onChange={(event) => setCurrency(event.target.value)}
-              disabled={discountType === 'percentage'}
+              disabled={discountType === 'percentage' || isReferral}
             >
               {currencyOptions.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -577,11 +600,7 @@ export function DiscountCodesPanel({
                 <td className='px-4 py-3 text-sm text-slate-700'>{formatScopeSummary(row, serviceById)}</td>
                 <td className='px-4 py-3'>{formatDate(row.validFrom)}</td>
                 <td className='px-4 py-3'>{formatDate(row.validUntil)}</td>
-                <td className='px-4 py-3'>
-                  {row.discountType === 'percentage'
-                    ? `${row.discountValue}%`
-                    : `${row.discountValue} ${row.currency ?? ''}`.trim()}
-                </td>
+                <td className='px-4 py-3'>{formatDiscountRowValue(row)}</td>
                 <td className='px-4 py-3'>
                   {row.currentUses}/{row.maxUses ?? '∞'}
                 </td>
@@ -637,6 +656,7 @@ export function DiscountCodesPanel({
         open={referralOpen}
         discountCode={referralCode}
         serviceSlug={referralServiceSlug}
+        discountType={referralDiscountType}
         onClose={() => setReferralOpen(false)}
       />
     </div>

--- a/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
@@ -13,10 +13,10 @@ import {
   buildPublicReferralUrlWithSlug,
   MY_BEST_AUNTIE_REFERRAL_LOCALES,
   REFERRAL_LOCALE_DISPLAY_LABELS,
-  REFERRAL_PARAM_DISPLAY_LABELS,
   type MyBestAuntieReferralLocale,
   type ReferralParamName,
 } from '@/lib/referral-links';
+import type { DiscountType } from '@/types/services';
 
 export interface ReferralLinkQrDialogProps {
   open: boolean;
@@ -24,6 +24,7 @@ export interface ReferralLinkQrDialogProps {
   discountCode: string;
   /** Public `services.slug` for deep link, or null for locale home. */
   serviceSlug: string | null;
+  discountType: DiscountType;
 }
 
 export function ReferralLinkQrDialog({
@@ -31,9 +32,10 @@ export function ReferralLinkQrDialog({
   onClose,
   discountCode,
   serviceSlug,
+  discountType,
 }: ReferralLinkQrDialogProps) {
   const [locale, setLocale] = useState<MyBestAuntieReferralLocale>('en');
-  const [paramName, setParamName] = useState<ReferralParamName>('ref');
+  const paramName: ReferralParamName = discountType === 'referral' ? 'ref' : 'discount';
   const [includeLogoInQr, setIncludeLogoInQr] = useState(true);
   const [previewDataUrl, setPreviewDataUrl] = useState('');
   const [isRenderingPreview, setIsRenderingPreview] = useState(false);
@@ -164,34 +166,21 @@ export function ReferralLinkQrDialog({
               ))}
             </Select>
           </div>
-          <div>
-            <Label htmlFor='referral-param'>URL parameter</Label>
-            <Select
-              id='referral-param'
-              value={paramName}
-              onChange={(event) => setParamName(event.target.value as ReferralParamName)}
-              disabled={Boolean(configError)}
-            >
-              {(['ref', 'discount'] as const satisfies readonly ReferralParamName[]).map((name) => (
-                <option key={name} value={name}>
-                  {REFERRAL_PARAM_DISPLAY_LABELS[name]}
-                </option>
-              ))}
-            </Select>
+          <div className='flex items-end'>
+            <div className='flex items-center gap-2 pb-1'>
+              <input
+                id='referral-qr-include-logo'
+                type='checkbox'
+                className='h-4 w-4 rounded border-slate-300 text-slate-900'
+                checked={includeLogoInQr}
+                onChange={(event) => setIncludeLogoInQr(event.target.checked)}
+                disabled={Boolean(configError)}
+              />
+              <Label htmlFor='referral-qr-include-logo' className='cursor-pointer font-normal'>
+                Include logo in QR code
+              </Label>
+            </div>
           </div>
-        </div>
-        <div className='flex items-center gap-2'>
-          <input
-            id='referral-qr-include-logo'
-            type='checkbox'
-            className='h-4 w-4 rounded border-slate-300 text-slate-900'
-            checked={includeLogoInQr}
-            onChange={(event) => setIncludeLogoInQr(event.target.checked)}
-            disabled={Boolean(configError)}
-          />
-          <Label htmlFor='referral-qr-include-logo' className='cursor-pointer font-normal'>
-            Include logo in QR code
-          </Label>
         </div>
         <div className='space-y-2'>
           <Label htmlFor='referral-preview-url'>Preview URL</Label>

--- a/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
@@ -166,8 +166,11 @@ export function ReferralLinkQrDialog({
               ))}
             </Select>
           </div>
-          <div className='flex items-end'>
-            <div className='flex items-center gap-2 pb-1'>
+          <div>
+            <Label aria-hidden='true' className='invisible mb-1 block select-none'>
+              {' '}
+            </Label>
+            <div className='flex items-center gap-2'>
               <input
                 id='referral-qr-include-logo'
                 type='checkbox'
@@ -176,7 +179,7 @@ export function ReferralLinkQrDialog({
                 onChange={(event) => setIncludeLogoInQr(event.target.checked)}
                 disabled={Boolean(configError)}
               />
-              <Label htmlFor='referral-qr-include-logo' className='cursor-pointer font-normal'>
+              <Label htmlFor='referral-qr-include-logo' className='mb-0 cursor-pointer font-normal'>
                 Include logo in QR code
               </Label>
             </div>

--- a/apps/admin_web/src/lib/discount-row-format.ts
+++ b/apps/admin_web/src/lib/discount-row-format.ts
@@ -1,0 +1,13 @@
+import type { DiscountCode } from '@/types/services';
+
+export function formatDiscountRowValue(
+  row: Pick<DiscountCode, 'discountType' | 'discountValue' | 'currency'>,
+): string {
+  if (row.discountType === 'referral') {
+    return 'Referral';
+  }
+  if (row.discountType === 'percentage') {
+    return `${row.discountValue}%`;
+  }
+  return `${row.discountValue} ${row.currency ?? ''}`.trim();
+}

--- a/apps/admin_web/src/lib/referral-links.ts
+++ b/apps/admin_web/src/lib/referral-links.ts
@@ -13,12 +13,6 @@ export const REFERRAL_LOCALE_DISPLAY_LABELS: Record<MyBestAuntieReferralLocale, 
 
 export type ReferralParamName = 'ref' | 'discount';
 
-/** Select labels for query param style; URL still uses `ref` or `discount`. */
-export const REFERRAL_PARAM_DISPLAY_LABELS: Record<ReferralParamName, string> = {
-  ref: 'Referral',
-  discount: 'Discount',
-};
-
 export interface BuildMyBestAuntieReferralUrlInput {
   baseUrl: string;
   locale: string;

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -3716,8 +3716,13 @@ export interface components {
         ConsultationPricingModel: "free" | "hourly" | "package";
         /** @enum {string} */
         InstanceStatus: "scheduled" | "open" | "full" | "in_progress" | "completed" | "cancelled";
-        /** @enum {string} */
-        DiscountType: "percentage" | "absolute";
+        /**
+         * @description Discount type. `referral` codes are tracking-only: the server always
+         *     coerces `discount_value` to "0" and `currency` to "HKD", and the public
+         *     discount-validate endpoint rejects referral codes.
+         * @enum {string}
+         */
+        DiscountType: "percentage" | "absolute" | "referral";
         /** @enum {string} */
         EnrollmentStatus: "registered" | "waitlisted" | "confirmed" | "cancelled" | "completed";
         ServiceTrainingDetails: {
@@ -4033,7 +4038,9 @@ export interface components {
             code: string;
             description?: string | null;
             discount_type: components["schemas"]["DiscountType"];
+            /** @description For `referral` type this value is ignored; the server coerces it to "0". */
             discount_value: string;
+            /** @description For `referral` type this is ignored; the server coerces it to "HKD". */
             currency?: string | null;
             /** Format: date-time */
             valid_from?: string | null;
@@ -4049,7 +4056,9 @@ export interface components {
         UpdateDiscountCodeRequest: {
             description?: string | null;
             discount_type?: components["schemas"]["DiscountType"];
+            /** @description For `referral` type this value is ignored; the server coerces it to "0". */
             discount_value?: string;
+            /** @description For `referral` type this is ignored; the server coerces it to "HKD". */
             currency?: string | null;
             /** Format: date-time */
             valid_from?: string | null;

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4038,9 +4038,9 @@ export interface components {
             code: string;
             description?: string | null;
             discount_type: components["schemas"]["DiscountType"];
-            /** @description For `referral` type this value is ignored; the server coerces it to "0". */
+            /** @description For `referral` type the server coerces this to "0"; client-supplied values are ignored (including malformed strings). */
             discount_value: string;
-            /** @description For `referral` type this is ignored; the server coerces it to "HKD". */
+            /** @description For `referral` type the server coerces this to "HKD"; client-supplied values are ignored. */
             currency?: string | null;
             /** Format: date-time */
             valid_from?: string | null;
@@ -4056,9 +4056,9 @@ export interface components {
         UpdateDiscountCodeRequest: {
             description?: string | null;
             discount_type?: components["schemas"]["DiscountType"];
-            /** @description For `referral` type this value is ignored; the server coerces it to "0". */
+            /** @description When the resulting type is `referral`, the server coerces this to "0"; client-supplied values are ignored. */
             discount_value?: string;
-            /** @description For `referral` type this is ignored; the server coerces it to "HKD". */
+            /** @description When the resulting type is `referral`, the server coerces this to "HKD"; client-supplied values are ignored. */
             currency?: string | null;
             /** Format: date-time */
             valid_from?: string | null;

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -53,8 +53,11 @@ export const INSTANCE_STATUSES = defineEnumValues<InstanceStatus>()(
 
 export type DiscountType = ApiSchemas['DiscountType'];
 export const DISCOUNT_TYPES = defineEnumValues<DiscountType>()(
-  ['percentage', 'absolute'] as const satisfies readonly DiscountType[]
+  ['percentage', 'absolute', 'referral'] as const satisfies readonly DiscountType[]
 );
+
+export const REFERRAL_DEFAULT_DISCOUNT_VALUE = '0';
+export const REFERRAL_DEFAULT_CURRENCY = 'HKD';
 
 export type EnrollmentStatus = ApiSchemas['EnrollmentStatus'];
 export const ENROLLMENT_STATUSES = defineEnumValues<EnrollmentStatus>()(

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -56,6 +56,7 @@ export const DISCOUNT_TYPES = defineEnumValues<DiscountType>()(
   ['percentage', 'absolute', 'referral'] as const satisfies readonly DiscountType[]
 );
 
+// Sibling defaults: backend `REFERRAL_DEFAULT_*` in `admin_services_payloads.py`.
 export const REFERRAL_DEFAULT_DISCOUNT_VALUE = '0';
 export const REFERRAL_DEFAULT_CURRENCY = 'HKD';
 

--- a/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
@@ -14,6 +14,14 @@ vi.mock('@/hooks/use-service-instance-options', () => ({
   }),
 }));
 
+vi.mock('@/lib/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/config')>();
+  return {
+    ...actual,
+    getPublicSiteBaseUrl: () => 'https://www.example.com',
+  };
+});
+
 describe('DiscountCodesPanel', () => {
   const baseService = {
     id: 'svc-1',
@@ -222,6 +230,170 @@ describe('DiscountCodesPanel', () => {
       expect(onUpdate).toHaveBeenCalled();
     });
     expect(onUpdate.mock.calls[0][1]).toMatchObject({ service_id: 'svc-2' });
+  });
+
+  it('referral type sets value and currency, disables inputs, and submits defaults', async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <DiscountCodesPanel
+        codes={[]}
+        filters={{ active: '', search: '', scope: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        isSaving={false}
+        hasMore={false}
+        error=''
+        serviceOptions={[{ ...baseService }]}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Code'), { target: { value: 'REFNEW' } });
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'referral' } });
+
+    const valueInput = screen.getByLabelText('Value') as HTMLInputElement;
+    expect(valueInput).toBeDisabled();
+    expect(valueInput.value).toBe('0');
+    const currencySelect = screen.getByLabelText('Currency') as HTMLSelectElement;
+    expect(currencySelect.value).toBe('HKD');
+    expect(currencySelect).toBeDisabled();
+
+    const createBtn = screen.getByRole('button', { name: 'Create code' });
+    expect(createBtn).not.toBeDisabled();
+
+    fireEvent.click(createBtn);
+
+    await vi.waitFor(() => {
+      expect(onCreate).toHaveBeenCalled();
+    });
+    expect(onCreate.mock.calls[0][0]).toMatchObject({
+      discount_type: 'referral',
+      discount_value: '0',
+      currency: 'HKD',
+    });
+  });
+
+  it('switching away from referral clears value and re-enables value input', () => {
+    render(
+      <DiscountCodesPanel
+        codes={[]}
+        filters={{ active: '', search: '', scope: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        isSaving={false}
+        hasMore={false}
+        error=''
+        serviceOptions={[{ ...baseService }]}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'referral' } });
+    expect((screen.getByLabelText('Value') as HTMLInputElement).value).toBe('0');
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'percentage' } });
+    expect((screen.getByLabelText('Value') as HTMLInputElement).value).toBe('');
+    expect(screen.getByLabelText('Value')).not.toBeDisabled();
+  });
+
+  it('renders Referral in the value column for referral rows', () => {
+    const row = {
+      id: 'dc-ref',
+      code: 'TRACK',
+      description: null,
+      discountType: 'referral' as const,
+      discountValue: '0',
+      currency: 'HKD',
+      validFrom: null,
+      validUntil: null,
+      maxUses: null,
+      currentUses: 0,
+      active: true,
+      serviceId: null,
+      instanceId: null,
+      createdAt: null,
+      updatedAt: null,
+    };
+
+    render(
+      <DiscountCodesPanel
+        codes={[row]}
+        filters={{ active: '', search: '', scope: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        isSaving={false}
+        hasMore={false}
+        error=''
+        serviceOptions={[{ ...baseService }]}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const table = screen.getByRole('table');
+    const dataRow = screen.getByText('TRACK').closest('tr');
+    expect(dataRow).toBeTruthy();
+    expect(table.contains(dataRow)).toBe(true);
+    expect(dataRow?.textContent).toContain('Referral');
+  });
+
+  it('opens referral QR dialog with row discount type for ref param', async () => {
+    const row = {
+      id: 'dc-ref',
+      code: 'SAVE10',
+      description: null,
+      discountType: 'referral' as const,
+      discountValue: '0',
+      currency: 'HKD',
+      validFrom: null,
+      validUntil: null,
+      maxUses: null,
+      currentUses: 0,
+      active: true,
+      serviceId: 'svc-1',
+      instanceId: null,
+      createdAt: null,
+      updatedAt: null,
+    };
+
+    render(
+      <DiscountCodesPanel
+        codes={[row]}
+        filters={{ active: '', search: '', scope: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        isSaving={false}
+        hasMore={false}
+        error=''
+        serviceOptions={[{ ...baseService }]}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Referral link and QR' }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('link', {
+          name: 'https://www.example.com/en/services/my-best-auntie?ref=SAVE10',
+        }),
+      ).toBeInTheDocument();
+    });
   });
 
   it('retries create with COPY, COPY2, … until duplicate 409 stops', async () => {

--- a/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
@@ -36,13 +36,14 @@ describe('ReferralLinkQrDialog', () => {
         onClose={() => {}}
         discountCode='SAVE10'
         serviceSlug='my-best-auntie-training-course'
+        discountType='percentage'
       />,
     );
 
     await vi.waitFor(() => {
       expect(
         screen.getByRole('link', {
-          name: 'https://www.example.com/en/services/my-best-auntie-training-course?ref=SAVE10',
+          name: 'https://www.example.com/en/services/my-best-auntie-training-course?discount=SAVE10',
         }),
       ).toBeInTheDocument();
     });
@@ -58,6 +59,46 @@ describe('ReferralLinkQrDialog', () => {
     expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
   });
 
+  it('uses ref query param when discountType is referral', async () => {
+    render(
+      <ReferralLinkQrDialog
+        open
+        onClose={() => {}}
+        discountCode='SAVE10'
+        serviceSlug='my-best-auntie-training-course'
+        discountType='referral'
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('link', {
+          name: 'https://www.example.com/en/services/my-best-auntie-training-course?ref=SAVE10',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('uses discount query param when discountType is absolute', async () => {
+    render(
+      <ReferralLinkQrDialog
+        open
+        onClose={() => {}}
+        discountCode='SAVE10'
+        serviceSlug='my-best-auntie-training-course'
+        discountType='absolute'
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('link', {
+          name: 'https://www.example.com/en/services/my-best-auntie-training-course?discount=SAVE10',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it('download uses createObjectURL', async () => {
     const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
     const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
@@ -67,7 +108,13 @@ describe('ReferralLinkQrDialog', () => {
     }) as typeof fetch;
 
     render(
-      <ReferralLinkQrDialog open onClose={() => {}} discountCode='ABC' serviceSlug={null} />,
+      <ReferralLinkQrDialog
+        open
+        onClose={() => {}}
+        discountCode='ABC'
+        serviceSlug={null}
+        discountType='percentage'
+      />,
     );
 
     await vi.waitFor(() => {
@@ -90,7 +137,7 @@ describe('ReferralLinkQrDialog', () => {
 
   it('omits logo from QR generation when include-logo is unchecked', async () => {
     render(
-      <ReferralLinkQrDialog open onClose={() => {}} discountCode='ABC' serviceSlug={null} />,
+      <ReferralLinkQrDialog open onClose={() => {}} discountCode='ABC' serviceSlug={null} discountType='percentage' />,
     );
 
     await vi.waitFor(() => {
@@ -111,12 +158,37 @@ describe('ReferralLinkQrDialog', () => {
 
   it('labels inner content for screen readers', async () => {
     render(
-      <ReferralLinkQrDialog open onClose={() => {}} discountCode='SAVE10' serviceSlug={null} />,
+      <ReferralLinkQrDialog
+        open
+        onClose={() => {}}
+        discountCode='SAVE10'
+        serviceSlug={null}
+        discountType='percentage'
+      />,
     );
     await vi.waitFor(() => {
       expect(
         screen.getByLabelText('Referral link configuration and preview'),
       ).toBeInTheDocument();
     });
+  });
+
+  it('does not render URL parameter selector', () => {
+    render(
+      <ReferralLinkQrDialog open onClose={() => {}} discountCode='X' serviceSlug={null} discountType='referral' />,
+    );
+    expect(screen.queryByLabelText('URL parameter')).toBeNull();
+  });
+
+  it('places include-logo checkbox in the same two-column grid as locale', () => {
+    const { container } = render(
+      <ReferralLinkQrDialog open onClose={() => {}} discountCode='X' serviceSlug={null} discountType='referral' />,
+    );
+    const checkbox = screen.getByRole('checkbox', { name: /include logo in qr code/i });
+    const localeSelect = screen.getByLabelText('Locale');
+    const grid = container.querySelector('.sm\\:grid-cols-2');
+    expect(grid).toBeTruthy();
+    expect(grid?.contains(checkbox)).toBe(true);
+    expect(grid?.contains(localeSelect)).toBe(true);
   });
 });

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -89,6 +89,14 @@ const DISCOUNT_CODE_FIXTURE: DiscountCode = {
   updatedAt: '2026-03-01T10:00:00Z',
 };
 
+const DISCOUNT_REFERRAL_FIXTURE: DiscountCode = {
+  ...DISCOUNT_CODE_FIXTURE,
+  id: 'discount-ref',
+  code: 'TRACK',
+  discountType: 'referral',
+  discountValue: '0',
+};
+
 describe('services tables value formatting', () => {
   it('formats enum and date values in service list table rows', () => {
     render(
@@ -131,7 +139,7 @@ describe('services tables value formatting', () => {
           onDeleteInstance={vi.fn()}
         />
         <DiscountCodesPanel
-          codes={[DISCOUNT_CODE_FIXTURE]}
+          codes={[DISCOUNT_CODE_FIXTURE, DISCOUNT_REFERRAL_FIXTURE]}
           filters={{ active: '', search: '', scope: '' }}
           isLoading={false}
           isLoadingMore={false}
@@ -152,6 +160,7 @@ describe('services tables value formatting', () => {
     expect(within(tables[0] as HTMLElement).getByText('In Progress')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('SAVE10')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('10%')).toBeInTheDocument();
+    expect(within(tables[1] as HTMLElement).getByText('Referral')).toBeInTheDocument();
     const currencySelect = screen.getByLabelText('Currency');
     expect(currencySelect.tagName).toBe('SELECT');
     expect(currencySelect).toBeDisabled();

--- a/apps/admin_web/tests/lib/discount-row-format.test.ts
+++ b/apps/admin_web/tests/lib/discount-row-format.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDiscountRowValue } from '@/lib/discount-row-format';
+
+describe('formatDiscountRowValue', () => {
+  it('returns Referral for referral type', () => {
+    expect(
+      formatDiscountRowValue({
+        discountType: 'referral',
+        discountValue: '0',
+        currency: 'HKD',
+      }),
+    ).toBe('Referral');
+  });
+
+  it('returns percentage suffix', () => {
+    expect(
+      formatDiscountRowValue({
+        discountType: 'percentage',
+        discountValue: '15',
+        currency: null,
+      }),
+    ).toBe('15%');
+  });
+
+  it('returns amount and currency for absolute', () => {
+    expect(
+      formatDiscountRowValue({
+        discountType: 'absolute',
+        discountValue: '50',
+        currency: 'HKD',
+      }),
+    ).toBe('50 HKD');
+  });
+});

--- a/backend/db/alembic/versions/0024_discount_referral_add_enum.py
+++ b/backend/db/alembic/versions/0024_discount_referral_add_enum.py
@@ -1,10 +1,15 @@
-"""Add referral value to discount_type enum and relax value check for referral rows.
+"""Add referral label to discount_type enum (committed before CHECK may reference it).
+
+PostgreSQL requires new enum values to be committed before use in the same
+database session. Adding `referral` and replacing the discount_codes CHECK in
+one Alembic transaction fails with "unsafe use of new value ... referral".
+This revision only adds the enum value; see `0025_discount_codes_value_check`.
 
 Seed-data assessment:
 1. Compatibility with existing seed SQL:
    - No discount_codes seed rows exist in `backend/db/seed/seed_data.sql`.
 2. New NOT NULL/CHECK-constrained columns handled in seed data:
-   - No new columns; CHECK constraint is replaced (referral allows discount_value >= 0).
+   - None (enum label only).
 3. Renamed/dropped columns reflected in seed data:
    - None.
 4. New tables evaluated for seed rows:
@@ -23,7 +28,7 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "0024_discount_referral_type"
+revision: str = "0024_discount_referral_add_enum"
 down_revision: Union[str, None] = "0023_services_add_slug"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -31,28 +36,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.execute("ALTER TYPE discount_type ADD VALUE IF NOT EXISTS 'referral'")
-    op.drop_constraint(
-        "discount_codes_positive_value",
-        "discount_codes",
-        type_="check",
-    )
-    op.create_check_constraint(
-        "discount_codes_value_by_type",
-        "discount_codes",
-        "(discount_type = 'referral' AND discount_value >= 0) "
-        "OR (discount_type <> 'referral' AND discount_value > 0)",
-    )
 
 
 def downgrade() -> None:
-    op.drop_constraint(
-        "discount_codes_value_by_type",
-        "discount_codes",
-        type_="check",
-    )
-    op.create_check_constraint(
-        "discount_codes_positive_value",
-        "discount_codes",
-        "discount_value > 0",
-    )
     # PostgreSQL enum value removals are intentionally not attempted.
+    return None

--- a/backend/db/alembic/versions/0024_discount_referral_type.py
+++ b/backend/db/alembic/versions/0024_discount_referral_type.py
@@ -1,0 +1,58 @@
+"""Add referral value to discount_type enum and relax value check for referral rows.
+
+Seed-data assessment:
+1. Compatibility with existing seed SQL:
+   - No discount_codes seed rows exist in `backend/db/seed/seed_data.sql`.
+2. New NOT NULL/CHECK-constrained columns handled in seed data:
+   - No new columns; CHECK constraint is replaced (referral allows discount_value >= 0).
+3. Renamed/dropped columns reflected in seed data:
+   - None.
+4. New tables evaluated for seed rows:
+   - None.
+5. Enum/allowed-value changes validated in seed rows:
+   - Additive enum value `referral`; existing rows unchanged.
+6. FK/cascade changes validated for insert order and references:
+   - None.
+
+Result: No seed updates are required for this migration.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0024_discount_referral_type"
+down_revision: Union[str, None] = "0023_services_add_slug"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE discount_type ADD VALUE IF NOT EXISTS 'referral'")
+    op.drop_constraint(
+        "discount_codes_positive_value",
+        "discount_codes",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "discount_codes_value_by_type",
+        "discount_codes",
+        "(discount_type = 'referral' AND discount_value >= 0) "
+        "OR (discount_type <> 'referral' AND discount_value > 0)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "discount_codes_value_by_type",
+        "discount_codes",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "discount_codes_positive_value",
+        "discount_codes",
+        "discount_value > 0",
+    )
+    # PostgreSQL enum value removals are intentionally not attempted.

--- a/backend/db/alembic/versions/0025_discount_codes_value_check.py
+++ b/backend/db/alembic/versions/0025_discount_codes_value_check.py
@@ -1,0 +1,59 @@
+"""Replace discount_codes positive-value CHECK after referral enum exists.
+
+Depends on `0024_discount_referral_add_enum` so the `referral` label is visible
+in a later transaction before this CHECK references it.
+
+Seed-data assessment:
+1. Compatibility with existing seed SQL:
+   - No discount_codes seed rows exist in `backend/db/seed/seed_data.sql`.
+2. New NOT NULL/CHECK-constrained columns handled in seed data:
+   - CHECK replaced only; referral allows discount_value >= 0.
+3. Renamed/dropped columns reflected in seed data:
+   - None.
+4. New tables evaluated for seed rows:
+   - None.
+5. Enum/allowed-value changes validated in seed rows:
+   - Uses existing `referral` enum member from prior revision.
+6. FK/cascade changes validated for insert order and references:
+   - None.
+
+Result: No seed updates are required for this migration.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0025_discount_codes_value_check"
+down_revision: Union[str, None] = "0024_discount_referral_add_enum"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "discount_codes_positive_value",
+        "discount_codes",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "discount_codes_value_by_type",
+        "discount_codes",
+        "(discount_type = 'referral' AND discount_value >= 0) "
+        "OR (discount_type <> 'referral' AND discount_value > 0)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "discount_codes_value_by_type",
+        "discount_codes",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "discount_codes_positive_value",
+        "discount_codes",
+        "discount_value > 0",
+    )

--- a/backend/src/app/api/admin_discount_codes.py
+++ b/backend/src/app/api/admin_discount_codes.py
@@ -18,12 +18,17 @@ from app.api.admin_services_common import (
     request_id,
     serialize_discount_code,
 )
-from app.api.admin_services_payloads import ensure_discount_validity_window
+from app.api.admin_services_payloads import (
+    REFERRAL_DEFAULT_CURRENCY,
+    REFERRAL_DEFAULT_DISCOUNT_VALUE,
+    ensure_discount_validity_window,
+)
 from app.api.discount_scope_validation import ensure_discount_code_scope
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.models import DiscountCode
+from app.db.models.enums import DiscountType
 from app.db.repositories import DiscountCodeRepository
 from app.exceptions import NotFoundError, ValidationError
 from app.utils import json_response
@@ -215,6 +220,15 @@ def _update_discount_code(
             payload["valid_until"] if "valid_until" in payload else code.valid_until
         )
         ensure_discount_validity_window(merged_from, merged_until)
+
+        effective_type = (
+            payload["discount_type"]
+            if "discount_type" in payload
+            else code.discount_type
+        )
+        if effective_type == DiscountType.REFERRAL:
+            payload["discount_value"] = REFERRAL_DEFAULT_DISCOUNT_VALUE
+            payload["currency"] = REFERRAL_DEFAULT_CURRENCY
 
         if "description" in payload:
             code.description = payload["description"]

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
 from app.api.admin_request import query_param
@@ -51,6 +52,9 @@ _MAX_CODE_LENGTH = 50
 _SERVICE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _MAX_SERVICE_SLUG_LENGTH = 80
 logger = get_logger(__name__)
+
+REFERRAL_DEFAULT_DISCOUNT_VALUE = Decimal("0")
+REFERRAL_DEFAULT_CURRENCY = "HKD"
 
 
 def parse_optional_service_slug(value: Any, field: str) -> str | None:
@@ -474,6 +478,17 @@ def parse_create_discount_code_payload(body: Mapping[str, Any]) -> dict[str, Any
     )
     valid_from = parse_optional_datetime(body.get("valid_from"), "valid_from")
     valid_until = parse_optional_datetime(body.get("valid_until"), "valid_until")
+    if discount_type == DiscountType.REFERRAL:
+        raw_dv = body.get("discount_value")
+        if raw_dv is not None and str(raw_dv).strip() != "":
+            parse_optional_decimal(raw_dv, "discount_value")
+        discount_value = REFERRAL_DEFAULT_DISCOUNT_VALUE
+        currency = REFERRAL_DEFAULT_CURRENCY
+    else:
+        discount_value = parse_required_decimal(
+            body.get("discount_value"), "discount_value"
+        )
+        currency = parse_optional_currency(body.get("currency"), "currency")
     payload = {
         "code": parse_required_text(
             body.get("code"), "code", max_length=_MAX_CODE_LENGTH
@@ -482,10 +497,8 @@ def parse_create_discount_code_payload(body: Mapping[str, Any]) -> dict[str, Any
             body.get("description"), max_length=MAX_DESCRIPTION_LENGTH
         ),
         "discount_type": discount_type,
-        "discount_value": parse_required_decimal(
-            body.get("discount_value"), "discount_value"
-        ),
-        "currency": parse_optional_currency(body.get("currency"), "currency"),
+        "discount_value": discount_value,
+        "currency": currency,
         "valid_from": valid_from,
         "valid_until": valid_until,
         "service_id": parse_optional_uuid(body.get("service_id"), "service_id"),
@@ -544,6 +557,9 @@ def parse_update_discount_code_payload(body: Mapping[str, Any]) -> dict[str, Any
         payload["active"] = parse_required_bool(body.get("active"), "active")
     if not payload:
         raise ValidationError("At least one updatable field is required", field="body")
+    if payload.get("discount_type") == DiscountType.REFERRAL:
+        payload["discount_value"] = REFERRAL_DEFAULT_DISCOUNT_VALUE
+        payload["currency"] = REFERRAL_DEFAULT_CURRENCY
     return payload
 
 

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -478,6 +478,8 @@ def parse_create_discount_code_payload(body: Mapping[str, Any]) -> dict[str, Any
     )
     valid_from = parse_optional_datetime(body.get("valid_from"), "valid_from")
     valid_until = parse_optional_datetime(body.get("valid_until"), "valid_until")
+    discount_value: Decimal
+    currency: str | None
     if discount_type == DiscountType.REFERRAL:
         raw_dv = body.get("discount_value")
         if raw_dv is not None and str(raw_dv).strip() != "":

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -53,6 +53,7 @@ _SERVICE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _MAX_SERVICE_SLUG_LENGTH = 80
 logger = get_logger(__name__)
 
+# Sibling defaults: admin_web `REFERRAL_DEFAULT_*` in `apps/admin_web/src/types/services.ts`.
 REFERRAL_DEFAULT_DISCOUNT_VALUE = Decimal("0")
 REFERRAL_DEFAULT_CURRENCY = "HKD"
 
@@ -481,9 +482,6 @@ def parse_create_discount_code_payload(body: Mapping[str, Any]) -> dict[str, Any
     discount_value: Decimal
     currency: str | None
     if discount_type == DiscountType.REFERRAL:
-        raw_dv = body.get("discount_value")
-        if raw_dv is not None and str(raw_dv).strip() != "":
-            parse_optional_decimal(raw_dv, "discount_value")
         discount_value = REFERRAL_DEFAULT_DISCOUNT_VALUE
         currency = REFERRAL_DEFAULT_CURRENCY
     else:

--- a/backend/src/app/api/public_discount_validate.py
+++ b/backend/src/app/api/public_discount_validate.py
@@ -87,7 +87,21 @@ def handle_public_discount_validate(
 
         repository = DiscountCodeRepository(session)
         row = repository.get_by_code(code)
-        if row is None or not _is_usable_now(row):
+        if row is None:
+            return json_response(
+                404,
+                {"error": "Discount code not found or inactive"},
+                event=event,
+            )
+
+        if row.discount_type == DiscountType.REFERRAL:
+            return json_response(
+                404,
+                {"error": "Discount code not found or inactive"},
+                event=event,
+            )
+
+        if not _is_usable_now(row):
             return json_response(
                 404,
                 {"error": "Discount code not found or inactive"},
@@ -99,13 +113,6 @@ def handle_public_discount_validate(
             resolved_request_service_id=resolved_service_id,
             request_instance_id=service_instance_id_body,
         ):
-            return json_response(
-                404,
-                {"error": "Discount code not found or inactive"},
-                event=event,
-            )
-
-        if row.discount_type == DiscountType.REFERRAL:
             return json_response(
                 404,
                 {"error": "Discount code not found or inactive"},

--- a/backend/src/app/api/public_discount_validate.py
+++ b/backend/src/app/api/public_discount_validate.py
@@ -105,6 +105,13 @@ def handle_public_discount_validate(
                 event=event,
             )
 
+        if row.discount_type == DiscountType.REFERRAL:
+            return json_response(
+                404,
+                {"error": "Discount code not found or inactive"},
+                event=event,
+            )
+
         rule = _discount_rule_payload(row)
         return json_response(
             200,

--- a/backend/src/app/db/models/discount_code.py
+++ b/backend/src/app/db/models/discount_code.py
@@ -41,8 +41,9 @@ class DiscountCode(Base):
         Index("discount_codes_service_idx", "service_id"),
         Index("discount_codes_instance_idx", "instance_id"),
         CheckConstraint(
-            "discount_value > 0",
-            name="discount_codes_positive_value",
+            "(discount_type = 'referral' AND discount_value >= 0) "
+            "OR (discount_type <> 'referral' AND discount_value > 0)",
+            name="discount_codes_value_by_type",
         ),
     )
 

--- a/backend/src/app/db/models/enums.py
+++ b/backend/src/app/db/models/enums.py
@@ -232,6 +232,7 @@ class DiscountType(str, enum.Enum):
 
     PERCENTAGE = "percentage"
     ABSOLUTE = "absolute"
+    REFERRAL = "referral"
 
 
 class EnrollmentStatus(str, enum.Enum):

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3064,7 +3064,11 @@ components:
       enum: [scheduled, open, full, in_progress, completed, cancelled]
     DiscountType:
       type: string
-      enum: [percentage, absolute]
+      enum: [percentage, absolute, referral]
+      description: |
+        Discount type. `referral` codes are tracking-only: the server always
+        coerces `discount_value` to "0" and `currency` to "HKD", and the public
+        discount-validate endpoint rejects referral codes.
     EnrollmentStatus:
       type: string
       enum: [registered, waitlisted, confirmed, cancelled, completed]
@@ -3800,9 +3804,13 @@ components:
           $ref: "#/components/schemas/DiscountType"
         discount_value:
           type: string
+          description: >
+            For `referral` type this value is ignored; the server coerces it to "0".
         currency:
           type: string
           nullable: true
+          description: >
+            For `referral` type this is ignored; the server coerces it to "HKD".
         valid_from:
           type: string
           format: date-time
@@ -3836,9 +3844,13 @@ components:
           $ref: "#/components/schemas/DiscountType"
         discount_value:
           type: string
+          description: >
+            For `referral` type this value is ignored; the server coerces it to "0".
         currency:
           type: string
           nullable: true
+          description: >
+            For `referral` type this is ignored; the server coerces it to "HKD".
         valid_from:
           type: string
           format: date-time

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3805,12 +3805,14 @@ components:
         discount_value:
           type: string
           description: >
-            For `referral` type this value is ignored; the server coerces it to "0".
+            For `referral` type the server coerces this to "0"; client-supplied
+            values are ignored (including malformed strings).
         currency:
           type: string
           nullable: true
           description: >
-            For `referral` type this is ignored; the server coerces it to "HKD".
+            For `referral` type the server coerces this to "HKD"; client-supplied
+            values are ignored.
         valid_from:
           type: string
           format: date-time
@@ -3845,12 +3847,14 @@ components:
         discount_value:
           type: string
           description: >
-            For `referral` type this value is ignored; the server coerces it to "0".
+            When the resulting type is `referral`, the server coerces this to "0";
+            client-supplied values are ignored.
         currency:
           type: string
           nullable: true
           description: >
-            For `referral` type this is ignored; the server coerces it to "HKD".
+            When the resulting type is `referral`, the server coerces this to "HKD";
+            client-supplied values are ignored.
         valid_from:
           type: string
           format: date-time

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -40,7 +40,7 @@ Seed data lives in `backend/db/seed/seed_data.sql`.
 - Enum `consultation_pricing_model`: `free`, `hourly`, `package`.
 - Enum `instance_status`: `scheduled`, `open`, `full`, `in_progress`,
   `completed`, `cancelled`.
-- Enum `discount_type`: `percentage`, `absolute`.
+- Enum `discount_type`: `percentage`, `absolute`, `referral`.
 - Enum `enrollment_status`: `registered`, `waitlisted`, `confirmed`,
   `cancelled`, `completed`.
 - Enum `expense_status`: `draft`, `submitted`, `paid`, `voided`, `amended`.
@@ -396,8 +396,10 @@ Indexes:
 ### `discount_codes`
 
 - Global, service-scoped, or instance-scoped promo codes.
-- Supports `percentage` and `absolute` discount types with usage limits and
-  optional validity windows.
+- Supports `percentage`, `absolute`, and `referral` discount types with usage
+  limits and optional validity windows.
+- Check constraint `discount_codes_value_by_type`: referral rows require
+  `discount_value >= 0`; non-referral rows require `discount_value > 0`.
 
 ### `enrollments`
 

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -400,6 +400,9 @@ Indexes:
   limits and optional validity windows.
 - Check constraint `discount_codes_value_by_type`: referral rows require
   `discount_value >= 0`; non-referral rows require `discount_value > 0`.
+- Migrations `0024_discount_referral_add_enum` (add enum label only) and
+  `0025_discount_codes_value_check` (replace CHECK) are split because PostgreSQL
+  does not allow referencing a newly added enum value in the same transaction.
 
 ### `enrollments`
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -60,7 +60,9 @@ their primary responsibilities.
   and `GET /v1/assets/free`,
   plus public website proxy routes including
   `/www/v1/discounts/validate` (native Aurora-backed discount validation; optional
-  `service_key` is resolved case-insensitively against `services.slug` in Aurora),
+  `service_key` is resolved case-insensitively against `services.slug` in Aurora;
+  codes with `discount_type` `referral` are rejected with the same 404 envelope as
+  unknown/inactive codes),
   `/www/v1/contact-us`, `/www/v1/reservations`,
   `/www/v1/calendar/public` (event instances include optional `slug` and
   `landing_page` from `service_instances`, and `spaces_total` / `spaces_left`

--- a/tests/test_admin_discount_codes_api.py
+++ b/tests/test_admin_discount_codes_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
@@ -9,10 +10,15 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from sqlalchemy.exc import IntegrityError
-
 from app.api import admin_discount_codes
-from app.api.admin_services_payloads import ensure_discount_validity_window
+from app.api.admin_services_payloads import (
+    REFERRAL_DEFAULT_CURRENCY,
+    REFERRAL_DEFAULT_DISCOUNT_VALUE,
+    ensure_discount_validity_window,
+    parse_create_discount_code_payload,
+    parse_update_discount_code_payload,
+)
+from app.db.models.enums import DiscountType
 from app.exceptions import ValidationError
 
 
@@ -121,3 +127,107 @@ def test_is_discount_code_unique_violation_false_for_other_constraint() -> None:
 
     exc = IntegrityError("stmt", {}, _FakeOrig())
     assert admin_discount_codes._is_discount_code_unique_violation(exc) is False
+
+
+def test_parse_create_discount_code_referral_coerces_value_and_currency() -> None:
+    payload = parse_create_discount_code_payload(
+        {
+            "code": "REF1",
+            "discount_type": "referral",
+            "discount_value": "99",
+            "currency": "USD",
+        }
+    )
+    assert payload["discount_type"] == DiscountType.REFERRAL
+    assert payload["discount_value"] == REFERRAL_DEFAULT_DISCOUNT_VALUE
+    assert payload["currency"] == REFERRAL_DEFAULT_CURRENCY
+
+
+def test_parse_create_discount_code_referral_accepts_missing_currency() -> None:
+    payload = parse_create_discount_code_payload(
+        {
+            "code": "REF2",
+            "discount_type": "referral",
+            "discount_value": "0",
+        }
+    )
+    assert payload["currency"] == REFERRAL_DEFAULT_CURRENCY
+
+
+def test_parse_update_discount_code_referral_type_coerces() -> None:
+    payload = parse_update_discount_code_payload(
+        {"discount_type": "referral", "discount_value": "50"}
+    )
+    assert payload["discount_type"] == DiscountType.REFERRAL
+    assert payload["discount_value"] == REFERRAL_DEFAULT_DISCOUNT_VALUE
+    assert payload["currency"] == REFERRAL_DEFAULT_CURRENCY
+
+
+def test_update_discount_code_clamps_partial_payload_for_existing_referral(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    code_id = uuid4()
+    row = SimpleNamespace(
+        id=code_id,
+        description=None,
+        discount_type=DiscountType.REFERRAL,
+        discount_value=Decimal("0"),
+        currency="HKD",
+        valid_from=None,
+        valid_until=None,
+        service_id=None,
+        instance_id=None,
+        max_uses=None,
+        active=True,
+    )
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id(self, _id: Any) -> Any:
+            return row
+
+        def update(self, entity: Any) -> Any:
+            return entity
+
+    monkeypatch.setattr(admin_discount_codes, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_discount_codes, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_discount_codes, "parse_body", lambda _e: {})
+    monkeypatch.setattr(
+        admin_discount_codes,
+        "parse_update_discount_code_payload",
+        lambda _body: {"discount_value": Decimal("25")},
+    )
+    monkeypatch.setattr(admin_discount_codes, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(admin_discount_codes, "ensure_discount_code_scope", lambda *_a, **_k: None)
+    monkeypatch.setattr(admin_discount_codes, "DiscountCodeRepository", _FakeRepo)
+    monkeypatch.setattr(
+        admin_discount_codes,
+        "serialize_discount_code",
+        lambda _c: {"id": str(code_id)},
+    )
+
+    admin_discount_codes._update_discount_code(
+        api_gateway_event(method="PUT", path=f"/v1/admin/discount-codes/{code_id}"),
+        code_id=code_id,
+        actor_sub="sub-1",
+    )
+
+    assert row.discount_value == REFERRAL_DEFAULT_DISCOUNT_VALUE
+    assert row.currency == REFERRAL_DEFAULT_CURRENCY

--- a/tests/test_admin_enrollments_api.py
+++ b/tests/test_admin_enrollments_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 from uuid import uuid4
 
@@ -81,3 +82,106 @@ def test_create_enrollment_rejects_invalid_or_exhausted_discount_code(
             instance_id=instance_id,
             actor_sub="test-admin-sub-12345",
         )
+
+
+def test_create_enrollment_with_discount_code_calls_validate_and_increment(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    instance_id = uuid4()
+    discount_code_id = uuid4()
+    contact_id = uuid4()
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    validate_calls: list[Any] = []
+
+    class _FakeDiscountCodeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def validate_and_increment(self, code_id: Any) -> bool:
+            validate_calls.append(code_id)
+            return True
+
+    created_holder: dict[str, Any] = {}
+
+    class _FakeEnrollment:
+        def __init__(self, **kwargs: Any) -> None:
+            self.__dict__.update(kwargs)
+
+    class _FakeEnrollmentRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def create_enrollment(self, enrollment: Any) -> Any:
+            created_holder["discount_code_id"] = enrollment.discount_code_id
+            created_holder["amount_paid"] = enrollment.amount_paid
+            return enrollment
+
+    monkeypatch.setattr(admin_enrollments, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_enrollments, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_enrollments, "set_audit_context", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        admin_enrollments,
+        "parse_body",
+        lambda _event: json.loads(_event["body"]),
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
+        "parse_create_enrollment_payload",
+        lambda _body: {
+            "contact_id": contact_id,
+            "family_id": None,
+            "organization_id": None,
+            "ticket_tier_id": None,
+            "discount_code_id": discount_code_id,
+            "status": EnrollmentStatus.REGISTERED,
+            "amount_paid": None,
+            "currency": None,
+            "notes": None,
+        },
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
+        "DiscountCodeRepository",
+        _FakeDiscountCodeRepository,
+    )
+    monkeypatch.setattr(admin_enrollments, "Enrollment", _FakeEnrollment)
+    monkeypatch.setattr(
+        admin_enrollments,
+        "EnrollmentRepository",
+        _FakeEnrollmentRepository,
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
+        "serialize_enrollment",
+        lambda e: {"id": "new-1", "discount_code_id": str(e.discount_code_id)},
+    )
+
+    response = admin_enrollments._create_enrollment(
+        api_gateway_event(
+            method="POST",
+            path="/v1/admin/services/x/instances/y/enrollments",
+            body=json.dumps({"contact_id": str(contact_id), "discount_code_id": str(discount_code_id)}),
+        ),
+        instance_id=instance_id,
+        actor_sub="test-admin-sub-12345",
+    )
+
+    assert response["statusCode"] == 201
+    assert validate_calls == [discount_code_id]
+    assert created_holder["discount_code_id"] == discount_code_id
+    assert created_holder["amount_paid"] is None

--- a/tests/test_public_discount_validate_api.py
+++ b/tests/test_public_discount_validate_api.py
@@ -212,6 +212,123 @@ def test_public_discount_validate_returns_rule_for_absolute_discount(
     assert body["data"]["currency_symbol"] == "HK$"
 
 
+def test_public_discount_validate_returns_404_for_referral_type_when_active(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    row = SimpleNamespace(
+        id=uuid4(),
+        code="REFTRACK",
+        description=None,
+        discount_type=DiscountType.REFERRAL,
+        discount_value=Decimal("0.00"),
+        currency="HKD",
+        active=True,
+        valid_from=None,
+        valid_until=None,
+        max_uses=None,
+        current_uses=0,
+        service_id=None,
+        instance_id=None,
+    )
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_code(self, code: str) -> Any:
+            assert code.strip().lower() == "reftrack"
+            return row
+
+    monkeypatch.setattr(public_discount_validate, "Session", _SessionCtx)
+    monkeypatch.setattr(public_discount_validate, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        public_discount_validate,
+        "DiscountCodeRepository",
+        _FakeRepository,
+    )
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/discounts/validate",
+        body=json.dumps({"code": "REFTRACK"}),
+    )
+    response = public_discount_validate.handle_public_discount_validate(event, "POST")
+    assert response["statusCode"] == 404
+    body = json.loads(response["body"])
+    assert body["error"] == "Discount code not found or inactive"
+
+
+def test_public_discount_validate_returns_404_for_referral_type_when_inactive(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    row = SimpleNamespace(
+        id=uuid4(),
+        code="REFOFF",
+        description=None,
+        discount_type=DiscountType.REFERRAL,
+        discount_value=Decimal("0.00"),
+        currency="HKD",
+        active=False,
+        valid_from=None,
+        valid_until=None,
+        max_uses=None,
+        current_uses=0,
+        service_id=None,
+        instance_id=None,
+    )
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_code(self, _code: str) -> Any:
+            return row
+
+    monkeypatch.setattr(public_discount_validate, "Session", _SessionCtx)
+    monkeypatch.setattr(public_discount_validate, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        public_discount_validate,
+        "DiscountCodeRepository",
+        _FakeRepository,
+    )
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/discounts/validate",
+        body=json.dumps({"code": "REFOFF"}),
+    )
+    response = public_discount_validate.handle_public_discount_validate(event, "POST")
+    assert response["statusCode"] == 404
+
+
 def test_public_discount_validate_returns_404_when_inactive(
     monkeypatch: Any,
     api_gateway_event: Any,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change introduces a third admin discount type, `referral`, that is tracking-only on the public site: the public validate endpoint returns the same 404 shape as an unknown code, while admin flows still create codes and attach them to enrollments with `validate_and_increment` updating `current_uses`.

## Details

- **Database:** Alembic `0024_discount_referral_type` adds enum value `referral` and replaces `discount_codes_positive_value` with `discount_codes_value_by_type` so referral rows may use `discount_value >= 0` and other types remain strictly positive.
- **Backend:** Create/update payloads coerce referral codes to `discount_value = 0` and `currency = HKD`; partial updates on existing referral rows are clamped in the admin handler. Public `POST /v1/discounts/validate` rejects referral rows after scope checks.
- **Admin web:** `DISCOUNT_TYPES` includes referral; the inline editor forces defaults and disables value/currency; the table shows **Referral** via `formatDiscountRowValue`. The referral QR dialog derives `ref` vs `discount` from the row type and removes the URL-parameter selector (logo checkbox moved beside locale).
- **Docs:** `docs/api/admin.yaml`, `database-schema.md`, and `lambdas.md` updated accordingly.
- **Tests:** Backend coverage for payloads, validate, enrollments; Vitest for panel, dialog, row formatting, and table display.

## Notes

- `apps/admin_web/src/components/admin/services/create-discount-code-dialog.tsx` remains unused; no change (per plan, optional future cleanup).
- Seed SQL: no `discount_codes` rows in seed; no seed update required.

## Validation

- `pre-commit run ruff-format --all-files`
- `pytest` on touched backend test modules
- `cd apps/admin_web && npm run lint && npm run test`
- `cd apps/public_www && npm run test`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b89cf0f4-c125-4661-91f3-d0c7fa8457cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b89cf0f4-c125-4661-91f3-d0c7fa8457cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

