### PR TITLE
Legacy CRM import: structured table/column/value logging

### DIFF
--- a/.github/workflows/import-legacy-crm.yml
+++ b/.github/workflows/import-legacy-crm.yml
@@ -19,7 +19,7 @@
 # `lambda:GetFunction` + `lambda:InvokeFunction` on the import Lambda.
 #
 # Security: do not echo presigned URLs. Step summary shows counts; when the Lambda sets
-# `preview_allowed: false` (PII entities), preview lines are omitted from the summary.
+# `preview_allowed: false` (PII entities), preview lines and row_details are omitted from the summary.
 # CloudWatch logs are not echoed into the summary to avoid accidental data leakage.
 
 name: Import legacy CRM
@@ -254,7 +254,7 @@ jobs:
           echo "## Lambda import result" >> "${GITHUB_STEP_SUMMARY}"
           {
             echo '```json'
-            jq 'if .preview_allowed == false then del(.preview) else . end' lambda-response-payload.json || cat lambda-response-payload.json
+            jq 'if .preview_allowed == false then del(.preview, .row_details) else . end' lambda-response-payload.json || cat lambda-response-payload.json
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}" || true
           if echo "$META" | jq -e '.FunctionError != null' >/dev/null 2>&1; then

--- a/backend/lambda/imports/legacy_crm/handler.py
+++ b/backend/lambda/imports/legacy_crm/handler.py
@@ -125,6 +125,8 @@ def _stats_to_json(stats: ImportStats, *, preview_allowed: bool) -> dict[str, An
     }
     if preview_allowed and stats.preview:
         out["preview"] = stats.preview
+    if preview_allowed and stats.row_details:
+        out["row_details"] = stats.row_details
     return out
 
 
@@ -151,6 +153,9 @@ def lambda_handler(event: Mapping[str, Any], context: Any) -> dict[str, Any]:
 
     preview_allowed = not importer.PII
     out = _stats_to_json(stats, preview_allowed=preview_allowed)
+    log_extra: dict[str, Any] = {}
+    if preview_allowed and stats.row_details:
+        log_extra["import_row_details"] = stats.row_details
     logger.info(
         "Import complete entity=%s inserted=%s skipped_duplicate=%s "
         "skipped_no_area=%s skipped_no_dep=%s dry_run=%s",
@@ -160,5 +165,6 @@ def lambda_handler(event: Mapping[str, Any], context: Any) -> dict[str, Any]:
         stats.skipped_no_area,
         stats.skipped_no_dep,
         stats.dry_run,
+        extra=log_extra,
     )
     return out

--- a/backend/src/app/imports/base.py
+++ b/backend/src/app/imports/base.py
@@ -45,6 +45,8 @@ class ImportStats:
     skipped_no_dep: int = 0
     dry_run: bool = False
     preview: list[str] = field(default_factory=list)
+    #: Structured rows for logging / API (table, columns, values); capped per importer.
+    row_details: list[dict[str, Any]] = field(default_factory=list)
 
 
 @runtime_checkable

--- a/backend/src/app/imports/entities/venues.py
+++ b/backend/src/app/imports/entities/venues.py
@@ -165,6 +165,53 @@ class VenueImporter:
             refs_by_entity={},
         )
 
+    def _row_detail(
+        self,
+        v: LegacyVenue,
+        *,
+        area_id: UUID,
+        new_location_id: UUID | None,
+        dry_run: bool,
+    ) -> dict[str, Any]:
+        """Structured description of DB rows touched (for logs / invoke response)."""
+        loc_columns = ["area_id", "name", "address", "lat", "lng"]
+        loc_values: dict[str, Any] = {
+            "area_id": str(area_id),
+            "name": preview_line(self, v.name) if v.name else None,
+            "address": preview_line(self, v.address) if v.address else None,
+            "lat": None,
+            "lng": None,
+        }
+        tables: list[dict[str, Any]] = [
+            {
+                "table": "locations",
+                "columns": loc_columns,
+                "values": loc_values,
+            },
+        ]
+        ref_values: dict[str, Any] = {
+            "entity": self.ENTITY,
+            "legacy_key": str(v.legacy_id),
+            "new_id": None
+            if dry_run or new_location_id is None
+            else str(new_location_id),
+        }
+        tables.append(
+            {
+                "table": "legacy_import_refs",
+                "columns": ["entity", "legacy_key", "new_id"],
+                "values": ref_values,
+            },
+        )
+        return {
+            "legacy_source": {
+                "table": "venue",
+                "primary_key": {"id": v.legacy_id},
+            },
+            "target": {"tables": tables},
+            "dry_run": dry_run,
+        }
+
     def apply(
         self,
         session: Session,
@@ -209,6 +256,12 @@ class VenueImporter:
             if dry_run:
                 if len(stats.preview) < self.PREVIEW_MAX_ROWS:
                     stats.preview.append(self.format_preview(v, None))
+                if len(stats.row_details) < self.PREVIEW_MAX_ROWS:
+                    stats.row_details.append(
+                        self._row_detail(
+                            v, area_id=area_id, new_location_id=None, dry_run=True
+                        ),
+                    )
                 stats.inserted += 1
                 existing_keys.add(key)
                 continue
@@ -231,6 +284,15 @@ class VenueImporter:
                 str(v.legacy_id),
                 new_uuid,
             )
+            if len(stats.row_details) < self.PREVIEW_MAX_ROWS:
+                stats.row_details.append(
+                    self._row_detail(
+                        v,
+                        area_id=area_id,
+                        new_location_id=new_uuid,
+                        dry_run=False,
+                    ),
+                )
             stats.inserted += 1
             existing_keys.add(key)
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -240,7 +240,8 @@ their primary responsibilities.
 - Purpose: parse mysqldump text, write target rows, record `legacy_import_refs` for idempotent re-imports
 - DB access: RDS Proxy + IAM as `evolvesprouts_admin`; reads/writes `legacy_import_refs` for mapped ids
 - Other: S3 read on import bucket; `HeadObject` size cap; temp SQL under `/tmp` with request id in the filename; **reserved concurrency 3** (parallel entity imports capped)
-- Response JSON: `entity`, counts (`inserted`, `skipped_duplicate`, `skipped_no_area`, `skipped_no_dep`), `dry_run`, `preview_allowed` (false for `PII=True` importers — workflow omits preview from step summary)
+- Response JSON: `entity`, counts (`inserted`, `skipped_duplicate`, `skipped_no_area`, `skipped_no_dep`), `dry_run`, `preview_allowed` (false for `PII=True` importers — workflow omits preview from step summary); when `preview_allowed` is true, optional `preview` (text lines) and `row_details` (structured table/column/value summaries per inserted row, capped)
+- CloudWatch: completion log includes `import_row_details` (same structure as `row_details`) when `preview_allowed` and details exist
 - Stack outputs: `ImportLegacyVenuesFunctionName` / `ImportLegacyFunctionName` (same value), `ImportDumpBucketName`
 - Payload: `{ "entity": "<key>", "s3_bucket": "...", "s3_key": "...", "dry_run": <bool> }` — `s3_bucket` must match `IMPORT_DUMP_BUCKET_NAME`
 

--- a/tests/imports/entities/test_venues.py
+++ b/tests/imports/entities/test_venues.py
@@ -104,6 +104,17 @@ def test_apply_venues_dry_run_no_commit(monkeypatch: pytest.MonkeyPatch) -> None
     stats = apply_venues(session, venues, dry_run=True)
     assert stats.inserted == 1
     assert stats.skipped_duplicate == 0
+    assert len(stats.row_details) == 1
+    rd = stats.row_details[0]
+    assert rd["legacy_source"]["table"] == "venue"
+    assert rd["legacy_source"]["primary_key"]["id"] == 1
+    loc_tbl = next(t for t in rd["target"]["tables"] if t["table"] == "locations")
+    assert loc_tbl["columns"] == ["area_id", "name", "address", "lat", "lng"]
+    assert loc_tbl["values"]["area_id"] == str(area)
+    assert loc_tbl["values"]["name"] == "  Foo Bar  "
+    assert loc_tbl["values"]["address"] == "1 St"
+    ref_tbl = next(t for t in rd["target"]["tables"] if t["table"] == "legacy_import_refs")
+    assert ref_tbl["values"]["new_id"] is None
     assert (
         stats.preview[0]
         == "Would insert: name='  Foo Bar  ' | address='1 St' | area='Central'"
@@ -148,6 +159,11 @@ def test_apply_venues_inserts_and_commits(monkeypatch: pytest.MonkeyPatch) -> No
     ]
     stats = apply_venues(session, venues, dry_run=False)
     assert stats.inserted == 1
+    assert len(stats.row_details) == 1
+    ref_tbl = next(
+        t for t in stats.row_details[0]["target"]["tables"] if t["table"] == "legacy_import_refs"
+    )
+    assert ref_tbl["values"]["new_id"] == str(assigned_id)
     session.add.assert_called_once()
     session.flush.assert_called()
     session.commit.assert_called_once()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **structured `row_details`** for the **venues** legacy CRM importer so CloudWatch and the Lambda invoke response can show **which tables**, **which columns**, and **what values** would be or were written.

## Behavior

- **`ImportStats.row_details`**: list of per-row dicts (capped with the same limit as preview, 50 for venues).
- **Venues**: each detail includes legacy source (`venue` + PK), then `locations` (`area_id`, `name`, `address`, `lat`, `lng`) and `legacy_import_refs` (`entity`, `legacy_key`, `new_id` — `new_id` is null on dry run).
- **Lambda**: completion log includes JSON field **`import_row_details`** (merged by `StructuredLogFormatter`); invoke payload includes **`row_details`** when `preview_allowed` is true (same rule as `preview`).
- **GitHub workflow**: strips **`row_details`** from the step summary when `preview_allowed` is false (PII entities), matching preview behavior.

## Docs

- `docs/architecture/lambdas.md` updated for import Lambda response and CloudWatch.

## Tests

- Extended `tests/imports/entities/test_venues.py` for dry-run and apply `row_details`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-320b37fc-c423-4bac-b716-06b73ed7f07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-320b37fc-c423-4bac-b716-06b73ed7f07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

