### PR TITLE
Admin referral QR: branding toggle and larger logo

### DIFF
--- a/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
@@ -37,6 +37,7 @@ export function ReferralLinkQrDialog({
   const [locale, setLocale] = useState<MyBestAuntieReferralLocale>('en');
   const paramName: ReferralParamName = discountType === 'referral' ? 'ref' : 'discount';
   const [includeLogoInQr, setIncludeLogoInQr] = useState(true);
+  const [applyBranding, setApplyBranding] = useState(true);
   const [previewDataUrl, setPreviewDataUrl] = useState('');
   const [isRenderingPreview, setIsRenderingPreview] = useState(false);
   const [renderError, setRenderError] = useState('');
@@ -79,6 +80,7 @@ export function ReferralLinkQrDialog({
         url: builtUrl,
         size: 220,
         logoSrc,
+        applyBranding,
       })
         .then((dataUrl) => {
           if (!cancelled) {
@@ -100,7 +102,7 @@ export function ReferralLinkQrDialog({
     return () => {
       cancelled = true;
     };
-  }, [builtUrl, includeLogoInQr, open]);
+  }, [applyBranding, builtUrl, includeLogoInQr, open]);
 
   async function downloadPng(size: number) {
     if (!builtUrl) {
@@ -111,6 +113,7 @@ export function ReferralLinkQrDialog({
       url: builtUrl,
       size,
       logoSrc,
+      applyBranding,
     });
     const response = await fetch(dataUrl);
     const blob = await response.blob();
@@ -170,18 +173,33 @@ export function ReferralLinkQrDialog({
             <Label aria-hidden='true' className='invisible mb-1 block select-none'>
               {' '}
             </Label>
-            <div className='flex items-center gap-2'>
-              <input
-                id='referral-qr-include-logo'
-                type='checkbox'
-                className='h-4 w-4 rounded border-slate-300 text-slate-900'
-                checked={includeLogoInQr}
-                onChange={(event) => setIncludeLogoInQr(event.target.checked)}
-                disabled={Boolean(configError)}
-              />
-              <Label htmlFor='referral-qr-include-logo' className='mb-0 cursor-pointer font-normal'>
-                Include logo in QR code
-              </Label>
+            <div className='space-y-2'>
+              <div className='flex items-center gap-2'>
+                <input
+                  id='referral-qr-include-logo'
+                  type='checkbox'
+                  className='h-4 w-4 rounded border-slate-300 text-slate-900'
+                  checked={includeLogoInQr}
+                  onChange={(event) => setIncludeLogoInQr(event.target.checked)}
+                  disabled={Boolean(configError)}
+                />
+                <Label htmlFor='referral-qr-include-logo' className='mb-0 cursor-pointer font-normal'>
+                  Include logo in QR code
+                </Label>
+              </div>
+              <div className='flex items-center gap-2'>
+                <input
+                  id='referral-qr-apply-branding'
+                  type='checkbox'
+                  className='h-4 w-4 rounded border-slate-300 text-slate-900'
+                  checked={applyBranding}
+                  onChange={(event) => setApplyBranding(event.target.checked)}
+                  disabled={Boolean(configError)}
+                />
+                <Label htmlFor='referral-qr-apply-branding' className='mb-0 cursor-pointer font-normal'>
+                  Apply branding
+                </Label>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/admin_web/src/lib/qr-code-image.ts
+++ b/apps/admin_web/src/lib/qr-code-image.ts
@@ -1,7 +1,7 @@
 import QRCode from 'qrcode';
 import type { QRCode as QrModel } from 'qrcode';
 
-/** Matches public site primary CTA (`apps/public_www/src/app/styles/original/base.css`). */
+/** Matches public site `--es-color-brand-orange` (`apps/public_www/src/app/styles/original/base.css`). */
 export const PUBLIC_SITE_PRIMARY_ORANGE = '#C84A16';
 
 export interface GenerateReferralQrPngDataUrlInput {
@@ -140,8 +140,9 @@ function getAlignmentRowColCoords(version: number): number[] {
   return positions.reverse();
 }
 
+/** Each entry is `[row, col]` — indices for `qr.modules.get(row, col)` (row first). */
 function getAlignmentPatternCenters(version: number): [number, number][] {
-  const coords: [number, number][] = [];
+  const centers: [number, number][] = [];
   const pos = getAlignmentRowColCoords(version);
   const posLength = pos.length;
   for (let i = 0; i < posLength; i += 1) {
@@ -153,10 +154,10 @@ function getAlignmentPatternCenters(version: number): [number, number][] {
       ) {
         continue;
       }
-      coords.push([pos[i]!, pos[j]!]);
+      centers.push([pos[i]!, pos[j]!]);
     }
   }
-  return coords;
+  return centers;
 }
 
 function drawBrandedQrModules(
@@ -189,10 +190,10 @@ function drawBrandedQrModules(
   }
 
   const alignmentOrigin = new Set<string>();
-  for (const [cx, cy] of alignmentCenters) {
+  for (const [row, col] of alignmentCenters) {
     for (let dr = -2; dr <= 2; dr += 1) {
       for (let dc = -2; dc <= 2; dc += 1) {
-        alignmentOrigin.add(`${cy + dr},${cx + dc}`);
+        alignmentOrigin.add(`${row + dr},${col + dc}`);
       }
     }
   }
@@ -205,9 +206,9 @@ function drawBrandedQrModules(
     drawFinderBlock(ctx, px, py, modulePx, dark, light);
   }
 
-  for (const [cx, cy] of alignmentCenters) {
-    const px = (cx - 2 + margin) * modulePx;
-    const py = (cy - 2 + margin) * modulePx;
+  for (const [row, col] of alignmentCenters) {
+    const px = (col - 2 + margin) * modulePx;
+    const py = (row - 2 + margin) * modulePx;
     drawAlignmentBlock(ctx, px, py, modulePx, dark, light);
   }
 
@@ -228,9 +229,20 @@ function drawBrandedQrModules(
   }
 }
 
+function canvasToPngDataUrl(canvas: HTMLCanvasElement): string {
+  try {
+    return canvas.toDataURL('image/png');
+  } catch {
+    throw new Error(
+      'Could not export QR image. If the logo loads from another origin, enable CORS or use a same-origin asset.',
+    );
+  }
+}
+
 async function loadImageElement(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const image = new Image();
+    image.crossOrigin = 'anonymous';
     image.onload = () => {
       resolve(image);
     };
@@ -375,7 +387,7 @@ export async function generateReferralQrPngDataUrl(
 
   const logoSrc = input.logoSrc?.trim() ?? '';
   if (!logoSrc) {
-    return canvas.toDataURL('image/png');
+    return canvasToPngDataUrl(canvas);
   }
 
   const logoSize = Math.round(input.size * 0.2);
@@ -395,5 +407,5 @@ export async function generateReferralQrPngDataUrl(
     'naturalHeight' in image && typeof image.naturalHeight === 'number' ? image.naturalHeight : image.height;
   drawLogoTrimmedToCanvas(ctx, image, naturalW, naturalH, centerX, centerY, logoSize);
 
-  return canvas.toDataURL('image/png');
+  return canvasToPngDataUrl(canvas);
 }

--- a/apps/admin_web/src/lib/qr-code-image.ts
+++ b/apps/admin_web/src/lib/qr-code-image.ts
@@ -1,10 +1,342 @@
 import QRCode from 'qrcode';
+import type { QRCode as QrModel } from 'qrcode';
+
+/** Matches public site primary CTA (`apps/public_www/src/app/styles/original/base.css`). */
+export const PUBLIC_SITE_PRIMARY_ORANGE = '#C84A16';
 
 export interface GenerateReferralQrPngDataUrlInput {
   url: string;
   size: number;
   /** When omitted or empty, the QR is generated without a centered logo. */
   logoSrc?: string;
+  /** When true, modules use brand orange and rounded module corners. Default true. */
+  applyBranding?: boolean;
+}
+
+function parseHexRgb(hex: string): { r: number; g: number; b: number } {
+  const normalized = hex.trim().replace(/^#/, '');
+  if (normalized.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    throw new Error(`Invalid hex color: ${hex}`);
+  }
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+  };
+}
+
+function fillRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  radius: number,
+): void {
+  const r = Math.min(radius, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+  ctx.fill();
+}
+
+const FINDER_PATTERN_GRID: number[][] = [
+  [1, 1, 1, 1, 1, 1, 1],
+  [1, 0, 0, 0, 0, 0, 1],
+  [1, 0, 1, 1, 1, 0, 1],
+  [1, 0, 1, 1, 1, 0, 1],
+  [1, 0, 1, 1, 1, 0, 1],
+  [1, 0, 0, 0, 0, 0, 1],
+  [1, 1, 1, 1, 1, 1, 1],
+];
+
+const ALIGNMENT_PATTERN_GRID: number[][] = [
+  [0, 0, 1, 0, 0],
+  [0, 1, 1, 1, 0],
+  [1, 1, 1, 1, 1],
+  [0, 1, 1, 1, 0],
+  [0, 0, 1, 0, 0],
+];
+
+function drawFinderBlock(
+  ctx: CanvasRenderingContext2D,
+  originX: number,
+  originY: number,
+  modulePx: number,
+  dark: string,
+  light: string,
+): void {
+  for (let r = 0; r < 7; r += 1) {
+    for (let c = 0; c < 7; c += 1) {
+      const v = FINDER_PATTERN_GRID[r]?.[c] ?? 0;
+      if (!v) {
+        continue;
+      }
+      const x = originX + c * modulePx;
+      const y = originY + r * modulePx;
+      const isOuter = r === 0 || r === 6 || c === 0 || c === 6;
+      const isInnerEye = r >= 2 && r <= 4 && c >= 2 && c <= 4;
+      ctx.fillStyle = isOuter || isInnerEye ? dark : light;
+      const cornerR = modulePx * 0.35;
+      fillRoundedRect(ctx, x, y, modulePx, modulePx, cornerR);
+    }
+  }
+}
+
+function drawAlignmentBlock(
+  ctx: CanvasRenderingContext2D,
+  originX: number,
+  originY: number,
+  modulePx: number,
+  dark: string,
+  light: string,
+): void {
+  for (let r = 0; r < 5; r += 1) {
+    for (let c = 0; c < 5; c += 1) {
+      const v = ALIGNMENT_PATTERN_GRID[r]?.[c] ?? 0;
+      if (!v) {
+        continue;
+      }
+      const x = originX + c * modulePx;
+      const y = originY + r * modulePx;
+      const isCenterCross = r === 2 || c === 2;
+      ctx.fillStyle = isCenterCross ? dark : light;
+      const cornerR = modulePx * 0.35;
+      fillRoundedRect(ctx, x, y, modulePx, modulePx, cornerR);
+    }
+  }
+}
+
+function getSymbolSize(version: number): number {
+  return version * 4 + 17;
+}
+
+function getFinderPatternPositions(version: number): [number, number][] {
+  const size = getSymbolSize(version);
+  const finderSize = 7;
+  return [
+    [0, 0],
+    [size - finderSize, 0],
+    [0, size - finderSize],
+  ];
+}
+
+function getAlignmentRowColCoords(version: number): number[] {
+  if (version === 1) {
+    return [];
+  }
+  const posCount = Math.floor(version / 7) + 2;
+  const size = getSymbolSize(version);
+  const intervals = size === 145 ? 26 : Math.ceil((size - 13) / (2 * posCount - 2)) * 2;
+  const positions: number[] = [size - 7];
+  for (let i = 1; i < posCount - 1; i += 1) {
+    positions[i] = positions[i - 1]! - intervals;
+  }
+  positions.push(6);
+  return positions.reverse();
+}
+
+function getAlignmentPatternCenters(version: number): [number, number][] {
+  const coords: [number, number][] = [];
+  const pos = getAlignmentRowColCoords(version);
+  const posLength = pos.length;
+  for (let i = 0; i < posLength; i += 1) {
+    for (let j = 0; j < posLength; j += 1) {
+      if (
+        (i === 0 && j === 0) ||
+        (i === 0 && j === posLength - 1) ||
+        (i === posLength - 1 && j === 0)
+      ) {
+        continue;
+      }
+      coords.push([pos[i]!, pos[j]!]);
+    }
+  }
+  return coords;
+}
+
+function drawBrandedQrModules(
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  qr: QrModel,
+  size: number,
+  darkHex: string,
+): void {
+  const n = qr.modules.size;
+  const margin = 2;
+  const innerModules = n + margin * 2;
+  const modulePx = size / innerModules;
+  const light = '#ffffff';
+  const dark = darkHex;
+
+  ctx.fillStyle = light;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const finderPositions = getFinderPatternPositions(qr.version);
+  const alignmentCenters = getAlignmentPatternCenters(qr.version);
+
+  const finderOrigin = new Set<string>();
+  for (const [fr, fc] of finderPositions) {
+    for (let dr = 0; dr < 7; dr += 1) {
+      for (let dc = 0; dc < 7; dc += 1) {
+        finderOrigin.add(`${fr + dr},${fc + dc}`);
+      }
+    }
+  }
+
+  const alignmentOrigin = new Set<string>();
+  for (const [cx, cy] of alignmentCenters) {
+    for (let dr = -2; dr <= 2; dr += 1) {
+      for (let dc = -2; dc <= 2; dc += 1) {
+        alignmentOrigin.add(`${cy + dr},${cx + dc}`);
+      }
+    }
+  }
+
+  const moduleCornerR = modulePx * 0.42;
+
+  for (const [fr, fc] of finderPositions) {
+    const px = (fc + margin) * modulePx;
+    const py = (fr + margin) * modulePx;
+    drawFinderBlock(ctx, px, py, modulePx, dark, light);
+  }
+
+  for (const [cx, cy] of alignmentCenters) {
+    const px = (cx - 2 + margin) * modulePx;
+    const py = (cy - 2 + margin) * modulePx;
+    drawAlignmentBlock(ctx, px, py, modulePx, dark, light);
+  }
+
+  for (let row = 0; row < n; row += 1) {
+    for (let col = 0; col < n; col += 1) {
+      const key = `${row},${col}`;
+      if (finderOrigin.has(key) || alignmentOrigin.has(key)) {
+        continue;
+      }
+      if (!qr.modules.get(row, col)) {
+        continue;
+      }
+      const x = (col + margin) * modulePx;
+      const y = (row + margin) * modulePx;
+      ctx.fillStyle = dark;
+      fillRoundedRect(ctx, x, y, modulePx, modulePx, moduleCornerR);
+    }
+  }
+}
+
+async function loadImageElement(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => {
+      resolve(image);
+    };
+    image.onerror = () => {
+      reject(new Error('Failed to load logo image'));
+    };
+    image.src = src;
+  });
+}
+
+/**
+ * Crop uniform transparent (or near-white) margins from an image by sampling edges.
+ */
+function drawLogoTrimmedToCanvas(
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImageSource,
+  sourceWidth: number,
+  sourceHeight: number,
+  destX: number,
+  destY: number,
+  destSize: number,
+): void {
+  const probe = document.createElement('canvas');
+  const maxProbe = 256;
+  const scale = Math.min(1, maxProbe / Math.max(sourceWidth, sourceHeight));
+  const w = Math.max(1, Math.round(sourceWidth * scale));
+  const h = Math.max(1, Math.round(sourceHeight * scale));
+  probe.width = w;
+  probe.height = h;
+  const pctx = probe.getContext('2d', { willReadFrequently: true });
+  if (!pctx) {
+    ctx.drawImage(image, destX, destY, destSize, destSize);
+    return;
+  }
+  pctx.drawImage(image, 0, 0, sourceWidth, sourceHeight, 0, 0, w, h);
+  let data: ImageData;
+  try {
+    data = pctx.getImageData(0, 0, w, h);
+  } catch {
+    ctx.drawImage(image, destX, destY, destSize, destSize);
+    return;
+  }
+
+  const pixels = data.data;
+  const isBackground = (idx: number) => {
+    const a = pixels[idx + 3] ?? 255;
+    if (a < 12) {
+      return true;
+    }
+    const r = pixels[idx] ?? 255;
+    const g = pixels[idx + 1] ?? 255;
+    const b = pixels[idx + 2] ?? 255;
+    return r > 245 && g > 245 && b > 245;
+  };
+
+  let top = 0;
+  let bottom = h - 1;
+  let left = 0;
+  let right = w - 1;
+
+  rowScan: for (let y = 0; y < h; y += 1) {
+    for (let x = 0; x < w; x += 1) {
+      if (!isBackground((y * w + x) * 4)) {
+        top = y;
+        break rowScan;
+      }
+    }
+  }
+
+  rowScan2: for (let y = h - 1; y >= 0; y -= 1) {
+    for (let x = 0; x < w; x += 1) {
+      if (!isBackground((y * w + x) * 4)) {
+        bottom = y;
+        break rowScan2;
+      }
+    }
+  }
+
+  colScan: for (let x = 0; x < w; x += 1) {
+    for (let y = top; y <= bottom; y += 1) {
+      if (!isBackground((y * w + x) * 4)) {
+        left = x;
+        break colScan;
+      }
+    }
+  }
+
+  colScan2: for (let x = w - 1; x >= 0; x -= 1) {
+    for (let y = top; y <= bottom; y += 1) {
+      if (!isBackground((y * w + x) * 4)) {
+        right = x;
+        break colScan2;
+      }
+    }
+  }
+
+  if (left > right || top > bottom) {
+    ctx.drawImage(image, destX, destY, destSize, destSize);
+    return;
+  }
+
+  const sx0 = left / scale;
+  const sy0 = top / scale;
+  const sw = Math.max(1, (right - left + 1) / scale);
+  const sh = Math.max(1, (bottom - top + 1) / scale);
+  ctx.drawImage(image, sx0, sy0, sw, sh, destX, destY, destSize, destSize);
 }
 
 /**
@@ -14,28 +346,40 @@ export interface GenerateReferralQrPngDataUrlInput {
 export async function generateReferralQrPngDataUrl(
   input: GenerateReferralQrPngDataUrlInput,
 ): Promise<string> {
+  const applyBranding = input.applyBranding !== false;
   const canvas = document.createElement('canvas');
   canvas.width = input.size;
   canvas.height = input.size;
-
-  await QRCode.toCanvas(canvas, input.url, {
-    errorCorrectionLevel: 'H',
-    margin: 2,
-    width: input.size,
-  });
-
-  const logoSrc = input.logoSrc?.trim() ?? '';
-  if (!logoSrc) {
-    return canvas.toDataURL('image/png');
-  }
 
   const ctx = canvas.getContext('2d');
   if (!ctx) {
     throw new Error('Canvas 2D context is not available');
   }
 
+  if (applyBranding) {
+    const qr = QRCode.create(input.url, { errorCorrectionLevel: 'H' });
+    const darkRgb = parseHexRgb(PUBLIC_SITE_PRIMARY_ORANGE);
+    const darkCss = `rgb(${darkRgb.r},${darkRgb.g},${darkRgb.b})`;
+    drawBrandedQrModules(ctx, canvas, qr, input.size, darkCss);
+  } else {
+    await QRCode.toCanvas(canvas, input.url, {
+      errorCorrectionLevel: 'H',
+      margin: 2,
+      width: input.size,
+      color: {
+        dark: '#000000',
+        light: '#ffffff',
+      },
+    });
+  }
+
+  const logoSrc = input.logoSrc?.trim() ?? '';
+  if (!logoSrc) {
+    return canvas.toDataURL('image/png');
+  }
+
   const logoSize = Math.round(input.size * 0.2);
-  const pad = 7;
+  const pad = 4;
   const centerX = Math.floor((input.size - logoSize) / 2);
   const centerY = Math.floor((input.size - logoSize) / 2);
   const padX = Math.round(pad);
@@ -44,21 +388,12 @@ export async function generateReferralQrPngDataUrl(
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(centerX - padX, centerY - padY, logoSize + padX * 2, logoSize + padY * 2);
 
-  await new Promise<void>((resolve, reject) => {
-    const image = new Image();
-    image.onload = () => {
-      try {
-        ctx.drawImage(image, centerX, centerY, logoSize, logoSize);
-        resolve();
-      } catch (error) {
-        reject(error instanceof Error ? error : new Error('Failed to draw logo'));
-      }
-    };
-    image.onerror = () => {
-      reject(new Error('Failed to load logo image'));
-    };
-    image.src = logoSrc;
-  });
+  const image = await loadImageElement(logoSrc);
+  const naturalW =
+    'naturalWidth' in image && typeof image.naturalWidth === 'number' ? image.naturalWidth : image.width;
+  const naturalH =
+    'naturalHeight' in image && typeof image.naturalHeight === 'number' ? image.naturalHeight : image.height;
+  drawLogoTrimmedToCanvas(ctx, image, naturalW, naturalH, centerX, centerY, logoSize);
 
   return canvas.toDataURL('image/png');
 }

--- a/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/referral-link-qr-dialog.test.tsx
@@ -123,6 +123,7 @@ describe('ReferralLinkQrDialog', () => {
 
     expect(generateSpy.mock.calls[0]?.[0]).toMatchObject({
       logoSrc: expect.stringMatching(/\/evolvesprouts-logo\.svg$/),
+      applyBranding: true,
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Download PNG (512)' }));
@@ -133,6 +134,31 @@ describe('ReferralLinkQrDialog', () => {
 
     createObjectUrlSpy.mockRestore();
     revokeSpy.mockRestore();
+  });
+
+  it('passes applyBranding true by default and false when branding is unchecked', async () => {
+    render(
+      <ReferralLinkQrDialog open onClose={() => {}} discountCode='ABC' serviceSlug={null} discountType='percentage' />,
+    );
+
+    await vi.waitFor(() => {
+      expect(generateSpy).toHaveBeenCalled();
+    });
+
+    expect(generateSpy.mock.calls[0]?.[0]).toMatchObject({
+      applyBranding: true,
+    });
+
+    generateSpy.mockClear();
+    fireEvent.click(screen.getByRole('checkbox', { name: /apply branding/i }));
+
+    await vi.waitFor(() => {
+      expect(generateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          applyBranding: false,
+        }),
+      );
+    });
   });
 
   it('omits logo from QR generation when include-logo is unchecked', async () => {
@@ -180,15 +206,17 @@ describe('ReferralLinkQrDialog', () => {
     expect(screen.queryByLabelText('URL parameter')).toBeNull();
   });
 
-  it('places include-logo checkbox in the same two-column grid as locale', () => {
+  it('places include-logo and apply-branding checkboxes in the same two-column grid as locale', () => {
     const { container } = render(
       <ReferralLinkQrDialog open onClose={() => {}} discountCode='X' serviceSlug={null} discountType='referral' />,
     );
-    const checkbox = screen.getByRole('checkbox', { name: /include logo in qr code/i });
+    const includeLogo = screen.getByRole('checkbox', { name: /include logo in qr code/i });
+    const applyBranding = screen.getByRole('checkbox', { name: /apply branding/i });
     const localeSelect = screen.getByLabelText('Locale');
     const grid = container.querySelector('.sm\\:grid-cols-2');
     expect(grid).toBeTruthy();
-    expect(grid?.contains(checkbox)).toBe(true);
+    expect(grid?.contains(includeLogo)).toBe(true);
+    expect(grid?.contains(applyBranding)).toBe(true);
     expect(grid?.contains(localeSelect)).toBe(true);
   });
 });

--- a/apps/admin_web/tests/lib/qr-code-image.test.ts
+++ b/apps/admin_web/tests/lib/qr-code-image.test.ts
@@ -4,18 +4,22 @@ const toCanvasMock = vi.fn(async (canvas: HTMLCanvasElement) => {
   void canvas;
 });
 
-vi.mock('qrcode', () => ({
-  default: {
-    toCanvas: (...args: unknown[]) => toCanvasMock(...args),
-  },
-}));
+vi.mock('qrcode', async () => {
+  const actual = await vi.importActual<typeof import('qrcode')>('qrcode');
+  return {
+    default: {
+      ...actual.default,
+      toCanvas: (...args: unknown[]) => toCanvasMock(...args),
+    },
+  };
+});
 
 describe('generateReferralQrPngDataUrl', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('draws QR first, white pad, then logo', async () => {
+  it('draws QR first, white pad, then logo when branding is off', async () => {
     const drawImageSpy = vi.fn();
     const fillRectSpy = vi.fn();
     const toDataURLSpy = vi.fn().mockReturnValue('data:image/png;base64,AA');
@@ -45,6 +49,10 @@ describe('generateReferralQrPngDataUrl', () => {
       onerror: (() => void) | null = null;
       src = '';
       crossOrigin = '';
+      naturalWidth = 10;
+      naturalHeight = 10;
+      width = 10;
+      height = 10;
       constructor() {
         queueMicrotask(() => {
           this.onload?.();
@@ -60,6 +68,7 @@ describe('generateReferralQrPngDataUrl', () => {
       url: 'https://example.com',
       size: 200,
       logoSrc: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>',
+      applyBranding: false,
     });
 
     expect(toCanvasMock).toHaveBeenCalled();
@@ -108,10 +117,56 @@ describe('generateReferralQrPngDataUrl', () => {
     await generateReferralQrPngDataUrl({
       url: 'https://example.com',
       size: 200,
+      applyBranding: false,
     });
 
     expect(toCanvasMock).toHaveBeenCalled();
     expect(fillRectSpy).not.toHaveBeenCalled();
+    expect(drawImageSpy).not.toHaveBeenCalled();
+    expect(toDataURLSpy).toHaveBeenCalledWith('image/png');
+
+    createElementSpy.mockRestore();
+  });
+
+  it('uses branded renderer without calling toCanvas when applyBranding is true', async () => {
+    toCanvasMock.mockClear();
+    const drawImageSpy = vi.fn();
+    const fillRectSpy = vi.fn();
+    const toDataURLSpy = vi.fn().mockReturnValue('data:image/png;base64,CC');
+
+    const originalCreateElement = Document.prototype.createElement.bind(document);
+    const createElementSpy = vi.spyOn(Document.prototype, 'createElement').mockImplementation(
+      function patchedCreateElement(this: Document, tagName: string, options?: unknown) {
+        if (tagName !== 'canvas') {
+          return originalCreateElement(tagName, options as never);
+        }
+        const canvas = originalCreateElement('canvas', options as never);
+        canvas.getContext = vi.fn(() => {
+          return {
+            fillStyle: '',
+            fillRect: fillRectSpy,
+            drawImage: drawImageSpy,
+            beginPath: vi.fn(),
+            moveTo: vi.fn(),
+            arcTo: vi.fn(),
+            closePath: vi.fn(),
+            fill: vi.fn(),
+          } as unknown as CanvasRenderingContext2D;
+        });
+        canvas.toDataURL = toDataURLSpy;
+        return canvas;
+      },
+    );
+
+    const { generateReferralQrPngDataUrl } = await import('@/lib/qr-code-image');
+
+    await generateReferralQrPngDataUrl({
+      url: 'https://example.com',
+      size: 200,
+    });
+
+    expect(toCanvasMock).not.toHaveBeenCalled();
+    expect(fillRectSpy).toHaveBeenCalled();
     expect(drawImageSpy).not.toHaveBeenCalled();
     expect(toDataURLSpy).toHaveBeenCalledWith('image/png');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds an **Apply branding** checkbox (default on) below **Include logo in QR code** in the referral QR dialog. When enabled, the QR uses the public site brand orange (`#C84A16`, `--es-color-brand-orange`) and draws modules with rounded corners via a custom canvas renderer (finder and alignment patterns drawn explicitly so eyes stay square).
- **Fix:** alignment pattern centers are now consistently `[row, col]` like `qrcode`’s `setupAlignmentPattern`: masking keys use `${row+dr},${col+dc}` and placement uses `px = (col - 2 + margin) * modulePx`, `py = (row - 2 + margin) * modulePx` so off-diagonal alignment patterns render correctly for larger QR versions.
- When branding is off, behavior matches the previous black-and-white `qrcode` canvas output.
- Reduces perceived whitespace around the centered logo by trimming uniform transparent or near-white margins from the loaded logo before drawing (with a safe fallback if pixel read fails), and slightly tightens the white quiet zone around the logo.
- `toDataURL` is wrapped so a tainted canvas (e.g. cross-origin logo without CORS) throws a clearer error; logo loads use `crossOrigin = 'anonymous'` for same-origin CORS-friendly assets.

## Testing

- `npm run test -- tests/lib/qr-code-image.test.ts tests/components/admin/services/referral-link-qr-dialog.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2605e736-3392-44ba-a4e8-798032cdff77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2605e736-3392-44ba-a4e8-798032cdff77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

