### PR TITLE
Admin web: organisation tags below status

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -409,29 +409,31 @@ export function OrganizationsPanel({
               />
             </div>
           </div>
-          {editorMode === 'edit' ? (
+          <div className='lg:col-span-4 space-y-4'>
+            {editorMode === 'edit' ? (
+              <div>
+                <Label htmlFor='crm-org-active'>Status</Label>
+                <Select
+                  id='crm-org-active'
+                  value={active ? 'true' : 'false'}
+                  onChange={(e) => setActive(e.target.value === 'true')}
+                >
+                  <option value='true'>Active</option>
+                  <option value='false'>Archived</option>
+                </Select>
+              </div>
+            ) : null}
             <div>
-              <Label htmlFor='crm-org-active'>Status</Label>
-              <Select
-                id='crm-org-active'
-                value={active ? 'true' : 'false'}
-                onChange={(e) => setActive(e.target.value === 'true')}
-              >
-                <option value='true'>Active</option>
-                <option value='false'>Archived</option>
-              </Select>
+              <CrmTagPicker
+                id='crm-org-tags'
+                label='Tags'
+                tags={tags}
+                selectedIds={tagIds}
+                onChange={setTagIds}
+                disabled={isSaving}
+                variant='collapsible'
+              />
             </div>
-          ) : null}
-          <div className='lg:col-span-2'>
-            <CrmTagPicker
-              id='crm-org-tags'
-              label='Tags'
-              tags={tags}
-              selectedIds={tagIds}
-              onChange={setTagIds}
-              disabled={isSaving}
-              variant='collapsible'
-            />
           </div>
           {editorMode === 'edit' && selected ? (
             <div className='lg:col-span-4 space-y-3 rounded-md border border-slate-200 bg-slate-50/40 p-4'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the Contacts → Organisations inline editor, the **Tags** control is now on a separate row **below** the **Status** dropdown (instead of beside it on large screens).

## Changes

- Wrapped the edit-mode Status field and `CrmTagPicker` in a full-width (`lg:col-span-4`) column with vertical spacing so Tags always follow Status on the next line.

## Testing

- `npm run test -- --run tests/components/admin/contacts/organizations-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5de478fa-6d46-4e94-bd45-a2e1fcaa9c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5de478fa-6d46-4e94-bd45-a2e1fcaa9c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

