### PR TITLE
Enforce family and organization CRM relationship constraints

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -31,8 +31,8 @@ import {
 import { formatEnumLabel } from '@/lib/format';
 import type { CrmListFilters } from '@/types/crm';
 import {
-  CRM_CONTACT_RELATIONSHIP_TYPES,
-  relationshipTypeForCrmEditor,
+  CONTACT_RELATIONSHIP_TYPES,
+  relationshipTypeForEditor,
 } from '@/types/crm-relationship';
 import type { AdminUser } from '@/types/leads';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
@@ -144,7 +144,7 @@ export function ContactsPanel({
   const [phone, setPhone] = useState('');
   const [contactType, setContactType] = useState<ApiSchemas['CrmContactType']>('parent');
   const [relationshipType, setRelationshipType] =
-    useState<(typeof CRM_CONTACT_RELATIONSHIP_TYPES)[number]>('prospect');
+    useState<(typeof CONTACT_RELATIONSHIP_TYPES)[number]>('prospect');
   const [source, setSource] = useState<ApiSchemas['CrmContactSource']>('manual');
   const [sourceDetail, setSourceDetail] = useState('');
   const [referralContactId, setReferralContactId] = useState('');
@@ -448,7 +448,7 @@ export function ContactsPanel({
     setInstagramHandle(row.instagram_handle ?? '');
     setPhone(row.phone ?? '');
     setContactType(row.contact_type);
-    setRelationshipType(relationshipTypeForCrmEditor(row.relationship_type));
+    setRelationshipType(relationshipTypeForEditor(row.relationship_type));
     setSource(row.source);
     setSourceDetail(row.source_detail ?? '');
     setReferralContactId(row.referral_contact_id ?? '');
@@ -536,10 +536,10 @@ export function ContactsPanel({
                 id='crm-contact-rel'
                 value={relationshipType}
                 onChange={(e) =>
-                  setRelationshipType(e.target.value as (typeof CRM_CONTACT_RELATIONSHIP_TYPES)[number])
+                  setRelationshipType(e.target.value as (typeof CONTACT_RELATIONSHIP_TYPES)[number])
                 }
               >
-                {CRM_CONTACT_RELATIONSHIP_TYPES.map((v) => (
+                {CONTACT_RELATIONSHIP_TYPES.map((v) => (
                   <option key={v} value={v}>
                     {formatEnumLabel(v)}
                   </option>

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -31,7 +31,7 @@ import {
 import { formatEnumLabel } from '@/lib/format';
 import type { CrmListFilters } from '@/types/crm';
 import {
-  CRM_ENTITY_RELATIONSHIP_TYPES,
+  CRM_CONTACT_RELATIONSHIP_TYPES,
   relationshipTypeForCrmEditor,
 } from '@/types/crm-relationship';
 import type { AdminUser } from '@/types/leads';
@@ -144,7 +144,7 @@ export function ContactsPanel({
   const [phone, setPhone] = useState('');
   const [contactType, setContactType] = useState<ApiSchemas['CrmContactType']>('parent');
   const [relationshipType, setRelationshipType] =
-    useState<(typeof CRM_ENTITY_RELATIONSHIP_TYPES)[number]>('prospect');
+    useState<(typeof CRM_CONTACT_RELATIONSHIP_TYPES)[number]>('prospect');
   const [source, setSource] = useState<ApiSchemas['CrmContactSource']>('manual');
   const [sourceDetail, setSourceDetail] = useState('');
   const [referralContactId, setReferralContactId] = useState('');
@@ -536,10 +536,10 @@ export function ContactsPanel({
                 id='crm-contact-rel'
                 value={relationshipType}
                 onChange={(e) =>
-                  setRelationshipType(e.target.value as (typeof CRM_ENTITY_RELATIONSHIP_TYPES)[number])
+                  setRelationshipType(e.target.value as (typeof CRM_CONTACT_RELATIONSHIP_TYPES)[number])
                 }
               >
-                {CRM_ENTITY_RELATIONSHIP_TYPES.map((v) => (
+                {CRM_CONTACT_RELATIONSHIP_TYPES.map((v) => (
                   <option key={v} value={v}>
                     {formatEnumLabel(v)}
                   </option>

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -22,7 +22,7 @@ import { formatEnumLabel } from '@/lib/format';
 import type { CrmTagRef } from '@/lib/crm-api';
 import type { CrmListFilters } from '@/types/crm';
 import {
-  CRM_ENTITY_RELATIONSHIP_TYPES,
+  CRM_FAMILY_RELATIONSHIP_TYPES,
   relationshipTypeForCrmEditor,
 } from '@/types/crm-relationship';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
@@ -93,7 +93,7 @@ export function FamiliesPanel({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [familyName, setFamilyName] = useState('');
   const [relationshipType, setRelationshipType] =
-    useState<(typeof CRM_ENTITY_RELATIONSHIP_TYPES)[number]>('prospect');
+    useState<(typeof CRM_FAMILY_RELATIONSHIP_TYPES)[number]>('prospect');
   const [pendingLocationId, setPendingLocationId] = useState<string | null>(null);
   const [optimisticLocationSummary, setOptimisticLocationSummary] =
     useState<InlineLocationEmbeddedSummary | null>(null);
@@ -282,7 +282,9 @@ export function FamiliesPanel({
     setSelectedId(id);
     setEditorMode('edit');
     setFamilyName(row.family_name);
-    setRelationshipType(relationshipTypeForCrmEditor(row.relationship_type));
+    setRelationshipType(
+      relationshipTypeForCrmEditor(row.relationship_type, CRM_FAMILY_RELATIONSHIP_TYPES)
+    );
     setPendingLocationId(row.location_id ?? null);
     setOptimisticLocationSummary(null);
     clearLocationSaveError();
@@ -329,10 +331,10 @@ export function FamiliesPanel({
               id='crm-family-rel'
               value={relationshipType}
               onChange={(e) =>
-                setRelationshipType(e.target.value as (typeof CRM_ENTITY_RELATIONSHIP_TYPES)[number])
+                setRelationshipType(e.target.value as (typeof CRM_FAMILY_RELATIONSHIP_TYPES)[number])
               }
             >
-              {CRM_ENTITY_RELATIONSHIP_TYPES.map((v) => (
+              {CRM_FAMILY_RELATIONSHIP_TYPES.map((v) => (
                 <option key={v} value={v}>
                   {formatEnumLabel(v)}
                 </option>

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -22,8 +22,8 @@ import { formatEnumLabel } from '@/lib/format';
 import type { CrmTagRef } from '@/lib/crm-api';
 import type { CrmListFilters } from '@/types/crm';
 import {
-  CRM_FAMILY_RELATIONSHIP_TYPES,
-  relationshipTypeForCrmEditor,
+  FAMILY_RELATIONSHIP_TYPES,
+  relationshipTypeForEditor,
 } from '@/types/crm-relationship';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
 import type { components } from '@/types/generated/admin-api.generated';
@@ -93,7 +93,7 @@ export function FamiliesPanel({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [familyName, setFamilyName] = useState('');
   const [relationshipType, setRelationshipType] =
-    useState<(typeof CRM_FAMILY_RELATIONSHIP_TYPES)[number]>('prospect');
+    useState<(typeof FAMILY_RELATIONSHIP_TYPES)[number]>('prospect');
   const [pendingLocationId, setPendingLocationId] = useState<string | null>(null);
   const [optimisticLocationSummary, setOptimisticLocationSummary] =
     useState<InlineLocationEmbeddedSummary | null>(null);
@@ -283,7 +283,7 @@ export function FamiliesPanel({
     setEditorMode('edit');
     setFamilyName(row.family_name);
     setRelationshipType(
-      relationshipTypeForCrmEditor(row.relationship_type, CRM_FAMILY_RELATIONSHIP_TYPES)
+      relationshipTypeForEditor(row.relationship_type, FAMILY_RELATIONSHIP_TYPES)
     );
     setPendingLocationId(row.location_id ?? null);
     setOptimisticLocationSummary(null);
@@ -331,10 +331,10 @@ export function FamiliesPanel({
               id='crm-family-rel'
               value={relationshipType}
               onChange={(e) =>
-                setRelationshipType(e.target.value as (typeof CRM_FAMILY_RELATIONSHIP_TYPES)[number])
+                setRelationshipType(e.target.value as (typeof FAMILY_RELATIONSHIP_TYPES)[number])
               }
             >
-              {CRM_FAMILY_RELATIONSHIP_TYPES.map((v) => (
+              {FAMILY_RELATIONSHIP_TYPES.map((v) => (
                 <option key={v} value={v}>
                   {formatEnumLabel(v)}
                 </option>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -22,8 +22,8 @@ import { formatEnumLabel } from '@/lib/format';
 import type { CrmTagRef } from '@/lib/crm-api';
 import type { CrmListFilters } from '@/types/crm';
 import {
-  CRM_ORGANIZATION_RELATIONSHIP_TYPES,
-  relationshipTypeForCrmEditor,
+  ORGANIZATION_RELATIONSHIP_TYPES,
+  relationshipTypeForEditor,
 } from '@/types/crm-relationship';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
 import type { components } from '@/types/generated/admin-api.generated';
@@ -94,7 +94,7 @@ export function OrganizationsPanel({
     addMember,
     removeMember,
     deleteOrganization,
-    crmRelationshipOptions,
+    relationshipOptions,
   } = organizations;
 
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
@@ -309,7 +309,7 @@ export function OrganizationsPanel({
     setName(row.name);
     setOrganizationType(row.organization_type);
     setRelationshipType(
-      relationshipTypeForCrmEditor(row.relationship_type, CRM_ORGANIZATION_RELATIONSHIP_TYPES)
+      relationshipTypeForEditor(row.relationship_type, ORGANIZATION_RELATIONSHIP_TYPES)
     );
     setSlug(row.slug ?? '');
     setWebsite(row.website ?? '');
@@ -362,7 +362,7 @@ export function OrganizationsPanel({
                 }
               }}
             >
-              {crmRelationshipOptions.map((v) => (
+              {relationshipOptions.map((v) => (
                 <option key={v} value={v}>
                   {formatEnumLabel(v)}
                 </option>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -22,7 +22,7 @@ import { formatEnumLabel } from '@/lib/format';
 import type { CrmTagRef } from '@/lib/crm-api';
 import type { CrmListFilters } from '@/types/crm';
 import {
-  type CrmEntityRelationshipType,
+  CRM_ORGANIZATION_RELATIONSHIP_TYPES,
   relationshipTypeForCrmEditor,
 } from '@/types/crm-relationship';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
@@ -105,7 +105,8 @@ export function OrganizationsPanel({
   const [name, setName] = useState('');
   const [organizationType, setOrganizationType] =
     useState<ApiSchemas['CrmOrganizationType']>('company');
-  const [relationshipType, setRelationshipType] = useState<CrmEntityRelationshipType>('prospect');
+  const [relationshipType, setRelationshipType] =
+    useState<ApiSchemas['CrmOrganizationRelationshipType']>('prospect');
   const [slug, setSlug] = useState('');
   const [website, setWebsite] = useState('');
   const [pendingLocationId, setPendingLocationId] = useState<string | null>(null);
@@ -307,7 +308,9 @@ export function OrganizationsPanel({
     setEditorMode('edit');
     setName(row.name);
     setOrganizationType(row.organization_type);
-    setRelationshipType(relationshipTypeForCrmEditor(row.relationship_type));
+    setRelationshipType(
+      relationshipTypeForCrmEditor(row.relationship_type, CRM_ORGANIZATION_RELATIONSHIP_TYPES)
+    );
     setSlug(row.slug ?? '');
     setWebsite(row.website ?? '');
     setPendingLocationId(row.location_id ?? null);
@@ -352,7 +355,7 @@ export function OrganizationsPanel({
               id='crm-org-rel'
               value={relationshipType}
               onChange={(e) => {
-                const next = e.target.value as CrmEntityRelationshipType;
+                const next = e.target.value as ApiSchemas['CrmOrganizationRelationshipType'];
                 setRelationshipType(next);
                 if (next !== 'partner') {
                   setSlug('');

--- a/apps/admin_web/src/hooks/use-admin-crm-contacts.ts
+++ b/apps/admin_web/src/hooks/use-admin-crm-contacts.ts
@@ -8,7 +8,7 @@ import {
   listAdminContacts,
   updateAdminContact,
 } from '@/lib/crm-api';
-import { DEFAULT_CRM_CONTACT_LIST_FILTERS, type CrmListFilters } from '@/types/crm';
+import { DEFAULT_CONTACT_LIST_FILTERS, type CrmListFilters } from '@/types/crm';
 import type { components } from '@/types/generated/admin-api.generated';
 
 import { usePaginatedList } from './use-paginated-list';
@@ -42,7 +42,7 @@ export function useAdminCrmContacts() {
     refetch: refetchContacts,
   } = usePaginatedList({
     fetcher,
-    defaultFilters: DEFAULT_CRM_CONTACT_LIST_FILTERS,
+    defaultFilters: DEFAULT_CONTACT_LIST_FILTERS,
     errorPrefix: 'Failed to load contacts',
     debounceKeys: ['query'],
     limit: 50,

--- a/apps/admin_web/src/hooks/use-admin-crm-organizations.ts
+++ b/apps/admin_web/src/hooks/use-admin-crm-organizations.ts
@@ -11,7 +11,7 @@ import {
   updateAdminOrganization,
 } from '@/lib/crm-api';
 import { DEFAULT_CRM_LIST_FILTERS, type CrmListFilters } from '@/types/crm';
-import { CRM_ENTITY_RELATIONSHIP_TYPES } from '@/types/crm-relationship';
+import { CRM_ORGANIZATION_RELATIONSHIP_TYPES } from '@/types/crm-relationship';
 import type { components } from '@/types/generated/admin-api.generated';
 
 import { usePaginatedList } from './use-paginated-list';
@@ -101,6 +101,6 @@ export function useAdminCrmOrganizations() {
     removeMember,
     deleteOrganization,
     refetch: list.refetch,
-    crmRelationshipOptions: CRM_ENTITY_RELATIONSHIP_TYPES.filter((v) => v !== 'vendor'),
+    crmRelationshipOptions: CRM_ORGANIZATION_RELATIONSHIP_TYPES,
   };
 }

--- a/apps/admin_web/src/hooks/use-admin-crm-organizations.ts
+++ b/apps/admin_web/src/hooks/use-admin-crm-organizations.ts
@@ -11,7 +11,7 @@ import {
   updateAdminOrganization,
 } from '@/lib/crm-api';
 import { DEFAULT_CRM_LIST_FILTERS, type CrmListFilters } from '@/types/crm';
-import { CRM_ORGANIZATION_RELATIONSHIP_TYPES } from '@/types/crm-relationship';
+import { ORGANIZATION_RELATIONSHIP_TYPES } from '@/types/crm-relationship';
 import type { components } from '@/types/generated/admin-api.generated';
 
 import { usePaginatedList } from './use-paginated-list';
@@ -101,6 +101,6 @@ export function useAdminCrmOrganizations() {
     removeMember,
     deleteOrganization,
     refetch: list.refetch,
-    crmRelationshipOptions: CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+    relationshipOptions: ORGANIZATION_RELATIONSHIP_TYPES,
   };
 }

--- a/apps/admin_web/src/types/crm-relationship.ts
+++ b/apps/admin_web/src/types/crm-relationship.ts
@@ -4,7 +4,7 @@ import type { components } from '@/types/generated/admin-api.generated';
 export type CrmRelationshipType = components['schemas']['CrmRelationshipType'];
 
 /** Relationship values allowed on contact create/update (matches API storage). */
-export const CRM_CONTACT_RELATIONSHIP_TYPES: readonly CrmRelationshipType[] = [
+export const CONTACT_RELATIONSHIP_TYPES: readonly CrmRelationshipType[] = [
   'prospect',
   'client',
   'past_client',
@@ -14,23 +14,23 @@ export const CRM_CONTACT_RELATIONSHIP_TYPES: readonly CrmRelationshipType[] = [
 ];
 
 /** Relationship values allowed when creating or editing a family. */
-export const CRM_FAMILY_RELATIONSHIP_TYPES: readonly components['schemas']['CrmFamilyRelationshipType'][] =
+export const FAMILY_RELATIONSHIP_TYPES: readonly components['schemas']['CrmFamilyRelationshipType'][] =
   ['prospect', 'client', 'other'];
 
 /**
- * Relationship values shown in the CRM organization editor (excludes `vendor`,
+ * Relationship values for the CRM organization editor (excludes `vendor`,
  * which is managed from Finance; excludes `past_client`, which organizations cannot use).
  */
-export const CRM_ORGANIZATION_RELATIONSHIP_TYPES: readonly components['schemas']['CrmOrganizationRelationshipType'][] =
+export const ORGANIZATION_RELATIONSHIP_TYPES: readonly components['schemas']['CrmOrganizationRelationshipType'][] =
   ['prospect', 'client', 'partner', 'other'];
 
 /**
  * Map a stored CRM relationship to a select value. Values outside `allowed` map to `other`
  * so the select stays valid.
  */
-export function relationshipTypeForCrmEditor(
+export function relationshipTypeForEditor(
   stored: CrmRelationshipType,
-  allowed: readonly CrmRelationshipType[] = CRM_CONTACT_RELATIONSHIP_TYPES
+  allowed: readonly CrmRelationshipType[] = CONTACT_RELATIONSHIP_TYPES
 ): CrmRelationshipType {
   const allowedSet = new Set<string>(allowed);
   if (allowedSet.has(stored)) {

--- a/apps/admin_web/src/types/crm-relationship.ts
+++ b/apps/admin_web/src/types/crm-relationship.ts
@@ -1,9 +1,10 @@
 import type { components } from '@/types/generated/admin-api.generated';
 
-/** Relationship values shown in CRM entity editors (includes vendor where the API allows it). */
-export type CrmEntityRelationshipType = components['schemas']['CrmRelationshipType'];
+/** Full stored CRM relationship (contacts, families, orgs in API responses). */
+export type CrmRelationshipType = components['schemas']['CrmRelationshipType'];
 
-export const CRM_ENTITY_RELATIONSHIP_TYPES: readonly CrmEntityRelationshipType[] = [
+/** Relationship values allowed on contact create/update (matches API storage). */
+export const CRM_CONTACT_RELATIONSHIP_TYPES: readonly CrmRelationshipType[] = [
   'prospect',
   'client',
   'past_client',
@@ -12,15 +13,27 @@ export const CRM_ENTITY_RELATIONSHIP_TYPES: readonly CrmEntityRelationshipType[]
   'other',
 ];
 
+/** Relationship values allowed when creating or editing a family. */
+export const CRM_FAMILY_RELATIONSHIP_TYPES: readonly components['schemas']['CrmFamilyRelationshipType'][] =
+  ['prospect', 'client', 'other'];
+
 /**
- * Map a stored CRM relationship to a dropdown value. Unknown values map to `other`
+ * Relationship values shown in the CRM organization editor (excludes `vendor`,
+ * which is managed from Finance; excludes `past_client`, which organizations cannot use).
+ */
+export const CRM_ORGANIZATION_RELATIONSHIP_TYPES: readonly components['schemas']['CrmOrganizationRelationshipType'][] =
+  ['prospect', 'client', 'partner', 'other'];
+
+/**
+ * Map a stored CRM relationship to a select value. Values outside `allowed` map to `other`
  * so the select stays valid.
  */
 export function relationshipTypeForCrmEditor(
-  stored: components['schemas']['CrmRelationshipType']
-): CrmEntityRelationshipType {
-  const allowed = new Set(CRM_ENTITY_RELATIONSHIP_TYPES);
-  if (allowed.has(stored)) {
+  stored: CrmRelationshipType,
+  allowed: readonly CrmRelationshipType[] = CRM_CONTACT_RELATIONSHIP_TYPES
+): CrmRelationshipType {
+  const allowedSet = new Set<string>(allowed);
+  if (allowedSet.has(stored)) {
     return stored;
   }
   return 'other';

--- a/apps/admin_web/src/types/crm.ts
+++ b/apps/admin_web/src/types/crm.ts
@@ -16,7 +16,7 @@ export const DEFAULT_CRM_LIST_FILTERS: CrmListFilters = {
 };
 
 /** Default filters for the contacts table (Active contacts only). */
-export const DEFAULT_CRM_CONTACT_LIST_FILTERS: CrmListFilters = {
+export const DEFAULT_CONTACT_LIST_FILTERS: CrmListFilters = {
   query: '',
   active: 'true',
   contact_type: '',

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4592,8 +4592,21 @@ export interface components {
         };
         /** @enum {string} */
         CrmContactType: "parent" | "child" | "helper" | "professional" | "other";
-        /** @enum {string} */
+        /**
+         * @description Stored relationship for contacts and read responses. Family and organization create/update requests use narrower enums (`CrmFamilyRelationshipType`, `CrmOrganizationRelationshipType`).
+         * @enum {string}
+         */
         CrmRelationshipType: "prospect" | "client" | "past_client" | "partner" | "vendor" | "other";
+        /**
+         * @description Allowed values when setting a family's CRM relationship.
+         * @enum {string}
+         */
+        CrmFamilyRelationshipType: "prospect" | "client" | "other";
+        /**
+         * @description Allowed values when setting an organization's CRM relationship. `past_client` is not permitted for organizations (use contacts for that lifecycle).
+         * @enum {string}
+         */
+        CrmOrganizationRelationshipType: "prospect" | "client" | "partner" | "vendor" | "other";
         /** @enum {string} */
         CrmContactSource: "free_guide" | "newsletter" | "contact_form" | "reservation" | "referral" | "instagram" | "whatsapp" | "linkedin" | "event" | "phone_call" | "public_website" | "manual";
         /** @enum {string} */
@@ -4771,14 +4784,14 @@ export interface components {
         };
         CreateAdminFamilyRequest: {
             family_name: string;
-            relationship_type?: components["schemas"]["CrmRelationshipType"];
+            relationship_type?: components["schemas"]["CrmFamilyRelationshipType"];
             /** Format: uuid */
             location_id?: string | null;
             tag_ids?: string[];
         };
         UpdateAdminFamilyRequest: {
             family_name?: string;
-            relationship_type?: components["schemas"]["CrmRelationshipType"];
+            relationship_type?: components["schemas"]["CrmFamilyRelationshipType"];
             /** Format: uuid */
             location_id?: string | null;
             active?: boolean;
@@ -4832,7 +4845,7 @@ export interface components {
         CreateAdminOrganizationRequest: {
             name: string;
             organization_type: components["schemas"]["CrmOrganizationType"];
-            relationship_type?: components["schemas"]["CrmRelationshipType"];
+            relationship_type?: components["schemas"]["CrmOrganizationRelationshipType"];
             /** @description Optional partner-only slug. Omit or null to clear. Must be null when relationship_type is not partner. */
             slug?: string | null;
             website?: string | null;
@@ -4845,7 +4858,7 @@ export interface components {
         UpdateAdminOrganizationRequest: {
             name?: string;
             organization_type?: components["schemas"]["CrmOrganizationType"];
-            relationship_type?: components["schemas"]["CrmRelationshipType"];
+            relationship_type?: components["schemas"]["CrmOrganizationRelationshipType"];
             /** @description Optional partner-only slug. Omit or null to clear. Must be null when relationship_type is not partner. */
             slug?: string | null;
             website?: string | null;

--- a/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
@@ -77,7 +77,7 @@ const defaultOrgsHook = {
   addMember: vi.fn(),
   removeMember: vi.fn(),
   refetch: vi.fn(),
-  crmRelationshipOptions: ['prospect', 'client', 'partner', 'other'] as const,
+  relationshipOptions: ['prospect', 'client', 'partner', 'other'] as const,
 };
 
 vi.mock('@/hooks/use-admin-crm-contacts', () => ({

--- a/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
@@ -77,7 +77,7 @@ const defaultOrgsHook = {
   addMember: vi.fn(),
   removeMember: vi.fn(),
   refetch: vi.fn(),
-  crmRelationshipOptions: ['prospect', 'client', 'past_client', 'partner', 'other'] as const,
+  crmRelationshipOptions: ['prospect', 'client', 'partner', 'other'] as const,
 };
 
 vi.mock('@/hooks/use-admin-crm-contacts', () => ({

--- a/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
@@ -56,9 +56,9 @@ function buildOrgsHook(
     removeMember: vi.fn().mockResolvedValue(null),
     deleteOrganization: vi.fn().mockResolvedValue(undefined),
     refetch: vi.fn(),
-    crmRelationshipOptions: ['prospect', 'customer', 'partner', 'vendor'] as unknown as ReturnType<
+    relationshipOptions: ['prospect', 'customer', 'partner', 'vendor'] as unknown as ReturnType<
       typeof useAdminCrmOrganizations
-    >['crmRelationshipOptions'],
+    >['relationshipOptions'],
     ...overrides,
   };
 }

--- a/apps/admin_web/tests/types/crm-relationship.test.ts
+++ b/apps/admin_web/tests/types/crm-relationship.test.ts
@@ -1,14 +1,30 @@
 import { describe, expect, it } from 'vitest';
 
-import { relationshipTypeForCrmEditor } from '@/types/crm-relationship';
+import {
+  CRM_FAMILY_RELATIONSHIP_TYPES,
+  CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+  relationshipTypeForCrmEditor,
+} from '@/types/crm-relationship';
 
 describe('relationshipTypeForCrmEditor', () => {
-  it('passes through vendor when present in the editor enum', () => {
-    expect(relationshipTypeForCrmEditor('vendor')).toBe('vendor');
+  it('passes through values in the allowed list', () => {
+    expect(relationshipTypeForCrmEditor('client', CRM_FAMILY_RELATIONSHIP_TYPES)).toBe('client');
+    expect(relationshipTypeForCrmEditor('partner', CRM_ORGANIZATION_RELATIONSHIP_TYPES)).toBe(
+      'partner'
+    );
   });
 
-  it('passes through allowed values', () => {
-    expect(relationshipTypeForCrmEditor('client')).toBe('client');
+  it('maps disallowed stored values to other for family editor', () => {
+    expect(relationshipTypeForCrmEditor('past_client', CRM_FAMILY_RELATIONSHIP_TYPES)).toBe(
+      'other'
+    );
+    expect(relationshipTypeForCrmEditor('vendor', CRM_FAMILY_RELATIONSHIP_TYPES)).toBe('other');
+  });
+
+  it('maps past_client to other for organization editor', () => {
+    expect(relationshipTypeForCrmEditor('past_client', CRM_ORGANIZATION_RELATIONSHIP_TYPES)).toBe(
+      'other'
+    );
   });
 
   it('maps unknown values to other', () => {

--- a/apps/admin_web/tests/types/crm-relationship.test.ts
+++ b/apps/admin_web/tests/types/crm-relationship.test.ts
@@ -1,33 +1,33 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  CRM_FAMILY_RELATIONSHIP_TYPES,
-  CRM_ORGANIZATION_RELATIONSHIP_TYPES,
-  relationshipTypeForCrmEditor,
+  FAMILY_RELATIONSHIP_TYPES,
+  ORGANIZATION_RELATIONSHIP_TYPES,
+  relationshipTypeForEditor,
 } from '@/types/crm-relationship';
 
-describe('relationshipTypeForCrmEditor', () => {
+describe('relationshipTypeForEditor', () => {
   it('passes through values in the allowed list', () => {
-    expect(relationshipTypeForCrmEditor('client', CRM_FAMILY_RELATIONSHIP_TYPES)).toBe('client');
-    expect(relationshipTypeForCrmEditor('partner', CRM_ORGANIZATION_RELATIONSHIP_TYPES)).toBe(
+    expect(relationshipTypeForEditor('client', FAMILY_RELATIONSHIP_TYPES)).toBe('client');
+    expect(relationshipTypeForEditor('partner', ORGANIZATION_RELATIONSHIP_TYPES)).toBe(
       'partner'
     );
   });
 
   it('maps disallowed stored values to other for family editor', () => {
-    expect(relationshipTypeForCrmEditor('past_client', CRM_FAMILY_RELATIONSHIP_TYPES)).toBe(
+    expect(relationshipTypeForEditor('past_client', FAMILY_RELATIONSHIP_TYPES)).toBe(
       'other'
     );
-    expect(relationshipTypeForCrmEditor('vendor', CRM_FAMILY_RELATIONSHIP_TYPES)).toBe('other');
+    expect(relationshipTypeForEditor('vendor', FAMILY_RELATIONSHIP_TYPES)).toBe('other');
   });
 
   it('maps past_client to other for organization editor', () => {
-    expect(relationshipTypeForCrmEditor('past_client', CRM_ORGANIZATION_RELATIONSHIP_TYPES)).toBe(
+    expect(relationshipTypeForEditor('past_client', ORGANIZATION_RELATIONSHIP_TYPES)).toBe(
       'other'
     );
   });
 
   it('maps unknown values to other', () => {
-    expect(relationshipTypeForCrmEditor('not_a_real_type' as never)).toBe('other');
+    expect(relationshipTypeForEditor('not_a_real_type' as never)).toBe('other');
   });
 });

--- a/backend/src/app/api/admin_contact_notes.py
+++ b/backend/src/app/api/admin_contact_notes.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.api.admin_crm_helpers import crm_request_id
+from app.api.admin_crm_helpers import request_id
 from app.api.admin_leads_common import serialize_note
 from app.api.admin_request import parse_body
 from app.api.admin_validators import MAX_DESCRIPTION_LENGTH, validate_string_length
@@ -29,7 +29,7 @@ def list_contact_notes(
 ) -> dict[str, Any]:
     """List standalone notes for a contact (newest first)."""
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         contact_repo = ContactRepository(session)
         if contact_repo.get_by_id_for_admin(contact_id) is None:
             raise NotFoundError("Contact", str(contact_id))
@@ -60,7 +60,7 @@ def create_contact_note(
         raise ValidationError("content is required", field="content")
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         contact_repo = ContactRepository(session)
         contact = contact_repo.get_by_id_for_admin(contact_id)
         if contact is None:
@@ -98,7 +98,7 @@ def update_contact_note(
         raise ValidationError("content is required", field="content")
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         contact_repo = ContactRepository(session)
         if contact_repo.get_by_id_for_admin(contact_id) is None:
             raise NotFoundError("Contact", str(contact_id))
@@ -126,7 +126,7 @@ def delete_contact_note(
 ) -> dict[str, Any]:
     """Delete a standalone note on a contact."""
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         contact_repo = ContactRepository(session)
         if contact_repo.get_by_id_for_admin(contact_id) is None:
             raise NotFoundError("Contact", str(contact_id))

--- a/backend/src/app/api/admin_contacts.py
+++ b/backend/src/app/api/admin_contacts.py
@@ -23,7 +23,7 @@ from app.api.admin_crm_helpers import (
     list_all_tags_for_picker,
     parse_active_filter,
     parse_contact_type_filter,
-    parse_crm_limit,
+    parse_limit,
     serialize_tag_ref,
 )
 from app.api.admin_crm_serializers import (
@@ -132,7 +132,7 @@ def handle_admin_contacts_request(
 
 
 def _search_contacts_for_picker(event: Mapping[str, Any]) -> dict[str, Any]:
-    limit = parse_crm_limit(event, default=_DEFAULT_LIMIT)
+    limit = parse_limit(event, default=_DEFAULT_LIMIT)
     raw_query = validate_string_length(
         query_param(event, "query"),
         "query",
@@ -175,7 +175,7 @@ def _list_contact_tags(event: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _list_contacts(event: Mapping[str, Any]) -> dict[str, Any]:
-    limit = parse_crm_limit(event, default=_DEFAULT_LIMIT)
+    limit = parse_limit(event, default=_DEFAULT_LIMIT)
     cursor = parse_cursor(query_param(event, "cursor"))
     query = validate_string_length(
         query_param(event, "query"),

--- a/backend/src/app/api/admin_contacts_mutations.py
+++ b/backend/src/app/api/admin_contacts_mutations.py
@@ -22,9 +22,9 @@ from app.api.admin_contacts_helpers import (
     validate_referrer_contact,
 )
 from app.api.admin_crm_helpers import (
-    crm_request_id,
+    request_id,
     ensure_location_exists,
-    parse_crm_relationship_type,
+    parse_relationship_type,
     parse_optional_bool_body,
     replace_contact_tags,
 )
@@ -79,7 +79,7 @@ def create_contact(
         required=False,
     )
     contact_type = parse_contact_type(body.get("contact_type"), field="contact_type")
-    relationship_type = parse_crm_relationship_type(
+    relationship_type = parse_relationship_type(
         body.get("relationship_type"), field="relationship_type"
     )
     source = parse_contact_source(body.get("source"), field="source")
@@ -109,7 +109,7 @@ def create_contact(
     )
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         has_membership = bool(family_ids or organization_ids)
         if location_id is not None and has_membership:
             raise ValidationError(
@@ -207,7 +207,7 @@ def update_contact(
     )
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = ContactRepository(session)
         contact = repository.get_by_id_for_admin(contact_id)
         if contact is None:
@@ -252,7 +252,7 @@ def update_contact(
                 body.get("contact_type"), field="contact_type"
             )
         if "relationship_type" in body:
-            contact.relationship_type = parse_crm_relationship_type(
+            contact.relationship_type = parse_relationship_type(
                 body.get("relationship_type"),
                 field="relationship_type",
             )
@@ -376,7 +376,7 @@ def delete_contact(
     )
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = ContactRepository(session)
         contact = repository.get_by_id_for_admin(contact_id)
         if contact is None:

--- a/backend/src/app/api/admin_crm_entity_deletes.py
+++ b/backend/src/app/api/admin_crm_entity_deletes.py
@@ -10,7 +10,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.admin_crm_helpers import crm_request_id
+from app.api.admin_crm_helpers import request_id
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.models import Enrollment, Note, RelationshipType, SalesLead
@@ -65,7 +65,7 @@ def delete_admin_crm_family(
     )
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = FamilyRepository(session)
         family = repository.get_by_id_for_admin(family_id)
         if family is None:
@@ -101,7 +101,7 @@ def delete_admin_crm_organization(
     )
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = OrganizationRepository(session)
         org = repository.get_organization_by_id(organization_id)
         if org is None:

--- a/backend/src/app/api/admin_crm_helpers.py
+++ b/backend/src/app/api/admin_crm_helpers.py
@@ -201,11 +201,36 @@ def parse_crm_relationship_type(
     value: Any,
     *,
     field: str,
+    allowed: frozenset[RelationshipType] | None = None,
 ) -> RelationshipType:
-    """Parse relationship_type for CRM organization payloads."""
+    """Parse relationship_type for CRM payloads.
+
+    When ``allowed`` is set, the parsed value must be a member of that set
+    (after resolving the string to :class:`RelationshipType`).
+    """
     if value is None or str(value).strip() == "":
-        return RelationshipType.PROSPECT
-    try:
-        return RelationshipType(str(value).strip().lower())
-    except ValueError as exc:
-        raise ValidationError(f"Invalid {field}", field=field) from exc
+        parsed = RelationshipType.PROSPECT
+    else:
+        try:
+            parsed = RelationshipType(str(value).strip().lower())
+        except ValueError as exc:
+            raise ValidationError(f"Invalid {field}", field=field) from exc
+    if allowed is not None and parsed not in allowed:
+        raise ValidationError(
+            f"{field} is not allowed for this entity",
+            field=field,
+        )
+    return parsed
+
+
+CRM_FAMILY_RELATIONSHIP_TYPES: frozenset[RelationshipType] = frozenset(
+    {
+        RelationshipType.PROSPECT,
+        RelationshipType.CLIENT,
+        RelationshipType.OTHER,
+    }
+)
+
+CRM_ORGANIZATION_RELATIONSHIP_TYPES: frozenset[RelationshipType] = frozenset(
+    set(RelationshipType) - {RelationshipType.PAST_CLIENT}
+)

--- a/backend/src/app/api/admin_crm_helpers.py
+++ b/backend/src/app/api/admin_crm_helpers.py
@@ -27,14 +27,14 @@ from app.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def parse_crm_limit(event: Mapping[str, Any], *, default: int = 25) -> int:
+def parse_limit(event: Mapping[str, Any], *, default: int = 25) -> int:
     raw = query_param(event, "limit")
     if raw is None or raw == "":
         return default
     try:
         parsed = int(raw)
     except (TypeError, ValueError) as exc:
-        logger.warning("Invalid CRM limit value", extra={"field": "limit"})
+        logger.warning("Invalid list limit value", extra={"field": "limit"})
         raise ValidationError("limit must be an integer", field="limit") from exc
     if parsed < 1 or parsed > 100:
         raise ValidationError("limit must be between 1 and 100", field="limit")
@@ -187,8 +187,8 @@ def list_all_tags_for_picker(session: Session) -> list[Tag]:
     return list(session.execute(statement).scalars().all())
 
 
-def crm_request_id(event: Mapping[str, Any]) -> str:
-    """API Gateway request id for audit context (shared by CRM admin handlers)."""
+def request_id(event: Mapping[str, Any]) -> str:
+    """API Gateway request id for audit context (shared by admin CRM handlers)."""
     request_context = event.get("requestContext")
     if isinstance(request_context, Mapping):
         request_id = request_context.get("requestId")
@@ -197,7 +197,7 @@ def crm_request_id(event: Mapping[str, Any]) -> str:
     return ""
 
 
-def parse_crm_relationship_type(
+def parse_relationship_type(
     value: Any,
     *,
     field: str,
@@ -223,7 +223,7 @@ def parse_crm_relationship_type(
     return parsed
 
 
-CRM_FAMILY_RELATIONSHIP_TYPES: frozenset[RelationshipType] = frozenset(
+FAMILY_RELATIONSHIP_TYPES: frozenset[RelationshipType] = frozenset(
     {
         RelationshipType.PROSPECT,
         RelationshipType.CLIENT,
@@ -231,6 +231,6 @@ CRM_FAMILY_RELATIONSHIP_TYPES: frozenset[RelationshipType] = frozenset(
     }
 )
 
-CRM_ORGANIZATION_RELATIONSHIP_TYPES: frozenset[RelationshipType] = frozenset(
+ORGANIZATION_RELATIONSHIP_TYPES: frozenset[RelationshipType] = frozenset(
     set(RelationshipType) - {RelationshipType.PAST_CLIENT}
 )

--- a/backend/src/app/api/admin_families.py
+++ b/backend/src/app/api/admin_families.py
@@ -16,6 +16,7 @@ from app.api.admin_crm_helpers import (
     ensure_location_exists,
     parse_active_filter,
     parse_crm_limit,
+    CRM_FAMILY_RELATIONSHIP_TYPES,
     parse_crm_relationship_type,
     parse_optional_bool_body,
     replace_family_tags,
@@ -170,7 +171,9 @@ def _create_family(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any
         required=True,
     )
     relationship_type = parse_crm_relationship_type(
-        body.get("relationship_type"), field="relationship_type"
+        body.get("relationship_type"),
+        field="relationship_type",
+        allowed=CRM_FAMILY_RELATIONSHIP_TYPES,
     )
     location_id = parse_optional_uuid(body.get("location_id"), "location_id")
     tag_ids = parse_uuid_list(body.get("tag_ids"), "tag_ids")
@@ -227,6 +230,7 @@ def _update_family(
             family.relationship_type = parse_crm_relationship_type(
                 body.get("relationship_type"),
                 field="relationship_type",
+                allowed=CRM_FAMILY_RELATIONSHIP_TYPES,
             )
         if "location_id" in body:
             loc = parse_optional_uuid(body.get("location_id"), "location_id")

--- a/backend/src/app/api/admin_families.py
+++ b/backend/src/app/api/admin_families.py
@@ -12,12 +12,12 @@ from sqlalchemy.orm import Session
 from app.api.admin_crm_entity_deletes import delete_admin_crm_family
 from app.api.admin_crm_helpers import (
     assert_contact_can_join_family,
-    crm_request_id,
+    request_id,
     ensure_location_exists,
     parse_active_filter,
-    parse_crm_limit,
-    CRM_FAMILY_RELATIONSHIP_TYPES,
-    parse_crm_relationship_type,
+    parse_limit,
+    FAMILY_RELATIONSHIP_TYPES,
+    parse_relationship_type,
     parse_optional_bool_body,
     replace_family_tags,
 )
@@ -114,7 +114,7 @@ def _parse_family_role(value: Any, *, field: str) -> FamilyRole:
 
 
 def _list_families(event: Mapping[str, Any]) -> dict[str, Any]:
-    limit = parse_crm_limit(event, default=_DEFAULT_LIMIT)
+    limit = parse_limit(event, default=_DEFAULT_LIMIT)
     cursor = parse_cursor(query_param(event, "cursor"))
     query = validate_string_length(
         query_param(event, "query"),
@@ -170,16 +170,16 @@ def _create_family(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any
         max_length=150,
         required=True,
     )
-    relationship_type = parse_crm_relationship_type(
+    relationship_type = parse_relationship_type(
         body.get("relationship_type"),
         field="relationship_type",
-        allowed=CRM_FAMILY_RELATIONSHIP_TYPES,
+        allowed=FAMILY_RELATIONSHIP_TYPES,
     )
     location_id = parse_optional_uuid(body.get("location_id"), "location_id")
     tag_ids = parse_uuid_list(body.get("tag_ids"), "tag_ids")
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         ensure_location_exists(session, location_id)
         repository = FamilyRepository(session)
         family = Family(
@@ -210,7 +210,7 @@ def _update_family(
     body = parse_body(event)
     now = datetime.now(UTC)
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = FamilyRepository(session)
         family = repository.get_by_id_for_admin(family_id)
         if family is None:
@@ -227,10 +227,10 @@ def _update_family(
                 or family.family_name
             )
         if "relationship_type" in body:
-            family.relationship_type = parse_crm_relationship_type(
+            family.relationship_type = parse_relationship_type(
                 body.get("relationship_type"),
                 field="relationship_type",
-                allowed=CRM_FAMILY_RELATIONSHIP_TYPES,
+                allowed=FAMILY_RELATIONSHIP_TYPES,
             )
         if "location_id" in body:
             loc = parse_optional_uuid(body.get("location_id"), "location_id")
@@ -282,7 +282,7 @@ def _add_family_member(
         )
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = FamilyRepository(session)
         family = repository.get_by_id_for_admin(family_id)
         if family is None:
@@ -322,7 +322,7 @@ def _remove_family_member(
     actor_sub: str,
 ) -> dict[str, Any]:
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = FamilyRepository(session)
         family = repository.get_by_id_for_admin(family_id)
         if family is None:

--- a/backend/src/app/api/admin_families_picker.py
+++ b/backend/src/app/api/admin_families_picker.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.admin_crm_helpers import parse_crm_limit
+from app.api.admin_crm_helpers import parse_limit
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.engine import get_engine
 from app.db.models import Family
@@ -49,7 +49,7 @@ def handle_admin_families_picker_request(
 
 
 def _list_family_picker(event: Mapping[str, Any]) -> dict[str, Any]:
-    limit = parse_crm_limit(event, default=_DEFAULT_LIMIT)
+    limit = parse_limit(event, default=_DEFAULT_LIMIT)
     with Session(get_engine()) as session:
         statement = (
             select(Family.id, Family.family_name)

--- a/backend/src/app/api/admin_organizations.py
+++ b/backend/src/app/api/admin_organizations.py
@@ -12,13 +12,13 @@ from sqlalchemy.orm import Session
 
 from app.api.admin_crm_entity_deletes import delete_admin_crm_organization
 from app.api.admin_crm_helpers import (
-    CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+    ORGANIZATION_RELATIONSHIP_TYPES,
     assert_contact_can_join_organization,
-    crm_request_id,
+    request_id,
     ensure_location_exists,
     parse_active_filter,
-    parse_crm_limit,
-    parse_crm_relationship_type,
+    parse_limit,
+    parse_relationship_type,
     parse_optional_bool_body,
     replace_organization_tags,
 )
@@ -190,7 +190,7 @@ def _is_organizations_partner_slug_unique_violation(exc: IntegrityError) -> bool
 
 
 def _list_organizations(event: Mapping[str, Any]) -> dict[str, Any]:
-    limit = parse_crm_limit(event, default=_DEFAULT_LIMIT)
+    limit = parse_limit(event, default=_DEFAULT_LIMIT)
     cursor = parse_cursor(query_param(event, "cursor"))
     query = validate_string_length(
         query_param(event, "query"),
@@ -266,10 +266,10 @@ def _create_organization(event: Mapping[str, Any], *, actor_sub: str) -> dict[st
     organization_type = _parse_organization_type(
         body.get("organization_type"), field="organization_type"
     )
-    relationship_type = parse_crm_relationship_type(
+    relationship_type = parse_relationship_type(
         body.get("relationship_type"),
         field="relationship_type",
-        allowed=CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+        allowed=ORGANIZATION_RELATIONSHIP_TYPES,
     )
     website = validate_string_length(
         body.get("website"),
@@ -281,7 +281,7 @@ def _create_organization(event: Mapping[str, Any], *, actor_sub: str) -> dict[st
     tag_ids = parse_uuid_list(body.get("tag_ids"), "tag_ids")
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         ensure_location_exists(session, location_id)
         repository = OrganizationRepository(session)
         org = Organization(
@@ -339,7 +339,7 @@ def _update_organization(
     body = parse_body(event)
     now = datetime.now(UTC)
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = OrganizationRepository(session)
         org = repository.get_crm_organization_by_id(organization_id)
         if org is None:
@@ -360,10 +360,10 @@ def _update_organization(
                 body.get("organization_type"), field="organization_type"
             )
         if "relationship_type" in body:
-            org.relationship_type = parse_crm_relationship_type(
+            org.relationship_type = parse_relationship_type(
                 body.get("relationship_type"),
                 field="relationship_type",
-                allowed=CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+                allowed=ORGANIZATION_RELATIONSHIP_TYPES,
             )
             if org.relationship_type != RelationshipType.PARTNER:
                 org.slug = None
@@ -427,7 +427,7 @@ def _add_organization_member(
     role = _parse_organization_role(body.get("role"), field="role")
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = OrganizationRepository(session)
         org = repository.get_crm_organization_by_id(organization_id)
         if org is None:
@@ -465,7 +465,7 @@ def _remove_organization_member(
     actor_sub: str,
 ) -> dict[str, Any]:
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=crm_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = OrganizationRepository(session)
         org = repository.get_crm_organization_by_id(organization_id)
         if org is None:

--- a/backend/src/app/api/admin_organizations.py
+++ b/backend/src/app/api/admin_organizations.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.api.admin_crm_entity_deletes import delete_admin_crm_organization
 from app.api.admin_crm_helpers import (
+    CRM_ORGANIZATION_RELATIONSHIP_TYPES,
     assert_contact_can_join_organization,
     crm_request_id,
     ensure_location_exists,
@@ -266,7 +267,9 @@ def _create_organization(event: Mapping[str, Any], *, actor_sub: str) -> dict[st
         body.get("organization_type"), field="organization_type"
     )
     relationship_type = parse_crm_relationship_type(
-        body.get("relationship_type"), field="relationship_type"
+        body.get("relationship_type"),
+        field="relationship_type",
+        allowed=CRM_ORGANIZATION_RELATIONSHIP_TYPES,
     )
     website = validate_string_length(
         body.get("website"),
@@ -360,6 +363,7 @@ def _update_organization(
             org.relationship_type = parse_crm_relationship_type(
                 body.get("relationship_type"),
                 field="relationship_type",
+                allowed=CRM_ORGANIZATION_RELATIONSHIP_TYPES,
             )
             if org.relationship_type != RelationshipType.PARTNER:
                 org.slug = None

--- a/backend/src/app/api/admin_organizations_picker.py
+++ b/backend/src/app/api/admin_organizations_picker.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.admin_crm_helpers import parse_crm_limit
+from app.api.admin_crm_helpers import parse_limit
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.engine import get_engine
 from app.db.models import Organization, RelationshipType
@@ -49,7 +49,7 @@ def handle_admin_organizations_picker_request(
 
 
 def _list_organization_picker(event: Mapping[str, Any]) -> dict[str, Any]:
-    limit = parse_crm_limit(event, default=_DEFAULT_LIMIT)
+    limit = parse_limit(event, default=_DEFAULT_LIMIT)
     with Session(get_engine()) as session:
         statement = (
             select(Organization.id, Organization.name)

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -4726,7 +4726,21 @@ components:
       enum: [parent, child, helper, professional, other]
     CrmRelationshipType:
       type: string
+      description: >
+        Stored relationship for contacts and read responses. Family and organization
+        create/update requests use narrower enums (`CrmFamilyRelationshipType`,
+        `CrmOrganizationRelationshipType`).
       enum: [prospect, client, past_client, partner, vendor, other]
+    CrmFamilyRelationshipType:
+      type: string
+      enum: [prospect, client, other]
+      description: Allowed values when setting a family's CRM relationship.
+    CrmOrganizationRelationshipType:
+      type: string
+      enum: [prospect, client, partner, vendor, other]
+      description: >
+        Allowed values when setting an organization's CRM relationship.
+        `past_client` is not permitted for organizations (use contacts for that lifecycle).
     CrmContactSource:
       type: string
       enum:
@@ -5185,7 +5199,7 @@ components:
           type: string
           maxLength: 150
         relationship_type:
-          $ref: "#/components/schemas/CrmRelationshipType"
+          $ref: "#/components/schemas/CrmFamilyRelationshipType"
         location_id:
           type: string
           format: uuid
@@ -5202,7 +5216,7 @@ components:
           type: string
           maxLength: 150
         relationship_type:
-          $ref: "#/components/schemas/CrmRelationshipType"
+          $ref: "#/components/schemas/CrmFamilyRelationshipType"
         location_id:
           type: string
           format: uuid
@@ -5344,7 +5358,7 @@ components:
         organization_type:
           $ref: "#/components/schemas/CrmOrganizationType"
         relationship_type:
-          $ref: "#/components/schemas/CrmRelationshipType"
+          $ref: "#/components/schemas/CrmOrganizationRelationshipType"
         slug:
           type: string
           maxLength: 128
@@ -5379,7 +5393,7 @@ components:
         organization_type:
           $ref: "#/components/schemas/CrmOrganizationType"
         relationship_type:
-          $ref: "#/components/schemas/CrmRelationshipType"
+          $ref: "#/components/schemas/CrmOrganizationRelationshipType"
         slug:
           type: string
           maxLength: 128

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -22,7 +22,9 @@ Seed data lives in `backend/db/seed/seed_data.sql`.
   `reservation`, `referral`, `instagram`, `manual`, `whatsapp`,
   `linkedin`, `event`, `phone_call`, `public_website`.
 - Enum `relationship_type`: `prospect`, `client`, `past_client`, `partner`,
-  `vendor`, `other`.
+  `vendor`, `other` (stored on contacts, families, and organizations). Admin API
+  write rules narrow allowed values: families may only use `prospect`, `client`,
+  or `other`; organizations may not use `past_client`.
 - Enum `mailchimp_sync_status`: `pending`, `synced`, `failed`, `unsubscribed`.
 - Enum `family_role`: `parent`, `child`, `helper`, `guardian`, `other`.
 - Enum `organization_type`: `school`, `company`, `community_group`, `ngo`, `other`.

--- a/tests/test_admin_crm_helpers.py
+++ b/tests/test_admin_crm_helpers.py
@@ -5,6 +5,8 @@ from typing import Any
 import pytest
 
 from app.api.admin_crm_helpers import (
+    CRM_FAMILY_RELATIONSHIP_TYPES,
+    CRM_ORGANIZATION_RELATIONSHIP_TYPES,
     crm_request_id,
     parse_contact_type_filter,
     parse_crm_relationship_type,
@@ -42,6 +44,40 @@ def test_parse_crm_relationship_type_accepts_client() -> None:
         parse_crm_relationship_type("client", field="relationship_type")
         == RelationshipType.CLIENT
     )
+
+
+def test_parse_crm_relationship_type_family_allowed_subset() -> None:
+    assert (
+        parse_crm_relationship_type(
+            "client",
+            field="relationship_type",
+            allowed=CRM_FAMILY_RELATIONSHIP_TYPES,
+        )
+        == RelationshipType.CLIENT
+    )
+    with pytest.raises(ValidationError, match="relationship_type"):
+        parse_crm_relationship_type(
+            "past_client",
+            field="relationship_type",
+            allowed=CRM_FAMILY_RELATIONSHIP_TYPES,
+        )
+
+
+def test_parse_crm_relationship_type_organization_excludes_past_client() -> None:
+    assert (
+        parse_crm_relationship_type(
+            "partner",
+            field="relationship_type",
+            allowed=CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+        )
+        == RelationshipType.PARTNER
+    )
+    with pytest.raises(ValidationError, match="relationship_type"):
+        parse_crm_relationship_type(
+            "past_client",
+            field="relationship_type",
+            allowed=CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+        )
 
 
 def test_parse_contact_type_filter_empty_means_no_filter() -> None:

--- a/tests/test_admin_crm_helpers.py
+++ b/tests/test_admin_crm_helpers.py
@@ -5,78 +5,78 @@ from typing import Any
 import pytest
 
 from app.api.admin_crm_helpers import (
-    CRM_FAMILY_RELATIONSHIP_TYPES,
-    CRM_ORGANIZATION_RELATIONSHIP_TYPES,
-    crm_request_id,
+    FAMILY_RELATIONSHIP_TYPES,
+    ORGANIZATION_RELATIONSHIP_TYPES,
+    request_id,
     parse_contact_type_filter,
-    parse_crm_relationship_type,
+    parse_relationship_type,
 )
 from app.db.models import RelationshipType
 from app.db.models.enums import ContactType
 from app.exceptions import ValidationError
 
 
-def test_crm_request_id_reads_api_gateway_request_id() -> None:
+def test_request_id_reads_api_gateway_request_id() -> None:
     event: dict[str, Any] = {
         "requestContext": {"requestId": "  req-abc  "},
     }
-    assert crm_request_id(event) == "req-abc"
+    assert request_id(event) == "req-abc"
 
 
-def test_crm_request_id_empty_when_missing() -> None:
-    assert crm_request_id({}) == ""
+def test_request_id_empty_when_missing() -> None:
+    assert request_id({}) == ""
 
 
-def test_parse_crm_relationship_type_defaults_to_prospect() -> None:
-    assert parse_crm_relationship_type(None, field="x") == RelationshipType.PROSPECT
-    assert parse_crm_relationship_type("", field="x") == RelationshipType.PROSPECT
+def test_parse_relationship_type_defaults_to_prospect() -> None:
+    assert parse_relationship_type(None, field="x") == RelationshipType.PROSPECT
+    assert parse_relationship_type("", field="x") == RelationshipType.PROSPECT
 
 
-def test_parse_crm_relationship_type_accepts_vendor() -> None:
+def test_parse_relationship_type_accepts_vendor() -> None:
     assert (
-        parse_crm_relationship_type("vendor", field="relationship_type")
+        parse_relationship_type("vendor", field="relationship_type")
         == RelationshipType.VENDOR
     )
 
 
-def test_parse_crm_relationship_type_accepts_client() -> None:
+def test_parse_relationship_type_accepts_client() -> None:
     assert (
-        parse_crm_relationship_type("client", field="relationship_type")
+        parse_relationship_type("client", field="relationship_type")
         == RelationshipType.CLIENT
     )
 
 
-def test_parse_crm_relationship_type_family_allowed_subset() -> None:
+def test_parse_relationship_type_family_allowed_subset() -> None:
     assert (
-        parse_crm_relationship_type(
+        parse_relationship_type(
             "client",
             field="relationship_type",
-            allowed=CRM_FAMILY_RELATIONSHIP_TYPES,
+            allowed=FAMILY_RELATIONSHIP_TYPES,
         )
         == RelationshipType.CLIENT
     )
     with pytest.raises(ValidationError, match="relationship_type"):
-        parse_crm_relationship_type(
+        parse_relationship_type(
             "past_client",
             field="relationship_type",
-            allowed=CRM_FAMILY_RELATIONSHIP_TYPES,
+            allowed=FAMILY_RELATIONSHIP_TYPES,
         )
 
 
-def test_parse_crm_relationship_type_organization_excludes_past_client() -> None:
+def test_parse_relationship_type_organization_excludes_past_client() -> None:
     assert (
-        parse_crm_relationship_type(
+        parse_relationship_type(
             "partner",
             field="relationship_type",
-            allowed=CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+            allowed=ORGANIZATION_RELATIONSHIP_TYPES,
         )
         == RelationshipType.PARTNER
     )
     with pytest.raises(ValidationError, match="relationship_type"):
-        parse_crm_relationship_type(
+        parse_relationship_type(
             "past_client",
             field="relationship_type",
-            allowed=CRM_ORGANIZATION_RELATIONSHIP_TYPES,
+            allowed=ORGANIZATION_RELATIONSHIP_TYPES,
         )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Families**: create/update API accepts only `prospect`, `client`, and `other` for `relationship_type`.
- **Organizations**: create/update rejects `past_client` for `relationship_type`.
- **OpenAPI**: `CrmFamilyRelationshipType`, `CrmOrganizationRelationshipType` on requests; full `CrmRelationshipType` for reads/contacts.
- **Admin web**: dropdowns and `relationshipTypeForEditor` aligned with API rules.
- **Naming (follow-up)**: Dropped redundant `crm_` / `CRM_` prefixes on shared helpers and TS constants (`parse_limit`, `request_id`, `parse_relationship_type`, `FAMILY_RELATIONSHIP_TYPES`, `ORGANIZATION_RELATIONSHIP_TYPES`, `CONTACT_RELATIONSHIP_TYPES`, `relationshipOptions`, `DEFAULT_CONTACT_LIST_FILTERS`). No DB renames: column remains `relationship_type`.

## Testing

- `python3 -m pytest tests/test_admin_crm_helpers.py`
- `npm run lint`, Vitest (crm-relationship + contacts org/page tests)
- `pre-commit run ruff-format --all-files`, `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95f912bd-cb62-4a2d-b991-50620d1902f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95f912bd-cb62-4a2d-b991-50620d1902f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

