### PR TITLE
Venues: partner org addresses, lock name, block delete

### DIFF
--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -270,6 +270,7 @@ export function ServicesPage() {
           onLoadMore={state.venues.loadMore}
           onCreate={state.venues.createVenue}
           onUpdate={state.venues.updateVenue}
+          onUpdatePartial={state.venues.updateVenuePartial}
           onDelete={state.venues.deleteVenue}
         />
       )}

--- a/apps/admin_web/src/components/admin/services/venues-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/venues-panel.tsx
@@ -37,6 +37,10 @@ export interface VenuesPanelProps {
   onLoadMore: () => Promise<void> | void;
   onCreate: (payload: ApiSchemas['CreateLocationRequest']) => Promise<unknown> | void;
   onUpdate: (venueId: string, payload: ApiSchemas['UpdateLocationRequest']) => Promise<unknown> | void;
+  onUpdatePartial: (
+    venueId: string,
+    payload: ApiSchemas['PartialUpdateLocationRequest']
+  ) => Promise<unknown> | void;
   onDelete: (venueId: string) => Promise<void> | void;
 }
 
@@ -63,6 +67,7 @@ export function VenuesPanel({
   onLoadMore,
   onCreate,
   onUpdate,
+  onUpdatePartial,
   onDelete,
 }: VenuesPanelProps) {
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
@@ -91,6 +96,7 @@ export function VenuesPanel({
     () => venues.find((entry) => entry.id === selectedVenueId) ?? null,
     [venues, selectedVenueId]
   );
+  const selectedVenueLocked = selectedVenue?.lockedFromPartnerOrg ?? false;
 
   const areasReady = !areasLoading && areaOptions.length > 0;
   const latTrim = lat.trim();
@@ -172,6 +178,15 @@ export function VenuesPanel({
         return;
       }
       if (!selectedVenue) {
+        return;
+      }
+      if (selectedVenue.lockedFromPartnerOrg) {
+        await onUpdatePartial(selectedVenue.id, {
+          area_id: areaId,
+          address: address.trim() || null,
+          lat: latValue,
+          lng: lngValue,
+        });
         return;
       }
       await onUpdate(selectedVenue.id, payload);
@@ -261,9 +276,18 @@ export function VenuesPanel({
                 id='venue-name'
                 value={name}
                 onChange={(event) => setName(event.target.value)}
-                disabled={isSaving}
+                disabled={isSaving || selectedVenueLocked}
                 placeholder='e.g. Central Studio'
               />
+              {selectedVenueLocked && selectedVenue ? (
+                <p className='mt-1 text-sm text-slate-600'>
+                  Name is managed from the partner organisation
+                  {selectedVenue.partnerOrganizationLabels.length > 0
+                    ? ` (${selectedVenue.partnerOrganizationLabels.join(', ')})`
+                    : ''}
+                  .
+                </p>
+              ) : null}
             </div>
             <div>
               <Label htmlFor='venue-area'>Geographic area</Label>
@@ -370,6 +394,7 @@ export function VenuesPanel({
             <tr>
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Address</th>
+              <th className='px-4 py-3 font-semibold'>Partner organisations</th>
               <th className='px-4 py-3 font-semibold'>Area</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
@@ -387,13 +412,18 @@ export function VenuesPanel({
                 >
                   <td className='px-4 py-3'>{row.name?.trim() || '—'}</td>
                   <td className='px-4 py-3'>{row.address?.trim() || '—'}</td>
+                  <td className='px-4 py-3'>
+                    {row.partnerOrganizationLabels.length > 0
+                      ? row.partnerOrganizationLabels.join(', ')
+                      : '—'}
+                  </td>
                   <td className='px-4 py-3'>{area?.name ?? row.areaId}</td>
                   <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
                     <Button
                       type='button'
                       size='sm'
                       variant='danger'
-                      disabled={isSaving}
+                      disabled={isSaving || row.lockedFromPartnerOrg}
                       onClick={() => void handleDeleteVenue(row)}
                       aria-label='Delete venue'
                       title='Delete venue'

--- a/apps/admin_web/src/hooks/use-venues.ts
+++ b/apps/admin_web/src/hooks/use-venues.ts
@@ -2,7 +2,14 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { createLocation, deleteLocation, listGeographicAreas, listLocations, updateLocation } from '@/lib/services-api';
+import {
+  createLocation,
+  deleteLocation,
+  listGeographicAreas,
+  listLocations,
+  updateLocation,
+  updateLocationPartial,
+} from '@/lib/services-api';
 import { DEFAULT_VENUE_FILTERS } from '@/types/services';
 import type { GeographicAreaSummary, LocationSummary, VenueFilters } from '@/types/services';
 
@@ -95,6 +102,12 @@ export function useVenues(options: { onMutationSuccess?: () => void | Promise<vo
     [mutate]
   );
 
+  const updateVenuePartial = useCallback(
+    async (venueId: string, payload: ApiSchemas['PartialUpdateLocationRequest']) =>
+      mutate(async () => updateLocationPartial(venueId, payload)),
+    [mutate]
+  );
+
   const deleteVenue = useCallback(
     async (venueId: string) =>
       mutate(async () => {
@@ -117,6 +130,7 @@ export function useVenues(options: { onMutationSuccess?: () => void | Promise<vo
     totalCount: list.totalCount,
     createVenue,
     updateVenue,
+    updateVenuePartial,
     deleteVenue,
     geographicAreas,
     areasLoading,

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -1,5 +1,12 @@
 import { adminApiRequest, isAbortRequestError } from './api-admin-client';
-import { asBoolean, asNullableFiniteNumber, asNullableString, asNumber, unwrapPayload } from './api-payload';
+import {
+  asBoolean,
+  asNullableFiniteNumber,
+  asNullableString,
+  asNumber,
+  asStringArray,
+  unwrapPayload,
+} from './api-payload';
 import { isRecord } from './type-guards';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -45,6 +52,7 @@ type ApiLocationResponse = ApiSchemas['LocationResponse'];
 type ApiGeographicAreaListResponse = ApiSchemas['GeographicAreaListResponse'];
 type ApiCreateLocationRequest = ApiSchemas['CreateLocationRequest'];
 type ApiUpdateLocationRequest = ApiSchemas['UpdateLocationRequest'];
+type ApiPartialUpdateLocationRequest = ApiSchemas['PartialUpdateLocationRequest'];
 type ApiGeocodeLocationRequest = ApiSchemas['GeocodeLocationRequest'];
 type ApiGeocodeLocationResponse = ApiSchemas['GeocodeLocationResponse'];
 type ApiDiscountCodeUsageSummaryResponse = ApiSchemas['DiscountCodeUsageSummaryResponse'];
@@ -86,6 +94,8 @@ function parseLocationSummary(value: unknown): LocationSummary {
     lng: asNullableFiniteNumber(item.lng),
     createdAt: asNullableString(item.created_at),
     updatedAt: asNullableString(item.updated_at),
+    lockedFromPartnerOrg: asBoolean(item.locked_from_partner_org, false),
+    partnerOrganizationLabels: asStringArray(item.partner_organization_labels),
   };
 }
 
@@ -404,6 +414,19 @@ export async function updateLocation(
   const payload = await adminApiRequest<ApiLocationResponse>({
     endpointPath: `/v1/admin/locations/${id}`,
     method: 'PUT',
+    body,
+  });
+  const root = unwrapPayload(payload);
+  return root.location ? parseLocationSummary(root.location) : null;
+}
+
+export async function updateLocationPartial(
+  id: string,
+  body: ApiPartialUpdateLocationRequest
+): Promise<LocationSummary | null> {
+  const payload = await adminApiRequest<ApiLocationResponse>({
+    endpointPath: `/v1/admin/locations/${id}`,
+    method: 'PATCH',
     body,
   });
   const root = unwrapPayload(payload);

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -928,6 +928,15 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
+                /** @description Location is linked to an active partner organisation. */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
             };
         };
         options?: never;
@@ -4451,6 +4460,10 @@ export interface components {
             created_at?: string | null;
             /** Format: date-time */
             updated_at?: string | null;
+            /** @description True when at least one active CRM organisation with relationship type partner references this location. The venue name is managed from the organisation record; delete is blocked server-side. */
+            locked_from_partner_org: boolean;
+            /** @description Names of active partner organisations linked to this venue (for display). */
+            partner_organization_labels: string[];
         };
         LocationResponse: {
             location: components["schemas"]["Location"];

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -143,6 +143,10 @@ export interface LocationSummary {
   lng: number | null;
   createdAt: string | null;
   updatedAt: string | null;
+  /** True when an active partner CRM organisation references this venue. */
+  lockedFromPartnerOrg: boolean;
+  /** Display labels for linked partner organisations (same venue address). */
+  partnerOrganizationLabels: string[];
 }
 
 export type GeographicAreaLevel = ApiSchemas['GeographicArea']['level'];

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -33,6 +33,8 @@ function buildLocationSummary(overrides: Partial<LocationSummary> = {}): Locatio
     lng: null,
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
+    lockedFromPartnerOrg: false,
+    partnerOrganizationLabels: [],
     ...overrides,
   };
 }

--- a/apps/admin_web/tests/components/admin/services/venues-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/venues-panel.test.tsx
@@ -51,6 +51,7 @@ describe('VenuesPanel', () => {
         onLoadMore={vi.fn()}
         onCreate={vi.fn()}
         onUpdate={vi.fn()}
+        onUpdatePartial={vi.fn()}
         onDelete={vi.fn()}
       />
     );
@@ -83,6 +84,8 @@ describe('VenuesPanel', () => {
             lng: 2,
             createdAt: null,
             updatedAt: '2025-01-01T00:00:00Z',
+            lockedFromPartnerOrg: false,
+            partnerOrganizationLabels: [],
           },
         ]}
         geographicAreas={[
@@ -108,12 +111,14 @@ describe('VenuesPanel', () => {
         onLoadMore={vi.fn()}
         onCreate={vi.fn()}
         onUpdate={vi.fn()}
+        onUpdatePartial={vi.fn()}
         onDelete={vi.fn()}
       />
     );
 
     expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Address' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Partner organisations' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Area' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Operations' })).toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Coordinates' })).not.toBeInTheDocument();

--- a/backend/src/app/api/admin_locations.py
+++ b/backend/src/app/api/admin_locations.py
@@ -136,10 +136,23 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
         has_more = len(rows) > limit
         rows = rows[:limit]
         next_cursor = encode_cursor(rows[-1].id) if has_more and rows else None
+        partner_by_loc = (
+            location_repo.active_partner_organization_names_by_location_ids(
+                [cast(UUID, loc.id) for loc in rows]
+            )
+        )
         return json_response(
             200,
             {
-                "items": [_serialize_location(location) for location in rows],
+                "items": [
+                    _serialize_location(
+                        location,
+                        partner_organization_names=partner_by_loc.get(
+                            cast(UUID, location.id)
+                        ),
+                    )
+                    for location in rows
+                ],
                 "next_cursor": next_cursor,
                 "total_count": total_count,
             },
@@ -182,9 +195,21 @@ def _create_location(event: Mapping[str, Any]) -> dict[str, Any]:
         )
         location = location_repo.create(location)
         session.commit()
+        partner_by_loc = (
+            location_repo.active_partner_organization_names_by_location_ids(
+                [cast(UUID, location.id)]
+            )
+        )
         return json_response(
             201,
-            {"location": _serialize_location(location)},
+            {
+                "location": _serialize_location(
+                    location,
+                    partner_organization_names=partner_by_loc.get(
+                        cast(UUID, location.id)
+                    ),
+                )
+            },
             event=event,
         )
 
@@ -195,9 +220,19 @@ def _get_location(event: Mapping[str, Any], location_id: UUID) -> dict[str, Any]
         location = location_repo.get_by_id(location_id)
         if location is None:
             raise NotFoundError("Location", str(location_id))
+        partner_by_loc = (
+            location_repo.active_partner_organization_names_by_location_ids(
+                [location_id]
+            )
+        )
         return json_response(
             200,
-            {"location": _serialize_location(location)},
+            {
+                "location": _serialize_location(
+                    location,
+                    partner_organization_names=partner_by_loc.get(location_id),
+                )
+            },
             event=event,
         )
 
@@ -224,6 +259,19 @@ def _update_location(
         if location is None:
             raise NotFoundError("Location", str(location_id))
 
+        partner_names = location_repo.active_partner_organization_names_by_location_ids(
+            [location_id]
+        ).get(location_id)
+        if partner_names and "name" in body:
+            parsed_name = _parse_name(body.get("name"), required=False)
+            current_norm = (location.name or "").strip()
+            incoming_norm = (parsed_name or "").strip()
+            if incoming_norm != current_norm:
+                raise ValidationError(
+                    "Location name is managed from the partner organisation record",
+                    field="name",
+                )
+
         if not partial:
             if "area_id" not in body:
                 raise ValidationError("area_id is required", field="area_id")
@@ -248,9 +296,19 @@ def _update_location(
 
         location = location_repo.update(location)
         session.commit()
+        partner_by_loc = (
+            location_repo.active_partner_organization_names_by_location_ids(
+                [location_id]
+            )
+        )
         return json_response(
             200,
-            {"location": _serialize_location(location)},
+            {
+                "location": _serialize_location(
+                    location,
+                    partner_organization_names=partner_by_loc.get(location_id),
+                )
+            },
             event=event,
         )
 
@@ -269,6 +327,15 @@ def _delete_location(event: Mapping[str, Any], location_id: UUID) -> dict[str, A
         location = location_repo.get_by_id(location_id)
         if location is None:
             raise NotFoundError("Location", str(location_id))
+        partner_names = location_repo.active_partner_organization_names_by_location_ids(
+            [location_id]
+        ).get(location_id)
+        if partner_names:
+            raise ValidationError(
+                "Cannot delete a venue linked to a partner organisation",
+                field="location_id",
+                status_code=409,
+            )
         location_repo.delete(location)
         session.commit()
         return json_response(204, {}, event=event)
@@ -285,7 +352,13 @@ def _optional_coordinate_json(value: Any) -> float | None:
     raise TypeError(f"coordinate must be numeric or None, got {type(value).__name__}")
 
 
-def _serialize_location(location: Location) -> dict[str, Any]:
+def _serialize_location(
+    location: Location,
+    *,
+    partner_organization_names: list[str] | None = None,
+) -> dict[str, Any]:
+    names = partner_organization_names or []
+    locked = bool(names)
     return {
         "id": str(location.id),
         "name": location.name,
@@ -295,6 +368,8 @@ def _serialize_location(location: Location) -> dict[str, Any]:
         "lng": _optional_coordinate_json(location.lng),
         "created_at": location.created_at,
         "updated_at": location.updated_at,
+        "locked_from_partner_org": locked,
+        "partner_organization_labels": names,
     }
 
 

--- a/backend/src/app/db/repositories/location.py
+++ b/backend/src/app/db/repositories/location.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
-from app.db.models import Location
+from app.db.models import Location, Organization, RelationshipType
 from app.db.repositories.base import BaseRepository
 
 
@@ -88,3 +89,28 @@ class LocationRepository(BaseRepository[Location]):
             func.lower(func.trim(Location.address)) == func.lower(func.trim(normalized))
         )
         return self._session.execute(query).scalar_one_or_none()
+
+    def active_partner_organization_names_by_location_ids(
+        self,
+        location_ids: Sequence[UUID],
+    ) -> dict[UUID, list[str]]:
+        """Map location ids to sorted names of active partner CRM organizations."""
+        if not location_ids:
+            return {}
+        stmt = (
+            select(Organization.location_id, Organization.name)
+            .where(
+                Organization.location_id.in_(location_ids),
+                Organization.relationship_type == RelationshipType.PARTNER,
+                Organization.archived_at.is_(None),
+            )
+            .order_by(Organization.name.asc())
+        )
+        rows = self._session.execute(stmt).all()
+        by_loc: dict[UUID, list[str]] = defaultdict(list)
+        for loc_id, name in rows:
+            if loc_id is None:
+                continue
+            label = (name or "").strip() or "Partner organisation"
+            by_loc[loc_id].append(label)
+        return dict(by_loc)

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -722,6 +722,12 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: Location is linked to an active partner organisation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/admin/users:
     get:
@@ -4248,6 +4254,8 @@ components:
       required:
         - id
         - area_id
+        - locked_from_partner_org
+        - partner_organization_labels
       properties:
         id:
           type: string
@@ -4278,6 +4286,18 @@ components:
           type: string
           format: date-time
           nullable: true
+        locked_from_partner_org:
+          type: boolean
+          description: >
+            True when at least one active CRM organisation with relationship type
+            partner references this location. The venue name is managed from the
+            organisation record; delete is blocked server-side.
+        partner_organization_labels:
+          type: array
+          description: >
+            Names of active partner organisations linked to this venue (for display).
+          items:
+            type: string
     LocationResponse:
       type: object
       required:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -298,6 +298,11 @@ Indexes:
 Purpose: Canonical address/location records referenced by contacts, families,
 and organizations.
 
+Admin venues: when an active CRM organisation has `relationship_type = partner`
+and points `location_id` at a row, the admin Venues UI treats that venue as
+partner-managed (name locked, delete blocked); the API exposes
+`locked_from_partner_org` and `partner_organization_labels` on location payloads.
+
 Columns:
 - `id` (UUID, PK, default `gen_random_uuid()`)
 - `name` (text, nullable) — display label for the venue/location

--- a/tests/test_admin_locations_api.py
+++ b/tests/test_admin_locations_api.py
@@ -91,6 +91,8 @@ def test_serialize_location_emits_float_coordinates_for_json() -> None:
         updated_at=None,
     )
     payload = admin_locations._serialize_location(location)  # type: ignore[arg-type]
+    assert payload["locked_from_partner_org"] is False
+    assert payload["partner_organization_labels"] == []
     assert payload["lat"] == 22.3193
     assert payload["lng"] == 114.1694
     assert isinstance(payload["lat"], float)
@@ -99,3 +101,24 @@ def test_serialize_location_emits_float_coordinates_for_json() -> None:
     roundtrip = json.loads(encoded)
     assert roundtrip["lat"] == pytest.approx(22.3193)
     assert roundtrip["lng"] == pytest.approx(114.1694)
+
+
+def test_serialize_location_partner_metadata() -> None:
+    loc_id = uuid4()
+    area_id = uuid4()
+    location = SimpleNamespace(
+        id=loc_id,
+        name="Venue",
+        area_id=area_id,
+        address="1 St",
+        lat=None,
+        lng=None,
+        created_at=None,
+        updated_at=None,
+    )
+    payload = admin_locations._serialize_location(
+        location,
+        partner_organization_names=["Alpha Partners", "Beta Co"],
+    )
+    assert payload["locked_from_partner_org"] is True
+    assert payload["partner_organization_labels"] == ["Alpha Partners", "Beta Co"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the **Services → Venues** admin experience for locations shared with **partner** CRM organisations.

## Behaviour

- **List:** Each venue row includes a **Partner organisations** column listing names of active CRM organisations with `relationship_type = partner` that reference that location (same underlying address as the venue).
- **Delete:** Disabled in the UI when the venue is partner-linked; **DELETE** `/v1/admin/locations/{id}` returns **409** if an active partner org still references the location.
- **Location name:** Read-only in the editor when partner-linked (name is managed from the organisation record). Saving uses **PATCH** with `area_id`, `address`, `lat`, and `lng` only so full PUT does not resend a changed name.

## API

Location responses now include:

- `locked_from_partner_org` (boolean)
- `partner_organization_labels` (string array)

## Docs

- `docs/api/admin.yaml` — Location schema + 409 on delete when blocked
- `docs/architecture/database-schema.md` — short note on partner-linked venues
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ba5a8f3-600b-4f9f-82d9-3fa91a8b4147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ba5a8f3-600b-4f9f-82d9-3fa91a8b4147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

