### PR TITLE
Admin web: family editor first row 2-1-1 layout

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -326,8 +326,8 @@ export function FamiliesPanel({
           </>
         }
       >
-        <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
-          <div>
+        <div className='grid grid-cols-1 gap-4 lg:grid-cols-4'>
+          <div className='lg:col-span-2'>
             <Label htmlFor='crm-family-name'>Family name</Label>
             <Input
               id='crm-family-name'
@@ -336,7 +336,7 @@ export function FamiliesPanel({
               autoComplete='off'
             />
           </div>
-          <div>
+          <div className='lg:col-span-1'>
             <Label htmlFor='crm-family-rel'>Relationship</Label>
             <Select
               id='crm-family-rel'
@@ -352,7 +352,22 @@ export function FamiliesPanel({
               ))}
             </Select>
           </div>
-          <div className='lg:col-span-2'>
+          {editorMode === 'edit' ? (
+            <div className='lg:col-span-1'>
+              <Label htmlFor='crm-family-active'>Status</Label>
+              <Select
+                id='crm-family-active'
+                value={active ? 'true' : 'false'}
+                onChange={(e) => setActive(e.target.value === 'true')}
+              >
+                <option value='true'>Active</option>
+                <option value='false'>Archived</option>
+              </Select>
+            </div>
+          ) : (
+            <div className='hidden lg:col-span-1 lg:block' aria-hidden />
+          )}
+          <div className='lg:col-span-4'>
             <AdminCollapsibleSection id='crm-family-location' title='Location'>
               <InlineLocationEditor
                 stateKey={inlineLocationStateKey}
@@ -387,20 +402,7 @@ export function FamiliesPanel({
               />
             </AdminCollapsibleSection>
           </div>
-          {editorMode === 'edit' ? (
-            <div>
-              <Label htmlFor='crm-family-active'>Status</Label>
-              <Select
-                id='crm-family-active'
-                value={active ? 'true' : 'false'}
-                onChange={(e) => setActive(e.target.value === 'true')}
-              >
-                <option value='true'>Active</option>
-                <option value='false'>Archived</option>
-              </Select>
-            </div>
-          ) : null}
-          <div className='lg:col-span-2'>
+          <div className='lg:col-span-4'>
             <EntityTagPicker
               id='crm-family-tags'
               label='Tags'
@@ -412,7 +414,7 @@ export function FamiliesPanel({
             />
           </div>
           {editorMode === 'edit' && selected ? (
-            <div className='lg:col-span-2'>
+            <div className='lg:col-span-4'>
               <AdminCollapsibleSection id='crm-family-members' title='Members'>
                 <div className='space-y-3 pt-1'>
                   <div className='flex flex-wrap items-end gap-3'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Restructures the Family inline editor (`AdminEditorCard` field area in `families-panel.tsx`) to use a four-column grid on large breakpoints.
- First row: family name spans 2 columns, relationship 1, status 1 (when editing). Location, tags, and members sections span the full width (4 columns).
- Create mode keeps an empty third column on `lg` so name and relationship stay at 2:1 horizontal proportion (status only appears when editing).

## Testing

- `npm run test -- tests/components/admin/contacts/families-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9b4abb9-51e9-4f74-9837-7d20dd5873dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9b4abb9-51e9-4f74-9837-7d20dd5873dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

