### PR TITLE
ci(import-legacy-crm): pass skip_legacy_keys from GitHub Actions

### DIFF
--- a/.github/workflows/import-legacy-crm.yml
+++ b/.github/workflows/import-legacy-crm.yml
@@ -2,7 +2,7 @@
 #
 # Flow: download the .sql → enforce ≤ 2 MB → upload to the import S3 bucket under
 # `dumps/<entity>/<run_id>/<entity>.sql` → invoke ImportLegacyVenuesFunction
-# with `{ entity, s3_bucket, s3_key, dry_run }`. The Lambda dispatches to the registered
+# with `{ entity, s3_bucket, s3_key, dry_run [, skip_legacy_keys] }`. The Lambda dispatches to the registered
 # importer for that entity.
 #
 # **Production only** — fails unless the GitHub Environment name is `production`.
@@ -43,6 +43,12 @@ on:
         required: false
         default: true
         type: boolean
+      skip_legacy_keys:
+        description: >
+          Comma-separated legacy primary-key values to exclude from this import (e.g. venue ids).
+          Leave empty to import every row from the dump.
+        required: false
+        type: string
       environment:
         description: GitHub Environment (must be `production` for this workflow).
         required: true
@@ -228,6 +234,7 @@ jobs:
           BUCKET: ${{ env.IMPORT_DUMP_BUCKET }}
           KEY: ${{ env.IMPORT_S3_KEY }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
+          SKIP_LEGACY_KEYS: ${{ github.event.inputs.skip_legacy_keys }}
           FUNC: ${{ env.IMPORT_LAMBDA_FUNCTION }}
         run: |
           set -euo pipefail
@@ -240,9 +247,16 @@ jobs:
           else
             DRY_JSON=false
           fi
-          PAYLOAD=$(jq -cn \
-            --arg e "$ENTITY" --arg b "$BUCKET" --arg k "$KEY" --argjson d "$DRY_JSON" \
-            '{entity:$e, s3_bucket:$b, s3_key:$k, dry_run:$d}')
+          SKIP_TRIMMED=$(echo "${SKIP_LEGACY_KEYS:-}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          if [ -z "$SKIP_TRIMMED" ]; then
+            PAYLOAD=$(jq -cn \
+              --arg e "$ENTITY" --arg b "$BUCKET" --arg k "$KEY" --argjson d "$DRY_JSON" \
+              '{entity:$e, s3_bucket:$b, s3_key:$k, dry_run:$d}')
+          else
+            PAYLOAD=$(jq -cn \
+              --arg e "$ENTITY" --arg b "$BUCKET" --arg k "$KEY" --argjson d "$DRY_JSON" --arg sk "$SKIP_TRIMMED" \
+              '{entity:$e, s3_bucket:$b, s3_key:$k, dry_run:$d, skip_legacy_keys:$sk}')
+          fi
           META=$(aws lambda invoke \
             --function-name "$FUNC" \
             --cli-binary-format raw-in-base64-out \

--- a/docs/architecture/setup.md
+++ b/docs/architecture/setup.md
@@ -147,6 +147,7 @@ For the OIDC provider itself, add the same tags:
   - Optional override vars: `IMPORT_DUMP_BUCKET_NAME`, `IMPORT_LAMBDA_FUNCTION_NAME`.
   - If either override is missing, the workflow auto-resolves from CloudFormation stack outputs on `evolvesprouts` (`ImportDumpBucketName` and `ImportLegacyFunctionName`, with fallback to `ImportLegacyVenuesFunctionName` for backward compatibility).
 - **Secrets (optional):** `IMPORT_LEGACY_CRM_SQL_URL` — HTTPS URL to the `.sql` file when the workflow input is left empty.
+- **Workflow input (optional):** `skip_legacy_keys` — comma-separated legacy primary-key values to exclude (passed through to the import Lambda as `skip_legacy_keys`; venues: numeric ids as strings, e.g. `10,11,12`). Leave empty to import every row from the dump.
 - **Obsolete for this workflow:** `DATABASE_URL`, `DATABASE_SECRET_ARN`, `DATABASE_PROXY_ENDPOINT`, and other runner-side DB variables used by the old script-based workflow are **not** read; remove them from the environment if you no longer need them elsewhere.
 
 ### Backend deploy manual seed toggle


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the merged legacy-key skip feature: wire the same CSV through the **Import legacy CRM** GitHub Actions workflow so operators can exclude rows without using the CLI.

### Changes

- **`.github/workflows/import-legacy-crm.yml`**
  - New optional `workflow_dispatch` input: **`skip_legacy_keys`** (comma-separated legacy primary keys, e.g. venue ids).
  - Invoke step trims the value; if empty after trim, **`skip_legacy_keys` is omitted** from the Lambda payload (matches handler optional field).
- **`docs/architecture/setup.md`** — documents the new workflow input under the production legacy import section.

## How to verify

Run the workflow manually in GitHub and set `skip_legacy_keys` to e.g. `1,2,3`; confirm the Lambda response includes `skipped_excluded_key` when those ids exist in the dump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dac0d3f-be0b-411d-aa90-02d4351c62ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dac0d3f-be0b-411d-aa90-02d4351c62ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

