### PR TITLE
feat(imports): CSV list of legacy keys to skip during import

### DIFF
--- a/backend/lambda/imports/legacy_crm/handler.py
+++ b/backend/lambda/imports/legacy_crm/handler.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.db.engine import get_engine
 from app.imports import entities  # noqa: F401 — register importers
 from app.imports.base import ImportStats
+from app.imports.base import parse_skip_legacy_keys_csv
 from app.imports.base import resolve_importer_context
 from app.imports.registry import get
 from app.imports.registry import known_entities
@@ -24,7 +25,7 @@ configure_logging()
 logger = get_logger(__name__)
 
 _ALLOWED_EVENT_KEYS = frozenset(
-    {"entity", "s3_bucket", "s3_key", "dry_run"},
+    {"entity", "s3_bucket", "s3_key", "dry_run", "skip_legacy_keys"},
 )
 
 
@@ -53,6 +54,7 @@ def _validate_event(event: Mapping[str, Any]) -> dict[str, Any]:
     bucket = event.get("s3_bucket")
     key = event.get("s3_key")
     dry_run = event.get("dry_run")
+    skip_legacy_keys = event.get("skip_legacy_keys")
     if not isinstance(entity, str) or not entity.strip():
         msg = "entity must be a non-empty string"
         raise ValueError(msg)
@@ -72,6 +74,9 @@ def _validate_event(event: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(dry_run, bool):
         msg = "dry_run must be a boolean"
         raise ValueError(msg)
+    if skip_legacy_keys is not None and not isinstance(skip_legacy_keys, str):
+        msg = "skip_legacy_keys must be a string or omitted"
+        raise ValueError(msg)
     expected = _env_bucket()
     if not expected:
         msg = "IMPORT_DUMP_BUCKET_NAME is not configured"
@@ -84,6 +89,9 @@ def _validate_event(event: Mapping[str, Any]) -> dict[str, Any]:
         "s3_bucket": bucket,
         "s3_key": key.strip(),
         "dry_run": dry_run,
+        "skip_legacy_keys": skip_legacy_keys.strip()
+        if isinstance(skip_legacy_keys, str)
+        else "",
     }
 
 
@@ -118,6 +126,7 @@ def _stats_to_json(stats: ImportStats, *, preview_allowed: bool) -> dict[str, An
         "entity": stats.entity,
         "inserted": stats.inserted,
         "skipped_duplicate": stats.skipped_duplicate,
+        "skipped_excluded_key": stats.skipped_excluded_key,
         "skipped_no_area": stats.skipped_no_area,
         "skipped_no_dep": stats.skipped_no_dep,
         "dry_run": stats.dry_run,
@@ -131,7 +140,7 @@ def _stats_to_json(stats: ImportStats, *, preview_allowed: bool) -> dict[str, An
 
 
 def lambda_handler(event: Mapping[str, Any], context: Any) -> dict[str, Any]:
-    """Direct invoke: ``{entity, s3_bucket, s3_key, dry_run}``."""
+    """Direct invoke: ``{entity, s3_bucket, s3_key, dry_run[, skip_legacy_keys]}``."""
     payload = _validate_event(event)
     importer = get(payload["entity"])
     req_id = getattr(context, "aws_request_id", None) or "local"
@@ -142,12 +151,16 @@ def lambda_handler(event: Mapping[str, Any], context: Any) -> dict[str, Any]:
     )
     rows = importer.parse(sql_text)
 
+    skip_keys = parse_skip_legacy_keys_csv(
+        payload["skip_legacy_keys"] or None,
+    )
     engine = get_engine(use_cache=False)
     with Session(engine) as session:
         ctx = resolve_importer_context(
             importer,
             session,
             dry_run=payload["dry_run"],
+            skip_legacy_keys=skip_keys,
         )
         stats = importer.apply(session, rows, ctx, dry_run=payload["dry_run"])
 
@@ -158,10 +171,11 @@ def lambda_handler(event: Mapping[str, Any], context: Any) -> dict[str, Any]:
         log_extra["import_row_details"] = stats.row_details
     logger.info(
         "Import complete entity=%s inserted=%s skipped_duplicate=%s "
-        "skipped_no_area=%s skipped_no_dep=%s dry_run=%s",
+        "skipped_excluded_key=%s skipped_no_area=%s skipped_no_dep=%s dry_run=%s",
         stats.entity,
         stats.inserted,
         stats.skipped_duplicate,
+        stats.skipped_excluded_key,
         stats.skipped_no_area,
         stats.skipped_no_dep,
         stats.dry_run,

--- a/backend/src/app/imports/base.py
+++ b/backend/src/app/imports/base.py
@@ -23,6 +23,17 @@ class DependencyNotMet(RuntimeError):
     """Raised when a non-dry-run import needs parent rows in legacy_import_refs."""
 
 
+def parse_skip_legacy_keys_csv(raw: str | None) -> frozenset[str]:
+    """Parse a comma-separated list of legacy primary-key strings to exclude from import."""
+    if raw is None:
+        return frozenset()
+    s = raw.strip()
+    if not s:
+        return frozenset()
+    parts = (p.strip() for p in s.split(","))
+    return frozenset(p for p in parts if p)
+
+
 @dataclass(frozen=True)
 class ImporterContext:
     """Per-invocation context built in ``resolve_context``."""
@@ -32,6 +43,8 @@ class ImporterContext:
     refs_by_entity: Mapping[str, Mapping[str, UUID]] = field(default_factory=dict)
     #: Optional legacy district id → label (venues tests / manual rows without labels).
     district_map: Mapping[int, str] | None = None
+    #: Legacy row keys (string form of PK, e.g. venue id) to skip for this run.
+    skip_legacy_keys: frozenset[str] = field(default_factory=frozenset)
 
 
 @dataclass
@@ -41,6 +54,7 @@ class ImportStats:
     entity: str = ""
     inserted: int = 0
     skipped_duplicate: int = 0
+    skipped_excluded_key: int = 0
     skipped_no_area: int = 0
     skipped_no_dep: int = 0
     dry_run: bool = False
@@ -121,6 +135,7 @@ def resolve_importer_context(
     session: Session,
     *,
     dry_run: bool,
+    skip_legacy_keys: frozenset[str] | None = None,
 ) -> ImporterContext:
     """Resolve importer context and attach dependency ref maps."""
     check_dependencies(importer, session, dry_run=dry_run)
@@ -129,4 +144,7 @@ def resolve_importer_context(
 
     base_ctx = importer.resolve_context(session, dry_run=dry_run)
     refs_by = {dep: refs.load_mapping(session, dep) for dep in importer.DEPENDS_ON}
-    return replace(base_ctx, refs_by_entity=refs_by)
+    merged_skip = frozenset(base_ctx.skip_legacy_keys)
+    if skip_legacy_keys:
+        merged_skip |= skip_legacy_keys
+    return replace(base_ctx, refs_by_entity=refs_by, skip_legacy_keys=merged_skip)

--- a/backend/src/app/imports/entities/venues.py
+++ b/backend/src/app/imports/entities/venues.py
@@ -227,6 +227,9 @@ class VenueImporter:
         for v in rows:
             if not isinstance(v, LegacyVenue):
                 continue
+            if str(v.legacy_id) in ctx.skip_legacy_keys:
+                stats.skipped_excluded_key += 1
+                continue
             dname = v.district_label
             if (
                 dname is None
@@ -332,12 +335,14 @@ def apply_venues(
     *,
     dry_run: bool,
     district_map: Mapping[int, str] | None = None,
+    skip_legacy_keys: frozenset[str] | None = None,
 ) -> ImportStats:
     """Apply venue rows (used by tests; delegates to :class:`VenueImporter`)."""
     importer = VenueImporter()
     ctx = importer.resolve_context(session, dry_run=dry_run)
     dm = dict(district_map) if district_map is not None else None
-    ctx = replace(ctx, district_map=dm)
+    sk = skip_legacy_keys or frozenset()
+    ctx = replace(ctx, district_map=dm, skip_legacy_keys=ctx.skip_legacy_keys | sk)
     return importer.apply(session, venues, ctx, dry_run=dry_run)
 
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -240,10 +240,10 @@ their primary responsibilities.
 - Purpose: parse mysqldump text, write target rows, record `legacy_import_refs` for idempotent re-imports
 - DB access: RDS Proxy + IAM as `evolvesprouts_admin`; reads/writes `legacy_import_refs` for mapped ids
 - Other: S3 read on import bucket; `HeadObject` size cap; temp SQL under `/tmp` with request id in the filename; **reserved concurrency 3** (parallel entity imports capped)
-- Response JSON: `entity`, counts (`inserted`, `skipped_duplicate`, `skipped_no_area`, `skipped_no_dep`), `dry_run`, `preview_allowed` (false for `PII=True` importers — workflow omits preview from step summary); when `preview_allowed` is true, optional `preview` (text lines) and `row_details` (structured table/column/value summaries per inserted row, capped)
+- Response JSON: `entity`, counts (`inserted`, `skipped_duplicate`, `skipped_excluded_key`, `skipped_no_area`, `skipped_no_dep`), `dry_run`, `preview_allowed` (false for `PII=True` importers — workflow omits preview from step summary); when `preview_allowed` is true, optional `preview` (text lines) and `row_details` (structured table/column/value summaries per inserted row, capped)
 - CloudWatch: completion log includes `import_row_details` (same structure as `row_details`) when `preview_allowed` and details exist
 - Stack outputs: `ImportLegacyVenuesFunctionName` / `ImportLegacyFunctionName` (same value), `ImportDumpBucketName`
-- Payload: `{ "entity": "<key>", "s3_bucket": "...", "s3_key": "...", "dry_run": <bool> }` — `s3_bucket` must match `IMPORT_DUMP_BUCKET_NAME`
+- Payload: `{ "entity": "<key>", "s3_bucket": "...", "s3_key": "...", "dry_run": <bool> [, "skip_legacy_keys": "<csv>"] }` — `s3_bucket` must match `IMPORT_DUMP_BUCKET_NAME`; optional `skip_legacy_keys` is a comma-separated list of legacy primary-key strings to skip (venues: numeric id as string, e.g. `"1,2,3"`)
 
 **How to add a new entity**
 

--- a/scripts/imports/import_legacy_crm.py
+++ b/scripts/imports/import_legacy_crm.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session
 
 from app.db.engine import get_engine
 from app.imports import entities  # noqa: F401 — register importers
+from app.imports.base import parse_skip_legacy_keys_csv
 from app.imports.base import resolve_importer_context
 from app.imports.registry import get
 from app.imports.registry import known_entities
@@ -60,6 +61,15 @@ def main() -> int:
         action="store_true",
         help="Parse and resolve but do not commit writes.",
     )
+    parser.add_argument(
+        "--skip-legacy-keys",
+        default="",
+        metavar="CSV",
+        help=(
+            "Comma-separated legacy primary-key values to skip (e.g. venue ids). "
+            "Whitespace around entries is trimmed; empty tokens are ignored."
+        ),
+    )
     args = parser.parse_args()
     path: Path = args.sql_path
     if not path.is_file():
@@ -70,17 +80,24 @@ def main() -> int:
     sql_text = path.read_text(encoding="utf-8", errors="replace")
     rows = importer.parse(sql_text)
 
+    skip_keys = parse_skip_legacy_keys_csv(args.skip_legacy_keys or None)
     engine = get_engine(use_cache=False)
     with Session(engine) as session:
-        ctx = resolve_importer_context(importer, session, dry_run=args.dry_run)
+        ctx = resolve_importer_context(
+            importer,
+            session,
+            dry_run=args.dry_run,
+            skip_legacy_keys=skip_keys,
+        )
         stats = importer.apply(session, rows, ctx, dry_run=args.dry_run)
 
     logger.info(
-        "Done entity=%s inserted=%s skipped_duplicate=%s skipped_no_area=%s "
-        "skipped_no_dep=%s dry_run=%s",
+        "Done entity=%s inserted=%s skipped_duplicate=%s skipped_excluded_key=%s "
+        "skipped_no_area=%s skipped_no_dep=%s dry_run=%s",
         stats.entity,
         stats.inserted,
         stats.skipped_duplicate,
+        stats.skipped_excluded_key,
         stats.skipped_no_area,
         stats.skipped_no_dep,
         stats.dry_run,

--- a/tests/imports/entities/test_venues.py
+++ b/tests/imports/entities/test_venues.py
@@ -204,6 +204,41 @@ def test_apply_venues_skips_duplicate_case_insensitive(
     session.add.assert_not_called()
 
 
+def test_apply_venues_skips_excluded_legacy_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.imports.entities import venues as mod
+
+    hk = uuid.uuid4()
+    area = uuid.uuid4()
+    monkeypatch.setattr(mod, "_hk_country_id", lambda _s: hk)
+    monkeypatch.setattr(
+        mod,
+        "_district_area_map",
+        lambda _s, _h: {"Central": area},
+    )
+
+    session = MagicMock()
+    session.execute.return_value.all.return_value = []
+
+    venues = [
+        LegacyVenue(
+            legacy_id=42,
+            name="Foo",
+            address="1 St",
+            district_id=1,
+            district_label="Central",
+        )
+    ]
+    stats = apply_venues(
+        session,
+        venues,
+        dry_run=False,
+        skip_legacy_keys=frozenset({"42"}),
+    )
+    assert stats.inserted == 0
+    assert stats.skipped_excluded_key == 1
+    session.add.assert_not_called()
+
+
 def test_apply_venues_skips_no_area(monkeypatch: pytest.MonkeyPatch) -> None:
     from app.imports.entities import venues as mod
 

--- a/tests/imports/test_base.py
+++ b/tests/imports/test_base.py
@@ -15,6 +15,7 @@ from app.imports.base import DependencyNotMet
 from app.imports.base import ImportStats
 from app.imports.base import ImporterContext
 from app.imports.base import check_dependencies
+from app.imports.base import parse_skip_legacy_keys_csv
 from app.imports.base import resolve_importer_context
 
 
@@ -84,6 +85,12 @@ def test_resolve_importer_context_attaches_dependency_maps(
     assert ctx.refs_by_entity["venues"]["1"] == UUID(int=1)
 
 
+def test_parse_skip_legacy_keys_csv_trims_and_splits() -> None:
+    assert parse_skip_legacy_keys_csv(" 1 , 2 , ") == frozenset({"1", "2"})
+    assert parse_skip_legacy_keys_csv("") == frozenset()
+    assert parse_skip_legacy_keys_csv(None) == frozenset()
+
+
 def test_resolve_importer_context_skips_dependency_check_during_dry_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -105,3 +112,41 @@ def test_resolve_importer_context_skips_dependency_check_during_dry_run(
     )
     assert ctx.refs_by_entity == {"venues": {}}
     assert called["has_mapping"] is False
+
+
+def test_resolve_importer_context_merges_skip_legacy_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.imports import refs
+
+    class _CtxImporter:
+        ENTITY: ClassVar[str] = "_ctx_skip_test"
+        DEPENDS_ON: ClassVar[tuple[str, ...]] = ()
+
+        def parse(self, sql_text: str) -> Sequence[Any]:
+            return []
+
+        def resolve_context(self, session: Session, *, dry_run: bool) -> ImporterContext:
+            return ImporterContext(skip_legacy_keys=frozenset({"a"}))
+
+        def apply(
+            self,
+            session: Session,
+            rows: Sequence[Any],
+            ctx: ImporterContext,
+            *,
+            dry_run: bool,
+        ) -> ImportStats:
+            return ImportStats(entity=self.ENTITY)
+
+        def format_preview(self, row: Any, mapped_id: UUID | None) -> str:
+            return ""
+
+    monkeypatch.setattr(refs, "has_mapping", lambda _s, _dep: True)
+    ctx = resolve_importer_context(
+        _CtxImporter(),
+        MagicMock(spec=Session),
+        dry_run=False,
+        skip_legacy_keys=frozenset({"b"}),
+    )
+    assert ctx.skip_legacy_keys == frozenset({"a", "b"})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional comma-separated legacy primary-key strings to exclude from a legacy CRM import run.

### CLI (`scripts/imports/import_legacy_crm.py`)

- New flag: `--skip-legacy-keys CSV` (e.g. `10,11,12`). Entries are trimmed; empty tokens ignored.

### Lambda (`backend/lambda/imports/legacy_crm/handler.py`)

- Optional event field: `skip_legacy_keys` (string, same CSV format). Omitted or empty means no exclusions.

### Importer behavior

- `ImporterContext` carries `skip_legacy_keys` (merged from `resolve_context` and invocation).
- **Venues** importer skips rows whose legacy id string is in that set and increments `skipped_excluded_key` in `ImportStats`.
- Response JSON and completion logs include `skipped_excluded_key`.

### Docs & tests

- `docs/architecture/lambdas.md` updated for payload and response.
- Unit tests for CSV parsing, context merge, and venue skip path.

## How to verify

```bash
python3 -m pytest tests/imports/test_base.py tests/imports/entities/test_venues.py tests/lambda_handlers/imports/test_handler_dispatch.py
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dac0d3f-be0b-411d-aa90-02d4351c62ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dac0d3f-be0b-411d-aa90-02d4351c62ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

