### PR TITLE
fix(admin_web): repair Vendor types for admin web build

### DIFF
--- a/apps/admin_web/src/types/vendors.ts
+++ b/apps/admin_web/src/types/vendors.ts
@@ -1,16 +1,12 @@
-import type { components } from '@/types/generated/admin-api.generated';
-
-type ApiSchemas = components['schemas'];
-type ApiVendor = ApiSchemas['Vendor'];
-
+/** Vendor rows are organizations with `relationship_type: vendor` (Finance UI view-model). */
 export interface Vendor {
-  id: ApiVendor['id'];
-  name: ApiVendor['name'];
-  website: ApiVendor['website'];
-  active: ApiVendor['active'];
-  archivedAt: ApiVendor['archived_at'];
-  createdAt: ApiVendor['created_at'];
-  updatedAt: ApiVendor['updated_at'];
+  id: string;
+  name: string;
+  website: string | null;
+  active: boolean;
+  archivedAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
 }
 
 export interface VendorFilters {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CI `deploy-admin-web` failed on `npm run build` with:

`Property 'Vendor' does not exist on type ...` in `apps/admin_web/src/types/vendors.ts`

OpenAPI no longer defines `Vendor` after merging vendors into organizations.

## Change

- Drop `ApiSchemas['Vendor']` usage; define the Finance `Vendor` view-model with explicit fields aligned with `vendors-api` parsing (`createdAt` / `updatedAt` as `string | null`).

## Validation

- `npm run lint` and `npm run build` in `apps/admin_web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0129dd88-2e8a-4d6d-b8f7-1f3c450ca6f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0129dd88-2e8a-4d6d-b8f7-1f3c450ca6f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

