### PR TITLE
Add legacy CRM venue import script (MariaDB dump → locations)

### DIFF
--- a/.github/workflows/import-legacy-crm-venues.yml
+++ b/.github/workflows/import-legacy-crm-venues.yml
@@ -4,8 +4,20 @@
 # - `sql_download_url` when running the workflow (HTTPS URL to the .sql file), or
 # - repository secret `IMPORT_LEGACY_CRM_SQL_URL` (same), if you leave the input empty.
 #
-# Database connection: set secret `DATABASE_URL` on the chosen GitHub Environment
-# (or repository secrets if you do not use environments).
+# Database connection (same resolution as app code / optional Alembic):
+#
+# Option A — Direct URL (typical for local Alembic: export DATABASE_URL=...):
+#   Set secret `DATABASE_URL` on the GitHub Environment.
+#
+# Option B — AWS CDK / Lambda-style (Secrets Manager + RDS Proxy + IAM), matching
+#   `app.db.connection.get_database_url`:
+#   Do **not** set DATABASE_URL. Set `DATABASE_SECRET_ARN` and configure AWS OIDC
+#   below. Also set vars aligned with CDK Lambda env, for example:
+#   - DATABASE_PROXY_ENDPOINT, DATABASE_USERNAME, DATABASE_NAME
+#   - DATABASE_IAM_AUTH=true
+#   - AWS_REGION
+#   The workflow assumes `arn:aws:iam::<AWS_ACCOUNT_ID>:role/GitHubActionsRole`
+#   when `vars.AWS_ACCOUNT_ID` is set (same pattern as deploy-backend).
 #
 # Security: presigned URLs and database URLs are sensitive. Do not echo them in steps.
 
@@ -25,12 +37,14 @@ on:
         default: true
         type: boolean
       environment:
-        description: GitHub Environment that provides DATABASE_URL (recommended).
+        description: >
+          GitHub Environment that provides DATABASE_URL or DATABASE_SECRET_ARN (+ AWS vars).
         required: true
         type: environment
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   import:
@@ -54,6 +68,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r backend/requirements.txt
 
+      - name: Configure AWS credentials (Secrets Manager + IAM DB auth)
+        if: ${{ vars.AWS_ACCOUNT_ID != '' && secrets.DATABASE_SECRET_ARN != '' }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/GitHubActionsRole
+          aws-region: ${{ vars.AWS_REGION }}
+          role-session-name: import-legacy-venues-${{ github.run_id }}
+
       - name: Download SQL dump
         env:
           INPUT_URL: ${{ github.event.inputs.sql_download_url }}
@@ -74,12 +96,27 @@ jobs:
       - name: Import venues
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_SECRET_ARN: ${{ secrets.DATABASE_SECRET_ARN }}
+          DATABASE_PROXY_ENDPOINT: ${{ vars.DATABASE_PROXY_ENDPOINT }}
+          DATABASE_USERNAME: ${{ vars.DATABASE_USERNAME }}
+          DATABASE_NAME: ${{ vars.DATABASE_NAME }}
+          DATABASE_PORT: ${{ vars.DATABASE_PORT }}
+          DATABASE_IAM_AUTH: ${{ vars.DATABASE_IAM_AUTH }}
           DATABASE_SSLMODE: ${{ vars.DATABASE_SSLMODE }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
         run: |
           set -euo pipefail
-          if [ -z "${DATABASE_URL:-}" ]; then
-            echo "DATABASE_URL is not set on this environment." >&2
+          if [ -z "${DATABASE_URL:-}" ] && [ -z "${DATABASE_SECRET_ARN:-}" ]; then
+            echo "Set either DATABASE_URL or DATABASE_SECRET_ARN on this environment." >&2
+            echo "For CDK/IAM: set DATABASE_SECRET_ARN and AWS_ACCOUNT_ID (for OIDC), plus proxy/user vars." >&2
             exit 1
+          fi
+          if [ -n "${DATABASE_SECRET_ARN:-}" ] && [ -z "${DATABASE_URL:-}" ]; then
+            if [ -z "${AWS_REGION:-}" ]; then
+              echo "AWS_REGION (var) is required when using DATABASE_SECRET_ARN without DATABASE_URL." >&2
+              exit 1
+            fi
           fi
           EXTRA=""
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then

--- a/.github/workflows/import-legacy-crm-venues.yml
+++ b/.github/workflows/import-legacy-crm-venues.yml
@@ -105,6 +105,7 @@ jobs:
           DATABASE_SSLMODE: ${{ vars.DATABASE_SSLMODE }}
           AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           set -euo pipefail
           if [ -z "${DATABASE_URL:-}" ] && [ -z "${DATABASE_SECRET_ARN:-}" ]; then
@@ -118,8 +119,8 @@ jobs:
               exit 1
             fi
           fi
-          EXTRA=""
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
-            EXTRA="--dry-run"
+          if [ "${DRY_RUN}" = "true" ]; then
+            python scripts/imports/import_legacy_crm_venues.py "${RUNNER_TEMP}/legacy_crm_venues.sql" --dry-run
+          else
+            python scripts/imports/import_legacy_crm_venues.py "${RUNNER_TEMP}/legacy_crm_venues.sql"
           fi
-          python scripts/imports/import_legacy_crm_venues.py "${RUNNER_TEMP}/legacy_crm_venues.sql" ${EXTRA}

--- a/.github/workflows/import-legacy-crm-venues.yml
+++ b/.github/workflows/import-legacy-crm-venues.yml
@@ -1,0 +1,88 @@
+# Manual import of legacy CRM venues from a MariaDB SQL dump into PostgreSQL `locations`.
+#
+# The dump file is not stored in git. Provide either:
+# - `sql_download_url` when running the workflow (HTTPS URL to the .sql file), or
+# - repository secret `IMPORT_LEGACY_CRM_SQL_URL` (same), if you leave the input empty.
+#
+# Database connection: set secret `DATABASE_URL` on the chosen GitHub Environment
+# (or repository secrets if you do not use environments).
+#
+# Security: presigned URLs and database URLs are sensitive. Do not echo them in steps.
+
+name: Import legacy CRM venues
+
+on:
+  workflow_dispatch:
+    inputs:
+      sql_download_url:
+        description: >
+          HTTPS URL to the MariaDB .sql backup (optional if secret IMPORT_LEGACY_CRM_SQL_URL is set).
+        required: false
+        type: string
+      dry_run:
+        description: If true, parse and print rows but do not insert into the database.
+        required: false
+        default: true
+        type: boolean
+      environment:
+        description: GitHub Environment that provides DATABASE_URL (recommended).
+        required: true
+        type: environment
+
+permissions:
+  contents: read
+
+jobs:
+  import:
+    name: Run import script
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r backend/requirements.txt
+
+      - name: Download SQL dump
+        env:
+          INPUT_URL: ${{ github.event.inputs.sql_download_url }}
+          SECRET_URL: ${{ secrets.IMPORT_LEGACY_CRM_SQL_URL }}
+        run: |
+          set -euo pipefail
+          URL="${INPUT_URL:-}"
+          if [ -z "${URL// }" ]; then
+            URL="${SECRET_URL:-}"
+          fi
+          if [ -z "${URL// }" ]; then
+            echo "Provide sql_download_url or set repository secret IMPORT_LEGACY_CRM_SQL_URL." >&2
+            exit 1
+          fi
+          curl -fsSL "$URL" -o "${RUNNER_TEMP}/legacy_crm_venues.sql"
+          echo "Downloaded SQL dump to ${RUNNER_TEMP}/legacy_crm_venues.sql (size $(wc -c < "${RUNNER_TEMP}/legacy_crm_venues.sql") bytes)"
+
+      - name: Import venues
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_SSLMODE: ${{ vars.DATABASE_SSLMODE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "DATABASE_URL is not set on this environment." >&2
+            exit 1
+          fi
+          EXTRA=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            EXTRA="--dry-run"
+          fi
+          python scripts/imports/import_legacy_crm_venues.py "${RUNNER_TEMP}/legacy_crm_venues.sql" ${EXTRA}

--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,6 @@ apps/evolvesprouts_app/ios/ExportOptions.plist
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local DB dumps (import scripts read paths; never commit SQL backups)
+scripts/imports/*.sql

--- a/scripts/imports/import_legacy_crm_venues.py
+++ b/scripts/imports/import_legacy_crm_venues.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Import venues from a legacy MariaDB/MySQL dump into PostgreSQL ``locations``.
+
+Reads a **local path** to a ``.sql`` dump (for example downloaded from S3 to
+``/tmp``). The dump is **not** committed to git; keep it outside the repo or
+under ``scripts/imports/`` (gitignored).
+
+Expected legacy tables (Evolve Sprouts CRM):
+
+- ``district`` — ``id``, ``name`` (Hong Kong district label), …
+- ``venue`` — ``name``, ``address_line1``, ``address_line2``, ``district_id``
+
+Each imported row becomes a ``locations`` row with ``area_id`` resolved by
+matching ``district.name`` to ``geographic_areas`` (child of country ``HK``,
+``level = 'district'``).
+
+Usage::
+
+    export DATABASE_URL=postgresql://...
+    python scripts/imports/import_legacy_crm_venues.py /path/to/backup.sql
+
+    # Preview without writing
+    python scripts/imports/import_legacy_crm_venues.py /path/to/backup.sql --dry-run
+
+Environment:
+
+- ``DATABASE_URL`` — required (same as Alembic / app).
+- ``DATABASE_SSLMODE`` — optional, default ``require``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from uuid import UUID
+
+# Repo layout: scripts/imports/ -> backend/src
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "backend" / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.engine import get_engine
+from app.db.models import GeographicArea, Location
+
+
+def _iter_mysql_insert_groups(values_sql: str) -> list[str]:
+    """Split a MySQL ``VALUES (..),(..)`` fragment into ``(..)`` group strings."""
+    depth = 0
+    start: int | None = None
+    i = 0
+    groups: list[str] = []
+    in_string = False
+    n = len(values_sql)
+    while i < n:
+        c = values_sql[i]
+        if in_string:
+            if c == "'" and i + 1 < n and values_sql[i + 1] == "'":
+                i += 2
+                continue
+            if c == "'":
+                in_string = False
+            i += 1
+            continue
+        if c == "'":
+            in_string = True
+            i += 1
+            continue
+        if c == "(":
+            depth += 1
+            if depth == 1:
+                start = i
+            i += 1
+            continue
+        if c == ")":
+            if depth == 1 and start is not None:
+                groups.append(values_sql[start : i + 1])
+                start = None
+            depth -= 1
+            i += 1
+            continue
+        i += 1
+    return groups
+
+
+def _split_mysql_tuple_fields(inner: str) -> list[str | None]:
+    """Parse fields inside one ``(...)`` group. Handles quoted strings and NULL."""
+    inner = inner.strip()
+    if not (inner.startswith("(") and inner.endswith(")")):
+        msg = f"Expected tuple wrapped in parentheses, got: {inner[:80]!r}"
+        raise ValueError(msg)
+    body = inner[1:-1]
+    fields: list[str | None] = []
+    i = 0
+    buf: list[str] = []
+    in_string = False
+    while i < len(body):
+        c = body[i]
+        if in_string:
+            if c == "'" and i + 1 < len(body) and body[i + 1] == "'":
+                buf.append("'")
+                i += 2
+                continue
+            if c == "'":
+                in_string = False
+                i += 1
+                continue
+            buf.append(c)
+            i += 1
+            continue
+        if c == "'":
+            in_string = True
+            buf = []
+            i += 1
+            continue
+        if c == ",":
+            raw = "".join(buf).strip()
+            fields.append(_parse_sql_atom(raw))
+            buf = []
+            i += 1
+            continue
+        if c.isspace():
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    tail = "".join(buf).strip()
+    if tail or fields:
+        fields.append(_parse_sql_atom(tail))
+    return fields
+
+
+def _parse_sql_atom(raw: str) -> str | None:
+    s = raw.strip()
+    if s.upper() == "NULL" or s == "":
+        return None
+    return s
+
+
+_INSERT_RE = re.compile(
+    r"INSERT\s+INTO\s+`(?P<table>[^`]+)`\s+VALUES\s*(?P<rest>.+?);",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _extract_insert_statement(sql_text: str, table: str) -> str | None:
+    m = _INSERT_RE.search(sql_text)
+    while m:
+        if m.group("table").lower() == table.lower():
+            return m.group(0)
+        m = _INSERT_RE.search(sql_text, m.end())
+    return None
+
+
+def _parse_legacy_districts(sql_text: str) -> dict[int, str]:
+    stmt = _extract_insert_statement(sql_text, "district")
+    if stmt is None:
+        msg = "Could not find INSERT INTO `district` in dump."
+        raise ValueError(msg)
+    m = _INSERT_RE.match(stmt)
+    if m is None:
+        raise ValueError("Unexpected district INSERT shape.")
+    rest = m.group("rest").rstrip()
+    if rest.endswith(";"):
+        rest = rest[:-1].rstrip()
+    groups = _iter_mysql_insert_groups(rest)
+    out: dict[int, str] = {}
+    for g in groups:
+        fields = _split_mysql_tuple_fields(g)
+        if len(fields) < 2:
+            continue
+        did = int(str(fields[0]))
+        name = str(fields[1])
+        out[did] = name
+    return out
+
+
+def _parse_legacy_venues(sql_text: str) -> list[dict[str, object]]:
+    stmt = _extract_insert_statement(sql_text, "venue")
+    if stmt is None:
+        msg = "Could not find INSERT INTO `venue` in dump."
+        raise ValueError(msg)
+    m = _INSERT_RE.match(stmt)
+    if m is None:
+        raise ValueError("Unexpected venue INSERT shape.")
+    rest = m.group("rest").rstrip()
+    if rest.endswith(";"):
+        rest = rest[:-1].rstrip()
+    groups = _iter_mysql_insert_groups(rest)
+    rows: list[dict[str, object]] = []
+    for g in groups:
+        fields = _split_mysql_tuple_fields(g)
+        if len(fields) < 5:
+            continue
+        legacy_id = int(str(fields[0]))
+        name = str(fields[1]) if fields[1] is not None else ""
+        line1 = fields[2]
+        line2 = fields[3]
+        district_raw = fields[4]
+        district_id = int(str(district_raw)) if district_raw is not None else None
+        parts = [p for p in (line1, line2) if p]
+        address = ", ".join(parts) if parts else None
+        rows.append(
+            {
+                "legacy_id": legacy_id,
+                "name": name.strip() or None,
+                "address": address,
+                "district_id": district_id,
+            }
+        )
+    return rows
+
+
+def _hk_country_id(session: Session) -> UUID:
+    q = select(GeographicArea.id).where(
+        GeographicArea.parent_id.is_(None),
+        GeographicArea.code == "HK",
+        GeographicArea.level == "country",
+    )
+    row = session.execute(q).scalar_one_or_none()
+    if row is None:
+        msg = "No geographic_areas row for Hong Kong (code=HK, root). Run migrations."
+        raise RuntimeError(msg)
+    return UUID(str(row))
+
+
+def _district_area_map(session: Session, hk_id: UUID) -> dict[str, UUID]:
+    q = select(GeographicArea.id, GeographicArea.name).where(
+        GeographicArea.parent_id == hk_id,
+        GeographicArea.level == "district",
+    )
+    m: dict[str, UUID] = {}
+    for aid, name in session.execute(q).all():
+        m[str(name)] = UUID(str(aid))
+    return m
+
+
+def _dedupe_key(name: str | None, address: str | None) -> tuple[str, str]:
+    n = (name or "").strip().lower()
+    a = (address or "").strip().lower()
+    return (n, a)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Import legacy CRM venue rows into locations.",
+    )
+    parser.add_argument(
+        "sql_path",
+        type=Path,
+        help="Path to local MariaDB .sql dump (not committed to git).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse and resolve areas but do not insert rows.",
+    )
+    args = parser.parse_args()
+    path: Path = args.sql_path
+    if not path.is_file():
+        print(f"File not found: {path}", file=sys.stderr)
+        return 1
+
+    sql_text = path.read_text(encoding="utf-8", errors="replace")
+    districts = _parse_legacy_districts(sql_text)
+    venues = _parse_legacy_venues(sql_text)
+
+    engine = get_engine(use_cache=False)
+    inserted = 0
+    skipped_dup = 0
+    skipped_area = 0
+
+    with Session(engine) as session:
+        hk_id = _hk_country_id(session)
+        area_by_name = _district_area_map(session, hk_id)
+
+        existing_keys: set[tuple[str, str]] = set()
+        for loc in session.execute(select(Location.name, Location.address)).all():
+            existing_keys.add(_dedupe_key(loc[0], loc[1]))
+
+        for v in venues:
+            did = v["district_id"]
+            dname = districts.get(int(did)) if did is not None else None
+            area_id = area_by_name.get(dname) if dname else None
+            if area_id is None:
+                print(
+                    f"Skip legacy venue id={v['legacy_id']}: "
+                    f"no geographic_areas match for district "
+                    f"id={did!r} name={dname!r}",
+                    file=sys.stderr,
+                )
+                skipped_area += 1
+                continue
+
+            name = v["name"]
+            address = v["address"]
+            key = _dedupe_key(name, address)
+            if key in existing_keys:
+                skipped_dup += 1
+                continue
+
+            if args.dry_run:
+                print(
+                    f"Would insert: {name!r} | {address!r} | area={dname!r}",
+                )
+                inserted += 1
+                existing_keys.add(key)
+                continue
+
+            loc = Location(
+                area_id=area_id,
+                name=name,
+                address=address,
+                lat=None,
+                lng=None,
+            )
+            session.add(loc)
+            session.flush()
+            inserted += 1
+            existing_keys.add(key)
+
+        if not args.dry_run:
+            session.commit()
+
+    print(
+        f"Done. inserted={inserted} skipped_duplicate={skipped_dup} "
+        f"skipped_no_area={skipped_area} dry_run={args.dry_run}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `scripts/imports/import_legacy_crm_venues.py`, a one-off importer that reads a **local** MariaDB/MySQL dump (Evolve Sprouts CRM: `district` + `venue` tables), maps each HK district name to `geographic_areas` under country `HK`, and inserts `locations` rows. Supports `--dry-run`.

Adds `scripts/imports/*.sql` to `.gitignore` so SQL backups dropped next to the script are not committed.

Adds **`.github/workflows/import-legacy-crm-venues.yml`**: manual workflow that downloads the dump from an HTTPS URL (workflow input or `IMPORT_LEGACY_CRM_SQL_URL` secret) and runs the import script using `DATABASE_URL` from the selected GitHub Environment.

## Usage (local)

Download the dump to a path **outside git** or under `scripts/imports/` (ignored), then:

```bash
export DATABASE_URL=postgresql://...
python scripts/imports/import_legacy_crm_venues.py /path/to/backup.sql --dry-run
python scripts/imports/import_legacy_crm_venues.py /path/to/backup.sql
```

## Usage (GitHub Actions)

Actions → **Import legacy CRM venues** → choose Environment (must define `DATABASE_URL`) → optional `sql_download_url` (or set secret `IMPORT_LEGACY_CRM_SQL_URL`) → `dry_run` default true.

## Notes

- Deduplicates by normalized `(name, address)` against existing `locations`.
- Rows whose district cannot be matched to a `geographic_areas` district are skipped with stderr messages.
- Does not preserve legacy integer IDs (new UUIDs via defaults).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc9efcbd-34fb-496e-a743-8bcd28d15721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc9efcbd-34fb-496e-a743-8bcd28d15721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

