### PR TITLE
fix(db): Alembic transaction_per_migration for PostgreSQL enum upgrades

### DIFF
--- a/backend/db/alembic/env.py
+++ b/backend/db/alembic/env.py
@@ -67,6 +67,10 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         compare_type=True,
+        # Each revision commits separately so PostgreSQL can use a new enum
+        # label added in one migration (e.g. ALTER TYPE ... ADD VALUE) in a
+        # later migration (UnsafeNewEnumValueUsage if all run in one txn).
+        transaction_per_migration=True,
     )
 
     with context.begin_transaction():
@@ -87,6 +91,10 @@ def run_migrations_online() -> None:
             connection=connection,
             target_metadata=target_metadata,
             compare_type=True,
+            # Each revision commits separately so PostgreSQL can use a new enum
+            # label added in one migration (e.g. ALTER TYPE ... ADD VALUE) in a
+            # later migration (UnsafeNewEnumValueUsage if all run in one txn).
+            transaction_per_migration=True,
         )
 
         with context.begin_transaction():

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -4,6 +4,11 @@ This document describes the PostgreSQL schema for the Evolve Sprouts
 backend. It is based on the Alembic migrations.
 
 Alembic migrations live in `backend/db/alembic/versions/`.
+The Alembic environment enables `transaction_per_migration` so each revision
+commits in its own transaction. That avoids PostgreSQL
+`UnsafeNewEnumValueUsage` when one revision adds an enum label and a later
+revision in the same upgrade run references that label (for example
+`0024_discount_referral_add_enum` then `0025_discount_codes_value_check`).
 Seed data lives in `backend/db/seed/seed_data.sql`.
 
 ## Extensions and enums


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The deploy job failed on `RunMigrations` with:

`psycopg.errors.UnsafeNewEnumValueUsage: unsafe use of new value "referral" of enum type discount_type` — PostgreSQL requires new enum labels to be committed before they can be referenced.

Migrations `0024_discount_referral_add_enum` and `0025_discount_codes_value_check` were split for this reason, but Alembic still ran the full `upgrade` in a single outer transaction, so 0025 still saw the new label as uncommitted.

## Changes

- Set `transaction_per_migration=True` in `backend/db/alembic/env.py` for both offline and online modes so each revision commits in its own transaction.
- Document this in `docs/architecture/database-schema.md`.

After merge, re-run the backend deploy; the migration chain should apply cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6d51ffa-1c4e-4732-b154-462f0fc970c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6d51ffa-1c4e-4732-b154-462f0fc970c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

