### PR TITLE
Remove Status column from admin contacts table

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -740,7 +740,6 @@ export function ContactsPanel({
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Email</th>
               <th className='px-4 py-3 font-semibold'>Type</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
           </AdminDataTableHead>
@@ -758,7 +757,6 @@ export function ContactsPanel({
                   <td className='px-4 py-3'>{name}</td>
                   <td className='px-4 py-3'>{row.email ?? '—'}</td>
                   <td className='px-4 py-3'>{formatEnumLabel(row.contact_type)}</td>
-                  <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
                   <td className='px-4 py-3 text-right'>
                     <div className='flex flex-wrap justify-end gap-2'>
                       <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Status** column (Active/Archived text) from the Contacts list table in the admin CRM.

## Notes

- The **Status** filter in the toolbar (All / Active / Archived) is unchanged.
- Archive and restore actions remain in the **Operations** column.

## Validation

- `npm run lint` (admin_web)
- `npx vitest run tests/components/admin/contacts/`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a59236df-b512-4d06-94dd-65fa2450048e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a59236df-b512-4d06-94dd-65fa2450048e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

