### PR TITLE
fix(api): defer discount service_key resolution for unscoped codes

### DIFF
--- a/backend/src/app/api/public_discount_validate.py
+++ b/backend/src/app/api/public_discount_validate.py
@@ -100,25 +100,18 @@ def handle_public_discount_validate(
         extra={"code": mask_pii(code.strip().upper(), visible_chars=2)},
     )
 
-    with Session(get_engine()) as session:
-        resolved_service_id: UUID | None = None
-        if service_key and service_key.strip():
-            svc = ServiceRepository(session).get_by_slug(service_key)
-            if svc is None:
-                _log_discount_validate_rejection(
-                    _REJECTION_UNKNOWN_SERVICE_KEY,
-                    code=code,
-                    extra={"service_key": service_key.strip()},
-                )
-                return json_response(
-                    404,
-                    {"error": "Discount code not found or inactive"},
-                    event=event,
-                )
-            resolved_service_id = svc.id
-        elif service_id_body is not None:
-            resolved_service_id = service_id_body
+    service_key_normalized = (
+        service_key.strip() if service_key and service_key.strip() else ""
+    )
+    # When `service_key` is sent it wins over `service_id` in the body (OpenAPI).
+    # Slug resolution is deferred until after we load the code row so unscoped
+    # ("all services") codes are not rejected when the page sends a stale or
+    # placeholder `service_key` that does not match `services.slug`.
+    resolved_service_id: UUID | None = (
+        None if service_key_normalized else service_id_body
+    )
 
+    with Session(get_engine()) as session:
         repository = DiscountCodeRepository(session)
         row = repository.get_by_code(code)
         if row is None:
@@ -158,6 +151,25 @@ def handle_public_discount_validate(
                 event=event,
             )
 
+        if service_key_normalized:
+            resolved_from_key, slug_unknown = _resolve_service_id_from_key_for_row(
+                session,
+                row,
+                service_key_normalized,
+            )
+            if slug_unknown:
+                _log_discount_validate_rejection(
+                    _REJECTION_UNKNOWN_SERVICE_KEY,
+                    code=code,
+                    extra={"service_key": service_key_normalized},
+                )
+                return json_response(
+                    404,
+                    {"error": "Discount code not found or inactive"},
+                    event=event,
+                )
+            resolved_service_id = resolved_from_key
+
         scope_reason = _scope_rejection_reason(
             row,
             resolved_request_service_id=resolved_service_id,
@@ -187,6 +199,35 @@ def handle_public_discount_validate(
             },
             event=event,
         )
+
+
+def _resolve_service_id_from_key_for_row(
+    session: Session,
+    row: DiscountCode,
+    service_key: str,
+) -> tuple[UUID | None, bool]:
+    """Resolve `service_key` to a service id when needed for scope checks.
+
+    Returns ``(resolved_service_id, slug_unknown)``. When ``slug_unknown`` is True,
+    the slug did not match any ``services.slug`` row while the code requires that
+    resolution (service-scoped code only).
+
+    Instance-scoped codes ignore ``service_key`` for resolution (instance id is
+    authoritative). Unscoped codes do not resolve the slug; an unknown slug must
+    not invalidate the code.
+    """
+    instance_id = getattr(row, "instance_id", None)
+    if instance_id is not None:
+        return (None, False)
+
+    service_id = getattr(row, "service_id", None)
+    if service_id is None:
+        return (None, False)
+
+    svc = ServiceRepository(session).get_by_slug(service_key)
+    if svc is None:
+        return (None, True)
+    return (svc.id, False)
 
 
 def _scope_rejection_reason(

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -297,13 +297,15 @@ paths:
         **on or before** `valid_until` (both ends inclusive).
 
         **Service scoping:** codes may be limited to a service and/or instance in Aurora.
-        Unscoped codes (no `service_id` / `instance_id`) validate like today. When the
-        code is scoped to a **service only**, the request must include a matching
-        `service_key` (matched case-insensitively against `services.slug`) or a matching
-        `service_id` UUID; if both are supplied, `service_key` wins. When the code is
-        scoped to an **instance**, the request must include `service_instance_id` equal
-        to the code's instance; otherwise this endpoint returns **404** (same generic
-        message as inactive codes).
+        Unscoped codes (no `service_id` / `instance_id`) validate regardless of
+        `service_key` (unknown slugs are ignored). When the code is scoped to a
+        **service only**, the request must include a matching `service_key` (matched
+        case-insensitively against `services.slug`) or a matching `service_id` UUID; if
+        both are supplied, `service_key` wins for resolving the request service. When the
+        code is scoped to an **instance**, the request must include `service_instance_id`
+        equal to the code's instance; `service_key` is optional and not used to reject
+        unknown slugs. Otherwise this endpoint returns **404** (same generic message as
+        inactive codes).
       security:
         - ApiKeyAuth: []
       requestBody:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -75,9 +75,10 @@ their primary responsibilities.
   and `GET /v1/assets/free`,
   plus public website proxy routes including
   `/www/v1/discounts/validate` (native Aurora-backed discount validation; optional
-  `service_key` is resolved case-insensitively against `services.slug` in Aurora;
-  codes with `discount_type` `referral` are rejected with the same 404 envelope as
-  unknown/inactive codes; on each 404 the Lambda logs a structured
+  `service_key` is resolved case-insensitively against `services.slug` in Aurora when
+  the code is service-scoped; unscoped and instance-scoped codes do not fail on an
+  unknown slug; codes with `discount_type` `referral` are rejected with the same 404
+  envelope as unknown/inactive codes; on each 404 the Lambda logs a structured
   `Public discount validate rejected` entry with `rejection_reason`, `code_hash`,
   and `code_prefix`—never the full code),
   `/www/v1/contact-us`, `/www/v1/reservations`,

--- a/tests/test_public_discount_validate_api.py
+++ b/tests/test_public_discount_validate_api.py
@@ -757,6 +757,27 @@ def test_public_discount_validate_unscoped_code_ignores_service_key(
     assert response["statusCode"] == 200
 
 
+def test_public_discount_validate_unscoped_code_succeeds_when_service_key_unknown(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    """Unscoped codes must not fail because the page sent a non-matching slug."""
+    row = _usable_row(code="ANY")
+    _patch_discount_validate_repositories(
+        monkeypatch,
+        discount_row=row,
+        slug_to_service_id={},
+    )
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/discounts/validate",
+        body=json.dumps({"code": "ANY", "service_key": "not-a-real-slug"}),
+    )
+    response = public_discount_validate.handle_public_discount_validate(event, "POST")
+    assert response["statusCode"] == 200
+
+
 def test_public_discount_validate_service_scoped_match(
     monkeypatch: Any,
     api_gateway_event: Any,
@@ -861,6 +882,35 @@ def test_public_discount_validate_instance_scoped_match_returns_200(
             {
                 "code": "INST",
                 "service_key": "my-best-auntie",
+                "service_instance_id": str(inst),
+            }
+        ),
+    )
+    response = public_discount_validate.handle_public_discount_validate(event, "POST")
+    assert response["statusCode"] == 200
+
+
+def test_public_discount_validate_instance_scoped_unknown_service_key_ignored(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    """Instance-scoped validation uses `service_instance_id`; slug is not required."""
+    svc = uuid4()
+    inst = uuid4()
+    row = _usable_row(code="INST", service_id=svc, instance_id=inst)
+    _patch_discount_validate_repositories(
+        monkeypatch,
+        discount_row=row,
+        slug_to_service_id={},
+    )
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/discounts/validate",
+        body=json.dumps(
+            {
+                "code": "INST",
+                "service_key": "not-a-real-slug",
                 "service_instance_id": str(inst),
             }
         ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`POST /v1/discounts/validate` resolved `service_key` to `services.slug` **before** loading the discount row. If the public site sent a slug that does not exist (e.g. `event-booking`), the handler returned 404 with `unknown_service_key` even when the code was **unscoped** (“all services”), so scope checks never ran.

## Change

- Load the discount code first; then resolve `service_key` only when the row is **service-scoped** (`service_id` set, no `instance_id`).
- **Unscoped** codes: ignore `service_key` for validation (unknown slugs no longer invalidate).
- **Instance-scoped** codes: do not require slug resolution; `service_instance_id` remains authoritative (unknown `service_key` does not 404).
- When `service_key` is present it still **wins over** `service_id` in the JSON body (OpenAPI).

## Docs

- `docs/api/public.yaml` — scoping description updated.
- `docs/architecture/lambdas.md` — note deferred slug resolution.

## Tests

- `python3 -m pytest tests/test_public_discount_validate_api.py` (22 passed)
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7614d3f1-8e9d-4dd5-bc01-1e4a9fb1dd45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7614d3f1-8e9d-4dd5-bc01-1e4a9fb1dd45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

