### PR TITLE
Contacts: show linked family/org location in table and API

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -28,7 +28,11 @@ import {
   searchEntityContactsForPicker,
   type EntityTagRef,
 } from '@/lib/entity-api';
-import { formatEnumLabel } from '@/lib/format';
+import {
+  formatEntityVenueLocationLabel,
+  formatEnumLabel,
+  formatLocationCoordinatesLabel,
+} from '@/lib/format';
 import type { EntityListFilters } from '@/types/entity-list';
 import {
   CONTACT_RELATIONSHIP_TYPES,
@@ -82,6 +86,49 @@ function contactNameMembershipSuffix(row: ApiSchemas['AdminContact']): string {
     parts.push(CONTACT_NAME_ORG_EMOJI);
   }
   return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
+
+function contactTableLinkedVenueBlocks(row: ApiSchemas['AdminContact']): {
+  blocks: { line1: string; line2: string }[];
+  caption: string | null;
+} {
+  const blocks: { line1: string; line2: string }[] = [];
+
+  function pushBlock(emoji: string, summary: ApiSchemas['EntityLocationVenueSummary'] | null) {
+    if (!summary) {
+      blocks.push({ line1: `${emoji} Not set`, line2: '' });
+      return;
+    }
+    blocks.push({
+      line1: `${emoji} ${formatEntityVenueLocationLabel({
+        id: summary.id,
+        name: summary.name,
+        address: summary.address,
+        areaName: summary.area_name,
+      })}`,
+      line2: formatLocationCoordinatesLabel(summary.lat ?? null, summary.lng ?? null),
+    });
+  }
+
+  if (row.family_ids.length > 0) {
+    pushBlock(CONTACT_NAME_FAMILY_EMOJI, row.family_location_summary ?? null);
+  }
+  if (row.organization_ids.length > 0) {
+    pushBlock(CONTACT_NAME_ORG_EMOJI, row.organization_location_summary ?? null);
+  }
+
+  if (blocks.length === 0) {
+    return { blocks: [], caption: null };
+  }
+
+  const caption =
+    row.family_ids.length > 0 && row.organization_ids.length > 0
+      ? 'Read-only. Edit addresses on the family and organisation records.'
+      : row.family_ids.length > 0
+        ? 'Read-only. Edit address on the family record.'
+        : 'Read-only. Edit address on the organisation record.';
+
+  return { blocks, caption };
 }
 
 export interface ContactsPanelProps {
@@ -854,12 +901,13 @@ export function ContactsPanel({
           </div>
         }
       >
-        <AdminDataTable tableClassName='min-w-[960px]'>
+        <AdminDataTable tableClassName='min-w-[1120px]'>
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Email</th>
               <th className='px-4 py-3 font-semibold'>Type</th>
+              <th className='px-4 py-3 font-semibold'>Location</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
           </AdminDataTableHead>
@@ -867,6 +915,7 @@ export function ContactsPanel({
             {rows.map((row) => {
               const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
               const membershipSuffix = contactNameMembershipSuffix(row);
+              const linkedVenue = contactTableLinkedVenueBlocks(row);
               return (
                 <tr
                   key={row.id}
@@ -891,6 +940,25 @@ export function ContactsPanel({
                   </td>
                   <td className='px-4 py-3'>{row.email ?? '—'}</td>
                   <td className='px-4 py-3'>{formatEnumLabel(row.contact_type)}</td>
+                  <td className='max-w-xs px-4 py-3 align-top text-sm text-slate-700'>
+                    {linkedVenue.blocks.length > 0 ? (
+                      <div className='space-y-2'>
+                        {linkedVenue.blocks.map((block, idx) => (
+                          <div key={idx}>
+                            <div>{block.line1}</div>
+                            {block.line2 ? (
+                              <div className='text-xs text-slate-500'>{block.line2}</div>
+                            ) : null}
+                          </div>
+                        ))}
+                        {linkedVenue.caption ? (
+                          <p className='text-xs text-slate-500'>{linkedVenue.caption}</p>
+                        ) : null}
+                      </div>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
                   <td className='px-4 py-3 text-right'>
                     <div className='flex flex-wrap justify-end gap-2'>
                       <Button

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4662,6 +4662,18 @@ export interface components {
             /** Format: uuid */
             location_id?: string | null;
             location_summary?: components["schemas"]["EntityLocationVenueSummary"] | null;
+            /**
+             * @description When the contact belongs to at least one family with a saved location, the venue
+             *     summary for the lexicographically first such family (by family id). Read-only in
+             *     the admin UI; edit location on the family record.
+             */
+            family_location_summary?: components["schemas"]["EntityLocationVenueSummary"] | null;
+            /**
+             * @description When the contact belongs to at least one organisation with a saved location, the
+             *     venue summary for the lexicographically first such organisation (by organisation id).
+             *     Read-only in the admin UI; edit location on the organisation record.
+             */
+            organization_location_summary?: components["schemas"]["EntityLocationVenueSummary"] | null;
             source: components["schemas"]["EntityContactSource"];
             source_detail?: string | null;
             /**

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -159,6 +159,8 @@ describe('ContactsPanel', () => {
       last_name: 'Family',
       family_ids: ['fam-1'],
       organization_ids: [],
+      family_location_summary: null,
+      organization_location_summary: null,
     };
     const orgOnly: components['schemas']['AdminContact'] = {
       ...baseRow,
@@ -167,6 +169,8 @@ describe('ContactsPanel', () => {
       last_name: 'Org',
       family_ids: [],
       organization_ids: ['org-1'],
+      family_location_summary: null,
+      organization_location_summary: null,
     };
     const both: components['schemas']['AdminContact'] = {
       ...baseRow,
@@ -175,6 +179,8 @@ describe('ContactsPanel', () => {
       last_name: 'Both',
       family_ids: ['fam-2'],
       organization_ids: ['org-2'],
+      family_location_summary: null,
+      organization_location_summary: null,
     };
     const contacts = buildContactsHook({ contacts: [familyOnly, orgOnly, both] });
 
@@ -194,6 +200,62 @@ describe('ContactsPanel', () => {
     expect(screen.getByText(/Ann Family/)).toHaveTextContent('Ann Family 👨‍👩‍👧');
     expect(screen.getByText(/Bob Org/)).toHaveTextContent('Bob Org 🏢');
     expect(screen.getByText(/Pat Both/)).toHaveTextContent('Pat Both 👨‍👩‍👧 🏢');
+  });
+
+  it('shows read-only family and organisation venue lines in the Location column', () => {
+    const summary = {
+      id: 'loc-1',
+      name: 'Studio',
+      area_id: 'area-hk',
+      area_name: 'Hong Kong',
+      address: '1 Road',
+      lat: 22.1,
+      lng: 114.2,
+    };
+    const row: components['schemas']['AdminContact'] = {
+      id: '11111111-1111-1111-1111-111111111111',
+      first_name: 'Pat',
+      last_name: 'Both',
+      email: null,
+      instagram_handle: null,
+      phone: null,
+      contact_type: 'parent',
+      relationship_type: 'prospect',
+      source: 'manual',
+      mailchimp_status: 'pending',
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+      tag_ids: [],
+      tags: [],
+      family_ids: ['fam-1'],
+      organization_ids: ['org-1'],
+      family_location_summary: summary,
+      organization_location_summary: summary,
+      standalone_note_count: 0,
+    };
+    const contacts = buildContactsHook({ contacts: [row] });
+
+    render(
+      <ContactsPanel
+        contacts={contacts}
+        adminUsers={[]}
+        onPatchStandaloneNoteCount={vi.fn()}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+      />
+    );
+
+    const familyLines = screen.getAllByText(/👨‍👩‍👧 1 Road · Hong Kong/);
+    expect(familyLines.length).toBeGreaterThanOrEqual(1);
+    const orgLines = screen.getAllByText(/🏢 1 Road · Hong Kong/);
+    expect(orgLines.length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByText('Read-only. Edit addresses on the family and organisation records.')
+    ).toBeInTheDocument();
   });
 
   it('calls deleteContact when Delete is confirmed', async () => {
@@ -293,6 +355,16 @@ describe('ContactsPanel', () => {
         lat: 22.1,
         lng: 114.2,
       },
+      family_location_summary: {
+        id: 'loc-1',
+        name: 'Studio',
+        area_id: 'area-hk',
+        area_name: 'Hong Kong',
+        address: '1 Road',
+        lat: 22.1,
+        lng: 114.2,
+      },
+      organization_location_summary: null,
       standalone_note_count: 0,
     };
     const contacts = buildContactsHook({ contacts: [row] });
@@ -312,8 +384,8 @@ describe('ContactsPanel', () => {
 
     await user.click(screen.getByText('Ann Lee'));
 
-    expect(screen.getByText('1 Road · Hong Kong')).toBeInTheDocument();
-    expect(screen.getByText('22.10000, 114.20000')).toBeInTheDocument();
+    expect(screen.getAllByText('1 Road · Hong Kong').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('22.10000, 114.20000').length).toBeGreaterThanOrEqual(1);
     expect(
       screen.getByText('Location is managed on the linked family or organisation.')
     ).toBeInTheDocument();

--- a/backend/src/app/api/admin_entities_serializers.py
+++ b/backend/src/app/api/admin_entities_serializers.py
@@ -57,6 +57,40 @@ def serialize_contact_picker_row(contact: Contact) -> dict[str, Any]:
     return {"id": str(contact.id), "label": label}
 
 
+def _first_linked_family_location_summary(contact: Contact) -> dict[str, Any] | None:
+    """Venue summary for the lexicographically first linked family that has a location."""
+    summaries: dict[str, dict[str, Any]] = {}
+    for member in contact.family_members:
+        family = member.family
+        if family is None:
+            continue
+        if family.location_id is None or family.location is None:
+            continue
+        summaries[str(family.id)] = serialize_location_venue(family.location)
+    if not summaries:
+        return None
+    first_id = min(summaries.keys())
+    return summaries[first_id]
+
+
+def _first_linked_organization_location_summary(
+    contact: Contact,
+) -> dict[str, Any] | None:
+    """Venue summary for the lexicographically first linked org that has a location."""
+    summaries: dict[str, dict[str, Any]] = {}
+    for member in contact.organization_members:
+        org = member.organization
+        if org is None:
+            continue
+        if org.location_id is None or org.location is None:
+            continue
+        summaries[str(org.id)] = serialize_location_venue(org.location)
+    if not summaries:
+        return None
+    first_id = min(summaries.keys())
+    return summaries[first_id]
+
+
 def serialize_contact_summary(
     contact: Contact,
     *,
@@ -85,6 +119,10 @@ def serialize_contact_summary(
         "location_summary": serialize_location_venue(contact.location)
         if contact.location_id is not None and contact.location is not None
         else None,
+        "family_location_summary": _first_linked_family_location_summary(contact),
+        "organization_location_summary": _first_linked_organization_location_summary(
+            contact
+        ),
         "source": contact.source.value,
         "source_detail": contact.source_detail,
         "referral_contact_id": _referral_contact_id_from_metadata(

--- a/backend/src/app/db/repositories/contact.py
+++ b/backend/src/app/db/repositories/contact.py
@@ -9,7 +9,9 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.db.models.note import Note
 from app.db.models.contact import Contact
+from app.db.models.family import Family, FamilyMember
 from app.db.models.location import Location
+from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.tag import ContactTag
 from app.db.models.enums import ContactSource, ContactType, RelationshipType
 from app.db.repositories.base import BaseRepository
@@ -145,8 +147,14 @@ class ContactRepository(BaseRepository[Contact]):
 
         statement = select(Contact).options(
             selectinload(Contact.contact_tags).selectinload(ContactTag.tag),
-            selectinload(Contact.family_members),
-            selectinload(Contact.organization_members),
+            selectinload(Contact.family_members)
+            .selectinload(FamilyMember.family)
+            .selectinload(Family.location)
+            .selectinload(Location.area),
+            selectinload(Contact.organization_members)
+            .selectinload(OrganizationMember.organization)
+            .selectinload(Organization.location)
+            .selectinload(Location.area),
             selectinload(Contact.location).selectinload(Location.area),
         )
         if cursor is not None:
@@ -256,8 +264,14 @@ class ContactRepository(BaseRepository[Contact]):
             .where(Contact.id == contact_id)
             .options(
                 selectinload(Contact.contact_tags).selectinload(ContactTag.tag),
-                selectinload(Contact.family_members),
-                selectinload(Contact.organization_members),
+                selectinload(Contact.family_members)
+                .selectinload(FamilyMember.family)
+                .selectinload(Family.location)
+                .selectinload(Location.area),
+                selectinload(Contact.organization_members)
+                .selectinload(OrganizationMember.organization)
+                .selectinload(Organization.location)
+                .selectinload(Location.area),
                 selectinload(Contact.location).selectinload(Location.area),
             )
         )

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -4892,6 +4892,22 @@ components:
           allOf:
             - $ref: "#/components/schemas/EntityLocationVenueSummary"
           nullable: true
+        family_location_summary:
+          allOf:
+            - $ref: "#/components/schemas/EntityLocationVenueSummary"
+          nullable: true
+          description: |
+            When the contact belongs to at least one family with a saved location, the venue
+            summary for the lexicographically first such family (by family id). Read-only in
+            the admin UI; edit location on the family record.
+        organization_location_summary:
+          allOf:
+            - $ref: "#/components/schemas/EntityLocationVenueSummary"
+          nullable: true
+          description: |
+            When the contact belongs to at least one organisation with a saved location, the
+            venue summary for the lexicographically first such organisation (by organisation id).
+            Read-only in the admin UI; edit location on the organisation record.
         source:
           $ref: "#/components/schemas/EntityContactSource"
         source_detail:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -51,7 +51,9 @@ their primary responsibilities.
   reconciliation job exists. **Caching:** share-link tokens stay stable on replace;
   CDN or browser caching keyed only by URL (not `s3_key`) may show stale bytes until TTL—
   downloads keyed by changing `s3_key` generally avoid that.
-  `/v1/admin/contacts/*` (including `GET /v1/admin/contacts` optional `contact_type` filter,
+  `/v1/admin/contacts/*` (including `GET /v1/admin/contacts` optional `contact_type` filter;
+  list and single-contact responses include read-only `family_location_summary` and
+  `organization_location_summary` when the contact is linked to a family or organisation that has a venue location),
   `GET /v1/admin/contacts/tags` for tag pickers,
   `GET /v1/admin/contacts/search` for contact picker search,
   `GET|POST /v1/admin/contacts/{id}/notes` and `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **API:** `AdminContact` now includes optional `family_location_summary` and `organization_location_summary` (`EntityLocationVenueSummary`), populated when the contact is linked to a family or organisation that has a venue location. When multiple links exist, the summary uses the lexicographically **first** family id / organisation id that has a location (documented in OpenAPI).
- **Backend:** `serialize_contact_summary` builds those fields; `ContactRepository.list_for_admin` and `get_by_id_for_admin` eager-load membership → family/org → location (with area) to avoid N+1 queries.
- **Admin web:** Contacts table adds a **Location** column: read-only lines with the same family/org emoji as the name column, venue label (`formatEntityVenueLocationLabel`), coordinates, and a short “read-only / edit on family or organisation” note. Inline editor behaviour is unchanged.
- **Docs:** `docs/architecture/lambdas.md` notes the new response fields for admin contacts.

## Tests / checks

- `npm run test -- --run tests/components/admin/contacts/contacts-panel.test.tsx`
- `npm run lint` (admin_web, includes `generate:admin-api-types` output)
- `bash scripts/validate-cursorrules.sh`
- `pre-commit run ruff-format` on touched Python files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf44f077-5bbf-4857-b5c0-1fc8c269167f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf44f077-5bbf-4857-b5c0-1fc8c269167f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

