### PR TITLE
Wire Little HK partner logo and align Missing Piece hero with Easter

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/landing-page-hero.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-hero.tsx
@@ -55,6 +55,7 @@ const KNOWN_PARTNER_LOGO_SOURCES: Readonly<Record<string, readonly string[]>> = 
   'evolvesprouts': ['/images/evolvesprouts-logo.svg'],
   'baumhaus': ['/images/partners/baumhaus.webp'],
   'happy-baton': ['/images/partners/happy-baton.webp'],
+  'little-hk': ['/images/partners/little-hk.webp'],
 };
 function buildPartnerLogoSources(partner: string): string[] {
   const normalizedPartner = partner.trim().toLowerCase();

--- a/apps/public_www/src/content/landing-pages/may-2026-the-missing-piece.json
+++ b/apps/public_www/src/content/landing-pages/may-2026-the-missing-piece.json
@@ -11,9 +11,9 @@
     "hero": {
       "subtitle": "",
       "description": "One hour. The right toys, a calmer home, and a helper who knows what to do. Bring your child, your helper, and — if you like — a photo of your toy shelf or play corner.",
-      "imageAlt": "Parent and young child playing together",
-      "imageSrc": "/images/parent-child.svg",
-      "imageMaxWidthPercent": 85
+      "imageAlt": "Child busy playing with a Montessori-style toy",
+      "imageSrc": "/images/hero/child-landing-hero.webp",
+      "imageMaxWidthPercent": 90
     },
     "outline": {
       "eyebrow": "Why this matters",
@@ -116,8 +116,8 @@
     "hero": {
       "subtitle": "",
       "description": "一小时，选对玩具、让家更平静，也让姐姐知道该怎么做。欢迎带孩子与姐姐同行，也可带上玩具架或游戏角的照片。",
-      "imageAlt": "家长与幼儿一起玩耍",
-      "imageSrc": "/images/parent-child.svg",
+      "imageAlt": "家长与孩子参加蒙特梭利游戏教练工作坊",
+      "imageSrc": "/images/hero/child-landing-hero.webp",
       "imageMaxWidthPercent": 65
     },
     "outline": {
@@ -221,8 +221,8 @@
     "hero": {
       "subtitle": "",
       "description": "一小時，揀啱玩具、令屋企更平靜，等姐姐都知道點做。歡迎帶埋小朋友同姐姐，亦可以帶玩具架或遊戲角嘅相。",
-      "imageAlt": "家長與幼兒一齊玩",
-      "imageSrc": "/images/parent-child.svg",
+      "imageAlt": "家長與小朋友參與蒙特梭利遊戲教練工作坊",
+      "imageSrc": "/images/hero/child-landing-hero.webp",
       "imageMaxWidthPercent": 65
     },
     "outline": {

--- a/apps/public_www/src/content/landing-pages/may-2026-the-missing-piece.json
+++ b/apps/public_www/src/content/landing-pages/may-2026-the-missing-piece.json
@@ -4,7 +4,7 @@
       "title": "The Missing Piece — Evolve Sprouts × Little HK",
       "description": "A hands-on workshop for families with children aged 0–2 at Acorn Playhouse: toys, play space, and tools your helper can use straight away.",
       "socialImage": {
-        "url": "/images/evolvesprouts-logo.svg",
+        "url": "/images/seo/evolvesprouts-og-default.png",
         "alt": "The Missing Piece workshop by Evolve Sprouts and Little HK"
       }
     },
@@ -109,7 +109,7 @@
       "title": "缺失的那一块 — Evolve Sprouts × Little HK",
       "description": "面向 0–2 岁家庭的实操工作坊，在 Acorn Playhouse 探讨玩具、游戏空间与姐姐可立即上手的方法。",
       "socialImage": {
-        "url": "/images/evolvesprouts-logo.svg",
+        "url": "/images/seo/evolvesprouts-og-default.png",
         "alt": "Evolve Sprouts 与 Little HK 合作工作坊"
       }
     },
@@ -214,7 +214,7 @@
       "title": "缺失嘅一塊 — Evolve Sprouts × Little HK",
       "description": "面向 0–2 歲家庭嘅實作工作坊，喺 Acorn Playhouse 傾玩具、遊戲空間同姐姐即刻用得著嘅方法。",
       "socialImage": {
-        "url": "/images/evolvesprouts-logo.svg",
+        "url": "/images/seo/evolvesprouts-og-default.png",
         "alt": "Evolve Sprouts 與 Little HK 合作工作坊"
       }
     },

--- a/apps/public_www/tests/components/sections/landing-pages/landing-page-hero.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/landing-page-hero.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { LandingPageHero } from '@/components/sections/landing-pages/landing-page-hero';
 import enContent from '@/content/en.json';
 import easterWorkshopContent from '@/content/landing-pages/easter-2026-montessori-play-coaching-workshop.json';
+import missingPieceContent from '@/content/landing-pages/may-2026-the-missing-piece.json';
 import type { EventBookingModalPayload } from '@/lib/events-data';
 
 vi.mock('next/image', () => ({
@@ -178,5 +179,63 @@ describe('LandingPageHero section', () => {
     );
 
     expect(document.querySelector('.es-type-subtitle-lg')).toBeNull();
+  });
+
+  it('renders Evolve Sprouts and little-hk partner logos for the Missing Piece landing page', () => {
+    const eventContent = {
+      title: 'The Missing Piece',
+      startDateTime: '2026-05-16T01:00:00Z',
+      endDateTime: '2026-05-16T02:00:00Z',
+      locationLabel: 'Wong Chuk Hang',
+      partners: ['little-hk'],
+      categoryChips: ['Workshop'],
+    };
+    const bookingPayload: EventBookingModalPayload = {
+      variant: 'event',
+      bookingSystem: 'event-booking',
+      serviceKey: 'the-missing-piece-test',
+      title: eventContent.title,
+      subtitle: 'Workshop',
+      originalAmount: 150,
+      locationName: 'Acorn Playhouse',
+      locationAddress: '3/F, 4 Yip Fat St, Wong Chuk Hang',
+      directionHref:
+        'https://www.google.com/maps/dir/?api=1&destination=3%2FF%2C+4+Yip+Fat+St%2C+Wong+Chuk+Hang',
+      dateParts: [
+        {
+          id: 'session-1',
+          startDateTime: eventContent.startDateTime,
+          endDateTime: eventContent.endDateTime,
+          description: 'Workshop',
+        },
+      ],
+      selectedDateLabel: '16 May 2026',
+      selectedDateStartTime: eventContent.startDateTime,
+    };
+
+    render(
+      <LandingPageHero
+        slug='may-2026-the-missing-piece'
+        content={missingPieceContent.en.hero}
+        ctaContent={missingPieceContent.en.cta}
+        ctaPriceLabel='HK$150'
+        commonContent={enContent.landingPages.common}
+        locale='en'
+        title={eventContent.title}
+        eventContent={eventContent}
+        bookingPayload={bookingPayload}
+        isFullyBooked={false}
+        bookingModalContent={enContent.bookingModal}
+      />,
+    );
+
+    const partnerContainer = screen.getByTestId('landing-page-hero-partners');
+    const partnerLogos = partnerContainer.querySelectorAll('[data-testid^="landing-page-partner-logo-"]');
+    expect(partnerLogos).toHaveLength(2);
+    expect(screen.getByTestId('landing-page-partner-logo-evolvesprouts')).toBeInTheDocument();
+    expect(screen.getByTestId('landing-page-partner-logo-little-hk')).toBeInTheDocument();
+    expect(screen.getByTestId('landing-page-partner-logo-little-hk')).toHaveClass('h-8');
+    const heroImage = screen.getByRole('img', { name: missingPieceContent.en.hero.imageAlt });
+    expect(heroImage).toHaveAttribute('src', missingPieceContent.en.hero.imageSrc);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Registers the Little HK partner logo in the landing page hero’s known partner map so `/images/partners/little-hk.webp` is used explicitly (same pattern as Baumhaus and Happy Baton).

Updates the May 2026 “The Missing Piece” landing page hero to use the same main image as the Easter workshop: `/images/hero/child-landing-hero.webp`, matching Easter’s per-locale `imageAlt` and `imageMaxWidthPercent` (90% en, 65% zh-CN/zh-HK).

Sets Missing Piece landing `meta.socialImage.url` to `/images/seo/evolvesprouts-og-default.png` for all locales (aligned with Easter and other event landings).

Adds a focused Vitest case that renders Evolve Sprouts + Little HK partner logos and asserts the hero image src/alt for the Missing Piece content.

## Testing

- `npm run test -- tests/components/sections/landing-pages/landing-page-hero.test.tsx` (public_www)
- `npm run test -- tests/lib/events-data.test.ts` (public_www)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-290a6ae7-da02-4626-82c9-084499385eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-290a6ae7-da02-4626-82c9-084499385eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

