### PR TITLE
fix(admin_web): normalize discount type for Type dropdown

### DIFF
--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -37,6 +37,7 @@ import {
 import type { components } from '@/types/generated/admin-api.generated';
 import {
   DISCOUNT_TYPES,
+  normalizeDiscountTypeFromApi,
   REFERRAL_DEFAULT_CURRENCY,
   REFERRAL_DEFAULT_DISCOUNT_VALUE,
 } from '@/types/services';
@@ -148,7 +149,8 @@ export function DiscountCodesPanel({
   const { instances, isLoading: instancesLoading, error: instancesError, loadForService } =
     useServiceInstanceOptions(instanceOptionsRefreshKey);
   const currencyOptions = getCurrencyOptions();
-  const isReferral = discountType === 'referral';
+  const discountTypeSelectValue = normalizeDiscountTypeFromApi(discountType);
+  const isReferral = discountTypeSelectValue === 'referral';
 
   const serviceById = useMemo(() => {
     const map = new Map<string, ServiceSummary>();
@@ -214,7 +216,7 @@ export function DiscountCodesPanel({
     const createPayload: ApiSchemas['CreateDiscountCodeRequest'] = {
       code: code.trim().toUpperCase(),
       description: description.trim() || null,
-      discount_type: discountType as DiscountType,
+      discount_type: discountTypeSelectValue,
       discount_value: isReferral ? REFERRAL_DEFAULT_DISCOUNT_VALUE : discountValue.trim(),
       currency: isReferral ? REFERRAL_DEFAULT_CURRENCY : currency.trim() || null,
       valid_from: validFromIso,
@@ -285,7 +287,7 @@ export function DiscountCodesPanel({
       }
       await onUpdate(selectedCode.id, {
         description: description.trim() || null,
-        discount_type: discountType as DiscountType,
+        discount_type: discountTypeSelectValue,
         discount_value: isReferral ? REFERRAL_DEFAULT_DISCOUNT_VALUE : discountValue.trim(),
         currency: isReferral ? REFERRAL_DEFAULT_CURRENCY : currency.trim() || null,
         valid_from: validFromIso,
@@ -307,7 +309,7 @@ export function DiscountCodesPanel({
     setEditorMode('edit');
     setCode(entry.code);
     setDescription(entry.description ?? '');
-    setDiscountType(entry.discountType);
+    setDiscountType(normalizeDiscountTypeFromApi(entry.discountType));
     setDiscountValue(entry.discountValue);
     setCurrency(entry.currency ?? 'HKD');
     setMaxUses(entry.maxUses?.toString() ?? '');
@@ -398,10 +400,10 @@ export function DiscountCodesPanel({
             <Label htmlFor='discount-type'>Type</Label>
             <Select
               id='discount-type'
-              value={discountType}
+              value={discountTypeSelectValue}
               onChange={(event) => {
                 const next = event.target.value as ApiSchemas['DiscountType'];
-                const prev = discountType;
+                const prev = discountTypeSelectValue;
                 setDiscountType(next);
                 if (next === 'referral') {
                   setDiscountValue(REFERRAL_DEFAULT_DISCOUNT_VALUE);
@@ -499,7 +501,7 @@ export function DiscountCodesPanel({
               id='discount-currency'
               value={currency}
               onChange={(event) => setCurrency(event.target.value)}
-              disabled={discountType === 'percentage' || isReferral}
+              disabled={discountTypeSelectValue === 'percentage' || isReferral}
             >
               {currencyOptions.map((option) => (
                 <option key={option.value} value={option.value}>

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -3,20 +3,21 @@ import { asBoolean, asNullableFiniteNumber, asNullableString, asNumber, unwrapPa
 import { isRecord } from './type-guards';
 
 import type { components } from '@/types/generated/admin-api.generated';
-import type {
-  DiscountCode,
-  DiscountCodeFilters,
-  Enrollment,
-  EnrollmentListFilters,
-  EventTicketTier,
-  GeographicAreaSummary,
-  LocationSummary,
-  ServiceDetail,
-  ServiceInstance,
-  ServiceListFilters,
-  ServiceSummary,
-  SessionSlot,
-  VenueFilters,
+import {
+  normalizeDiscountTypeFromApi,
+  type DiscountCode,
+  type DiscountCodeFilters,
+  type Enrollment,
+  type EnrollmentListFilters,
+  type EventTicketTier,
+  type GeographicAreaSummary,
+  type LocationSummary,
+  type ServiceDetail,
+  type ServiceInstance,
+  type ServiceListFilters,
+  type ServiceSummary,
+  type SessionSlot,
+  type VenueFilters,
 } from '@/types/services';
 
 type ApiSchemas = components['schemas'];
@@ -271,7 +272,7 @@ function parseDiscountCode(value: unknown): DiscountCode {
     id: asNullableString(item.id) ?? '',
     code: asNullableString(item.code) ?? '',
     description: asNullableString(item.description),
-    discountType: (asNullableString(item.discount_type) ?? 'percentage') as DiscountCode['discountType'],
+    discountType: normalizeDiscountTypeFromApi(item.discount_type),
     discountValue: asNullableString(item.discount_value) ?? '0',
     currency: asNullableString(item.currency),
     validFrom: asNullableString(item.valid_from),

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -56,6 +56,21 @@ export const DISCOUNT_TYPES = defineEnumValues<DiscountType>()(
   ['percentage', 'absolute', 'referral'] as const satisfies readonly DiscountType[]
 );
 
+const DISCOUNT_TYPE_SET = new Set<string>(DISCOUNT_TYPES);
+
+/**
+ * Map API `discount_type` to a value that matches `<option value>` entries.
+ * Non-string or unknown values fall back to `percentage` so native `<select>`
+ * controlled values always match an option (avoids a "stuck" first option).
+ */
+export function normalizeDiscountTypeFromApi(raw: unknown): DiscountType {
+  if (typeof raw !== 'string') {
+    return 'percentage';
+  }
+  const normalized = raw.trim().toLowerCase();
+  return DISCOUNT_TYPE_SET.has(normalized) ? (normalized as DiscountType) : 'percentage';
+}
+
 // Sibling defaults: backend `REFERRAL_DEFAULT_*` in `admin_services_payloads.py`.
 export const REFERRAL_DEFAULT_DISCOUNT_VALUE = '0';
 export const REFERRAL_DEFAULT_CURRENCY = 'HKD';

--- a/apps/admin_web/tests/lib/services-api.test.ts
+++ b/apps/admin_web/tests/lib/services-api.test.ts
@@ -14,7 +14,12 @@ vi.mock('@/lib/api-admin-client', async () => {
   };
 });
 
-import { createServiceCoverImageUpload, listLocations, listServices } from '@/lib/services-api';
+import {
+  createServiceCoverImageUpload,
+  listDiscountCodes,
+  listLocations,
+  listServices,
+} from '@/lib/services-api';
 
 describe('services-api', () => {
   beforeEach(() => {
@@ -121,6 +126,58 @@ describe('services-api', () => {
         },
       })
     );
+  });
+
+  it('normalizes discount_type from listDiscountCodes (string casing and non-string)', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: 'dc-1',
+            code: 'A',
+            description: null,
+            discount_type: 'REFERRAL',
+            discount_value: '0',
+            currency: 'HKD',
+            valid_from: null,
+            valid_until: null,
+            service_id: null,
+            instance_id: null,
+            max_uses: null,
+            current_uses: 0,
+            active: true,
+            created_by: 'u',
+            created_at: null,
+            updated_at: null,
+          },
+          {
+            id: 'dc-2',
+            code: 'B',
+            description: null,
+            discount_type: 'unknown_kind',
+            discount_value: '10',
+            currency: 'HKD',
+            valid_from: null,
+            valid_until: null,
+            service_id: null,
+            instance_id: null,
+            max_uses: null,
+            current_uses: 0,
+            active: true,
+            created_by: 'u',
+            created_at: null,
+            updated_at: null,
+          },
+        ],
+        next_cursor: null,
+        total_count: 2,
+      },
+    });
+
+    const result = await listDiscountCodes({ limit: 50 });
+
+    expect(result.items[0].discountType).toBe('referral');
+    expect(result.items[1].discountType).toBe('percentage');
   });
 
   it('parses venue coordinates from number or string response', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Services → Discount Codes **Type** control is a native `<select>` whose options use lowercase API values (`percentage`, `absolute`, `referral`). If `discount_type` from the API was not exactly one of those strings (for example different casing or an unexpected value), React state could disagree with every `<option value>`, so the browser showed the first option while changes did not appear to apply—including choosing **Referral**.

## Changes

- Add `normalizeDiscountTypeFromApi()` in `apps/admin_web/src/types/services.ts` to trim, lowercase, and validate against `DISCOUNT_TYPES`, with a safe fallback to `percentage`.
- Use it in `parseDiscountCode()` in `apps/admin_web/src/lib/services-api.ts` when mapping list/create/update responses.
- Bind the discount editor `<select>` to the normalized value and use the same value for create/update payloads in `discount-codes-panel.tsx`.
- Add a unit test for `listDiscountCodes` parsing (`REFERRAL` casing and unknown type).

## Testing

- `npm run lint` (admin_web)
- `npx vitest run tests/lib/services-api.test.ts tests/components/admin/services/discount-codes-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92a5db1e-28e7-4be3-8467-d9725aecedba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92a5db1e-28e7-4be3-8467-d9725aecedba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

