### PR TITLE
Fix import workflow preflight when import vars are unset

### DIFF
--- a/.github/workflows/import-legacy-crm.yml
+++ b/.github/workflows/import-legacy-crm.yml
@@ -8,8 +8,10 @@
 # **Production only** — fails unless the GitHub Environment name is `production`.
 #
 # GitHub Environment (production):
-# - vars: `AWS_ACCOUNT_ID`, `AWS_REGION`, `IMPORT_DUMP_BUCKET_NAME`, `IMPORT_LAMBDA_FUNCTION_NAME`
-#   (copy from CDK outputs `ImportDumpBucketName` and `ImportLegacyVenuesFunctionName`).
+# - vars: `AWS_ACCOUNT_ID`, `AWS_REGION` (required).
+# - optional vars: `IMPORT_DUMP_BUCKET_NAME`, `IMPORT_LAMBDA_FUNCTION_NAME`
+#   (if omitted, workflow resolves from stack outputs `ImportDumpBucketName` and
+#   `ImportLegacyFunctionName`/`ImportLegacyVenuesFunctionName` on stack `evolvesprouts`).
 # - secrets (optional): `IMPORT_LEGACY_CRM_SQL_URL` when `sql_download_url` is empty.
 # - Obsolete for this workflow: runner-side `DATABASE_*` secrets — not used.
 #
@@ -79,18 +81,82 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-session-name: import-legacy-crm-${{ github.run_id }}
 
+      - name: Resolve import resources (vars or stack outputs)
+        env:
+          IMPORT_DUMP_BUCKET_NAME: ${{ vars.IMPORT_DUMP_BUCKET_NAME }}
+          IMPORT_LAMBDA_FUNCTION_NAME: ${{ vars.IMPORT_LAMBDA_FUNCTION_NAME }}
+          IMPORT_STACK_NAME: ${{ vars.IMPORT_STACK_NAME }}
+        run: |
+          set -euo pipefail
+          STACK_NAME="${IMPORT_STACK_NAME:-evolvesprouts}"
+          RESOLVED_BUCKET="${IMPORT_DUMP_BUCKET_NAME:-}"
+          RESOLVED_FUNC="${IMPORT_LAMBDA_FUNCTION_NAME:-}"
+
+          if [ -z "${RESOLVED_BUCKET:-}" ] || [ -z "${RESOLVED_FUNC:-}" ]; then
+            STACK_EXISTS=$(aws cloudformation describe-stacks \
+              --stack-name "$STACK_NAME" \
+              --query 'Stacks[0].StackName' \
+              --output text 2>/dev/null || true)
+            if [ -z "${STACK_EXISTS:-}" ] || [ "${STACK_EXISTS}" = "None" ]; then
+              echo "Stack ${STACK_NAME} not found and required import vars are missing." >&2
+              echo "Set IMPORT_STACK_NAME or provide IMPORT_DUMP_BUCKET_NAME + IMPORT_LAMBDA_FUNCTION_NAME." >&2
+              exit 1
+            fi
+          fi
+
+          if [ -z "${RESOLVED_BUCKET:-}" ]; then
+            RESOLVED_BUCKET=$(aws cloudformation describe-stacks \
+              --stack-name "$STACK_NAME" \
+              --query "Stacks[0].Outputs[?OutputKey=='ImportDumpBucketName'].OutputValue | [0]" \
+              --output text)
+          fi
+          if [ -z "${RESOLVED_FUNC:-}" ]; then
+            RESOLVED_FUNC=$(aws cloudformation describe-stacks \
+              --stack-name "$STACK_NAME" \
+              --query "Stacks[0].Outputs[?OutputKey=='ImportLegacyFunctionName'].OutputValue | [0]" \
+              --output text)
+          fi
+          if [ -z "${RESOLVED_FUNC:-}" ] || [ "${RESOLVED_FUNC}" = "None" ]; then
+            RESOLVED_FUNC=$(aws cloudformation describe-stacks \
+              --stack-name "$STACK_NAME" \
+              --query "Stacks[0].Outputs[?OutputKey=='ImportLegacyVenuesFunctionName'].OutputValue | [0]" \
+              --output text)
+          fi
+
+          if [ -z "${RESOLVED_BUCKET:-}" ] || [ "${RESOLVED_BUCKET}" = "None" ]; then
+            echo "Could not resolve ImportDumpBucketName from stack ${STACK_NAME}." >&2
+            exit 1
+          fi
+          if [ -z "${RESOLVED_FUNC:-}" ] || [ "${RESOLVED_FUNC}" = "None" ]; then
+            echo "Could not resolve ImportLegacyFunctionName/ImportLegacyVenuesFunctionName from stack ${STACK_NAME}." >&2
+            exit 1
+          fi
+
+          echo "IMPORT_DUMP_BUCKET=${RESOLVED_BUCKET}" >> "${GITHUB_ENV}"
+          echo "IMPORT_LAMBDA_FUNCTION=${RESOLVED_FUNC}" >> "${GITHUB_ENV}"
+
       - name: Verify Lambda and IAM (preflight)
         env:
-          FUNC: ${{ vars.IMPORT_LAMBDA_FUNCTION_NAME }}
+          FUNC: ${{ env.IMPORT_LAMBDA_FUNCTION }}
+          BUCKET: ${{ env.IMPORT_DUMP_BUCKET }}
         run: |
           set -euo pipefail
           if [ -z "${FUNC:-}" ]; then
-            echo "Set IMPORT_LAMBDA_FUNCTION_NAME (CDK output ImportLegacyVenuesFunctionName)." >&2
+            echo "Set IMPORT_LAMBDA_FUNCTION_NAME or stack output ImportLegacyFunctionName." >&2
+            exit 1
+          fi
+          if [ -z "${BUCKET:-}" ]; then
+            echo "Set IMPORT_DUMP_BUCKET_NAME or stack output ImportDumpBucketName." >&2
             exit 1
           fi
           echo "Checking Lambda exists: $FUNC"
           if ! aws lambda get-function --function-name "$FUNC" --query 'Configuration.FunctionArn' --output text; then
             echo "lambda:GetFunction failed. Fix IMPORT_LAMBDA_FUNCTION_NAME or IAM." >&2
+            exit 1
+          fi
+          echo "Checking S3 bucket exists/access: $BUCKET"
+          if ! aws s3api head-bucket --bucket "$BUCKET"; then
+            echo "s3:HeadBucket failed. Fix IMPORT_DUMP_BUCKET_NAME or IAM." >&2
             exit 1
           fi
 
@@ -120,7 +186,7 @@ jobs:
       - name: Upload dump to S3
         env:
           ENTITY: ${{ github.event.inputs.entity }}
-          IMPORT_DUMP_BUCKET: ${{ vars.IMPORT_DUMP_BUCKET_NAME }}
+          IMPORT_DUMP_BUCKET: ${{ env.IMPORT_DUMP_BUCKET }}
         run: |
           set -euo pipefail
           if [ -z "${IMPORT_DUMP_BUCKET:-}" ]; then
@@ -136,10 +202,10 @@ jobs:
       - name: Invoke import Lambda
         env:
           ENTITY: ${{ github.event.inputs.entity }}
-          BUCKET: ${{ vars.IMPORT_DUMP_BUCKET_NAME }}
+          BUCKET: ${{ env.IMPORT_DUMP_BUCKET }}
           KEY: ${{ env.IMPORT_S3_KEY }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
-          FUNC: ${{ vars.IMPORT_LAMBDA_FUNCTION_NAME }}
+          FUNC: ${{ env.IMPORT_LAMBDA_FUNCTION }}
         run: |
           set -euo pipefail
           if [ -z "${FUNC:-}" ]; then
@@ -183,7 +249,7 @@ jobs:
       - name: Remove uploaded dump from S3
         if: always()
         env:
-          IMPORT_DUMP_BUCKET: ${{ vars.IMPORT_DUMP_BUCKET_NAME }}
+          IMPORT_DUMP_BUCKET: ${{ env.IMPORT_DUMP_BUCKET }}
           KEY: ${{ env.IMPORT_S3_KEY }}
         run: |
           set -euo pipefail

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -13,7 +13,7 @@ This document maps all AWS resources created by the `backend-deploy` workflow
 The import workflow (`.github/workflows/import-legacy-crm.yml`) uses OIDC to assume `GitHubActionsRole` (see `docs/architecture/setup.md`). That role is **not** created by this CDK stack. If the role is narrowly scoped instead of administrator-like, attach least-privilege statements for the legacy import path:
 
 - `s3:PutObject` and `s3:DeleteObject` on `arn:aws:s3:::evolvesprouts-import-dump-{account}-{region}/dumps/*` (objects live under `dumps/<entity>/<run_id>/`; delete is post-run cleanup).
-- `lambda:InvokeFunction` and `lambda:GetFunction` on `arn:aws:lambda:{region}:{account}:function:evolvesprouts-EvolvesproutsImportLegacyVenuesFunction` (preflight name check uses `get-function`; copy the exact function name from stack output `ImportLegacyVenuesFunctionName`).
+- `lambda:InvokeFunction` and `lambda:GetFunction` on `arn:aws:lambda:{region}:{account}:function:evolvesprouts-EvolvesproutsImportLegacyVenuesFunction` (preflight uses `get-function`; it first checks explicit GitHub vars and then falls back to `evolvesprouts` stack outputs).
 
 ---
 
@@ -620,9 +620,9 @@ configured by stack custom resources (including retention and KMS association).
 | `ApiUrl` | API Gateway REST API URL | Base URL for API endpoints |
 | `DatabaseSecretArn` | Secrets Manager secret ARN | ARN of database credentials secret |
 | `DatabaseProxyEndpoint` | RDS Proxy endpoint | Endpoint for database connections via proxy |
-| `ImportLegacyVenuesFunctionName` | Lambda function name | Physical name of `EvolvesproutsImportLegacyVenuesFunction` (set GitHub `IMPORT_LAMBDA_FUNCTION_NAME` to this value) |
+| `ImportLegacyVenuesFunctionName` | Lambda function name | Physical name of `EvolvesproutsImportLegacyVenuesFunction` (workflow auto-resolves from stack output when GitHub var is unset) |
 | `ImportLegacyFunctionName` | Lambda function name | Same value as `ImportLegacyVenuesFunctionName` (alias output) |
-| `ImportDumpBucketName` | S3 bucket name | Ephemeral legacy-import SQL dumps bucket (set GitHub `IMPORT_DUMP_BUCKET_NAME` to this value) |
+| `ImportDumpBucketName` | S3 bucket name | Ephemeral legacy-import SQL dumps bucket (workflow auto-resolves from stack output when GitHub var is unset) |
 | `UserPoolId` | Cognito User Pool ID | User Pool identifier |
 | `UserPoolClientId` | Cognito User Pool Client ID | OAuth client identifier |
 | `AssetsBucketName` | S3 bucket name | Assets bucket |

--- a/docs/architecture/setup.md
+++ b/docs/architecture/setup.md
@@ -143,7 +143,9 @@ For the OIDC provider itself, add the same tags:
 
 `.github/workflows/import-legacy-crm.yml` is **production-only** (it fails if the selected environment name is not `production`). On the **`production`** GitHub Environment, set:
 
-- **Variables:** `AWS_ACCOUNT_ID`, `AWS_REGION`. After each backend deploy, copy **`ImportDumpBucketName`** and **`ImportLegacyVenuesFunctionName`** from the `evolvesprouts` stack CloudFormation outputs into `IMPORT_DUMP_BUCKET_NAME` and `IMPORT_LAMBDA_FUNCTION_NAME` (single source of truth — do not hand-type the function name).
+- **Variables:** `AWS_ACCOUNT_ID`, `AWS_REGION`.
+  - Optional override vars: `IMPORT_DUMP_BUCKET_NAME`, `IMPORT_LAMBDA_FUNCTION_NAME`.
+  - If either override is missing, the workflow auto-resolves from CloudFormation stack outputs on `evolvesprouts` (`ImportDumpBucketName` and `ImportLegacyFunctionName`, with fallback to `ImportLegacyVenuesFunctionName` for backward compatibility).
 - **Secrets (optional):** `IMPORT_LEGACY_CRM_SQL_URL` — HTTPS URL to the `.sql` file when the workflow input is left empty.
 - **Obsolete for this workflow:** `DATABASE_URL`, `DATABASE_SECRET_ARN`, `DATABASE_PROXY_ENDPOINT`, and other runner-side DB variables used by the old script-based workflow are **not** read; remove them from the environment if you no longer need them elsewhere.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Auto-resolve import resources in `.github/workflows/import-legacy-crm.yml` when production environment vars are missing:
  - Resolve `IMPORT_DUMP_BUCKET` from stack output `ImportDumpBucketName`
  - Resolve `IMPORT_LAMBDA_FUNCTION` from stack output `ImportLegacyFunctionName` with fallback to `ImportLegacyVenuesFunctionName`
  - Default stack name is `evolvesprouts`, with optional override via `IMPORT_STACK_NAME`
- Keep explicit vars as overrides when set.
- Add clearer preflight checks/errors for both Lambda and S3 bucket access (`aws s3api head-bucket`).
- Continue suppressing CloudWatch tail in step summary.
- Update docs to match runtime behavior:
  - `docs/architecture/setup.md`
  - `docs/architecture/aws-assets-map.md`

## Why

GitHub Actions run `24651960554` failed because `IMPORT_LAMBDA_FUNCTION_NAME` was unset in the production environment. This change makes the workflow resilient to missing override vars by using stack outputs as source of truth.

## Validation

- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
- `python3 -m py_compile backend/src/app/imports/base.py backend/src/app/imports/entities/venues.py backend/lambda/imports/legacy_crm/handler.py scripts/imports/import_legacy_crm.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cebacd2-a259-4801-ae95-1620f3304d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cebacd2-a259-4801-ae95-1620f3304d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

