### PR TITLE
Log public discount validate rejection reasons in CloudWatch

### DIFF
--- a/backend/src/app/api/public_discount_validate.py
+++ b/backend/src/app/api/public_discount_validate.py
@@ -19,12 +19,41 @@ from app.db.models.enums import DiscountType
 from app.db.repositories import DiscountCodeRepository, ServiceRepository
 from app.exceptions import ValidationError
 from app.utils import json_response
-from app.utils.logging import get_logger, mask_pii
+from app.utils.logging import get_logger, hash_for_correlation, mask_pii
 
 logger = get_logger(__name__)
 
+# Logged on 404 responses only; stable for CloudWatch Insights. Never log raw codes.
+_REJECTION_UNKNOWN_SERVICE_KEY = "unknown_service_key"
+_REJECTION_CODE_NOT_FOUND = "code_not_found"
+_REJECTION_REFERRAL_TYPE = "referral_type_not_allowed"
+_REJECTION_INACTIVE = "inactive"
+_REJECTION_NOT_YET_VALID = "not_yet_valid"
+_REJECTION_EXPIRED = "expired"
+_REJECTION_MAX_USES = "max_uses_exhausted"
+_REJECTION_INSTANCE_ID_REQUIRED = "instance_id_required"
+_REJECTION_INSTANCE_SCOPE_MISMATCH = "instance_scope_mismatch"
+_REJECTION_SERVICE_SCOPE_MISMATCH = "service_scope_mismatch"
+
 _MAX_CODE_LENGTH = 100
 _MAX_SERVICE_KEY_LENGTH = 120
+
+
+def _log_discount_validate_rejection(
+    reason: str,
+    *,
+    code: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Log why validation returned 404 without exposing the full discount code."""
+    payload: dict[str, Any] = {
+        "rejection_reason": reason,
+        "code_hash": hash_for_correlation(code.strip().lower()),
+        "code_prefix": mask_pii(code.strip().upper(), visible_chars=2),
+    }
+    if extra:
+        payload.update(extra)
+    logger.info("Public discount validate rejected", extra=payload)
 
 
 def handle_public_discount_validate(
@@ -76,6 +105,11 @@ def handle_public_discount_validate(
         if service_key and service_key.strip():
             svc = ServiceRepository(session).get_by_slug(service_key)
             if svc is None:
+                _log_discount_validate_rejection(
+                    _REJECTION_UNKNOWN_SERVICE_KEY,
+                    code=code,
+                    extra={"service_key": service_key.strip()},
+                )
                 return json_response(
                     404,
                     {"error": "Discount code not found or inactive"},
@@ -88,6 +122,10 @@ def handle_public_discount_validate(
         repository = DiscountCodeRepository(session)
         row = repository.get_by_code(code)
         if row is None:
+            _log_discount_validate_rejection(
+                _REJECTION_CODE_NOT_FOUND,
+                code=code,
+            )
             return json_response(
                 404,
                 {"error": "Discount code not found or inactive"},
@@ -95,24 +133,43 @@ def handle_public_discount_validate(
             )
 
         if row.discount_type == DiscountType.REFERRAL:
+            _log_discount_validate_rejection(
+                _REJECTION_REFERRAL_TYPE,
+                code=code,
+                extra={"discount_code_id": str(row.id)},
+            )
             return json_response(
                 404,
                 {"error": "Discount code not found or inactive"},
                 event=event,
             )
 
-        if not _is_usable_now(row):
+        unusable = _unusable_reason(row)
+        if unusable is not None:
+            reason_code, detail = unusable
+            _log_discount_validate_rejection(
+                reason_code,
+                code=code,
+                extra={"discount_code_id": str(row.id), **detail},
+            )
             return json_response(
                 404,
                 {"error": "Discount code not found or inactive"},
                 event=event,
             )
 
-        if not _discount_scope_allows_validate(
+        scope_reason = _scope_rejection_reason(
             row,
             resolved_request_service_id=resolved_service_id,
             request_instance_id=service_instance_id_body,
-        ):
+        )
+        if scope_reason is not None:
+            reason_code, detail = scope_reason
+            _log_discount_validate_rejection(
+                reason_code,
+                code=code,
+                extra={"discount_code_id": str(row.id), **detail},
+            )
             return json_response(
                 404,
                 {"error": "Discount code not found or inactive"},
@@ -132,6 +189,45 @@ def handle_public_discount_validate(
         )
 
 
+def _scope_rejection_reason(
+    row: DiscountCode,
+    *,
+    resolved_request_service_id: UUID | None,
+    request_instance_id: UUID | None,
+) -> tuple[str, dict[str, Any]] | None:
+    """Return a rejection reason when scope does not match the request context."""
+    instance_id = getattr(row, "instance_id", None)
+    service_id = getattr(row, "service_id", None)
+    if instance_id is not None:
+        if request_instance_id is None:
+            return (
+                _REJECTION_INSTANCE_ID_REQUIRED,
+                {"expected_service_instance_id": str(instance_id)},
+            )
+        if request_instance_id != instance_id:
+            return (
+                _REJECTION_INSTANCE_SCOPE_MISMATCH,
+                {
+                    "expected_service_instance_id": str(instance_id),
+                    "request_service_instance_id": str(request_instance_id),
+                },
+            )
+        return None
+    if service_id is None:
+        return None
+    if resolved_request_service_id is None:
+        return None
+    if service_id != resolved_request_service_id:
+        return (
+            _REJECTION_SERVICE_SCOPE_MISMATCH,
+            {
+                "expected_service_id": str(service_id),
+                "request_service_id": str(resolved_request_service_id),
+            },
+        )
+    return None
+
+
 def _discount_scope_allows_validate(
     row: DiscountCode,
     *,
@@ -139,32 +235,46 @@ def _discount_scope_allows_validate(
     request_instance_id: UUID | None,
 ) -> bool:
     """Return False when scope does not match the request context."""
-    instance_id = getattr(row, "instance_id", None)
-    service_id = getattr(row, "service_id", None)
-    if instance_id is not None:
-        if request_instance_id is None:
-            return False
-        return request_instance_id == instance_id
-    if service_id is None:
-        return True
-    if resolved_request_service_id is None:
-        return True
-    return service_id == resolved_request_service_id
+    return (
+        _scope_rejection_reason(
+            row,
+            resolved_request_service_id=resolved_request_service_id,
+            request_instance_id=request_instance_id,
+        )
+        is None
+    )
 
 
-def _is_usable_now(row: DiscountCode) -> bool:
+def _unusable_reason(row: DiscountCode) -> tuple[str, dict[str, Any]] | None:
+    """Return a rejection reason when the code cannot be used at the current time."""
     if not row.active:
-        return False
+        return (_REJECTION_INACTIVE, {"active": False})
     # Truncate to whole seconds so inclusive valid_until boundaries match values
     # stored at second (or coarser) resolution — aligns with OpenAPI "both ends inclusive".
     now = datetime.now(UTC).replace(microsecond=0)
     if row.valid_from is not None and row.valid_from > now:
-        return False
+        return (
+            _REJECTION_NOT_YET_VALID,
+            {"valid_from": row.valid_from.isoformat(), "now": now.isoformat()},
+        )
     if row.valid_until is not None and row.valid_until < now:
-        return False
+        return (
+            _REJECTION_EXPIRED,
+            {"valid_until": row.valid_until.isoformat(), "now": now.isoformat()},
+        )
     if row.max_uses is not None and row.current_uses >= row.max_uses:
-        return False
-    return True
+        return (
+            _REJECTION_MAX_USES,
+            {
+                "current_uses": row.current_uses,
+                "max_uses": row.max_uses,
+            },
+        )
+    return None
+
+
+def _is_usable_now(row: DiscountCode) -> bool:
+    return _unusable_reason(row) is None
 
 
 def _discount_rule_payload(row: DiscountCode) -> dict[str, Any]:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -77,7 +77,9 @@ their primary responsibilities.
   `/www/v1/discounts/validate` (native Aurora-backed discount validation; optional
   `service_key` is resolved case-insensitively against `services.slug` in Aurora;
   codes with `discount_type` `referral` are rejected with the same 404 envelope as
-  unknown/inactive codes),
+  unknown/inactive codes; on each 404 the Lambda logs a structured
+  `Public discount validate rejected` entry with `rejection_reason`, `code_hash`,
+  and `code_prefix`—never the full code),
   `/www/v1/contact-us`, `/www/v1/reservations`,
   `/www/v1/calendar/public` (event instances include optional `slug` and
   `landing_page` from `service_instances`, and `spaces_total` / `spaces_left`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds structured `INFO` logs when `POST /v1/discounts/validate` (and `/www/v1/...`) returns 404, so operators can see **why** validation failed without logging full discount codes.

## Behavior

Each rejection emits `Public discount validate rejected` with:

- `rejection_reason` — stable string for CloudWatch Insights (e.g. `code_not_found`, `expired`, `service_scope_mismatch`)
- `code_hash` — SHA-256 prefix of the normalized (lowercased) code for correlation
- `code_prefix` — masked prefix (same style as existing validation log)
- Additional fields where safe and useful: `discount_code_id`, `service_key` (when slug unknown), timestamps for date windows, scope UUIDs on mismatch

## Docs

- `docs/architecture/lambdas.md` — notes the new logging on the discount validate route.

## Tests

- `python3 -m pytest tests/test_public_discount_validate_api.py`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7614d3f1-8e9d-4dd5-bc01-1e4a9fb1dd45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7614d3f1-8e9d-4dd5-bc01-1e4a9fb1dd45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

