### PR TITLE
Admin web: family members UX and contact-derived roles

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
@@ -102,6 +102,7 @@ export function ContactsPage() {
     () =>
       contacts.contacts.map((c) => ({
         id: c.id,
+        contact_type: c.contact_type,
         family_ids: c.family_ids,
         organization_ids: c.organization_ids,
       })),

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, type MouseEvent } from 'react';
+import { useCallback, useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminEntityFamilies } from '@/hooks/use-admin-entity-families';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
@@ -30,14 +30,6 @@ import type { components } from '@/types/generated/admin-api.generated';
 
 type ApiSchemas = components['schemas'];
 
-const FAMILY_ROLES: ApiSchemas['EntityFamilyRole'][] = [
-  'parent',
-  'child',
-  'helper',
-  'guardian',
-  'other',
-];
-
 function contactEligibleForFamilyMember(
   contact: { id: string; family_ids: string[]; organization_ids: string[] },
   selectedFamilyId: string | null
@@ -56,7 +48,12 @@ export interface FamiliesPanelProps {
   areasLoading: boolean;
   refreshLocations: () => Promise<void> | void;
   contactOptions: { id: string; label: string }[];
-  contactsForMembership: { id: string; family_ids: string[]; organization_ids: string[] }[];
+  contactsForMembership: {
+    id: string;
+    contact_type: ApiSchemas['EntityContactType'];
+    family_ids: string[];
+    organization_ids: string[];
+  }[];
 }
 
 export function FamiliesPanel({
@@ -83,6 +80,7 @@ export function FamiliesPanel({
     updateFamily,
     addMember,
     removeMember,
+    updateMember,
     deleteFamily,
   } = families;
 
@@ -101,8 +99,6 @@ export function FamiliesPanel({
   const [active, setActive] = useState(true);
 
   const [memberContactId, setMemberContactId] = useState('');
-  const [memberRole, setMemberRole] = useState<ApiSchemas['EntityFamilyRole']>('parent');
-  const [memberPrimary, setMemberPrimary] = useState(false);
 
   const [removeTarget, setRemoveTarget] = useState<{ memberId: string; label: string } | null>(
     null
@@ -179,6 +175,25 @@ export function FamiliesPanel({
     });
   }, [contactOptions, contactsForMembership, selectedId]);
 
+  const primaryMemberLabel = useCallback((members: ApiSchemas['AdminFamilyMember'][]) => {
+    const primary = members.find((m) => m.is_primary_contact);
+    return primary?.contact_label?.trim() || null;
+  }, []);
+
+  async function handlePrimaryMemberChange(
+    memberId: string,
+    nextChecked: boolean
+  ): Promise<void> {
+    if (!selected) {
+      return;
+    }
+    try {
+      await updateMember(selected.id, memberId, { is_primary_contact: nextChecked });
+    } catch {
+      // Retry preserved.
+    }
+  }
+
   function resetCreateForm() {
     if (editorMode === 'create' && pendingLocationId && typeof window !== 'undefined') {
       const ok = window.confirm(
@@ -198,8 +213,6 @@ export function FamiliesPanel({
     setTagIds([]);
     setActive(true);
     setMemberContactId('');
-    setMemberRole('parent');
-    setMemberPrimary(false);
   }
 
   async function handleSubmit(): Promise<void> {
@@ -237,12 +250,9 @@ export function FamiliesPanel({
     try {
       await addMember(selected.id, {
         contact_id: memberContactId.trim(),
-        role: memberRole,
-        is_primary_contact: memberPrimary,
+        is_primary_contact: false,
       });
       setMemberContactId('');
-      setMemberRole('parent');
-      setMemberPrimary(false);
     } catch {
       // Retry preserved.
     }
@@ -419,31 +429,6 @@ export function FamiliesPanel({
                     ))}
                   </Select>
                 </div>
-                <div className='min-w-[140px]'>
-                  <Label htmlFor='crm-family-member-role'>Role</Label>
-                  <Select
-                    id='crm-family-member-role'
-                    value={memberRole}
-                    onChange={(e) =>
-                      setMemberRole(e.target.value as ApiSchemas['EntityFamilyRole'])
-                    }
-                  >
-                    {FAMILY_ROLES.map((r) => (
-                      <option key={r} value={r}>
-                        {formatEnumLabel(r)}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-                <label className='flex items-center gap-2 text-sm'>
-                  <input
-                    type='checkbox'
-                    className='h-4 w-4 rounded border-slate-300'
-                    checked={memberPrimary}
-                    onChange={(e) => setMemberPrimary(e.target.checked)}
-                  />
-                  Primary contact
-                </label>
                 <Button
                   type='button'
                   disabled={isSaving || !memberContactId}
@@ -452,11 +437,15 @@ export function FamiliesPanel({
                   Add member
                 </Button>
               </div>
+              <p className='text-xs text-slate-600'>
+                Role for each member follows the contact type set on the contact record.
+              </p>
               <AdminDataTable tableClassName='min-w-[520px]'>
                 <AdminDataTableHead>
                   <tr>
                     <th className='px-3 py-2 font-semibold'>Contact</th>
                     <th className='px-3 py-2 font-semibold'>Role</th>
+                    <th className='px-3 py-2 font-semibold'>Primary contact</th>
                     <th className='px-3 py-2 font-semibold text-right'>Operations</th>
                   </tr>
                 </AdminDataTableHead>
@@ -464,15 +453,25 @@ export function FamiliesPanel({
                   {selected.members.map((m) => (
                     <tr key={m.id}>
                       <td className='px-3 py-2'>{m.contact_label || m.contact_id}</td>
+                      <td className='px-3 py-2'>{formatEnumLabel(m.role)}</td>
                       <td className='px-3 py-2'>
-                        {formatEnumLabel(m.role)}
-                        {m.is_primary_contact ? ' · primary' : ''}
+                        <input
+                          type='checkbox'
+                          className='h-4 w-4 rounded border-slate-300'
+                          checked={m.is_primary_contact}
+                          disabled={isSaving}
+                          onChange={(e) => {
+                            void handlePrimaryMemberChange(m.id, e.target.checked);
+                          }}
+                          aria-label={`Primary contact for ${m.contact_label || m.contact_id}`}
+                        />
                       </td>
                       <td className='px-3 py-2 text-right'>
                         <Button
                           type='button'
                           size='sm'
                           variant='danger'
+                          className='h-8 min-w-8 px-0'
                           disabled={isSaving}
                           onClick={() =>
                             setRemoveTarget({
@@ -480,8 +479,10 @@ export function FamiliesPanel({
                               label: m.contact_label || m.contact_id,
                             })
                           }
+                          aria-label={`Remove ${m.contact_label || m.contact_id} from family`}
+                          title='Remove member'
                         >
-                          Remove
+                          <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                         </Button>
                       </td>
                     </tr>
@@ -543,7 +544,9 @@ export function FamiliesPanel({
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
-            {rows.map((row) => (
+            {rows.map((row) => {
+              const primaryLabel = primaryMemberLabel(row.members);
+              return (
               <tr
                 key={row.id}
                 className={`cursor-pointer transition ${
@@ -551,7 +554,15 @@ export function FamiliesPanel({
                 }`}
                 onClick={() => selectRow(row.id)}
               >
-                <td className='px-4 py-3'>{row.family_name}</td>
+                <td className='px-4 py-3'>
+                  {row.family_name}
+                  {primaryLabel ? (
+                    <>
+                      <span aria-hidden> · </span>
+                      {primaryLabel}
+                    </>
+                  ) : null}
+                </td>
                 <td className='px-4 py-3'>{row.members.length}</td>
                 <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
                 <td className='px-4 py-3 text-right'>
@@ -573,7 +584,8 @@ export function FamiliesPanel({
                   </div>
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </AdminDataTableBody>
         </AdminDataTable>
       </PaginatedTableCard>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -66,7 +66,12 @@ export interface OrganizationsPanelProps {
   areasLoading: boolean;
   refreshLocations: () => Promise<void> | void;
   contactOptions: { id: string; label: string }[];
-  contactsForMembership: { id: string; family_ids: string[]; organization_ids: string[] }[];
+  contactsForMembership: {
+    id: string;
+    contact_type?: ApiSchemas['EntityContactType'];
+    family_ids: string[];
+    organization_ids: string[];
+  }[];
 }
 
 export function OrganizationsPanel({

--- a/apps/admin_web/src/hooks/use-admin-entity-families.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-families.ts
@@ -7,6 +7,7 @@ import {
   createAdminFamily,
   deleteAdminFamily,
   listAdminFamilies,
+  patchAdminFamilyMember,
   removeAdminFamilyMember,
   updateAdminFamily,
 } from '@/lib/entity-api';
@@ -77,6 +78,15 @@ export function useAdminEntityFamilies() {
     [mutate]
   );
 
+  const updateMember = useCallback(
+    async (
+      familyId: string,
+      memberId: string,
+      payload: ApiSchemas['UpdateFamilyMemberRequest']
+    ) => mutate(async () => patchAdminFamilyMember(familyId, memberId, payload)),
+    [mutate]
+  );
+
   const deleteFamily = useCallback(
     async (familyId: string) => mutate(async () => deleteAdminFamily(familyId)),
     [mutate]
@@ -97,6 +107,7 @@ export function useAdminEntityFamilies() {
     updateFamily,
     addMember,
     removeMember,
+    updateMember,
     deleteFamily,
     refetch: list.refetch,
   };

--- a/apps/admin_web/src/lib/entity-api.ts
+++ b/apps/admin_web/src/lib/entity-api.ts
@@ -315,6 +315,20 @@ export async function removeAdminFamilyMember(
   return root.family ?? null;
 }
 
+export async function patchAdminFamilyMember(
+  familyId: string,
+  memberId: string,
+  body: ApiSchemas['UpdateFamilyMemberRequest']
+): Promise<AdminFamilyRow | null> {
+  const payload = await adminApiRequest<ApiFamilyResponse>({
+    endpointPath: `/v1/admin/families/${familyId}/members/${memberId}`,
+    method: 'PATCH',
+    body,
+  });
+  const root = unwrapPayload(payload);
+  return root.family ?? null;
+}
+
 export async function listAdminOrganizations(
   params: Partial<EntityListFilters> & { cursor?: string | null; limit?: number },
   signal?: AbortSignal

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2932,7 +2932,44 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update family member
+         * @description Currently supports toggling the family's primary contact. At most one member may be
+         *     primary; setting `is_primary_contact` to true clears the flag on other members in the
+         *     same family.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description CRM family identifier. */
+                    id: components["parameters"]["AdminFamilyId"];
+                    /** @description Family membership row identifier. */
+                    memberId: components["parameters"]["AdminFamilyMemberId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateFamilyMemberRequest"];
+                };
+            };
+            responses: {
+                /** @description Family with updated members. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminFamilyResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         trace?: never;
     };
     "/v1/admin/organizations/picker": {
@@ -4812,8 +4849,20 @@ export interface components {
         AddFamilyMemberRequest: {
             /** Format: uuid */
             contact_id: string;
-            role: components["schemas"]["EntityFamilyRole"];
+            /**
+             * @deprecated
+             * @description Ignored. Membership role is derived from the contact's `contact_type` (parent, child,
+             *     helper map to the same family roles; professional and other map to `other`).
+             */
+            role?: string;
             is_primary_contact?: boolean;
+        };
+        UpdateFamilyMemberRequest: {
+            /**
+             * @description When true, this member becomes the family's sole primary contact. When false, this
+             *     member is cleared as primary (other members are unchanged).
+             */
+            is_primary_contact: boolean;
         };
         AdminOrganizationMember: {
             /** Format: uuid */

--- a/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
@@ -53,6 +53,7 @@ function buildFamiliesHook(
     updateFamily: vi.fn().mockResolvedValue(null),
     addMember: vi.fn().mockResolvedValue(null),
     removeMember: vi.fn().mockResolvedValue(null),
+    updateMember: vi.fn().mockResolvedValue(null),
     deleteFamily: vi.fn().mockResolvedValue(undefined),
     refetch: vi.fn(),
     ...overrides,
@@ -183,6 +184,62 @@ describe('FamiliesPanel', () => {
       });
     });
     expect(updateLocationPartial.mock.calls[0][1]).not.toHaveProperty('name');
+  });
+
+  it('toggles primary contact from the members table', async () => {
+    const user = userEvent.setup();
+    const updateMember = vi.fn().mockResolvedValue(null);
+    const families = buildFamiliesHook({
+      updateMember,
+      families: [
+        {
+          id: 'fam-1',
+          family_name: 'Smith',
+          relationship_type: 'prospect',
+          location_id: null,
+          location_summary: null,
+          tag_ids: [],
+          tags: [],
+          members: [
+            {
+              id: 'mem-1',
+              contact_id: 'c-1',
+              contact_label: 'Alex Smith',
+              role: 'parent',
+              is_primary_contact: false,
+            },
+          ],
+          active: true,
+          created_at: '2020-01-01T00:00:00.000Z',
+          updated_at: '2020-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    render(
+      <FamiliesPanel
+        families={families}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+        contactOptions={[]}
+        contactsForMembership={[]}
+      />
+    );
+
+    await user.click(screen.getByText('Smith'));
+    const primaryCheckbox = screen.getByRole('checkbox', {
+      name: 'Primary contact for Alex Smith',
+    });
+    await user.click(primaryCheckbox);
+
+    await waitFor(() => {
+      expect(updateMember).toHaveBeenCalledWith('fam-1', 'mem-1', {
+        is_primary_contact: true,
+      });
+    });
   });
 
   it('deletes a family after confirmation', async () => {

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -3110,6 +3110,10 @@ export class ApiStack extends cdk.Stack {
       authorizer: adminAuthorizer,
     });
     const adminFamilyMemberById = adminFamilyMembers.addResource("{memberId}");
+    adminFamilyMemberById.addMethod("PATCH", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
     adminFamilyMemberById.addMethod("DELETE", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,

--- a/backend/src/app/api/admin_families.py
+++ b/backend/src/app/api/admin_families.py
@@ -34,7 +34,7 @@ from app.api.admin_validators import validate_string_length
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
-from app.db.models import Contact, Family, FamilyMember, FamilyRole
+from app.db.models import Contact, ContactType, Family, FamilyMember, FamilyRole
 from app.db.repositories import FamilyRepository
 from app.exceptions import DatabaseError, NotFoundError, ValidationError
 from app.utils import json_response
@@ -92,6 +92,13 @@ def handle_admin_families_request(
 
     if len(parts) == 5 and parts[3] == "members":
         member_id = parse_uuid(parts[4])
+        if method == "PATCH":
+            return _update_family_member(
+                event,
+                family_id=family_id,
+                member_id=member_id,
+                actor_sub=identity.user_sub,
+            )
         if method == "DELETE":
             return _remove_family_member(
                 event,
@@ -104,13 +111,15 @@ def handle_admin_families_request(
     return json_response(404, {"error": "Not found"}, event=event)
 
 
-def _parse_family_role(value: Any, *, field: str) -> FamilyRole:
-    if value is None or str(value).strip() == "":
-        raise ValidationError(f"{field} is required", field=field)
-    try:
-        return FamilyRole(str(value).strip().lower())
-    except ValueError as exc:
-        raise ValidationError(f"Invalid {field}", field=field) from exc
+def _family_role_from_contact_type(contact_type: ContactType) -> FamilyRole:
+    """Map contact category to stored family membership role."""
+    if contact_type is ContactType.PARENT:
+        return FamilyRole.PARENT
+    if contact_type is ContactType.CHILD:
+        return FamilyRole.CHILD
+    if contact_type is ContactType.HELPER:
+        return FamilyRole.HELPER
+    return FamilyRole.OTHER
 
 
 def _list_families(event: Mapping[str, Any]) -> dict[str, Any]:
@@ -265,7 +274,6 @@ def _add_family_member(
 ) -> dict[str, Any]:
     body = parse_body(event)
     contact_id = parse_uuid(str(body.get("contact_id")))
-    role = _parse_family_role(body.get("role"), field="role")
     is_primary = body.get("is_primary_contact")
     if is_primary is None:
         is_primary_contact = False
@@ -294,6 +302,7 @@ def _add_family_member(
             session, contact_id=contact_id, family_id=family_id
         )
 
+        role = _family_role_from_contact_type(contact.contact_type)
         member = FamilyMember(
             family_id=family_id,
             contact_id=contact_id,
@@ -309,6 +318,59 @@ def _add_family_member(
             raise DatabaseError("Failed to load family after adding member")
         return json_response(
             201,
+            {"family": serialize_family_summary(loaded)},
+            event=event,
+        )
+
+
+def _update_family_member(
+    event: Mapping[str, Any],
+    *,
+    family_id: UUID,
+    member_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    body = parse_body(event)
+    if "is_primary_contact" not in body:
+        raise ValidationError(
+            "is_primary_contact is required",
+            field="is_primary_contact",
+        )
+    is_primary = body.get("is_primary_contact")
+    if isinstance(is_primary, bool):
+        is_primary_contact = is_primary
+    elif isinstance(is_primary, str) and is_primary.strip().lower() in {"true", "1"}:
+        is_primary_contact = True
+    elif isinstance(is_primary, str) and is_primary.strip().lower() in {"false", "0"}:
+        is_primary_contact = False
+    else:
+        raise ValidationError(
+            "is_primary_contact must be true or false",
+            field="is_primary_contact",
+        )
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
+        repository = FamilyRepository(session)
+        family = repository.get_by_id_for_admin(family_id)
+        if family is None:
+            raise NotFoundError("Family", str(family_id))
+        member = session.get(FamilyMember, member_id)
+        if member is None or member.family_id != family_id:
+            raise NotFoundError("FamilyMember", str(member_id))
+
+        if is_primary_contact:
+            for m in family.family_members:
+                m.is_primary_contact = m.id == member_id
+        else:
+            member.is_primary_contact = False
+
+        session.commit()
+        loaded = repository.get_by_id_for_admin(family_id)
+        if loaded is None:
+            raise DatabaseError("Failed to load family after updating member")
+        return json_response(
+            200,
             {"family": serialize_family_summary(loaded)},
             event=event,
         )

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -34,7 +34,7 @@ info:
     - `GET|POST /v1/admin/families`
     - `GET|PATCH|DELETE /v1/admin/families/{id}`
     - `POST /v1/admin/families/{id}/members`
-    - `DELETE /v1/admin/families/{id}/members/{memberId}`
+    - `PATCH|DELETE /v1/admin/families/{id}/members/{memberId}`
     - `GET /v1/admin/organizations/picker`
     - `GET|POST /v1/admin/organizations`
     - `GET|PATCH|DELETE /v1/admin/organizations/{id}`
@@ -2012,6 +2012,33 @@ paths:
     parameters:
       - $ref: "#/components/parameters/AdminFamilyId"
       - $ref: "#/components/parameters/AdminFamilyMemberId"
+    patch:
+      summary: Update family member
+      description: |
+        Currently supports toggling the family's primary contact. At most one member may be
+        primary; setting `is_primary_contact` to true clears the flag on other members in the
+        same family.
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFamilyMemberRequest"
+      responses:
+        "200":
+          description: Family with updated members.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminFamilyResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
     delete:
       summary: Remove family member
       security:
@@ -5250,15 +5277,28 @@ components:
       type: object
       required:
         - contact_id
-        - role
       properties:
         contact_id:
           type: string
           format: uuid
         role:
-          $ref: "#/components/schemas/EntityFamilyRole"
+          type: string
+          deprecated: true
+          description: |
+            Ignored. Membership role is derived from the contact's `contact_type` (parent, child,
+            helper map to the same family roles; professional and other map to `other`).
         is_primary_contact:
           type: boolean
+    UpdateFamilyMemberRequest:
+      type: object
+      required:
+        - is_primary_contact
+      properties:
+        is_primary_contact:
+          type: boolean
+          description: |
+            When true, this member becomes the family's sole primary contact. When false, this
+            member is cleared as primary (other members are unchanged).
     AdminOrganizationMember:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -60,7 +60,9 @@ their primary responsibilities.
   for standalone CRM notes on a contact (not tied to a sales lead), and `DELETE /v1/admin/contacts/{id}`
   for hard-deleting a contact after clearing blocking CRM rows),
   `/v1/admin/families/picker`, `/v1/admin/families/*` (including `DELETE /v1/admin/families/{id}`
-  for hard-deleting a family after clearing blocking CRM rows),
+  for hard-deleting a family after clearing blocking CRM rows; `POST /v1/admin/families/{id}/members`
+  derives each member's role from the linked contact's `contact_type`; `PATCH /v1/admin/families/{id}/members/{memberId}`
+  updates membership fields such as primary contact),
   `/v1/admin/organizations/picker`, `/v1/admin/organizations/*` (CRM organisations and vendor
   rows share one resource; default list excludes vendors, Finance lists vendors with
   `GET /v1/admin/organizations?relationship_type=vendor`; includes `DELETE /v1/admin/organizations/{id}`

--- a/tests/test_admin_crm_routes.py
+++ b/tests/test_admin_crm_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 from uuid import uuid4
 
@@ -255,6 +256,46 @@ def test_handle_admin_families_delete(
         ),
         "DELETE",
         f"/v1/admin/families/{expected_family_id}",
+    )
+
+    assert response is marker
+
+
+def test_handle_admin_families_member_patch(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    marker = {"statusCode": 200, "body": "{}"}
+    monkeypatch.setattr(
+        admin_families,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+    family_id = str(uuid4())
+    member_id = str(uuid4())
+
+    def _fake_update(
+        _event: Any,
+        *,
+        family_id: Any,
+        member_id: Any,
+        actor_sub: str,
+    ) -> dict[str, Any]:
+        assert actor_sub == "admin-sub"
+        assert str(family_id)
+        assert str(member_id)
+        return marker
+
+    monkeypatch.setattr(admin_families, "_update_family_member", _fake_update)
+
+    response = admin_families.handle_admin_families_request(
+        api_gateway_event(
+            method="PATCH",
+            path=f"/v1/admin/families/{family_id}/members/{member_id}",
+            body=json.dumps({"is_primary_contact": True}),
+        ),
+        "PATCH",
+        f"/v1/admin/families/{family_id}/members/{member_id}",
     )
 
     assert response is marker


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Families
- Role removed from add-member UI; server derives from contact `contact_type`.
- Primary contact via per-row checkbox + `PATCH .../families/{id}/members/{memberId}`.
- Remove member as icon; list shows `Family name · primary` when set.

### Organisations (latest commits)
- Same UX: no role dropdown on add; role derived from contact type on the server (parent→client, child→member, helper→staff, professional→partner, other→other).
- `organization_members.is_primary_contact` added (Alembic `0030_org_member_primary_contact`).
- `PATCH /v1/admin/organizations/{id}/members/{memberId}` for primary toggling; CDK + OpenAPI updated.
- Members table: primary checkbox column, remove as icon; organisations list shows `Name · primary` when set.

## Tests
- Vitest: families + organisations panel primary checkbox tests.
- Pytest: family and organisation member PATCH route wiring.

Branch: `cursor/family-members-ui-0fb2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6741df0-54ba-4043-9d23-ae6662b60fb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6741df0-54ba-4043-9d23-ae6662b60fb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

