### PR TITLE
Admin web: match contact location box to family panel

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -13,6 +13,7 @@ import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { ArchiveIcon, DeleteIcon, NoteIcon, RestoreIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Input } from '@/components/ui/input';
@@ -732,46 +733,6 @@ export function ContactsPanel({
             </div>
           </div>
 
-          <div className='rounded-md border border-slate-200 bg-slate-50/40 p-3'>
-            <InlineLocationEditor
-              stateKey={inlineLocationStateKey}
-              location={resolvedLocation}
-              embeddedSummary={embeddedLocationSummary}
-              areas={geographicAreas}
-              areasLoading={areasLoading}
-              canModify={!linkedToFamilyOrOrg}
-              readOnlyLockedLines={readOnlyLockedLinesForEditor}
-              readOnlyNote={
-                linkedToFamilyOrOrg
-                  ? 'Location is managed on the linked family or organisation.'
-                  : null
-              }
-              isSaving={isSaving || locationSaveStatus.isSaving}
-              isGeocoding={locationGeocoding}
-              saveError={locationSaveStatus.error}
-              onRequestEdit={() => {}}
-              onCancelEdit={() => {}}
-              onSaveCreate={async (payload) => {
-                const created = await createSharedLocation(payload);
-                if (created) {
-                  setPendingLocationId(created.id);
-                  setOptimisticLocationSummary(summaryFromLocationRow(created));
-                  return created.id;
-                }
-                return null;
-              }}
-              onSaveUpdate={async (id, payload) => {
-                await updateSharedLocation(id, payload);
-              }}
-              onClear={() => {
-                setPendingLocationId(null);
-                setOptimisticLocationSummary(null);
-                clearLocationSaveError();
-              }}
-              onGeocode={geocodeLocation}
-            />
-          </div>
-
           <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
             <div>
               <Label htmlFor='crm-contact-family'>Family</Label>
@@ -831,6 +792,46 @@ export function ContactsPanel({
               </div>
             ) : null}
           </div>
+
+          <AdminCollapsibleSection id='crm-contact-location' title='Location' disabled={isSaving}>
+            <InlineLocationEditor
+              stateKey={inlineLocationStateKey}
+              location={resolvedLocation}
+              embeddedSummary={embeddedLocationSummary}
+              areas={geographicAreas}
+              areasLoading={areasLoading}
+              canModify={!linkedToFamilyOrOrg}
+              readOnlyLockedLines={readOnlyLockedLinesForEditor}
+              readOnlyNote={
+                linkedToFamilyOrOrg
+                  ? 'Location is managed on the linked family or organisation.'
+                  : null
+              }
+              isSaving={isSaving || locationSaveStatus.isSaving}
+              isGeocoding={locationGeocoding}
+              saveError={locationSaveStatus.error}
+              onRequestEdit={() => {}}
+              onCancelEdit={() => {}}
+              onSaveCreate={async (payload) => {
+                const created = await createSharedLocation(payload);
+                if (created) {
+                  setPendingLocationId(created.id);
+                  setOptimisticLocationSummary(summaryFromLocationRow(created));
+                  return created.id;
+                }
+                return null;
+              }}
+              onSaveUpdate={async (id, payload) => {
+                await updateSharedLocation(id, payload);
+              }}
+              onClear={() => {
+                setPendingLocationId(null);
+                setOptimisticLocationSummary(null);
+                clearLocationSaveError();
+              }}
+              onGeocode={geocodeLocation}
+            />
+          </AdminCollapsibleSection>
 
           <EntityTagPicker
             id='crm-contact-tags'

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -251,6 +251,7 @@ describe('ContactsPanel', () => {
     );
 
     await user.click(screen.getByText('Pat Both'));
+    await user.click(screen.getByText('Location', { selector: 'summary' }));
 
     const familyLines = screen.getAllByText(/👨‍👩‍👧 1 Road · Hong Kong/);
     expect(familyLines.length).toBeGreaterThanOrEqual(1);
@@ -386,6 +387,7 @@ describe('ContactsPanel', () => {
     );
 
     await user.click(screen.getByText('Ann Lee'));
+    await user.click(screen.getByText('Location', { selector: 'summary' }));
 
     expect(screen.getAllByText(/👨‍👩‍👧 1 Road · Hong Kong/).length).toBeGreaterThanOrEqual(1);
     expect(
@@ -431,6 +433,7 @@ describe('ContactsPanel', () => {
       />
     );
 
+    await user.click(screen.getByText('Location', { selector: 'summary' }));
     await user.type(screen.getByLabelText('First name'), 'Jane');
     await user.selectOptions(screen.getByLabelText('Geographic area'), 'area-hk');
     await user.type(screen.getByLabelText('Address'), '1 Test Road');
@@ -513,6 +516,7 @@ describe('ContactsPanel', () => {
     );
 
     await user.click(screen.getByText('Bob'));
+    await user.click(screen.getByText('Location', { selector: 'summary' }));
     await user.click(screen.getByRole('button', { name: 'Clear' }));
     await user.click(screen.getByRole('button', { name: 'Update contact' }));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Wraps the contact inline location editor in `AdminCollapsibleSection` (same collapsible, bold summary title, and bordered container as the family page).
- Moves the location block to sit directly above the tags picker.
- Passes `disabled={isSaving}` on the collapsible section so location controls are disabled during save, consistent with other pickers.
- Updates `contacts-panel` tests to expand the section via the `summary` control before querying location UI (avoids clashing with the inline editor’s "Location" label).

## Test plan

- `npm run test -- --run tests/components/admin/contacts/contacts-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a197174-356e-47d6-b5d6-de3462e43134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a197174-356e-47d6-b5d6-de3462e43134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

