### PR TITLE
fix(ci): parse error in import-legacy-crm-venues workflow `if` expression

### DIFF
--- a/.github/workflows/import-legacy-crm-venues.yml
+++ b/.github/workflows/import-legacy-crm-venues.yml
@@ -68,8 +68,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r backend/requirements.txt
 
+      # Note: `secrets` is not available in `if:` expressions. Gate on vars used for
+      # the CDK/IAM path (same as deploy-backend); DATABASE_SECRET_ARN is validated in the import step.
       - name: Configure AWS credentials (Secrets Manager + IAM DB auth)
-        if: ${{ vars.AWS_ACCOUNT_ID != '' && secrets.DATABASE_SECRET_ARN != '' }}
+        if: ${{ vars.AWS_ACCOUNT_ID != '' }}
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/GitHubActionsRole


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GitHub Actions rejects the `secrets` context in step `if:` conditions, which caused the workflow to fail parsing with "Unrecognized named-value: 'secrets'".

## Changes

- Gate the AWS OIDC step on `vars.AWS_ACCOUNT_ID != ''` only (aligned with the documented CDK/IAM path).
- The import step already validates that `DATABASE_URL` or `DATABASE_SECRET_ARN` is set.

## Risk

If someone sets `AWS_ACCOUNT_ID` but only intends to use `DATABASE_URL` (no IAM), the configure-aws-credentials step runs unnecessarily. That is harmless; credentials are unused when `DATABASE_URL` is set and `DATABASE_SECRET_ARN` is empty.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59ad85ed-4101-425e-93f0-66dc0fa850df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59ad85ed-4101-425e-93f0-66dc0fa850df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

