### PR TITLE
Add partner-only slug for CRM organizations

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -92,6 +92,7 @@ export function OrganizationsPanel({
   const [organizationType, setOrganizationType] =
     useState<ApiSchemas['CrmOrganizationType']>('company');
   const [relationshipType, setRelationshipType] = useState<CrmEntityRelationshipType>('prospect');
+  const [slug, setSlug] = useState('');
   const [website, setWebsite] = useState('');
   const [locationId, setLocationId] = useState('');
   const [tagIds, setTagIds] = useState<string[]>([]);
@@ -133,6 +134,7 @@ export function OrganizationsPanel({
     setName('');
     setOrganizationType('company');
     setRelationshipType('prospect');
+    setSlug('');
     setWebsite('');
     setLocationId('');
     setTagIds([]);
@@ -149,6 +151,8 @@ export function OrganizationsPanel({
           name: name.trim(),
           organization_type: organizationType,
           relationship_type: relationshipType,
+          slug:
+            relationshipType === 'partner' ? slug.trim() || null : null,
           website: website.trim() || null,
           location_id: loc,
           tag_ids: tagIds,
@@ -163,6 +167,8 @@ export function OrganizationsPanel({
         name: name.trim(),
         organization_type: organizationType,
         relationship_type: relationshipType,
+        slug:
+          relationshipType === 'partner' ? slug.trim() || null : null,
         website: website.trim() || null,
         location_id: loc,
         active,
@@ -199,6 +205,7 @@ export function OrganizationsPanel({
     setName(row.name);
     setOrganizationType(row.organization_type);
     setRelationshipType(relationshipTypeForCrmEditor(row.relationship_type));
+    setSlug(row.slug ?? '');
     setWebsite(row.website ?? '');
     setLocationId(row.location_id ?? '');
     setTagIds([...row.tag_ids]);
@@ -254,9 +261,13 @@ export function OrganizationsPanel({
             <Select
               id='crm-org-rel'
               value={relationshipType}
-              onChange={(e) =>
-                setRelationshipType(e.target.value as CrmEntityRelationshipType)
-              }
+              onChange={(e) => {
+                const next = e.target.value as CrmEntityRelationshipType;
+                setRelationshipType(next);
+                if (next !== 'partner') {
+                  setSlug('');
+                }
+              }}
             >
               {crmRelationshipOptions.map((v) => (
                 <option key={v} value={v}>
@@ -265,6 +276,22 @@ export function OrganizationsPanel({
               ))}
             </Select>
           </div>
+          {relationshipType === 'partner' ? (
+            <div>
+              <Label htmlFor='crm-org-slug'>Slug</Label>
+              <Input
+                id='crm-org-slug'
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
+                autoComplete='off'
+                placeholder='e.g. acme-partners'
+              />
+              <p className='mt-1 text-sm text-slate-600'>
+                Lowercase letters, numbers, and hyphens only. Optional; must be unique among partner
+                organisations.
+              </p>
+            </div>
+          ) : null}
           <div>
             <Label htmlFor='crm-org-web'>Website</Label>
             <Input

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4898,6 +4898,8 @@ export interface components {
             name: string;
             organization_type: components["schemas"]["CrmOrganizationType"];
             relationship_type: components["schemas"]["CrmRelationshipType"];
+            /** @description Optional URL-safe identifier for partner organisations only (lowercase letters, digits, single hyphens between segments). Null when not a partner or unset. Uniqueness is enforced case-insensitively among partner rows. */
+            slug?: string | null;
             website?: string | null;
             /** Format: uuid */
             location_id?: string | null;
@@ -4925,6 +4927,8 @@ export interface components {
             name: string;
             organization_type: components["schemas"]["CrmOrganizationType"];
             relationship_type?: components["schemas"]["CrmRelationshipType"];
+            /** @description Optional partner-only slug. Omit or null to clear. Must be null when relationship_type is not partner. */
+            slug?: string | null;
             website?: string | null;
             /** Format: uuid */
             location_id?: string | null;
@@ -4934,6 +4938,8 @@ export interface components {
             name?: string;
             organization_type?: components["schemas"]["CrmOrganizationType"];
             relationship_type?: components["schemas"]["CrmRelationshipType"];
+            /** @description Optional partner-only slug. Omit or null to clear. Must be null when relationship_type is not partner. */
+            slug?: string | null;
             website?: string | null;
             /** Format: uuid */
             location_id?: string | null;

--- a/backend/db/alembic/versions/0029_organizations_partner_slug.py
+++ b/backend/db/alembic/versions/0029_organizations_partner_slug.py
@@ -1,0 +1,43 @@
+"""Add nullable partner-only slug on organizations with case-insensitive uniqueness.
+
+Seed-data assessment:
+1. Compatibility with existing seed SQL: seed does not insert `organizations` rows.
+2. New NOT NULL/CHECK: column is nullable; no NOT NULL.
+3. Renamed/dropped: N/A (additive).
+4. New tables: N/A.
+5. Enum: N/A.
+6. FK order: N/A.
+
+Result: No seed update — `backend/db/seed/seed_data.sql` does not reference `organizations`.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0029_organizations_partner_slug"
+down_revision: Union[str, None] = "0028_unify_notes_storage"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column("slug", sa.String(length=128), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX organizations_partner_slug_unique_idx "
+            "ON organizations (lower(slug)) "
+            "WHERE relationship_type = 'partner' AND slug IS NOT NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP INDEX IF EXISTS organizations_partner_slug_unique_idx"))
+    op.drop_column("organizations", "slug")

--- a/backend/src/app/api/admin_crm_serializers.py
+++ b/backend/src/app/api/admin_crm_serializers.py
@@ -173,6 +173,7 @@ def serialize_organization_summary(org: Organization) -> dict[str, Any]:
         "name": org.name,
         "organization_type": org.organization_type.value,
         "relationship_type": org.relationship_type.value,
+        "slug": org.slug,
         "website": org.website,
         "location_id": str(org.location_id) if org.location_id else None,
         "location_summary": serialize_location_venue(org.location)

--- a/backend/src/app/api/admin_organizations_crm.py
+++ b/backend/src/app/api/admin_organizations_crm.py
@@ -7,6 +7,7 @@ from typing import Any
 from collections.abc import Mapping
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.admin_crm_helpers import (
@@ -28,7 +29,10 @@ from app.api.admin_request import (
     query_param,
 )
 from app.api.admin_services_payload_utils import parse_optional_uuid, parse_uuid_list
-from app.api.admin_validators import validate_string_length
+from app.api.admin_validators import (
+    parse_optional_service_instance_slug,
+    validate_string_length,
+)
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
@@ -38,6 +42,7 @@ from app.db.models import (
     OrganizationMember,
     OrganizationRole,
     OrganizationType,
+    RelationshipType,
 )
 from app.db.repositories import OrganizationRepository
 from app.exceptions import DatabaseError, NotFoundError, ValidationError
@@ -120,6 +125,41 @@ def _parse_organization_role(value: Any, *, field: str) -> OrganizationRole:
         return OrganizationRole(str(value).strip().lower())
     except ValueError as exc:
         raise ValidationError(f"Invalid {field}", field=field) from exc
+
+
+def _apply_organization_slug_from_body(
+    org: Organization,
+    body: Mapping[str, Any],
+    *,
+    relationship_type: RelationshipType | None = None,
+) -> None:
+    """Set slug from request body; only partner orgs may have a slug."""
+    if "slug" not in body:
+        return
+    slug = parse_optional_service_instance_slug(body.get("slug"), field="slug")
+    effective = (
+        relationship_type if relationship_type is not None else org.relationship_type
+    )
+    if effective != RelationshipType.PARTNER:
+        if slug is not None:
+            raise ValidationError(
+                "slug is only allowed when relationship_type is partner",
+                field="slug",
+            )
+        org.slug = None
+        return
+    org.slug = slug
+
+
+def _is_organizations_partner_slug_unique_violation(exc: IntegrityError) -> bool:
+    constraint = getattr(getattr(exc, "orig", None), "diag", None)
+    constraint_name = (
+        getattr(constraint, "constraint_name", None) if constraint else None
+    )
+    if constraint_name == "organizations_partner_slug_unique_idx":
+        return True
+    message = str(exc).lower()
+    return "organizations_partner_slug_unique_idx" in message
 
 
 def _list_organizations(event: Mapping[str, Any]) -> dict[str, Any]:
@@ -207,12 +247,25 @@ def _create_organization(event: Mapping[str, Any], *, actor_sub: str) -> dict[st
             website=website,
             location_id=location_id,
         )
+        _apply_organization_slug_from_body(
+            org, body, relationship_type=relationship_type
+        )
         created = repository.create(org)
         if tag_ids:
             replace_organization_tags(
                 session, organization_id=created.id, tag_ids=tag_ids
             )
-        session.commit()
+        try:
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            if _is_organizations_partner_slug_unique_violation(exc):
+                raise ValidationError(
+                    "Slug already in use",
+                    field="slug",
+                    status_code=409,
+                ) from exc
+            raise
         loaded = repository.get_crm_organization_by_id(created.id)
         if loaded is None:
             raise DatabaseError("Failed to load organization after create")
@@ -258,6 +311,8 @@ def _update_organization(
                 field="relationship_type",
                 forbid_vendor=True,
             )
+            if org.relationship_type != RelationshipType.PARTNER:
+                org.slug = None
         if "website" in body:
             org.website = validate_string_length(
                 body.get("website"),
@@ -278,8 +333,20 @@ def _update_organization(
             tag_ids = parse_uuid_list(body.get("tag_ids"), "tag_ids")
             replace_organization_tags(session, organization_id=org.id, tag_ids=tag_ids)
 
+        _apply_organization_slug_from_body(org, body)
+
         repository.update(org)
-        session.commit()
+        try:
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            if _is_organizations_partner_slug_unique_violation(exc):
+                raise ValidationError(
+                    "Slug already in use",
+                    field="slug",
+                    status_code=409,
+                ) from exc
+            raise
         loaded = repository.get_crm_organization_by_id(organization_id)
         if loaded is None:
             raise DatabaseError("Failed to load organization after update")

--- a/backend/src/app/db/models/organization.py
+++ b/backend/src/app/db/models/organization.py
@@ -66,6 +66,7 @@ class Organization(Base):
         server_default=text("'prospect'"),
     )
     website: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    slug: Mapped[str | None] = mapped_column(String(128), nullable=True)
     location_id: Mapped[UUID | None] = mapped_column(
         PG_UUID(as_uuid=True),
         ForeignKey("locations.id", ondelete="SET NULL"),

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -5378,6 +5378,13 @@ components:
           $ref: "#/components/schemas/CrmOrganizationType"
         relationship_type:
           $ref: "#/components/schemas/CrmRelationshipType"
+        slug:
+          type: string
+          nullable: true
+          description: >
+            Optional URL-safe identifier for partner organisations only (lowercase
+            letters, digits, single hyphens between segments). Null when not a partner
+            or unset. Uniqueness is enforced case-insensitively among partner rows.
         website:
           type: string
           nullable: true
@@ -5450,6 +5457,13 @@ components:
           $ref: "#/components/schemas/CrmOrganizationType"
         relationship_type:
           $ref: "#/components/schemas/CrmRelationshipType"
+        slug:
+          type: string
+          maxLength: 128
+          nullable: true
+          description: >
+            Optional partner-only slug. Omit or null to clear. Must be null when
+            relationship_type is not partner.
         website:
           type: string
           maxLength: 500
@@ -5473,6 +5487,13 @@ components:
           $ref: "#/components/schemas/CrmOrganizationType"
         relationship_type:
           $ref: "#/components/schemas/CrmRelationshipType"
+        slug:
+          type: string
+          maxLength: 128
+          nullable: true
+          description: >
+            Optional partner-only slug. Omit or null to clear. Must be null when
+            relationship_type is not partner.
         website:
           type: string
           maxLength: 500

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -393,6 +393,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 ### `organizations` and `organization_members`
 
 - `organizations` stores external organization entities.
+- `organizations.slug` is an optional URL-safe identifier used when
+  `relationship_type` is `partner`; uniqueness is enforced case-insensitively
+  among partner rows with a non-null slug (partial unique index).
 - `organizations.location_id` optionally links an organization to a canonical
   row in `locations` for address management.
 - `organization_members` links contacts to organizations with role/title.

--- a/tests/test_admin_organizations_slug.py
+++ b/tests/test_admin_organizations_slug.py
@@ -1,0 +1,51 @@
+"""Tests for partner-only organization slug handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.api import admin_organizations_crm
+from app.db.models import RelationshipType
+from app.exceptions import ValidationError
+
+
+def _org_stub(
+    *,
+    relationship_type: RelationshipType,
+    slug: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(relationship_type=relationship_type, slug=slug)
+
+
+def test_apply_slug_partner_sets_normalized_value() -> None:
+    org = _org_stub(relationship_type=RelationshipType.PARTNER)
+    admin_organizations_crm._apply_organization_slug_from_body(
+        org, {"slug": "  Acme-Partner  "}
+    )
+    assert org.slug == "acme-partner"
+
+
+def test_apply_slug_non_partner_clears_when_empty() -> None:
+    org = _org_stub(relationship_type=RelationshipType.PROSPECT, slug="should-clear")
+    admin_organizations_crm._apply_organization_slug_from_body(org, {"slug": ""})
+    assert org.slug is None
+
+
+def test_apply_slug_non_partner_rejects_non_empty() -> None:
+    org = _org_stub(relationship_type=RelationshipType.PROSPECT)
+    with pytest.raises(ValidationError, match="only allowed when"):
+        admin_organizations_crm._apply_organization_slug_from_body(
+            org, {"slug": "no-partners"}
+        )
+
+
+def test_apply_slug_create_uses_passed_relationship_type() -> None:
+    org = _org_stub(relationship_type=RelationshipType.PROSPECT)
+    admin_organizations_crm._apply_organization_slug_from_body(
+        org,
+        {"slug": "partner-slug"},
+        relationship_type=RelationshipType.PARTNER,
+    )
+    assert org.slug == "partner-slug"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an optional **slug** for CRM organisations when **Relationship** is **partner**, persisted in the database and exposed through the admin API.

## Changes

- **Database:** New nullable `organizations.slug` column (128 chars) with a partial unique index on `lower(slug)` where `relationship_type = 'partner'` and slug is not null.
- **API:** `slug` on `AdminOrganization`, `CreateAdminOrganizationRequest`, and `UpdateAdminOrganizationRequest`. Parsed with the same URL-safe rules as service instance slugs; rejected when relationship is not partner; duplicate slugs return HTTP 409 with `field: slug`.
- **Admin UI:** Contacts → Organisations inline editor shows a Slug field when Relationship is Partner; clearing relationship to non-partner clears slug in the UI and sends null on save.
- **Docs:** `docs/api/admin.yaml`, `docs/architecture/database-schema.md`.
- **Tests:** `tests/test_admin_organizations_slug.py` for slug application helpers.

## Seed

`backend/db/seed/seed_data.sql` does not insert `organizations` rows; no seed update.

## Post-merge

Run Alembic migration `0029_organizations_partner_slug` in deployed environments.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ba5a8f3-600b-4f9f-82d9-3fa91a8b4147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ba5a8f3-600b-4f9f-82d9-3fa91a8b4147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

