### PR TITLE
fix: parse mysqldump INSERT with column lists in legacy CRM venue import

### DIFF
--- a/.github/workflows/import-legacy-crm-venues.yml
+++ b/.github/workflows/import-legacy-crm-venues.yml
@@ -1,4 +1,6 @@
 # Manual import of legacy CRM venues from a MariaDB SQL dump into PostgreSQL `locations`.
+# The import script accepts both `INSERT INTO `t` VALUES ...` and mysqldump-style
+# `INSERT INTO `t` (`c1`,...) VALUES ...` statements.
 #
 # The dump file is not stored in git. Provide either:
 # - `sql_download_url` when running the workflow (HTTPS URL to the .sql file), or

--- a/scripts/imports/import_legacy_crm_venues.py
+++ b/scripts/imports/import_legacy_crm_venues.py
@@ -142,8 +142,12 @@ def _parse_sql_atom(raw: str) -> str | None:
     return s
 
 
+# mysqldump often emits `INSERT INTO `t` (`c1`, `c2`) VALUES ...`; support both that
+# and the shorter `INSERT INTO `t` VALUES ...` form.
 _INSERT_RE = re.compile(
-    r"INSERT\s+INTO\s+`(?P<table>[^`]+)`\s+VALUES\s*(?P<rest>.+?);",
+    r"INSERT\s+INTO\s+`(?P<table>[^`]+)`"
+    r"\s*(?:\([^)]*\))?"
+    r"\s+VALUES\s*(?P<rest>.+?);",
     re.IGNORECASE | re.DOTALL,
 )
 

--- a/tests/test_import_legacy_crm_venues.py
+++ b/tests/test_import_legacy_crm_venues.py
@@ -1,0 +1,62 @@
+"""Tests for legacy MariaDB dump parsing in ``import_legacy_crm_venues``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_IMPORTS = Path(__file__).resolve().parents[1] / "scripts" / "imports"
+if str(_SCRIPTS_IMPORTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_IMPORTS))
+
+import import_legacy_crm_venues as legacy_venues  # noqa: E402
+
+
+def test_parse_legacy_districts_accepts_column_list_form() -> None:
+    sql = """
+    SET NAMES utf8;
+    INSERT INTO `district` (`id`, `name`, `x`) VALUES
+    (1, 'Central', NULL),
+    (2, 'Wan Chai', 'y');
+    """
+    districts = legacy_venues._parse_legacy_districts(sql)
+    assert districts[1] == "Central"
+    assert districts[2] == "Wan Chai"
+
+
+def test_parse_legacy_venues_accepts_column_list_form() -> None:
+    sql = """
+    INSERT INTO `venue` (`id`, `name`, `address_line1`, `address_line2`, `district_id`)
+    VALUES (10, 'Hall', '1 Road', NULL, 1);
+    """
+    venues = legacy_venues._parse_legacy_venues(sql)
+    assert len(venues) == 1
+    v = venues[0]
+    assert v["legacy_id"] == 10
+    assert v["name"] == "Hall"
+    assert v["address"] == "1 Road"
+    assert v["district_id"] == 1
+
+
+def test_parse_legacy_still_supports_short_insert_form() -> None:
+    sql = """
+    INSERT INTO `district` VALUES (3,'Kowloon');
+    INSERT INTO `venue` VALUES (20,'B','Addr1',NULL,3);
+    """
+    assert legacy_venues._parse_legacy_districts(sql)[3] == "Kowloon"
+    venues = legacy_venues._parse_legacy_venues(sql)
+    assert venues[0]["legacy_id"] == 20
+    assert venues[0]["district_id"] == 3
+
+
+def test_extract_insert_skips_other_tables() -> None:
+    sql = """
+    INSERT INTO `other` VALUES (1);
+    INSERT INTO `district` (`id`, `name`) VALUES (5, 'North');
+    """
+    stmt = legacy_venues._extract_insert_statement(sql, "district")
+    assert stmt is not None
+    assert "`district`" in stmt
+    assert "`other`" not in stmt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Import legacy CRM venues** workflow failed because `import_legacy_crm_venues.py` only matched `INSERT INTO \`table\` VALUES ...`. Typical **mysqldump** output uses `INSERT INTO \`table\` (\`col1\`, ...) VALUES ...`, so the parser raised "Could not find INSERT INTO \`district\`/\`venue\`".

## Changes

- Extend the INSERT regex to allow an optional parenthesized column list before `VALUES`.
- Add unit tests for both dump styles (short form and column-list form).
- Document the supported dump shapes in the workflow file.

## Validation

- `pytest tests/test_import_legacy_crm_venues.py`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30e5b11c-a65e-4acc-abb9-b8c93d1bfe2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30e5b11c-a65e-4acc-abb9-b8c93d1bfe2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

