### PR TITLE
Admin: remove coordinates from inline location summary blocks

### DIFF
--- a/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
+++ b/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { formatGeocodeErrorMessage } from '@/hooks/hook-errors';
-import { formatEntityVenueLocationLabel, formatEnumLabel, formatLocationCoordinatesLabel } from '@/lib/format';
+import { formatEntityVenueLocationLabel, formatEnumLabel } from '@/lib/format';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
 import type { components } from '@/types/generated/admin-api.generated';
 
@@ -57,7 +57,7 @@ function resolveDisplaySummary(
   location: LocationSummary | null,
   embedded: InlineLocationEmbeddedSummary | null | undefined,
   areaNameForLocation: string
-): { line1: string; line2: string; labels: string[] } | null {
+): { line1: string; labels: string[] } | null {
   if (location) {
     const line1 = formatEntityVenueLocationLabel({
       id: location.id,
@@ -65,8 +65,7 @@ function resolveDisplaySummary(
       address: location.address,
       areaName: areaNameForLocation,
     });
-    const line2 = formatLocationCoordinatesLabel(location.lat, location.lng);
-    return { line1, line2, labels: location.partnerOrganizationLabels };
+    return { line1, labels: location.partnerOrganizationLabels };
   }
   if (embedded) {
     const line1 = formatEntityVenueLocationLabel({
@@ -75,8 +74,7 @@ function resolveDisplaySummary(
       address: embedded.address,
       areaName: embedded.areaName,
     });
-    const line2 = formatLocationCoordinatesLabel(embedded.lat ?? null, embedded.lng ?? null);
-    return { line1, line2, labels: [] };
+    return { line1, labels: [] };
   }
   return null;
 }
@@ -323,7 +321,6 @@ function InlineLocationEditorInner({
         <Label>Location</Label>
         <div className='rounded-md border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-800'>
           <div>{displaySummary.line1}</div>
-          <div className='mt-1 text-slate-600'>{displaySummary.line2}</div>
         </div>
         {lockedFromPartner ? (
           <p className='text-sm text-slate-600'>
@@ -359,7 +356,6 @@ function InlineLocationEditorInner({
           <div className='mt-2 space-y-2'>
             <div className='rounded-md border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-800'>
               <div>{displaySummary.line1}</div>
-              <div className='mt-1 text-slate-600'>{displaySummary.line2}</div>
             </div>
             {lockedFromPartner ? (
               <p className='text-sm text-slate-600'>

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -313,7 +313,6 @@ describe('ContactsPanel', () => {
     await user.click(screen.getByText('Ann Lee'));
 
     expect(screen.getByText('1 Road · Hong Kong')).toBeInTheDocument();
-    expect(screen.getByText('22.10000, 114.20000')).toBeInTheDocument();
     expect(
       screen.getByText('Location is managed on the linked family or organisation.')
     ).toBeInTheDocument();

--- a/apps/admin_web/tests/components/admin/locations/inline-location-editor.test.tsx
+++ b/apps/admin_web/tests/components/admin/locations/inline-location-editor.test.tsx
@@ -48,7 +48,6 @@ describe('InlineLocationEditor', () => {
     );
 
     expect(screen.getByText('1 Road · Hong Kong')).toBeInTheDocument();
-    expect(screen.getByText('22.10000, 114.20000')).toBeInTheDocument();
   });
 
   it('disables Save location until an area is selected', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`InlineLocationEditor` (used on **Contacts**, **Families**, and **Organizations** CRM screens) no longer shows the lat/lng line under the read-only location summary or the non-editing summary card. The address · area line is unchanged; **Latitude** / **Longitude** fields remain in the edit form when the user opens **Change** or creates a location.

## Tests

- `npm run test -- --run tests/components/admin/locations/inline-location-editor.test.tsx tests/components/admin/contacts/contacts-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf44f077-5bbf-4857-b5c0-1fc8c269167f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf44f077-5bbf-4857-b5c0-1fc8c269167f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

