### PR TITLE
Admin web: Contacts CRM editor layout tweaks

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -588,33 +588,71 @@ export function ContactsPanel({
             </div>
           </div>
 
-          <div className='grid grid-cols-1 gap-4 lg:grid-cols-4 lg:items-end'>
-            <div className='lg:col-span-1'>
-              <Label htmlFor='crm-contact-source'>Source</Label>
-              <Select
-                id='crm-contact-source'
-                value={source}
-                onChange={(e) => {
-                  const v = e.target.value as ApiSchemas['CrmContactSource'];
-                  setSource(v);
-                  if (v !== 'referral') {
-                    setReferralContactId('');
-                    setReferralSearchInput('');
-                    setReferralSearchResults([]);
-                    setReferralPinnedLabel('');
-                  } else {
-                    setReferralSearchResults([]);
-                  }
-                }}
-              >
-                {SOURCES.map((v) => (
-                  <option key={v} value={v}>
-                    {formatEnumLabel(v)}
-                  </option>
-                ))}
-              </Select>
+          <div className='space-y-4'>
+            <div className='grid grid-cols-1 gap-4 lg:grid-cols-4 lg:items-end'>
+              <div className='lg:col-span-1'>
+                <Label htmlFor='crm-contact-source'>Source</Label>
+                <Select
+                  id='crm-contact-source'
+                  value={source}
+                  onChange={(e) => {
+                    const v = e.target.value as ApiSchemas['CrmContactSource'];
+                    setSource(v);
+                    if (v !== 'referral') {
+                      setReferralContactId('');
+                      setReferralSearchInput('');
+                      setReferralSearchResults([]);
+                      setReferralPinnedLabel('');
+                    } else {
+                      setReferralSearchResults([]);
+                    }
+                  }}
+                >
+                  {SOURCES.map((v) => (
+                    <option key={v} value={v}>
+                      {formatEnumLabel(v)}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+              {source === 'referral' ? (
+                <>
+                  <div className='lg:col-span-1'>
+                    <Label htmlFor='crm-contact-referral-search'>Find referring contact</Label>
+                    <Input
+                      id='crm-contact-referral-search'
+                      value={referralSearchInput}
+                      onChange={(e) => setReferralSearchInput(e.target.value)}
+                      placeholder='Type at least 2 characters (name, email, phone, Instagram)'
+                      autoComplete='off'
+                    />
+                  </div>
+                  <div className='lg:col-span-1'>
+                    <Label htmlFor='crm-contact-referral'>Referred by contact</Label>
+                    <Select
+                      id='crm-contact-referral'
+                      value={referralContactId}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setReferralContactId(v);
+                        const picked = referralSelectOptions.find((o) => o.id === v);
+                        if (picked) {
+                          setReferralPinnedLabel(picked.label);
+                        }
+                      }}
+                    >
+                      <option value=''>Select contact</option>
+                      {referralSelectOptions.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.label}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
+                </>
+              ) : null}
             </div>
-            <div className={source === 'referral' ? 'lg:col-span-1' : 'lg:col-span-3'}>
+            <div>
               <Label htmlFor='crm-contact-source-detail'>Source detail</Label>
               <Textarea
                 id='crm-contact-source-detail'
@@ -623,42 +661,6 @@ export function ContactsPanel({
                 rows={2}
               />
             </div>
-            {source === 'referral' ? (
-              <>
-                <div className='lg:col-span-1'>
-                  <Label htmlFor='crm-contact-referral-search'>Find referring contact</Label>
-                  <Input
-                    id='crm-contact-referral-search'
-                    value={referralSearchInput}
-                    onChange={(e) => setReferralSearchInput(e.target.value)}
-                    placeholder='Type at least 2 characters (name, email, phone, Instagram)'
-                    autoComplete='off'
-                  />
-                </div>
-                <div className='lg:col-span-1'>
-                  <Label htmlFor='crm-contact-referral'>Referred by contact</Label>
-                  <Select
-                    id='crm-contact-referral'
-                    value={referralContactId}
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      setReferralContactId(v);
-                      const picked = referralSelectOptions.find((o) => o.id === v);
-                      if (picked) {
-                        setReferralPinnedLabel(picked.label);
-                      }
-                    }}
-                  >
-                    <option value=''>Select contact</option>
-                    {referralSelectOptions.map((c) => (
-                      <option key={c.id} value={c.id}>
-                        {c.label}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-              </>
-            ) : null}
           </div>
 
           <div className='rounded-md border border-slate-200 bg-slate-50/40 p-3'>

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -362,6 +362,7 @@ export function FamiliesPanel({
               selectedIds={tagIds}
               onChange={setTagIds}
               disabled={isSaving}
+              variant='collapsible'
             />
           </div>
           {editorMode === 'edit' && selected ? (

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -302,7 +302,7 @@ export function OrganizationsPanel({
         }
       >
         <div className='grid grid-cols-1 gap-4 lg:grid-cols-4'>
-          <div>
+          <div className='lg:col-span-2'>
             <Label htmlFor='crm-org-name'>Name</Label>
             <Input
               id='crm-org-name'
@@ -311,7 +311,7 @@ export function OrganizationsPanel({
               autoComplete='off'
             />
           </div>
-          <div className='lg:max-w-[9rem]'>
+          <div className='lg:col-span-1'>
             <Label htmlFor='crm-org-rel'>Relationship</Label>
             <Select
               id='crm-org-rel'
@@ -331,7 +331,19 @@ export function OrganizationsPanel({
               ))}
             </Select>
           </div>
-          <div>
+          {relationshipType === 'partner' ? (
+            <div className='lg:col-span-1'>
+              <Label htmlFor='crm-org-slug'>Slug</Label>
+              <Input
+                id='crm-org-slug'
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
+                autoComplete='off'
+                placeholder='e.g. acme-partners'
+              />
+            </div>
+          ) : null}
+          <div className='lg:col-span-2'>
             <Label htmlFor='crm-org-type'>Organisation type</Label>
             <Select
               id='crm-org-type'
@@ -347,39 +359,15 @@ export function OrganizationsPanel({
               ))}
             </Select>
           </div>
-          {relationshipType === 'partner' ? (
-            <div>
-              <Label htmlFor='crm-org-slug'>Slug</Label>
-              <Input
-                id='crm-org-slug'
-                value={slug}
-                onChange={(e) => setSlug(e.target.value)}
-                autoComplete='off'
-                placeholder='e.g. acme-partners'
-              />
-            </div>
-          ) : (
-            <div>
-              <Label htmlFor='crm-org-web'>Website</Label>
-              <Input
-                id='crm-org-web'
-                value={website}
-                onChange={(e) => setWebsite(e.target.value)}
-                autoComplete='off'
-              />
-            </div>
-          )}
-          {relationshipType === 'partner' ? (
-            <div className='lg:col-span-4'>
-              <Label htmlFor='crm-org-web-partner'>Website</Label>
-              <Input
-                id='crm-org-web-partner'
-                value={website}
-                onChange={(e) => setWebsite(e.target.value)}
-                autoComplete='off'
-              />
-            </div>
-          ) : null}
+          <div className='lg:col-span-2'>
+            <Label htmlFor='crm-org-web'>Website</Label>
+            <Input
+              id='crm-org-web'
+              value={website}
+              onChange={(e) => setWebsite(e.target.value)}
+              autoComplete='off'
+            />
+          </div>
           <div className='lg:col-span-4'>
             <div className='rounded-md border border-slate-200 bg-slate-50/40 p-3'>
               <InlineLocationEditor
@@ -442,6 +430,7 @@ export function OrganizationsPanel({
               selectedIds={tagIds}
               onChange={setTagIds}
               disabled={isSaving}
+              variant='collapsible'
             />
           </div>
           {editorMode === 'edit' && selected ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Contacts tab**: Source detail is on its own row below the Source row (and referral search/select when source is referral).
- **Families & Organisations tabs**: Tag pickers use the same collapsible disclosure pattern as contact tags.
- **Organisations tab**: Row 1 — name spans two columns, relationship in column 3, slug in column 4 when partner. Row 2 — organisation type spans columns 1–2, website spans columns 3–4 (single website field for all relationship types).

## Validation

- `npm run lint` and `npm run test` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55125518-2e04-4110-a805-6dc30ab6cab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55125518-2e04-4110-a805-6dc30ab6cab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

