### PR TITLE
Admin web: organisation editor second row 2/4–1/4–1/4 layout

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -388,6 +388,15 @@ export function OrganizationsPanel({
             </div>
           ) : null}
           <div className='lg:col-span-2'>
+            <Label htmlFor='crm-org-web'>Website</Label>
+            <Input
+              id='crm-org-web'
+              value={website}
+              onChange={(e) => setWebsite(e.target.value)}
+              autoComplete='off'
+            />
+          </div>
+          <div className='lg:col-span-1'>
             <Label htmlFor='crm-org-type'>Organisation type</Label>
             <Select
               id='crm-org-type'
@@ -403,14 +412,20 @@ export function OrganizationsPanel({
               ))}
             </Select>
           </div>
-          <div className='lg:col-span-2'>
-            <Label htmlFor='crm-org-web'>Website</Label>
-            <Input
-              id='crm-org-web'
-              value={website}
-              onChange={(e) => setWebsite(e.target.value)}
-              autoComplete='off'
-            />
+          <div className='lg:col-span-1'>
+            {editorMode === 'edit' ? (
+              <>
+                <Label htmlFor='crm-org-active'>Status</Label>
+                <Select
+                  id='crm-org-active'
+                  value={active ? 'true' : 'false'}
+                  onChange={(e) => setActive(e.target.value === 'true')}
+                >
+                  <option value='true'>Active</option>
+                  <option value='false'>Archived</option>
+                </Select>
+              </>
+            ) : null}
           </div>
           <div className='lg:col-span-4'>
             <AdminCollapsibleSection id='crm-org-location' title='Location'>
@@ -454,19 +469,6 @@ export function OrganizationsPanel({
             </AdminCollapsibleSection>
           </div>
           <div className='lg:col-span-4 space-y-4'>
-            {editorMode === 'edit' ? (
-              <div>
-                <Label htmlFor='crm-org-active'>Status</Label>
-                <Select
-                  id='crm-org-active'
-                  value={active ? 'true' : 'false'}
-                  onChange={(e) => setActive(e.target.value === 'true')}
-                >
-                  <option value='true'>Active</option>
-                  <option value='false'>Archived</option>
-                </Select>
-              </div>
-            ) : null}
             <div>
               <EntityTagPicker
                 id='crm-org-tags'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On Contacts → Organisations, the **Organisation** inline editor’s second row now uses a single large-screen grid row with proportional columns: **Website** (half width), **Organisation type** (quarter), **Status** (quarter).

## Changes

- Reordered fields in `organizations-panel.tsx` so Website comes first with `lg:col-span-2`, type with `lg:col-span-1`, and Status with `lg:col-span-1`.
- Moved the Status control out of the right-hand tags column into that second row (edit mode only; create mode leaves the last quarter empty so the grid stays aligned).

## Testing

- `npm run test -- --run tests/components/admin/contacts/organizations-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5eb3b972-94e0-459e-98a8-a2bfe3168177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eb3b972-94e0-459e-98a8-a2bfe3168177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

