### PR TITLE
fix(admin_web): unblock deploy-admin-web TypeScript build

### DIFF
--- a/apps/admin_web/src/hooks/use-asset-mutations.ts
+++ b/apps/admin_web/src/hooks/use-asset-mutations.ts
@@ -401,9 +401,13 @@ export function useAssetMutations({
     setUploadPhase('put');
     setUploadState('uploading');
     setUploadError('');
+    const uploadUrlForPut = effectiveUpload.uploadUrl;
+    if (!uploadUrlForPut) {
+      return;
+    }
     try {
       await uploadFileToPresignedUrl({
-        uploadUrl: effectiveUpload.uploadUrl,
+        uploadUrl: uploadUrlForPut,
         uploadMethod: effectiveUpload.uploadMethod,
         uploadHeaders: effectiveUpload.uploadHeaders,
         file,

--- a/apps/admin_web/src/types/assets.ts
+++ b/apps/admin_web/src/types/assets.ts
@@ -122,10 +122,12 @@ export interface UpdateAdminAssetPatchInput {
 }
 
 export interface CreatedAssetUpload {
-  uploadUrl: OptionalToNullable<ApiCreateAssetResponse['upload_url']>;
+  /** Null when absent, blank after trim, or not returned (trimmed presigned URL). */
+  uploadUrl: OptionalToNullable<ApiCreateAssetResponse['upload_url']> | null;
   uploadMethod: string;
   uploadHeaders: NonNullable<ApiCreateAssetResponse['upload_headers']>;
-  expiresAt: OptionalToNullable<ApiCreateAssetResponse['expires_at']>;
+  /** Null when absent or not a string in the payload (ISO date-time when present). */
+  expiresAt: OptionalToNullable<ApiCreateAssetResponse['expires_at']> | null;
 }
 
 type ApiInitAssetContentReplaceResponse = ApiSchemas['InitAssetContentReplaceResponse'];
@@ -133,10 +135,12 @@ type ApiInitAssetContentReplaceResponse = ApiSchemas['InitAssetContentReplaceRes
 /** Presigned upload for replacing an existing asset file (step 1). */
 export interface InitAdminAssetContentReplaceUpload {
   pendingS3Key: ApiInitAssetContentReplaceResponse['pending_s3_key'];
-  uploadUrl: OptionalToNullable<ApiInitAssetContentReplaceResponse['upload_url']>;
+  /** Null when absent, blank after trim, or not returned (trimmed presigned URL). */
+  uploadUrl: OptionalToNullable<ApiInitAssetContentReplaceResponse['upload_url']> | null;
   uploadMethod: string;
   uploadHeaders: NonNullable<ApiInitAssetContentReplaceResponse['upload_headers']>;
-  expiresAt: OptionalToNullable<ApiInitAssetContentReplaceResponse['expires_at']>;
+  /** Null when absent or not a string in the payload (ISO date-time when present). */
+  expiresAt: OptionalToNullable<ApiInitAssetContentReplaceResponse['expires_at']> | null;
 }
 
 export interface CreateAssetGrantInput {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `deploy-admin-web` workflow failed on `npm run build` after the asset content-replace work merged in PR #1257. Next.js type checking failed because `asTrimmedString` / `asNullableString` return `string | null`, while `CreatedAssetUpload` and `InitAdminAssetContentReplaceUpload` only allowed non-null strings for `uploadUrl` and `expiresAt`.

## Changes

- Extend `CreatedAssetUpload` and `InitAdminAssetContentReplaceUpload` so `uploadUrl` and `expiresAt` explicitly include `null` when parsing yields no usable value.
- In `retryPendingUpload`, narrow `uploadUrl` to a string before calling `uploadFileToPresignedUrl` after optional refresh (TypeScript does not narrow `effectiveUpload.uploadUrl` across the refresh branch).

## Validation

- `cd apps/admin_web && npm run build`
- `npm run test -- --run tests/lib/assets-api.test.ts tests/hooks/use-asset-mutations.test.ts`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7fa6c27-c1cb-4f36-8810-7295f80ec54f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7fa6c27-c1cb-4f36-8810-7295f80ec54f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

