### PR TITLE
fix(admin): allow discount_value 0 when discount type is referral

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4160,7 +4160,7 @@ export interface components {
         UpdateDiscountCodeRequest: {
             description?: string | null;
             discount_type?: components["schemas"]["DiscountType"];
-            /** @description When the resulting type is `referral`, the server coerces this to "0"; client-supplied values are ignored. */
+            /** @description Must be greater than 0 unless the effective discount type after this update is `referral` (tracking-only), in which case `0` is accepted and the server coerces the stored value to "0"; other client-supplied values are ignored for referral. */
             discount_value?: string;
             /** @description When the resulting type is `referral`, the server coerces this to "HKD"; client-supplied values are ignored. */
             currency?: string | null;

--- a/backend/src/app/api/admin_discount_codes.py
+++ b/backend/src/app/api/admin_discount_codes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
@@ -226,6 +227,15 @@ def _update_discount_code(
             if "discount_type" in payload
             else code.discount_type
         )
+        if (
+            effective_type != DiscountType.REFERRAL
+            and "discount_value" in payload
+            and payload["discount_value"] <= Decimal("0")
+        ):
+            raise ValidationError(
+                "discount_value must be greater than 0",
+                field="discount_value",
+            )
         if effective_type == DiscountType.REFERRAL:
             payload["discount_value"] = REFERRAL_DEFAULT_DISCOUNT_VALUE
             payload["currency"] = REFERRAL_DEFAULT_CURRENCY

--- a/backend/src/app/api/admin_services_payload_utils.py
+++ b/backend/src/app/api/admin_services_payload_utils.py
@@ -402,6 +402,16 @@ def parse_required_decimal(value: Any, field: str) -> Decimal:
     return parsed
 
 
+def parse_required_non_negative_decimal(value: Any, field: str) -> Decimal:
+    """Parse a required decimal that may be zero (used where referral allows 0)."""
+    parsed = parse_optional_decimal(value, field)
+    if parsed is None:
+        raise ValidationError(f"{field} is required", field=field)
+    if parsed < Decimal("0"):
+        raise ValidationError(f"{field} must be >= 0", field=field)
+    return parsed
+
+
 def parse_optional_currency(value: Any, field: str) -> str | None:
     parsed = parse_optional_text(value, max_length=_MAX_CURRENCY_LENGTH)
     if parsed is None:

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -28,6 +28,7 @@ from app.api.admin_services_payload_utils import (
     parse_optional_uuid,
     parse_required_bool,
     parse_required_decimal,
+    parse_required_non_negative_decimal,
     parse_required_enum,
     parse_required_text,
     parse_service_type_details,
@@ -528,7 +529,7 @@ def parse_update_discount_code_payload(body: Mapping[str, Any]) -> dict[str, Any
             body.get("discount_type"), DiscountType, "discount_type"
         )
     if has_field(body, "discount_value"):
-        payload["discount_value"] = parse_required_decimal(
+        payload["discount_value"] = parse_required_non_negative_decimal(
             body.get("discount_value"), "discount_value"
         )
     if has_field(body, "currency"):

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3923,8 +3923,10 @@ components:
         discount_value:
           type: string
           description: >
-            When the resulting type is `referral`, the server coerces this to "0";
-            client-supplied values are ignored.
+            Must be greater than 0 unless the effective discount type after this update
+            is `referral` (tracking-only), in which case `0` is accepted and the server
+            coerces the stored value to "0"; other client-supplied values are ignored
+            for referral.
         currency:
           type: string
           nullable: true

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -62,7 +62,9 @@ their primary responsibilities.
   filters and `GET /v1/admin/services/{id}/discount-code-usage-summary` for
   aggregate discount usage before service slug changes), `/v1/admin/discount-codes/*`
   (`POST` returns `409` with `field: code` when the code collides with the
-  case-insensitive unique index),
+  case-insensitive unique index; `PUT` accepts `discount_value` `0` only when the
+  effective discount type after the update is `referral`, otherwise `discount_value`
+  must be greater than `0`),
   `/v1/admin/vendors/*`,
   `/v1/admin/expenses/*`,
   `/v1/user/assets/*`,

--- a/tests/test_admin_discount_codes_api.py
+++ b/tests/test_admin_discount_codes_api.py
@@ -163,6 +163,22 @@ def test_parse_update_discount_code_referral_type_coerces() -> None:
     assert payload["currency"] == REFERRAL_DEFAULT_CURRENCY
 
 
+def test_parse_update_discount_code_referral_accepts_zero_discount_value() -> None:
+    """Update payload may include 0 before referral coercion (admin UI sends 0)."""
+    payload = parse_update_discount_code_payload(
+        {"discount_type": "referral", "discount_value": "0"}
+    )
+    assert payload["discount_type"] == DiscountType.REFERRAL
+    assert payload["discount_value"] == REFERRAL_DEFAULT_DISCOUNT_VALUE
+    assert payload["currency"] == REFERRAL_DEFAULT_CURRENCY
+
+
+def test_parse_update_discount_code_rejects_negative_discount_value() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        parse_update_discount_code_payload({"discount_value": "-1"})
+    assert exc_info.value.field == "discount_value"
+
+
 def test_update_discount_code_clamps_partial_payload_for_existing_referral(
     monkeypatch: Any,
     api_gateway_event: Any,
@@ -231,3 +247,67 @@ def test_update_discount_code_clamps_partial_payload_for_existing_referral(
 
     assert row.discount_value == REFERRAL_DEFAULT_DISCOUNT_VALUE
     assert row.currency == REFERRAL_DEFAULT_CURRENCY
+
+
+def test_update_discount_code_rejects_zero_discount_value_for_percentage(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    code_id = uuid4()
+    row = SimpleNamespace(
+        id=code_id,
+        description=None,
+        discount_type=DiscountType.PERCENTAGE,
+        discount_value=Decimal("10"),
+        currency=None,
+        valid_from=None,
+        valid_until=None,
+        service_id=None,
+        instance_id=None,
+        max_uses=None,
+        active=True,
+    )
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id(self, _id: Any) -> Any:
+            return row
+
+        def update(self, entity: Any) -> Any:
+            return entity
+
+    monkeypatch.setattr(admin_discount_codes, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_discount_codes, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_discount_codes, "parse_body", lambda _e: {})
+    monkeypatch.setattr(
+        admin_discount_codes,
+        "parse_update_discount_code_payload",
+        lambda _body: {"discount_value": Decimal("0")},
+    )
+    monkeypatch.setattr(admin_discount_codes, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(admin_discount_codes, "ensure_discount_code_scope", lambda *_a, **_k: None)
+    monkeypatch.setattr(admin_discount_codes, "DiscountCodeRepository", _FakeRepo)
+
+    with pytest.raises(ValidationError) as exc_info:
+        admin_discount_codes._update_discount_code(
+            api_gateway_event(method="PUT", path=f"/v1/admin/discount-codes/{code_id}"),
+            code_id=code_id,
+            actor_sub="sub-1",
+        )
+    assert exc_info.value.field == "discount_value"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin discount code **updates** failed with `discount_value must be greater than 0` when switching to referral and submitting `discount_value: "0"` (the admin UI sends this). The update parser used `parse_required_decimal`, which rejects zero before referral coercion runs.

## Changes

- Add `parse_required_non_negative_decimal` and use it for `discount_value` in `parse_update_discount_code_payload` so `0` parses successfully.
- In `_update_discount_code`, after computing `effective_type`, reject `discount_value <= 0` when the effective type is **not** referral; then apply existing referral coercion to `0` / HKD.
- Update OpenAPI (`UpdateDiscountCodeRequest.discount_value`), `docs/architecture/lambdas.md`, regenerate `admin-api.generated.ts`, and extend unit tests.

## Testing

- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
- `python3 -m pytest tests/test_admin_discount_codes_api.py`
- `npm run generate:admin-api-types && npm run check:admin-api-types` (admin_web)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-376b1542-53f5-48e3-b59a-c09c06ba6e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-376b1542-53f5-48e3-b59a-c09c06ba6e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

