### PR TITLE
feat(admin): hard-delete CRM contacts

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminCrmContacts } from '@/hooks/use-admin-crm-contacts';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { CrmTagPicker } from '@/components/admin/contacts/crm-tag-picker';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Input } from '@/components/ui/input';
@@ -79,7 +81,11 @@ export function ContactsPanel({ contacts, tags, locations, geographicAreas }: Co
     isSaving,
     createContact,
     updateContact,
+    deleteContact,
   } = contacts;
+
+  const [confirmDialogProps, requestConfirm] = useConfirmDialog();
+  const [deleteActionError, setDeleteActionError] = useState('');
 
   const [familyPicker, setFamilyPicker] = useState<CrmPickerListItem[]>([]);
   const [organizationPicker, setOrganizationPicker] = useState<CrmPickerListItem[]>([]);
@@ -315,6 +321,43 @@ export function ContactsPanel({ contacts, tags, locations, geographicAreas }: Co
     }
   }
 
+  function contactRowLabel(row: ApiSchemas['AdminContact']): string {
+    const name = [row.first_name, row.last_name].filter(Boolean).join(' ').trim();
+    if (name) {
+      return name;
+    }
+    if (row.email?.trim()) {
+      return row.email.trim();
+    }
+    return row.id;
+  }
+
+  async function handleDeleteContact(
+    row: ApiSchemas['AdminContact'],
+    clickEvent: MouseEvent<HTMLButtonElement>
+  ): Promise<void> {
+    clickEvent.stopPropagation();
+    const confirmed = await requestConfirm({
+      title: 'Delete contact',
+      description: `Permanently delete "${contactRowLabel(row)}"? This removes the contact from the database and cannot be undone.`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) {
+      return;
+    }
+    setDeleteActionError('');
+    try {
+      await deleteContact(row.id);
+      if (selectedId === row.id) {
+        resetCreateForm();
+      }
+    } catch (err) {
+      setDeleteActionError(err instanceof Error ? err.message : 'Failed to delete contact');
+    }
+  }
+
   function selectRow(row: ApiSchemas['AdminContact']) {
     setSelectedId(row.id);
     setEditorMode('edit');
@@ -346,6 +389,7 @@ export function ContactsPanel({ contacts, tags, locations, geographicAreas }: Co
 
   return (
     <div className='space-y-6'>
+      <ConfirmDialog {...confirmDialogProps} />
       <AdminEditorCard
         title='Contact'
         description='Create a contact or select a row below to edit. Relationship excludes vendor (vendors are organisation records under Finance). When this contact is linked to a family or organisation, set location on that record instead. Mailchimp sync status is read-only from the API.'
@@ -635,7 +679,7 @@ export function ContactsPanel({ contacts, tags, locations, geographicAreas }: Co
         isLoading={isLoading}
         isLoadingMore={isLoadingMore}
         hasMore={hasMore}
-        error={error}
+        error={error || deleteActionError}
         loadingLabel='Loading contacts...'
         onLoadMore={loadMore}
         toolbar={
@@ -645,7 +689,10 @@ export function ContactsPanel({ contacts, tags, locations, geographicAreas }: Co
               <Input
                 id='crm-contacts-search'
                 value={filters.query}
-                onChange={(e) => setFilter('query', e.target.value)}
+                onChange={(e) => {
+                  setDeleteActionError('');
+                  setFilter('query', e.target.value);
+                }}
                 placeholder='Name, email, phone, Instagram'
               />
             </div>
@@ -654,7 +701,10 @@ export function ContactsPanel({ contacts, tags, locations, geographicAreas }: Co
               <Select
                 id='crm-contacts-active'
                 value={filters.active}
-                onChange={(e) => setFilter('active', e.target.value as CrmListFilters['active'])}
+                onChange={(e) => {
+                  setDeleteActionError('');
+                  setFilter('active', e.target.value as CrmListFilters['active']);
+                }}
               >
                 <option value=''>All</option>
                 <option value='true'>Active</option>
@@ -690,18 +740,31 @@ export function ContactsPanel({ contacts, tags, locations, geographicAreas }: Co
                   <td className='px-4 py-3'>{formatEnumLabel(row.contact_type)}</td>
                   <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
                   <td className='px-4 py-3 text-right'>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant='outline'
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void updateContact(row.id, { active: !row.active });
-                      }}
-                      disabled={isSaving}
-                    >
-                      {row.active ? 'Archive' : 'Restore'}
-                    </Button>
+                    <div className='flex flex-wrap justify-end gap-2'>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='outline'
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void updateContact(row.id, { active: !row.active });
+                        }}
+                        disabled={isSaving}
+                      >
+                        {row.active ? 'Archive' : 'Restore'}
+                      </Button>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='danger'
+                        onClick={(e) => {
+                          void handleDeleteContact(row, e);
+                        }}
+                        disabled={isSaving}
+                      >
+                        Delete
+                      </Button>
+                    </div>
                   </td>
                 </tr>
               );

--- a/apps/admin_web/src/hooks/use-admin-crm-contacts.ts
+++ b/apps/admin_web/src/hooks/use-admin-crm-contacts.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 
 import {
   createAdminContact,
+  deleteAdminContact,
   listAdminContacts,
   updateAdminContact,
 } from '@/lib/crm-api';
@@ -62,6 +63,11 @@ export function useAdminCrmContacts() {
     [mutate]
   );
 
+  const deleteContact = useCallback(
+    async (contactId: string) => mutate(async () => deleteAdminContact(contactId)),
+    [mutate]
+  );
+
   return {
     contacts: list.items,
     filters: list.filters,
@@ -75,6 +81,7 @@ export function useAdminCrmContacts() {
     isSaving,
     createContact,
     updateContact,
+    deleteContact,
     refetch: list.refetch,
   };
 }

--- a/apps/admin_web/src/lib/crm-api.ts
+++ b/apps/admin_web/src/lib/crm-api.ts
@@ -160,6 +160,14 @@ export async function updateAdminContact(
   return root.contact ?? null;
 }
 
+export async function deleteAdminContact(contactId: string): Promise<void> {
+  await adminApiRequest<unknown>({
+    endpointPath: `/v1/admin/contacts/${contactId}`,
+    method: 'DELETE',
+    expectedSuccessStatuses: [204],
+  });
+}
+
 export async function listAdminFamilies(
   params: Partial<CrmListFilters> & { cursor?: string | null; limit?: number },
   signal?: AbortSignal

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2382,7 +2382,36 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete CRM contact
+         * @description Permanently removes the contact row. Dependent CRM notes on linked sales leads
+         *     are removed first; enrollments and other references that use `ON DELETE SET NULL`
+         *     clear their `contact_id`. Returns `400` if the database still blocks deletion.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description CRM contact identifier. */
+                    id: components["parameters"]["AdminContactId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Contact deleted. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         options?: never;
         head?: never;
         /** Update CRM contact */

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -5,6 +5,20 @@ import { describe, expect, it, vi } from 'vitest';
 import { ContactsPanel } from '@/components/admin/contacts/contacts-panel';
 
 import type { useAdminCrmContacts } from '@/hooks/use-admin-crm-contacts';
+import type { components } from '@/types/generated/admin-api.generated';
+
+vi.mock('@/hooks/use-confirm-dialog', () => ({
+  useConfirmDialog: () => [
+    {
+      open: false,
+      title: '',
+      description: '',
+      onConfirm: () => {},
+      onCancel: () => {},
+    },
+    () => Promise.resolve(true),
+  ],
+}));
 
 vi.mock('@/lib/crm-api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/crm-api')>();
@@ -31,6 +45,7 @@ function buildContactsHook(
     isSaving: false,
     createContact: vi.fn().mockResolvedValue(null),
     updateContact: vi.fn().mockResolvedValue(null),
+    deleteContact: vi.fn().mockResolvedValue(undefined),
     refetch: vi.fn(),
     ...overrides,
   };
@@ -70,6 +85,42 @@ describe('ContactsPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Load more' }));
 
     expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('calls deleteContact when Delete is confirmed', async () => {
+    const user = userEvent.setup();
+    const deleteContact = vi.fn().mockResolvedValue(undefined);
+    const row: components['schemas']['AdminContact'] = {
+      id: '11111111-1111-1111-1111-111111111111',
+      first_name: 'Ann',
+      last_name: 'Lee',
+      email: null,
+      instagram_handle: null,
+      phone: null,
+      contact_type: 'parent',
+      relationship_type: 'prospect',
+      source: 'manual',
+      mailchimp_status: 'pending',
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+      tag_ids: [],
+      tags: [],
+      family_ids: [],
+      organization_ids: [],
+    };
+    const contacts = buildContactsHook({
+      deleteContact,
+      contacts: [row],
+    });
+
+    render(
+      <ContactsPanel contacts={contacts} tags={[]} locations={[]} geographicAreas={[]} />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(deleteContact).toHaveBeenCalledWith(row.id);
   });
 
   it('shows list error from the hook in the table card', () => {

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -3054,6 +3054,10 @@ export class ApiStack extends cdk.Stack {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,
     });
+    adminContactById.addMethod("DELETE", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
 
     const adminFamilies = admin.addResource("families");
     const adminFamiliesPicker = adminFamilies.addResource("picker");

--- a/backend/src/app/api/admin_contacts.py
+++ b/backend/src/app/api/admin_contacts.py
@@ -8,7 +8,11 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.api.admin_contacts_mutations import create_contact, update_contact
+from app.api.admin_contacts_mutations import (
+    create_contact,
+    delete_contact,
+    update_contact,
+)
 from app.api.admin_crm_helpers import (
     list_all_tags_for_picker,
     parse_active_filter,
@@ -80,6 +84,10 @@ def handle_admin_contacts_request(
             return _get_contact(event, contact_id=contact_id)
         if method == "PATCH":
             return _update_contact(
+                event, contact_id=contact_id, actor_sub=identity.user_sub
+            )
+        if method == "DELETE":
+            return delete_contact(
                 event, contact_id=contact_id, actor_sub=identity.user_sub
             )
         return json_response(405, {"error": "Method not allowed"}, event=event)

--- a/backend/src/app/api/admin_contacts_mutations.py
+++ b/backend/src/app/api/admin_contacts_mutations.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -34,6 +35,8 @@ from app.api.admin_validators import validate_email, validate_string_length
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.models import Contact, ContactSource
+from app.db.models.crm_note import CrmNote
+from app.db.models.sales_lead import SalesLead
 from app.db.repositories import ContactRepository
 from app.exceptions import DatabaseError, NotFoundError, ValidationError
 from app.utils import json_response
@@ -347,6 +350,48 @@ def update_contact(
             {"contact": serialize_contact_summary(loaded)},
             event=event,
         )
+
+
+def delete_contact(
+    event: Mapping[str, Any],
+    *,
+    contact_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    """Permanently delete one CRM contact and dependent CRM rows."""
+    logger.info(
+        "Deleting admin CRM contact",
+        extra={"contact_id": str(contact_id), "actor_sub": actor_sub},
+    )
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        repository = ContactRepository(session)
+        contact = repository.get_by_id_for_admin(contact_id)
+        if contact is None:
+            raise NotFoundError("Contact", str(contact_id))
+
+        lead_ids = list(
+            session.scalars(
+                select(SalesLead.id).where(SalesLead.contact_id == contact_id)
+            ).all()
+        )
+        if lead_ids:
+            session.execute(delete(CrmNote).where(CrmNote.lead_id.in_(tuple(lead_ids))))
+        session.execute(delete(CrmNote).where(CrmNote.contact_id == contact_id))
+        session.execute(delete(SalesLead).where(SalesLead.contact_id == contact_id))
+
+        try:
+            repository.delete(contact)
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            raise ValidationError(
+                "Contact cannot be deleted while it is still referenced",
+                field="contact_id",
+            ) from exc
+
+        return json_response(204, {}, event=event)
 
 
 def _resolve_referral_contact_id_for_referral_source(

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -27,7 +27,7 @@ info:
     - `GET /v1/admin/contacts/tags`
     - `GET /v1/admin/contacts/search`
     - `GET|POST /v1/admin/contacts`
-    - `GET|PATCH /v1/admin/contacts/{id}`
+    - `GET|PATCH|DELETE /v1/admin/contacts/{id}`
     - `GET /v1/admin/families/picker`
     - `GET|POST /v1/admin/families`
     - `GET|PATCH /v1/admin/families/{id}`
@@ -1682,6 +1682,23 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AdminContactResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete CRM contact
+      description: |
+        Permanently removes the contact row. Dependent CRM notes on linked sales leads
+        are removed first; enrollments and other references that use `ON DELETE SET NULL`
+        clear their `contact_id`. Returns `400` if the database still blocks deletion.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "204":
+          description: Contact deleted.
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -51,8 +51,9 @@ their primary responsibilities.
   reconciliation job exists. **Caching:** share-link tokens stay stable on replace;
   CDN or browser caching keyed only by URL (not `s3_key`) may show stale bytes until TTL—
   downloads keyed by changing `s3_key` generally avoid that.
-  `/v1/admin/contacts/*` (including `GET /v1/admin/contacts/tags` for tag pickers and
-  `GET /v1/admin/contacts/search` for contact picker search),
+  `/v1/admin/contacts/*` (including `GET /v1/admin/contacts/tags` for tag pickers,
+  `GET /v1/admin/contacts/search` for contact picker search, and `DELETE /v1/admin/contacts/{id}`
+  for hard-deleting a contact after clearing blocking CRM rows),
   `/v1/admin/families/picker`, `/v1/admin/families/*`,
   `/v1/admin/organizations/picker`, `/v1/admin/organizations/*` (CRM organisations excluding
   vendors; vendors remain under `/v1/admin/vendors`),

--- a/tests/test_admin_crm_routes.py
+++ b/tests/test_admin_crm_routes.py
@@ -48,6 +48,39 @@ def test_handle_admin_contacts_search_get(
     assert response is marker
 
 
+def test_handle_admin_contacts_delete(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    marker = {"statusCode": 204, "body": "{}"}
+    contact_id = str(uuid4())
+
+    def _fake_delete(
+        _event: Any,
+        *,
+        contact_id: Any,
+        actor_sub: str,
+    ) -> dict[str, Any]:
+        assert actor_sub == "admin-sub"
+        assert str(contact_id)
+        return marker
+
+    monkeypatch.setattr(admin_contacts, "delete_contact", _fake_delete)
+    monkeypatch.setattr(
+        admin_contacts,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_contacts.handle_admin_contacts_request(
+        api_gateway_event(method="DELETE", path=f"/v1/admin/contacts/{contact_id}"),
+        "DELETE",
+        f"/v1/admin/contacts/{contact_id}",
+    )
+
+    assert response is marker
+
+
 def test_handle_admin_families_member_delete(
     monkeypatch: Any,
     api_gateway_event: Any,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Delete** row action on the Admin **Contacts** table that permanently removes the contact after confirmation.

## Backend

- New `DELETE /v1/admin/contacts/{id}` returning **204** on success.
- Before deleting the contact row, removes **CRM notes** tied to sales leads for that contact, then deletes those **sales leads**, then contact-scoped **CRM notes**. Other FKs use `ON DELETE SET NULL` / cascades as defined in the schema.
- API Gateway wiring, OpenAPI (`docs/api/admin.yaml`), and `docs/architecture/lambdas.md` updated.

## Admin web

- `deleteAdminContact` client + `useAdminCrmContacts().deleteContact`.
- Operations column: **Archive/Restore** plus **Delete** (danger button) with `ConfirmDialog`.

## Tests

- Python: route dispatch test for `DELETE` on contacts.
- Vitest: contacts panel calls `deleteContact` when Delete is clicked (confirm mocked).

## Notes

- If the database still blocks deletion (unexpected FK), the API returns **400** with a generic validation message; the UI surfaces the error on the table card.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1a8c6df-b4a1-448b-82f2-5b2040280030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1a8c6df-b4a1-448b-82f2-5b2040280030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

