### PR TITLE
Admin CRM: contacts layout, unified location styling, org field order, vendor relationship

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -482,7 +482,7 @@ export function ContactsPanel({
       />
       <AdminEditorCard
         title='Contact'
-        description='Create a contact or select a row below to edit. Relationship excludes vendor (vendors are organisation records under Finance). When this contact is linked to a family or organisation, set location on that record instead. Mailchimp sync status is read-only from the API.'
+        description='Create a contact or select a row below to edit. When this contact is linked to a family or organisation, set location on that record instead. Mailchimp sync status is read-only from the API.'
         actions={
           <>
             {editorMode === 'edit' ? (
@@ -588,8 +588,8 @@ export function ContactsPanel({
             </div>
           </div>
 
-          <div className='flex flex-wrap items-end gap-3'>
-            <div className='min-w-[min(100%,12rem)] flex-1'>
+          <div className='grid grid-cols-1 gap-4 lg:grid-cols-4 lg:items-end'>
+            <div className='lg:col-span-1'>
               <Label htmlFor='crm-contact-source'>Source</Label>
               <Select
                 id='crm-contact-source'
@@ -614,9 +614,18 @@ export function ContactsPanel({
                 ))}
               </Select>
             </div>
+            <div className={source === 'referral' ? 'lg:col-span-1' : 'lg:col-span-3'}>
+              <Label htmlFor='crm-contact-source-detail'>Source detail</Label>
+              <Textarea
+                id='crm-contact-source-detail'
+                value={sourceDetail}
+                onChange={(e) => setSourceDetail(e.target.value)}
+                rows={2}
+              />
+            </div>
             {source === 'referral' ? (
               <>
-                <div className='min-w-[min(100%,14rem)] flex-1'>
+                <div className='lg:col-span-1'>
                   <Label htmlFor='crm-contact-referral-search'>Find referring contact</Label>
                   <Input
                     id='crm-contact-referral-search'
@@ -626,7 +635,7 @@ export function ContactsPanel({
                     autoComplete='off'
                   />
                 </div>
-                <div className='min-w-[min(100%,14rem)] flex-1'>
+                <div className='lg:col-span-1'>
                   <Label htmlFor='crm-contact-referral'>Referred by contact</Label>
                   <Select
                     id='crm-contact-referral'
@@ -749,16 +758,6 @@ export function ContactsPanel({
                 </Select>
               </div>
             ) : null}
-          </div>
-
-          <div>
-            <Label htmlFor='crm-contact-source-detail'>Source detail</Label>
-            <Textarea
-              id='crm-contact-source-detail'
-              value={sourceDetail}
-              onChange={(e) => setSourceDetail(e.target.value)}
-              rows={2}
-            />
           </div>
 
           <CrmTagPicker

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -262,7 +262,7 @@ export function FamiliesPanel({
     <div className='space-y-6'>
       <AdminEditorCard
         title='Family'
-        description='Create a family or select one below. Add members by linking an existing contact. Relationship excludes vendor (aligned with non-vendor CRM entities).'
+        description='Create a family or select one below. Add members by linking an existing contact.'
         actions={
           <>
             {editorMode === 'edit' ? (
@@ -307,37 +307,39 @@ export function FamiliesPanel({
             </Select>
           </div>
           <div className='lg:col-span-2'>
-            <InlineLocationEditor
-              stateKey={inlineLocationStateKey}
-              location={resolvedLocation}
-              embeddedSummary={embeddedLocationSummary}
-              areas={geographicAreas}
-              areasLoading={areasLoading}
-              canModify
-              isSaving={isSaving || locationSaveStatus.isSaving}
-              isGeocoding={locationGeocoding}
-              saveError={locationSaveStatus.error}
-              onRequestEdit={() => {}}
-              onCancelEdit={() => {}}
-              onSaveCreate={async (payload) => {
-                const created = await createSharedLocation(payload);
-                if (created) {
-                  setPendingLocationId(created.id);
-                  setOptimisticLocationSummary(summaryFromLocationRow(created));
-                  return created.id;
-                }
-                return null;
-              }}
-              onSaveUpdate={async (id, payload) => {
-                await updateSharedLocation(id, payload);
-              }}
-              onClear={() => {
-                setPendingLocationId(null);
-                setOptimisticLocationSummary(null);
-                clearLocationSaveError();
-              }}
-              onGeocode={geocodeLocation}
-            />
+            <div className='rounded-md border border-slate-200 bg-slate-50/40 p-3'>
+              <InlineLocationEditor
+                stateKey={inlineLocationStateKey}
+                location={resolvedLocation}
+                embeddedSummary={embeddedLocationSummary}
+                areas={geographicAreas}
+                areasLoading={areasLoading}
+                canModify
+                isSaving={isSaving || locationSaveStatus.isSaving}
+                isGeocoding={locationGeocoding}
+                saveError={locationSaveStatus.error}
+                onRequestEdit={() => {}}
+                onCancelEdit={() => {}}
+                onSaveCreate={async (payload) => {
+                  const created = await createSharedLocation(payload);
+                  if (created) {
+                    setPendingLocationId(created.id);
+                    setOptimisticLocationSummary(summaryFromLocationRow(created));
+                    return created.id;
+                  }
+                  return null;
+                }}
+                onSaveUpdate={async (id, payload) => {
+                  await updateSharedLocation(id, payload);
+                }}
+                onClear={() => {
+                  setPendingLocationId(null);
+                  setOptimisticLocationSummary(null);
+                  clearLocationSaveError();
+                }}
+                onGeocode={geocodeLocation}
+              />
+            </div>
           </div>
           {editorMode === 'edit' ? (
             <div>
@@ -363,7 +365,7 @@ export function FamiliesPanel({
             />
           </div>
           {editorMode === 'edit' && selected ? (
-            <div className='lg:col-span-2 space-y-3 rounded-md border border-slate-200 p-4'>
+            <div className='lg:col-span-2 space-y-3 rounded-md border border-slate-200 bg-slate-50/40 p-4'>
               <h3 className='text-sm font-semibold text-slate-800'>Members</h3>
               <div className='flex flex-wrap items-end gap-3'>
                 <div className='min-w-[200px] flex-1'>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -301,7 +301,7 @@ export function OrganizationsPanel({
           </>
         }
       >
-        <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
+        <div className='grid grid-cols-1 gap-4 lg:grid-cols-4'>
           <div>
             <Label htmlFor='crm-org-name'>Name</Label>
             <Input
@@ -311,23 +311,7 @@ export function OrganizationsPanel({
               autoComplete='off'
             />
           </div>
-          <div>
-            <Label htmlFor='crm-org-type'>Organisation type</Label>
-            <Select
-              id='crm-org-type'
-              value={organizationType}
-              onChange={(e) =>
-                setOrganizationType(e.target.value as ApiSchemas['CrmOrganizationType'])
-              }
-            >
-              {ORG_TYPES.map((v) => (
-                <option key={v} value={v}>
-                  {formatEnumLabel(v)}
-                </option>
-              ))}
-            </Select>
-          </div>
-          <div>
+          <div className='lg:max-w-[9rem]'>
             <Label htmlFor='crm-org-rel'>Relationship</Label>
             <Select
               id='crm-org-rel'
@@ -347,6 +331,22 @@ export function OrganizationsPanel({
               ))}
             </Select>
           </div>
+          <div>
+            <Label htmlFor='crm-org-type'>Organisation type</Label>
+            <Select
+              id='crm-org-type'
+              value={organizationType}
+              onChange={(e) =>
+                setOrganizationType(e.target.value as ApiSchemas['CrmOrganizationType'])
+              }
+            >
+              {ORG_TYPES.map((v) => (
+                <option key={v} value={v}>
+                  {formatEnumLabel(v)}
+                </option>
+              ))}
+            </Select>
+          </div>
           {relationshipType === 'partner' ? (
             <div>
               <Label htmlFor='crm-org-slug'>Slug</Label>
@@ -357,59 +357,69 @@ export function OrganizationsPanel({
                 autoComplete='off'
                 placeholder='e.g. acme-partners'
               />
-              <p className='mt-1 text-sm text-slate-600'>
-                Lowercase letters, numbers, and hyphens only. Optional; must be unique among partner
-                organisations.
-              </p>
+            </div>
+          ) : (
+            <div>
+              <Label htmlFor='crm-org-web'>Website</Label>
+              <Input
+                id='crm-org-web'
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+                autoComplete='off'
+              />
+            </div>
+          )}
+          {relationshipType === 'partner' ? (
+            <div className='lg:col-span-4'>
+              <Label htmlFor='crm-org-web-partner'>Website</Label>
+              <Input
+                id='crm-org-web-partner'
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+                autoComplete='off'
+              />
             </div>
           ) : null}
-          <div>
-            <Label htmlFor='crm-org-web'>Website</Label>
-            <Input
-              id='crm-org-web'
-              value={website}
-              onChange={(e) => setWebsite(e.target.value)}
-              autoComplete='off'
-            />
-          </div>
-          <div className='lg:col-span-2'>
-            <InlineLocationEditor
-              stateKey={inlineLocationStateKey}
-              location={resolvedLocation}
-              embeddedSummary={embeddedLocationSummary}
-              areas={geographicAreas}
-              areasLoading={areasLoading}
-              canModify
-              allowClearWhenLocked={locationLockedReadOnly}
-              lockedSummaryExtra={
-                locationLockedReadOnly
-                  ? 'To change the venue name or switch to a different address, use Services → Venues or update the partner organisation record.'
-                  : null
-              }
-              isSaving={isSaving || locationSaveStatus.isSaving}
-              isGeocoding={locationGeocoding}
-              saveError={locationSaveStatus.error}
-              onRequestEdit={() => {}}
-              onCancelEdit={() => {}}
-              onSaveCreate={async (payload) => {
-                const created = await createSharedLocation(payload);
-                if (created) {
-                  setPendingLocationId(created.id);
-                  setOptimisticLocationSummary(summaryFromLocationRow(created));
-                  return created.id;
+          <div className='lg:col-span-4'>
+            <div className='rounded-md border border-slate-200 bg-slate-50/40 p-3'>
+              <InlineLocationEditor
+                stateKey={inlineLocationStateKey}
+                location={resolvedLocation}
+                embeddedSummary={embeddedLocationSummary}
+                areas={geographicAreas}
+                areasLoading={areasLoading}
+                canModify
+                allowClearWhenLocked={locationLockedReadOnly}
+                lockedSummaryExtra={
+                  locationLockedReadOnly
+                    ? 'To change the venue name or switch to a different address, use Services → Venues or update the partner organisation record.'
+                    : null
                 }
-                return null;
-              }}
-              onSaveUpdate={async (id, payload) => {
-                await updateSharedLocation(id, payload);
-              }}
-              onClear={() => {
-                setPendingLocationId(null);
-                setOptimisticLocationSummary(null);
-                clearLocationSaveError();
-              }}
-              onGeocode={geocodeLocation}
-            />
+                isSaving={isSaving || locationSaveStatus.isSaving}
+                isGeocoding={locationGeocoding}
+                saveError={locationSaveStatus.error}
+                onRequestEdit={() => {}}
+                onCancelEdit={() => {}}
+                onSaveCreate={async (payload) => {
+                  const created = await createSharedLocation(payload);
+                  if (created) {
+                    setPendingLocationId(created.id);
+                    setOptimisticLocationSummary(summaryFromLocationRow(created));
+                    return created.id;
+                  }
+                  return null;
+                }}
+                onSaveUpdate={async (id, payload) => {
+                  await updateSharedLocation(id, payload);
+                }}
+                onClear={() => {
+                  setPendingLocationId(null);
+                  setOptimisticLocationSummary(null);
+                  clearLocationSaveError();
+                }}
+                onGeocode={geocodeLocation}
+              />
+            </div>
           </div>
           {editorMode === 'edit' ? (
             <div>
@@ -435,7 +445,7 @@ export function OrganizationsPanel({
             />
           </div>
           {editorMode === 'edit' && selected ? (
-            <div className='lg:col-span-2 space-y-3 rounded-md border border-slate-200 p-4'>
+            <div className='lg:col-span-4 space-y-3 rounded-md border border-slate-200 bg-slate-50/40 p-4'>
               <h3 className='text-sm font-semibold text-slate-800'>Members</h3>
               <div className='flex flex-wrap items-end gap-3'>
                 <div className='min-w-[200px] flex-1'>

--- a/apps/admin_web/src/hooks/use-admin-crm-organizations.ts
+++ b/apps/admin_web/src/hooks/use-admin-crm-organizations.ts
@@ -93,6 +93,6 @@ export function useAdminCrmOrganizations() {
     addMember,
     removeMember,
     refetch: list.refetch,
-    crmRelationshipOptions: CRM_ENTITY_RELATIONSHIP_TYPES,
+    crmRelationshipOptions: CRM_ENTITY_RELATIONSHIP_TYPES.filter((v) => v !== 'vendor'),
   };
 }

--- a/apps/admin_web/src/types/crm-relationship.ts
+++ b/apps/admin_web/src/types/crm-relationship.ts
@@ -1,28 +1,27 @@
 import type { components } from '@/types/generated/admin-api.generated';
 
-/** Relationship values allowed for CRM contacts, families, and non-vendor organisations (no vendor). */
-export type CrmEntityRelationshipType = Exclude<
-  components['schemas']['CrmRelationshipType'],
-  'vendor'
->;
+/** Relationship values shown in CRM entity editors (includes vendor where the API allows it). */
+export type CrmEntityRelationshipType = components['schemas']['CrmRelationshipType'];
 
 export const CRM_ENTITY_RELATIONSHIP_TYPES: readonly CrmEntityRelationshipType[] = [
   'prospect',
   'client',
   'past_client',
   'partner',
+  'vendor',
   'other',
 ];
 
 /**
- * Map a stored CRM relationship to a dropdown value. Vendor is not editable here
- * (Finance / vendor orgs); unknown values map to `other` so the select stays valid.
+ * Map a stored CRM relationship to a dropdown value. Unknown values map to `other`
+ * so the select stays valid.
  */
 export function relationshipTypeForCrmEditor(
   stored: components['schemas']['CrmRelationshipType']
 ): CrmEntityRelationshipType {
-  if (stored === 'vendor') {
-    return 'other';
+  const allowed = new Set(CRM_ENTITY_RELATIONSHIP_TYPES);
+  if (allowed.has(stored)) {
+    return stored;
   }
-  return stored as CrmEntityRelationshipType;
+  return 'other';
 }

--- a/apps/admin_web/tests/types/crm-relationship.test.ts
+++ b/apps/admin_web/tests/types/crm-relationship.test.ts
@@ -3,11 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { relationshipTypeForCrmEditor } from '@/types/crm-relationship';
 
 describe('relationshipTypeForCrmEditor', () => {
-  it('maps vendor to other for editor compatibility', () => {
-    expect(relationshipTypeForCrmEditor('vendor')).toBe('other');
+  it('passes through vendor when present in the editor enum', () => {
+    expect(relationshipTypeForCrmEditor('vendor')).toBe('vendor');
   });
 
   it('passes through allowed values', () => {
     expect(relationshipTypeForCrmEditor('client')).toBe('client');
+  });
+
+  it('maps unknown values to other', () => {
+    expect(relationshipTypeForCrmEditor('not_a_real_type' as never)).toBe('other');
   });
 });

--- a/backend/src/app/api/admin_contacts_mutations.py
+++ b/backend/src/app/api/admin_contacts_mutations.py
@@ -80,7 +80,7 @@ def create_contact(
     )
     contact_type = parse_contact_type(body.get("contact_type"), field="contact_type")
     relationship_type = parse_crm_relationship_type(
-        body.get("relationship_type"), field="relationship_type", forbid_vendor=True
+        body.get("relationship_type"), field="relationship_type"
     )
     source = parse_contact_source(body.get("source"), field="source")
     source_detail = validate_string_length(
@@ -255,7 +255,6 @@ def update_contact(
             contact.relationship_type = parse_crm_relationship_type(
                 body.get("relationship_type"),
                 field="relationship_type",
-                forbid_vendor=True,
             )
         if "source" in body:
             contact.source = parse_contact_source(body.get("source"), field="source")

--- a/backend/src/app/api/admin_families.py
+++ b/backend/src/app/api/admin_families.py
@@ -165,7 +165,7 @@ def _create_family(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any
         required=True,
     )
     relationship_type = parse_crm_relationship_type(
-        body.get("relationship_type"), field="relationship_type", forbid_vendor=True
+        body.get("relationship_type"), field="relationship_type"
     )
     location_id = parse_optional_uuid(body.get("location_id"), "location_id")
     tag_ids = parse_uuid_list(body.get("tag_ids"), "tag_ids")
@@ -222,7 +222,6 @@ def _update_family(
             family.relationship_type = parse_crm_relationship_type(
                 body.get("relationship_type"),
                 field="relationship_type",
-                forbid_vendor=True,
             )
         if "location_id" in body:
             loc = parse_optional_uuid(body.get("location_id"), "location_id")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Contacts panel**: Source uses a 4-column grid so the Source select is one column wide; Source detail sits in columns 2–4 (or 2 only when referral is selected); referral search and “Referred by” occupy columns 3–4 on large screens. Source detail sits between the source row and the location block.
- **Families / organisations**: Location editors use the same bordered, tinted wrapper as contacts. Members sections use the same border + `bg-slate-50/40` as location blocks for a single visual style.
- **Organisations panel**: Relationship appears before Organisation type; relationship column is constrained (~half width on large screens); when relationship is Partner, Slug appears in column 4; website is on a full-width row below (partner case only); removed the slug helper paragraph under the field.
- **Vendor relationship**: Added `vendor` to the shared CRM relationship list for **contacts** and **families**. Backend `parse_crm_relationship_type` no longer blocks vendor on contact/family create/update. **Organisation** CRM API still rejects vendor (Finance-only vendor orgs); the org hook filters `vendor` out of the dropdown so users cannot submit invalid org payloads.

## Tests

- `apps/admin_web`: `npm run lint`, `npm run test`
- `tests/test_admin_crm_helpers.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8de7c30f-ea46-4f51-bdcf-262d3cd2e9d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8de7c30f-ea46-4f51-bdcf-262d3cd2e9d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

