### PR TITLE
fix(admin_web): Link and QR label and PNG filename

### DIFF
--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -642,8 +642,8 @@ export function DiscountCodesPanel({
                         event.stopPropagation();
                         openReferralDialog(row);
                       }}
-                      aria-label='Referral link and QR'
-                      title='Referral link and QR'
+                      aria-label='Link and QR'
+                      title='Link and QR'
                     >
                       <QrLinkIcon className='h-4 w-4' />
                     </Button>

--- a/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
@@ -120,7 +120,7 @@ export function ReferralLinkQrDialog({
     const objectUrl = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
     anchor.href = objectUrl;
-    anchor.download = `referral-${discountCode.trim().toUpperCase()}-${size}.png`;
+    anchor.download = `${discountCode.trim().toUpperCase()}-${size}.png`;
     anchor.click();
     URL.revokeObjectURL(objectUrl);
     trackAdminAnalyticsEvent('admin_referral_qr_downloaded', {
@@ -142,7 +142,7 @@ export function ReferralLinkQrDialog({
   return (
     <ConfirmDialog
       open={open}
-      title='Referral link and QR'
+      title='Link and QR'
       description={`Share this link or QR. ${destinationHint} Locale is included in the URL for consistent scanning.`}
       cancelLabel='Close'
       confirmLabel='Close'

--- a/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
@@ -117,7 +117,7 @@ describe('DiscountCodesPanel', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Referral link and QR' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Link and QR' })).toBeInTheDocument();
   });
 
   it('shows archived service title in Scope while picker omits archived services', () => {
@@ -385,7 +385,7 @@ describe('DiscountCodesPanel', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Referral link and QR' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Link and QR' }));
 
     await vi.waitFor(() => {
       expect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Renamed the referral QR modal title from "Referral link and QR" to "Link and QR" (same label on the discount codes table QR button for consistency).
- Removed the `referral-` prefix from downloaded PNG filenames; files are now named `{CODE}-{size}.png` (e.g. `SAVE10-512.png`).

## Testing

- `npm run test -- --run tests/components/admin/services/discount-codes-panel.test.tsx tests/components/admin/services/referral-link-qr-dialog.test.tsx`
- `npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cc51730-1614-4508-a434-2e34a5295ffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cc51730-1614-4508-a434-2e34a5295ffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

