### PR TITLE
Admin web: shared inline location editor for CRM and venues

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
@@ -38,6 +38,7 @@ export function ContactsPage() {
   const [tags, setTags] = useState<CrmTagRef[]>([]);
   const [locations, setLocations] = useState<LocationSummary[]>([]);
   const [geographicAreas, setGeographicAreas] = useState<GeographicAreaSummary[]>([]);
+  const [pickerLoading, setPickerLoading] = useState(true);
   const [pickerError, setPickerError] = useState('');
 
   const contacts = useAdminCrmContacts();
@@ -53,9 +54,15 @@ export function ContactsPage() {
     patchStandaloneNoteCountRef.current(contactId, count);
   }, []);
 
+  const refreshLocations = useCallback(async () => {
+    const locList = await listAllLocations();
+    setLocations(locList);
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
+      setPickerLoading(true);
       try {
         const [tagList, locList, areaList] = await Promise.all([
           listCrmTags(),
@@ -71,6 +78,10 @@ export function ContactsPage() {
       } catch (error) {
         if (!cancelled) {
           setPickerError(toErrorMessage(error, 'Failed to load tags or locations.'));
+        }
+      } finally {
+        if (!cancelled) {
+          setPickerLoading(false);
         }
       }
     })();
@@ -126,6 +137,8 @@ export function ContactsPage() {
           tags={tags}
           locations={locations}
           geographicAreas={geographicAreas}
+          areasLoading={pickerLoading}
+          refreshLocations={refreshLocations}
         />
       ) : activeView === 'families' ? (
         <FamiliesPanel
@@ -133,6 +146,8 @@ export function ContactsPage() {
           tags={tags}
           locations={locations}
           geographicAreas={geographicAreas}
+          areasLoading={pickerLoading}
+          refreshLocations={refreshLocations}
           contactOptions={contactOptions}
           contactsForMembership={contactsForMembership}
         />
@@ -142,6 +157,8 @@ export function ContactsPage() {
           tags={tags}
           locations={locations}
           geographicAreas={geographicAreas}
+          areasLoading={pickerLoading}
+          refreshLocations={refreshLocations}
           contactOptions={contactOptions}
           contactsForMembership={contactsForMembership}
         />

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminCrmContacts } from '@/hooks/use-admin-crm-contacts';
+import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
+import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
 import { ContactNotesModal } from '@/components/admin/contacts/contact-notes-modal';
 import { CrmTagPicker } from '@/components/admin/contacts/crm-tag-picker';
 import { ArchiveIcon, DeleteIcon, NoteIcon, RestoreIcon } from '@/components/icons/action-icons';
@@ -24,7 +27,7 @@ import {
   searchCrmContactsForPicker,
   type CrmTagRef,
 } from '@/lib/crm-api';
-import { formatCrmVenueLocationLabel, formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel } from '@/lib/format';
 import type { CrmListFilters } from '@/types/crm';
 import {
   CRM_ENTITY_RELATIONSHIP_TYPES,
@@ -71,6 +74,8 @@ export interface ContactsPanelProps {
   tags: CrmTagRef[];
   locations: LocationSummary[];
   geographicAreas: GeographicAreaSummary[];
+  areasLoading: boolean;
+  refreshLocations: () => Promise<void> | void;
 }
 
 export function ContactsPanel({
@@ -80,6 +85,8 @@ export function ContactsPanel({
   tags,
   locations,
   geographicAreas,
+  areasLoading,
+  refreshLocations,
 }: ContactsPanelProps) {
   const {
     contacts: rows,
@@ -127,13 +134,13 @@ export function ContactsPanel({
     };
   }, []);
 
-  const areaNameById = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const a of geographicAreas) {
-      map[a.id] = a.name;
-    }
-    return map;
-  }, [geographicAreas]);
+  const {
+    status: locationSaveStatus,
+    createSharedLocation,
+    updateSharedLocation,
+    geocode: geocodeLocation,
+    clearError: clearLocationSaveError,
+  } = useInlineLocationSave(refreshLocations);
 
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -152,7 +159,9 @@ export function ContactsPanel({
   const [referralSearchResults, setReferralSearchResults] = useState<CrmPickerListItem[]>([]);
   const [referralPinnedLabel, setReferralPinnedLabel] = useState('');
   const [dateOfBirth, setDateOfBirth] = useState('');
-  const [locationId, setLocationId] = useState('');
+  const [pendingLocationId, setPendingLocationId] = useState<string | null>(null);
+  const [optimisticLocationSummary, setOptimisticLocationSummary] =
+    useState<InlineLocationEmbeddedSummary | null>(null);
   const [familySelectId, setFamilySelectId] = useState('');
   const [organizationSelectId, setOrganizationSelectId] = useState('');
   const [tagIds, setTagIds] = useState<string[]>([]);
@@ -165,6 +174,56 @@ export function ContactsPanel({
 
   const linkedToFamilyOrOrg = Boolean(familySelectId.trim() || organizationSelectId.trim());
   const locationFieldLocked = linkedToFamilyOrOrg;
+
+  const inlineLocationStateKey =
+    editorMode === 'create'
+      ? `contact-new:${pendingLocationId ?? 'none'}`
+      : `contact:${selectedId ?? 'none'}:${pendingLocationId ?? 'none'}`;
+
+  const resolvedLocation = useMemo(() => {
+    if (!pendingLocationId) {
+      return null;
+    }
+    return locations.find((l) => l.id === pendingLocationId) ?? null;
+  }, [locations, pendingLocationId]);
+
+  const embeddedLocationSummary = useMemo((): InlineLocationEmbeddedSummary | null => {
+    if (resolvedLocation) {
+      return null;
+    }
+    if (!pendingLocationId) {
+      return null;
+    }
+    if (optimisticLocationSummary && optimisticLocationSummary.id === pendingLocationId) {
+      return optimisticLocationSummary;
+    }
+    const s = selected?.location_summary;
+    if (s && s.id === pendingLocationId) {
+      return {
+        id: s.id,
+        name: s.name ?? null,
+        address: s.address ?? null,
+        areaName: s.area_name,
+        areaId: s.area_id,
+        lat: s.lat ?? null,
+        lng: s.lng ?? null,
+      };
+    }
+    return null;
+  }, [resolvedLocation, pendingLocationId, optimisticLocationSummary, selected?.location_summary]);
+
+  function summaryFromLocationRow(loc: LocationSummary): InlineLocationEmbeddedSummary {
+    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? '';
+    return {
+      id: loc.id,
+      name: loc.name,
+      address: loc.address,
+      areaName,
+      areaId: loc.areaId,
+      lat: loc.lat,
+      lng: loc.lng,
+    };
+  }
 
   const referralSelectOptions = useMemo(() => {
     const byId = new Map<string, string>();
@@ -261,7 +320,9 @@ export function ContactsPanel({
     setReferralSearchResults([]);
     setReferralPinnedLabel('');
     setDateOfBirth('');
-    setLocationId('');
+    setPendingLocationId(null);
+    setOptimisticLocationSummary(null);
+    clearLocationSaveError();
     setFamilySelectId('');
     setOrganizationSelectId('');
     setTagIds([]);
@@ -271,7 +332,7 @@ export function ContactsPanel({
   async function handleSubmit(): Promise<void> {
     try {
       const dob = dateOfBirth.trim() ? dateOfBirth.trim() : null;
-      const loc = locationId.trim() ? locationId.trim() : null;
+      const loc = pendingLocationId;
       const fam = familySelectId.trim();
       const org = organizationSelectId.trim();
       const family_ids = fam ? [fam] : [];
@@ -388,7 +449,9 @@ export function ContactsPanel({
     setReferralSearchResults([]);
     setReferralPinnedLabel('');
     setDateOfBirth(row.date_of_birth ?? '');
-    setLocationId(row.location_id ?? '');
+    setPendingLocationId(row.location_id ?? null);
+    setOptimisticLocationSummary(null);
+    clearLocationSaveError();
     setFamilySelectId(row.family_ids[0] ?? '');
     setOrganizationSelectId(row.organization_ids[0] ?? '');
     setTagIds([...row.tag_ids]);
@@ -571,46 +634,43 @@ export function ContactsPanel({
               </div>
             </div>
           ) : null}
-          <div>
-            <Label htmlFor='crm-contact-loc'>Location</Label>
-            <Select
-              id='crm-contact-loc'
-              value={locationFieldLocked ? '' : locationId}
-              onChange={(e) => setLocationId(e.target.value)}
-              disabled={locationFieldLocked}
-            >
-              <option value=''>None</option>
-              {!locationFieldLocked
-                ? locations.map((loc) => (
-                    <option key={loc.id} value={loc.id}>
-                      {formatCrmVenueLocationLabel({
-                        id: loc.id,
-                        name: loc.name,
-                        address: loc.address,
-                        areaName: areaNameById[loc.areaId] ?? '',
-                      })}
-                    </option>
-                  ))
-                : null}
-            </Select>
-            {locationFieldLocked ? (
-              <p className='mt-1 text-sm text-slate-600'>
-                Location is managed on the linked family or organisation.
-              </p>
-            ) : null}
-            {!locationFieldLocked &&
-            editorMode === 'edit' &&
-            selected?.location_summary != null ? (
-              <p className='mt-1 text-sm text-slate-600'>
-                Current:{' '}
-                {formatCrmVenueLocationLabel({
-                  id: selected.location_summary.id,
-                  name: selected.location_summary.name,
-                  address: selected.location_summary.address,
-                  areaName: selected.location_summary.area_name,
-                })}
-              </p>
-            ) : null}
+          <div className='lg:col-span-2'>
+            <InlineLocationEditor
+              stateKey={inlineLocationStateKey}
+              location={resolvedLocation}
+              embeddedSummary={embeddedLocationSummary}
+              areas={geographicAreas}
+              areasLoading={areasLoading}
+              canModify={!linkedToFamilyOrOrg}
+              readOnlyNote={
+                linkedToFamilyOrOrg
+                  ? 'Location is managed on the linked family or organisation.'
+                  : null
+              }
+              isSaving={isSaving || locationSaveStatus.isSaving}
+              isGeocoding={locationSaveStatus.isGeocoding}
+              saveError={locationSaveStatus.error}
+              onRequestEdit={() => {}}
+              onCancelEdit={() => {}}
+              onSaveCreate={async (payload) => {
+                const created = await createSharedLocation(payload);
+                if (created) {
+                  setPendingLocationId(created.id);
+                  setOptimisticLocationSummary(summaryFromLocationRow(created));
+                  return created.id;
+                }
+                return null;
+              }}
+              onSaveUpdate={async (id, payload) => {
+                await updateSharedLocation(id, payload);
+              }}
+              onClear={() => {
+                setPendingLocationId(null);
+                setOptimisticLocationSummary(null);
+                clearLocationSaveError();
+              }}
+              onGeocode={geocodeLocation}
+            />
           </div>
           <div>
             <Label htmlFor='crm-contact-family'>Family</Label>
@@ -621,7 +681,8 @@ export function ContactsPanel({
                 const v = e.target.value;
                 setFamilySelectId(v);
                 if (v) {
-                  setLocationId('');
+                  setPendingLocationId(null);
+                  setOptimisticLocationSummary(null);
                 }
               }}
             >
@@ -642,7 +703,8 @@ export function ContactsPanel({
                 const v = e.target.value;
                 setOrganizationSelectId(v);
                 if (v) {
-                  setLocationId('');
+                  setPendingLocationId(null);
+                  setOptimisticLocationSummary(null);
                 }
               }}
             >

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminCrmContacts } from '@/hooks/use-admin-crm-contacts';
+import { useGeocodeVenueAddress } from '@/hooks/use-geocode-venue-address';
 import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
@@ -134,14 +135,6 @@ export function ContactsPanel({
     };
   }, []);
 
-  const {
-    status: locationSaveStatus,
-    createSharedLocation,
-    updateSharedLocation,
-    geocode: geocodeLocation,
-    clearError: clearLocationSaveError,
-  } = useInlineLocationSave(refreshLocations);
-
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [firstName, setFirstName] = useState('');
@@ -167,6 +160,14 @@ export function ContactsPanel({
   const [tagIds, setTagIds] = useState<string[]>([]);
   const [active, setActive] = useState(true);
 
+  const {
+    status: locationSaveStatus,
+    createSharedLocation,
+    updateSharedLocation,
+    clearError: clearLocationSaveError,
+  } = useInlineLocationSave(refreshLocations);
+  const { geocode: geocodeLocation, isGeocoding: locationGeocoding } = useGeocodeVenueAddress();
+
   const selected = useMemo(
     () => rows.find((c) => c.id === selectedId) ?? null,
     [rows, selectedId]
@@ -176,9 +177,7 @@ export function ContactsPanel({
   const locationFieldLocked = linkedToFamilyOrOrg;
 
   const inlineLocationStateKey =
-    editorMode === 'create'
-      ? `contact-new:${pendingLocationId ?? 'none'}`
-      : `contact:${selectedId ?? 'none'}:${pendingLocationId ?? 'none'}`;
+    editorMode === 'create' ? 'contact-new' : `contact:${selectedId ?? 'none'}`;
 
   const resolvedLocation = useMemo(() => {
     if (!pendingLocationId) {
@@ -213,7 +212,7 @@ export function ContactsPanel({
   }, [resolvedLocation, pendingLocationId, optimisticLocationSummary, selected?.location_summary]);
 
   function summaryFromLocationRow(loc: LocationSummary): InlineLocationEmbeddedSummary {
-    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? '';
+    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? 'Unknown area';
     return {
       id: loc.id,
       name: loc.name,
@@ -304,6 +303,14 @@ export function ContactsPanel({
   }, [referralContactId, source]);
 
   function resetCreateForm() {
+    if (editorMode === 'create' && pendingLocationId && typeof window !== 'undefined') {
+      const ok = window.confirm(
+        'You saved an address to a new location but have not finished creating this contact yet. Leave anyway? The location row stays in the directory.'
+      );
+      if (!ok) {
+        return;
+      }
+    }
     setEditorMode('create');
     setSelectedId(null);
     setFirstName('');
@@ -648,7 +655,7 @@ export function ContactsPanel({
                   : null
               }
               isSaving={isSaving || locationSaveStatus.isSaving}
-              isGeocoding={locationSaveStatus.isGeocoding}
+              isGeocoding={locationGeocoding}
               saveError={locationSaveStatus.error}
               onRequestEdit={() => {}}
               onCancelEdit={() => {}}

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 
 import type { useAdminCrmFamilies } from '@/hooks/use-admin-crm-families';
+import { useGeocodeVenueAddress } from '@/hooks/use-geocode-venue-address';
 import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
 import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
@@ -107,9 +108,7 @@ export function FamiliesPanel({
   );
 
   const inlineLocationStateKey =
-    editorMode === 'create'
-      ? `family-new:${pendingLocationId ?? 'none'}`
-      : `family:${selectedId ?? 'none'}:${pendingLocationId ?? 'none'}`;
+    editorMode === 'create' ? 'family-new' : `family:${selectedId ?? 'none'}`;
 
   const resolvedLocation = useMemo(() => {
     if (!pendingLocationId) {
@@ -144,7 +143,7 @@ export function FamiliesPanel({
   }, [resolvedLocation, pendingLocationId, optimisticLocationSummary, selected?.location_summary]);
 
   function summaryFromLocationRow(loc: LocationSummary): InlineLocationEmbeddedSummary {
-    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? '';
+    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? 'Unknown area';
     return {
       id: loc.id,
       name: loc.name,
@@ -160,9 +159,9 @@ export function FamiliesPanel({
     status: locationSaveStatus,
     createSharedLocation,
     updateSharedLocation,
-    geocode: geocodeLocation,
     clearError: clearLocationSaveError,
   } = useInlineLocationSave(refreshLocations);
+  const { geocode: geocodeLocation, isGeocoding: locationGeocoding } = useGeocodeVenueAddress();
 
   const memberContactOptions = useMemo(() => {
     return contactOptions.filter((c) => {
@@ -175,6 +174,14 @@ export function FamiliesPanel({
   }, [contactOptions, contactsForMembership, selectedId]);
 
   function resetCreateForm() {
+    if (editorMode === 'create' && pendingLocationId && typeof window !== 'undefined') {
+      const ok = window.confirm(
+        'You saved an address to a new location but have not finished creating this family yet. Leave anyway? The location row stays in the directory.'
+      );
+      if (!ok) {
+        return;
+      }
+    }
     setEditorMode('create');
     setSelectedId(null);
     setFamilyName('');
@@ -308,7 +315,7 @@ export function FamiliesPanel({
               areasLoading={areasLoading}
               canModify
               isSaving={isSaving || locationSaveStatus.isSaving}
-              isGeocoding={locationSaveStatus.isGeocoding}
+              isGeocoding={locationGeocoding}
               saveError={locationSaveStatus.error}
               onRequestEdit={() => {}}
               onCancelEdit={() => {}}

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -3,6 +3,9 @@
 import { useMemo, useState } from 'react';
 
 import type { useAdminCrmFamilies } from '@/hooks/use-admin-crm-families';
+import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
+import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
+import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
 import { CrmTagPicker } from '@/components/admin/contacts/crm-tag-picker';
 import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
@@ -12,7 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
-import { formatCrmVenueLocationLabel, formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel } from '@/lib/format';
 import type { CrmTagRef } from '@/lib/crm-api';
 import type { CrmListFilters } from '@/types/crm';
 import {
@@ -47,6 +50,8 @@ export interface FamiliesPanelProps {
   tags: CrmTagRef[];
   locations: LocationSummary[];
   geographicAreas: GeographicAreaSummary[];
+  areasLoading: boolean;
+  refreshLocations: () => Promise<void> | void;
   contactOptions: { id: string; label: string }[];
   contactsForMembership: { id: string; family_ids: string[]; organization_ids: string[] }[];
 }
@@ -56,6 +61,8 @@ export function FamiliesPanel({
   tags,
   locations,
   geographicAreas,
+  areasLoading,
+  refreshLocations,
   contactOptions,
   contactsForMembership,
 }: FamiliesPanelProps) {
@@ -80,7 +87,9 @@ export function FamiliesPanel({
   const [familyName, setFamilyName] = useState('');
   const [relationshipType, setRelationshipType] =
     useState<(typeof CRM_ENTITY_RELATIONSHIP_TYPES)[number]>('prospect');
-  const [locationId, setLocationId] = useState('');
+  const [pendingLocationId, setPendingLocationId] = useState<string | null>(null);
+  const [optimisticLocationSummary, setOptimisticLocationSummary] =
+    useState<InlineLocationEmbeddedSummary | null>(null);
   const [tagIds, setTagIds] = useState<string[]>([]);
   const [active, setActive] = useState(true);
 
@@ -97,13 +106,63 @@ export function FamiliesPanel({
     [rows, selectedId]
   );
 
-  const areaNameById = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const a of geographicAreas) {
-      map[a.id] = a.name;
+  const inlineLocationStateKey =
+    editorMode === 'create'
+      ? `family-new:${pendingLocationId ?? 'none'}`
+      : `family:${selectedId ?? 'none'}:${pendingLocationId ?? 'none'}`;
+
+  const resolvedLocation = useMemo(() => {
+    if (!pendingLocationId) {
+      return null;
     }
-    return map;
-  }, [geographicAreas]);
+    return locations.find((l) => l.id === pendingLocationId) ?? null;
+  }, [locations, pendingLocationId]);
+
+  const embeddedLocationSummary = useMemo((): InlineLocationEmbeddedSummary | null => {
+    if (resolvedLocation) {
+      return null;
+    }
+    if (!pendingLocationId) {
+      return null;
+    }
+    if (optimisticLocationSummary && optimisticLocationSummary.id === pendingLocationId) {
+      return optimisticLocationSummary;
+    }
+    const s = selected?.location_summary;
+    if (s && s.id === pendingLocationId) {
+      return {
+        id: s.id,
+        name: s.name ?? null,
+        address: s.address ?? null,
+        areaName: s.area_name,
+        areaId: s.area_id,
+        lat: s.lat ?? null,
+        lng: s.lng ?? null,
+      };
+    }
+    return null;
+  }, [resolvedLocation, pendingLocationId, optimisticLocationSummary, selected?.location_summary]);
+
+  function summaryFromLocationRow(loc: LocationSummary): InlineLocationEmbeddedSummary {
+    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? '';
+    return {
+      id: loc.id,
+      name: loc.name,
+      address: loc.address,
+      areaName,
+      areaId: loc.areaId,
+      lat: loc.lat,
+      lng: loc.lng,
+    };
+  }
+
+  const {
+    status: locationSaveStatus,
+    createSharedLocation,
+    updateSharedLocation,
+    geocode: geocodeLocation,
+    clearError: clearLocationSaveError,
+  } = useInlineLocationSave(refreshLocations);
 
   const memberContactOptions = useMemo(() => {
     return contactOptions.filter((c) => {
@@ -120,7 +179,9 @@ export function FamiliesPanel({
     setSelectedId(null);
     setFamilyName('');
     setRelationshipType('prospect');
-    setLocationId('');
+    setPendingLocationId(null);
+    setOptimisticLocationSummary(null);
+    clearLocationSaveError();
     setTagIds([]);
     setActive(true);
     setMemberContactId('');
@@ -130,7 +191,7 @@ export function FamiliesPanel({
 
   async function handleSubmit(): Promise<void> {
     try {
-      const loc = locationId.trim() ? locationId.trim() : null;
+      const loc = pendingLocationId;
       if (editorMode === 'create') {
         await createFamily({
           family_name: familyName.trim(),
@@ -183,7 +244,9 @@ export function FamiliesPanel({
     setEditorMode('edit');
     setFamilyName(row.family_name);
     setRelationshipType(relationshipTypeForCrmEditor(row.relationship_type));
-    setLocationId(row.location_id ?? '');
+    setPendingLocationId(row.location_id ?? null);
+    setOptimisticLocationSummary(null);
+    clearLocationSaveError();
     setTagIds([...row.tag_ids]);
     setActive(row.active);
   }
@@ -236,36 +299,38 @@ export function FamiliesPanel({
               ))}
             </Select>
           </div>
-          <div>
-            <Label htmlFor='crm-family-loc'>Location</Label>
-            <Select
-              id='crm-family-loc'
-              value={locationId}
-              onChange={(e) => setLocationId(e.target.value)}
-            >
-              <option value=''>None</option>
-              {locations.map((loc) => (
-                <option key={loc.id} value={loc.id}>
-                  {formatCrmVenueLocationLabel({
-                    id: loc.id,
-                    name: loc.name,
-                    address: loc.address,
-                    areaName: areaNameById[loc.areaId] ?? '',
-                  })}
-                </option>
-              ))}
-            </Select>
-            {editorMode === 'edit' && selected?.location_summary != null ? (
-              <p className='mt-1 text-sm text-slate-600'>
-                Current:{' '}
-                {formatCrmVenueLocationLabel({
-                  id: selected.location_summary.id,
-                  name: selected.location_summary.name,
-                  address: selected.location_summary.address,
-                  areaName: selected.location_summary.area_name,
-                })}
-              </p>
-            ) : null}
+          <div className='lg:col-span-2'>
+            <InlineLocationEditor
+              stateKey={inlineLocationStateKey}
+              location={resolvedLocation}
+              embeddedSummary={embeddedLocationSummary}
+              areas={geographicAreas}
+              areasLoading={areasLoading}
+              canModify
+              isSaving={isSaving || locationSaveStatus.isSaving}
+              isGeocoding={locationSaveStatus.isGeocoding}
+              saveError={locationSaveStatus.error}
+              onRequestEdit={() => {}}
+              onCancelEdit={() => {}}
+              onSaveCreate={async (payload) => {
+                const created = await createSharedLocation(payload);
+                if (created) {
+                  setPendingLocationId(created.id);
+                  setOptimisticLocationSummary(summaryFromLocationRow(created));
+                  return created.id;
+                }
+                return null;
+              }}
+              onSaveUpdate={async (id, payload) => {
+                await updateSharedLocation(id, payload);
+              }}
+              onClear={() => {
+                setPendingLocationId(null);
+                setOptimisticLocationSummary(null);
+                clearLocationSaveError();
+              }}
+              onGeocode={geocodeLocation}
+            />
           </div>
           {editorMode === 'edit' ? (
             <div>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -3,6 +3,9 @@
 import { useMemo, useState } from 'react';
 
 import type { useAdminCrmOrganizations } from '@/hooks/use-admin-crm-organizations';
+import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
+import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
+import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
 import { CrmTagPicker } from '@/components/admin/contacts/crm-tag-picker';
 import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
@@ -12,7 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
-import { formatCrmVenueLocationLabel, formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel } from '@/lib/format';
 import type { CrmTagRef } from '@/lib/crm-api';
 import type { CrmListFilters } from '@/types/crm';
 import {
@@ -57,6 +60,8 @@ export interface OrganizationsPanelProps {
   tags: CrmTagRef[];
   locations: LocationSummary[];
   geographicAreas: GeographicAreaSummary[];
+  areasLoading: boolean;
+  refreshLocations: () => Promise<void> | void;
   contactOptions: { id: string; label: string }[];
   contactsForMembership: { id: string; family_ids: string[]; organization_ids: string[] }[];
 }
@@ -66,6 +71,8 @@ export function OrganizationsPanel({
   tags,
   locations,
   geographicAreas,
+  areasLoading,
+  refreshLocations,
   contactOptions,
   contactsForMembership,
 }: OrganizationsPanelProps) {
@@ -94,7 +101,9 @@ export function OrganizationsPanel({
   const [relationshipType, setRelationshipType] = useState<CrmEntityRelationshipType>('prospect');
   const [slug, setSlug] = useState('');
   const [website, setWebsite] = useState('');
-  const [locationId, setLocationId] = useState('');
+  const [pendingLocationId, setPendingLocationId] = useState<string | null>(null);
+  const [optimisticLocationSummary, setOptimisticLocationSummary] =
+    useState<InlineLocationEmbeddedSummary | null>(null);
   const [tagIds, setTagIds] = useState<string[]>([]);
   const [active, setActive] = useState(true);
 
@@ -110,13 +119,65 @@ export function OrganizationsPanel({
     [rows, selectedId]
   );
 
-  const areaNameById = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const a of geographicAreas) {
-      map[a.id] = a.name;
+  const inlineLocationStateKey =
+    editorMode === 'create'
+      ? `org-new:${pendingLocationId ?? 'none'}`
+      : `org:${selectedId ?? 'none'}:${pendingLocationId ?? 'none'}`;
+
+  const resolvedLocation = useMemo(() => {
+    if (!pendingLocationId) {
+      return null;
     }
-    return map;
-  }, [geographicAreas]);
+    return locations.find((l) => l.id === pendingLocationId) ?? null;
+  }, [locations, pendingLocationId]);
+
+  const embeddedLocationSummary = useMemo((): InlineLocationEmbeddedSummary | null => {
+    if (resolvedLocation) {
+      return null;
+    }
+    if (!pendingLocationId) {
+      return null;
+    }
+    if (optimisticLocationSummary && optimisticLocationSummary.id === pendingLocationId) {
+      return optimisticLocationSummary;
+    }
+    const s = selected?.location_summary;
+    if (s && s.id === pendingLocationId) {
+      return {
+        id: s.id,
+        name: s.name ?? null,
+        address: s.address ?? null,
+        areaName: s.area_name,
+        areaId: s.area_id,
+        lat: s.lat ?? null,
+        lng: s.lng ?? null,
+      };
+    }
+    return null;
+  }, [resolvedLocation, pendingLocationId, optimisticLocationSummary, selected?.location_summary]);
+
+  function summaryFromLocationRow(loc: LocationSummary): InlineLocationEmbeddedSummary {
+    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? '';
+    return {
+      id: loc.id,
+      name: loc.name,
+      address: loc.address,
+      areaName,
+      areaId: loc.areaId,
+      lat: loc.lat,
+      lng: loc.lng,
+    };
+  }
+
+  const {
+    status: locationSaveStatus,
+    createSharedLocation,
+    updateSharedLocation,
+    geocode: geocodeLocation,
+    clearError: clearLocationSaveError,
+  } = useInlineLocationSave(refreshLocations);
+
+  const locationLockedReadOnly = Boolean(resolvedLocation?.lockedFromPartnerOrg);
 
   const memberContactOptions = useMemo(() => {
     return contactOptions.filter((c) => {
@@ -136,7 +197,9 @@ export function OrganizationsPanel({
     setRelationshipType('prospect');
     setSlug('');
     setWebsite('');
-    setLocationId('');
+    setPendingLocationId(null);
+    setOptimisticLocationSummary(null);
+    clearLocationSaveError();
     setTagIds([]);
     setActive(true);
     setMemberContactId('');
@@ -145,7 +208,7 @@ export function OrganizationsPanel({
 
   async function handleSubmit(): Promise<void> {
     try {
-      const loc = locationId.trim() ? locationId.trim() : null;
+      const loc = pendingLocationId;
       if (editorMode === 'create') {
         await createOrganization({
           name: name.trim(),
@@ -207,7 +270,9 @@ export function OrganizationsPanel({
     setRelationshipType(relationshipTypeForCrmEditor(row.relationship_type));
     setSlug(row.slug ?? '');
     setWebsite(row.website ?? '');
-    setLocationId(row.location_id ?? '');
+    setPendingLocationId(row.location_id ?? null);
+    setOptimisticLocationSummary(null);
+    clearLocationSaveError();
     setTagIds([...row.tag_ids]);
     setActive(row.active);
   }
@@ -301,36 +366,38 @@ export function OrganizationsPanel({
               autoComplete='off'
             />
           </div>
-          <div>
-            <Label htmlFor='crm-org-loc'>Location</Label>
-            <Select
-              id='crm-org-loc'
-              value={locationId}
-              onChange={(e) => setLocationId(e.target.value)}
-            >
-              <option value=''>None</option>
-              {locations.map((loc) => (
-                <option key={loc.id} value={loc.id}>
-                  {formatCrmVenueLocationLabel({
-                    id: loc.id,
-                    name: loc.name,
-                    address: loc.address,
-                    areaName: areaNameById[loc.areaId] ?? '',
-                  })}
-                </option>
-              ))}
-            </Select>
-            {editorMode === 'edit' && selected?.location_summary != null ? (
-              <p className='mt-1 text-sm text-slate-600'>
-                Current:{' '}
-                {formatCrmVenueLocationLabel({
-                  id: selected.location_summary.id,
-                  name: selected.location_summary.name,
-                  address: selected.location_summary.address,
-                  areaName: selected.location_summary.area_name,
-                })}
-              </p>
-            ) : null}
+          <div className='lg:col-span-2'>
+            <InlineLocationEditor
+              stateKey={inlineLocationStateKey}
+              location={resolvedLocation}
+              embeddedSummary={embeddedLocationSummary}
+              areas={geographicAreas}
+              areasLoading={areasLoading}
+              canModify={!locationLockedReadOnly}
+              isSaving={isSaving || locationSaveStatus.isSaving}
+              isGeocoding={locationSaveStatus.isGeocoding}
+              saveError={locationSaveStatus.error}
+              onRequestEdit={() => {}}
+              onCancelEdit={() => {}}
+              onSaveCreate={async (payload) => {
+                const created = await createSharedLocation(payload);
+                if (created) {
+                  setPendingLocationId(created.id);
+                  setOptimisticLocationSummary(summaryFromLocationRow(created));
+                  return created.id;
+                }
+                return null;
+              }}
+              onSaveUpdate={async (id, payload) => {
+                await updateSharedLocation(id, payload);
+              }}
+              onClear={() => {
+                setPendingLocationId(null);
+                setOptimisticLocationSummary(null);
+                clearLocationSaveError();
+              }}
+              onGeocode={geocodeLocation}
+            />
           </div>
           {editorMode === 'edit' ? (
             <div>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 
 import type { useAdminCrmOrganizations } from '@/hooks/use-admin-crm-organizations';
+import { useGeocodeVenueAddress } from '@/hooks/use-geocode-venue-address';
 import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
 import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
@@ -119,10 +120,7 @@ export function OrganizationsPanel({
     [rows, selectedId]
   );
 
-  const inlineLocationStateKey =
-    editorMode === 'create'
-      ? `org-new:${pendingLocationId ?? 'none'}`
-      : `org:${selectedId ?? 'none'}:${pendingLocationId ?? 'none'}`;
+  const inlineLocationStateKey = editorMode === 'create' ? 'org-new' : `org:${selectedId ?? 'none'}`;
 
   const resolvedLocation = useMemo(() => {
     if (!pendingLocationId) {
@@ -157,7 +155,7 @@ export function OrganizationsPanel({
   }, [resolvedLocation, pendingLocationId, optimisticLocationSummary, selected?.location_summary]);
 
   function summaryFromLocationRow(loc: LocationSummary): InlineLocationEmbeddedSummary {
-    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? '';
+    const areaName = geographicAreas.find((a) => a.id === loc.areaId)?.name ?? 'Unknown area';
     return {
       id: loc.id,
       name: loc.name,
@@ -173,9 +171,9 @@ export function OrganizationsPanel({
     status: locationSaveStatus,
     createSharedLocation,
     updateSharedLocation,
-    geocode: geocodeLocation,
     clearError: clearLocationSaveError,
   } = useInlineLocationSave(refreshLocations);
+  const { geocode: geocodeLocation, isGeocoding: locationGeocoding } = useGeocodeVenueAddress();
 
   const locationLockedReadOnly = Boolean(resolvedLocation?.lockedFromPartnerOrg);
 
@@ -190,6 +188,14 @@ export function OrganizationsPanel({
   }, [contactOptions, contactsForMembership, selectedId]);
 
   function resetCreateForm() {
+    if (editorMode === 'create' && pendingLocationId && typeof window !== 'undefined') {
+      const ok = window.confirm(
+        'You saved an address to a new location but have not finished creating this organisation yet. Leave anyway? The location row stays in the directory.'
+      );
+      if (!ok) {
+        return;
+      }
+    }
     setEditorMode('create');
     setSelectedId(null);
     setName('');
@@ -373,9 +379,15 @@ export function OrganizationsPanel({
               embeddedSummary={embeddedLocationSummary}
               areas={geographicAreas}
               areasLoading={areasLoading}
-              canModify={!locationLockedReadOnly}
+              canModify
+              allowClearWhenLocked={locationLockedReadOnly}
+              lockedSummaryExtra={
+                locationLockedReadOnly
+                  ? 'To change the venue name or switch to a different address, use Services → Venues or update the partner organisation record.'
+                  : null
+              }
               isSaving={isSaving || locationSaveStatus.isSaving}
-              isGeocoding={locationSaveStatus.isGeocoding}
+              isGeocoding={locationGeocoding}
               saveError={locationSaveStatus.error}
               onRequestEdit={() => {}}
               onCancelEdit={() => {}}

--- a/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
+++ b/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
@@ -7,8 +7,7 @@ import { AdminInlineError } from '@/components/ui/admin-inline-error';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
-import { toErrorMessage } from '@/hooks/hook-errors';
-import { AdminApiError } from '@/lib/api-admin-client';
+import { formatGeocodeErrorMessage } from '@/hooks/hook-errors';
 import { formatCrmVenueLocationLabel, formatEnumLabel, formatLocationCoordinatesLabel } from '@/lib/format';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
 import type { components } from '@/types/generated/admin-api.generated';
@@ -41,16 +40,17 @@ export interface InlineLocationEditorProps {
   onRequestEdit(): void;
   onCancelEdit(): void;
   onSaveCreate(payload: ApiSchemas['CreateLocationRequest']): Promise<string | null>;
-  onSaveUpdate(
-    id: string,
-    payload: ApiSchemas['UpdateLocationRequest'] | ApiSchemas['PartialUpdateLocationRequest']
-  ): Promise<void>;
+  onSaveUpdate(id: string, payload: ApiSchemas['PartialUpdateLocationRequest']): Promise<void>;
   onClear(): void;
   onGeocode(args: { area_id: string; address: string }): Promise<{ lat: number; lng: number }>;
   /** When true, geocode / save-location runs are in flight (disables actions). */
   isGeocoding?: boolean;
   /** Hook-level error (e.g. create/update location failed). */
   saveError?: string;
+  /** Allow Clear to unlink the owner when the linked venue is partner-org locked (Change stays hidden). */
+  allowClearWhenLocked?: boolean;
+  /** Extra line under the partner-managed copy when the location is partner-locked (for example orgs screen). */
+  lockedSummaryExtra?: string | null;
 }
 
 function resolveDisplaySummary(
@@ -136,6 +136,8 @@ function InlineLocationEditorInner({
   onGeocode,
   isGeocoding = false,
   saveError = '',
+  allowClearWhenLocked = false,
+  lockedSummaryExtra,
 }: InnerProps) {
   const initial = deriveInitialDraft(canModify, location, embeddedSummary);
   const [isEditing, setIsEditing] = useState(initial.isEditing);
@@ -262,11 +264,12 @@ function InlineLocationEditorInner({
       setLatState(String(result.lat));
       setLngState(String(result.lng));
     } catch (error) {
-      const fallback =
-        error instanceof AdminApiError && error.statusCode === 404
-          ? 'Geocoding is not available in this environment yet.'
-          : 'Geocoding failed. Check the address and geographic area, then try again.';
-      setGeocodeError(toErrorMessage(error, fallback));
+      setGeocodeError(
+        formatGeocodeErrorMessage(
+          error,
+          'Geocoding failed. Check the address and geographic area, then try again.'
+        )
+      );
     }
   }
 
@@ -278,15 +281,15 @@ function InlineLocationEditorInner({
     const lngParsed = parseOptionalCoordinate(lng);
     const latValue: number | null = latTrim === '' ? null : (latParsed as number);
     const lngValue: number | null = lngTrim === '' ? null : (lngParsed as number);
-    const payload: ApiSchemas['CreateLocationRequest'] = {
-      area_id: areaId,
-      name: null,
-      address: address.trim() || null,
-      lat: latValue,
-      lng: lngValue,
-    };
     if (!location) {
-      const id = await onSaveCreate(payload);
+      const createPayload: ApiSchemas['CreateLocationRequest'] = {
+        area_id: areaId,
+        name: null,
+        address: address.trim() || null,
+        lat: latValue,
+        lng: lngValue,
+      };
+      const id = await onSaveCreate(createPayload);
       if (id) {
         setIsEditing(false);
       }
@@ -295,8 +298,14 @@ function InlineLocationEditorInner({
     if (lockedFromPartner) {
       return;
     }
+    const partialPayload: ApiSchemas['PartialUpdateLocationRequest'] = {
+      area_id: areaId,
+      address: address.trim() || null,
+      lat: latValue,
+      lng: lngValue,
+    };
     try {
-      await onSaveUpdate(location.id, payload);
+      await onSaveUpdate(location.id, partialPayload);
       setIsEditing(false);
     } catch {
       // Parent surfaces error; keep edit mode.
@@ -305,6 +314,8 @@ function InlineLocationEditorInner({
 
   const showReadBlock = Boolean(displaySummary) && !isEditing;
   const showEditForm = canModify && !effectiveReadOnly && (isEditing || (!location && !embeddedSummary));
+  const showChangeButton = canModify && !lockedFromPartner;
+  const showClearButton = canModify && (!lockedFromPartner || allowClearWhenLocked);
 
   if (!canModify && displaySummary) {
     return (
@@ -322,6 +333,9 @@ function InlineLocationEditorInner({
               : ''}
             .
           </p>
+        ) : null}
+        {lockedFromPartner && lockedSummaryExtra ? (
+          <p className='text-sm text-slate-600'>{lockedSummaryExtra}</p>
         ) : null}
         {readOnlyNote ? <p className='text-sm text-slate-600'>{readOnlyNote}</p> : null}
       </div>
@@ -356,28 +370,35 @@ function InlineLocationEditorInner({
                 .
               </p>
             ) : null}
-            {canModify && !lockedFromPartner ? (
+            {lockedFromPartner && lockedSummaryExtra ? (
+              <p className='text-sm text-slate-600'>{lockedSummaryExtra}</p>
+            ) : null}
+            {showChangeButton || showClearButton ? (
               <div className='flex flex-wrap gap-2'>
-                <Button type='button' size='sm' variant='secondary' disabled={isSaving} onClick={handleRequestEdit}>
-                  Change
-                </Button>
-                <Button
-                  type='button'
-                  size='sm'
-                  variant='danger'
-                  disabled={isSaving}
-                  onClick={() => {
-                    onClear();
-                    setIsEditing(true);
-                    setAreaIdState('');
-                    setAddressState('');
-                    setLatState('');
-                    setLngState('');
-                    setGeocodeError('');
-                  }}
-                >
-                  Clear
-                </Button>
+                {showChangeButton ? (
+                  <Button type='button' size='sm' variant='secondary' disabled={isSaving} onClick={handleRequestEdit}>
+                    Change
+                  </Button>
+                ) : null}
+                {showClearButton ? (
+                  <Button
+                    type='button'
+                    size='sm'
+                    variant='danger'
+                    disabled={isSaving}
+                    onClick={() => {
+                      onClear();
+                      setIsEditing(true);
+                      setAreaIdState('');
+                      setAddressState('');
+                      setLatState('');
+                      setLngState('');
+                      setGeocodeError('');
+                    }}
+                  >
+                    Clear
+                  </Button>
+                ) : null}
               </div>
             ) : null}
           </div>
@@ -432,7 +453,9 @@ function InlineLocationEditorInner({
                 />
               </div>
             </div>
-            <p className='text-sm text-slate-600'>Editing updates this location wherever it is used.</p>
+            {location || embeddedSummary ? (
+              <p className='text-sm text-slate-600'>Editing updates this location wherever it is used.</p>
+            ) : null}
             {saveError ? <AdminInlineError>{saveError}</AdminInlineError> : null}
             {geocodeError ? <AdminInlineError>{geocodeError}</AdminInlineError> : null}
             {(latParseError || lngParseError) ? (

--- a/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
+++ b/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
@@ -1,0 +1,488 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { AdminInlineError } from '@/components/ui/admin-inline-error';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+import { toErrorMessage } from '@/hooks/hook-errors';
+import { AdminApiError } from '@/lib/api-admin-client';
+import { formatCrmVenueLocationLabel, formatEnumLabel, formatLocationCoordinatesLabel } from '@/lib/format';
+import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
+import type { components } from '@/types/generated/admin-api.generated';
+
+import { computeLatLngErrors, parseOptionalCoordinate } from '@/components/admin/locations/inline-location-validation';
+
+type ApiSchemas = components['schemas'];
+
+export interface InlineLocationEmbeddedSummary {
+  id: string;
+  name: string | null;
+  address: string | null;
+  areaName: string;
+  areaId?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+}
+
+export interface InlineLocationEditorProps {
+  /** Changes when the owning editor switches row or create vs edit — resets draft state. */
+  stateKey: string;
+  location: LocationSummary | null;
+  embeddedSummary?: InlineLocationEmbeddedSummary | null;
+  areas: GeographicAreaSummary[];
+  areasLoading: boolean;
+  canModify: boolean;
+  isSaving: boolean;
+  /** When false and the block is read-only (e.g. contact linked to family/org), show this note under the summary. */
+  readOnlyNote?: string | null;
+  onRequestEdit(): void;
+  onCancelEdit(): void;
+  onSaveCreate(payload: ApiSchemas['CreateLocationRequest']): Promise<string | null>;
+  onSaveUpdate(
+    id: string,
+    payload: ApiSchemas['UpdateLocationRequest'] | ApiSchemas['PartialUpdateLocationRequest']
+  ): Promise<void>;
+  onClear(): void;
+  onGeocode(args: { area_id: string; address: string }): Promise<{ lat: number; lng: number }>;
+  /** When true, geocode / save-location runs are in flight (disables actions). */
+  isGeocoding?: boolean;
+  /** Hook-level error (e.g. create/update location failed). */
+  saveError?: string;
+}
+
+function resolveDisplaySummary(
+  location: LocationSummary | null,
+  embedded: InlineLocationEmbeddedSummary | null | undefined,
+  areaNameForLocation: string
+): { line1: string; line2: string; labels: string[] } | null {
+  if (location) {
+    const line1 = formatCrmVenueLocationLabel({
+      id: location.id,
+      name: location.name,
+      address: location.address,
+      areaName: areaNameForLocation,
+    });
+    const line2 = formatLocationCoordinatesLabel(location.lat, location.lng);
+    return { line1, line2, labels: location.partnerOrganizationLabels };
+  }
+  if (embedded) {
+    const line1 = formatCrmVenueLocationLabel({
+      id: embedded.id,
+      name: embedded.name,
+      address: embedded.address,
+      areaName: embedded.areaName,
+    });
+    const line2 = formatLocationCoordinatesLabel(embedded.lat ?? null, embedded.lng ?? null);
+    return { line1, line2, labels: [] };
+  }
+  return null;
+}
+
+function seedDraftFromLocation(loc: LocationSummary) {
+  return {
+    areaId: loc.areaId,
+    address: loc.address ?? '',
+    lat: loc.lat !== null ? String(loc.lat) : '',
+    lng: loc.lng !== null ? String(loc.lng) : '',
+  };
+}
+
+function seedDraftFromEmbedded(emb: InlineLocationEmbeddedSummary) {
+  return {
+    areaId: emb.areaId ?? '',
+    address: emb.address ?? '',
+    lat: emb.lat != null ? String(emb.lat) : '',
+    lng: emb.lng != null ? String(emb.lng) : '',
+  };
+}
+
+function deriveInitialDraft(
+  canModify: boolean,
+  location: LocationSummary | null,
+  embeddedSummary: InlineLocationEmbeddedSummary | null | undefined
+): { isEditing: boolean; areaId: string; address: string; lat: string; lng: string } {
+  if (!canModify) {
+    return { isEditing: false, areaId: '', address: '', lat: '', lng: '' };
+  }
+  if (location) {
+    const s = seedDraftFromLocation(location);
+    return { isEditing: false, ...s };
+  }
+  if (embeddedSummary) {
+    const s = seedDraftFromEmbedded(embeddedSummary);
+    return { isEditing: false, ...s };
+  }
+  return { isEditing: true, areaId: '', address: '', lat: '', lng: '' };
+}
+
+type InnerProps = Omit<InlineLocationEditorProps, 'stateKey'>;
+
+function InlineLocationEditorInner({
+  location,
+  embeddedSummary,
+  areas,
+  areasLoading,
+  canModify,
+  isSaving,
+  readOnlyNote,
+  onRequestEdit,
+  onCancelEdit,
+  onSaveCreate,
+  onSaveUpdate,
+  onClear,
+  onGeocode,
+  isGeocoding = false,
+  saveError = '',
+}: InnerProps) {
+  const initial = deriveInitialDraft(canModify, location, embeddedSummary);
+  const [isEditing, setIsEditing] = useState(initial.isEditing);
+  const [areaId, setAreaIdState] = useState(initial.areaId);
+  const [address, setAddressState] = useState(initial.address);
+  const [lat, setLatState] = useState(initial.lat);
+  const [lng, setLngState] = useState(initial.lng);
+  const [geocodeError, setGeocodeError] = useState('');
+
+  const setAreaId = (v: string) => {
+    setGeocodeError('');
+    setAreaIdState(v);
+  };
+  const setAddress = (v: string) => {
+    setGeocodeError('');
+    setAddressState(v);
+  };
+  const setLat = (v: string) => {
+    setGeocodeError('');
+    setLatState(v);
+  };
+  const setLng = (v: string) => {
+    setGeocodeError('');
+    setLngState(v);
+  };
+
+  const areaOptions = useMemo(() => {
+    return [...areas].sort((a, b) => {
+      if (a.displayOrder !== b.displayOrder) {
+        return a.displayOrder - b.displayOrder;
+      }
+      return a.name.localeCompare(b.name);
+    });
+  }, [areas]);
+
+  const areaById = useMemo(() => new Map(areas.map((a) => [a.id, a])), [areas]);
+
+  const areaNameForLocation = location ? areaById.get(location.areaId)?.name ?? '' : '';
+
+  const lockedFromPartner = Boolean(location?.lockedFromPartnerOrg);
+  const effectiveReadOnly = !canModify || lockedFromPartner;
+
+  const {
+    latParseError,
+    lngParseError,
+    latRangeError,
+    lngRangeError,
+    coordinatesInvalid,
+    onlyOneCoordinate,
+  } = computeLatLngErrors(lat, lng);
+
+  const latTrim = lat.trim();
+  const lngTrim = lng.trim();
+
+  const areasReady = !areasLoading && areaOptions.length > 0;
+  const canSubmitLocation =
+    areasReady &&
+    Boolean(areaId) &&
+    !coordinatesInvalid &&
+    !onlyOneCoordinate &&
+    !effectiveReadOnly;
+
+  const displaySummary = resolveDisplaySummary(location, embeddedSummary, areaNameForLocation);
+
+  function handleRequestEdit() {
+    if (effectiveReadOnly) {
+      return;
+    }
+    if (location) {
+      const s = seedDraftFromLocation(location);
+      setAreaIdState(s.areaId);
+      setAddressState(s.address);
+      setLatState(s.lat);
+      setLngState(s.lng);
+    } else if (embeddedSummary) {
+      const s = seedDraftFromEmbedded(embeddedSummary);
+      setAreaIdState(s.areaId);
+      setAddressState(s.address);
+      setLatState(s.lat);
+      setLngState(s.lng);
+    }
+    setGeocodeError('');
+    setIsEditing(true);
+    onRequestEdit();
+  }
+
+  function handleCancelEdit() {
+    if (!location && !embeddedSummary) {
+      setAreaIdState('');
+      setAddressState('');
+      setLatState('');
+      setLngState('');
+      setGeocodeError('');
+      setIsEditing(true);
+      onCancelEdit();
+      return;
+    }
+    if (location) {
+      const s = seedDraftFromLocation(location);
+      setAreaIdState(s.areaId);
+      setAddressState(s.address);
+      setLatState(s.lat);
+      setLngState(s.lng);
+    } else if (embeddedSummary) {
+      const s = seedDraftFromEmbedded(embeddedSummary);
+      setAreaIdState(s.areaId);
+      setAddressState(s.address);
+      setLatState(s.lat);
+      setLngState(s.lng);
+    }
+    setGeocodeError('');
+    setIsEditing(false);
+    onCancelEdit();
+  }
+
+  async function handleFillCoordinates() {
+    const trimmedAddress = address.trim();
+    if (!areaId || !trimmedAddress || !areasReady || isGeocoding || isSaving) {
+      return;
+    }
+    setGeocodeError('');
+    try {
+      const result = await onGeocode({ area_id: areaId, address: trimmedAddress });
+      setLatState(String(result.lat));
+      setLngState(String(result.lng));
+    } catch (error) {
+      const fallback =
+        error instanceof AdminApiError && error.statusCode === 404
+          ? 'Geocoding is not available in this environment yet.'
+          : 'Geocoding failed. Check the address and geographic area, then try again.';
+      setGeocodeError(toErrorMessage(error, fallback));
+    }
+  }
+
+  async function handleSaveLocation() {
+    if (!canSubmitLocation || !areaId) {
+      return;
+    }
+    const latParsed = parseOptionalCoordinate(lat);
+    const lngParsed = parseOptionalCoordinate(lng);
+    const latValue: number | null = latTrim === '' ? null : (latParsed as number);
+    const lngValue: number | null = lngTrim === '' ? null : (lngParsed as number);
+    const payload: ApiSchemas['CreateLocationRequest'] = {
+      area_id: areaId,
+      name: null,
+      address: address.trim() || null,
+      lat: latValue,
+      lng: lngValue,
+    };
+    if (!location) {
+      const id = await onSaveCreate(payload);
+      if (id) {
+        setIsEditing(false);
+      }
+      return;
+    }
+    if (lockedFromPartner) {
+      return;
+    }
+    try {
+      await onSaveUpdate(location.id, payload);
+      setIsEditing(false);
+    } catch {
+      // Parent surfaces error; keep edit mode.
+    }
+  }
+
+  const showReadBlock = Boolean(displaySummary) && !isEditing;
+  const showEditForm = canModify && !effectiveReadOnly && (isEditing || (!location && !embeddedSummary));
+
+  if (!canModify && displaySummary) {
+    return (
+      <div className='space-y-2'>
+        <Label>Location</Label>
+        <div className='rounded-md border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-800'>
+          <div>{displaySummary.line1}</div>
+          <div className='mt-1 text-slate-600'>{displaySummary.line2}</div>
+        </div>
+        {lockedFromPartner ? (
+          <p className='text-sm text-slate-600'>
+            Managed from the partner organisation
+            {location && location.partnerOrganizationLabels.length > 0
+              ? ` (${location.partnerOrganizationLabels.join(', ')})`
+              : ''}
+            .
+          </p>
+        ) : null}
+        {readOnlyNote ? <p className='text-sm text-slate-600'>{readOnlyNote}</p> : null}
+      </div>
+    );
+  }
+
+  if (!canModify && !displaySummary) {
+    return (
+      <div className='space-y-2'>
+        <Label>Location</Label>
+        <p className='text-sm text-slate-600'>—</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-3'>
+      <div>
+        <Label>Location</Label>
+        {showReadBlock && displaySummary ? (
+          <div className='mt-2 space-y-2'>
+            <div className='rounded-md border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-800'>
+              <div>{displaySummary.line1}</div>
+              <div className='mt-1 text-slate-600'>{displaySummary.line2}</div>
+            </div>
+            {lockedFromPartner ? (
+              <p className='text-sm text-slate-600'>
+                Managed from the partner organisation
+                {location && location.partnerOrganizationLabels.length > 0
+                  ? ` (${location.partnerOrganizationLabels.join(', ')})`
+                  : ''}
+                .
+              </p>
+            ) : null}
+            {canModify && !lockedFromPartner ? (
+              <div className='flex flex-wrap gap-2'>
+                <Button type='button' size='sm' variant='secondary' disabled={isSaving} onClick={handleRequestEdit}>
+                  Change
+                </Button>
+                <Button
+                  type='button'
+                  size='sm'
+                  variant='danger'
+                  disabled={isSaving}
+                  onClick={() => {
+                    onClear();
+                    setIsEditing(true);
+                    setAreaIdState('');
+                    setAddressState('');
+                    setLatState('');
+                    setLngState('');
+                    setGeocodeError('');
+                  }}
+                >
+                  Clear
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {showEditForm ? (
+          <div className='mt-2 space-y-3'>
+            <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+              <div className='sm:col-span-2'>
+                <Label htmlFor='inline-loc-area'>Geographic area</Label>
+                <Select
+                  id='inline-loc-area'
+                  value={areaId}
+                  onChange={(e) => setAreaId(e.target.value)}
+                  disabled={areasLoading || isSaving}
+                >
+                  <option value=''>{areasLoading ? 'Loading areas…' : 'Select an area'}</option>
+                  {areaOptions.map((area) => (
+                    <option key={area.id} value={area.id}>
+                      {area.name} ({formatEnumLabel(area.level)})
+                    </option>
+                  ))}
+                </Select>
+              </div>
+              <div className='sm:col-span-2'>
+                <Label htmlFor='inline-loc-address'>Address</Label>
+                <Input
+                  id='inline-loc-address'
+                  value={address}
+                  onChange={(e) => setAddress(e.target.value)}
+                  disabled={isSaving}
+                />
+              </div>
+              <div>
+                <Label htmlFor='inline-loc-lat'>Latitude</Label>
+                <Input
+                  id='inline-loc-lat'
+                  value={lat}
+                  onChange={(e) => setLat(e.target.value)}
+                  disabled={isSaving}
+                  inputMode='decimal'
+                />
+              </div>
+              <div>
+                <Label htmlFor='inline-loc-lng'>Longitude</Label>
+                <Input
+                  id='inline-loc-lng'
+                  value={lng}
+                  onChange={(e) => setLng(e.target.value)}
+                  disabled={isSaving}
+                  inputMode='decimal'
+                />
+              </div>
+            </div>
+            <p className='text-sm text-slate-600'>Editing updates this location wherever it is used.</p>
+            {saveError ? <AdminInlineError>{saveError}</AdminInlineError> : null}
+            {geocodeError ? <AdminInlineError>{geocodeError}</AdminInlineError> : null}
+            {(latParseError || lngParseError) ? (
+              <AdminInlineError>Latitude and longitude must be valid numbers.</AdminInlineError>
+            ) : null}
+            {onlyOneCoordinate ? (
+              <AdminInlineError>Provide both latitude and longitude, or leave both empty.</AdminInlineError>
+            ) : null}
+            {(latRangeError || lngRangeError) ? (
+              <AdminInlineError>
+                Latitude must be between -90 and 90; longitude between -180 and 180.
+              </AdminInlineError>
+            ) : null}
+            <div className='flex flex-wrap items-center gap-2'>
+              <Button
+                type='button'
+                size='sm'
+                variant='secondary'
+                disabled={
+                  isSaving ||
+                  isGeocoding ||
+                  !areasReady ||
+                  !areaId ||
+                  !address.trim()
+                }
+                onClick={() => void handleFillCoordinates()}
+              >
+                {isGeocoding ? 'Looking up…' : 'Fill coordinates from address'}
+              </Button>
+              {location || embeddedSummary ? (
+                <Button type='button' size='sm' variant='secondary' disabled={isSaving} onClick={handleCancelEdit}>
+                  Cancel
+                </Button>
+              ) : null}
+              <Button
+                type='button'
+                size='sm'
+                disabled={isSaving || isGeocoding || !canSubmitLocation}
+                onClick={() => void handleSaveLocation()}
+              >
+                {location ? 'Update location' : 'Save location'}
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function InlineLocationEditor({ stateKey, ...rest }: InlineLocationEditorProps) {
+  return <InlineLocationEditorInner key={stateKey} {...rest} />;
+}

--- a/apps/admin_web/src/components/admin/locations/inline-location-validation.ts
+++ b/apps/admin_web/src/components/admin/locations/inline-location-validation.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared coordinate parsing and validation for venue/location inline editors.
+ * Semantics match the legacy VenuesPanel implementation.
+ */
+export function parseOptionalCoordinate(raw: string): number | null | typeof NaN {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+export interface LatLngFieldErrors {
+  latParseError: boolean;
+  lngParseError: boolean;
+  latRangeError: boolean;
+  lngRangeError: boolean;
+  coordinatesInvalid: boolean;
+  onlyOneCoordinate: boolean;
+}
+
+export function computeLatLngErrors(latRaw: string, lngRaw: string): LatLngFieldErrors {
+  const latTrim = latRaw.trim();
+  const lngTrim = lngRaw.trim();
+  const latNum = parseOptionalCoordinate(latRaw);
+  const lngNum = parseOptionalCoordinate(lngRaw);
+  const latParseError = latTrim !== '' && Number.isNaN(latNum);
+  const lngParseError = lngTrim !== '' && Number.isNaN(lngNum);
+  const latRangeError =
+    latTrim !== '' && !latParseError && latNum !== null && (latNum < -90 || latNum > 90);
+  const lngRangeError =
+    lngTrim !== '' && !lngParseError && lngNum !== null && (lngNum < -180 || lngNum > 180);
+  const coordinatesInvalid = latParseError || lngParseError || latRangeError || lngRangeError;
+  const onlyOneCoordinate =
+    (latTrim !== '') !== (lngTrim !== '') && !latParseError && !lngParseError;
+  return {
+    latParseError,
+    lngParseError,
+    latRangeError,
+    lngRangeError,
+    coordinatesInvalid,
+    onlyOneCoordinate,
+  };
+}

--- a/apps/admin_web/src/components/admin/services/venues-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/venues-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
@@ -13,10 +13,12 @@ import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { toErrorMessage } from '@/hooks/hook-errors';
 import { formatEnumLabel, formatLocationLabel } from '@/lib/format';
 import { AdminApiError } from '@/lib/api-admin-client';
-import { geocodeVenueAddress } from '@/lib/services-api';
+
+import { computeLatLngErrors, parseOptionalCoordinate } from '@/components/admin/locations/inline-location-validation';
 
 import type { components } from '@/types/generated/admin-api.generated';
 import type { GeographicAreaSummary, LocationSummary, VenueFilters } from '@/types/services';
@@ -44,15 +46,6 @@ export interface VenuesPanelProps {
   onDelete: (venueId: string) => Promise<void> | void;
 }
 
-function parseOptionalCoordinate(raw: string): number | null {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const n = Number(trimmed);
-  return Number.isFinite(n) ? n : NaN;
-}
-
 export function VenuesPanel({
   venues,
   geographicAreas,
@@ -70,16 +63,34 @@ export function VenuesPanel({
   onUpdatePartial,
   onDelete,
 }: VenuesPanelProps) {
+  const { geocode: geocodeLocation, status: inlineLocStatus } = useInlineLocationSave(async () => {});
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
   const [selectedVenueId, setSelectedVenueId] = useState<string | null>(null);
   const [name, setName] = useState('');
-  const [areaId, setAreaId] = useState('');
-  const [address, setAddress] = useState('');
-  const [lat, setLat] = useState('');
-  const [lng, setLng] = useState('');
+  const [areaId, setAreaIdState] = useState('');
+  const [address, setAddressState] = useState('');
+  const [lat, setLatState] = useState('');
+  const [lng, setLngState] = useState('');
   const [geocodeError, setGeocodeError] = useState('');
-  const [isGeocoding, setIsGeocoding] = useState(false);
+  const isGeocoding = inlineLocStatus.isGeocoding;
+
+  const setAreaId = (v: string) => {
+    setGeocodeError('');
+    setAreaIdState(v);
+  };
+  const setAddress = (v: string) => {
+    setGeocodeError('');
+    setAddressState(v);
+  };
+  const setLat = (v: string) => {
+    setGeocodeError('');
+    setLatState(v);
+  };
+  const setLng = (v: string) => {
+    setGeocodeError('');
+    setLngState(v);
+  };
 
   const areaOptions = useMemo(() => {
     return [...geographicAreas].sort((a, b) => {
@@ -103,33 +114,28 @@ export function VenuesPanel({
   const lngTrim = lng.trim();
   const latNum = parseOptionalCoordinate(lat);
   const lngNum = parseOptionalCoordinate(lng);
-  const latParseError = latTrim !== '' && Number.isNaN(latNum);
-  const lngParseError = lngTrim !== '' && Number.isNaN(lngNum);
-  const latRangeError =
-    latTrim !== '' && !latParseError && latNum !== null && (latNum < -90 || latNum > 90);
-  const lngRangeError =
-    lngTrim !== '' && !lngParseError && lngNum !== null && (lngNum < -180 || lngNum > 180);
-  const coordinatesInvalid = latParseError || lngParseError || latRangeError || lngRangeError;
-  const onlyOneCoordinate =
-    (latTrim !== '') !== (lngTrim !== '') && !latParseError && !lngParseError;
+  const {
+    latParseError,
+    lngParseError,
+    latRangeError,
+    lngRangeError,
+    coordinatesInvalid,
+    onlyOneCoordinate,
+  } = computeLatLngErrors(lat, lng);
   const canSubmit =
     areasReady &&
     Boolean(areaId) &&
     !coordinatesInvalid &&
     !onlyOneCoordinate;
 
-  useEffect(() => {
-    setGeocodeError('');
-  }, [address, areaId, selectedVenueId]);
-
   const resetCreateForm = () => {
     setEditorMode('create');
     setSelectedVenueId(null);
     setName('');
-    setAreaId('');
-    setAddress('');
-    setLat('');
-    setLng('');
+    setAreaIdState('');
+    setAddressState('');
+    setLatState('');
+    setLngState('');
     setGeocodeError('');
   };
 
@@ -139,9 +145,8 @@ export function VenuesPanel({
       return;
     }
     setGeocodeError('');
-    setIsGeocoding(true);
     try {
-      const result = await geocodeVenueAddress({
+      const result = await geocodeLocation({
         area_id: areaId,
         address: trimmedAddress,
       });
@@ -153,8 +158,6 @@ export function VenuesPanel({
           ? 'Geocoding is not available in this environment yet.'
           : 'Geocoding failed. Check the address and geographic area, then try again.';
       setGeocodeError(toErrorMessage(error, fallback));
-    } finally {
-      setIsGeocoding(false);
     }
   };
 

--- a/apps/admin_web/src/components/admin/services/venues-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/venues-panel.tsx
@@ -13,11 +13,9 @@ import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
-import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
-import { toErrorMessage } from '@/hooks/hook-errors';
+import { useGeocodeVenueAddress } from '@/hooks/use-geocode-venue-address';
+import { formatGeocodeErrorMessage } from '@/hooks/hook-errors';
 import { formatEnumLabel, formatLocationLabel } from '@/lib/format';
-import { AdminApiError } from '@/lib/api-admin-client';
-
 import { computeLatLngErrors, parseOptionalCoordinate } from '@/components/admin/locations/inline-location-validation';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -63,7 +61,7 @@ export function VenuesPanel({
   onUpdatePartial,
   onDelete,
 }: VenuesPanelProps) {
-  const { geocode: geocodeLocation, status: inlineLocStatus } = useInlineLocationSave(async () => {});
+  const { geocode: geocodeLocation, isGeocoding } = useGeocodeVenueAddress();
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
   const [selectedVenueId, setSelectedVenueId] = useState<string | null>(null);
@@ -73,8 +71,6 @@ export function VenuesPanel({
   const [lat, setLatState] = useState('');
   const [lng, setLngState] = useState('');
   const [geocodeError, setGeocodeError] = useState('');
-  const isGeocoding = inlineLocStatus.isGeocoding;
-
   const setAreaId = (v: string) => {
     setGeocodeError('');
     setAreaIdState(v);
@@ -153,11 +149,12 @@ export function VenuesPanel({
       setLat(String(result.lat));
       setLng(String(result.lng));
     } catch (error) {
-      const fallback =
-        error instanceof AdminApiError && error.statusCode === 404
-          ? 'Geocoding is not available in this environment yet.'
-          : 'Geocoding failed. Check the address and geographic area, then try again.';
-      setGeocodeError(toErrorMessage(error, fallback));
+      setGeocodeError(
+        formatGeocodeErrorMessage(
+          error,
+          'Geocoding failed. Check the address and geographic area, then try again.'
+        )
+      );
     }
   };
 

--- a/apps/admin_web/src/hooks/hook-errors.ts
+++ b/apps/admin_web/src/hooks/hook-errors.ts
@@ -1,5 +1,16 @@
 import { AdminApiError } from '@/lib/api-admin-client';
 
+/**
+ * User-facing geocode errors: keep 404 copy specific to geocoding (not the generic
+ * deployment message from {@link toErrorMessage}).
+ */
+export function formatGeocodeErrorMessage(error: unknown, fallbackNon404: string): string {
+  if (error instanceof AdminApiError && error.statusCode === 404) {
+    return 'Geocoding is not available in this environment yet.';
+  }
+  return toErrorMessage(error, fallbackNon404);
+}
+
 export function toErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof AdminApiError) {
     if (error.statusCode === 404) {

--- a/apps/admin_web/src/hooks/use-geocode-venue-address.ts
+++ b/apps/admin_web/src/hooks/use-geocode-venue-address.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { geocodeVenueAddress } from '@/lib/services-api';
+
+/**
+ * Geocode-only helper for forms that do not need create/update location state
+ * (for example VenuesPanel).
+ */
+export function useGeocodeVenueAddress() {
+  const [isGeocoding, setIsGeocoding] = useState(false);
+
+  const geocode = useCallback(
+    async (args: { area_id: string; address: string }): Promise<{ lat: number; lng: number }> => {
+      setIsGeocoding(true);
+      try {
+        const result = await geocodeVenueAddress(args);
+        return { lat: result.lat, lng: result.lng };
+      } finally {
+        setIsGeocoding(false);
+      }
+    },
+    []
+  );
+
+  return { geocode, isGeocoding };
+}

--- a/apps/admin_web/src/hooks/use-inline-location-save.ts
+++ b/apps/admin_web/src/hooks/use-inline-location-save.ts
@@ -3,11 +3,8 @@
 import { useCallback, useState } from 'react';
 
 import { toErrorMessage } from '@/hooks/hook-errors';
-import { AdminApiError } from '@/lib/api-admin-client';
 import {
   createLocation,
-  geocodeVenueAddress,
-  updateLocation,
   updateLocationPartial,
 } from '@/lib/services-api';
 import type { LocationSummary } from '@/types/services';
@@ -17,13 +14,15 @@ type ApiSchemas = components['schemas'];
 
 export interface InlineLocationSaveStatus {
   isSaving: boolean;
-  isGeocoding: boolean;
   error: string;
 }
 
+/**
+ * Create and partially update shared locations for CRM inline editors.
+ * Updates always use PATCH so omitted fields (for example `name`) are not wiped.
+ */
 export function useInlineLocationSave(refreshLocations: () => Promise<void> | void) {
   const [isSaving, setIsSaving] = useState(false);
-  const [isGeocoding, setIsGeocoding] = useState(false);
   const [error, setError] = useState('');
 
   const createSharedLocation = useCallback(
@@ -45,19 +44,11 @@ export function useInlineLocationSave(refreshLocations: () => Promise<void> | vo
   );
 
   const updateSharedLocation = useCallback(
-    async (
-      id: string,
-      payload: ApiSchemas['UpdateLocationRequest'] | ApiSchemas['PartialUpdateLocationRequest'],
-      options?: { partial?: boolean }
-    ): Promise<void> => {
+    async (id: string, payload: ApiSchemas['PartialUpdateLocationRequest']): Promise<void> => {
       setError('');
       setIsSaving(true);
       try {
-        if (options?.partial) {
-          await updateLocationPartial(id, payload as ApiSchemas['PartialUpdateLocationRequest']);
-        } else {
-          await updateLocation(id, payload as ApiSchemas['UpdateLocationRequest']);
-        }
+        await updateLocationPartial(id, payload);
         await refreshLocations();
       } catch (err) {
         setError(toErrorMessage(err, 'Failed to update location.'));
@@ -69,26 +60,12 @@ export function useInlineLocationSave(refreshLocations: () => Promise<void> | vo
     [refreshLocations]
   );
 
-  const geocode = useCallback(
-    async (args: { area_id: string; address: string }): Promise<{ lat: number; lng: number }> => {
-      setIsGeocoding(true);
-      try {
-        const result = await geocodeVenueAddress(args);
-        return { lat: result.lat, lng: result.lng };
-      } finally {
-        setIsGeocoding(false);
-      }
-    },
-    []
-  );
-
   const clearError = useCallback(() => {
     setError('');
   }, []);
 
   const status: InlineLocationSaveStatus = {
     isSaving,
-    isGeocoding,
     error,
   };
 
@@ -96,11 +73,6 @@ export function useInlineLocationSave(refreshLocations: () => Promise<void> | vo
     status,
     createSharedLocation,
     updateSharedLocation,
-    geocode,
     clearError,
-    /** Classify geocode failures for inline copy (404 → environment message). */
-    isGeocodeNotAvailableError(err: unknown): boolean {
-      return err instanceof AdminApiError && err.statusCode === 404;
-    },
   };
 }

--- a/apps/admin_web/src/hooks/use-inline-location-save.ts
+++ b/apps/admin_web/src/hooks/use-inline-location-save.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { toErrorMessage } from '@/hooks/hook-errors';
+import { AdminApiError } from '@/lib/api-admin-client';
+import {
+  createLocation,
+  geocodeVenueAddress,
+  updateLocation,
+  updateLocationPartial,
+} from '@/lib/services-api';
+import type { LocationSummary } from '@/types/services';
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+
+export interface InlineLocationSaveStatus {
+  isSaving: boolean;
+  isGeocoding: boolean;
+  error: string;
+}
+
+export function useInlineLocationSave(refreshLocations: () => Promise<void> | void) {
+  const [isSaving, setIsSaving] = useState(false);
+  const [isGeocoding, setIsGeocoding] = useState(false);
+  const [error, setError] = useState('');
+
+  const createSharedLocation = useCallback(
+    async (payload: ApiSchemas['CreateLocationRequest']): Promise<LocationSummary | null> => {
+      setError('');
+      setIsSaving(true);
+      try {
+        const loc = await createLocation(payload);
+        await refreshLocations();
+        return loc;
+      } catch (err) {
+        setError(toErrorMessage(err, 'Failed to save location.'));
+        return null;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [refreshLocations]
+  );
+
+  const updateSharedLocation = useCallback(
+    async (
+      id: string,
+      payload: ApiSchemas['UpdateLocationRequest'] | ApiSchemas['PartialUpdateLocationRequest'],
+      options?: { partial?: boolean }
+    ): Promise<void> => {
+      setError('');
+      setIsSaving(true);
+      try {
+        if (options?.partial) {
+          await updateLocationPartial(id, payload as ApiSchemas['PartialUpdateLocationRequest']);
+        } else {
+          await updateLocation(id, payload as ApiSchemas['UpdateLocationRequest']);
+        }
+        await refreshLocations();
+      } catch (err) {
+        setError(toErrorMessage(err, 'Failed to update location.'));
+        throw err;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [refreshLocations]
+  );
+
+  const geocode = useCallback(
+    async (args: { area_id: string; address: string }): Promise<{ lat: number; lng: number }> => {
+      setIsGeocoding(true);
+      try {
+        const result = await geocodeVenueAddress(args);
+        return { lat: result.lat, lng: result.lng };
+      } finally {
+        setIsGeocoding(false);
+      }
+    },
+    []
+  );
+
+  const clearError = useCallback(() => {
+    setError('');
+  }, []);
+
+  const status: InlineLocationSaveStatus = {
+    isSaving,
+    isGeocoding,
+    error,
+  };
+
+  return {
+    status,
+    createSharedLocation,
+    updateSharedLocation,
+    geocode,
+    clearError,
+    /** Classify geocode failures for inline copy (404 → environment message). */
+    isGeocodeNotAvailableError(err: unknown): boolean {
+      return err instanceof AdminApiError && err.statusCode === 404;
+    },
+  };
+}

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -42,10 +42,12 @@ export function formatCrmVenueLocationLabel(location: {
   return location.id;
 }
 
+const COORD_DISPLAY_FRACTION_DIGITS = 5;
+
 /** Single-line coordinates display for admin location summaries. */
 export function formatLocationCoordinatesLabel(lat: number | null, lng: number | null): string {
   if (lat !== null && lng !== null) {
-    return `${lat}, ${lng}`;
+    return `${lat.toFixed(COORD_DISPLAY_FRACTION_DIGITS)}, ${lng.toFixed(COORD_DISPLAY_FRACTION_DIGITS)}`;
   }
   return 'No coordinates set';
 }

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -42,6 +42,14 @@ export function formatCrmVenueLocationLabel(location: {
   return location.id;
 }
 
+/** Single-line coordinates display for admin location summaries. */
+export function formatLocationCoordinatesLabel(lat: number | null, lng: number | null): string {
+  if (lat !== null && lng !== null) {
+    return `${lat}, ${lng}`;
+  }
+  return 'No coordinates set';
+}
+
 export function toTitleCase(value: string): string {
   return value
     .split('_')

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -1,6 +1,20 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+
+const { createLocation, geocodeVenueAddress } = vi.hoisted(() => ({
+  createLocation: vi.fn(),
+  geocodeVenueAddress: vi.fn(),
+}));
+
+vi.mock('@/lib/services-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/services-api')>('@/lib/services-api');
+  return {
+    ...actual,
+    createLocation,
+    geocodeVenueAddress,
+  };
+});
 
 import { ContactsPanel } from '@/components/admin/contacts/contacts-panel';
 
@@ -29,6 +43,8 @@ vi.mock('@/lib/crm-api', async (importOriginal) => {
   };
 });
 
+const noopRefresh = vi.fn().mockResolvedValue(undefined);
+
 function buildContactsHook(
   overrides: Partial<ReturnType<typeof useAdminCrmContacts>> = {}
 ): ReturnType<typeof useAdminCrmContacts> {
@@ -52,6 +68,17 @@ function buildContactsHook(
   };
 }
 
+const hkArea = {
+  id: 'area-hk',
+  parentId: null,
+  name: 'Hong Kong',
+  level: 'country' as const,
+  code: 'HK',
+  sovereignCountryId: null,
+  active: true,
+  displayOrder: 0,
+};
+
 describe('ContactsPanel', () => {
   it('submits create with relationship types that exclude vendor', async () => {
     const user = userEvent.setup();
@@ -66,6 +93,8 @@ describe('ContactsPanel', () => {
         tags={[]}
         locations={[]}
         geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
       />
     );
 
@@ -94,6 +123,8 @@ describe('ContactsPanel', () => {
         tags={[]}
         locations={[]}
         geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
       />
     );
 
@@ -138,6 +169,8 @@ describe('ContactsPanel', () => {
         tags={[]}
         locations={[]}
         geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
       />
     );
 
@@ -157,9 +190,130 @@ describe('ContactsPanel', () => {
         tags={[]}
         locations={[]}
         geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
       />
     );
 
     expect(screen.getByText('Failed to load contacts')).toBeInTheDocument();
+  });
+
+  it('shows read-only location summary when contact is linked to family', async () => {
+    const user = userEvent.setup();
+    const row: components['schemas']['AdminContact'] = {
+      id: '11111111-1111-1111-1111-111111111111',
+      first_name: 'Ann',
+      last_name: 'Lee',
+      email: null,
+      instagram_handle: null,
+      phone: null,
+      contact_type: 'parent',
+      relationship_type: 'prospect',
+      source: 'manual',
+      mailchimp_status: 'pending',
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+      tag_ids: [],
+      tags: [],
+      family_ids: ['fam-1'],
+      organization_ids: [],
+      location_id: 'loc-1',
+      location_summary: {
+        id: 'loc-1',
+        name: 'Studio',
+        area_id: 'area-hk',
+        area_name: 'Hong Kong',
+        address: '1 Road',
+        lat: 22.1,
+        lng: 114.2,
+      },
+      standalone_note_count: 0,
+    };
+    const contacts = buildContactsHook({ contacts: [row] });
+
+    render(
+      <ContactsPanel
+        contacts={contacts}
+        adminUsers={[]}
+        onPatchStandaloneNoteCount={vi.fn()}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[hkArea]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+      />
+    );
+
+    await user.click(screen.getByText('Ann Lee'));
+
+    expect(screen.getByText('1 Road · Hong Kong')).toBeInTheDocument();
+    expect(screen.getByText('22.1, 114.2')).toBeInTheDocument();
+    expect(
+      screen.getByText('Location is managed on the linked family or organisation.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Change' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+  });
+
+  it('includes location_id on create after inline Save location', async () => {
+    const user = userEvent.setup();
+    const createContact = vi.fn().mockResolvedValue(null);
+    const contacts = buildContactsHook({ createContact });
+
+    createLocation.mockResolvedValue({
+      id: 'loc-new',
+      name: null,
+      areaId: 'area-hk',
+      address: '1 Test Road',
+      lat: 22.3193,
+      lng: 114.1694,
+      createdAt: null,
+      updatedAt: null,
+      lockedFromPartnerOrg: false,
+      partnerOrganizationLabels: [],
+    });
+    geocodeVenueAddress.mockResolvedValue({
+      lat: 22.3193,
+      lng: 114.1694,
+      displayName: null,
+    });
+
+    render(
+      <ContactsPanel
+        contacts={contacts}
+        adminUsers={[]}
+        onPatchStandaloneNoteCount={vi.fn()}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[hkArea]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+      />
+    );
+
+    await user.type(screen.getByLabelText('First name'), 'Jane');
+    await user.selectOptions(screen.getByLabelText('Geographic area'), 'area-hk');
+    await user.type(screen.getByLabelText('Address'), '1 Test Road');
+    await user.click(screen.getByRole('button', { name: 'Fill coordinates from address' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Latitude')).toHaveValue('22.3193');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Save location' }));
+
+    await waitFor(() => {
+      expect(createLocation).toHaveBeenCalled();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Create contact' }));
+
+    expect(createContact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        first_name: 'Jane',
+        location_id: 'loc-new',
+      })
+    );
   });
 });

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -2,9 +2,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-const { createLocation, geocodeVenueAddress } = vi.hoisted(() => ({
+const { createLocation, geocodeVenueAddress, updateLocationPartial } = vi.hoisted(() => ({
   createLocation: vi.fn(),
   geocodeVenueAddress: vi.fn(),
+  updateLocationPartial: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/lib/services-api', async () => {
@@ -13,6 +14,7 @@ vi.mock('@/lib/services-api', async () => {
     ...actual,
     createLocation,
     geocodeVenueAddress,
+    updateLocationPartial,
   };
 });
 
@@ -179,7 +181,7 @@ describe('ContactsPanel', () => {
     expect(deleteContact).toHaveBeenCalledWith(row.id);
   });
 
-  it('shows list error from the hook in the table card', () => {
+  it('shows list error from the hook in the table card', async () => {
     const contacts = buildContactsHook({ error: 'Failed to load contacts' });
 
     render(
@@ -195,7 +197,9 @@ describe('ContactsPanel', () => {
       />
     );
 
-    expect(screen.getByText('Failed to load contacts')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load contacts')).toBeInTheDocument();
+    });
   });
 
   it('shows read-only location summary when contact is linked to family', async () => {
@@ -248,7 +252,7 @@ describe('ContactsPanel', () => {
     await user.click(screen.getByText('Ann Lee'));
 
     expect(screen.getByText('1 Road · Hong Kong')).toBeInTheDocument();
-    expect(screen.getByText('22.1, 114.2')).toBeInTheDocument();
+    expect(screen.getByText('22.10000, 114.20000')).toBeInTheDocument();
     expect(
       screen.getByText('Location is managed on the linked family or organisation.')
     ).toBeInTheDocument();
@@ -315,5 +319,74 @@ describe('ContactsPanel', () => {
         location_id: 'loc-new',
       })
     );
+  });
+
+  it('sends location_id null on update after Clear', async () => {
+    const user = userEvent.setup();
+    const updateContact = vi.fn().mockResolvedValue(null);
+    const row: components['schemas']['AdminContact'] = {
+      id: '22222222-2222-2222-2222-222222222222',
+      first_name: 'Bob',
+      last_name: null,
+      email: null,
+      instagram_handle: null,
+      phone: null,
+      contact_type: 'parent',
+      relationship_type: 'prospect',
+      source: 'manual',
+      mailchimp_status: 'pending',
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+      tag_ids: [],
+      tags: [],
+      family_ids: [],
+      organization_ids: [],
+      location_id: 'loc-1',
+      location_summary: null,
+      standalone_note_count: 0,
+    };
+    const contacts = buildContactsHook({
+      updateContact,
+      contacts: [row],
+    });
+
+    render(
+      <ContactsPanel
+        contacts={contacts}
+        adminUsers={[]}
+        onPatchStandaloneNoteCount={vi.fn()}
+        tags={[]}
+        locations={[
+          {
+            id: 'loc-1',
+            name: null,
+            areaId: 'area-hk',
+            address: 'X',
+            lat: null,
+            lng: null,
+            createdAt: null,
+            updatedAt: null,
+            lockedFromPartnerOrg: false,
+            partnerOrganizationLabels: [],
+          },
+        ]}
+        geographicAreas={[hkArea]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+      />
+    );
+
+    await user.click(screen.getByText('Bob'));
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+    await user.click(screen.getByRole('button', { name: 'Update contact' }));
+
+    expect(updateContact).toHaveBeenCalledWith(
+      row.id,
+      expect.objectContaining({
+        location_id: null,
+      })
+    );
+    expect(updateLocationPartial).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
@@ -6,6 +6,8 @@ import { FamiliesPanel } from '@/components/admin/contacts/families-panel';
 
 import type { useAdminCrmFamilies } from '@/hooks/use-admin-crm-families';
 
+const noopRefresh = vi.fn().mockResolvedValue(undefined);
+
 function buildFamiliesHook(
   overrides: Partial<ReturnType<typeof useAdminCrmFamilies>> = {}
 ): ReturnType<typeof useAdminCrmFamilies> {
@@ -41,6 +43,8 @@ describe('FamiliesPanel', () => {
         tags={[]}
         locations={[]}
         geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
         contactOptions={[]}
         contactsForMembership={[]}
       />
@@ -68,6 +72,8 @@ describe('FamiliesPanel', () => {
         tags={[]}
         locations={[]}
         geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
         contactOptions={[]}
         contactsForMembership={[]}
       />

--- a/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
@@ -1,12 +1,39 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+
+const { createLocation, geocodeVenueAddress, updateLocationPartial } = vi.hoisted(() => ({
+  createLocation: vi.fn(),
+  geocodeVenueAddress: vi.fn(),
+  updateLocationPartial: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/services-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/services-api')>('@/lib/services-api');
+  return {
+    ...actual,
+    createLocation,
+    geocodeVenueAddress,
+    updateLocationPartial,
+  };
+});
 
 import { FamiliesPanel } from '@/components/admin/contacts/families-panel';
 
 import type { useAdminCrmFamilies } from '@/hooks/use-admin-crm-families';
 
 const noopRefresh = vi.fn().mockResolvedValue(undefined);
+
+const hkArea = {
+  id: 'area-hk',
+  parentId: null,
+  name: 'Hong Kong',
+  level: 'country' as const,
+  code: 'HK',
+  sovereignCountryId: null,
+  active: true,
+  displayOrder: 0,
+};
 
 function buildFamiliesHook(
   overrides: Partial<ReturnType<typeof useAdminCrmFamilies>> = {}
@@ -82,5 +109,78 @@ describe('FamiliesPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Load more' }));
 
     expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('PATCHes location without name when updating address inline', async () => {
+    const user = userEvent.setup();
+    const updateFamily = vi.fn().mockResolvedValue(null);
+    const families = buildFamiliesHook({
+      updateFamily,
+      families: [
+        {
+          id: 'fam-1',
+          family_name: 'Smith',
+          relationship_type: 'prospect',
+          location_id: 'loc-1',
+          location_summary: {
+            id: 'loc-1',
+            name: 'Venue Name',
+            area_id: 'area-hk',
+            area_name: 'Hong Kong',
+            address: '1 Old',
+            lat: null,
+            lng: null,
+          },
+          tag_ids: [],
+          tags: [],
+          members: [],
+          active: true,
+          created_at: '2020-01-01T00:00:00.000Z',
+          updated_at: '2020-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    render(
+      <FamiliesPanel
+        families={families}
+        tags={[]}
+        locations={[
+          {
+            id: 'loc-1',
+            name: 'Venue Name',
+            areaId: 'area-hk',
+            address: '1 Old',
+            lat: null,
+            lng: null,
+            createdAt: null,
+            updatedAt: null,
+            lockedFromPartnerOrg: false,
+            partnerOrganizationLabels: [],
+          },
+        ]}
+        geographicAreas={[hkArea]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+        contactOptions={[]}
+        contactsForMembership={[]}
+      />
+    );
+
+    await user.click(screen.getByText('Smith'));
+    await user.click(screen.getByRole('button', { name: 'Change' }));
+    await user.clear(screen.getByLabelText('Address'));
+    await user.type(screen.getByLabelText('Address'), '2 New St');
+    await user.click(screen.getByRole('button', { name: 'Update location' }));
+
+    await waitFor(() => {
+      expect(updateLocationPartial).toHaveBeenCalledWith('loc-1', {
+        area_id: 'area-hk',
+        address: '2 New St',
+        lat: null,
+        lng: null,
+      });
+    });
+    expect(updateLocationPartial.mock.calls[0][1]).not.toHaveProperty('name');
   });
 });

--- a/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
@@ -1,6 +1,22 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+
+const { createLocation, geocodeVenueAddress, updateLocationPartial } = vi.hoisted(() => ({
+  createLocation: vi.fn(),
+  geocodeVenueAddress: vi.fn(),
+  updateLocationPartial: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/services-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/services-api')>('@/lib/services-api');
+  return {
+    ...actual,
+    createLocation,
+    geocodeVenueAddress,
+    updateLocationPartial,
+  };
+});
 
 import { OrganizationsPanel } from '@/components/admin/contacts/organizations-panel';
 
@@ -135,6 +151,85 @@ describe('OrganizationsPanel', () => {
     await user.click(screen.getByText('Partner Org'));
 
     expect(screen.queryByRole('button', { name: 'Change' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
     expect(screen.getByText(/Managed from the partner organisation/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/To change the venue name or switch to a different address/)
+    ).toBeInTheDocument();
+  });
+
+  it('PATCHes location on inline update without name field', async () => {
+    const user = userEvent.setup();
+    const updateOrganization = vi.fn().mockResolvedValue(null);
+    const row: components['schemas']['AdminOrganization'] = {
+      id: 'org-2',
+      name: 'School Co',
+      organization_type: 'school',
+      relationship_type: 'customer',
+      slug: null,
+      website: null,
+      location_id: 'loc-2',
+      location_summary: {
+        id: 'loc-2',
+        name: 'Named Venue',
+        area_id: 'area-hk',
+        area_name: 'Hong Kong',
+        address: 'Old Addr',
+        lat: 1,
+        lng: 2,
+      },
+      tag_ids: [],
+      tags: [],
+      members: [],
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+    };
+    const organizations = buildOrgsHook({
+      updateOrganization,
+      organizations: [row],
+    });
+
+    render(
+      <OrganizationsPanel
+        organizations={organizations}
+        tags={[]}
+        locations={[
+          {
+            id: 'loc-2',
+            name: 'Named Venue',
+            areaId: 'area-hk',
+            address: 'Old Addr',
+            lat: 1,
+            lng: 2,
+            createdAt: null,
+            updatedAt: null,
+            lockedFromPartnerOrg: false,
+            partnerOrganizationLabels: [],
+          },
+        ]}
+        geographicAreas={[hkArea]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+        contactOptions={[]}
+        contactsForMembership={[]}
+      />
+    );
+
+    await user.click(screen.getByText('School Co'));
+    await user.click(screen.getByRole('button', { name: 'Change' }));
+    await user.clear(screen.getByLabelText('Address'));
+    await user.type(screen.getByLabelText('Address'), 'New Addr');
+    await user.click(screen.getByRole('button', { name: 'Update location' }));
+
+    await waitFor(() => {
+      expect(updateLocationPartial).toHaveBeenCalledWith('loc-2', {
+        area_id: 'area-hk',
+        address: 'New Addr',
+        lat: 1,
+        lng: 2,
+      });
+    });
+    expect(updateLocationPartial.mock.calls[0][1]).not.toHaveProperty('name');
   });
 });

--- a/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { OrganizationsPanel } from '@/components/admin/contacts/organizations-panel';
+
+import type { useAdminCrmOrganizations } from '@/hooks/use-admin-crm-organizations';
+import type { components } from '@/types/generated/admin-api.generated';
+
+const noopRefresh = vi.fn().mockResolvedValue(undefined);
+
+const hkArea = {
+  id: 'area-hk',
+  parentId: null,
+  name: 'Hong Kong',
+  level: 'country' as const,
+  code: 'HK',
+  sovereignCountryId: null,
+  active: true,
+  displayOrder: 0,
+};
+
+function buildOrgsHook(
+  overrides: Partial<ReturnType<typeof useAdminCrmOrganizations>> = {}
+): ReturnType<typeof useAdminCrmOrganizations> {
+  return {
+    organizations: [],
+    filters: { query: '', active: '' as const },
+    setFilter: vi.fn(),
+    isLoading: false,
+    isLoadingMore: false,
+    hasMore: false,
+    error: '',
+    loadMore: vi.fn(),
+    totalCount: 0,
+    isSaving: false,
+    createOrganization: vi.fn().mockResolvedValue(null),
+    updateOrganization: vi.fn().mockResolvedValue(null),
+    addMember: vi.fn().mockResolvedValue(null),
+    removeMember: vi.fn().mockResolvedValue(null),
+    refetch: vi.fn(),
+    crmRelationshipOptions: ['prospect', 'customer', 'partner', 'vendor'] as unknown as ReturnType<
+      typeof useAdminCrmOrganizations
+    >['crmRelationshipOptions'],
+    ...overrides,
+  };
+}
+
+describe('OrganizationsPanel', () => {
+  it('creates an organisation with default type', async () => {
+    const user = userEvent.setup();
+    const createOrganization = vi.fn().mockResolvedValue(null);
+    const organizations = buildOrgsHook({ createOrganization });
+
+    render(
+      <OrganizationsPanel
+        organizations={organizations}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+        contactOptions={[]}
+        contactsForMembership={[]}
+      />
+    );
+
+    await user.type(screen.getByLabelText('Name'), 'Acme');
+    await user.click(screen.getByRole('button', { name: 'Create organisation' }));
+
+    expect(createOrganization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Acme',
+        organization_type: 'company',
+      })
+    );
+  });
+
+  it('read-only when linked location is partner-org locked', async () => {
+    const user = userEvent.setup();
+    const row: components['schemas']['AdminOrganization'] = {
+      id: 'org-1',
+      name: 'Partner Org',
+      organization_type: 'company',
+      relationship_type: 'partner',
+      slug: 'partner-org',
+      website: null,
+      location_id: 'loc-1',
+      location_summary: {
+        id: 'loc-1',
+        name: null,
+        area_id: 'area-hk',
+        area_name: 'Hong Kong',
+        address: 'Locked St',
+        lat: null,
+        lng: null,
+      },
+      tag_ids: [],
+      tags: [],
+      members: [],
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+    };
+    const organizations = buildOrgsHook({
+      organizations: [row],
+    });
+
+    render(
+      <OrganizationsPanel
+        organizations={organizations}
+        tags={[]}
+        locations={[
+          {
+            id: 'loc-1',
+            name: null,
+            areaId: 'area-hk',
+            address: 'Locked St',
+            lat: null,
+            lng: null,
+            createdAt: null,
+            updatedAt: null,
+            lockedFromPartnerOrg: true,
+            partnerOrganizationLabels: ['Partner Org'],
+          },
+        ]}
+        geographicAreas={[hkArea]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+        contactOptions={[]}
+        contactsForMembership={[]}
+      />
+    );
+
+    await user.click(screen.getByText('Partner Org'));
+
+    expect(screen.queryByRole('button', { name: 'Change' })).not.toBeInTheDocument();
+    expect(screen.getByText(/Managed from the partner organisation/)).toBeInTheDocument();
+  });
+});

--- a/apps/admin_web/tests/components/admin/locations/inline-location-editor.test.tsx
+++ b/apps/admin_web/tests/components/admin/locations/inline-location-editor.test.tsx
@@ -48,7 +48,7 @@ describe('InlineLocationEditor', () => {
     );
 
     expect(screen.getByText('1 Road · Hong Kong')).toBeInTheDocument();
-    expect(screen.getByText('22.1, 114.2')).toBeInTheDocument();
+    expect(screen.getByText('22.10000, 114.20000')).toBeInTheDocument();
   });
 
   it('disables Save location until an area is selected', async () => {
@@ -143,9 +143,118 @@ describe('InlineLocationEditor', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('The requested resource is not available in this deployment yet.')
+        screen.getByText('Geocoding is not available in this environment yet.')
       ).toBeInTheDocument();
     });
+  });
+
+  it('does not show propagation helper on create-new path', () => {
+    render(
+      <InlineLocationEditor
+        stateKey='new1'
+        location={null}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={vi.fn()}
+        onClear={vi.fn()}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByText('Editing updates this location wherever it is used.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('PATCH update sends partial fields without name', async () => {
+    const user = userEvent.setup();
+    const onSaveUpdate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InlineLocationEditor
+        stateKey='patch1'
+        location={{
+          id: 'loc-1',
+          name: 'Central Studio',
+          areaId: 'area-1',
+          address: '1 Road',
+          lat: 22,
+          lng: 114,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: false,
+          partnerOrganizationLabels: [],
+        }}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={onSaveUpdate}
+        onClear={vi.fn()}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Change' }));
+    await user.clear(screen.getByLabelText('Address'));
+    await user.type(screen.getByLabelText('Address'), '2 Road');
+    await user.click(screen.getByRole('button', { name: 'Update location' }));
+
+    await waitFor(() => {
+      expect(onSaveUpdate).toHaveBeenCalledWith('loc-1', {
+        area_id: 'area-1',
+        address: '2 Road',
+        lat: 22,
+        lng: 114,
+      });
+    });
+    expect(onSaveUpdate.mock.calls[0][1]).not.toHaveProperty('name');
+  });
+
+  it('allowClearWhenLocked shows Clear without Change', async () => {
+    const user = userEvent.setup();
+    const onClear = vi.fn();
+
+    render(
+      <InlineLocationEditor
+        stateKey='ac1'
+        location={{
+          id: 'loc-1',
+          name: null,
+          areaId: 'area-1',
+          address: 'A',
+          lat: null,
+          lng: null,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: true,
+          partnerOrganizationLabels: ['X'],
+        }}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        allowClearWhenLocked
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={vi.fn()}
+        onClear={onClear}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Change' })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(onClear).toHaveBeenCalled();
   });
 
   it('partner-org-locked: hides Change and Clear and shows managed note', () => {

--- a/apps/admin_web/tests/components/admin/locations/inline-location-editor.test.tsx
+++ b/apps/admin_web/tests/components/admin/locations/inline-location-editor.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
+
+import { AdminApiError } from '@/lib/api-admin-client';
+
+const baseArea = {
+  id: 'area-1',
+  parentId: null,
+  name: 'Hong Kong',
+  level: 'country' as const,
+  code: 'HK',
+  sovereignCountryId: null,
+  active: true,
+  displayOrder: 0,
+};
+
+describe('InlineLocationEditor', () => {
+  it('renders State A summary when a location is provided', () => {
+    render(
+      <InlineLocationEditor
+        stateKey='t1'
+        location={{
+          id: 'loc-1',
+          name: 'Studio',
+          areaId: 'area-1',
+          address: '1 Road',
+          lat: 22.1,
+          lng: 114.2,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: false,
+          partnerOrganizationLabels: [],
+        }}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={vi.fn()}
+        onClear={vi.fn()}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('1 Road · Hong Kong')).toBeInTheDocument();
+    expect(screen.getByText('22.1, 114.2')).toBeInTheDocument();
+  });
+
+  it('disables Save location until an area is selected', async () => {
+    const user = userEvent.setup();
+    const onSaveCreate = vi.fn();
+
+    render(
+      <InlineLocationEditor
+        stateKey='new-empty'
+        location={null}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={onSaveCreate}
+        onSaveUpdate={vi.fn()}
+        onClear={vi.fn()}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    const saveBtn = screen.getByRole('button', { name: 'Save location' });
+    expect(saveBtn).toBeDisabled();
+
+    await user.selectOptions(screen.getByLabelText('Geographic area'), 'area-1');
+    await user.type(screen.getByLabelText('Address'), 'Somewhere');
+
+    await waitFor(() => {
+      expect(saveBtn).not.toBeDisabled();
+    });
+  });
+
+  it('geocode success updates lat/lng', async () => {
+    const user = userEvent.setup();
+    const onGeocode = vi.fn().mockResolvedValue({ lat: 22.3193, lng: 114.1694 });
+
+    render(
+      <InlineLocationEditor
+        stateKey='g1'
+        location={null}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={vi.fn()}
+        onClear={vi.fn()}
+        onGeocode={onGeocode}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText('Geographic area'), 'area-1');
+    await user.type(screen.getByLabelText('Address'), '1 Test Road');
+    await user.click(screen.getByRole('button', { name: 'Fill coordinates from address' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Latitude')).toHaveValue('22.3193');
+      expect(screen.getByLabelText('Longitude')).toHaveValue('114.1694');
+    });
+  });
+
+  it('geocode 404 shows environment copy', async () => {
+    const user = userEvent.setup();
+    const onGeocode = vi
+      .fn()
+      .mockRejectedValue(new AdminApiError({ statusCode: 404, message: 'nope', payload: null }));
+
+    render(
+      <InlineLocationEditor
+        stateKey='g404'
+        location={null}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={vi.fn()}
+        onClear={vi.fn()}
+        onGeocode={onGeocode}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText('Geographic area'), 'area-1');
+    await user.type(screen.getByLabelText('Address'), 'Somewhere');
+    await user.click(screen.getByRole('button', { name: 'Fill coordinates from address' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('The requested resource is not available in this deployment yet.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('partner-org-locked: hides Change and Clear and shows managed note', () => {
+    render(
+      <InlineLocationEditor
+        stateKey='lock1'
+        location={{
+          id: 'loc-1',
+          name: null,
+          areaId: 'area-1',
+          address: 'A',
+          lat: null,
+          lng: null,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: true,
+          partnerOrganizationLabels: ['Partner Co'],
+        }}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={vi.fn()}
+        onClear={vi.fn()}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Change' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    expect(screen.getByText(/Managed from the partner organisation \(Partner Co\)/)).toBeInTheDocument();
+  });
+
+  it('Clear calls onClear and does not call onSaveUpdate', async () => {
+    const user = userEvent.setup();
+    const onClear = vi.fn();
+    const onSaveUpdate = vi.fn();
+
+    render(
+      <InlineLocationEditor
+        stateKey='clear1'
+        location={{
+          id: 'loc-1',
+          name: null,
+          areaId: 'area-1',
+          address: 'A',
+          lat: null,
+          lng: null,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: false,
+          partnerOrganizationLabels: [],
+        }}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={onSaveUpdate}
+        onClear={onClear}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(onClear).toHaveBeenCalled();
+    expect(onSaveUpdate).not.toHaveBeenCalled();
+  });
+
+  it('Cancel in edit-existing restores read state', async () => {
+    const user = userEvent.setup();
+    const onCancelEdit = vi.fn();
+
+    render(
+      <InlineLocationEditor
+        stateKey='cancel1'
+        location={{
+          id: 'loc-1',
+          name: null,
+          areaId: 'area-1',
+          address: 'Original',
+          lat: null,
+          lng: null,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: false,
+          partnerOrganizationLabels: [],
+        }}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={onCancelEdit}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={vi.fn()}
+        onClear={vi.fn()}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Change' }));
+    await user.clear(screen.getByLabelText('Address'));
+    await user.type(screen.getByLabelText('Address'), 'Edited');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByText('Original · Hong Kong')).toBeInTheDocument();
+    expect(onCancelEdit).toHaveBeenCalled();
+  });
+});

--- a/apps/admin_web/tests/components/admin/locations/inline-location-validation.test.ts
+++ b/apps/admin_web/tests/components/admin/locations/inline-location-validation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeLatLngErrors, parseOptionalCoordinate } from '@/components/admin/locations/inline-location-validation';
+
+describe('parseOptionalCoordinate', () => {
+  it('returns null for empty or whitespace', () => {
+    expect(parseOptionalCoordinate('')).toBeNull();
+    expect(parseOptionalCoordinate('   ')).toBeNull();
+  });
+
+  it('returns finite numbers for valid numeric strings', () => {
+    expect(parseOptionalCoordinate('22.3')).toBe(22.3);
+    expect(parseOptionalCoordinate('-114')).toBe(-114);
+  });
+
+  it('returns NaN for non-numeric input', () => {
+    const r = parseOptionalCoordinate('abc');
+    expect(Number.isNaN(r)).toBe(true);
+  });
+});
+
+describe('computeLatLngErrors', () => {
+  it('detects parse errors', () => {
+    const e = computeLatLngErrors('x', '1');
+    expect(e.latParseError).toBe(true);
+    expect(e.coordinatesInvalid).toBe(true);
+  });
+
+  it('detects range errors', () => {
+    const e = computeLatLngErrors('100', '0');
+    expect(e.latRangeError).toBe(true);
+    expect(e.coordinatesInvalid).toBe(true);
+  });
+
+  it('detects only one coordinate provided', () => {
+    const e = computeLatLngErrors('1', '');
+    expect(e.onlyOneCoordinate).toBe(true);
+  });
+
+  it('allows both empty', () => {
+    const e = computeLatLngErrors('', '');
+    expect(e.onlyOneCoordinate).toBe(false);
+    expect(e.coordinatesInvalid).toBe(false);
+  });
+});

--- a/apps/admin_web/tests/components/admin/services/venues-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/venues-panel.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@/lib/services-api', async () => {
   return {
     ...actual,
     geocodeVenueAddress,
+    listAllLocations: vi.fn().mockResolvedValue([]),
   };
 });
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -33,6 +33,7 @@ Flutter Mobile / Next.js Admin
 
 ### Admin console (Next.js App Router)
 - Admin users manage assets and access grants.
+- **Locations:** CRM contacts, families, organisations, and Services venues all edit shared `locations` rows through the same inline location editor (`InlineLocationEditor`). Saving a location updates that row for every record that references it.
 - Hosted on Amplify Hosting (release jobs triggered in CI).
 
 ### Public website (Next.js static export)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements shared `locations` row editing across Contacts (contacts, families, organisations) and aligns Venues with the same validation and geocoding hook.

## Follow-up fixes (review)

- **CRM location updates** use **PATCH** (`updateLocationPartial`) only, with `area_id`, `address`, `lat`, `lng` — **no `name` field**, so venue names set on Services are not cleared.
- **`useGeocodeVenueAddress`** split out; **`useInlineLocationSave`** handles create + partial update only.
- **`formatGeocodeErrorMessage`** — geocode 404 uses the geocoding-specific copy (not the generic deployment message).
- **Organisations**: `allowClearWhenLocked` + extra note when partner-locked; **Clear** unlinks `location_id` without editing the shared row.
- **`stateKey`** no longer includes `pendingLocationId` (remount only on row/mode change).
- **Confirm** when leaving create with a saved-but-unlinked pending location.
- Coordinate labels rounded to **5 decimal places**.

## Verification

- `npm run lint` and `npm test` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cff81212-9bd4-49fc-9f8c-a168342ae75c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cff81212-9bd4-49fc-9f8c-a168342ae75c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

