### PR TITLE
fix(admin_web): restore code styling on referral Link and QR preview URL

### DIFF
--- a/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/referral-link-qr-dialog.tsx
@@ -211,9 +211,9 @@ export function ReferralLinkQrDialog({
               href={builtUrl}
               target='_blank'
               rel='noopener noreferrer'
-              className='block max-w-full break-all rounded bg-slate-100 px-2 py-1 text-xs text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950'
+              className='block max-w-full rounded bg-slate-100 px-2 py-1 text-xs text-slate-800 no-underline outline-offset-2 hover:text-slate-950 hover:underline hover:decoration-slate-400 hover:underline-offset-2'
             >
-              {builtUrl}
+              <code className='block break-all font-mono text-[0.8125rem] text-inherit'>{builtUrl}</code>
             </a>
           ) : (
             <p


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restores monospace `<code>` presentation for the preview URL in the Link and QR modal while keeping it a normal anchor (opens in a new tab). The link uses underline on hover so the default state reads like inline code again.

Tests: `npm run test -- --run tests/components/admin/services/referral-link-qr-dialog.test.tsx`, `npm run lint`, `bash scripts/validate-cursorrules.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be5dcc8b-4383-4ad4-a6c7-482626833193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be5dcc8b-4383-4ad4-a6c7-482626833193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

