### PR TITLE
Admin web: show linked family/org location in Contact card, drop table column

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -28,11 +28,7 @@ import {
   searchEntityContactsForPicker,
   type EntityTagRef,
 } from '@/lib/entity-api';
-import {
-  formatEntityVenueLocationLabel,
-  formatEnumLabel,
-  formatLocationCoordinatesLabel,
-} from '@/lib/format';
+import { formatEntityVenueLocationLabel, formatEnumLabel } from '@/lib/format';
 import type { EntityListFilters } from '@/types/entity-list';
 import {
   CONTACT_RELATIONSHIP_TYPES,
@@ -88,47 +84,46 @@ function contactNameMembershipSuffix(row: ApiSchemas['AdminContact']): string {
   return parts.length > 0 ? ` ${parts.join(' ')}` : '';
 }
 
-function contactTableLinkedVenueBlocks(row: ApiSchemas['AdminContact']): {
-  blocks: { line1: string; line2: string }[];
-  caption: string | null;
+function linkedVenueReadOnlyLines(row: ApiSchemas['AdminContact']): {
+  lines: string[];
+  footerNote: string | null;
 } {
-  const blocks: { line1: string; line2: string }[] = [];
+  const lines: string[] = [];
 
-  function pushBlock(emoji: string, summary: ApiSchemas['EntityLocationVenueSummary'] | null) {
+  function pushLine(emoji: string, summary: ApiSchemas['EntityLocationVenueSummary'] | null) {
     if (!summary) {
-      blocks.push({ line1: `${emoji} Not set`, line2: '' });
+      lines.push(`${emoji} Not set`);
       return;
     }
-    blocks.push({
-      line1: `${emoji} ${formatEntityVenueLocationLabel({
+    lines.push(
+      `${emoji} ${formatEntityVenueLocationLabel({
         id: summary.id,
         name: summary.name,
         address: summary.address,
         areaName: summary.area_name,
-      })}`,
-      line2: formatLocationCoordinatesLabel(summary.lat ?? null, summary.lng ?? null),
-    });
+      })}`
+    );
   }
 
   if (row.family_ids.length > 0) {
-    pushBlock(CONTACT_NAME_FAMILY_EMOJI, row.family_location_summary ?? null);
+    pushLine(CONTACT_NAME_FAMILY_EMOJI, row.family_location_summary ?? null);
   }
   if (row.organization_ids.length > 0) {
-    pushBlock(CONTACT_NAME_ORG_EMOJI, row.organization_location_summary ?? null);
+    pushLine(CONTACT_NAME_ORG_EMOJI, row.organization_location_summary ?? null);
   }
 
-  if (blocks.length === 0) {
-    return { blocks: [], caption: null };
+  if (lines.length === 0) {
+    return { lines: [], footerNote: null };
   }
 
-  const caption =
+  const footerNote =
     row.family_ids.length > 0 && row.organization_ids.length > 0
       ? 'Read-only. Edit addresses on the family and organisation records.'
       : row.family_ids.length > 0
         ? 'Read-only. Edit address on the family record.'
         : 'Read-only. Edit address on the organisation record.';
 
-  return { blocks, caption };
+  return { lines, footerNote };
 }
 
 export interface ContactsPanelProps {
@@ -238,6 +233,17 @@ export function ContactsPanel({
 
   const linkedToFamilyOrOrg = Boolean(familySelectId.trim() || organizationSelectId.trim());
   const locationFieldLocked = linkedToFamilyOrOrg;
+
+  const readOnlyLockedLinesForEditor = useMemo(() => {
+    if (!linkedToFamilyOrOrg || !selected) {
+      return null;
+    }
+    const { lines, footerNote } = linkedVenueReadOnlyLines(selected);
+    if (lines.length === 0) {
+      return null;
+    }
+    return { lines, footerNote };
+  }, [linkedToFamilyOrOrg, selected]);
 
   const inlineLocationStateKey =
     editorMode === 'create' ? 'contact-new' : `contact:${selectedId ?? 'none'}`;
@@ -734,6 +740,7 @@ export function ContactsPanel({
               areas={geographicAreas}
               areasLoading={areasLoading}
               canModify={!linkedToFamilyOrOrg}
+              readOnlyLockedLines={readOnlyLockedLinesForEditor}
               readOnlyNote={
                 linkedToFamilyOrOrg
                   ? 'Location is managed on the linked family or organisation.'
@@ -901,13 +908,12 @@ export function ContactsPanel({
           </div>
         }
       >
-        <AdminDataTable tableClassName='min-w-[1120px]'>
+        <AdminDataTable tableClassName='min-w-[960px]'>
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Email</th>
               <th className='px-4 py-3 font-semibold'>Type</th>
-              <th className='px-4 py-3 font-semibold'>Location</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
           </AdminDataTableHead>
@@ -915,7 +921,6 @@ export function ContactsPanel({
             {rows.map((row) => {
               const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
               const membershipSuffix = contactNameMembershipSuffix(row);
-              const linkedVenue = contactTableLinkedVenueBlocks(row);
               return (
                 <tr
                   key={row.id}
@@ -940,25 +945,6 @@ export function ContactsPanel({
                   </td>
                   <td className='px-4 py-3'>{row.email ?? '—'}</td>
                   <td className='px-4 py-3'>{formatEnumLabel(row.contact_type)}</td>
-                  <td className='max-w-xs px-4 py-3 align-top text-sm text-slate-700'>
-                    {linkedVenue.blocks.length > 0 ? (
-                      <div className='space-y-2'>
-                        {linkedVenue.blocks.map((block, idx) => (
-                          <div key={idx}>
-                            <div>{block.line1}</div>
-                            {block.line2 ? (
-                              <div className='text-xs text-slate-500'>{block.line2}</div>
-                            ) : null}
-                          </div>
-                        ))}
-                        {linkedVenue.caption ? (
-                          <p className='text-xs text-slate-500'>{linkedVenue.caption}</p>
-                        ) : null}
-                      </div>
-                    ) : (
-                      '—'
-                    )}
-                  </td>
                   <td className='px-4 py-3 text-right'>
                     <div className='flex flex-wrap justify-end gap-2'>
                       <Button

--- a/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
+++ b/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
@@ -51,6 +51,11 @@ export interface InlineLocationEditorProps {
   allowClearWhenLocked?: boolean;
   /** Extra line under the partner-managed copy when the location is partner-locked (for example orgs screen). */
   lockedSummaryExtra?: string | null;
+  /**
+   * When `canModify` is false and there is no contact-level location to show, render these
+   * lines instead of an em dash (for example family/org venue summaries on a linked contact).
+   */
+  readOnlyLockedLines?: { lines: string[]; footerNote?: string | null } | null;
 }
 
 function resolveDisplaySummary(
@@ -136,6 +141,7 @@ function InlineLocationEditorInner({
   saveError = '',
   allowClearWhenLocked = false,
   lockedSummaryExtra,
+  readOnlyLockedLines = null,
 }: InnerProps) {
   const initial = deriveInitialDraft(canModify, location, embeddedSummary);
   const [isEditing, setIsEditing] = useState(initial.isEditing);
@@ -314,6 +320,23 @@ function InlineLocationEditorInner({
   const showEditForm = canModify && !effectiveReadOnly && (isEditing || (!location && !embeddedSummary));
   const showChangeButton = canModify && !lockedFromPartner;
   const showClearButton = canModify && (!lockedFromPartner || allowClearWhenLocked);
+
+  if (!canModify && readOnlyLockedLines && readOnlyLockedLines.lines.length > 0) {
+    return (
+      <div className='space-y-2'>
+        <Label>Location</Label>
+        <div className='space-y-2 rounded-md border border-slate-200 bg-slate-50/60 px-3 py-2 text-sm text-slate-800'>
+          {readOnlyLockedLines.lines.map((line, idx) => (
+            <div key={idx}>{line}</div>
+          ))}
+        </div>
+        {readOnlyLockedLines.footerNote ? (
+          <p className='text-sm text-slate-600'>{readOnlyLockedLines.footerNote}</p>
+        ) : null}
+        {readOnlyNote ? <p className='text-sm text-slate-600'>{readOnlyNote}</p> : null}
+      </div>
+    );
+  }
 
   if (!canModify && displaySummary) {
     return (

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -202,7 +202,8 @@ describe('ContactsPanel', () => {
     expect(screen.getByText(/Pat Both/)).toHaveTextContent('Pat Both 👨‍👩‍👧 🏢');
   });
 
-  it('shows read-only family and organisation venue lines in the Location column', () => {
+  it('shows read-only family and organisation venue lines in the Location box when the row is selected', async () => {
+    const user = userEvent.setup();
     const summary = {
       id: 'loc-1',
       name: 'Studio',
@@ -248,6 +249,8 @@ describe('ContactsPanel', () => {
         refreshLocations={noopRefresh}
       />
     );
+
+    await user.click(screen.getByText('Pat Both'));
 
     const familyLines = screen.getAllByText(/👨‍👩‍👧 1 Road · Hong Kong/);
     expect(familyLines.length).toBeGreaterThanOrEqual(1);
@@ -384,7 +387,7 @@ describe('ContactsPanel', () => {
 
     await user.click(screen.getByText('Ann Lee'));
 
-    expect(screen.getAllByText('1 Road · Hong Kong').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/👨‍👩‍👧 1 Road · Hong Kong/).length).toBeGreaterThanOrEqual(1);
     expect(
       screen.getByText('Location is managed on the linked family or organisation.')
     ).toBeInTheDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removes the **Location** column from the contacts list table (Name, Email, Type, Operations only).
- When a contact is linked to a family and/or organisation, the **Location** box in the Contact editor now shows the same venue text as before (emoji + address/area label) **without coordinates**, plus the existing read-only footer and the note that location is managed on the linked record.

## Implementation

- `InlineLocationEditor` accepts optional `readOnlyLockedLines` for the `canModify === false` case when there is no contact-level `location`/`embeddedSummary`, so the UI shows structured lines instead of "—".
- `ContactsPanel` derives those lines from `family_location_summary` / `organization_location_summary` on the selected contact.

## Tests

- `npm run test -- --run tests/components/admin/contacts/contacts-panel.test.tsx tests/components/admin/locations/inline-location-editor.test.tsx`
- `npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfcbab4e-eae6-43fb-8fcf-0e4f2d0da20a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfcbab4e-eae6-43fb-8fcf-0e4f2d0da20a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

