### PR TITLE
CDK Lambda naming guidance and ImportLegacyVenues rename

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -114,6 +114,11 @@ repo root
     helpers.
   - Keep `backend/src/app/api/admin.py` focused on request dispatch orchestration.
 
+### CDK Lambda physical names (`backend/infrastructure/**`)
+
+- Stack helpers set physical Lambda names to `${resourcePrefix}-${constructId}` (CloudWatch log groups follow `/aws/lambda/${functionName}`). **Do not** use construct ids that repeat the product or `resourcePrefix` token (for example `EvolvesproutsFooFunction` when `resourcePrefix` is `evolvesprouts`), or the deployed name becomes redundant (`evolvesprouts-EvolvesproutsFooFunction`). Prefer a single descriptive PascalCase id without a second product prefix (for example `ImportLegacyVenuesFunction`, `AwsApiProxyFunction`).
+- Renaming a Lambda construct id replaces the CloudFormation resource; update `docs/architecture/lambdas.md`, `docs/architecture/aws-assets-map.md`, and any workflow or IAM examples that reference the physical name.
+
 ## Database change rules (MANDATORY for schema changes)
 
 - Alembic revision IDs must be <= 32 characters.

--- a/.github/workflows/import-legacy-crm.yml
+++ b/.github/workflows/import-legacy-crm.yml
@@ -1,7 +1,7 @@
 # Manual import from a legacy MariaDB SQL dump (entity-specific parsers).
 #
 # Flow: download the .sql → enforce ≤ 2 MB → upload to the import S3 bucket under
-# `dumps/<entity>/<run_id>/<entity>.sql` → invoke EvolvesproutsImportLegacyVenuesFunction
+# `dumps/<entity>/<run_id>/<entity>.sql` → invoke ImportLegacyVenuesFunction
 # with `{ entity, s3_bucket, s3_key, dry_run }`. The Lambda dispatches to the registered
 # importer for that entity.
 #

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2097,7 +2097,7 @@ export class ApiStack extends cdk.Stack {
     });
 
     const importLegacyVenuesFunction = createPythonFunction(
-      "EvolvesproutsImportLegacyVenuesFunction",
+      "ImportLegacyVenuesFunction",
       {
         handler: "lambda/imports/legacy_crm/handler.lambda_handler",
         timeout: cdk.Duration.minutes(10),
@@ -3431,7 +3431,7 @@ export class ApiStack extends cdk.Stack {
     new cdk.CfnOutput(this, "ImportLegacyVenuesFunctionName", {
       value: importLegacyVenuesFunction.functionName,
       description:
-        "Physical name for EvolvesproutsImportLegacyVenuesFunction (GitHub IMPORT_LAMBDA_FUNCTION_NAME)",
+        "Physical name for ImportLegacyVenuesFunction (GitHub IMPORT_LAMBDA_FUNCTION_NAME)",
     });
 
     new cdk.CfnOutput(this, "ImportLegacyFunctionName", {

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -13,7 +13,7 @@ This document maps all AWS resources created by the `backend-deploy` workflow
 The import workflow (`.github/workflows/import-legacy-crm.yml`) uses OIDC to assume `GitHubActionsRole` (see `docs/architecture/setup.md`). That role is **not** created by this CDK stack. If the role is narrowly scoped instead of administrator-like, attach least-privilege statements for the legacy import path:
 
 - `s3:PutObject` and `s3:DeleteObject` on `arn:aws:s3:::evolvesprouts-import-dump-{account}-{region}/dumps/*` (objects live under `dumps/<entity>/<run_id>/`; delete is post-run cleanup).
-- `lambda:InvokeFunction` and `lambda:GetFunction` on `arn:aws:lambda:{region}:{account}:function:evolvesprouts-EvolvesproutsImportLegacyVenuesFunction` (preflight uses `get-function`; it first checks explicit GitHub vars and then falls back to `evolvesprouts` stack outputs).
+- `lambda:InvokeFunction` and `lambda:GetFunction` on `arn:aws:lambda:{region}:{account}:function:evolvesprouts-ImportLegacyVenuesFunction` (preflight uses `get-function`; it first checks explicit GitHub vars and then falls back to `evolvesprouts` stack outputs).
 
 ---
 
@@ -153,7 +153,7 @@ credentials):
 |--------------|------------|------------------|-------|
 | S3 Bucket | `AssetsBucket` | `evolvesprouts-assets-{account}-{region}` | Private bucket for assets |
 | S3 Bucket | `AssetsLogBucket` | `evolvesprouts-assets-logs-{account}-{region}` | Access logs for the assets bucket |
-| S3 Bucket | `ImportDumpBucket` | `evolvesprouts-import-dump-{account}-{region}` | Ephemeral legacy-import SQL dumps (SSE-S3, 7-day expiration on current and noncurrent versions, abort incomplete multipart after 1 day); GitHub Actions uploads; `EvolvesproutsImportLegacyVenuesFunction` reads |
+| S3 Bucket | `ImportDumpBucket` | `evolvesprouts-import-dump-{account}-{region}` | Ephemeral legacy-import SQL dumps (SSE-S3, 7-day expiration on current and noncurrent versions, abort incomplete multipart after 1 day); GitHub Actions uploads; `ImportLegacyVenuesFunction` reads |
 | S3 Prefix | `AssetsBucket/inbound-email/raw/` | `s3://evolvesprouts-assets-{account}-{region}/inbound-email/raw/` | Reserved prefix for raw inbound invoice emails |
 
 ## Asset download CDN (CloudFront)
@@ -336,7 +336,7 @@ Each Lambda function created by `PythonLambda` construct includes:
 |---------------------|---------|--------|---------|-----|-------------|
 | `EvolvesproutsAdminFunction` | `lambda/admin/handler.lambda_handler` | 512 MB | 30s | Yes | - |
 | `EvolvesproutsMigrationFunction` | `lambda/migrations/handler.lambda_handler` | 512 MB | 5 min | Yes | `db` |
-| `EvolvesproutsImportLegacyVenuesFunction` | `lambda/imports/legacy_crm/handler.lambda_handler` | 512 MB | 10 min | Yes | - |
+| `ImportLegacyVenuesFunction` | `lambda/imports/legacy_crm/handler.lambda_handler` | 512 MB | 10 min | Yes | - |
 | `HealthCheckFunction` | `lambda/health/handler.lambda_handler` | 256 MB | 10s | Yes | - |
 
 ### Auth Functions
@@ -397,7 +397,7 @@ For each function above, the following resources are created:
 | `EvolvesproutsAdminFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_admin`, invoke `AwsApiProxyFunction`, SNS publish to media, expense parser, and Eventbrite sync topics, SES send email + **SendTemplatedEmail** (internal + `AuthEmailFromAddress` identities), Secrets Manager read for Mailchimp secret (public form marketing hooks), S3 read/write for the assets bucket; `DEPLOYMENT_STAGE` set to `production` in deployed stacks; `PUBLIC_WWW_BASE_URL` plus optional `PUBLIC_WWW_INSTAGRAM_URL` / `PUBLIC_WWW_LINKEDIN_URL` / `PUBLIC_WWW_WHATSAPP_URL` / `PUBLIC_WWW_BUSINESS_PHONE_NUMBER` for transactional HTML shell data; `SALES_RECAP_DISPLAY_TIMEZONE` from CDK parameter `SalesRecapDisplayTimezone` (optional; app default if empty) |
 | `AwsApiProxyFunction` | Cognito admin operations (`ListUsers`, `ListUsersInGroup`, `AdminGetUser`, `AdminDeleteUser`, `AdminAddUserToGroup`, `AdminRemoveUserFromGroup`, `AdminListGroupsForUser`, `AdminUserGlobalSignOut`, `AdminUpdateUserAttributes`) |
 | `EvolvesproutsMigrationFunction` | Read DB secret, direct connect to Aurora as `postgres`, Cognito user management, CloudFormation invoke permission |
-| `EvolvesproutsImportLegacyVenuesFunction` | Read admin DB secret, connect to RDS Proxy as `evolvesprouts_admin`, S3 read on `ImportDumpBucket` only |
+| `ImportLegacyVenuesFunction` | Read admin DB secret, connect to RDS Proxy as `evolvesprouts_admin`, S3 read on `ImportDumpBucket` only |
 | `HealthCheckFunction` | Read DB secret, connect to RDS Proxy as `evolvesprouts_app` |
 | `AuthCreateChallengeFunction` | SES `SendEmail`, `SendRawEmail` for the configured email address |
 | `AdminBootstrapFunction` | Cognito `AdminCreateUser`, `AdminUpdateUserAttributes`, `AdminSetUserPassword`, `AdminAddUserToGroup`, CloudFormation invoke permission |
@@ -620,7 +620,7 @@ configured by stack custom resources (including retention and KMS association).
 | `ApiUrl` | API Gateway REST API URL | Base URL for API endpoints |
 | `DatabaseSecretArn` | Secrets Manager secret ARN | ARN of database credentials secret |
 | `DatabaseProxyEndpoint` | RDS Proxy endpoint | Endpoint for database connections via proxy |
-| `ImportLegacyVenuesFunctionName` | Lambda function name | Physical name of `EvolvesproutsImportLegacyVenuesFunction` (workflow auto-resolves from stack output when GitHub var is unset) |
+| `ImportLegacyVenuesFunctionName` | Lambda function name | Physical name of `ImportLegacyVenuesFunction` (workflow auto-resolves from stack output when GitHub var is unset) |
 | `ImportLegacyFunctionName` | Lambda function name | Same value as `ImportLegacyVenuesFunctionName` (alias output) |
 | `ImportDumpBucketName` | S3 bucket name | Ephemeral legacy-import SQL dumps bucket (workflow auto-resolves from stack output when GitHub var is unset) |
 | `UserPoolId` | Cognito User Pool ID | User Pool identifier |

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -317,7 +317,7 @@ Purpose: Soft mapping from legacy CRM primary keys to Aurora row ids for
 operator-triggered imports. No foreign keys to target tables (avoids cycles;
 deleting a `locations` row can orphan a ref — expected; cleanup is operator-driven).
 
-Populated only by `EvolvesproutsImportLegacyVenuesFunction` during legacy CRM import
+Populated only by `ImportLegacyVenuesFunction` during legacy CRM import
 runs (and future entity importers sharing that Lambda).
 
 Columns:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -233,7 +233,7 @@ their primary responsibilities.
 - DB access: direct cluster endpoint with password auth
 
 ### Import legacy CRM
-- Function: EvolvesproutsImportLegacyVenuesFunction (construct id unchanged to avoid CloudFormation replacement)
+- Function: ImportLegacyVenuesFunction (physical name `evolvesprouts-ImportLegacyVenuesFunction`)
 - Handler: backend/lambda/imports/legacy_crm/handler.py — **entity dispatcher**; loads `app.imports` registry and runs the importer for `payload["entity"]`
 - Supported entities (today): `venues` (more added later with code + workflow choice list only — no CDK rename)
 - Trigger: direct `aws lambda invoke` (for example GitHub Actions after `dumps/<entity>/<run_id>/<entity>.sql` upload)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a **Backend and API** subsection in `.cursorrules` for CDK Lambda physical names: avoid construct ids that repeat `resourcePrefix` (e.g. `EvolvesproutsFooFunction` when prefix is `evolvesprouts`), which produced redundant names like `evolvesprouts-EvolvesproutsFooFunction`. Notes that renaming constructs replaces the CloudFormation resource and requires doc updates.
- Renames the legacy CRM import Lambda construct from `EvolvesproutsImportLegacyVenuesFunction` to **`ImportLegacyVenuesFunction`**, so the deployed name becomes **`evolvesprouts-ImportLegacyVenuesFunction`** (log group `/aws/lambda/evolvesprouts-ImportLegacyVenuesFunction`).
- Updates `docs/architecture/lambdas.md`, `database-schema.md`, `aws-assets-map.md`, and a comment in `.github/workflows/import-legacy-crm.yml`.

## Deploy note

Stack outputs `ImportLegacyVenuesFunctionName` / `ImportLegacyFunctionName` are unchanged; workflows that resolve the function name from outputs keep working. Anyone with **hardcoded** `IMPORT_LAMBDA_FUNCTION_NAME` or IAM ARNs must update to the new physical name after deploy.

## Testing

- `bash scripts/validate-cursorrules.sh`
- `npm run build` in `backend/infrastructure`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b450965c-d425-4d73-b98f-6b1c257ffae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b450965c-d425-4d73-b98f-6b1c257ffae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

