### PR TITLE
fix(admin_web): Refetch discount codes after successful create

### DIFF
--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -249,7 +249,6 @@ export function ServicesPage() {
           onCreate={(payload, options) =>
             state.discountCodes.createCode(payload, {
               suppressSaving: options?.batchSaving,
-              suppressRefetch: options?.batchSaving,
             })
           }
           onUpdate={state.discountCodes.updateCode}

--- a/apps/admin_web/tests/hooks/use-discount-codes.test.ts
+++ b/apps/admin_web/tests/hooks/use-discount-codes.test.ts
@@ -1,0 +1,120 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockCreateDiscountCode, mockRefetch, paginatedState } = vi.hoisted(() => {
+  const mockRefetch = vi.fn().mockResolvedValue(undefined);
+  const paginatedState = {
+    items: [],
+    filters: { active: '', search: '', scope: '' },
+    setFilter: vi.fn(),
+    clearFilters: vi.fn(),
+    isLoading: false,
+    isLoadingMore: false,
+    error: '',
+    refetch: mockRefetch,
+    loadMore: vi.fn(),
+    hasMore: false,
+    totalCount: 0,
+  };
+
+  return {
+    mockCreateDiscountCode: vi.fn(),
+    mockRefetch,
+    paginatedState,
+  };
+});
+
+vi.mock('@/hooks/use-paginated-list', () => ({
+  usePaginatedList: vi.fn(() => paginatedState),
+}));
+
+vi.mock('@/lib/services-api', () => ({
+  createDiscountCode: mockCreateDiscountCode,
+  deleteDiscountCode: vi.fn(),
+  listDiscountCodes: vi.fn(),
+  updateDiscountCode: vi.fn(),
+}));
+
+import { useDiscountCodes } from '@/hooks/use-discount-codes';
+
+describe('useDiscountCodes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateDiscountCode.mockResolvedValue({ discount_code: {} });
+  });
+
+  it('refetches after create by default', async () => {
+    const { result } = renderHook(() => useDiscountCodes());
+
+    await act(async () => {
+      await result.current.createCode({
+        code: 'SAVE10',
+        description: null,
+        discount_type: 'percentage',
+        discount_value: '10',
+        currency: 'HKD',
+        valid_from: null,
+        valid_until: null,
+        max_uses: null,
+        active: true,
+        service_id: null,
+        instance_id: null,
+      });
+    });
+
+    expect(mockCreateDiscountCode).toHaveBeenCalled();
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it('refetches after create when only suppressSaving is true (batch duplicate-retry UI)', async () => {
+    const { result } = renderHook(() => useDiscountCodes());
+
+    await act(async () => {
+      await result.current.createCode(
+        {
+          code: 'SAVE10',
+          description: null,
+          discount_type: 'percentage',
+          discount_value: '10',
+          currency: 'HKD',
+          valid_from: null,
+          valid_until: null,
+          max_uses: null,
+          active: true,
+          service_id: null,
+          instance_id: null,
+        },
+        { suppressSaving: true },
+      );
+    });
+
+    expect(mockCreateDiscountCode).toHaveBeenCalled();
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it('skips refetch when suppressRefetch is true', async () => {
+    const { result } = renderHook(() => useDiscountCodes());
+
+    await act(async () => {
+      await result.current.createCode(
+        {
+          code: 'SAVE10',
+          description: null,
+          discount_type: 'percentage',
+          discount_value: '10',
+          currency: 'HKD',
+          valid_from: null,
+          valid_until: null,
+          max_uses: null,
+          active: true,
+          service_id: null,
+          instance_id: null,
+        },
+        { suppressRefetch: true },
+      );
+    });
+
+    expect(mockCreateDiscountCode).toHaveBeenCalled();
+    expect(mockRefetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Creating a discount code did not refresh the table because `ServicesPage` passed `suppressRefetch: true` whenever duplicate-retry batch saving was active (`batchSaving`). The panel sets `batchSaving` to true for every successful create attempt except the last of up to 16 rounds—so the common case (first attempt succeeds) skipped the post-create refetch. Updates never used that flag, so they refetched as expected.

## Changes

- Stop passing `suppressRefetch` from `batchSaving` in `services-page.tsx`; keep `suppressSaving` so the global saving indicator stays correct during duplicate retries.
- Add `useDiscountCodes` hook tests covering default create refetch, `suppressSaving` without skipping refetch, and explicit `suppressRefetch`.

## Validation

- `bash scripts/validate-cursorrules.sh`
- `cd apps/admin_web && npm run lint`
- `npm run test -- --run tests/hooks/use-discount-codes.test.ts` and `services-page` tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-791ff9ff-6063-4a6a-b08c-46a7da65540e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-791ff9ff-6063-4a6a-b08c-46a7da65540e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

