### PR TITLE
Admin website QR: code-style URL preview and optional src query

### DIFF
--- a/apps/admin_web/src/components/admin/website/website-qr-page.tsx
+++ b/apps/admin_web/src/components/admin/website/website-qr-page.tsx
@@ -35,6 +35,8 @@ export function WebsiteQrPage() {
   const [locale, setLocale] = useState<MyBestAuntieReferralLocale>('en');
   const [presetValue, setPresetValue] = useState<string>(PUBLIC_SITE_PAGE_PRESETS[0]?.pathInput ?? '/');
   const [customPathInput, setCustomPathInput] = useState('');
+  const [appendSrcQuery, setAppendSrcQuery] = useState(false);
+  const [srcQueryValue, setSrcQueryValue] = useState('qr');
   const isCustom = presetValue === CUSTOM_PRESET_VALUE;
 
   const normalizedPathResult = useMemo(() => {
@@ -56,17 +58,37 @@ export function WebsiteQrPage() {
     });
   }, [baseUrl, locale, normalizedPathResult.error, normalizedPathResult.path]);
 
+  const builtUrlForQr = useMemo(() => {
+    if (!builtUrl) {
+      return '';
+    }
+    if (!appendSrcQuery) {
+      return builtUrl;
+    }
+    const trimmed = srcQueryValue.trim();
+    if (!trimmed) {
+      return builtUrl;
+    }
+    try {
+      const url = new URL(builtUrl);
+      url.searchParams.set('src', trimmed);
+      return url.toString();
+    } catch {
+      return builtUrl;
+    }
+  }, [appendSrcQuery, builtUrl, srcQueryValue]);
+
   const pathForAnalytics = normalizedPathResult.path || '';
 
   useEffect(() => {
-    if (!builtUrl) {
+    if (!builtUrlForQr) {
       return;
     }
     trackAdminAnalyticsEvent('admin_public_page_qr_opened', {
       public_site_path: pathForAnalytics,
       locale,
     });
-  }, [builtUrl, locale, pathForAnalytics]);
+  }, [builtUrlForQr, locale, pathForAnalytics]);
 
   const configError = !baseUrl.trim()
     ? 'Set NEXT_PUBLIC_PUBLIC_SITE_BASE_URL to generate public page links.'
@@ -136,8 +158,48 @@ export function WebsiteQrPage() {
           </div>
         ) : null}
         {pathError ? <p className='text-sm text-red-600'>{pathError}</p> : null}
+        <div className='space-y-2'>
+          <div className='flex items-center gap-2'>
+            <input
+              id='website-qr-append-src'
+              type='checkbox'
+              className='h-4 w-4 rounded border-slate-300 text-slate-900'
+              checked={appendSrcQuery}
+              onChange={(event) => {
+                const next = event.target.checked;
+                setAppendSrcQuery(next);
+                if (next && !srcQueryValue.trim()) {
+                  setSrcQueryValue('qr');
+                }
+              }}
+              disabled={Boolean(configError) || Boolean(pathError) || !builtUrl}
+            />
+            <Label htmlFor='website-qr-append-src' className='mb-0 cursor-pointer font-normal'>
+              Append <code className='rounded bg-slate-100 px-1 py-0.5 text-xs'>src</code> query
+              parameter
+            </Label>
+          </div>
+          {appendSrcQuery ? (
+            <div>
+              <Label htmlFor='website-qr-src-value'>src value</Label>
+              <Input
+                id='website-qr-src-value'
+                value={srcQueryValue}
+                onChange={(event) => setSrcQueryValue(event.target.value)}
+                placeholder='e.g. qr'
+                disabled={Boolean(configError) || Boolean(pathError) || !builtUrl}
+                autoComplete='off'
+              />
+              <p className='mt-1 text-xs text-slate-500'>
+                Adds <code className='rounded bg-slate-100 px-1'>?src=…</code> (or{' '}
+                <code className='rounded bg-slate-100 px-1'>&amp;src=…</code>) for attribution. Leave
+                blank to omit.
+              </p>
+            </div>
+          ) : null}
+        </div>
         <PublicSiteQrExportPanel
-          builtUrl={builtUrl && !pathError ? builtUrl : ''}
+          builtUrl={builtUrl && !pathError ? builtUrlForQr : ''}
           configError={configError}
           previewAriaLabel={`QR code preview for public page ${pathForAnalytics || '/'}`}
           downloadFilenameBase={downloadBase}
@@ -146,6 +208,7 @@ export function WebsiteQrPage() {
             public_site_path: pathForAnalytics,
             locale,
           }}
+          previewUrlPresentation='referral'
         />
       </AdminEditorCard>
     </div>

--- a/apps/admin_web/tests/components/admin/website/website-qr-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/website/website-qr-page.test.tsx
@@ -58,4 +58,32 @@ describe('WebsiteQrPage', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('appends src query when enabled', async () => {
+    render(<WebsiteQrPage />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Append .*src.* query parameter/i }));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'https://www.example.com/en/?src=qr' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('updates src query value in preview URL', async () => {
+    render(<WebsiteQrPage />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Append .*src.* query parameter/i }));
+
+    fireEvent.change(screen.getByLabelText('src value'), {
+      target: { value: 'poster' },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'https://www.example.com/en/?src=poster' }),
+      ).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **URL preview** on the Website admin page now uses the same presentation as Link and QR (`PublicSiteQrExportPanel` with `previewUrlPresentation='referral'`): monospace `<code>` inside the underlined link.
- **Optional attribution**: checkbox to append a `src` query parameter, with a text field for the value (defaults to `qr` when enabled). Empty value omits `src` so the URL stays unchanged.

## Testing

- `npm run test -- --run tests/components/admin/website/website-qr-page.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65c450ec-2884-4725-bf72-d2f457701d06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65c450ec-2884-4725-bf72-d2f457701d06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

