### PR TITLE
Admin: delete families and organisations (Operations column)

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminCrmFamilies } from '@/hooks/use-admin-crm-families';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useGeocodeVenueAddress } from '@/hooks/use-geocode-venue-address';
 import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
 import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
 import { CrmTagPicker } from '@/components/admin/contacts/crm-tag-picker';
+import { DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -81,7 +83,11 @@ export function FamiliesPanel({
     updateFamily,
     addMember,
     removeMember,
+    deleteFamily,
   } = families;
+
+  const [confirmDialogProps, requestConfirm] = useConfirmDialog();
+  const [deleteActionError, setDeleteActionError] = useState('');
 
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -242,6 +248,32 @@ export function FamiliesPanel({
     }
   }
 
+  async function handleDeleteFamily(
+    row: ApiSchemas['AdminFamily'],
+    clickEvent: MouseEvent<HTMLButtonElement>
+  ): Promise<void> {
+    clickEvent.stopPropagation();
+    const confirmed = await requestConfirm({
+      title: 'Delete family',
+      description: `Permanently delete "${row.family_name}"? This removes the family from the database and cannot be undone.`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) {
+      return;
+    }
+    setDeleteActionError('');
+    try {
+      await deleteFamily(row.id);
+      if (selectedId === row.id) {
+        resetCreateForm();
+      }
+    } catch (err) {
+      setDeleteActionError(err instanceof Error ? err.message : 'Failed to delete family');
+    }
+  }
+
   function selectRow(id: string) {
     const row = rows.find((f) => f.id === id);
     if (!row) {
@@ -260,6 +292,7 @@ export function FamiliesPanel({
 
   return (
     <div className='space-y-6'>
+      <ConfirmDialog {...confirmDialogProps} />
       <AdminEditorCard
         title='Family'
         description='Create a family or select one below. Add members by linking an existing contact.'
@@ -463,7 +496,7 @@ export function FamiliesPanel({
         isLoading={isLoading}
         isLoadingMore={isLoadingMore}
         hasMore={hasMore}
-        error={error}
+        error={error || deleteActionError}
         loadingLabel='Loading families...'
         onLoadMore={loadMore}
         toolbar={
@@ -473,7 +506,10 @@ export function FamiliesPanel({
               <Input
                 id='crm-families-search'
                 value={filters.query}
-                onChange={(e) => setFilter('query', e.target.value)}
+                onChange={(e) => {
+                  setDeleteActionError('');
+                  setFilter('query', e.target.value);
+                }}
                 placeholder='Family name'
               />
             </div>
@@ -482,7 +518,10 @@ export function FamiliesPanel({
               <Select
                 id='crm-families-active'
                 value={filters.active}
-                onChange={(e) => setFilter('active', e.target.value as CrmListFilters['active'])}
+                onChange={(e) => {
+                  setDeleteActionError('');
+                  setFilter('active', e.target.value as CrmListFilters['active']);
+                }}
               >
                 <option value=''>All</option>
                 <option value='true'>Active</option>
@@ -492,12 +531,13 @@ export function FamiliesPanel({
           </div>
         }
       >
-        <AdminDataTable tableClassName='min-w-[640px]'>
+        <AdminDataTable tableClassName='min-w-[720px]'>
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Members</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
+              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
@@ -512,6 +552,24 @@ export function FamiliesPanel({
                 <td className='px-4 py-3'>{row.family_name}</td>
                 <td className='px-4 py-3'>{row.members.length}</td>
                 <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
+                <td className='px-4 py-3 text-right'>
+                  <div className='flex flex-wrap justify-end gap-2'>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='danger'
+                      className='h-8 min-w-8 px-0'
+                      onClick={(e) => {
+                        void handleDeleteFamily(row, e);
+                      }}
+                      disabled={isSaving}
+                      aria-label='Delete family'
+                      title='Delete family'
+                    >
+                      <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
+                    </Button>
+                  </div>
+                </td>
               </tr>
             ))}
           </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminCrmOrganizations } from '@/hooks/use-admin-crm-organizations';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useGeocodeVenueAddress } from '@/hooks/use-geocode-venue-address';
 import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
 import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
 import { CrmTagPicker } from '@/components/admin/contacts/crm-tag-picker';
+import { DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -91,8 +93,12 @@ export function OrganizationsPanel({
     updateOrganization,
     addMember,
     removeMember,
+    deleteOrganization,
     crmRelationshipOptions,
   } = organizations;
+
+  const [confirmDialogProps, requestConfirm] = useConfirmDialog();
+  const [deleteActionError, setDeleteActionError] = useState('');
 
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -264,6 +270,34 @@ export function OrganizationsPanel({
     }
   }
 
+  async function handleDeleteOrganization(
+    row: ApiSchemas['AdminOrganization'],
+    clickEvent: MouseEvent<HTMLButtonElement>
+  ): Promise<void> {
+    clickEvent.stopPropagation();
+    const confirmed = await requestConfirm({
+      title: 'Delete organisation',
+      description: `Permanently delete "${row.name}"? This removes the organisation from the database and cannot be undone.`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) {
+      return;
+    }
+    setDeleteActionError('');
+    try {
+      await deleteOrganization(row.id);
+      if (selectedId === row.id) {
+        resetCreateForm();
+      }
+    } catch (err) {
+      setDeleteActionError(
+        err instanceof Error ? err.message : 'Failed to delete organisation'
+      );
+    }
+  }
+
   function selectRow(id: string) {
     const row = rows.find((o) => o.id === id);
     if (!row) {
@@ -285,6 +319,7 @@ export function OrganizationsPanel({
 
   return (
     <div className='space-y-6'>
+      <ConfirmDialog {...confirmDialogProps} />
       <AdminEditorCard
         title='Organisation'
         description='Non-vendor organisations only. Vendors are managed under Finance.'
@@ -519,7 +554,7 @@ export function OrganizationsPanel({
         isLoading={isLoading}
         isLoadingMore={isLoadingMore}
         hasMore={hasMore}
-        error={error}
+        error={error || deleteActionError}
         loadingLabel='Loading organisations...'
         onLoadMore={loadMore}
         toolbar={
@@ -529,7 +564,10 @@ export function OrganizationsPanel({
               <Input
                 id='crm-orgs-search'
                 value={filters.query}
-                onChange={(e) => setFilter('query', e.target.value)}
+                onChange={(e) => {
+                  setDeleteActionError('');
+                  setFilter('query', e.target.value);
+                }}
                 placeholder='Organisation name'
               />
             </div>
@@ -538,7 +576,10 @@ export function OrganizationsPanel({
               <Select
                 id='crm-orgs-active'
                 value={filters.active}
-                onChange={(e) => setFilter('active', e.target.value as CrmListFilters['active'])}
+                onChange={(e) => {
+                  setDeleteActionError('');
+                  setFilter('active', e.target.value as CrmListFilters['active']);
+                }}
               >
                 <option value=''>All</option>
                 <option value='true'>Active</option>
@@ -548,13 +589,14 @@ export function OrganizationsPanel({
           </div>
         }
       >
-        <AdminDataTable tableClassName='min-w-[720px]'>
+        <AdminDataTable tableClassName='min-w-[800px]'>
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Type</th>
               <th className='px-4 py-3 font-semibold'>Members</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
+              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
@@ -570,6 +612,24 @@ export function OrganizationsPanel({
                 <td className='px-4 py-3'>{formatEnumLabel(row.organization_type)}</td>
                 <td className='px-4 py-3'>{row.members.length}</td>
                 <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
+                <td className='px-4 py-3 text-right'>
+                  <div className='flex flex-wrap justify-end gap-2'>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='danger'
+                      className='h-8 min-w-8 px-0'
+                      onClick={(e) => {
+                        void handleDeleteOrganization(row, e);
+                      }}
+                      disabled={isSaving}
+                      aria-label='Delete organisation'
+                      title='Delete organisation'
+                    >
+                      <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
+                    </Button>
+                  </div>
+                </td>
               </tr>
             ))}
           </AdminDataTableBody>

--- a/apps/admin_web/src/hooks/use-admin-crm-families.ts
+++ b/apps/admin_web/src/hooks/use-admin-crm-families.ts
@@ -5,6 +5,7 @@ import { useCallback, useState } from 'react';
 import {
   addAdminFamilyMember,
   createAdminFamily,
+  deleteAdminFamily,
   listAdminFamilies,
   removeAdminFamilyMember,
   updateAdminFamily,
@@ -76,6 +77,11 @@ export function useAdminCrmFamilies() {
     [mutate]
   );
 
+  const deleteFamily = useCallback(
+    async (familyId: string) => mutate(async () => deleteAdminFamily(familyId)),
+    [mutate]
+  );
+
   return {
     families: list.items,
     filters: list.filters,
@@ -91,6 +97,7 @@ export function useAdminCrmFamilies() {
     updateFamily,
     addMember,
     removeMember,
+    deleteFamily,
     refetch: list.refetch,
   };
 }

--- a/apps/admin_web/src/hooks/use-admin-crm-organizations.ts
+++ b/apps/admin_web/src/hooks/use-admin-crm-organizations.ts
@@ -5,6 +5,7 @@ import { useCallback, useState } from 'react';
 import {
   addAdminOrganizationMember,
   createAdminOrganization,
+  deleteAdminOrganization,
   listAdminOrganizations,
   removeAdminOrganizationMember,
   updateAdminOrganization,
@@ -77,6 +78,12 @@ export function useAdminCrmOrganizations() {
     [mutate]
   );
 
+  const deleteOrganization = useCallback(
+    async (organizationId: string) =>
+      mutate(async () => deleteAdminOrganization(organizationId)),
+    [mutate]
+  );
+
   return {
     organizations: list.items,
     filters: list.filters,
@@ -92,6 +99,7 @@ export function useAdminCrmOrganizations() {
     updateOrganization,
     addMember,
     removeMember,
+    deleteOrganization,
     refetch: list.refetch,
     crmRelationshipOptions: CRM_ENTITY_RELATIONSHIP_TYPES.filter((v) => v !== 'vendor'),
   };

--- a/apps/admin_web/src/lib/crm-api.ts
+++ b/apps/admin_web/src/lib/crm-api.ts
@@ -277,6 +277,14 @@ export async function updateAdminFamily(
   return root.family ?? null;
 }
 
+export async function deleteAdminFamily(familyId: string): Promise<void> {
+  await adminApiRequest<unknown>({
+    endpointPath: `/v1/admin/families/${familyId}`,
+    method: 'DELETE',
+    expectedSuccessStatuses: [204],
+  });
+}
+
 export async function addAdminFamilyMember(
   familyId: string,
   body: ApiSchemas['AddFamilyMemberRequest']
@@ -350,6 +358,14 @@ export async function updateAdminOrganization(
   });
   const root = unwrapPayload(payload);
   return root.organization ?? null;
+}
+
+export async function deleteAdminOrganization(organizationId: string): Promise<void> {
+  await adminApiRequest<unknown>({
+    endpointPath: `/v1/admin/organizations/${organizationId}`,
+    method: 'DELETE',
+    expectedSuccessStatuses: [204],
+  });
 }
 
 export async function addAdminOrganizationMember(

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2772,7 +2772,36 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete CRM family
+         * @description Permanently removes the family row. Sales leads linked to the family (and their
+         *     lead notes) are deleted first; standalone notes and enrollments that reference the
+         *     family are cleared. Returns `400` if the database still blocks deletion.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description CRM family identifier. */
+                    id: components["parameters"]["AdminFamilyId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Family deleted. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         options?: never;
         head?: never;
         /** Update CRM family */
@@ -3061,7 +3090,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete CRM organization
+         * @description Permanently removes a non-vendor organisation row. Vendor organisations must be
+         *     managed under Finance. Sales leads linked to the organisation (and their lead notes)
+         *     are deleted first; standalone notes and enrollments that reference the organisation
+         *     are cleared. Returns `400` if the database still blocks deletion.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description CRM organization identifier. */
+                    id: components["parameters"]["AdminOrganizationId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization deleted. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         options?: never;
         head?: never;
         /** Update CRM organization */

--- a/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
@@ -53,6 +53,7 @@ function buildFamiliesHook(
     updateFamily: vi.fn().mockResolvedValue(null),
     addMember: vi.fn().mockResolvedValue(null),
     removeMember: vi.fn().mockResolvedValue(null),
+    deleteFamily: vi.fn().mockResolvedValue(undefined),
     refetch: vi.fn(),
     ...overrides,
   };
@@ -182,5 +183,48 @@ describe('FamiliesPanel', () => {
       });
     });
     expect(updateLocationPartial.mock.calls[0][1]).not.toHaveProperty('name');
+  });
+
+  it('deletes a family after confirmation', async () => {
+    const user = userEvent.setup();
+    const deleteFamily = vi.fn().mockResolvedValue(undefined);
+    const families = buildFamiliesHook({
+      deleteFamily,
+      families: [
+        {
+          id: 'fam-del',
+          family_name: 'Delete Me',
+          relationship_type: 'prospect',
+          location_id: null,
+          location_summary: null,
+          tag_ids: [],
+          tags: [],
+          members: [],
+          active: true,
+          created_at: '2020-01-01T00:00:00.000Z',
+          updated_at: '2020-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    render(
+      <FamiliesPanel
+        families={families}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+        contactOptions={[]}
+        contactsForMembership={[]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete family' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(deleteFamily).toHaveBeenCalledWith('fam-del');
+    });
   });
 });

--- a/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
@@ -54,6 +54,7 @@ function buildOrgsHook(
     updateOrganization: vi.fn().mockResolvedValue(null),
     addMember: vi.fn().mockResolvedValue(null),
     removeMember: vi.fn().mockResolvedValue(null),
+    deleteOrganization: vi.fn().mockResolvedValue(undefined),
     refetch: vi.fn(),
     crmRelationshipOptions: ['prospect', 'customer', 'partner', 'vendor'] as unknown as ReturnType<
       typeof useAdminCrmOrganizations
@@ -231,5 +232,50 @@ describe('OrganizationsPanel', () => {
       });
     });
     expect(updateLocationPartial.mock.calls[0][1]).not.toHaveProperty('name');
+  });
+
+  it('deletes an organisation after confirmation', async () => {
+    const user = userEvent.setup();
+    const deleteOrganization = vi.fn().mockResolvedValue(undefined);
+    const row: components['schemas']['AdminOrganization'] = {
+      id: 'org-del',
+      name: 'Delete Org',
+      organization_type: 'company',
+      relationship_type: 'customer',
+      slug: null,
+      website: null,
+      location_id: null,
+      location_summary: null,
+      tag_ids: [],
+      tags: [],
+      members: [],
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+    };
+    const organizations = buildOrgsHook({
+      deleteOrganization,
+      organizations: [row],
+    });
+
+    render(
+      <OrganizationsPanel
+        organizations={organizations}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+        contactOptions={[]}
+        contactsForMembership={[]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete organisation' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(deleteOrganization).toHaveBeenCalledWith('org-del');
+    });
   });
 });

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -3100,6 +3100,10 @@ export class ApiStack extends cdk.Stack {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,
     });
+    adminFamilyById.addMethod("DELETE", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
     const adminFamilyMembers = adminFamilyById.addResource("members");
     adminFamilyMembers.addMethod("POST", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
@@ -3131,6 +3135,10 @@ export class ApiStack extends cdk.Stack {
       authorizer: adminAuthorizer,
     });
     adminOrganizationCrmById.addMethod("PATCH", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminOrganizationCrmById.addMethod("DELETE", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,
     });

--- a/backend/src/app/api/admin_crm_entity_deletes.py
+++ b/backend/src/app/api/admin_crm_entity_deletes.py
@@ -1,0 +1,131 @@
+"""Permanent delete helpers for admin CRM family and organisation records."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.api.admin_crm_helpers import crm_request_id
+from app.db.audit import set_audit_context
+from app.db.engine import get_engine
+from app.db.models import Enrollment, Note, RelationshipType, SalesLead
+from app.db.repositories import FamilyRepository, OrganizationRepository
+from app.exceptions import NotFoundError, ValidationError
+from app.utils import json_response
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _delete_notes_for_leads(session: Session, lead_ids: list[UUID]) -> None:
+    if not lead_ids:
+        return
+    session.execute(delete(Note).where(Note.lead_id.in_(tuple(lead_ids))))
+
+
+def _delete_sales_leads_for_family(session: Session, family_id: UUID) -> None:
+    lead_ids = list(
+        session.scalars(
+            select(SalesLead.id).where(SalesLead.family_id == family_id)
+        ).all()
+    )
+    _delete_notes_for_leads(session, lead_ids)
+    if lead_ids:
+        session.execute(delete(SalesLead).where(SalesLead.id.in_(tuple(lead_ids))))
+
+
+def _delete_sales_leads_for_organization(
+    session: Session, organization_id: UUID
+) -> None:
+    lead_ids = list(
+        session.scalars(
+            select(SalesLead.id).where(SalesLead.organization_id == organization_id)
+        ).all()
+    )
+    _delete_notes_for_leads(session, lead_ids)
+    if lead_ids:
+        session.execute(delete(SalesLead).where(SalesLead.id.in_(tuple(lead_ids))))
+
+
+def delete_admin_crm_family(
+    event: Mapping[str, Any],
+    *,
+    family_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    """Permanently delete one CRM family and dependent rows that would block deletion."""
+    logger.info(
+        "Deleting admin CRM family",
+        extra={"family_id": str(family_id), "actor_sub": actor_sub},
+    )
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        repository = FamilyRepository(session)
+        family = repository.get_by_id_for_admin(family_id)
+        if family is None:
+            raise NotFoundError("Family", str(family_id))
+
+        _delete_sales_leads_for_family(session, family_id)
+        session.execute(delete(Note).where(Note.family_id == family_id))
+        session.execute(delete(Enrollment).where(Enrollment.family_id == family_id))
+
+        try:
+            repository.delete(family)
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            raise ValidationError(
+                "Family cannot be deleted while it is still referenced",
+                field="family_id",
+            ) from exc
+
+        return json_response(204, {}, event=event)
+
+
+def delete_admin_crm_organization(
+    event: Mapping[str, Any],
+    *,
+    organization_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    """Permanently delete one non-vendor CRM organisation and dependent rows."""
+    logger.info(
+        "Deleting admin CRM organization",
+        extra={"organization_id": str(organization_id), "actor_sub": actor_sub},
+    )
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        repository = OrganizationRepository(session)
+        org = repository.get_crm_organization_by_id(organization_id)
+        if org is None:
+            raise NotFoundError("Organization", str(organization_id))
+        if org.relationship_type == RelationshipType.VENDOR:
+            raise ValidationError(
+                "Vendor organizations are managed under Finance",
+                field="organization_id",
+            )
+
+        _delete_sales_leads_for_organization(session, organization_id)
+        session.execute(delete(Note).where(Note.organization_id == organization_id))
+        session.execute(
+            delete(Enrollment).where(Enrollment.organization_id == organization_id)
+        )
+
+        try:
+            repository.delete(org)
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            raise ValidationError(
+                "Organization cannot be deleted while it is still referenced",
+                field="organization_id",
+            ) from exc
+
+        return json_response(204, {}, event=event)

--- a/backend/src/app/api/admin_families.py
+++ b/backend/src/app/api/admin_families.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from app.api.admin_crm_entity_deletes import delete_admin_crm_family
 from app.api.admin_crm_helpers import (
     assert_contact_can_join_family,
     crm_request_id,
@@ -73,6 +74,10 @@ def handle_admin_families_request(
             return _get_family(event, family_id=family_id)
         if method == "PATCH":
             return _update_family(
+                event, family_id=family_id, actor_sub=identity.user_sub
+            )
+        if method == "DELETE":
+            return delete_admin_crm_family(
                 event, family_id=family_id, actor_sub=identity.user_sub
             )
         return json_response(405, {"error": "Method not allowed"}, event=event)

--- a/backend/src/app/api/admin_organizations_crm.py
+++ b/backend/src/app/api/admin_organizations_crm.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.api.admin_crm_entity_deletes import delete_admin_crm_organization
 from app.api.admin_crm_helpers import (
     assert_contact_can_join_organization,
     crm_request_id,
@@ -85,6 +86,12 @@ def handle_admin_organizations_crm_request(
         if method == "PATCH":
             return _update_organization(
                 event, organization_id=organization_id, actor_sub=identity.user_sub
+            )
+        if method == "DELETE":
+            return delete_admin_crm_organization(
+                event,
+                organization_id=organization_id,
+                actor_sub=identity.user_sub,
             )
         return json_response(405, {"error": "Method not allowed"}, event=event)
 

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -32,12 +32,12 @@ info:
     - `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`
     - `GET /v1/admin/families/picker`
     - `GET|POST /v1/admin/families`
-    - `GET|PATCH /v1/admin/families/{id}`
+    - `GET|PATCH|DELETE /v1/admin/families/{id}`
     - `POST /v1/admin/families/{id}/members`
     - `DELETE /v1/admin/families/{id}/members/{memberId}`
     - `GET /v1/admin/organizations/picker`
     - `GET|POST /v1/admin/organizations`
-    - `GET|PATCH /v1/admin/organizations/{id}`
+    - `GET|PATCH|DELETE /v1/admin/organizations/{id}`
     - `POST /v1/admin/organizations/{id}/members`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
     - `GET|POST /v1/admin/vendors`
@@ -1965,6 +1965,23 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete CRM family
+      description: |
+        Permanently removes the family row. Sales leads linked to the family (and their
+        lead notes) are deleted first; standalone notes and enrollments that reference the
+        family are cleared. Returns `400` if the database still blocks deletion.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "204":
+          description: Family deleted.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /v1/admin/families/{id}/members:
     parameters:
@@ -2137,6 +2154,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AdminOrganizationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete CRM organization
+      description: |
+        Permanently removes a non-vendor organisation row. Vendor organisations must be
+        managed under Finance. Sales leads linked to the organisation (and their lead notes)
+        are deleted first; standalone notes and enrollments that reference the organisation
+        are cleared. Returns `400` if the database still blocks deletion.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "204":
+          description: Organization deleted.
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -57,9 +57,11 @@ their primary responsibilities.
   `GET|POST /v1/admin/contacts/{id}/notes` and `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`
   for standalone CRM notes on a contact (not tied to a sales lead), and `DELETE /v1/admin/contacts/{id}`
   for hard-deleting a contact after clearing blocking CRM rows),
-  `/v1/admin/families/picker`, `/v1/admin/families/*`,
+  `/v1/admin/families/picker`, `/v1/admin/families/*` (including `DELETE /v1/admin/families/{id}`
+  for hard-deleting a family after clearing blocking CRM rows),
   `/v1/admin/organizations/picker`, `/v1/admin/organizations/*` (CRM organisations excluding
-  vendors; vendors remain under `/v1/admin/vendors`),
+  vendors; vendors remain under `/v1/admin/vendors`; includes `DELETE /v1/admin/organizations/{id}`
+  for non-vendor orgs),
   `/v1/admin/leads/*`, `/v1/admin/users`, `/v1/admin/instructors`,
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for
   cross-service instance listing with optional `service_id` / `service_type`

--- a/tests/test_admin_crm_routes.py
+++ b/tests/test_admin_crm_routes.py
@@ -225,6 +225,41 @@ def test_handle_admin_contacts_note_delete(
     assert response is marker
 
 
+def test_handle_admin_families_delete(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    marker = {"statusCode": 204, "body": "{}"}
+    expected_family_id = str(uuid4())
+
+    def _fake_delete(
+        _event: Any,
+        *,
+        family_id: Any,
+        actor_sub: str,
+    ) -> dict[str, Any]:
+        assert actor_sub == "admin-sub"
+        assert str(family_id) == expected_family_id
+        return marker
+
+    monkeypatch.setattr(admin_families, "delete_admin_crm_family", _fake_delete)
+    monkeypatch.setattr(
+        admin_families,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_families.handle_admin_families_request(
+        api_gateway_event(
+            method="DELETE", path=f"/v1/admin/families/{expected_family_id}"
+        ),
+        "DELETE",
+        f"/v1/admin/families/{expected_family_id}",
+    )
+
+    assert response is marker
+
+
 def test_handle_admin_families_member_delete(
     monkeypatch: Any,
     api_gateway_event: Any,
@@ -259,6 +294,43 @@ def test_handle_admin_families_member_delete(
         ),
         "DELETE",
         f"/v1/admin/families/{family_id}/members/{member_id}",
+    )
+
+    assert response is marker
+
+
+def test_handle_admin_organizations_crm_delete(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    marker = {"statusCode": 204, "body": "{}"}
+    expected_org_id = str(uuid4())
+
+    def _fake_delete(
+        _event: Any,
+        *,
+        organization_id: Any,
+        actor_sub: str,
+    ) -> dict[str, Any]:
+        assert actor_sub == "admin-sub"
+        assert str(organization_id) == expected_org_id
+        return marker
+
+    monkeypatch.setattr(
+        admin_organizations_crm, "delete_admin_crm_organization", _fake_delete
+    )
+    monkeypatch.setattr(
+        admin_organizations_crm,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_organizations_crm.handle_admin_organizations_crm_request(
+        api_gateway_event(
+            method="DELETE", path=f"/v1/admin/organizations/{expected_org_id}"
+        ),
+        "DELETE",
+        f"/v1/admin/organizations/{expected_org_id}",
     )
 
     assert response is marker


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **Operations** column to the **Families** and **Organisations** list tables in admin Contacts, with a **Delete** control that matches **Contacts** (`variant='danger'`, `DeleteIcon`, `h-8 min-w-8 px-0`). Deletion uses the same confirm-dialog pattern as contacts (title, description, **Delete** / **Cancel**).

## Backend

- New `DELETE /v1/admin/families/{id}` and `DELETE /v1/admin/organizations/{id}` returning **204**.
- Implementation deletes dependent rows that would block FK constraints: sales leads linked to the family/org (and notes on those leads), then standalone notes and enrollments referencing the family/org, then the family/org row. Vendor organisations are rejected with **400** (Finance path).

## Docs / infra

- `docs/api/admin.yaml` and `backend/infrastructure/lib/api-stack.ts` updated; `docs/architecture/lambdas.md` note added.
- Regenerated `apps/admin_web/src/types/generated/admin-api.generated.ts`.

## Testing

- `python3 -m pytest tests/test_admin_crm_routes.py`
- `npm run test -- --run tests/components/admin/contacts/families-panel.test.tsx tests/components/admin/contacts/organizations-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5de478fa-6d46-4e94-bd45-a2e1fcaa9c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5de478fa-6d46-4e94-bd45-a2e1fcaa9c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

