### PR TITLE
Admin asset file replacement (hardened API + UX)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -301,6 +301,10 @@ should extend the shared primitives rather than reintroducing one-off layouts.
   appropriate), not in the editor footer. `ConfirmDialog` may render optional
   `children` between the description and the action buttons when extra input
   is required (for example a void reason).
+- **Asset file replacement** (upload new binary for the selected asset) lives in
+  the **inline editor** field area, not the list **Operations** column, because
+  it depends on editor context (metadata, PDF validation, and the two-step
+  presigned flow) rather than being a row-only table action.
 
 ### Public WWW XSS policy (MANDATORY for `apps/public_www/**`)
 

--- a/apps/admin_web/src/components/admin/assets/asset-editor-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-editor-panel.tsx
@@ -40,7 +40,7 @@ interface AssetEditorPanelProps {
   isDeletingCurrentAsset: boolean;
   assetMutationError: string;
   uploadState: 'idle' | 'uploading' | 'failed' | 'succeeded';
-  uploadPhase: AssetUploadPhase;
+  uploadPhase: AssetUploadPhase | null;
   uploadError: string;
   hasPendingUpload: boolean;
   onRetryUpload: () => Promise<void>;
@@ -121,6 +121,45 @@ function normalizeResourceKey(value: string): string {
     .replaceAll(/-+$/g, '');
 }
 
+function buildEditMetadataPatch(
+  asset: AdminAsset,
+  input: {
+    title: string;
+    description: string | null;
+    resourceKey: string | null;
+    visibility: AssetVisibility;
+    contentLanguage: AdminAssetWriteContentLanguage | null;
+    clientTagValue: typeof CLIENT_DOCUMENT_ASSET_TAG | null;
+    isExpenseLinked: boolean;
+  }
+): UpdateAdminAssetPatchInput {
+  const patch: UpdateAdminAssetPatchInput = {};
+  if (input.title !== asset.title) {
+    patch.title = input.title;
+  }
+  if (input.description !== (asset.description ?? null)) {
+    patch.description = input.description;
+  }
+  if (input.resourceKey !== (asset.resourceKey ?? null)) {
+    patch.resourceKey = input.resourceKey;
+  }
+  if (input.visibility !== asset.visibility) {
+    patch.visibility = input.visibility;
+  }
+  const prevLangCanonical = canonicalContentLanguageFromApi(asset.contentLanguage);
+  if (input.contentLanguage !== prevLangCanonical) {
+    patch.contentLanguage = input.contentLanguage;
+  }
+  if (!input.isExpenseLinked) {
+    const hadClient = assetHasClientDocumentTag(asset);
+    const nextHasClient = input.clientTagValue === CLIENT_DOCUMENT_ASSET_TAG;
+    if (hadClient !== nextHasClient) {
+      patch.clientTag = input.clientTagValue;
+    }
+  }
+  return patch;
+}
+
 export function AssetEditorPanel({
   selectedAsset,
   isSavingAsset,
@@ -142,12 +181,43 @@ export function AssetEditorPanel({
   const [formError, setFormError] = useState('');
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [replacementFile, setReplacementFile] = useState<File | null>(null);
+  const [metadataSaveWarningAfterReplace, setMetadataSaveWarningAfterReplace] = useState(false);
 
   const isEditMode = Boolean(selectedAsset);
   const isExpenseLinked = Boolean(
     selectedAsset?.tags.some((t) => t.name.toLowerCase() === EXPENSE_ATTACHMENT_ASSET_TAG)
   );
   const canReplaceFile = isEditMode && Boolean(onReplaceFile) && !isExpenseLinked;
+
+  const metadataPatch = useMemo(() => {
+    if (!selectedAsset) {
+      return {} as UpdateAdminAssetPatchInput;
+    }
+    const title = formState.title.trim();
+    const normalizedResourceKey = normalizeResourceKey(formState.resourceKey);
+    const resourceKey = normalizedResourceKey || null;
+    const contentLanguageTrimmed = formState.contentLanguage.trim();
+    let contentLanguage: AdminAssetWriteContentLanguage | null = null;
+    if (contentLanguageTrimmed !== '') {
+      const matched = matchAdminSelectableContentLanguage(contentLanguageTrimmed);
+      if (matched !== 'unrecognized') {
+        contentLanguage = matched;
+      }
+    }
+    const clientTagValue: typeof CLIENT_DOCUMENT_ASSET_TAG | null =
+      formState.clientTag === CLIENT_DOCUMENT_ASSET_TAG ? CLIENT_DOCUMENT_ASSET_TAG : null;
+    return buildEditMetadataPatch(selectedAsset, {
+      title,
+      description: formState.description.trim() || null,
+      resourceKey,
+      visibility: formState.visibility,
+      contentLanguage,
+      clientTagValue,
+      isExpenseLinked,
+    });
+  }, [selectedAsset, formState, isExpenseLinked]);
+
+  const hasMetadataChangesForSubmit = Object.keys(metadataPatch).length > 0;
 
   const cardTitle = isEditMode ? 'Edit Asset' : 'Create Asset';
   const cardDescription = isEditMode
@@ -159,14 +229,21 @@ export function AssetEditorPanel({
       if (!isEditMode) {
         return 'Creating...';
       }
-      return replacementFile ? 'Saving and replacing...' : 'Saving...';
+      if (!replacementFile) {
+        return 'Saving...';
+      }
+      return hasMetadataChangesForSubmit ? 'Save and replace...' : 'Replacing...';
+    }
+    if (isEditMode && replacementFile) {
+      return hasMetadataChangesForSubmit ? 'Save and replace' : 'Replace file';
     }
     return isEditMode ? 'Save changes' : 'Create asset';
-  }, [isEditMode, isSavingAsset, replacementFile]);
+  }, [isEditMode, isSavingAsset, replacementFile, hasMetadataChangesForSubmit]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setFormError('');
+    setMetadataSaveWarningAfterReplace(false);
 
     const title = formState.title.trim();
     if (!title) {
@@ -228,32 +305,7 @@ export function AssetEditorPanel({
         }
       }
 
-      const nextDescription = formState.description.trim() || null;
-      const patch: UpdateAdminAssetPatchInput = {};
-      if (title !== selectedAsset.title) {
-        patch.title = title;
-      }
-      if (nextDescription !== (selectedAsset.description ?? null)) {
-        patch.description = nextDescription;
-      }
-      if (resourceKey !== (selectedAsset.resourceKey ?? null)) {
-        patch.resourceKey = resourceKey;
-      }
-      if (formState.visibility !== selectedAsset.visibility) {
-        patch.visibility = formState.visibility;
-      }
-      const nextLang = contentLanguage;
-      const prevLangCanonical = canonicalContentLanguageFromApi(selectedAsset.contentLanguage);
-      if (nextLang !== prevLangCanonical) {
-        patch.contentLanguage = nextLang;
-      }
-      if (!isExpenseLinked) {
-        const hadClient = assetHasClientDocumentTag(selectedAsset);
-        const nextHasClient = clientTagValue === CLIENT_DOCUMENT_ASSET_TAG;
-        if (hadClient !== nextHasClient) {
-          patch.clientTag = clientTagValue;
-        }
-      }
+      const patch = metadataPatch;
       if (replacementFile && onReplaceFile) {
         const replaceOk = await onReplaceFile(replacementFile);
         if (!replaceOk) {
@@ -266,9 +318,11 @@ export function AssetEditorPanel({
         }
       }
       if (Object.keys(patch).length > 0) {
-        try {
-          await onUpdate(selectedAsset.id, patch);
-        } catch {
+        const updateOk = await onUpdate(selectedAsset.id, patch);
+        if (!updateOk) {
+          if (replacementFile) {
+            setMetadataSaveWarningAfterReplace(true);
+          }
           setFormError(
             'Metadata may not have saved. The new file may already be live. Refresh the list or fix the error in the Asset banner and save again.'
           );
@@ -324,7 +378,11 @@ export function AssetEditorPanel({
           <Button
             type='submit'
             form={ASSET_EDITOR_FORM_ID}
-            disabled={isSavingAsset}
+            disabled={
+              isSavingAsset ||
+              isDeletingCurrentAsset ||
+              (hasPendingUpload && uploadState === 'failed')
+            }
           >
             {submitLabel}
           </Button>
@@ -353,7 +411,14 @@ export function AssetEditorPanel({
         </StatusBanner>
       ) : null}
 
-      {uploadState === 'succeeded' ? (
+      {uploadState === 'succeeded' && metadataSaveWarningAfterReplace ? (
+        <StatusBanner variant='info' title='File replaced'>
+          The PDF was replaced. Metadata may not have saved; check the Validation message above or
+          the Asset banner, then save again if needed.
+        </StatusBanner>
+      ) : null}
+
+      {uploadState === 'succeeded' && !metadataSaveWarningAfterReplace ? (
         <StatusBanner variant='success' title='Upload complete'>
           {isEditMode ? 'PDF updated successfully.' : 'PDF content uploaded successfully.'}
         </StatusBanner>

--- a/apps/admin_web/src/components/admin/assets/assets-page.tsx
+++ b/apps/admin_web/src/components/admin/assets/assets-page.tsx
@@ -92,14 +92,7 @@ export function AssetsPage() {
               // The hook stores the actionable error state for UI display.
             }
           }}
-          onUpdate={async (assetId, payload) => {
-            try {
-              await updateAssetEntry(assetId, payload);
-              return true;
-            } catch {
-              return false;
-            }
-          }}
+          onUpdate={async (assetId, payload) => updateAssetEntry(assetId, payload)}
           onStartCreate={clearSelectedAsset}
         />
 

--- a/apps/admin_web/src/hooks/use-asset-mutations.ts
+++ b/apps/admin_web/src/hooks/use-asset-mutations.ts
@@ -22,8 +22,19 @@ import { toErrorMessage } from './hook-errors';
 
 type UploadState = 'idle' | 'uploading' | 'failed' | 'succeeded';
 
-/** When uploadState is uploading, distinguishes presigned PUT vs finalize (complete) step. */
-export type AssetUploadPhase = 'idle' | 'put' | 'complete';
+/** Meaningful only when ``uploadState === 'uploading'``: PUT vs finalize (complete). */
+export type AssetUploadPhase = 'put' | 'complete';
+
+function isPresignedUploadExpired(iso: string | null | undefined): boolean {
+  if (!iso) {
+    return false;
+  }
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) {
+    return false;
+  }
+  return Date.now() >= parsed - 2000;
+}
 
 type PendingAssetFileMutation =
   | {
@@ -61,7 +72,7 @@ export interface UseAssetMutationsReturn {
   isSavingAsset: boolean;
   isDeletingAssetId: string | null;
   uploadState: UploadState;
-  uploadPhase: AssetUploadPhase;
+  uploadPhase: AssetUploadPhase | null;
   uploadError: string;
   hasPendingUpload: boolean;
   createAssetEntry: (input: UpsertAdminAssetInput, file: File) => Promise<void>;
@@ -70,7 +81,7 @@ export interface UseAssetMutationsReturn {
     file: File,
     contentType: string | null
   ) => Promise<boolean>;
-  updateAssetEntry: (assetId: string, input: UpdateAdminAssetPatchInput) => Promise<void>;
+  updateAssetEntry: (assetId: string, input: UpdateAdminAssetPatchInput) => Promise<boolean>;
   deleteAssetEntry: (assetId: string) => Promise<void>;
   retryPendingUpload: () => Promise<void>;
   resetMutationState: () => void;
@@ -87,7 +98,7 @@ export function useAssetMutations({
   const [isSavingAsset, setIsSavingAsset] = useState(false);
   const [isDeletingAssetId, setIsDeletingAssetId] = useState<string | null>(null);
   const [uploadState, setUploadState] = useState<UploadState>('idle');
-  const [uploadPhase, setUploadPhase] = useState<AssetUploadPhase>('idle');
+  const [uploadPhase, setUploadPhase] = useState<AssetUploadPhase | null>(null);
   const [uploadError, setUploadError] = useState('');
   const [pendingUpload, setPendingUpload] = useState<PendingAssetFileMutation | null>(null);
   const pendingUploadRef = useRef<PendingAssetFileMutation | null>(null);
@@ -101,7 +112,7 @@ export function useAssetMutations({
   const resetMutationState = useCallback(() => {
     setAssetMutationError('');
     setUploadState('idle');
-    setUploadPhase('idle');
+    setUploadPhase(null);
     setUploadError('');
     setPendingUploadState(null);
   }, [setPendingUploadState]);
@@ -111,7 +122,7 @@ export function useAssetMutations({
       setIsSavingAsset(true);
       setAssetMutationError('');
       setUploadState('idle');
-      setUploadPhase('idle');
+      setUploadPhase(null);
       setUploadError('');
       setPendingUploadState(null);
 
@@ -138,12 +149,12 @@ export function useAssetMutations({
             file,
           });
           setUploadState('succeeded');
-          setUploadPhase('idle');
+          setUploadPhase(null);
           setUploadError('');
           setPendingUploadState(null);
         } catch (uploadFailure) {
           setUploadState('failed');
-          setUploadPhase('idle');
+          setUploadPhase(null);
           setUploadError(toErrorMessage(uploadFailure, 'File upload failed.'));
         }
       } catch (error) {
@@ -161,7 +172,7 @@ export function useAssetMutations({
       setIsSavingAsset(true);
       setAssetMutationError('');
       setUploadState('idle');
-      setUploadPhase('idle');
+      setUploadPhase(null);
       setUploadError('');
       setPendingUploadState(null);
 
@@ -172,7 +183,7 @@ export function useAssetMutations({
         });
         if (!initUpload.uploadUrl) {
           setUploadState('failed');
-          setUploadPhase('idle');
+          setUploadPhase(null);
           setUploadError('Upload URL was not returned by the API.');
           return false;
         }
@@ -197,7 +208,7 @@ export function useAssetMutations({
           });
         } catch (uploadFailure) {
           setUploadState('failed');
-          setUploadPhase('idle');
+          setUploadPhase(null);
           setUploadError(toErrorMessage(uploadFailure, 'File upload failed.'));
           return false;
         }
@@ -211,14 +222,14 @@ export function useAssetMutations({
           });
           await applyUpdatedAsset(assetId, updatedAsset);
           setUploadState('succeeded');
-          setUploadPhase('idle');
+          setUploadPhase(null);
           setUploadError('');
           setPendingUploadState(null);
           setReplaceSuccessNonce((n) => n + 1);
           return true;
         } catch (completeFailure) {
           setUploadState('failed');
-          setUploadPhase('idle');
+          setUploadPhase(null);
           setUploadError(toErrorMessage(completeFailure, 'Failed to finalize file replacement.'));
           setPendingUploadState({
             kind: 'replace',
@@ -232,7 +243,7 @@ export function useAssetMutations({
         }
       } catch (error) {
         setAssetMutationError(toErrorMessage(error, 'Failed to replace asset file.'));
-        setUploadPhase('idle');
+        setUploadPhase(null);
         return false;
       } finally {
         setIsSavingAsset(false);
@@ -242,20 +253,21 @@ export function useAssetMutations({
   );
 
   const updateAssetEntry = useCallback(
-    async (assetId: string, input: UpdateAdminAssetPatchInput) => {
+    async (assetId: string, input: UpdateAdminAssetPatchInput): Promise<boolean> => {
       setIsSavingAsset(true);
       setAssetMutationError('');
       setUploadState('idle');
-      setUploadPhase('idle');
+      setUploadPhase(null);
       setUploadError('');
       setPendingUploadState(null);
 
       try {
         const updatedAsset = await updateAdminAsset(assetId, input);
         await applyUpdatedAsset(assetId, updatedAsset);
+        return true;
       } catch (error) {
         setAssetMutationError(toErrorMessage(error, 'Failed to update asset.'));
-        throw error;
+        return false;
       } finally {
         setIsSavingAsset(false);
       }
@@ -268,7 +280,7 @@ export function useAssetMutations({
       setIsDeletingAssetId(assetId);
       setAssetMutationError('');
       setUploadState('idle');
-      setUploadPhase('idle');
+      setUploadPhase(null);
       setUploadError('');
       setPendingUploadState(null);
 
@@ -303,13 +315,13 @@ export function useAssetMutations({
         });
         await applyUpdatedAsset(pending.assetId, updatedAsset);
         setUploadState('succeeded');
-        setUploadPhase('idle');
+        setUploadPhase(null);
         setUploadError('');
         setPendingUploadState(null);
         setReplaceSuccessNonce((n) => n + 1);
       } catch (error) {
         setUploadState('failed');
-        setUploadPhase('idle');
+        setUploadPhase(null);
         setUploadError(toErrorMessage(error, 'Failed to finalize file replacement.'));
       }
       return;
@@ -318,6 +330,16 @@ export function useAssetMutations({
     if (pending.kind === 'create') {
       const { upload, file } = pending;
       if (!upload.uploadUrl) {
+        return;
+      }
+
+      if (isPresignedUploadExpired(upload.expiresAt)) {
+        setUploadState('failed');
+        setUploadPhase(null);
+        setUploadError(
+          'Upload window expired. If a draft asset appears in the list, delete it, then create the asset again.'
+        );
+        setPendingUploadState(null);
         return;
       }
 
@@ -332,12 +354,12 @@ export function useAssetMutations({
           file,
         });
         setUploadState('succeeded');
-        setUploadPhase('idle');
+        setUploadPhase(null);
         setUploadError('');
         setPendingUploadState(null);
       } catch (error) {
         setUploadState('failed');
-        setUploadPhase('idle');
+        setUploadPhase(null);
         setUploadError(toErrorMessage(error, 'File upload failed.'));
       }
       return;
@@ -348,32 +370,60 @@ export function useAssetMutations({
       return;
     }
 
+    let effectiveUpload = upload;
+    if (isPresignedUploadExpired(upload.expiresAt)) {
+      try {
+        const refreshed = await initAdminAssetContentReplace(pending.assetId, {
+          fileName: pending.fileName,
+          contentType: pending.contentType ?? undefined,
+        });
+        if (!refreshed.uploadUrl) {
+          setUploadState('failed');
+          setUploadPhase(null);
+          setUploadError('Upload URL was not returned when refreshing the upload.');
+          return;
+        }
+        effectiveUpload = refreshed;
+        setPendingUploadState({
+          ...pending,
+          upload: refreshed,
+        });
+      } catch (error) {
+        setUploadState('failed');
+        setUploadPhase(null);
+        setUploadError(
+          toErrorMessage(error, 'Upload window expired and could not be refreshed.')
+        );
+        return;
+      }
+    }
+
     setUploadPhase('put');
     setUploadState('uploading');
     setUploadError('');
     try {
       await uploadFileToPresignedUrl({
-        uploadUrl: upload.uploadUrl,
-        uploadMethod: upload.uploadMethod,
-        uploadHeaders: upload.uploadHeaders,
+        uploadUrl: effectiveUpload.uploadUrl,
+        uploadMethod: effectiveUpload.uploadMethod,
+        uploadHeaders: effectiveUpload.uploadHeaders,
         file,
       });
       try {
         setUploadPhase('complete');
         const updatedAsset = await completeAdminAssetContentReplace(pending.assetId, {
-          pendingS3Key: upload.pendingS3Key,
+          pendingS3Key: effectiveUpload.pendingS3Key,
           fileName: pending.fileName,
           contentType: pending.contentType,
         });
         await applyUpdatedAsset(pending.assetId, updatedAsset);
         setUploadState('succeeded');
-        setUploadPhase('idle');
+        setUploadPhase(null);
         setUploadError('');
         setPendingUploadState(null);
         setReplaceSuccessNonce((n) => n + 1);
       } catch (completeFailure) {
         setUploadState('failed');
-        setUploadPhase('idle');
+        setUploadPhase(null);
         setUploadError(
           toErrorMessage(completeFailure, 'Failed to finalize file replacement.')
         );
@@ -381,14 +431,14 @@ export function useAssetMutations({
           kind: 'replace',
           stage: 'complete',
           assetId: pending.assetId,
-          pendingS3Key: upload.pendingS3Key,
+          pendingS3Key: effectiveUpload.pendingS3Key,
           fileName: pending.fileName,
           contentType: pending.contentType,
         });
       }
     } catch (error) {
       setUploadState('failed');
-      setUploadPhase('idle');
+      setUploadPhase(null);
       setUploadError(toErrorMessage(error, 'File upload failed.'));
     }
   }, [applyUpdatedAsset, setPendingUploadState]);

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -276,7 +276,7 @@ export interface paths {
         put?: never;
         /**
          * Begin admin asset file replacement
-         * @description Step 1 of 2 for replacing the binary stored for an asset while keeping the same asset id. Returns a presigned upload URL for a new S3 key under `assets/{id}/...`. Call `POST /v1/admin/assets/{id}/content/complete` after the client uploads to that URL. Not allowed when the asset has the `expense_attachment` tag (400).
+         * @description Step 1 of 2 for replacing the binary stored for an asset while keeping the same asset id. Returns a presigned upload URL for a new S3 key under `assets/{id}/...`. Call `POST /v1/admin/assets/{id}/content/complete` after the client uploads to that URL. Not allowed when the asset has the `expense_attachment` tag (400). The presigned PUT binds `Content-Type: application/pdf` regardless of optional `content_type` in the body.
          */
         post: {
             parameters: {
@@ -328,7 +328,7 @@ export interface paths {
         put?: never;
         /**
          * Complete admin asset file replacement
-         * @description Step 2 of 2: verifies the object exists at `pending_s3_key`, updates the asset to point at it, deletes the previous S3 object, and returns the updated asset. The `pending_s3_key` must be the value returned by `POST .../content/init` for this asset id. Not allowed when the asset has the `expense_attachment` tag (400). `file_name` must match the filename embedded in `pending_s3_key` after server-side sanitization (same rules as init). This call is not idempotent across different `pending_s3_key` values: repeating complete with a stale key after a successful replace returns 400. When `content_type` is null or omitted, the stored content type is taken from the uploaded object's S3 `Content-Type` metadata when present.
+         * @description Step 2 of 2: verifies the object exists at `pending_s3_key`, updates the asset to point at it, deletes the previous S3 object, and returns the updated asset. The `pending_s3_key` must be the value returned by `POST .../content/init` for this asset id. Not allowed when the asset has the `expense_attachment` tag (400). `file_name` must match the filename embedded in `pending_s3_key` after server-side sanitization (same rules as init). The object name segment must begin with a standard UUID prefix (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-`) from init. Stored `content_type` is always `application/pdf`; the uploaded object's S3 Content-Type and size are validated on complete (max 50 MiB). This call is not idempotent across different `pending_s3_key` values: repeating complete with a stale key after a successful replace returns 400. Concurrent replaces for the same asset are last-writer-wins; earlier pending keys may become orphans if never completed. BadRequest responses may include `field` values such as `pending_s3_key`, `file_name`, `content_type`, or `asset` depending on the failure.
          */
         post: {
             parameters: {
@@ -4342,13 +4342,13 @@ export interface components {
         CreateAssetResponse: {
             asset: components["schemas"]["Asset"];
             /** Format: uri */
-            upload_url?: string | null;
-            upload_method?: string;
-            upload_headers?: {
+            upload_url: string;
+            upload_method: string;
+            upload_headers: {
                 [key: string]: string;
             };
             /** Format: date-time */
-            expires_at?: string | null;
+            expires_at: string;
         };
         InitAssetContentReplaceRequest: {
             file_name: string;
@@ -4357,13 +4357,13 @@ export interface components {
         InitAssetContentReplaceResponse: {
             pending_s3_key: string;
             /** Format: uri */
-            upload_url?: string | null;
+            upload_url?: string;
             upload_method: string;
             upload_headers: {
                 [key: string]: string;
             };
             /** Format: date-time */
-            expires_at: string | null;
+            expires_at: string;
         };
         CompleteAssetContentReplaceRequest: {
             pending_s3_key: string;

--- a/apps/admin_web/tests/components/admin/assets/asset-editor-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/assets/asset-editor-panel.test.tsx
@@ -45,7 +45,7 @@ function renderEditor(overrides: Partial<ComponentProps<typeof AssetEditorPanel>
       isDeletingCurrentAsset={false}
       assetMutationError=''
       uploadState='idle'
-      uploadPhase='idle'
+      uploadPhase={null}
       uploadError=''
       hasPendingUpload={false}
       onRetryUpload={onRetryUpload}
@@ -212,7 +212,7 @@ describe('AssetEditorPanel', () => {
     const replaceInput = screen.getByLabelText('Replace PDF file');
     const pdf = new File(['%PDF-1.4'], 'new-guide.pdf', { type: 'application/pdf' });
     await user.upload(replaceInput, pdf);
-    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+    await user.click(screen.getByRole('button', { name: 'Save and replace' }));
 
     await waitFor(() => {
       expect(onReplaceFile).toHaveBeenCalledWith(pdf);
@@ -238,7 +238,7 @@ describe('AssetEditorPanel', () => {
     const replaceInput = screen.getByLabelText('Replace PDF file');
     const pdf = new File(['%PDF-1.4'], 'new-guide.pdf', { type: 'application/pdf' });
     await user.upload(replaceInput, pdf);
-    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+    await user.click(screen.getByRole('button', { name: 'Save and replace' }));
 
     await waitFor(() => {
       expect(onReplaceFile).toHaveBeenCalled();

--- a/apps/admin_web/tests/hooks/use-admin-assets.test.ts
+++ b/apps/admin_web/tests/hooks/use-admin-assets.test.ts
@@ -45,7 +45,7 @@ const {
     isSavingAsset: false,
     isDeletingAssetId: null,
     uploadState: 'idle',
-    uploadPhase: 'idle',
+    uploadPhase: null,
     uploadError: '',
     hasPendingUpload: false,
     createAssetEntry: vi.fn(),

--- a/apps/admin_web/tests/hooks/use-asset-mutations.test.ts
+++ b/apps/admin_web/tests/hooks/use-asset-mutations.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCreateAdminAsset,
+  mockInitAdminAssetContentReplace,
+  mockCompleteAdminAssetContentReplace,
+  mockUploadFileToPresignedUrl,
+  mockUpdateAdminAsset,
+  mockDeleteAdminAsset,
+} = vi.hoisted(() => ({
+  mockCreateAdminAsset: vi.fn(),
+  mockInitAdminAssetContentReplace: vi.fn(),
+  mockCompleteAdminAssetContentReplace: vi.fn(),
+  mockUploadFileToPresignedUrl: vi.fn(),
+  mockUpdateAdminAsset: vi.fn(),
+  mockDeleteAdminAsset: vi.fn(),
+}));
+
+vi.mock('@/lib/assets-api', () => ({
+  createAdminAsset: mockCreateAdminAsset,
+  initAdminAssetContentReplace: mockInitAdminAssetContentReplace,
+  completeAdminAssetContentReplace: mockCompleteAdminAssetContentReplace,
+  uploadFileToPresignedUrl: mockUploadFileToPresignedUrl,
+  updateAdminAsset: mockUpdateAdminAsset,
+  deleteAdminAsset: mockDeleteAdminAsset,
+}));
+
+import { useAssetMutations } from '@/hooks/use-asset-mutations';
+
+describe('useAssetMutations', () => {
+  const applyCreatedAsset = vi.fn();
+  const applyUpdatedAsset = vi.fn();
+  const applyDeletedAsset = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('re-inits replace upload when retrying PUT and presign is expired', async () => {
+    const expiredIso = new Date(Date.now() - 60_000).toISOString();
+    const fresh = {
+      pendingS3Key: 'assets/asset-1/refreshed-key.pdf',
+      uploadUrl: 'https://fresh.example/put',
+      uploadMethod: 'PUT',
+      uploadHeaders: {},
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    };
+    mockInitAdminAssetContentReplace
+      .mockResolvedValueOnce({
+        pendingS3Key: 'assets/asset-1/old-key.pdf',
+        uploadUrl: 'https://old.example/put',
+        uploadMethod: 'PUT',
+        uploadHeaders: {},
+        expiresAt: expiredIso,
+      })
+      .mockResolvedValueOnce(fresh);
+    mockUploadFileToPresignedUrl.mockRejectedValueOnce(new Error('upload failed'));
+    mockUploadFileToPresignedUrl.mockResolvedValueOnce(undefined);
+    mockCompleteAdminAssetContentReplace.mockResolvedValueOnce({ id: 'asset-1' });
+
+    const { result } = renderHook(() =>
+      useAssetMutations({
+        applyCreatedAsset,
+        applyUpdatedAsset,
+        applyDeletedAsset,
+      })
+    );
+
+    await act(async () => {
+      await result.current.replaceAssetFileEntry(
+        'asset-1',
+        new File(['%PDF'], 'doc.pdf', { type: 'application/pdf' }),
+        'application/pdf'
+      );
+    });
+
+    expect(result.current.uploadState).toBe('failed');
+    expect(mockInitAdminAssetContentReplace).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.retryPendingUpload();
+    });
+
+    expect(mockInitAdminAssetContentReplace).toHaveBeenCalledTimes(2);
+    expect(mockUploadFileToPresignedUrl).toHaveBeenLastCalledWith(
+      expect.objectContaining({ uploadUrl: 'https://fresh.example/put' })
+    );
+    expect(mockCompleteAdminAssetContentReplace).toHaveBeenCalledWith(
+      'asset-1',
+      expect.objectContaining({ pendingS3Key: 'assets/asset-1/refreshed-key.pdf' })
+    );
+  });
+
+  it('retries complete-only path without re-init', async () => {
+    mockInitAdminAssetContentReplace.mockResolvedValueOnce({
+      pendingS3Key: 'assets/asset-1/k1.pdf',
+      uploadUrl: 'https://u.example/1',
+      uploadMethod: 'PUT',
+      uploadHeaders: {},
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    });
+    mockUploadFileToPresignedUrl.mockResolvedValueOnce(undefined);
+    mockCompleteAdminAssetContentReplace
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ id: 'asset-1' });
+
+    const { result } = renderHook(() =>
+      useAssetMutations({
+        applyCreatedAsset,
+        applyUpdatedAsset,
+        applyDeletedAsset,
+      })
+    );
+
+    await act(async () => {
+      await result.current.replaceAssetFileEntry(
+        'asset-1',
+        new File(['%PDF'], 'doc.pdf', { type: 'application/pdf' }),
+        'application/pdf'
+      );
+    });
+
+    expect(result.current.uploadState).toBe('failed');
+    expect(mockInitAdminAssetContentReplace).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.retryPendingUpload();
+    });
+
+    expect(mockInitAdminAssetContentReplace).toHaveBeenCalledTimes(1);
+    expect(mockCompleteAdminAssetContentReplace).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/admin_web/tests/types/asset-tags.test.ts
+++ b/apps/admin_web/tests/types/asset-tags.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { EXPENSE_ATTACHMENT_ASSET_TAG } from '@/types/assets';
+
+/**
+ * Must stay aligned with `EXPENSE_ATTACHMENT_TAG_NAME` in
+ * `backend/src/app/services/asset_expense_tagging.py` and admin OpenAPI
+ * `tag_name` / expense filter examples.
+ */
+describe('asset tag constants', () => {
+  it('expense attachment tag matches backend literal', () => {
+    expect(EXPENSE_ATTACHMENT_ASSET_TAG).toBe('expense_attachment');
+  });
+});

--- a/backend/src/app/api/assets/admin_assets.py
+++ b/backend/src/app/api/assets/admin_assets.py
@@ -2,54 +2,47 @@
 
 from __future__ import annotations
 
-import base64
-import json
 from typing import Any
 from collections.abc import Mapping
 from uuid import UUID, uuid4
 
-from botocore.exceptions import ClientError
 from sqlalchemy.orm import Session
 
 from app.api.admin_request import parse_uuid
+from app.api.assets.admin_assets_content_replace import (
+    complete_asset_content_replace,
+    init_asset_content_replace,
+)
+from app.api.assets.admin_share_links import (
+    get_or_create_share_link,
+    get_share_link,
+    revoke_share_link,
+    rotate_share_link,
+)
 from app.api.assets.assets_common import (
     asset_links_expense_attachment,
     build_s3_key,
     delete_s3_object,
     extract_identity,
-    file_name_from_pending_asset_content_key,
     generate_upload_url,
-    head_s3_object,
     paginate_response,
     parse_admin_asset_list_filters,
-    parse_complete_asset_content_replace_payload,
     parse_create_asset_payload,
     parse_cursor,
     parse_grant_payload,
-    parse_init_asset_content_replace_payload,
     parse_limit,
     parse_partial_update_asset_payload,
     parse_update_asset_payload,
     serialize_asset,
-    sanitize_file_name,
     serialize_grant,
     split_route_parts,
-    validate_pending_asset_content_s3_key,
-)
-from app.api.assets.share_links import (
-    build_share_link_url,
-    generate_share_token,
-    normalize_allowed_domains,
-    resolve_default_allowed_domains,
 )
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.repositories.asset import AssetRepository
 from app.exceptions import NotFoundError, ValidationError
 from app.services.asset_expense_tagging import CLIENT_DOCUMENT_TAG_NAME
-from app.utils import get_logger, json_response
-
-logger = get_logger(__name__)
+from app.utils import json_response
 
 
 def handle_admin_assets_request(
@@ -98,23 +91,48 @@ def handle_admin_assets_request(
 
     if len(parts) == 5 and parts[3] == "content":
         if parts[4] == "init" and method == "POST":
-            return _init_asset_content_replace(event, asset_id)
+            return init_asset_content_replace(
+                event,
+                asset_id,
+                identity_user_sub=identity.user_sub,
+                request_id=_request_id(event),
+            )
         if parts[4] == "complete" and method == "POST":
-            return _complete_asset_content_replace(event, asset_id)
+            return complete_asset_content_replace(
+                event,
+                asset_id,
+                identity_user_sub=identity.user_sub,
+                request_id=_request_id(event),
+            )
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     if len(parts) == 4 and parts[3] == "share-link":
         if method == "GET":
-            return _get_share_link(event, asset_id)
+            return get_share_link(event, asset_id)
         if method == "POST":
-            return _get_or_create_share_link(event, asset_id, identity.user_sub)
+            return get_or_create_share_link(
+                event,
+                asset_id,
+                identity.user_sub,
+                request_id=_request_id(event),
+            )
         if method == "DELETE":
-            return _revoke_share_link(event, asset_id, identity.user_sub)
+            return revoke_share_link(
+                event,
+                asset_id,
+                identity.user_sub,
+                request_id=_request_id(event),
+            )
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     if len(parts) == 5 and parts[3] == "share-link" and parts[4] == "rotate":
         if method == "POST":
-            return _rotate_share_link(event, asset_id, identity.user_sub)
+            return rotate_share_link(
+                event,
+                asset_id,
+                identity.user_sub,
+                request_id=_request_id(event),
+            )
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     return json_response(404, {"error": "Not found"}, event=event)
@@ -276,142 +294,6 @@ def _delete_asset(event: Mapping[str, Any], asset_id: UUID) -> dict[str, Any]:
         return json_response(204, {}, event=event)
 
 
-def _init_asset_content_replace(
-    event: Mapping[str, Any],
-    asset_id: UUID,
-) -> dict[str, Any]:
-    payload = parse_init_asset_content_replace_payload(event)
-    identity = extract_identity(event)
-    request_id = _request_id(event)
-
-    with Session(get_engine()) as session:
-        set_audit_context(
-            session, user_id=identity.user_sub or "", request_id=request_id
-        )
-        repository = AssetRepository(session)
-        asset = repository.get_with_asset_tags(asset_id)
-        if asset is None:
-            raise NotFoundError("Asset", str(asset_id))
-        if asset_links_expense_attachment(asset):
-            raise ValidationError(
-                "File replacement is not allowed for expense-linked assets",
-                field="asset",
-            )
-
-        pending_key = build_s3_key(asset_id, payload["file_name"])
-        upload = generate_upload_url(
-            s3_key=pending_key, content_type=payload["content_type"]
-        )
-        return json_response(
-            200,
-            {
-                "pending_s3_key": pending_key,
-                **upload,
-            },
-            event=event,
-        )
-
-
-def _complete_asset_content_replace(
-    event: Mapping[str, Any],
-    asset_id: UUID,
-) -> dict[str, Any]:
-    payload = parse_complete_asset_content_replace_payload(event)
-    validate_pending_asset_content_s3_key(
-        asset_id=asset_id, pending_key=payload["pending_s3_key"]
-    )
-    identity = extract_identity(event)
-    request_id = _request_id(event)
-
-    try:
-        head_meta = head_s3_object(s3_key=payload["pending_s3_key"])
-    except ClientError as exc:
-        error_code = str(exc.response.get("Error", {}).get("Code", ""))
-        http_status = int(
-            exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
-        )
-        if http_status == 404 or error_code in {"404", "NoSuchKey", "NotFound"}:
-            raise ValidationError(
-                "Uploaded object was not found; complete the presigned upload first",
-                field="pending_s3_key",
-            ) from exc
-        logger.exception(
-            "S3 head_object failed for asset content replace",
-            extra={"asset_id": str(asset_id), "error_code": error_code},
-        )
-        raise ValidationError(
-            "Could not verify the uploaded object",
-            field="pending_s3_key",
-        ) from exc
-
-    key_derived_name = file_name_from_pending_asset_content_key(
-        payload["pending_s3_key"]
-    )
-    client_file_name = sanitize_file_name(payload["file_name"])
-    if client_file_name != key_derived_name:
-        raise ValidationError(
-            "file_name does not match the pending upload key",
-            field="file_name",
-        )
-
-    resolved_content_type = payload["content_type"]
-    if not resolved_content_type:
-        head_ct = head_meta.get("ContentType")
-        if isinstance(head_ct, str) and head_ct.strip():
-            resolved_content_type = head_ct.strip()
-
-    with Session(get_engine()) as session:
-        set_audit_context(
-            session, user_id=identity.user_sub or "", request_id=request_id
-        )
-        repository = AssetRepository(session)
-        asset = repository.get_with_asset_tags(asset_id)
-        if asset is None:
-            raise NotFoundError("Asset", str(asset_id))
-        if asset_links_expense_attachment(asset):
-            raise ValidationError(
-                "File replacement is not allowed for expense-linked assets",
-                field="asset",
-            )
-
-        previous_key = asset.s3_key
-        if previous_key == payload["pending_s3_key"]:
-            raise ValidationError(
-                "pending_s3_key matches the current object; nothing to replace",
-                field="pending_s3_key",
-            )
-
-        repository.update_asset(
-            asset,
-            s3_key=payload["pending_s3_key"],
-            file_name=payload["file_name"],
-            content_type=resolved_content_type,
-        )
-        session.flush()
-        refreshed = repository.get_with_asset_tags(asset_id)
-        serialized = serialize_asset(refreshed or asset)
-        session.commit()
-
-        if previous_key and previous_key != payload["pending_s3_key"]:
-            try:
-                delete_s3_object(s3_key=previous_key)
-            except ClientError:
-                logger.warning(
-                    "replace_delete_failed: previous S3 object delete failed after successful replace",
-                    extra={
-                        "asset_id": str(asset_id),
-                        "s3_key": previous_key,
-                        "outcome": "replace_delete_failed",
-                    },
-                )
-
-        return json_response(
-            200,
-            {"asset": serialized},
-            event=event,
-        )
-
-
 def _list_grants(event: Mapping[str, Any], asset_id: UUID) -> dict[str, Any]:
     with Session(get_engine()) as session:
         repository = AssetRepository(session)
@@ -479,201 +361,6 @@ def _delete_grant(
         repository.delete_grant(grant)
         session.commit()
         return json_response(204, {}, event=event)
-
-
-def _get_or_create_share_link(
-    event: Mapping[str, Any],
-    asset_id: UUID,
-    actor_sub: str,
-) -> dict[str, Any]:
-    request_id = _request_id(event)
-    requested_allowed_domains = _parse_share_link_allowed_domains(event)
-
-    with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
-        repository = AssetRepository(session)
-        asset = repository.get_by_id(asset_id)
-        if asset is None:
-            raise NotFoundError("Asset", str(asset_id))
-
-        share_link = repository.get_share_link(asset_id=asset_id)
-        status_code = 200
-        if share_link is None:
-            allowed_domains = (
-                requested_allowed_domains or resolve_default_allowed_domains()
-            )
-            share_link = repository.create_share_link(
-                asset_id=asset_id,
-                share_token=generate_share_token(),
-                allowed_domains=allowed_domains,
-                created_by=actor_sub,
-            )
-            status_code = 201
-        elif requested_allowed_domains is not None:
-            share_link = repository.update_share_link_allowed_domains(
-                share_link,
-                allowed_domains=requested_allowed_domains,
-            )
-        session.commit()
-
-        return json_response(
-            status_code,
-            _serialize_share_link_response(
-                event=event,
-                asset_id=asset_id,
-                token=share_link.share_token,
-                allowed_domains=share_link.allowed_domains,
-            ),
-            event=event,
-        )
-
-
-def _get_share_link(event: Mapping[str, Any], asset_id: UUID) -> dict[str, Any]:
-    with Session(get_engine()) as session:
-        repository = AssetRepository(session)
-        asset = repository.get_by_id(asset_id)
-        if asset is None:
-            raise NotFoundError("Asset", str(asset_id))
-
-        share_link = repository.get_share_link(asset_id=asset_id)
-        if share_link is None:
-            raise NotFoundError("Share link", str(asset_id))
-
-        return json_response(
-            200,
-            _serialize_share_link_response(
-                event=event,
-                asset_id=asset_id,
-                token=share_link.share_token,
-                allowed_domains=share_link.allowed_domains,
-            ),
-            event=event,
-        )
-
-
-def _rotate_share_link(
-    event: Mapping[str, Any],
-    asset_id: UUID,
-    actor_sub: str,
-) -> dict[str, Any]:
-    request_id = _request_id(event)
-    requested_allowed_domains = _parse_share_link_allowed_domains(event)
-
-    with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
-        repository = AssetRepository(session)
-        asset = repository.get_by_id(asset_id)
-        if asset is None:
-            raise NotFoundError("Asset", str(asset_id))
-
-        share_link = repository.get_share_link(asset_id=asset_id)
-        next_token = generate_share_token()
-        if share_link is None:
-            allowed_domains = (
-                requested_allowed_domains or resolve_default_allowed_domains()
-            )
-            share_link = repository.create_share_link(
-                asset_id=asset_id,
-                share_token=next_token,
-                allowed_domains=allowed_domains,
-                created_by=actor_sub,
-            )
-        else:
-            share_link = repository.rotate_share_link(
-                share_link,
-                share_token=next_token,
-                allowed_domains=requested_allowed_domains,
-            )
-        session.commit()
-
-        return json_response(
-            200,
-            _serialize_share_link_response(
-                event=event,
-                asset_id=asset_id,
-                token=share_link.share_token,
-                allowed_domains=share_link.allowed_domains,
-            ),
-            event=event,
-        )
-
-
-def _revoke_share_link(
-    event: Mapping[str, Any],
-    asset_id: UUID,
-    actor_sub: str,
-) -> dict[str, Any]:
-    request_id = _request_id(event)
-
-    with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
-        repository = AssetRepository(session)
-        asset = repository.get_by_id(asset_id)
-        if asset is None:
-            raise NotFoundError("Asset", str(asset_id))
-
-        share_link = repository.get_share_link(asset_id=asset_id)
-        if share_link is not None:
-            repository.revoke_share_link(share_link)
-        session.commit()
-        return json_response(204, {}, event=event)
-
-
-def _serialize_share_link_response(
-    *,
-    event: Mapping[str, Any],
-    asset_id: UUID,
-    token: str,
-    allowed_domains: list[str],
-) -> dict[str, Any]:
-    return {
-        "asset_id": str(asset_id),
-        "share_url": build_share_link_url(event, token),
-        "allowed_domains": list(allowed_domains),
-    }
-
-
-def _parse_share_link_allowed_domains(event: Mapping[str, Any]) -> list[str] | None:
-    body = _parse_optional_json_body(event)
-    if body is None:
-        return None
-
-    raw_allowed_domains = body.get("allowed_domains")
-    if raw_allowed_domains is None:
-        raw_allowed_domains = body.get("allowedDomains")
-    if raw_allowed_domains is None:
-        return None
-    if not isinstance(raw_allowed_domains, list):
-        raise ValidationError(
-            "allowed_domains must be an array of domains",
-            field="allowed_domains",
-        )
-    return normalize_allowed_domains(raw_allowed_domains)
-
-
-def _parse_optional_json_body(event: Mapping[str, Any]) -> Mapping[str, Any] | None:
-    raw_body = event.get("body")
-    if raw_body is None:
-        return None
-    if not isinstance(raw_body, str):
-        raise ValidationError("Request body must be a JSON object", field="body")
-    if not raw_body.strip():
-        return None
-
-    decoded_body = raw_body
-    if event.get("isBase64Encoded"):
-        try:
-            decoded_body = base64.b64decode(raw_body).decode("utf-8")
-        except (ValueError, UnicodeDecodeError) as exc:
-            raise ValidationError("Request body is not valid base64 JSON") from exc
-
-    try:
-        parsed_body = json.loads(decoded_body)
-    except json.JSONDecodeError as exc:
-        raise ValidationError("Request body must be valid JSON", field="body") from exc
-    if not isinstance(parsed_body, Mapping):
-        raise ValidationError("Request body must be a JSON object", field="body")
-    return parsed_body
 
 
 def _request_id(event: Mapping[str, Any]) -> str | None:

--- a/backend/src/app/api/assets/admin_assets_content_replace.py
+++ b/backend/src/app/api/assets/admin_assets_content_replace.py
@@ -1,0 +1,206 @@
+"""Admin asset file replacement (presigned upload + complete)."""
+
+from __future__ import annotations
+
+from typing import Any
+from collections.abc import Mapping
+from uuid import UUID
+
+from botocore.exceptions import ClientError
+from sqlalchemy.orm import Session
+
+from app.api.assets.assets_common import (
+    admin_asset_replace_content_type,
+    asset_links_expense_attachment,
+    build_s3_key,
+    delete_s3_object,
+    file_name_from_pending_asset_content_key,
+    generate_upload_url,
+    head_s3_object,
+    max_asset_presigned_upload_bytes,
+    parse_complete_asset_content_replace_payload,
+    parse_init_asset_content_replace_payload,
+    sanitize_file_name,
+    serialize_asset,
+    validate_pending_asset_content_s3_key,
+)
+from app.db.audit import set_audit_context
+from app.db.engine import get_engine
+from app.db.repositories.asset import AssetRepository
+from app.exceptions import NotFoundError, ValidationError
+from app.utils import get_logger, json_response
+
+logger = get_logger(__name__)
+
+
+def init_asset_content_replace(
+    event: Mapping[str, Any],
+    asset_id: UUID,
+    *,
+    identity_user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    payload = parse_init_asset_content_replace_payload(event)
+    bound_ct = admin_asset_replace_content_type()
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=identity_user_sub, request_id=request_id)
+        repository = AssetRepository(session)
+        asset = repository.get_with_asset_tags(asset_id)
+        if asset is None:
+            raise NotFoundError("Asset", str(asset_id))
+        if asset_links_expense_attachment(asset):
+            raise ValidationError(
+                "File replacement is not allowed for expense-linked assets",
+                field="asset",
+            )
+
+        pending_key = build_s3_key(asset_id, payload["file_name"])
+        upload = generate_upload_url(s3_key=pending_key, content_type=bound_ct)
+        return json_response(
+            200,
+            {
+                "pending_s3_key": pending_key,
+                **upload,
+            },
+            event=event,
+        )
+
+
+def complete_asset_content_replace(
+    event: Mapping[str, Any],
+    asset_id: UUID,
+    *,
+    identity_user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    payload = parse_complete_asset_content_replace_payload(event)
+    validate_pending_asset_content_s3_key(
+        asset_id=asset_id, pending_key=payload["pending_s3_key"]
+    )
+    bound_ct = admin_asset_replace_content_type()
+    max_bytes = max_asset_presigned_upload_bytes()
+
+    try:
+        head_meta = head_s3_object(s3_key=payload["pending_s3_key"])
+    except ClientError as exc:
+        error_code = str(exc.response.get("Error", {}).get("Code", ""))
+        http_status = int(
+            exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
+        )
+        if http_status == 404 or error_code in {"404", "NoSuchKey", "NotFound"}:
+            raise ValidationError(
+                "Uploaded object was not found; complete the presigned upload first",
+                field="pending_s3_key",
+            ) from exc
+        logger.exception(
+            "S3 head_object failed for asset content replace",
+            extra={"asset_id": str(asset_id), "error_code": error_code},
+        )
+        raise ValidationError(
+            "Could not verify the uploaded object",
+            field="pending_s3_key",
+        ) from exc
+
+    try:
+        key_derived_name = file_name_from_pending_asset_content_key(
+            payload["pending_s3_key"]
+        )
+    except ValidationError:
+        raise
+    client_file_name = sanitize_file_name(payload["file_name"])
+    if client_file_name != key_derived_name:
+        raise ValidationError(
+            "file_name does not match the pending upload key",
+            field="file_name",
+        )
+
+    raw_ct = payload["content_type"]
+    if raw_ct is not None and str(raw_ct).strip() and str(raw_ct).strip() != bound_ct:
+        raise ValidationError(
+            "content_type must be application/pdf for file replacement",
+            field="content_type",
+        )
+
+    head_ct = head_meta.get("ContentType")
+    if isinstance(head_ct, str) and head_ct.strip() and head_ct.strip() != bound_ct:
+        raise ValidationError(
+            "Uploaded object Content-Type must be application/pdf",
+            field="content_type",
+        )
+
+    cl_raw = head_meta.get("ContentLength")
+    if cl_raw is None:
+        raise ValidationError(
+            "Uploaded object size could not be verified",
+            field="pending_s3_key",
+        )
+    try:
+        content_length = int(cl_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValidationError(
+            "Uploaded object size could not be verified",
+            field="pending_s3_key",
+        ) from exc
+    if content_length < 1 or content_length > max_bytes:
+        raise ValidationError(
+            f"Uploaded object must be between 1 and {max_bytes} bytes",
+            field="pending_s3_key",
+        )
+
+    resolved_content_type = bound_ct
+
+    with Session(get_engine()) as session:
+        set_audit_context(
+            session, user_id=identity_user_sub, request_id=request_id
+        )
+        repository = AssetRepository(session)
+        asset = repository.get_with_asset_tags(asset_id)
+        if asset is None:
+            raise NotFoundError("Asset", str(asset_id))
+        if asset_links_expense_attachment(asset):
+            raise ValidationError(
+                "File replacement is not allowed for expense-linked assets",
+                field="asset",
+            )
+
+        previous_key = asset.s3_key
+        if previous_key == payload["pending_s3_key"]:
+            raise ValidationError(
+                "pending_s3_key matches the current object; nothing to replace",
+                field="pending_s3_key",
+            )
+
+        try:
+            repository.update_asset(
+                asset,
+                s3_key=payload["pending_s3_key"],
+                file_name=payload["file_name"],
+                content_type=resolved_content_type,
+            )
+            session.flush()
+            refreshed = repository.get_with_asset_tags(asset_id)
+            serialized = serialize_asset(refreshed or asset)
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+
+        if previous_key and previous_key != payload["pending_s3_key"]:
+            try:
+                delete_s3_object(s3_key=previous_key)
+            except ClientError:
+                logger.warning(
+                    "replace_delete_failed: previous S3 object delete failed after successful replace",
+                    extra={
+                        "asset_id": str(asset_id),
+                        "s3_key": previous_key,
+                        "outcome": "replace_delete_failed",
+                    },
+                )
+
+        return json_response(
+            200,
+            {"asset": serialized},
+            event=event,
+        )

--- a/backend/src/app/api/assets/admin_assets_content_replace.py
+++ b/backend/src/app/api/assets/admin_assets_content_replace.py
@@ -151,9 +151,7 @@ def complete_asset_content_replace(
     resolved_content_type = bound_ct
 
     with Session(get_engine()) as session:
-        set_audit_context(
-            session, user_id=identity_user_sub, request_id=request_id
-        )
+        set_audit_context(session, user_id=identity_user_sub, request_id=request_id)
         repository = AssetRepository(session)
         asset = repository.get_with_asset_tags(asset_id)
         if asset is None:

--- a/backend/src/app/api/assets/admin_share_links.py
+++ b/backend/src/app/api/assets/admin_share_links.py
@@ -1,0 +1,220 @@
+"""Admin asset share-link API handlers."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+from collections.abc import Mapping
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.api.assets.share_links import (
+    build_share_link_url,
+    generate_share_token,
+    normalize_allowed_domains,
+    resolve_default_allowed_domains,
+)
+from app.db.audit import set_audit_context
+from app.db.engine import get_engine
+from app.db.repositories.asset import AssetRepository
+from app.exceptions import NotFoundError, ValidationError
+from app.utils import json_response
+
+
+def parse_optional_json_body(event: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    raw_body = event.get("body")
+    if raw_body is None:
+        return None
+    if not isinstance(raw_body, str):
+        raise ValidationError("Request body must be a JSON object", field="body")
+    if not raw_body.strip():
+        return None
+
+    decoded_body = raw_body
+    if event.get("isBase64Encoded"):
+        try:
+            decoded_body = base64.b64decode(raw_body).decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise ValidationError("Request body is not valid base64 JSON") from exc
+
+    try:
+        parsed_body = json.loads(decoded_body)
+    except json.JSONDecodeError as exc:
+        raise ValidationError("Request body must be valid JSON", field="body") from exc
+    if not isinstance(parsed_body, Mapping):
+        raise ValidationError("Request body must be a JSON object", field="body")
+    return parsed_body
+
+
+def parse_share_link_allowed_domains(event: Mapping[str, Any]) -> list[str] | None:
+    body = parse_optional_json_body(event)
+    if body is None:
+        return None
+
+    raw_allowed_domains = body.get("allowed_domains")
+    if raw_allowed_domains is None:
+        raw_allowed_domains = body.get("allowedDomains")
+    if raw_allowed_domains is None:
+        return None
+    if not isinstance(raw_allowed_domains, list):
+        raise ValidationError(
+            "allowed_domains must be an array of domains",
+            field="allowed_domains",
+        )
+    return normalize_allowed_domains(raw_allowed_domains)
+
+
+def serialize_share_link_response(
+    *,
+    event: Mapping[str, Any],
+    asset_id: UUID,
+    token: str,
+    allowed_domains: list[str],
+) -> dict[str, Any]:
+    return {
+        "asset_id": str(asset_id),
+        "share_url": build_share_link_url(event, token),
+        "allowed_domains": list(allowed_domains),
+    }
+
+
+def get_or_create_share_link(
+    event: Mapping[str, Any],
+    asset_id: UUID,
+    actor_sub: str,
+    *,
+    request_id: str | None,
+) -> dict[str, Any]:
+    requested_allowed_domains = parse_share_link_allowed_domains(event)
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        repository = AssetRepository(session)
+        asset = repository.get_by_id(asset_id)
+        if asset is None:
+            raise NotFoundError("Asset", str(asset_id))
+
+        share_link = repository.get_share_link(asset_id=asset_id)
+        status_code = 200
+        if share_link is None:
+            allowed_domains = (
+                requested_allowed_domains or resolve_default_allowed_domains()
+            )
+            share_link = repository.create_share_link(
+                asset_id=asset_id,
+                share_token=generate_share_token(),
+                allowed_domains=allowed_domains,
+                created_by=actor_sub,
+            )
+            status_code = 201
+        elif requested_allowed_domains is not None:
+            share_link = repository.update_share_link_allowed_domains(
+                share_link,
+                allowed_domains=requested_allowed_domains,
+            )
+        session.commit()
+
+        return json_response(
+            status_code,
+            serialize_share_link_response(
+                event=event,
+                asset_id=asset_id,
+                token=share_link.share_token,
+                allowed_domains=share_link.allowed_domains,
+            ),
+            event=event,
+        )
+
+
+def get_share_link(event: Mapping[str, Any], asset_id: UUID) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        repository = AssetRepository(session)
+        asset = repository.get_by_id(asset_id)
+        if asset is None:
+            raise NotFoundError("Asset", str(asset_id))
+
+        share_link = repository.get_share_link(asset_id=asset_id)
+        if share_link is None:
+            raise NotFoundError("Share link", str(asset_id))
+
+        return json_response(
+            200,
+            serialize_share_link_response(
+                event=event,
+                asset_id=asset_id,
+                token=share_link.share_token,
+                allowed_domains=share_link.allowed_domains,
+            ),
+            event=event,
+        )
+
+
+def rotate_share_link(
+    event: Mapping[str, Any],
+    asset_id: UUID,
+    actor_sub: str,
+    *,
+    request_id: str | None,
+) -> dict[str, Any]:
+    requested_allowed_domains = parse_share_link_allowed_domains(event)
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        repository = AssetRepository(session)
+        asset = repository.get_by_id(asset_id)
+        if asset is None:
+            raise NotFoundError("Asset", str(asset_id))
+
+        share_link = repository.get_share_link(asset_id=asset_id)
+        next_token = generate_share_token()
+        if share_link is None:
+            allowed_domains = (
+                requested_allowed_domains or resolve_default_allowed_domains()
+            )
+            share_link = repository.create_share_link(
+                asset_id=asset_id,
+                share_token=next_token,
+                allowed_domains=allowed_domains,
+                created_by=actor_sub,
+            )
+        else:
+            share_link = repository.rotate_share_link(
+                share_link,
+                share_token=next_token,
+                allowed_domains=requested_allowed_domains,
+            )
+        session.commit()
+
+        return json_response(
+            200,
+            serialize_share_link_response(
+                event=event,
+                asset_id=asset_id,
+                token=share_link.share_token,
+                allowed_domains=share_link.allowed_domains,
+            ),
+            event=event,
+        )
+
+
+def revoke_share_link(
+    event: Mapping[str, Any],
+    asset_id: UUID,
+    actor_sub: str,
+    *,
+    request_id: str | None,
+) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        repository = AssetRepository(session)
+        asset = repository.get_by_id(asset_id)
+        if asset is None:
+            raise NotFoundError("Asset", str(asset_id))
+
+        share_link = repository.get_share_link(asset_id=asset_id)
+        if share_link is not None:
+            repository.revoke_share_link(share_link)
+        session.commit()
+        return json_response(204, {}, event=event)

--- a/backend/src/app/api/assets/assets_common.py
+++ b/backend/src/app/api/assets/assets_common.py
@@ -35,6 +35,13 @@ from app.utils import json_response, require_env
 from sqlalchemy import inspect
 
 _MAX_FILE_NAME_LENGTH = 255
+# Admin presigned PUT uploads (create + replace): reject completes larger than this (bytes).
+_MAX_ASSET_PRESIGNED_UPLOAD_BYTES = 52_428_800  # 50 MiB
+_ADMIN_ASSET_REPLACE_CONTENT_TYPE = "application/pdf"
+_UUID_OBJECT_NAME_PREFIX_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-",
+    re.IGNORECASE,
+)
 _MAX_MIME_TYPE_LENGTH = 127
 _MAX_RESOURCE_KEY_LENGTH = 64
 _MAX_CONTENT_LANGUAGE_LENGTH = 35
@@ -463,12 +470,31 @@ def build_s3_key(asset_id: UUID, file_name: str) -> str:
 
 
 def file_name_from_pending_asset_content_key(s3_key: str) -> str:
-    """Return the filename segment after the random UUID prefix in a pending replace key."""
+    """Return the filename segment after the UUID prefix in a key from ``build_s3_key``."""
     segment = s3_key.rsplit("/", maxsplit=1)[-1]
-    # Keys from build_s3_key: "{uuid4}-{sanitized_name}" (UUID is 36 chars).
-    if len(segment) >= 38 and segment[36] == "-":
-        return segment[37:] or segment
-    return segment
+    match = _UUID_OBJECT_NAME_PREFIX_RE.match(segment)
+    if match is None:
+        raise ValidationError(
+            "pending_s3_key has an unexpected object name format",
+            field="pending_s3_key",
+        )
+    suffix = segment[match.end() :]
+    if not suffix:
+        raise ValidationError(
+            "pending_s3_key has an unexpected object name format",
+            field="pending_s3_key",
+        )
+    return suffix
+
+
+def max_asset_presigned_upload_bytes() -> int:
+    """Maximum allowed S3 object size for admin asset uploads (create and replace complete)."""
+    return _MAX_ASSET_PRESIGNED_UPLOAD_BYTES
+
+
+def admin_asset_replace_content_type() -> str:
+    """Content-Type bound for admin PDF replace presigns and enforced on complete."""
+    return _ADMIN_ASSET_REPLACE_CONTENT_TYPE
 
 
 def validate_pending_asset_content_s3_key(*, asset_id: UUID, pending_key: str) -> None:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -267,7 +267,8 @@ paths:
         Step 1 of 2 for replacing the binary stored for an asset while keeping the same asset id.
         Returns a presigned upload URL for a new S3 key under `assets/{id}/...`. Call
         `POST /v1/admin/assets/{id}/content/complete` after the client uploads to that URL.
-        Not allowed when the asset has the `expense_attachment` tag (400).
+        Not allowed when the asset has the `expense_attachment` tag (400). The presigned PUT binds
+        `Content-Type: application/pdf` regardless of optional `content_type` in the body.
       security:
         - AdminBearerAuth: []
       requestBody:
@@ -301,10 +302,14 @@ paths:
         the value returned by `POST .../content/init` for this asset id. Not allowed when the asset
         has the `expense_attachment` tag (400).
         `file_name` must match the filename embedded in `pending_s3_key` after server-side sanitization
-        (same rules as init). This call is not idempotent across different `pending_s3_key` values:
-        repeating complete with a stale key after a successful replace returns 400.
-        When `content_type` is null or omitted, the stored content type is taken from the uploaded
-        object's S3 `Content-Type` metadata when present.
+        (same rules as init). The object name segment must begin with a standard UUID prefix
+        (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-`) from init. Stored `content_type` is always
+        `application/pdf`; the uploaded object's S3 Content-Type and size are validated on complete
+        (max 50 MiB). This call is not idempotent across different `pending_s3_key` values: repeating
+        complete with a stale key after a successful replace returns 400. Concurrent replaces for the
+        same asset are last-writer-wins; earlier pending keys may become orphans if never completed.
+        BadRequest responses may include `field` values such as `pending_s3_key`, `file_name`,
+        `content_type`, or `asset` depending on the failure.
       security:
         - AdminBearerAuth: []
       requestBody:
@@ -4333,13 +4338,16 @@ components:
       type: object
       required:
         - asset
+        - upload_url
+        - upload_method
+        - upload_headers
+        - expires_at
       properties:
         asset:
           $ref: "#/components/schemas/Asset"
         upload_url:
           type: string
           format: uri
-          nullable: true
         upload_method:
           type: string
         upload_headers:
@@ -4349,7 +4357,6 @@ components:
         expires_at:
           type: string
           format: date-time
-          nullable: true
     InitAssetContentReplaceRequest:
       type: object
       required:
@@ -4376,7 +4383,6 @@ components:
         upload_url:
           type: string
           format: uri
-          nullable: true
         upload_method:
           type: string
         upload_headers:
@@ -4386,7 +4392,6 @@ components:
         expires_at:
           type: string
           format: date-time
-          nullable: true
     CompleteAssetContentReplaceRequest:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -42,9 +42,15 @@ their primary responsibilities.
   Nominatim-backed address geocoding via `AwsApiProxyFunction`),
   `/v1/admin/assets/*` (including `POST /v1/admin/assets/{id}/content/init` and
   `POST /v1/admin/assets/{id}/content/complete` for two-step S3 file replacement
-  while preserving the asset id; complete validates `file_name` against the pending
-  key, fills `content_type` from S3 metadata when omitted, and logs a warning with
-  `outcome=replace_delete_failed` if deleting the previous object fails after commit),
+  while preserving the asset id; complete validates the pending key segment
+  (`UUID-` prefix + filename), enforces PDF `Content-Type` and max upload size on
+  S3 head, and logs a warning with `outcome=replace_delete_failed` if deleting the
+  previous object fails after commit). **Operational caveats:** concurrent replaces
+  are last-writer-wins; abandoned `complete` calls can leave orphan objects under
+  `assets/{id}/`; failed old-key deletes are log-only until a follow-up lifecycle or
+  reconciliation job exists. **Caching:** share-link tokens stay stable on replace;
+  CDN or browser caching keyed only by URL (not `s3_key`) may show stale bytes until TTL—
+  downloads keyed by changing `s3_key` generally avoid that.
   `/v1/admin/contacts/*` (including `GET /v1/admin/contacts/tags` for tag pickers and
   `GET /v1/admin/contacts/search` for contact picker search),
   `/v1/admin/families/picker`, `/v1/admin/families/*`,

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -142,6 +142,14 @@ const deviceAttestationFailClosed = new cdk.CfnParameter(
 
 ## API Security
 
+### Admin asset file replacement
+
+`POST /v1/admin/assets/{id}/content/init` and `.../complete` are **admin-authenticated**
+writes. The replace presign binds **`Content-Type: application/pdf`**, and **complete**
+rejects non-PDF S3 metadata, enforces a **maximum object size** on head, and validates the
+pending key’s **`UUID-` filename prefix** so arbitrary key suffixes cannot be smuggled in.
+Expense-linked assets cannot use replace.
+
 ### CORS Configuration
 
 **Never use `Cors.ALL_ORIGINS` in production.** Always restrict to specific allowed origins.

--- a/tests/test_admin_asset_content_replace.py
+++ b/tests/test_admin_asset_content_replace.py
@@ -1,4 +1,4 @@
-"""Tests for admin asset content replace (init/complete) handlers."""
+"""Tests for admin asset file replacement (init/complete)."""
 
 from __future__ import annotations
 
@@ -9,18 +9,9 @@ from uuid import UUID, uuid4
 import pytest
 from botocore.exceptions import ClientError
 
-from app.api.assets import admin_assets
-from app.api.assets.assets_common import RequestIdentity
+from app.api.assets import admin_assets_content_replace as content_replace
 from app.db.models import Asset, AssetType, AssetVisibility
 from app.exceptions import ValidationError
-
-
-def _identity() -> RequestIdentity:
-    return RequestIdentity(
-        user_sub="admin-sub",
-        groups={"admin"},
-        organization_ids=set(),
-    )
 
 
 def _make_asset(
@@ -43,34 +34,26 @@ def _make_asset(
     )
 
 
-def test_complete_rejects_file_name_mismatch_with_key_derived_name(
+def _good_head(*, content_length: int = 12) -> dict[str, Any]:
+    return {
+        "ContentType": "application/pdf",
+        "ContentLength": content_length,
+    }
+
+
+def test_complete_rejects_file_name_mismatch(
     monkeypatch: pytest.MonkeyPatch,
     api_gateway_event: Any,
 ) -> None:
     asset_id = uuid4()
     pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-guide.pdf"
-
-    monkeypatch.setattr(admin_assets, "extract_identity", lambda _e: _identity())
-    monkeypatch.setattr(
-        admin_assets,
-        "parse_complete_asset_content_replace_payload",
-        lambda _e: {
-            "pending_s3_key": pending,
-            "file_name": "wrong.pdf",
-            "content_type": "application/pdf",
-        },
-    )
-
-    def _head_ok(**_kwargs: Any) -> dict[str, Any]:
-        return {"ContentType": "application/pdf"}
-
-    monkeypatch.setattr(admin_assets, "head_s3_object", _head_ok)
+    monkeypatch.setattr(content_replace, "head_s3_object", lambda **_k: _good_head())
 
     with pytest.raises(ValidationError, match="file_name"):
-        admin_assets._complete_asset_content_replace(  # noqa: SLF001
+        content_replace.complete_asset_content_replace(
             api_gateway_event(
                 method="POST",
-                path=f"/v1/admin/assets/{asset_id}/content/complete",
+                path="/x",
                 body=json.dumps(
                     {
                         "pending_s3_key": pending,
@@ -80,6 +63,8 @@ def test_complete_rejects_file_name_mismatch_with_key_derived_name(
                 ),
             ),
             asset_id,
+            identity_user_sub="u",
+            request_id=None,
         )
 
 
@@ -90,29 +75,30 @@ def test_complete_raises_when_head_no_such_key(
     asset_id = uuid4()
     pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-missing.pdf"
 
-    monkeypatch.setattr(admin_assets, "extract_identity", lambda _e: _identity())
-    monkeypatch.setattr(
-        admin_assets,
-        "parse_complete_asset_content_replace_payload",
-        lambda _e: {
-            "pending_s3_key": pending,
-            "file_name": "missing.pdf",
-            "content_type": None,
-        },
-    )
-
     def _head_fail(**_kwargs: Any) -> dict[str, Any]:
         raise ClientError(
             {"Error": {"Code": "NoSuchKey"}, "ResponseMetadata": {"HTTPStatusCode": 404}},
             "HeadObject",
         )
 
-    monkeypatch.setattr(admin_assets, "head_s3_object", _head_fail)
+    monkeypatch.setattr(content_replace, "head_s3_object", _head_fail)
 
     with pytest.raises(ValidationError, match="not found"):
-        admin_assets._complete_asset_content_replace(  # noqa: SLF001
-            api_gateway_event(method="POST", path="/x", body="{}"),
+        content_replace.complete_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps(
+                    {
+                        "pending_s3_key": pending,
+                        "file_name": "missing.pdf",
+                        "content_type": None,
+                    }
+                ),
+            ),
             asset_id,
+            identity_user_sub="u",
+            request_id=None,
         )
 
 
@@ -122,19 +108,8 @@ def test_complete_blocks_expense_tagged_asset(
 ) -> None:
     asset_id = uuid4()
     pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-x.pdf"
-
-    monkeypatch.setattr(admin_assets, "extract_identity", lambda _e: _identity())
-    monkeypatch.setattr(
-        admin_assets,
-        "parse_complete_asset_content_replace_payload",
-        lambda _e: {
-            "pending_s3_key": pending,
-            "file_name": "x.pdf",
-            "content_type": None,
-        },
-    )
-    monkeypatch.setattr(admin_assets, "head_s3_object", lambda **_k: {"ContentType": "application/pdf"})
-    monkeypatch.setattr(admin_assets, "asset_links_expense_attachment", lambda _a: True)
+    monkeypatch.setattr(content_replace, "head_s3_object", lambda **_k: _good_head())
+    monkeypatch.setattr(content_replace, "asset_links_expense_attachment", lambda _a: True)
 
     class _Repo:
         def get_with_asset_tags(self, _id: UUID) -> Asset:
@@ -147,34 +122,200 @@ def test_complete_blocks_expense_tagged_asset(
         def __exit__(self, *args: object) -> None:
             return None
 
-    monkeypatch.setattr(admin_assets, "Session", lambda _e: _Sess())
-    monkeypatch.setattr(admin_assets, "get_engine", lambda: object())
-    monkeypatch.setattr(admin_assets, "set_audit_context", lambda *a, **k: None)
-    monkeypatch.setattr(admin_assets, "AssetRepository", lambda _s: _Repo())
+    monkeypatch.setattr(content_replace, "Session", lambda _e: _Sess())
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: _Repo())
 
     with pytest.raises(ValidationError, match="expense"):
-        admin_assets._complete_asset_content_replace(  # noqa: SLF001
-            api_gateway_event(method="POST", path="/x", body="{}"),
+        content_replace.complete_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps(
+                    {
+                        "pending_s3_key": pending,
+                        "file_name": "x.pdf",
+                        "content_type": None,
+                    }
+                ),
+            ),
             asset_id,
+            identity_user_sub="u",
+            request_id=None,
         )
 
 
-def test_validate_pending_key_rejects_traversal_and_prefix(
+def test_init_returns_404_when_asset_missing(
     monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
 ) -> None:
-    from app.api.assets.assets_common import validate_pending_asset_content_s3_key
+    from app.exceptions import NotFoundError
 
-    aid = uuid4()
-    with pytest.raises(ValidationError):
-        validate_pending_asset_content_s3_key(
-            asset_id=aid, pending_key=f"assets/{aid}/../other/x.pdf"
+    asset_id = uuid4()
+
+    class _Repo:
+        def get_with_asset_tags(self, _id: UUID) -> None:
+            return None
+
+    class _Sess:
+        def __enter__(self) -> _Sess:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(content_replace, "Session", lambda _e: _Sess())
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: _Repo())
+
+    with pytest.raises(NotFoundError):
+        content_replace.init_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps({"file_name": "a.pdf", "content_type": "application/pdf"}),
+            ),
+            asset_id,
+            identity_user_sub="u",
+            request_id=None,
         )
-    with pytest.raises(ValidationError):
-        validate_pending_asset_content_s3_key(
-            asset_id=aid, pending_key=f"  assets/{aid}/x.pdf"
+
+
+def test_init_blocks_expense_linked_asset(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    asset_id = uuid4()
+
+    class _Repo:
+        def get_with_asset_tags(self, _id: UUID) -> Asset:
+            return _make_asset(asset_id=asset_id)
+
+    class _Sess:
+        def __enter__(self) -> _Sess:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(content_replace, "Session", lambda _e: _Sess())
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: _Repo())
+    monkeypatch.setattr(content_replace, "asset_links_expense_attachment", lambda _a: True)
+
+    with pytest.raises(ValidationError, match="expense"):
+        content_replace.init_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps({"file_name": "a.pdf"}),
+            ),
+            asset_id,
+            identity_user_sub="u",
+            request_id=None,
         )
-    with pytest.raises(ValidationError):
-        validate_pending_asset_content_s3_key(asset_id=aid, pending_key="assets/other/x.pdf")
+
+
+def test_complete_rejects_oversized_object(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    asset_id = uuid4()
+    pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-huge.pdf"
+    monkeypatch.setattr(
+        content_replace,
+        "head_s3_object",
+        lambda **_k: _good_head(content_length=99_000_000),
+    )
+
+    class _Repo:
+        def get_with_asset_tags(self, _id: UUID) -> Asset:
+            return _make_asset(asset_id=asset_id)
+
+    class _Sess:
+        def __enter__(self) -> _Sess:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(content_replace, "Session", lambda _e: _Sess())
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: _Repo())
+    monkeypatch.setattr(content_replace, "asset_links_expense_attachment", lambda _a: False)
+
+    with pytest.raises(ValidationError, match="between 1 and"):
+        content_replace.complete_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps(
+                    {
+                        "pending_s3_key": pending,
+                        "file_name": "huge.pdf",
+                        "content_type": "application/pdf",
+                    }
+                ),
+            ),
+            asset_id,
+            identity_user_sub="u",
+            request_id=None,
+        )
+
+
+def test_complete_rejects_non_pdf_head_content_type(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    asset_id = uuid4()
+    pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-bad.pdf"
+    monkeypatch.setattr(
+        content_replace,
+        "head_s3_object",
+        lambda **_k: {
+            "ContentType": "application/octet-stream",
+            "ContentLength": 100,
+        },
+    )
+
+    class _Repo:
+        def get_with_asset_tags(self, _id: UUID) -> Asset:
+            return _make_asset(asset_id=asset_id)
+
+    class _Sess:
+        def __enter__(self) -> _Sess:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(content_replace, "Session", lambda _e: _Sess())
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: _Repo())
+    monkeypatch.setattr(content_replace, "asset_links_expense_attachment", lambda _a: False)
+
+    with pytest.raises(ValidationError, match="Content-Type"):
+        content_replace.complete_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps(
+                    {
+                        "pending_s3_key": pending,
+                        "file_name": "bad.pdf",
+                        "content_type": None,
+                    }
+                ),
+            ),
+            asset_id,
+            identity_user_sub="u",
+            request_id=None,
+        )
 
 
 def test_complete_success_updates_and_deletes_previous(
@@ -186,28 +327,14 @@ def test_complete_success_updates_and_deletes_previous(
     pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-newdoc.pdf"
     asset = _make_asset(asset_id=asset_id, s3_key=old_key)
 
-    monkeypatch.setattr(admin_assets, "extract_identity", lambda _e: _identity())
-    monkeypatch.setattr(
-        admin_assets,
-        "parse_complete_asset_content_replace_payload",
-        lambda _e: {
-            "pending_s3_key": pending,
-            "file_name": "newdoc.pdf",
-            "content_type": None,
-        },
-    )
-    monkeypatch.setattr(
-        admin_assets,
-        "head_s3_object",
-        lambda **_k: {"ContentType": "application/pdf"},
-    )
+    monkeypatch.setattr(content_replace, "head_s3_object", lambda **_k: _good_head())
 
     deleted: list[str] = []
 
     def _delete_s3(*, s3_key: str) -> None:
         deleted.append(s3_key)
 
-    monkeypatch.setattr(admin_assets, "delete_s3_object", _delete_s3)
+    monkeypatch.setattr(content_replace, "delete_s3_object", _delete_s3)
 
     class _Repo:
         def __init__(self) -> None:
@@ -240,15 +367,31 @@ def test_complete_success_updates_and_deletes_previous(
         def flush(self) -> None:
             return None
 
-    sess = _Sess()
-    monkeypatch.setattr(admin_assets, "Session", lambda _e: sess)
-    monkeypatch.setattr(admin_assets, "get_engine", lambda: object())
-    monkeypatch.setattr(admin_assets, "set_audit_context", lambda *a, **k: None)
-    monkeypatch.setattr(admin_assets, "AssetRepository", lambda _s: repo)
+        def rollback(self) -> None:
+            return None
 
-    resp = admin_assets._complete_asset_content_replace(  # noqa: SLF001
-        api_gateway_event(method="POST", path="/x", body="{}"),
+    sess = _Sess()
+    monkeypatch.setattr(content_replace, "Session", lambda _e: sess)
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: repo)
+    monkeypatch.setattr(content_replace, "asset_links_expense_attachment", lambda _a: False)
+
+    resp = content_replace.complete_asset_content_replace(
+        api_gateway_event(
+            method="POST",
+            path="/x",
+            body=json.dumps(
+                {
+                    "pending_s3_key": pending,
+                    "file_name": "newdoc.pdf",
+                    "content_type": None,
+                }
+            ),
+        ),
         asset_id,
+        identity_user_sub="u",
+        request_id=None,
     )
     assert resp["statusCode"] == 200
     assert repo.updated is True
@@ -260,30 +403,83 @@ def test_complete_success_updates_and_deletes_previous(
     assert body["asset"]["content_type"] == "application/pdf"
 
 
+def test_complete_does_not_delete_when_update_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    asset_id = uuid4()
+    old_key = f"assets/{asset_id}/old.pdf"
+    pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-new.pdf"
+    asset = _make_asset(asset_id=asset_id, s3_key=old_key)
+
+    monkeypatch.setattr(content_replace, "head_s3_object", lambda **_k: _good_head())
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        content_replace, "delete_s3_object", lambda *, s3_key: deleted.append(s3_key)
+    )
+
+    class _Repo:
+        def get_with_asset_tags(self, _id: UUID) -> Asset:
+            return asset
+
+        def update_asset(self, a: Asset, **kwargs: Any) -> Asset:
+            raise RuntimeError("simulated db failure")
+
+    class _Sess:
+        rolled_back = False
+
+        def __enter__(self) -> _Sess:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def commit(self) -> None:
+            return None
+
+        def flush(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            self.rolled_back = True
+
+    sess = _Sess()
+    monkeypatch.setattr(content_replace, "Session", lambda _e: sess)
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: _Repo())
+    monkeypatch.setattr(content_replace, "asset_links_expense_attachment", lambda _a: False)
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        content_replace.complete_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps(
+                    {
+                        "pending_s3_key": pending,
+                        "file_name": "new.pdf",
+                        "content_type": "application/pdf",
+                    }
+                ),
+            ),
+            asset_id,
+            identity_user_sub="u",
+            request_id=None,
+        )
+    assert deleted == []
+    assert sess.rolled_back is True
+
+
 def test_second_complete_same_pending_after_success_raises(
     monkeypatch: pytest.MonkeyPatch,
     api_gateway_event: Any,
 ) -> None:
-    """After DB points at pending key, second complete with same key hits 'nothing to replace'."""
     asset_id = uuid4()
     pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-doc.pdf"
 
-    monkeypatch.setattr(admin_assets, "extract_identity", lambda _e: _identity())
-    monkeypatch.setattr(
-        admin_assets,
-        "parse_complete_asset_content_replace_payload",
-        lambda _e: {
-            "pending_s3_key": pending,
-            "file_name": "doc.pdf",
-            "content_type": "application/pdf",
-        },
-    )
-    monkeypatch.setattr(
-        admin_assets,
-        "head_s3_object",
-        lambda **_k: {"ContentType": "application/pdf"},
-    )
-    monkeypatch.setattr(admin_assets, "delete_s3_object", lambda **_k: None)
+    monkeypatch.setattr(content_replace, "head_s3_object", lambda **_k: _good_head())
+    monkeypatch.setattr(content_replace, "delete_s3_object", lambda **_k: None)
 
     asset = _make_asset(asset_id=asset_id, s3_key=pending)
 
@@ -307,15 +503,31 @@ def test_second_complete_same_pending_after_success_raises(
         def flush(self) -> None:
             return None
 
-    monkeypatch.setattr(admin_assets, "Session", lambda _e: _Sess())
-    monkeypatch.setattr(admin_assets, "get_engine", lambda: object())
-    monkeypatch.setattr(admin_assets, "set_audit_context", lambda *a, **k: None)
-    monkeypatch.setattr(admin_assets, "AssetRepository", lambda _s: _Repo())
+        def rollback(self) -> None:
+            return None
+
+    monkeypatch.setattr(content_replace, "Session", lambda _e: _Sess())
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: _Repo())
+    monkeypatch.setattr(content_replace, "asset_links_expense_attachment", lambda _a: False)
 
     with pytest.raises(ValidationError, match="nothing to replace"):
-        admin_assets._complete_asset_content_replace(  # noqa: SLF001
-            api_gateway_event(method="POST", path="/x", body="{}"),
+        content_replace.complete_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps(
+                    {
+                        "pending_s3_key": pending,
+                        "file_name": "doc.pdf",
+                        "content_type": "application/pdf",
+                    }
+                ),
+            ),
             asset_id,
+            identity_user_sub="u",
+            request_id=None,
         )
 
 
@@ -331,21 +543,7 @@ def test_delete_previous_logs_warning_on_failure(
     pending = f"assets/{asset_id}/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-new.pdf"
     asset = _make_asset(asset_id=asset_id, s3_key=old_key)
 
-    monkeypatch.setattr(admin_assets, "extract_identity", lambda _e: _identity())
-    monkeypatch.setattr(
-        admin_assets,
-        "parse_complete_asset_content_replace_payload",
-        lambda _e: {
-            "pending_s3_key": pending,
-            "file_name": "new.pdf",
-            "content_type": "application/pdf",
-        },
-    )
-    monkeypatch.setattr(
-        admin_assets,
-        "head_s3_object",
-        lambda **_k: {"ContentType": "application/pdf"},
-    )
+    monkeypatch.setattr(content_replace, "head_s3_object", lambda **_k: _good_head())
 
     def _delete_fail(**_kwargs: Any) -> None:
         raise ClientError(
@@ -353,7 +551,7 @@ def test_delete_previous_logs_warning_on_failure(
             "DeleteObject",
         )
 
-    monkeypatch.setattr(admin_assets, "delete_s3_object", _delete_fail)
+    monkeypatch.setattr(content_replace, "delete_s3_object", _delete_fail)
 
     class _Repo:
         def get_with_asset_tags(self, _id: UUID) -> Asset:
@@ -375,15 +573,31 @@ def test_delete_previous_logs_warning_on_failure(
         def flush(self) -> None:
             return None
 
-    monkeypatch.setattr(admin_assets, "Session", lambda _e: _Sess())
-    monkeypatch.setattr(admin_assets, "get_engine", lambda: object())
-    monkeypatch.setattr(admin_assets, "set_audit_context", lambda *a, **k: None)
-    monkeypatch.setattr(admin_assets, "AssetRepository", lambda _s: _Repo())
+        def rollback(self) -> None:
+            return None
+
+    monkeypatch.setattr(content_replace, "Session", lambda _e: _Sess())
+    monkeypatch.setattr(content_replace, "get_engine", lambda: object())
+    monkeypatch.setattr(content_replace, "set_audit_context", lambda *a, **k: None)
+    monkeypatch.setattr(content_replace, "AssetRepository", lambda _s: _Repo())
+    monkeypatch.setattr(content_replace, "asset_links_expense_attachment", lambda _a: False)
 
     with caplog.at_level(logging.WARNING):
-        resp = admin_assets._complete_asset_content_replace(  # noqa: SLF001
-            api_gateway_event(method="POST", path="/x", body="{}"),
+        resp = content_replace.complete_asset_content_replace(
+            api_gateway_event(
+                method="POST",
+                path="/x",
+                body=json.dumps(
+                    {
+                        "pending_s3_key": pending,
+                        "file_name": "new.pdf",
+                        "content_type": "application/pdf",
+                    }
+                ),
+            ),
             asset_id,
+            identity_user_sub="u",
+            request_id=None,
         )
     assert resp["statusCode"] == 200
     assert any("replace_delete_failed" in r.message for r in caplog.records)

--- a/tests/test_admin_assets_routes.py
+++ b/tests/test_admin_assets_routes.py
@@ -104,7 +104,7 @@ def test_handle_admin_assets_dispatches_content_init_route(
         "extract_identity",
         lambda _: _build_admin_identity(admin_identity),
     )
-    monkeypatch.setattr(admin_assets, "_init_asset_content_replace", lambda *_: marker)
+    monkeypatch.setattr(admin_assets, "init_asset_content_replace", lambda *_a, **_k: marker)
     asset_id = str(uuid4())
 
     response = admin_assets.handle_admin_assets_request(
@@ -126,7 +126,9 @@ def test_handle_admin_assets_dispatches_content_complete_route(
         "extract_identity",
         lambda _: _build_admin_identity(admin_identity),
     )
-    monkeypatch.setattr(admin_assets, "_complete_asset_content_replace", lambda *_: marker)
+    monkeypatch.setattr(
+        admin_assets, "complete_asset_content_replace", lambda *_a, **_k: marker
+    )
     asset_id = str(uuid4())
 
     response = admin_assets.handle_admin_assets_request(

--- a/tests/test_assets_common.py
+++ b/tests/test_assets_common.py
@@ -356,6 +356,13 @@ def test_file_name_from_pending_asset_content_key_strips_uuid_prefix() -> None:
     assert file_name_from_pending_asset_content_key(key) == "my-file.pdf"
 
 
+def test_file_name_from_pending_asset_content_key_rejects_non_uuid_prefix() -> None:
+    long_fake = "a" * 36 + "-attacker.pdf"
+    key = f"assets/550e8400-e29b-41d4-a716-446655440000/{long_fake}"
+    with pytest.raises(ValidationError, match="unexpected object name"):
+        file_name_from_pending_asset_content_key(key)
+
+
 def test_validate_pending_asset_content_s3_key_rejects_wrong_prefix() -> None:
     aid = uuid4()
     with pytest.raises(ValidationError):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
CI fix: `ruff-format` collapsed a multi-line `set_audit_context(...)` call in `admin_assets_content_replace.py` — committed in `404f0dd4` so **Lint → lint-python** (`pre-commit run --all-files`) passes.

## Tests

```bash
pre-commit run --all-files
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1be7e4be-75de-439c-8a30-ea73c24c3d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1be7e4be-75de-439c-8a30-ea73c24c3d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

