### PR TITLE
Contacts table: family and organisation emoji after name

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -38,6 +38,11 @@ import type { AdminUser } from '@/types/leads';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
 import type { components } from '@/types/generated/admin-api.generated';
 
+/** Shown after the contact name in the list when `family_ids` is non-empty. */
+const CONTACT_NAME_FAMILY_EMOJI = '👨‍👩‍👧';
+/** Shown after the contact name in the list when `organization_ids` is non-empty. */
+const CONTACT_NAME_ORG_EMOJI = '🏢';
+
 type ApiSchemas = components['schemas'];
 
 const CONTACT_TYPES: ApiSchemas['EntityContactType'][] = [
@@ -67,6 +72,17 @@ const SOURCES: ApiSchemas['EntityContactSource'][] = [
   'public_website',
   'manual',
 ];
+
+function contactNameMembershipSuffix(row: ApiSchemas['AdminContact']): string {
+  const parts: string[] = [];
+  if (row.family_ids.length > 0) {
+    parts.push(CONTACT_NAME_FAMILY_EMOJI);
+  }
+  if (row.organization_ids.length > 0) {
+    parts.push(CONTACT_NAME_ORG_EMOJI);
+  }
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
 
 export interface ContactsPanelProps {
   contacts: ReturnType<typeof useAdminEntityContacts>;
@@ -850,6 +866,7 @@ export function ContactsPanel({
           <AdminDataTableBody>
             {rows.map((row) => {
               const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
+              const membershipSuffix = contactNameMembershipSuffix(row);
               return (
                 <tr
                   key={row.id}
@@ -858,7 +875,20 @@ export function ContactsPanel({
                   }`}
                   onClick={() => selectRow(row)}
                 >
-                  <td className='px-4 py-3'>{name}</td>
+                  <td className='px-4 py-3'>
+                    {name}
+                    {membershipSuffix ? (
+                      <>
+                        <span aria-hidden>{membershipSuffix}</span>
+                        {row.family_ids.length > 0 ? (
+                          <span className='sr-only'>, linked to a family</span>
+                        ) : null}
+                        {row.organization_ids.length > 0 ? (
+                          <span className='sr-only'>, linked to an organisation</span>
+                        ) : null}
+                      </>
+                    ) : null}
+                  </td>
                   <td className='px-4 py-3'>{row.email ?? '—'}</td>
                   <td className='px-4 py-3'>{formatEnumLabel(row.contact_type)}</td>
                   <td className='px-4 py-3 text-right'>

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -135,6 +135,67 @@ describe('ContactsPanel', () => {
     expect(loadMore).toHaveBeenCalled();
   });
 
+  it('shows family and organisation emoji after the name when the contact is linked', () => {
+    const baseRow = {
+      id: '11111111-1111-1111-1111-111111111111',
+      email: null,
+      instagram_handle: null,
+      phone: null,
+      contact_type: 'parent' as const,
+      relationship_type: 'prospect' as const,
+      source: 'manual' as const,
+      mailchimp_status: 'pending' as const,
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+      tag_ids: [],
+      tags: [],
+      standalone_note_count: 0,
+    };
+    const familyOnly: components['schemas']['AdminContact'] = {
+      ...baseRow,
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      first_name: 'Ann',
+      last_name: 'Family',
+      family_ids: ['fam-1'],
+      organization_ids: [],
+    };
+    const orgOnly: components['schemas']['AdminContact'] = {
+      ...baseRow,
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      first_name: 'Bob',
+      last_name: 'Org',
+      family_ids: [],
+      organization_ids: ['org-1'],
+    };
+    const both: components['schemas']['AdminContact'] = {
+      ...baseRow,
+      id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      first_name: 'Pat',
+      last_name: 'Both',
+      family_ids: ['fam-2'],
+      organization_ids: ['org-2'],
+    };
+    const contacts = buildContactsHook({ contacts: [familyOnly, orgOnly, both] });
+
+    render(
+      <ContactsPanel
+        contacts={contacts}
+        adminUsers={[]}
+        onPatchStandaloneNoteCount={vi.fn()}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+      />
+    );
+
+    expect(screen.getByText(/Ann Family/)).toHaveTextContent('Ann Family 👨‍👩‍👧');
+    expect(screen.getByText(/Bob Org/)).toHaveTextContent('Bob Org 🏢');
+    expect(screen.getByText(/Pat Both/)).toHaveTextContent('Pat Both 👨‍👩‍👧 🏢');
+  });
+
   it('calls deleteContact when Delete is confirmed', async () => {
     const user = userEvent.setup();
     const deleteContact = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the admin **Contacts** tab, the **Name** column now appends small emoji when a contact is linked to a family and/or an organisation, using existing `family_ids` and `organization_ids` from the API.

- Family: 👨‍👩‍👧 (ZWJ sequence; renders as a family-style pictograph where supported)
- Organisation: 🏢

Screen-reader-only text describes the links so the extra symbols are not purely decorative for assistive tech.

## Tests

- `npm run test -- --run tests/components/admin/contacts/contacts-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf44f077-5bbf-4857-b5c0-1fc8c269167f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf44f077-5bbf-4857-b5c0-1fc8c269167f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

