### PR TITLE
Admin contacts: layout, type filter, collapsible tags

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -496,152 +496,163 @@ export function ContactsPanel({
           </>
         }
       >
-        <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
-          <div>
-            <Label htmlFor='crm-contact-first'>First name</Label>
-            <Input
-              id='crm-contact-first'
-              value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
-              autoComplete='off'
-            />
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-last'>Last name</Label>
-            <Input
-              id='crm-contact-last'
-              value={lastName}
-              onChange={(e) => setLastName(e.target.value)}
-              autoComplete='off'
-            />
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-email'>Email</Label>
-            <Input
-              id='crm-contact-email'
-              type='email'
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              autoComplete='off'
-            />
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-phone'>Phone</Label>
-            <Input
-              id='crm-contact-phone'
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              autoComplete='off'
-            />
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-ig'>Instagram</Label>
-            <Input
-              id='crm-contact-ig'
-              value={instagramHandle}
-              onChange={(e) => setInstagramHandle(e.target.value)}
-              autoComplete='off'
-            />
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-dob'>Date of birth</Label>
-            <Input
-              id='crm-contact-dob'
-              type='date'
-              value={dateOfBirth}
-              onChange={(e) => setDateOfBirth(e.target.value)}
-            />
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-type'>Contact type</Label>
-            <Select
-              id='crm-contact-type'
-              value={contactType}
-              onChange={(e) => setContactType(e.target.value as ApiSchemas['CrmContactType'])}
-            >
-              {CONTACT_TYPES.map((v) => (
-                <option key={v} value={v}>
-                  {formatEnumLabel(v)}
-                </option>
-              ))}
-            </Select>
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-rel'>Relationship</Label>
-            <Select
-              id='crm-contact-rel'
-              value={relationshipType}
-              onChange={(e) =>
-                setRelationshipType(e.target.value as (typeof CRM_ENTITY_RELATIONSHIP_TYPES)[number])
-              }
-            >
-              {CRM_ENTITY_RELATIONSHIP_TYPES.map((v) => (
-                <option key={v} value={v}>
-                  {formatEnumLabel(v)}
-                </option>
-              ))}
-            </Select>
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-source'>Source</Label>
-            <Select
-              id='crm-contact-source'
-              value={source}
-              onChange={(e) => {
-                const v = e.target.value as ApiSchemas['CrmContactSource'];
-                setSource(v);
-                if (v !== 'referral') {
-                  setReferralContactId('');
-                  setReferralSearchInput('');
-                  setReferralSearchResults([]);
-                  setReferralPinnedLabel('');
-                } else {
-                  setReferralSearchResults([]);
-                }
-              }}
-            >
-              {SOURCES.map((v) => (
-                <option key={v} value={v}>
-                  {formatEnumLabel(v)}
-                </option>
-              ))}
-            </Select>
-          </div>
-          {source === 'referral' ? (
-            <div className='space-y-2 lg:col-span-2'>
-              <Label htmlFor='crm-contact-referral-search'>Find referring contact</Label>
+        <div className='space-y-4'>
+          <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+            <div>
+              <Label htmlFor='crm-contact-first'>First name</Label>
               <Input
-                id='crm-contact-referral-search'
-                value={referralSearchInput}
-                onChange={(e) => setReferralSearchInput(e.target.value)}
-                placeholder='Type at least 2 characters (name, email, phone, Instagram)'
+                id='crm-contact-first'
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
                 autoComplete='off'
               />
-              <div>
-                <Label htmlFor='crm-contact-referral'>Referred by contact</Label>
-                <Select
-                  id='crm-contact-referral'
-                  value={referralContactId}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    setReferralContactId(v);
-                    const picked = referralSelectOptions.find((o) => o.id === v);
-                    if (picked) {
-                      setReferralPinnedLabel(picked.label);
-                    }
-                  }}
-                >
-                  <option value=''>Select contact</option>
-                  {referralSelectOptions.map((c) => (
-                    <option key={c.id} value={c.id}>
-                      {c.label}
-                    </option>
-                  ))}
-                </Select>
-              </div>
             </div>
-          ) : null}
-          <div className='lg:col-span-2'>
+            <div>
+              <Label htmlFor='crm-contact-last'>Last name</Label>
+              <Input
+                id='crm-contact-last'
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                autoComplete='off'
+              />
+            </div>
+            <div>
+              <Label htmlFor='crm-contact-type'>Contact type</Label>
+              <Select
+                id='crm-contact-type'
+                value={contactType}
+                onChange={(e) => setContactType(e.target.value as ApiSchemas['CrmContactType'])}
+              >
+                {CONTACT_TYPES.map((v) => (
+                  <option key={v} value={v}>
+                    {formatEnumLabel(v)}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor='crm-contact-rel'>Relationship</Label>
+              <Select
+                id='crm-contact-rel'
+                value={relationshipType}
+                onChange={(e) =>
+                  setRelationshipType(e.target.value as (typeof CRM_ENTITY_RELATIONSHIP_TYPES)[number])
+                }
+              >
+                {CRM_ENTITY_RELATIONSHIP_TYPES.map((v) => (
+                  <option key={v} value={v}>
+                    {formatEnumLabel(v)}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          </div>
+
+          <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+            <div>
+              <Label htmlFor='crm-contact-email'>Email</Label>
+              <Input
+                id='crm-contact-email'
+                type='email'
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete='off'
+              />
+            </div>
+            <div>
+              <Label htmlFor='crm-contact-phone'>Phone</Label>
+              <Input
+                id='crm-contact-phone'
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                autoComplete='off'
+              />
+            </div>
+            <div>
+              <Label htmlFor='crm-contact-ig'>Instagram</Label>
+              <Input
+                id='crm-contact-ig'
+                value={instagramHandle}
+                onChange={(e) => setInstagramHandle(e.target.value)}
+                autoComplete='off'
+              />
+            </div>
+            <div>
+              <Label htmlFor='crm-contact-dob'>Date of birth</Label>
+              <Input
+                id='crm-contact-dob'
+                type='date'
+                value={dateOfBirth}
+                onChange={(e) => setDateOfBirth(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className='flex flex-wrap items-end gap-3'>
+            <div className='min-w-[min(100%,12rem)] flex-1'>
+              <Label htmlFor='crm-contact-source'>Source</Label>
+              <Select
+                id='crm-contact-source'
+                value={source}
+                onChange={(e) => {
+                  const v = e.target.value as ApiSchemas['CrmContactSource'];
+                  setSource(v);
+                  if (v !== 'referral') {
+                    setReferralContactId('');
+                    setReferralSearchInput('');
+                    setReferralSearchResults([]);
+                    setReferralPinnedLabel('');
+                  } else {
+                    setReferralSearchResults([]);
+                  }
+                }}
+              >
+                {SOURCES.map((v) => (
+                  <option key={v} value={v}>
+                    {formatEnumLabel(v)}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            {source === 'referral' ? (
+              <>
+                <div className='min-w-[min(100%,14rem)] flex-1'>
+                  <Label htmlFor='crm-contact-referral-search'>Find referring contact</Label>
+                  <Input
+                    id='crm-contact-referral-search'
+                    value={referralSearchInput}
+                    onChange={(e) => setReferralSearchInput(e.target.value)}
+                    placeholder='Type at least 2 characters (name, email, phone, Instagram)'
+                    autoComplete='off'
+                  />
+                </div>
+                <div className='min-w-[min(100%,14rem)] flex-1'>
+                  <Label htmlFor='crm-contact-referral'>Referred by contact</Label>
+                  <Select
+                    id='crm-contact-referral'
+                    value={referralContactId}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      setReferralContactId(v);
+                      const picked = referralSelectOptions.find((o) => o.id === v);
+                      if (picked) {
+                        setReferralPinnedLabel(picked.label);
+                      }
+                    }}
+                  >
+                    <option value=''>Select contact</option>
+                    {referralSelectOptions.map((c) => (
+                      <option key={c.id} value={c.id}>
+                        {c.label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+              </>
+            ) : null}
+          </div>
+
+          <div className='rounded-md border border-slate-200 bg-slate-50/40 p-3'>
             <InlineLocationEditor
               stateKey={inlineLocationStateKey}
               location={resolvedLocation}
@@ -679,64 +690,68 @@ export function ContactsPanel({
               onGeocode={geocodeLocation}
             />
           </div>
-          <div>
-            <Label htmlFor='crm-contact-family'>Family</Label>
-            <Select
-              id='crm-contact-family'
-              value={familySelectId}
-              onChange={(e) => {
-                const v = e.target.value;
-                setFamilySelectId(v);
-                if (v) {
-                  setPendingLocationId(null);
-                  setOptimisticLocationSummary(null);
-                }
-              }}
-            >
-              <option value=''>None</option>
-              {familyPicker.map((f) => (
-                <option key={f.id} value={f.id}>
-                  {f.label}
-                </option>
-              ))}
-            </Select>
-          </div>
-          <div>
-            <Label htmlFor='crm-contact-org'>Organisation</Label>
-            <Select
-              id='crm-contact-org'
-              value={organizationSelectId}
-              onChange={(e) => {
-                const v = e.target.value;
-                setOrganizationSelectId(v);
-                if (v) {
-                  setPendingLocationId(null);
-                  setOptimisticLocationSummary(null);
-                }
-              }}
-            >
-              <option value=''>None</option>
-              {organizationPicker.map((o) => (
-                <option key={o.id} value={o.id}>
-                  {o.label}
-                </option>
-              ))}
-            </Select>
-          </div>
-          {editorMode === 'edit' ? (
+
+          <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
             <div>
-              <Label htmlFor='crm-contact-active'>Status</Label>
+              <Label htmlFor='crm-contact-family'>Family</Label>
               <Select
-                id='crm-contact-active'
-                value={active ? 'true' : 'false'}
-                onChange={(e) => setActive(e.target.value === 'true')}
+                id='crm-contact-family'
+                value={familySelectId}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setFamilySelectId(v);
+                  if (v) {
+                    setPendingLocationId(null);
+                    setOptimisticLocationSummary(null);
+                  }
+                }}
               >
-                <option value='true'>Active</option>
-                <option value='false'>Archived</option>
+                <option value=''>None</option>
+                {familyPicker.map((f) => (
+                  <option key={f.id} value={f.id}>
+                    {f.label}
+                  </option>
+                ))}
               </Select>
             </div>
-          ) : null}
-          <div className='lg:col-span-2'>
+            <div>
+              <Label htmlFor='crm-contact-org'>Organisation</Label>
+              <Select
+                id='crm-contact-org'
+                value={organizationSelectId}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setOrganizationSelectId(v);
+                  if (v) {
+                    setPendingLocationId(null);
+                    setOptimisticLocationSummary(null);
+                  }
+                }}
+              >
+                <option value=''>None</option>
+                {organizationPicker.map((o) => (
+                  <option key={o.id} value={o.id}>
+                    {o.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            {editorMode === 'edit' ? (
+              <div>
+                <Label htmlFor='crm-contact-active'>Status</Label>
+                <Select
+                  id='crm-contact-active'
+                  value={active ? 'true' : 'false'}
+                  onChange={(e) => setActive(e.target.value === 'true')}
+                >
+                  <option value='true'>Active</option>
+                  <option value='false'>Archived</option>
+                </Select>
+              </div>
+            ) : null}
+          </div>
+
+          <div>
             <Label htmlFor='crm-contact-source-detail'>Source detail</Label>
             <Textarea
               id='crm-contact-source-detail'
@@ -745,18 +760,19 @@ export function ContactsPanel({
               rows={2}
             />
           </div>
-          <div className='lg:col-span-2'>
-            <CrmTagPicker
-              id='crm-contact-tags'
-              label='Tags'
-              tags={tags}
-              selectedIds={tagIds}
-              onChange={setTagIds}
-              disabled={isSaving}
-            />
-          </div>
+
+          <CrmTagPicker
+            id='crm-contact-tags'
+            label='Tags'
+            tags={tags}
+            selectedIds={tagIds}
+            onChange={setTagIds}
+            disabled={isSaving}
+            variant='collapsible'
+          />
+
           {editorMode === 'edit' && selected ? (
-            <div className='lg:col-span-2 text-sm text-slate-600'>
+            <div className='text-sm text-slate-600'>
               <p>Mailchimp: {formatEnumLabel(selected.mailchimp_status)}</p>
             </div>
           ) : null}
@@ -784,6 +800,24 @@ export function ContactsPanel({
                 }}
                 placeholder='Name, email, phone, Instagram'
               />
+            </div>
+            <div className='min-w-[140px]'>
+              <Label htmlFor='crm-contacts-type'>Type</Label>
+              <Select
+                id='crm-contacts-type'
+                value={filters.contact_type}
+                onChange={(e) => {
+                  setDeleteActionError('');
+                  setFilter('contact_type', e.target.value as CrmListFilters['contact_type']);
+                }}
+              >
+                <option value=''>All</option>
+                {CONTACT_TYPES.map((v) => (
+                  <option key={v} value={v}>
+                    {formatEnumLabel(v)}
+                  </option>
+                ))}
+              </Select>
             </div>
             <div className='min-w-[140px]'>
               <Label htmlFor='crm-contacts-active'>Status</Label>

--- a/apps/admin_web/src/components/admin/contacts/crm-tag-picker.tsx
+++ b/apps/admin_web/src/components/admin/contacts/crm-tag-picker.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import { Label } from '@/components/ui/label';
 
 import type { CrmTagRef } from '@/lib/crm-api';
@@ -11,10 +13,21 @@ export interface CrmTagPickerProps {
   selectedIds: string[];
   onChange: (ids: string[]) => void;
   disabled?: boolean;
+  /** When set, the picker is hidden behind a disclosure (same pattern as structured JSON fields elsewhere in admin). */
+  variant?: 'default' | 'collapsible';
 }
 
-export function CrmTagPicker({ id, label, tags, selectedIds, onChange, disabled }: CrmTagPickerProps) {
+export function CrmTagPicker({
+  id,
+  label,
+  tags,
+  selectedIds,
+  onChange,
+  disabled,
+  variant = 'default',
+}: CrmTagPickerProps) {
   const set = new Set(selectedIds);
+  const [disclosureOpen, setDisclosureOpen] = useState(false);
 
   function toggle(tagId: string) {
     const next = new Set(set);
@@ -37,22 +50,51 @@ export function CrmTagPicker({ id, label, tags, selectedIds, onChange, disabled 
     );
   }
 
+  const list = (
+    <div className='max-h-40 space-y-2 overflow-y-auto rounded-md border border-slate-200 bg-white p-3'>
+      {tags.map((tag) => (
+        <label key={tag.id} className='flex cursor-pointer items-center gap-2 text-sm'>
+          <input
+            type='checkbox'
+            className='h-4 w-4 rounded border-slate-300'
+            checked={set.has(tag.id)}
+            onChange={() => toggle(tag.id)}
+          />
+          <span>{tag.name}</span>
+        </label>
+      ))}
+    </div>
+  );
+
+  if (variant === 'collapsible') {
+    const panelId = `${id}-panel`;
+    return (
+      <fieldset disabled={disabled}>
+        <details
+          className='rounded-md border border-slate-200 bg-white'
+          open={disclosureOpen}
+          onToggle={(event) => {
+            setDisclosureOpen(event.currentTarget.open);
+          }}
+        >
+          <summary
+            className='cursor-pointer select-none px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-slate-50'
+            aria-controls={panelId}
+          >
+            {label}
+          </summary>
+          <div className='border-t border-slate-200 px-3 pb-3 pt-2' id={panelId}>
+            {list}
+          </div>
+        </details>
+      </fieldset>
+    );
+  }
+
   return (
     <fieldset disabled={disabled} className='space-y-2'>
       <legend className='text-sm font-medium text-slate-800'>{label}</legend>
-      <div className='max-h-40 space-y-2 overflow-y-auto rounded-md border border-slate-200 p-3'>
-        {tags.map((tag) => (
-          <label key={tag.id} className='flex cursor-pointer items-center gap-2 text-sm'>
-            <input
-              type='checkbox'
-              className='h-4 w-4 rounded border-slate-300'
-              checked={set.has(tag.id)}
-              onChange={() => toggle(tag.id)}
-            />
-            <span>{tag.name}</span>
-          </label>
-        ))}
-      </div>
+      {list}
     </fieldset>
   );
 }

--- a/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
+++ b/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
@@ -407,7 +407,7 @@ function InlineLocationEditorInner({
         {showEditForm ? (
           <div className='mt-2 space-y-3'>
             <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
-              <div className='sm:col-span-2'>
+              <div>
                 <Label htmlFor='inline-loc-area'>Geographic area</Label>
                 <Select
                   id='inline-loc-area'
@@ -423,7 +423,7 @@ function InlineLocationEditorInner({
                   ))}
                 </Select>
               </div>
-              <div className='sm:col-span-2'>
+              <div>
                 <Label htmlFor='inline-loc-address'>Address</Label>
                 <Input
                   id='inline-loc-address'

--- a/apps/admin_web/src/hooks/use-admin-crm-contacts.ts
+++ b/apps/admin_web/src/hooks/use-admin-crm-contacts.ts
@@ -8,7 +8,7 @@ import {
   listAdminContacts,
   updateAdminContact,
 } from '@/lib/crm-api';
-import { DEFAULT_CRM_LIST_FILTERS, type CrmListFilters } from '@/types/crm';
+import { DEFAULT_CRM_CONTACT_LIST_FILTERS, type CrmListFilters } from '@/types/crm';
 import type { components } from '@/types/generated/admin-api.generated';
 
 import { usePaginatedList } from './use-paginated-list';
@@ -21,6 +21,7 @@ export function useAdminCrmContacts() {
       listAdminContacts({
         query: params.query,
         active: params.active || undefined,
+        contact_type: params.contact_type || undefined,
         cursor: params.cursor,
         limit: params.limit,
       }),
@@ -41,7 +42,7 @@ export function useAdminCrmContacts() {
     refetch: refetchContacts,
   } = usePaginatedList({
     fetcher,
-    defaultFilters: DEFAULT_CRM_LIST_FILTERS,
+    defaultFilters: DEFAULT_CRM_CONTACT_LIST_FILTERS,
     errorPrefix: 'Failed to load contacts',
     debounceKeys: ['query'],
     limit: 50,

--- a/apps/admin_web/src/lib/crm-api.ts
+++ b/apps/admin_web/src/lib/crm-api.ts
@@ -130,6 +130,7 @@ export async function listAdminContacts(
   if (typeof params.limit === 'number') query.set('limit', `${params.limit}`);
   if (params.query?.trim()) query.set('query', params.query.trim());
   if (params.active) query.set('active', params.active);
+  if (params.contact_type) query.set('contact_type', params.contact_type);
   const qs = query.toString();
   const payload = await adminApiRequest<ApiContactList>({
     endpointPath: `/v1/admin/contacts${qs ? `?${qs}` : ''}`,

--- a/apps/admin_web/src/types/crm.ts
+++ b/apps/admin_web/src/types/crm.ts
@@ -1,9 +1,23 @@
+import type { components } from '@/types/generated/admin-api.generated';
+
+type CrmContactType = components['schemas']['CrmContactType'];
+
 export interface CrmListFilters {
   query: string;
   active: '' | 'true' | 'false';
+  /** Empty string means no filter (contacts list only). */
+  contact_type: '' | CrmContactType;
 }
 
 export const DEFAULT_CRM_LIST_FILTERS: CrmListFilters = {
   query: '',
   active: '',
+  contact_type: '',
+};
+
+/** Default filters for the contacts table (Active contacts only). */
+export const DEFAULT_CRM_CONTACT_LIST_FILTERS: CrmListFilters = {
+  query: '',
+  active: 'true',
+  contact_type: '',
 };

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2296,6 +2296,8 @@ export interface paths {
                     /** @description Search first name, last name, email, phone, or Instagram handle. */
                     query?: string;
                     active?: boolean;
+                    /** @description When set, only contacts with this contact type are returned. */
+                    contact_type?: components["schemas"]["CrmContactType"];
                     cursor?: string;
                     limit?: number;
                 };

--- a/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
@@ -27,7 +27,7 @@ vi.mock('@/lib/services-api', async (importOriginal) => {
 
 const defaultContactsHook = {
   contacts: [],
-  filters: { query: '', active: '' as const },
+  filters: { query: '', active: 'true' as const, contact_type: '' as const },
   setFilter: vi.fn(),
   isLoading: false,
   isLoadingMore: false,

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -52,7 +52,7 @@ function buildContactsHook(
 ): ReturnType<typeof useAdminCrmContacts> {
   return {
     contacts: [],
-    filters: { query: '', active: '' as const },
+    filters: { query: '', active: 'true' as const, contact_type: '' as const },
     setFilter: vi.fn(),
     isLoading: false,
     isLoadingMore: false,

--- a/backend/src/app/api/admin_contacts.py
+++ b/backend/src/app/api/admin_contacts.py
@@ -22,6 +22,7 @@ from app.api.admin_contacts_mutations import (
 from app.api.admin_crm_helpers import (
     list_all_tags_for_picker,
     parse_active_filter,
+    parse_contact_type_filter,
     parse_crm_limit,
     serialize_tag_ref,
 )
@@ -183,6 +184,7 @@ def _list_contacts(event: Mapping[str, Any]) -> dict[str, Any]:
         required=False,
     )
     active = parse_active_filter(query_param(event, "active"))
+    contact_type = parse_contact_type_filter(query_param(event, "contact_type"))
 
     with Session(get_engine()) as session:
         repository = ContactRepository(session)
@@ -191,13 +193,16 @@ def _list_contacts(event: Mapping[str, Any]) -> dict[str, Any]:
             cursor=cursor,
             query=query,
             active=active,
+            contact_type=contact_type,
         )
         has_more = len(rows) > limit
         page_rows = rows[:limit]
         next_cursor = (
             encode_cursor(page_rows[-1].id) if has_more and page_rows else None
         )
-        total_count = repository.count_for_admin(query=query, active=active)
+        total_count = repository.count_for_admin(
+            query=query, active=active, contact_type=contact_type
+        )
         note_counts = repository.count_standalone_notes_for_contacts(
             [r.id for r in page_rows]
         )

--- a/backend/src/app/api/admin_crm_helpers.py
+++ b/backend/src/app/api/admin_crm_helpers.py
@@ -21,6 +21,7 @@ from app.db.models import (
     RelationshipType,
     Tag,
 )
+from app.db.models.enums import ContactType
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -49,6 +50,19 @@ def parse_active_filter(raw: str | None) -> bool | None:
     if normalized in {"false", "0"}:
         return False
     raise ValidationError("active must be true or false", field="active")
+
+
+def parse_contact_type_filter(raw: str | None) -> ContactType | None:
+    """Parse optional CRM contact_type query value; empty means no filter."""
+    if raw is None or raw.strip() == "":
+        return None
+    normalized = raw.strip().lower()
+    for member in ContactType:
+        if member.value == normalized:
+            return member
+    raise ValidationError(
+        "contact_type must be a valid contact type", field="contact_type"
+    )
 
 
 def parse_optional_bool_body(value: Any, *, field: str) -> bool | None:

--- a/backend/src/app/db/repositories/contact.py
+++ b/backend/src/app/db/repositories/contact.py
@@ -138,6 +138,7 @@ class ContactRepository(BaseRepository[Contact]):
         cursor: UUID | None = None,
         query: str | None = None,
         active: bool | None = None,
+        contact_type: ContactType | None = None,
     ) -> list[Contact]:
         """List contacts with optional text search and active (non-archived) filter."""
         from app.db.repositories.organization import _escape_like_pattern
@@ -177,6 +178,8 @@ class ContactRepository(BaseRepository[Contact]):
             statement = statement.where(Contact.archived_at.is_(None))
         if active is False:
             statement = statement.where(Contact.archived_at.is_not(None))
+        if contact_type is not None:
+            statement = statement.where(Contact.contact_type == contact_type)
         statement = statement.order_by(
             Contact.created_at.desc(),
             Contact.id.desc(),
@@ -221,6 +224,7 @@ class ContactRepository(BaseRepository[Contact]):
         *,
         query: str | None = None,
         active: bool | None = None,
+        contact_type: ContactType | None = None,
     ) -> int:
         from app.db.repositories.organization import _escape_like_pattern
 
@@ -241,6 +245,8 @@ class ContactRepository(BaseRepository[Contact]):
             statement = statement.where(Contact.archived_at.is_(None))
         if active is False:
             statement = statement.where(Contact.archived_at.is_not(None))
+        if contact_type is not None:
+            statement = statement.where(Contact.contact_type == contact_type)
         count = self._session.execute(statement).scalar_one_or_none()
         return int(count or 0)
 

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1633,6 +1633,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: contact_type
+          in: query
+          schema:
+            $ref: "#/components/schemas/CrmContactType"
+          description: When set, only contacts with this contact type are returned.
         - name: cursor
           in: query
           schema:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -51,7 +51,8 @@ their primary responsibilities.
   reconciliation job exists. **Caching:** share-link tokens stay stable on replace;
   CDN or browser caching keyed only by URL (not `s3_key`) may show stale bytes until TTL—
   downloads keyed by changing `s3_key` generally avoid that.
-  `/v1/admin/contacts/*` (including `GET /v1/admin/contacts/tags` for tag pickers,
+  `/v1/admin/contacts/*` (including `GET /v1/admin/contacts` optional `contact_type` filter,
+  `GET /v1/admin/contacts/tags` for tag pickers,
   `GET /v1/admin/contacts/search` for contact picker search,
   `GET|POST /v1/admin/contacts/{id}/notes` and `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`
   for standalone CRM notes on a contact (not tied to a sales lead), and `DELETE /v1/admin/contacts/{id}`

--- a/tests/test_admin_crm_helpers.py
+++ b/tests/test_admin_crm_helpers.py
@@ -4,8 +4,13 @@ from typing import Any
 
 import pytest
 
-from app.api.admin_crm_helpers import crm_request_id, parse_crm_relationship_type
+from app.api.admin_crm_helpers import (
+    crm_request_id,
+    parse_contact_type_filter,
+    parse_crm_relationship_type,
+)
 from app.db.models import RelationshipType
+from app.db.models.enums import ContactType
 from app.exceptions import ValidationError
 
 
@@ -35,3 +40,19 @@ def test_parse_crm_relationship_type_allows_non_vendor() -> None:
         parse_crm_relationship_type("client", field="relationship_type", forbid_vendor=True)
         == RelationshipType.CLIENT
     )
+
+
+def test_parse_contact_type_filter_empty_means_no_filter() -> None:
+    assert parse_contact_type_filter(None) is None
+    assert parse_contact_type_filter("") is None
+    assert parse_contact_type_filter("  ") is None
+
+
+def test_parse_contact_type_filter_accepts_known_values() -> None:
+    assert parse_contact_type_filter("parent") == ContactType.PARENT
+    assert parse_contact_type_filter("CHILD") == ContactType.CHILD
+
+
+def test_parse_contact_type_filter_rejects_unknown() -> None:
+    with pytest.raises(ValidationError, match="contact_type"):
+        parse_contact_type_filter("not_a_type")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Contact editor:** First row: first name, last name, contact type, relationship. Second row: email, phone, Instagram, date of birth. Source sits on one flex row with referral search + referred-by when source is referral.
- **Location:** Wrapped the inline location block in a bordered container; **geographic area and address** share one row in the edit form (`sm:grid-cols-2`).
- **Tags:** `CrmTagPicker` supports a **collapsible** variant (same `details`/`summary` pattern as structured JSON fields elsewhere in admin).
- **Contacts table:** New **Type** filter (All + each `CrmContactType`) before **Status**. **Status** defaults to **Active** (requires backend support for filtering by type).

## Backend

- `GET /v1/admin/contacts` accepts optional `contact_type` query parameter; `ContactRepository.list_for_admin` / `count_for_admin` apply the filter.
- OpenAPI (`docs/api/admin.yaml`) and generated admin types updated.

## Tests

- `apps/admin_web`: vitest for contacts panel and page; `npm run lint`.
- `tests/test_admin_crm_helpers.py`: `parse_contact_type_filter` coverage.
- `pytest tests/test_admin_crm_routes.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c650873d-bc6f-4140-a82c-d2bfdba0cce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c650873d-bc6f-4140-a82c-d2bfdba0cce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

