### PR TITLE
Drop legacy families/orgs status column; default list filter to Active

### DIFF
--- a/apps/admin_web/src/hooks/use-admin-entity-families.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-families.ts
@@ -11,7 +11,10 @@ import {
   removeAdminFamilyMember,
   updateAdminFamily,
 } from '@/lib/entity-api';
-import { DEFAULT_LIST_FILTERS, type EntityListFilters } from '@/types/entity-list';
+import {
+  DEFAULT_FAMILY_ORG_LIST_FILTERS,
+  type EntityListFilters,
+} from '@/types/entity-list';
 import type { components } from '@/types/generated/admin-api.generated';
 
 import { usePaginatedList } from './use-paginated-list';
@@ -32,7 +35,7 @@ export function useAdminEntityFamilies() {
 
   const list = usePaginatedList({
     fetcher,
-    defaultFilters: DEFAULT_LIST_FILTERS,
+    defaultFilters: DEFAULT_FAMILY_ORG_LIST_FILTERS,
     errorPrefix: 'Failed to load families',
     debounceKeys: ['query'],
     limit: 50,

--- a/apps/admin_web/src/hooks/use-admin-entity-organizations.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-organizations.ts
@@ -10,7 +10,10 @@ import {
   removeAdminOrganizationMember,
   updateAdminOrganization,
 } from '@/lib/entity-api';
-import { DEFAULT_LIST_FILTERS, type EntityListFilters } from '@/types/entity-list';
+import {
+  DEFAULT_FAMILY_ORG_LIST_FILTERS,
+  type EntityListFilters,
+} from '@/types/entity-list';
 import { ORGANIZATION_RELATIONSHIP_TYPES } from '@/types/entity-relationship';
 import type { components } from '@/types/generated/admin-api.generated';
 
@@ -32,7 +35,7 @@ export function useAdminEntityOrganizations() {
 
   const list = usePaginatedList({
     fetcher,
-    defaultFilters: DEFAULT_LIST_FILTERS,
+    defaultFilters: DEFAULT_FAMILY_ORG_LIST_FILTERS,
     errorPrefix: 'Failed to load organizations',
     debounceKeys: ['query'],
     limit: 50,

--- a/apps/admin_web/src/types/entity-list.ts
+++ b/apps/admin_web/src/types/entity-list.ts
@@ -9,7 +9,14 @@ export interface EntityListFilters {
   contact_type: '' | EntityContactType;
 }
 
-/** Default filters for family and organization lists (all activeness). */
+/** Default filters for family and organization lists (active records only). */
+export const DEFAULT_FAMILY_ORG_LIST_FILTERS: EntityListFilters = {
+  query: '',
+  active: 'true',
+  contact_type: '',
+};
+
+/** Default filters for generic entity lists (all activeness). */
 export const DEFAULT_LIST_FILTERS: EntityListFilters = {
   query: '',
   active: '',

--- a/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-page.test.tsx
@@ -45,7 +45,7 @@ const defaultContactsHook = {
 
 const defaultFamiliesHook = {
   families: [],
-  filters: { query: '', active: '' as const },
+  filters: { query: '', active: 'true' as const },
   setFilter: vi.fn(),
   isLoading: false,
   isLoadingMore: false,
@@ -63,7 +63,7 @@ const defaultFamiliesHook = {
 
 const defaultOrgsHook = {
   organizations: [],
-  filters: { query: '', active: '' as const },
+  filters: { query: '', active: 'true' as const },
   setFilter: vi.fn(),
   isLoading: false,
   isLoadingMore: false,

--- a/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
@@ -40,7 +40,7 @@ function buildFamiliesHook(
 ): ReturnType<typeof useAdminEntityFamilies> {
   return {
     families: [],
-    filters: { query: '', active: '' as const },
+    filters: { query: '', active: 'true' as const },
     setFilter: vi.fn(),
     isLoading: false,
     isLoadingMore: false,

--- a/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
@@ -41,7 +41,7 @@ function buildOrgsHook(
 ): ReturnType<typeof useAdminEntityOrganizations> {
   return {
     organizations: [],
-    filters: { query: '', active: '' as const },
+    filters: { query: '', active: 'true' as const },
     setFilter: vi.fn(),
     isLoading: false,
     isLoadingMore: false,

--- a/backend/db/alembic/versions/0030_drop_families_org_status.py
+++ b/backend/db/alembic/versions/0030_drop_families_org_status.py
@@ -1,0 +1,45 @@
+"""Drop legacy ``status`` column from CRM family/org tables if present.
+
+Some environments may still carry a ``status`` column on ``families`` and/or
+``organizations`` from earlier experiments. This migration removes it when
+present so the canonical activeness model is ``archived_at`` only.
+
+Seed-data assessment:
+1. Compatibility: ``backend/db/seed/seed_data.sql`` does not reference these columns.
+2. NOT NULL: N/A (column removal only when present).
+3. Renamed/dropped: columns dropped only if they exist.
+4. New tables: N/A.
+5. Enum: N/A.
+6. FK order: N/A.
+
+Result: No seed update required.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0030_drop_families_org_status"
+down_revision: Union[str, None] = "0029_organizations_partner_slug"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("ALTER TABLE families DROP COLUMN IF EXISTS status"))
+    op.execute(sa.text("ALTER TABLE organizations DROP COLUMN IF EXISTS status"))
+
+
+def downgrade() -> None:
+    """Re-add nullable placeholder columns; original types may differ per environment."""
+    op.add_column(
+        "families",
+        sa.Column("status", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "organizations",
+        sa.Column("status", sa.String(length=64), nullable=True),
+    )

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -393,6 +393,7 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 ### `families` and `family_members`
 
 - `families` stores household-level entities.
+- Activeness is derived from `archived_at` (no separate `status` column).
 - `family_members` links contacts to families with role metadata.
 - `family_members` rows are deleted automatically when either parent record is
   deleted (`ON DELETE CASCADE`).
@@ -400,6 +401,7 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 ### `organizations` and `organization_members`
 
 - `organizations` stores external organization entities.
+- Activeness is derived from `archived_at` (no separate `status` column).
 - `organizations.slug` is an optional URL-safe identifier used when
   `relationship_type` is `partner`; uniqueness is enforced case-insensitively
   among partner rows with a non-null slug (partial unique index).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds Alembic revision `0030_drop_families_org_status` that runs `ALTER TABLE ... DROP COLUMN IF EXISTS status` on `families` and `organizations` so any legacy `status` column is removed without failing on clean databases.
- Defaults the **Families** and **Organisations** admin list **Status** toolbar filter to **Active** via a dedicated `DEFAULT_FAMILY_ORG_LIST_FILTERS` constant (contacts and other screens keep their existing defaults).
- Updates `docs/architecture/database-schema.md` to state activeness is `archived_at`-based with no separate `status` column.

## Testing

- `npm run test -- tests/components/admin/contacts/families-panel.test.tsx tests/components/admin/contacts/organizations-panel.test.tsx tests/components/admin/contacts/contacts-page.test.tsx`
- `bash scripts/validate-cursorrules.sh`
- `pre-commit run ruff-format --files backend/db/alembic/versions/0030_drop_families_org_status.py`

## Notes

- Downgrade re-adds nullable `String(64)` placeholder columns only; environments that never had `status` are unaffected by upgrade.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe43cd8c-d323-49e2-99e0-b638548f70dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe43cd8c-d323-49e2-99e0-b638548f70dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

