### PR TITLE
Admin contacts: collapsible Location and Members like Tags

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/entity-tag-picker.tsx
+++ b/apps/admin_web/src/components/admin/contacts/entity-tag-picker.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-
 import { Label } from '@/components/ui/label';
+import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
 
 import type { EntityTagRef } from '@/lib/entity-api';
 
@@ -27,7 +26,6 @@ export function EntityTagPicker({
   variant = 'default',
 }: EntityTagPickerProps) {
   const set = new Set(selectedIds);
-  const [disclosureOpen, setDisclosureOpen] = useState(false);
 
   function toggle(tagId: string) {
     const next = new Set(set);
@@ -40,6 +38,15 @@ export function EntityTagPicker({
   }
 
   if (tags.length === 0) {
+    if (variant === 'collapsible') {
+      return (
+        <AdminCollapsibleSection id={id} title={label} disabled={disabled}>
+          <p id={id} className='text-sm text-slate-500'>
+            No tags in the database yet.
+          </p>
+        </AdminCollapsibleSection>
+      );
+    }
     return (
       <div>
         <Label htmlFor={id}>{label}</Label>
@@ -51,7 +58,13 @@ export function EntityTagPicker({
   }
 
   const list = (
-    <div className='max-h-40 space-y-2 overflow-y-auto rounded-md border border-slate-200 bg-white p-3'>
+    <div
+      className={
+        variant === 'collapsible'
+          ? 'max-h-40 space-y-2 overflow-y-auto pt-1'
+          : 'max-h-40 space-y-2 overflow-y-auto rounded-md border border-slate-200 bg-white p-3'
+      }
+    >
       {tags.map((tag) => (
         <label key={tag.id} className='flex cursor-pointer items-center gap-2 text-sm'>
           <input
@@ -67,27 +80,10 @@ export function EntityTagPicker({
   );
 
   if (variant === 'collapsible') {
-    const panelId = `${id}-panel`;
     return (
-      <fieldset disabled={disabled}>
-        <details
-          className='rounded-md border border-slate-200 bg-white'
-          open={disclosureOpen}
-          onToggle={(event) => {
-            setDisclosureOpen(event.currentTarget.open);
-          }}
-        >
-          <summary
-            className='cursor-pointer select-none px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-slate-50'
-            aria-controls={panelId}
-          >
-            {label}
-          </summary>
-          <div className='border-t border-slate-200 px-3 pb-3 pt-2' id={panelId}>
-            {list}
-          </div>
-        </details>
-      </fieldset>
+      <AdminCollapsibleSection id={id} title={label} disabled={disabled}>
+        {list}
+      </AdminCollapsibleSection>
     );
   }
 

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -11,6 +11,7 @@ import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations
 import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
+import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -352,7 +353,7 @@ export function FamiliesPanel({
             </Select>
           </div>
           <div className='lg:col-span-2'>
-            <div className='rounded-md border border-slate-200 bg-slate-50/40 p-3'>
+            <AdminCollapsibleSection id='crm-family-location' title='Location'>
               <InlineLocationEditor
                 stateKey={inlineLocationStateKey}
                 location={resolvedLocation}
@@ -384,7 +385,7 @@ export function FamiliesPanel({
                 }}
                 onGeocode={geocodeLocation}
               />
-            </div>
+            </AdminCollapsibleSection>
           </div>
           {editorMode === 'edit' ? (
             <div>
@@ -411,84 +412,87 @@ export function FamiliesPanel({
             />
           </div>
           {editorMode === 'edit' && selected ? (
-            <div className='lg:col-span-2 space-y-3 rounded-md border border-slate-200 bg-slate-50/40 p-4'>
-              <h3 className='text-sm font-semibold text-slate-800'>Members</h3>
-              <div className='flex flex-wrap items-end gap-3'>
-                <div className='min-w-[200px] flex-1'>
-                  <Label htmlFor='crm-family-member-contact'>Contact</Label>
-                  <Select
-                    id='crm-family-member-contact'
-                    value={memberContactId}
-                    onChange={(e) => setMemberContactId(e.target.value)}
-                  >
-                    <option value=''>Select contact</option>
-                    {memberContactOptions.map((c) => (
-                      <option key={c.id} value={c.id}>
-                        {c.label}
-                      </option>
-                    ))}
-                  </Select>
+            <div className='lg:col-span-2'>
+              <AdminCollapsibleSection id='crm-family-members' title='Members'>
+                <div className='space-y-3 pt-1'>
+                  <div className='flex flex-wrap items-end gap-3'>
+                    <div className='min-w-[200px] flex-1'>
+                      <Label htmlFor='crm-family-member-contact'>Contact</Label>
+                      <Select
+                        id='crm-family-member-contact'
+                        value={memberContactId}
+                        onChange={(e) => setMemberContactId(e.target.value)}
+                      >
+                        <option value=''>Select contact</option>
+                        {memberContactOptions.map((c) => (
+                          <option key={c.id} value={c.id}>
+                            {c.label}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                    <Button
+                      type='button'
+                      disabled={isSaving || !memberContactId}
+                      onClick={() => void handleAddMember()}
+                    >
+                      Add member
+                    </Button>
+                  </div>
+                  <p className='text-xs text-slate-600'>
+                    Role for each member follows the contact type set on the contact record.
+                  </p>
+                  <AdminDataTable tableClassName='min-w-[520px]'>
+                    <AdminDataTableHead>
+                      <tr>
+                        <th className='px-3 py-2 font-semibold'>Contact</th>
+                        <th className='px-3 py-2 font-semibold'>Role</th>
+                        <th className='px-3 py-2 font-semibold'>Primary contact</th>
+                        <th className='px-3 py-2 font-semibold text-right'>Operations</th>
+                      </tr>
+                    </AdminDataTableHead>
+                    <AdminDataTableBody>
+                      {selected.members.map((m) => (
+                        <tr key={m.id}>
+                          <td className='px-3 py-2'>{m.contact_label || m.contact_id}</td>
+                          <td className='px-3 py-2'>{formatEnumLabel(m.role)}</td>
+                          <td className='px-3 py-2'>
+                            <input
+                              type='checkbox'
+                              className='h-4 w-4 rounded border-slate-300'
+                              checked={m.is_primary_contact}
+                              disabled={isSaving}
+                              onChange={(e) => {
+                                void handlePrimaryMemberChange(m.id, e.target.checked);
+                              }}
+                              aria-label={`Primary contact for ${m.contact_label || m.contact_id}`}
+                            />
+                          </td>
+                          <td className='px-3 py-2 text-right'>
+                            <Button
+                              type='button'
+                              size='sm'
+                              variant='danger'
+                              className='h-8 min-w-8 px-0'
+                              disabled={isSaving}
+                              onClick={() =>
+                                setRemoveTarget({
+                                  memberId: m.id,
+                                  label: m.contact_label || m.contact_id,
+                                })
+                              }
+                              aria-label={`Remove ${m.contact_label || m.contact_id} from family`}
+                              title='Remove member'
+                            >
+                              <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </AdminDataTableBody>
+                  </AdminDataTable>
                 </div>
-                <Button
-                  type='button'
-                  disabled={isSaving || !memberContactId}
-                  onClick={() => void handleAddMember()}
-                >
-                  Add member
-                </Button>
-              </div>
-              <p className='text-xs text-slate-600'>
-                Role for each member follows the contact type set on the contact record.
-              </p>
-              <AdminDataTable tableClassName='min-w-[520px]'>
-                <AdminDataTableHead>
-                  <tr>
-                    <th className='px-3 py-2 font-semibold'>Contact</th>
-                    <th className='px-3 py-2 font-semibold'>Role</th>
-                    <th className='px-3 py-2 font-semibold'>Primary contact</th>
-                    <th className='px-3 py-2 font-semibold text-right'>Operations</th>
-                  </tr>
-                </AdminDataTableHead>
-                <AdminDataTableBody>
-                  {selected.members.map((m) => (
-                    <tr key={m.id}>
-                      <td className='px-3 py-2'>{m.contact_label || m.contact_id}</td>
-                      <td className='px-3 py-2'>{formatEnumLabel(m.role)}</td>
-                      <td className='px-3 py-2'>
-                        <input
-                          type='checkbox'
-                          className='h-4 w-4 rounded border-slate-300'
-                          checked={m.is_primary_contact}
-                          disabled={isSaving}
-                          onChange={(e) => {
-                            void handlePrimaryMemberChange(m.id, e.target.checked);
-                          }}
-                          aria-label={`Primary contact for ${m.contact_label || m.contact_id}`}
-                        />
-                      </td>
-                      <td className='px-3 py-2 text-right'>
-                        <Button
-                          type='button'
-                          size='sm'
-                          variant='danger'
-                          className='h-8 min-w-8 px-0'
-                          disabled={isSaving}
-                          onClick={() =>
-                            setRemoveTarget({
-                              memberId: m.id,
-                              label: m.contact_label || m.contact_id,
-                            })
-                          }
-                          aria-label={`Remove ${m.contact_label || m.contact_id} from family`}
-                          title='Remove member'
-                        >
-                          <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
-                        </Button>
-                      </td>
-                    </tr>
-                  ))}
-                </AdminDataTableBody>
-              </AdminDataTable>
+              </AdminCollapsibleSection>
             </div>
           ) : null}
         </div>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -11,6 +11,7 @@ import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations
 import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
+import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -412,7 +413,7 @@ export function OrganizationsPanel({
             />
           </div>
           <div className='lg:col-span-4'>
-            <div className='rounded-md border border-slate-200 bg-slate-50/40 p-3'>
+            <AdminCollapsibleSection id='crm-org-location' title='Location'>
               <InlineLocationEditor
                 stateKey={inlineLocationStateKey}
                 location={resolvedLocation}
@@ -450,7 +451,7 @@ export function OrganizationsPanel({
                 }}
                 onGeocode={geocodeLocation}
               />
-            </div>
+            </AdminCollapsibleSection>
           </div>
           <div className='lg:col-span-4 space-y-4'>
             {editorMode === 'edit' ? (
@@ -479,81 +480,84 @@ export function OrganizationsPanel({
             </div>
           </div>
           {editorMode === 'edit' && selected ? (
-            <div className='lg:col-span-4 space-y-3 rounded-md border border-slate-200 bg-slate-50/40 p-4'>
-              <h3 className='text-sm font-semibold text-slate-800'>Members</h3>
-              <div className='flex flex-wrap items-end gap-3'>
-                <div className='min-w-[200px] flex-1'>
-                  <Label htmlFor='crm-org-member-contact'>Contact</Label>
-                  <Select
-                    id='crm-org-member-contact'
-                    value={memberContactId}
-                    onChange={(e) => setMemberContactId(e.target.value)}
-                  >
-                    <option value=''>Select contact</option>
-                    {memberContactOptions.map((c) => (
-                      <option key={c.id} value={c.id}>
-                        {c.label}
-                      </option>
-                    ))}
-                  </Select>
+            <div className='lg:col-span-4'>
+              <AdminCollapsibleSection id='crm-org-members' title='Members'>
+                <div className='space-y-3 pt-1'>
+                  <div className='flex flex-wrap items-end gap-3'>
+                    <div className='min-w-[200px] flex-1'>
+                      <Label htmlFor='crm-org-member-contact'>Contact</Label>
+                      <Select
+                        id='crm-org-member-contact'
+                        value={memberContactId}
+                        onChange={(e) => setMemberContactId(e.target.value)}
+                      >
+                        <option value=''>Select contact</option>
+                        {memberContactOptions.map((c) => (
+                          <option key={c.id} value={c.id}>
+                            {c.label}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                    <div className='min-w-[140px]'>
+                      <Label htmlFor='crm-org-member-role'>Role</Label>
+                      <Select
+                        id='crm-org-member-role'
+                        value={memberRole}
+                        onChange={(e) =>
+                          setMemberRole(e.target.value as ApiSchemas['EntityOrganizationRole'])
+                        }
+                      >
+                        {ORG_ROLES.map((r) => (
+                          <option key={r} value={r}>
+                            {formatEnumLabel(r)}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                    <Button
+                      type='button'
+                      disabled={isSaving || !memberContactId}
+                      onClick={() => void handleAddMember()}
+                    >
+                      Add member
+                    </Button>
+                  </div>
+                  <AdminDataTable tableClassName='min-w-[520px]'>
+                    <AdminDataTableHead>
+                      <tr>
+                        <th className='px-3 py-2 font-semibold'>Contact</th>
+                        <th className='px-3 py-2 font-semibold'>Role</th>
+                        <th className='px-3 py-2 font-semibold text-right'>Operations</th>
+                      </tr>
+                    </AdminDataTableHead>
+                    <AdminDataTableBody>
+                      {selected.members.map((m) => (
+                        <tr key={m.id}>
+                          <td className='px-3 py-2'>{m.contact_label || m.contact_id}</td>
+                          <td className='px-3 py-2'>{formatEnumLabel(m.role)}</td>
+                          <td className='px-3 py-2 text-right'>
+                            <Button
+                              type='button'
+                              size='sm'
+                              variant='danger'
+                              disabled={isSaving}
+                              onClick={() =>
+                                setRemoveTarget({
+                                  memberId: m.id,
+                                  label: m.contact_label || m.contact_id,
+                                })
+                              }
+                            >
+                              Remove
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </AdminDataTableBody>
+                  </AdminDataTable>
                 </div>
-                <div className='min-w-[140px]'>
-                  <Label htmlFor='crm-org-member-role'>Role</Label>
-                  <Select
-                    id='crm-org-member-role'
-                    value={memberRole}
-                    onChange={(e) =>
-                      setMemberRole(e.target.value as ApiSchemas['EntityOrganizationRole'])
-                    }
-                  >
-                    {ORG_ROLES.map((r) => (
-                      <option key={r} value={r}>
-                        {formatEnumLabel(r)}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-                <Button
-                  type='button'
-                  disabled={isSaving || !memberContactId}
-                  onClick={() => void handleAddMember()}
-                >
-                  Add member
-                </Button>
-              </div>
-              <AdminDataTable tableClassName='min-w-[520px]'>
-                <AdminDataTableHead>
-                  <tr>
-                    <th className='px-3 py-2 font-semibold'>Contact</th>
-                    <th className='px-3 py-2 font-semibold'>Role</th>
-                    <th className='px-3 py-2 font-semibold text-right'>Operations</th>
-                  </tr>
-                </AdminDataTableHead>
-                <AdminDataTableBody>
-                  {selected.members.map((m) => (
-                    <tr key={m.id}>
-                      <td className='px-3 py-2'>{m.contact_label || m.contact_id}</td>
-                      <td className='px-3 py-2'>{formatEnumLabel(m.role)}</td>
-                      <td className='px-3 py-2 text-right'>
-                        <Button
-                          type='button'
-                          size='sm'
-                          variant='danger'
-                          disabled={isSaving}
-                          onClick={() =>
-                            setRemoveTarget({
-                              memberId: m.id,
-                              label: m.contact_label || m.contact_id,
-                            })
-                          }
-                        >
-                          Remove
-                        </Button>
-                      </td>
-                    </tr>
-                  ))}
-                </AdminDataTableBody>
-              </AdminDataTable>
+              </AdminCollapsibleSection>
             </div>
           ) : null}
         </div>

--- a/apps/admin_web/src/components/ui/admin-collapsible-section.tsx
+++ b/apps/admin_web/src/components/ui/admin-collapsible-section.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+
+export interface AdminCollapsibleSectionProps {
+  /** Stable id prefix; panel id becomes `${id}-panel`. */
+  id: string;
+  title: string;
+  children: ReactNode;
+  /** When true, wraps body in a disabled fieldset (for example tag pickers while saving). */
+  disabled?: boolean;
+}
+
+export function AdminCollapsibleSection({ id, title, children, disabled }: AdminCollapsibleSectionProps) {
+  const panelId = `${id}-panel`;
+  const [open, setOpen] = useState(false);
+
+  const body = disabled ? (
+    <fieldset disabled className='m-0 min-w-0 border-0 p-0'>
+      {children}
+    </fieldset>
+  ) : (
+    children
+  );
+
+  return (
+    <details
+      className='rounded-md border border-slate-200 bg-slate-50/40'
+      open={open}
+      onToggle={(event) => {
+        setOpen(event.currentTarget.open);
+      }}
+    >
+      <summary
+        className='cursor-pointer select-none px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-slate-100/60'
+        aria-controls={panelId}
+      >
+        {title}
+      </summary>
+      <div className='px-3 pb-3 pt-1' id={panelId}>
+        {body}
+      </div>
+    </details>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Introduces `AdminCollapsibleSection`, a shared `<details>` block with bold title, slate border, and `bg-slate-50/40` to match the previous members box styling.
- **Families** and **Organisations** editors: **Location** and **Members** use this component (collapsed by default, same interaction as Tags).
- **`EntityTagPicker`** (`variant='collapsible'`): uses the same shell; removes the inner bordered white box and the summary/content divider so the collapsible shows **title + checkboxes** only inside the grey panel. Empty-tag state uses the same collapsible for consistency (also affects Contacts panel, which uses the same picker).

## Validation

- `npm run lint` (admin_web)
- `vitest run` for `families-panel`, `organizations-panel`, and `contacts-panel` tests
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36117645-664c-4729-8e12-4a5e96eadb56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36117645-664c-4729-8e12-4a5e96eadb56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

