### PR TITLE
refactor(admin_web): shared clipboard helper and copy feedback

### DIFF
--- a/apps/admin_web/src/components/admin/assets/asset-share-link-section.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-share-link-section.tsx
@@ -9,7 +9,9 @@ import {
   getOrCreateAdminAssetShareLink,
   revokeAdminAssetShareLink,
   rotateAdminAssetShareLink,
+  type AssetShareLink,
 } from '@/lib/assets-api';
+import { copyTextToClipboard } from '@/lib/clipboard';
 
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { CopyIcon, DeleteIcon, RotateIcon } from '@/components/icons/action-icons';
@@ -88,20 +90,14 @@ export function AssetShareLinkSection({ selectedAsset }: { selectedAsset: AdminA
     allowedDomains: parseAllowedDomainList(allowedDomainsInput),
   });
 
-  const handleCopyAssetLink = async () => {
-    setIsCopyingLink(true);
-    setLinkError('');
-    setLinkNotice('');
-    setIsLinkCopied(false);
+  const applyShareLinkCopiedUi = async (link: AssetShareLink, successNotice: string) => {
     try {
-      const policyInput = buildSharePolicyInput();
-      const link = await getOrCreateAdminAssetShareLink(selectedAsset.id, policyInput);
-      await navigator.clipboard.writeText(link.shareUrl);
+      await copyTextToClipboard(link.shareUrl);
       if (link.allowedDomains.length > 0) {
         setAllowedDomainsInput(link.allowedDomains.join('\n'));
       }
       setLinkError('');
-      setLinkNotice('Share link copied to clipboard.');
+      setLinkNotice(successNotice);
       setIsLinkCopied(true);
       if (copiedStateTimeoutRef.current !== null) {
         window.clearTimeout(copiedStateTimeoutRef.current);
@@ -110,6 +106,22 @@ export function AssetShareLinkSection({ selectedAsset }: { selectedAsset: AdminA
         setIsLinkCopied(false);
         copiedStateTimeoutRef.current = null;
       }, 2000);
+    } catch (error) {
+      setLinkError(
+        error instanceof Error ? error.message : 'Unable to copy the link to clipboard.'
+      );
+    }
+  };
+
+  const handleCopyAssetLink = async () => {
+    setIsCopyingLink(true);
+    setLinkError('');
+    setLinkNotice('');
+    setIsLinkCopied(false);
+    try {
+      const policyInput = buildSharePolicyInput();
+      const link = await getOrCreateAdminAssetShareLink(selectedAsset.id, policyInput);
+      await applyShareLinkCopiedUi(link, 'Share link copied to clipboard.');
     } catch (error) {
       setLinkError(error instanceof Error ? error.message : 'Unable to copy the link to clipboard.');
     } finally {
@@ -136,19 +148,10 @@ export function AssetShareLinkSection({ selectedAsset }: { selectedAsset: AdminA
     try {
       const policyInput = buildSharePolicyInput();
       const link = await rotateAdminAssetShareLink(selectedAsset.id, policyInput);
-      await navigator.clipboard.writeText(link.shareUrl);
-      if (link.allowedDomains.length > 0) {
-        setAllowedDomainsInput(link.allowedDomains.join('\n'));
-      }
-      setLinkNotice('Share link rotated and copied. Previous links are revoked.');
-      setIsLinkCopied(true);
-      if (copiedStateTimeoutRef.current !== null) {
-        window.clearTimeout(copiedStateTimeoutRef.current);
-      }
-      copiedStateTimeoutRef.current = window.setTimeout(() => {
-        setIsLinkCopied(false);
-        copiedStateTimeoutRef.current = null;
-      }, 2000);
+      await applyShareLinkCopiedUi(
+        link,
+        'Share link rotated and copied. Previous links are revoked.'
+      );
     } catch (error) {
       setLinkError(error instanceof Error ? error.message : 'Unable to rotate and copy the share link.');
     } finally {

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -11,9 +11,11 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { CopyIcon, DeleteIcon, QrLinkIcon } from '@/components/icons/action-icons';
+import { DeleteIcon, QrLinkIcon } from '@/components/icons/action-icons';
+import { CopyFeedbackIconButton } from '@/components/ui/copy-feedback-icon-button';
 import { ReferralLinkQrDialog } from '@/components/admin/services/referral-link-qr-dialog';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import { useServiceInstanceOptions } from '@/hooks/use-service-instance-options';
 import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
 import { tryCopyTextToClipboard } from '@/lib/clipboard';
@@ -146,6 +148,7 @@ export function DiscountCodesPanel({
   const [referralServiceSlug, setReferralServiceSlug] = useState<string | null>(null);
   const [referralDiscountType, setReferralDiscountType] = useState<DiscountType>('percentage');
   const [isBatchCreating, setIsBatchCreating] = useState(false);
+  const { copiedKey: copiedDiscountCodeId, markCopied: markDiscountCodeCopied } = useCopyFeedback(1000);
   const directoryList = serviceDirectoryForDisplay ?? serviceOptions;
   const { instances, isLoading: instancesLoading, error: instancesError, loadForService } =
     useServiceInstanceOptions(instanceOptionsRefreshKey);
@@ -340,8 +343,11 @@ export function DiscountCodesPanel({
     }
   };
 
-  async function handleCopyCode(value: string) {
-    await tryCopyTextToClipboard(value.trim().toUpperCase());
+  async function handleCopyDiscountCode(rowId: string, value: string) {
+    const ok = await tryCopyTextToClipboard(value.trim().toUpperCase());
+    if (ok) {
+      markDiscountCodeCopied(rowId);
+    }
   }
 
   function openReferralDialog(entry: DiscountCode) {
@@ -645,17 +651,19 @@ export function DiscountCodesPanel({
                     >
                       <QrLinkIcon className='h-4 w-4' />
                     </Button>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant='secondary'
+                    <CopyFeedbackIconButton
+                      copied={copiedDiscountCodeId === row.id}
                       disabled={editorIsBusy}
-                      onClick={() => void handleCopyCode(row.code)}
-                      aria-label='Copy discount code'
-                      title='Copy code'
-                    >
-                      <CopyIcon className='h-4 w-4' />
-                    </Button>
+                      idleVariant='secondary'
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void handleCopyDiscountCode(row.id, row.code);
+                      }}
+                      idleLabel='Copy discount code'
+                      copiedLabel='Discount code copied'
+                      idleTitle='Copy code'
+                      copiedTitle='Copied'
+                    />
                     <Button
                       type='button'
                       size='sm'

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -16,6 +16,7 @@ import { ReferralLinkQrDialog } from '@/components/admin/services/referral-link-
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useServiceInstanceOptions } from '@/hooks/use-service-instance-options';
 import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
+import { tryCopyTextToClipboard } from '@/lib/clipboard';
 import {
   bumpDuplicateDiscountCode,
   DISCOUNT_CODE_ALLOCATION_FAILED_MESSAGE,
@@ -340,10 +341,7 @@ export function DiscountCodesPanel({
   };
 
   async function handleCopyCode(value: string) {
-    if (typeof navigator === 'undefined' || !navigator.clipboard) {
-      return;
-    }
-    await navigator.clipboard.writeText(value.trim().toUpperCase());
+    await tryCopyTextToClipboard(value.trim().toUpperCase());
   }
 
   function openReferralDialog(entry: DiscountCode) {

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -5,7 +5,8 @@ import type { KeyboardEvent, MouseEvent } from 'react';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
-import { CopyIcon, DeleteIcon } from '@/components/icons/action-icons';
+import { DeleteIcon } from '@/components/icons/action-icons';
+import { CopyFeedbackIconButton } from '@/components/ui/copy-feedback-icon-button';
 import { trackAdminAnalyticsEvent } from '@/lib/admin-analytics';
 import { tryCopyTextToClipboard } from '@/lib/clipboard';
 import { Input } from '@/components/ui/input';
@@ -13,6 +14,7 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import { formatEnumLabel } from '@/lib/format';
 
 import type { ServiceInstance, ServiceType } from '@/types/services';
@@ -73,6 +75,7 @@ export function InstanceListPanel({
   showTypeColumn = false,
 }: InstanceListPanelProps) {
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
+  const { copiedKey: copiedInstanceId, markCopied: markInstanceIdCopied } = useCopyFeedback(1000);
 
   const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, instanceId: string) => {
     if (event.target !== event.currentTarget) {
@@ -109,6 +112,7 @@ export function InstanceListPanel({
     event.stopPropagation();
     const copied = await tryCopyTextToClipboard(instance.id);
     if (copied) {
+      markInstanceIdCopied(instance.id);
       trackAdminAnalyticsEvent('admin_instance_uuid_copied', {
         service_id: instance.serviceId,
       });
@@ -220,16 +224,15 @@ export function InstanceListPanel({
                 <td className='px-4 py-3'>{instance.instructorId ?? '-'}</td>
                 <td className='px-4 py-3 text-right'>
                   <div className='flex justify-end gap-2'>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant='outline'
+                    <CopyFeedbackIconButton
+                      copied={copiedInstanceId === instance.id}
+                      idleVariant='outline'
                       onClick={(event) => void handleCopyInstanceId(instance, event)}
-                      aria-label='Copy instance UUID'
-                      title='Copy instance UUID'
-                    >
-                      <CopyIcon className='h-4 w-4' />
-                    </Button>
+                      idleLabel='Copy instance UUID'
+                      copiedLabel='Instance UUID copied'
+                      idleTitle='Copy instance UUID'
+                      copiedTitle='Copied'
+                    />
                     <Button
                       type='button'
                       size='sm'

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { CopyIcon, DeleteIcon } from '@/components/icons/action-icons';
 import { trackAdminAnalyticsEvent } from '@/lib/admin-analytics';
+import { tryCopyTextToClipboard } from '@/lib/clipboard';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
@@ -106,13 +107,12 @@ export function InstanceListPanel({
     event: MouseEvent<HTMLButtonElement>,
   ) => {
     event.stopPropagation();
-    if (typeof navigator === 'undefined' || !navigator.clipboard) {
-      return;
+    const copied = await tryCopyTextToClipboard(instance.id);
+    if (copied) {
+      trackAdminAnalyticsEvent('admin_instance_uuid_copied', {
+        service_id: instance.serviceId,
+      });
     }
-    await navigator.clipboard.writeText(instance.id);
-    trackAdminAnalyticsEvent('admin_instance_uuid_copied', {
-      service_id: instance.serviceId,
-    });
   };
 
   return (

--- a/apps/admin_web/src/components/icons/action-icons.tsx
+++ b/apps/admin_web/src/components/icons/action-icons.tsx
@@ -1,6 +1,7 @@
 export { default as GoogleIcon } from './svg/google-icon.svg';
 export { default as EmailIcon } from './svg/email-icon.svg';
 export { default as CopyIcon } from './svg/copy-icon.svg';
+export { default as CheckIcon } from './svg/check-icon.svg';
 export { default as RotateIcon } from './svg/rotate-icon.svg';
 export { default as DeleteIcon } from './svg/delete-icon.svg';
 export { default as MarkPaidIcon } from './svg/mark-paid-icon.svg';

--- a/apps/admin_web/src/components/icons/svg/check-icon.svg
+++ b/apps/admin_web/src/components/icons/svg/check-icon.svg
@@ -1,0 +1,12 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M20 6 9 17l-5-5" />
+</svg>

--- a/apps/admin_web/src/components/ui/copy-feedback-icon-button.tsx
+++ b/apps/admin_web/src/components/ui/copy-feedback-icon-button.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { MouseEvent } from 'react';
+
+import { CheckIcon, CopyIcon } from '@/components/icons/action-icons';
+import { Button } from '@/components/ui/button';
+
+export interface CopyFeedbackIconButtonProps {
+  copied: boolean;
+  disabled?: boolean;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  idleLabel: string;
+  copiedLabel: string;
+  idleTitle?: string;
+  copiedTitle?: string;
+  /** Visual variant when not showing success (default `secondary`). */
+  idleVariant?: 'secondary' | 'outline';
+  className?: string;
+}
+
+/**
+ * Icon-only copy control: shows a green check briefly after `copied` is true,
+ * then callers clear via {@link useCopyFeedback}.
+ */
+export function CopyFeedbackIconButton({
+  copied,
+  disabled,
+  onClick,
+  idleLabel,
+  copiedLabel,
+  idleTitle,
+  copiedTitle,
+  idleVariant = 'secondary',
+  className,
+}: CopyFeedbackIconButtonProps) {
+  return (
+    <Button
+      type='button'
+      size='sm'
+      variant={copied ? 'success' : idleVariant}
+      disabled={disabled}
+      className={
+        className
+          ? `transition-colors duration-300 ease-out ${className}`
+          : 'transition-colors duration-300 ease-out'
+      }
+      aria-label={copied ? copiedLabel : idleLabel}
+      title={copied ? (copiedTitle ?? copiedLabel) : (idleTitle ?? idleLabel)}
+      onClick={onClick}
+    >
+      {copied ? <CheckIcon className='h-4 w-4' /> : <CopyIcon className='h-4 w-4' />}
+    </Button>
+  );
+}

--- a/apps/admin_web/src/hooks/use-copy-feedback.ts
+++ b/apps/admin_web/src/hooks/use-copy-feedback.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Tracks which item key was last copied successfully, clearing after `durationMs`.
+ * Use with row-scoped copy buttons that show a brief success state.
+ */
+export function useCopyFeedback(durationMs = 1000) {
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+    },
+    []
+  );
+
+  const markCopied = useCallback(
+    (key: string) => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+      setCopiedKey(key);
+      timeoutRef.current = setTimeout(() => {
+        setCopiedKey(null);
+        timeoutRef.current = null;
+      }, durationMs);
+    },
+    [durationMs]
+  );
+
+  return { copiedKey, markCopied };
+}

--- a/apps/admin_web/src/lib/clipboard.ts
+++ b/apps/admin_web/src/lib/clipboard.ts
@@ -1,0 +1,23 @@
+/**
+ * Writes text to the system clipboard. Rejects if the Clipboard API is unavailable
+ * (for example non-secure context) or if the write fails.
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+    throw new Error('Clipboard is not available in this browser or context.');
+  }
+  await navigator.clipboard.writeText(text);
+}
+
+/**
+ * Same as {@link copyTextToClipboard} but returns false instead of throwing.
+ * Use when the UI has no channel for errors (for example icon-only actions).
+ */
+export async function tryCopyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    await copyTextToClipboard(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
@@ -1,9 +1,20 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DiscountCodesPanel } from '@/components/admin/services/discount-codes-panel';
 import { AdminApiError } from '@/lib/api-admin-client';
+import { tryCopyTextToClipboard } from '@/lib/clipboard';
+
+vi.mock('@/lib/clipboard', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/clipboard')>();
+  return {
+    ...actual,
+    tryCopyTextToClipboard: vi.fn(actual.tryCopyTextToClipboard),
+  };
+});
+
+const mockTryCopyTextToClipboard = vi.mocked(tryCopyTextToClipboard);
 
 vi.mock('@/hooks/use-service-instance-options', () => ({
   useServiceInstanceOptions: () => ({
@@ -23,6 +34,13 @@ vi.mock('@/lib/config', async (importOriginal) => {
 });
 
 describe('DiscountCodesPanel', () => {
+  beforeEach(() => {
+    mockTryCopyTextToClipboard.mockImplementation(async (text: string) => {
+      const mod = await vi.importActual<typeof import('@/lib/clipboard')>('@/lib/clipboard');
+      return mod.tryCopyTextToClipboard(text);
+    });
+  });
+
   const baseService = {
     id: 'svc-1',
     serviceType: 'training_course' as const,
@@ -394,6 +412,64 @@ describe('DiscountCodesPanel', () => {
         }),
       ).toBeInTheDocument();
     });
+  });
+
+  it('shows copy success state on the row copy button when clipboard succeeds', async () => {
+    vi.useFakeTimers();
+    mockTryCopyTextToClipboard.mockResolvedValue(true);
+    try {
+    const row = {
+      id: 'dc-copy',
+      code: 'SAVE10',
+      description: null,
+      discountType: 'percentage' as const,
+      discountValue: '10',
+      currency: 'HKD',
+      validFrom: null,
+      validUntil: null,
+      maxUses: null,
+      currentUses: 0,
+      active: true,
+      serviceId: null,
+      instanceId: null,
+      createdAt: null,
+      updatedAt: null,
+    };
+
+    render(
+      <DiscountCodesPanel
+        codes={[row]}
+        filters={{ active: '', search: '', scope: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        isSaving={false}
+        hasMore={false}
+        error=''
+        serviceOptions={[{ ...baseService }]}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy discount code' }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Discount code copied' })).toBeInTheDocument();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Copy discount code' })).toBeInTheDocument();
+    });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('retries create with COPY, COPY2, … until duplicate 409 stops', async () => {

--- a/apps/admin_web/tests/hooks/use-copy-feedback.test.tsx
+++ b/apps/admin_web/tests/hooks/use-copy-feedback.test.tsx
@@ -1,0 +1,25 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useCopyFeedback } from '@/hooks/use-copy-feedback';
+
+describe('useCopyFeedback', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears copied key after duration', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useCopyFeedback(1000));
+
+    act(() => {
+      result.current.markCopied('row-1');
+    });
+    expect(result.current.copiedKey).toBe('row-1');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.copiedKey).toBeNull();
+  });
+});

--- a/apps/admin_web/tests/lib/clipboard.test.ts
+++ b/apps/admin_web/tests/lib/clipboard.test.ts
@@ -21,6 +21,14 @@ describe('copyTextToClipboard', () => {
 
     await expect(copyTextToClipboard('x')).rejects.toThrow(/Clipboard is not available/);
   });
+
+  it('rejects when writeText rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new DOMException('The request is not allowed', 'NotAllowedError'));
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    await expect(copyTextToClipboard('hello')).rejects.toThrow();
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
 });
 
 describe('tryCopyTextToClipboard', () => {
@@ -38,5 +46,13 @@ describe('tryCopyTextToClipboard', () => {
     vi.stubGlobal('navigator', {});
 
     await expect(tryCopyTextToClipboard('x')).resolves.toBe(false);
+  });
+
+  it('returns false when writeText rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('write failed'));
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    await expect(tryCopyTextToClipboard('x')).resolves.toBe(false);
+    expect(writeText).toHaveBeenCalledWith('x');
   });
 });

--- a/apps/admin_web/tests/lib/clipboard.test.ts
+++ b/apps/admin_web/tests/lib/clipboard.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { copyTextToClipboard, tryCopyTextToClipboard } from '@/lib/clipboard';
+
+describe('copyTextToClipboard', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('writes via navigator.clipboard.writeText', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    await copyTextToClipboard('hello');
+
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('rejects when clipboard is unavailable', async () => {
+    vi.stubGlobal('navigator', {});
+
+    await expect(copyTextToClipboard('x')).rejects.toThrow(/Clipboard is not available/);
+  });
+});
+
+describe('tryCopyTextToClipboard', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns true on success', async () => {
+    vi.stubGlobal('navigator', { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+
+    await expect(tryCopyTextToClipboard('ok')).resolves.toBe(true);
+  });
+
+  it('returns false when copyTextToClipboard would reject', async () => {
+    vi.stubGlobal('navigator', {});
+
+    await expect(tryCopyTextToClipboard('x')).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces `apps/admin_web/src/lib/clipboard.ts` with:
- `copyTextToClipboard` — throws when Clipboard API is missing or `writeText` fails.
- `tryCopyTextToClipboard` — returns `true`/`false` for silent flows.

## UI consolidation

- **Discount codes** and **instance list** row copy actions use shared `CopyFeedbackIconButton` + `useCopyFeedback` (1s): success shows green `Button` `success` variant + check icon, then transitions back via `transition-colors`.
- **Asset share link** still uses `copyTextToClipboard` with inline notices (API + policy flow); not the row-level icon pattern.

## Tests

- Clipboard: success, missing API, **`writeText` rejection** for both `copyTextToClipboard` and `tryCopyTextToClipboard`.
- `useCopyFeedback` timer behavior.
- `DiscountCodesPanel` copy button success state (mocked `tryCopyTextToClipboard`).

## Validation

- `npm run lint` and `npm run test` in `apps/admin_web`.
- `bash scripts/validate-cursorrules.sh`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab925219-4713-41ee-94d8-2e0ab437575f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab925219-4713-41ee-94d8-2e0ab437575f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

