### PR TITLE
Admin Services Venues: hide CRM family/org addresses

### DIFF
--- a/apps/admin_web/src/hooks/use-venues.ts
+++ b/apps/admin_web/src/hooks/use-venues.ts
@@ -62,7 +62,7 @@ export function useVenues(options: { onMutationSuccess?: () => void | Promise<vo
         limit: params.limit,
         areaId: params.areaId || undefined,
         search: params.search,
-        excludeCrmAddresses: true,
+        excludeAddresses: true,
       }),
     []
   );

--- a/apps/admin_web/src/hooks/use-venues.ts
+++ b/apps/admin_web/src/hooks/use-venues.ts
@@ -62,6 +62,7 @@ export function useVenues(options: { onMutationSuccess?: () => void | Promise<vo
         limit: params.limit,
         areaId: params.areaId || undefined,
         search: params.search,
+        excludeCrmAddresses: true,
       }),
     []
   );

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -331,7 +331,7 @@ export async function listLocations(
     cursor?: string | null;
     limit?: number;
     /** When true, omit locations used as a non-archived family or organisation venue. */
-    excludeCrmAddresses?: boolean;
+    excludeAddresses?: boolean;
   },
   signal?: AbortSignal
 ): Promise<{ items: LocationSummary[]; nextCursor: string | null; totalCount: number }> {
@@ -340,7 +340,7 @@ export async function listLocations(
   if (typeof params.limit === 'number') query.set('limit', `${params.limit}`);
   if (params.areaId) query.set('area_id', params.areaId);
   if (params.search?.trim()) query.set('search', params.search.trim());
-  if (params.excludeCrmAddresses) query.set('exclude_crm_addresses', 'true');
+  if (params.excludeAddresses) query.set('exclude_addresses', 'true');
   const queryString = query.toString();
 
   const payload = await adminApiRequest<ApiLocationListResponse>({

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -327,7 +327,12 @@ export async function listGeographicAreas(
 }
 
 export async function listLocations(
-  params: Partial<VenueFilters> & { cursor?: string | null; limit?: number },
+  params: Partial<VenueFilters> & {
+    cursor?: string | null;
+    limit?: number;
+    /** When true, omit locations used as a non-archived family or organisation venue. */
+    excludeCrmAddresses?: boolean;
+  },
   signal?: AbortSignal
 ): Promise<{ items: LocationSummary[]; nextCursor: string | null; totalCount: number }> {
   const query = new URLSearchParams();
@@ -335,6 +340,7 @@ export async function listLocations(
   if (typeof params.limit === 'number') query.set('limit', `${params.limit}`);
   if (params.areaId) query.set('area_id', params.areaId);
   if (params.search?.trim()) query.set('search', params.search.trim());
+  if (params.excludeCrmAddresses) query.set('exclude_crm_addresses', 'true');
   const queryString = query.toString();
 
   const payload = await adminApiRequest<ApiLocationListResponse>({

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -711,11 +711,11 @@ export interface paths {
                     search?: string;
                     /**
                      * @description When `true`, omit locations linked as the saved venue for a non-archived
-                     *     CRM family or organisation (so Services → Venues lists only service-oriented
+                     *     family or organisation (so Services → Venues lists only service-oriented
                      *     venues). Partner organisations are still included when they use the same
                      *     location row; those rows remain visible with partner lock metadata.
                      */
-                    exclude_crm_addresses?: boolean;
+                    exclude_addresses?: boolean;
                 };
                 header?: never;
                 path?: never;

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -709,6 +709,13 @@ export interface paths {
                     area_id?: string;
                     /** @description Case-insensitive substring match on location name or address. */
                     search?: string;
+                    /**
+                     * @description When `true`, omit locations linked as the saved venue for a non-archived
+                     *     CRM family or organisation (so Services → Venues lists only service-oriented
+                     *     venues). Partner organisations are still included when they use the same
+                     *     location row; those rows remain visible with partner lock metadata.
+                     */
+                    exclude_crm_addresses?: boolean;
                 };
                 header?: never;
                 path?: never;

--- a/apps/admin_web/tests/lib/services-api.test.ts
+++ b/apps/admin_web/tests/lib/services-api.test.ts
@@ -217,4 +217,23 @@ describe('services-api', () => {
     expect(result.items[1].lat).toBe(33.3);
     expect(result.items[1].lng).toBe(55.5);
   });
+
+  it('adds exclude_crm_addresses when listLocations requests CRM address exclusion', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      data: {
+        items: [],
+        next_cursor: null,
+        total_count: 0,
+      },
+    });
+
+    await listLocations({ limit: 50, excludeCrmAddresses: true });
+
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        endpointPath: '/v1/admin/locations?limit=50&exclude_crm_addresses=true',
+      })
+    );
+  });
 });

--- a/apps/admin_web/tests/lib/services-api.test.ts
+++ b/apps/admin_web/tests/lib/services-api.test.ts
@@ -218,7 +218,7 @@ describe('services-api', () => {
     expect(result.items[1].lng).toBe(55.5);
   });
 
-  it('adds exclude_crm_addresses when listLocations requests CRM address exclusion', async () => {
+  it('adds exclude_addresses when listLocations requests family/org address exclusion', async () => {
     mockAdminApiRequest.mockResolvedValueOnce({
       data: {
         items: [],
@@ -227,12 +227,12 @@ describe('services-api', () => {
       },
     });
 
-    await listLocations({ limit: 50, excludeCrmAddresses: true });
+    await listLocations({ limit: 50, excludeAddresses: true });
 
     expect(mockAdminApiRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         method: 'GET',
-        endpointPath: '/v1/admin/locations?limit=50&exclude_crm_addresses=true',
+        endpointPath: '/v1/admin/locations?limit=50&exclude_addresses=true',
       })
     );
   });

--- a/backend/src/app/api/admin_locations.py
+++ b/backend/src/app/api/admin_locations.py
@@ -112,6 +112,11 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
     limit = _parse_limit(event)
     cursor = parse_cursor(query_param(event, "cursor"))
     area_id = _parse_optional_uuid(query_param(event, "area_id"), field="area_id")
+    exclude_crm_addresses = _parse_query_bool(
+        query_param(event, "exclude_crm_addresses"),
+        field="exclude_crm_addresses",
+        default=False,
+    )
     search_raw = query_param(event, "search")
     search: str | None = None
     if search_raw is not None and str(search_raw).strip() != "":
@@ -124,13 +129,18 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
 
     with Session(get_engine()) as session:
         location_repo = LocationRepository(session)
-        total_count = location_repo.count_with_filters(area_id=area_id, search=search)
+        total_count = location_repo.count_with_filters(
+            area_id=area_id,
+            search=search,
+            exclude_crm_addresses=exclude_crm_addresses,
+        )
         rows = list(
             location_repo.list_with_filters(
                 limit=limit + 1,
                 cursor=cursor,
                 area_id=area_id,
                 search=search,
+                exclude_crm_addresses=exclude_crm_addresses,
             )
         )
         has_more = len(rows) > limit
@@ -371,6 +381,22 @@ def _serialize_location(
         "locked_from_partner_org": locked,
         "partner_organization_labels": names,
     }
+
+
+def _parse_query_bool(
+    raw_value: str | None,
+    *,
+    field: str,
+    default: bool,
+) -> bool:
+    if raw_value is None or str(raw_value).strip() == "":
+        return default
+    normalized = str(raw_value).strip().lower()
+    if normalized in {"true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no"}:
+        return False
+    raise ValidationError(f"{field} must be true or false", field=field)
 
 
 def _parse_limit(event: Mapping[str, Any]) -> int:

--- a/backend/src/app/api/admin_locations.py
+++ b/backend/src/app/api/admin_locations.py
@@ -112,9 +112,9 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
     limit = _parse_limit(event)
     cursor = parse_cursor(query_param(event, "cursor"))
     area_id = _parse_optional_uuid(query_param(event, "area_id"), field="area_id")
-    exclude_crm_addresses = _parse_query_bool(
-        query_param(event, "exclude_crm_addresses"),
-        field="exclude_crm_addresses",
+    exclude_addresses = _parse_query_bool(
+        query_param(event, "exclude_addresses"),
+        field="exclude_addresses",
         default=False,
     )
     search_raw = query_param(event, "search")
@@ -132,7 +132,7 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
         total_count = location_repo.count_with_filters(
             area_id=area_id,
             search=search,
-            exclude_crm_addresses=exclude_crm_addresses,
+            exclude_addresses=exclude_addresses,
         )
         rows = list(
             location_repo.list_with_filters(
@@ -140,7 +140,7 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
                 cursor=cursor,
                 area_id=area_id,
                 search=search,
-                exclude_crm_addresses=exclude_crm_addresses,
+                exclude_addresses=exclude_addresses,
             )
         )
         has_more = len(rows) > limit

--- a/backend/src/app/db/repositories/location.py
+++ b/backend/src/app/db/repositories/location.py
@@ -42,7 +42,7 @@ class LocationRepository(BaseRepository[Location]):
         cursor: UUID | None = None,
         area_id: UUID | None = None,
         search: str | None = None,
-        exclude_crm_addresses: bool = False,
+        exclude_addresses: bool = False,
     ) -> Sequence[Location]:
         """List locations with optional area and address search (case-insensitive)."""
         query = select(Location).order_by(Location.id)
@@ -59,7 +59,7 @@ class LocationRepository(BaseRepository[Location]):
                 pattern, escape="\\"
             )
             query = query.where(or_(name_match, address_match))
-        if exclude_crm_addresses:
+        if exclude_addresses:
             query = query.where(self._not_linked_to_active_family_or_org())
         return self._session.execute(query.limit(limit)).scalars().all()
 
@@ -68,7 +68,7 @@ class LocationRepository(BaseRepository[Location]):
         *,
         area_id: UUID | None = None,
         search: str | None = None,
-        exclude_crm_addresses: bool = False,
+        exclude_addresses: bool = False,
     ) -> int:
         """Count locations matching optional area and address search."""
         query = select(func.count()).select_from(Location)
@@ -83,7 +83,7 @@ class LocationRepository(BaseRepository[Location]):
                 pattern, escape="\\"
             )
             query = query.where(or_(name_match, address_match))
-        if exclude_crm_addresses:
+        if exclude_addresses:
             query = query.where(self._not_linked_to_active_family_or_org())
         return int(self._session.execute(query).scalar_one())
 

--- a/backend/src/app/db/repositories/location.py
+++ b/backend/src/app/db/repositories/location.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Sequence
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, not_, or_, select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import exists
 
-from app.db.models import Location, Organization, RelationshipType
+from app.db.models import Family, Location, Organization, RelationshipType
 from app.db.repositories.base import BaseRepository
 
 
@@ -40,6 +42,7 @@ class LocationRepository(BaseRepository[Location]):
         cursor: UUID | None = None,
         area_id: UUID | None = None,
         search: str | None = None,
+        exclude_crm_addresses: bool = False,
     ) -> Sequence[Location]:
         """List locations with optional area and address search (case-insensitive)."""
         query = select(Location).order_by(Location.id)
@@ -56,6 +59,8 @@ class LocationRepository(BaseRepository[Location]):
                 pattern, escape="\\"
             )
             query = query.where(or_(name_match, address_match))
+        if exclude_crm_addresses:
+            query = query.where(self._not_linked_to_active_family_or_org())
         return self._session.execute(query.limit(limit)).scalars().all()
 
     def count_with_filters(
@@ -63,6 +68,7 @@ class LocationRepository(BaseRepository[Location]):
         *,
         area_id: UUID | None = None,
         search: str | None = None,
+        exclude_crm_addresses: bool = False,
     ) -> int:
         """Count locations matching optional area and address search."""
         query = select(func.count()).select_from(Location)
@@ -77,7 +83,22 @@ class LocationRepository(BaseRepository[Location]):
                 pattern, escape="\\"
             )
             query = query.where(or_(name_match, address_match))
+        if exclude_crm_addresses:
+            query = query.where(self._not_linked_to_active_family_or_org())
         return int(self._session.execute(query).scalar_one())
+
+    @staticmethod
+    def _not_linked_to_active_family_or_org() -> Any:
+        """Exclude rows referenced as venue by a non-archived family or organisation."""
+        family_link = exists().where(
+            Family.location_id == Location.id,
+            Family.archived_at.is_(None),
+        )
+        org_link = exists().where(
+            Organization.location_id == Location.id,
+            Organization.archived_at.is_(None),
+        )
+        return and_(not_(family_link), not_(org_link))
 
     def find_by_address_case_insensitive(
         self,

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -558,6 +558,17 @@ paths:
           schema:
             type: string
             maxLength: 500
+        - name: exclude_crm_addresses
+          in: query
+          required: false
+          description: |
+            When `true`, omit locations linked as the saved venue for a non-archived
+            CRM family or organisation (so Services → Venues lists only service-oriented
+            venues). Partner organisations are still included when they use the same
+            location row; those rows remain visible with partner lock metadata.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: Location list response.

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -558,12 +558,12 @@ paths:
           schema:
             type: string
             maxLength: 500
-        - name: exclude_crm_addresses
+        - name: exclude_addresses
           in: query
           required: false
           description: |
             When `true`, omit locations linked as the saved venue for a non-archived
-            CRM family or organisation (so Services → Venues lists only service-oriented
+            family or organisation (so Services → Venues lists only service-oriented
             venues). Partner organisations are still included when they use the same
             location row; those rows remain visible with partner lock metadata.
           schema:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -38,8 +38,8 @@ their primary responsibilities.
   `/v1/contact-us`,
   `/v1/admin/geographic-areas`,
   `/v1/mailchimp/webhook` (GET/POST),
-  `/v1/admin/locations/*` (including `GET /v1/admin/locations?exclude_crm_addresses=true`
-  to list service venues without CRM family/organisation home addresses, and
+  `/v1/admin/locations/*` (including `GET /v1/admin/locations?exclude_addresses=true`
+  to list service venues without family/organisation home addresses, and
   `POST /v1/admin/locations/geocode` for
   Nominatim-backed address geocoding via `AwsApiProxyFunction`),
   `/v1/admin/assets/*` (including `POST /v1/admin/assets/{id}/content/init` and

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -38,7 +38,9 @@ their primary responsibilities.
   `/v1/contact-us`,
   `/v1/admin/geographic-areas`,
   `/v1/mailchimp/webhook` (GET/POST),
-  `/v1/admin/locations/*` (including `POST /v1/admin/locations/geocode` for
+  `/v1/admin/locations/*` (including `GET /v1/admin/locations?exclude_crm_addresses=true`
+  to list service venues without CRM family/organisation home addresses, and
+  `POST /v1/admin/locations/geocode` for
   Nominatim-backed address geocoding via `AwsApiProxyFunction`),
   `/v1/admin/assets/*` (including `POST /v1/admin/assets/{id}/content/init` and
   `POST /v1/admin/assets/{id}/content/complete` for two-step S3 file replacement

--- a/tests/test_admin_locations_api.py
+++ b/tests/test_admin_locations_api.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 import pytest
 
 from app.api import admin_locations
+from app.exceptions import ValidationError
 
 
 def test_handle_admin_locations_dispatches_geocode_post(
@@ -101,6 +102,20 @@ def test_serialize_location_emits_float_coordinates_for_json() -> None:
     roundtrip = json.loads(encoded)
     assert roundtrip["lat"] == pytest.approx(22.3193)
     assert roundtrip["lng"] == pytest.approx(114.1694)
+
+
+def test_parse_query_bool_defaults_and_accepts_aliases() -> None:
+    assert admin_locations._parse_query_bool(None, field="f", default=False) is False
+    assert admin_locations._parse_query_bool("", field="f", default=True) is True
+    assert admin_locations._parse_query_bool("true", field="f", default=False) is True
+    assert admin_locations._parse_query_bool("1", field="f", default=False) is True
+    assert admin_locations._parse_query_bool("FALSE", field="f", default=True) is False
+
+
+def test_parse_query_bool_rejects_invalid() -> None:
+    with pytest.raises(ValidationError) as exc:
+        admin_locations._parse_query_bool("maybe", field="exclude_crm_addresses", default=False)
+    assert exc.value.field == "exclude_crm_addresses"
 
 
 def test_serialize_location_partner_metadata() -> None:

--- a/tests/test_admin_locations_api.py
+++ b/tests/test_admin_locations_api.py
@@ -114,8 +114,8 @@ def test_parse_query_bool_defaults_and_accepts_aliases() -> None:
 
 def test_parse_query_bool_rejects_invalid() -> None:
     with pytest.raises(ValidationError) as exc:
-        admin_locations._parse_query_bool("maybe", field="exclude_crm_addresses", default=False)
-    assert exc.value.field == "exclude_crm_addresses"
+        admin_locations._parse_query_bool("maybe", field="exclude_addresses", default=False)
+    assert exc.value.field == "exclude_addresses"
 
 
 def test_serialize_location_partner_metadata() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Venues list under **Services** was showing every `locations` row, including addresses saved as a family or organisation venue in CRM.

## Changes

- **API:** `GET /v1/admin/locations` accepts optional `exclude_addresses=true`. When set, results exclude locations referenced by a **non-archived** `families` or `organizations` row (`location_id`). Cursor pagination and `total_count` use the same filter.
- **Admin web:** The venues hook passes this flag so **Services → Venues** only lists service-oriented venues. **Contacts** flows that call `listAllLocations()` / `listLocations()` without the flag are unchanged.
- **Docs:** OpenAPI (`docs/api/admin.yaml`) and Lambda catalog note (`docs/architecture/lambdas.md`) updated.

## Notes

- Partner organisations that share a venue row still appear when that row is not also a family/org-only venue; existing partner lock behaviour is unchanged.

## Validation

- `python3 -m pytest tests/test_admin_locations_api.py`
- `npm run lint` and `npx vitest run tests/lib/services-api.test.ts` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82838ccd-ddc6-4e99-a6f1-452d49cf062f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82838ccd-ddc6-4e99-a6f1-452d49cf062f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

