### PR TITLE
Organisations: member UX aligned with families (primary, roles, delete icon)

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, type MouseEvent } from 'react';
+import { useCallback, useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminEntityOrganizations } from '@/hooks/use-admin-entity-organizations';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
@@ -36,16 +36,6 @@ const ORG_TYPES: ApiSchemas['EntityOrganizationType'][] = [
   'company',
   'community_group',
   'ngo',
-  'other',
-];
-
-const ORG_ROLES: ApiSchemas['EntityOrganizationRole'][] = [
-  'admin',
-  'staff',
-  'teacher',
-  'member',
-  'client',
-  'partner',
   'other',
 ];
 
@@ -99,6 +89,7 @@ export function OrganizationsPanel({
     updateOrganization,
     addMember,
     removeMember,
+    updateMember,
     deleteOrganization,
     relationshipOptions,
   } = organizations;
@@ -122,7 +113,6 @@ export function OrganizationsPanel({
   const [active, setActive] = useState(true);
 
   const [memberContactId, setMemberContactId] = useState('');
-  const [memberRole, setMemberRole] = useState<ApiSchemas['EntityOrganizationRole']>('member');
 
   const [removeTarget, setRemoveTarget] = useState<{ memberId: string; label: string } | null>(
     null
@@ -200,6 +190,25 @@ export function OrganizationsPanel({
     });
   }, [contactOptions, contactsForMembership, selectedId]);
 
+  const primaryMemberLabel = useCallback((members: ApiSchemas['AdminOrganizationMember'][]) => {
+    const primary = members.find((m) => m.is_primary_contact);
+    return primary?.contact_label?.trim() || null;
+  }, []);
+
+  async function handlePrimaryMemberChange(
+    memberId: string,
+    nextChecked: boolean
+  ): Promise<void> {
+    if (!selected) {
+      return;
+    }
+    try {
+      await updateMember(selected.id, memberId, { is_primary_contact: nextChecked });
+    } catch {
+      // Retry preserved.
+    }
+  }
+
   function resetCreateForm() {
     if (editorMode === 'create' && pendingLocationId && typeof window !== 'undefined') {
       const ok = window.confirm(
@@ -222,7 +231,6 @@ export function OrganizationsPanel({
     setTagIds([]);
     setActive(true);
     setMemberContactId('');
-    setMemberRole('member');
   }
 
   async function handleSubmit(): Promise<void> {
@@ -268,10 +276,9 @@ export function OrganizationsPanel({
     try {
       await addMember(selected.id, {
         contact_id: memberContactId.trim(),
-        role: memberRole,
+        is_primary_contact: false,
       });
       setMemberContactId('');
-      setMemberRole('member');
     } catch {
       // Retry preserved.
     }
@@ -501,22 +508,6 @@ export function OrganizationsPanel({
                         ))}
                       </Select>
                     </div>
-                    <div className='min-w-[140px]'>
-                      <Label htmlFor='crm-org-member-role'>Role</Label>
-                      <Select
-                        id='crm-org-member-role'
-                        value={memberRole}
-                        onChange={(e) =>
-                          setMemberRole(e.target.value as ApiSchemas['EntityOrganizationRole'])
-                        }
-                      >
-                        {ORG_ROLES.map((r) => (
-                          <option key={r} value={r}>
-                            {formatEnumLabel(r)}
-                          </option>
-                        ))}
-                      </Select>
-                    </div>
                     <Button
                       type='button'
                       disabled={isSaving || !memberContactId}
@@ -525,11 +516,15 @@ export function OrganizationsPanel({
                       Add member
                     </Button>
                   </div>
+                  <p className='text-xs text-slate-600'>
+                    Role for each member follows the contact type set on the contact record.
+                  </p>
                   <AdminDataTable tableClassName='min-w-[520px]'>
                     <AdminDataTableHead>
                       <tr>
                         <th className='px-3 py-2 font-semibold'>Contact</th>
                         <th className='px-3 py-2 font-semibold'>Role</th>
+                        <th className='px-3 py-2 font-semibold'>Primary contact</th>
                         <th className='px-3 py-2 font-semibold text-right'>Operations</th>
                       </tr>
                     </AdminDataTableHead>
@@ -538,11 +533,24 @@ export function OrganizationsPanel({
                         <tr key={m.id}>
                           <td className='px-3 py-2'>{m.contact_label || m.contact_id}</td>
                           <td className='px-3 py-2'>{formatEnumLabel(m.role)}</td>
+                          <td className='px-3 py-2'>
+                            <input
+                              type='checkbox'
+                              className='h-4 w-4 rounded border-slate-300'
+                              checked={m.is_primary_contact}
+                              disabled={isSaving}
+                              onChange={(e) => {
+                                void handlePrimaryMemberChange(m.id, e.target.checked);
+                              }}
+                              aria-label={`Primary contact for ${m.contact_label || m.contact_id}`}
+                            />
+                          </td>
                           <td className='px-3 py-2 text-right'>
                             <Button
                               type='button'
                               size='sm'
                               variant='danger'
+                              className='h-8 min-w-8 px-0'
                               disabled={isSaving}
                               onClick={() =>
                                 setRemoveTarget({
@@ -550,8 +558,10 @@ export function OrganizationsPanel({
                                   label: m.contact_label || m.contact_id,
                                 })
                               }
+                              aria-label={`Remove ${m.contact_label || m.contact_id} from organisation`}
+                              title='Remove member'
                             >
-                              Remove
+                              <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                             </Button>
                           </td>
                         </tr>
@@ -616,7 +626,9 @@ export function OrganizationsPanel({
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
-            {rows.map((row) => (
+            {rows.map((row) => {
+              const primaryLabel = primaryMemberLabel(row.members);
+              return (
               <tr
                 key={row.id}
                 className={`cursor-pointer transition ${
@@ -624,7 +636,15 @@ export function OrganizationsPanel({
                 }`}
                 onClick={() => selectRow(row.id)}
               >
-                <td className='px-4 py-3'>{row.name}</td>
+                <td className='px-4 py-3'>
+                  {row.name}
+                  {primaryLabel ? (
+                    <>
+                      <span aria-hidden> · </span>
+                      {primaryLabel}
+                    </>
+                  ) : null}
+                </td>
                 <td className='px-4 py-3'>{formatEnumLabel(row.organization_type)}</td>
                 <td className='px-4 py-3'>{row.members.length}</td>
                 <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
@@ -647,7 +667,8 @@ export function OrganizationsPanel({
                   </div>
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </AdminDataTableBody>
         </AdminDataTable>
       </PaginatedTableCard>

--- a/apps/admin_web/src/hooks/use-admin-entity-organizations.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-organizations.ts
@@ -7,6 +7,7 @@ import {
   createAdminOrganization,
   deleteAdminOrganization,
   listAdminOrganizations,
+  patchAdminOrganizationMember,
   removeAdminOrganizationMember,
   updateAdminOrganization,
 } from '@/lib/entity-api';
@@ -81,6 +82,15 @@ export function useAdminEntityOrganizations() {
     [mutate]
   );
 
+  const updateMember = useCallback(
+    async (
+      organizationId: string,
+      memberId: string,
+      payload: ApiSchemas['UpdateOrganizationMemberRequest']
+    ) => mutate(async () => patchAdminOrganizationMember(organizationId, memberId, payload)),
+    [mutate]
+  );
+
   const deleteOrganization = useCallback(
     async (organizationId: string) =>
       mutate(async () => deleteAdminOrganization(organizationId)),
@@ -102,6 +112,7 @@ export function useAdminEntityOrganizations() {
     updateOrganization,
     addMember,
     removeMember,
+    updateMember,
     deleteOrganization,
     refetch: list.refetch,
     relationshipOptions: ORGANIZATION_RELATIONSHIP_TYPES,

--- a/apps/admin_web/src/lib/entity-api.ts
+++ b/apps/admin_web/src/lib/entity-api.ts
@@ -411,3 +411,17 @@ export async function removeAdminOrganizationMember(
   const root = unwrapPayload(payload);
   return root.organization ?? null;
 }
+
+export async function patchAdminOrganizationMember(
+  organizationId: string,
+  memberId: string,
+  body: ApiSchemas['UpdateOrganizationMemberRequest']
+): Promise<AdminOrganizationRow | null> {
+  const payload = await adminApiRequest<ApiOrganizationResponse>({
+    endpointPath: `/v1/admin/organizations/${organizationId}/members/${memberId}`,
+    method: 'PATCH',
+    body,
+  });
+  const root = unwrapPayload(payload);
+  return root.organization ?? null;
+}

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -3302,7 +3302,43 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update organization member
+         * @description Updates membership fields such as primary contact. Membership role is derived from the
+         *     linked contact's `contact_type` (see `POST /v1/admin/organizations/{id}/members`).
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description CRM organization identifier. */
+                    id: components["parameters"]["AdminOrganizationId"];
+                    /** @description Organization membership row identifier. */
+                    memberId: components["parameters"]["AdminOrganizationMemberId"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateOrganizationMemberRequest"];
+                };
+            };
+            responses: {
+                /** @description Organization with updated members. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminOrganizationResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         trace?: never;
     };
     "/v1/admin/expenses": {
@@ -4871,13 +4907,26 @@ export interface components {
              */
             is_primary_contact: boolean;
         };
+        UpdateOrganizationMemberRequest: {
+            /**
+             * @description When true, this member becomes the organisation's sole primary contact. When false, this
+             *     member is cleared as primary (other members are unchanged).
+             */
+            is_primary_contact: boolean;
+        };
         AdminOrganizationMember: {
             /** Format: uuid */
             id: string;
             /** Format: uuid */
             contact_id: string;
             contact_label: string;
+            /**
+             * @description Stored organisation membership role derived from the contact's `contact_type` (parent,
+             *     helper, and professional map to `staff`; child maps to `member`; other maps to
+             *     `other`).
+             */
             role: components["schemas"]["EntityOrganizationRole"];
+            is_primary_contact: boolean;
         };
         AdminOrganization: {
             /** Format: uuid */
@@ -4938,7 +4987,13 @@ export interface components {
         AddOrganizationMemberRequest: {
             /** Format: uuid */
             contact_id: string;
-            role: components["schemas"]["EntityOrganizationRole"];
+            /**
+             * @deprecated
+             * @description Ignored. Membership role is derived from the contact's `contact_type` (parent, helper,
+             *     and professional map to `staff`; child maps to `member`; other maps to `other`).
+             */
+            role?: string;
+            is_primary_contact?: boolean;
         };
         ActionMessageResponse: {
             message: string;

--- a/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
@@ -54,6 +54,7 @@ function buildOrgsHook(
     updateOrganization: vi.fn().mockResolvedValue(null),
     addMember: vi.fn().mockResolvedValue(null),
     removeMember: vi.fn().mockResolvedValue(null),
+    updateMember: vi.fn().mockResolvedValue(null),
     deleteOrganization: vi.fn().mockResolvedValue(undefined),
     refetch: vi.fn(),
     relationshipOptions: ['prospect', 'customer', 'partner', 'vendor'] as unknown as ReturnType<

--- a/backend/db/alembic/versions/0031_org_member_primary.py
+++ b/backend/db/alembic/versions/0031_org_member_primary.py
@@ -1,0 +1,62 @@
+"""Add ``is_primary_contact`` to ``organization_members``.
+
+Seed-data assessment:
+1. Compatibility: ``backend/db/seed/seed_data.sql`` does not insert into
+   ``organization_members``.
+2. NOT NULL: new column uses ``server_default=false`` then enforces NOT NULL.
+3. Renamed/dropped: N/A.
+4. New tables: N/A.
+5. Enum: N/A.
+6. FK order: N/A.
+
+Result: No seed update required.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0031_org_member_primary"
+down_revision: Union[str, None] = "0030_drop_families_org_status"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organization_members",
+        sa.Column(
+            "is_primary_contact",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.alter_column(
+        "organization_members",
+        "is_primary_contact",
+        server_default=None,
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE organization_members AS om
+            SET role = CASE c.contact_type::text
+              WHEN 'parent' THEN 'staff'
+              WHEN 'child' THEN 'member'
+              WHEN 'helper' THEN 'staff'
+              WHEN 'professional' THEN 'staff'
+              ELSE 'other'
+            END::organization_role
+            FROM contacts AS c
+            WHERE c.id = om.contact_id
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organization_members", "is_primary_contact")

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -3152,6 +3152,10 @@ export class ApiStack extends cdk.Stack {
       authorizer: adminAuthorizer,
     });
     const adminOrganizationCrmMemberById = adminOrganizationCrmMembers.addResource("{memberId}");
+    adminOrganizationCrmMemberById.addMethod("PATCH", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
     adminOrganizationCrmMemberById.addMethod("DELETE", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,

--- a/backend/src/app/api/admin_contacts_helpers.py
+++ b/backend/src/app/api/admin_contacts_helpers.py
@@ -24,7 +24,7 @@ from app.db.models import (
     OrganizationMember,
     RelationshipType,
 )
-from app.db.models.enums import FamilyRole, OrganizationRole
+from app.db.models.enums import FamilyRole
 from app.db.models.organization import organization_membership_role_from_contact_type
 from app.exceptions import ValidationError
 from app.utils.logging import get_logger

--- a/backend/src/app/api/admin_contacts_helpers.py
+++ b/backend/src/app/api/admin_contacts_helpers.py
@@ -25,6 +25,7 @@ from app.db.models import (
     RelationshipType,
 )
 from app.db.models.enums import FamilyRole, OrganizationRole
+from app.db.models.organization import organization_membership_role_from_contact_type
 from app.exceptions import ValidationError
 from app.utils.logging import get_logger
 
@@ -156,11 +157,17 @@ def sync_memberships_from_body(
             )
         ).scalar_one()
         if not has_org_row:
+            subject = session.get(Contact, contact_id)
+            if subject is None:
+                raise ValidationError("contact_id not found", field="organization_ids")
             session.add(
                 OrganizationMember(
                     organization_id=want_org,
                     contact_id=contact_id,
-                    role=OrganizationRole.MEMBER,
+                    role=organization_membership_role_from_contact_type(
+                        subject.contact_type
+                    ),
+                    is_primary_contact=False,
                 )
             )
 
@@ -215,3 +222,24 @@ def parse_referral_contact_id_from_metadata(contact: Contact) -> UUID | None:
         if raw_meta is not None and str(raw_meta).strip() != ""
         else None
     )
+
+
+def refresh_organization_member_roles_for_contact(
+    session: Session, *, contact_id: UUID
+) -> None:
+    """Recompute stored org membership roles when a contact's type changes."""
+    members = list(
+        session.execute(
+            select(OrganizationMember).where(
+                OrganizationMember.contact_id == contact_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    contact = session.get(Contact, contact_id)
+    if contact is None:
+        return
+    next_role = organization_membership_role_from_contact_type(contact.contact_type)
+    for m in members:
+        m.role = next_role

--- a/backend/src/app/api/admin_contacts_mutations.py
+++ b/backend/src/app/api/admin_contacts_mutations.py
@@ -18,6 +18,7 @@ from app.api.admin_contacts_helpers import (
     parse_contact_type,
     parse_optional_date,
     parse_referral_contact_id_from_metadata,
+    refresh_organization_member_roles_for_contact,
     sync_memberships_from_body,
     validate_referrer_contact,
 )
@@ -250,6 +251,9 @@ def update_contact(
         if "contact_type" in body:
             contact.contact_type = parse_contact_type(
                 body.get("contact_type"), field="contact_type"
+            )
+            refresh_organization_member_roles_for_contact(
+                session, contact_id=contact.id
             )
         if "relationship_type" in body:
             contact.relationship_type = parse_relationship_type(

--- a/backend/src/app/api/admin_entities_serializers.py
+++ b/backend/src/app/api/admin_entities_serializers.py
@@ -194,6 +194,7 @@ def serialize_organization_member_row(member: OrganizationMember) -> dict[str, A
         "contact_id": str(member.contact_id),
         "contact_label": label,
         "role": member.role.value,
+        "is_primary_contact": member.is_primary_contact,
     }
 
 

--- a/backend/src/app/api/admin_organizations.py
+++ b/backend/src/app/api/admin_organizations.py
@@ -42,10 +42,10 @@ from app.db.models import (
     Contact,
     Organization,
     OrganizationMember,
-    OrganizationRole,
     OrganizationType,
     RelationshipType,
 )
+from app.db.models.organization import organization_membership_role_from_contact_type
 from app.db.repositories import OrganizationRepository
 from app.exceptions import DatabaseError, NotFoundError, ValidationError
 from app.utils import json_response
@@ -105,6 +105,13 @@ def handle_admin_organizations_request(
 
     if len(parts) == 5 and parts[3] == "members":
         member_id = parse_uuid(parts[4])
+        if method == "PATCH":
+            return _update_organization_member(
+                event,
+                organization_id=organization_id,
+                member_id=member_id,
+                actor_sub=identity.user_sub,
+            )
         if method == "DELETE":
             return _remove_organization_member(
                 event,
@@ -122,15 +129,6 @@ def _parse_organization_type(value: Any, *, field: str) -> OrganizationType:
         raise ValidationError(f"{field} is required", field=field)
     try:
         return OrganizationType(str(value).strip().lower())
-    except ValueError as exc:
-        raise ValidationError(f"Invalid {field}", field=field) from exc
-
-
-def _parse_organization_role(value: Any, *, field: str) -> OrganizationRole:
-    if value is None or str(value).strip() == "":
-        raise ValidationError(f"{field} is required", field=field)
-    try:
-        return OrganizationRole(str(value).strip().lower())
     except ValueError as exc:
         raise ValidationError(f"Invalid {field}", field=field) from exc
 
@@ -424,7 +422,20 @@ def _add_organization_member(
 ) -> dict[str, Any]:
     body = parse_body(event)
     contact_id = parse_uuid(str(body.get("contact_id")))
-    role = _parse_organization_role(body.get("role"), field="role")
+    is_primary = body.get("is_primary_contact")
+    if is_primary is None:
+        is_primary_contact = False
+    elif isinstance(is_primary, bool):
+        is_primary_contact = is_primary
+    elif isinstance(is_primary, str) and is_primary.strip().lower() in {"true", "1"}:
+        is_primary_contact = True
+    elif isinstance(is_primary, str) and is_primary.strip().lower() in {"false", "0"}:
+        is_primary_contact = False
+    else:
+        raise ValidationError(
+            "is_primary_contact must be true or false",
+            field="is_primary_contact",
+        )
 
     with Session(get_engine()) as session:
         set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
@@ -439,10 +450,12 @@ def _add_organization_member(
             session, contact_id=contact_id, organization_id=organization_id
         )
 
+        role = organization_membership_role_from_contact_type(contact.contact_type)
         member = OrganizationMember(
             organization_id=organization_id,
             contact_id=contact_id,
             role=role,
+            is_primary_contact=is_primary_contact,
         )
         session.add(member)
         contact.location_id = None
@@ -452,6 +465,59 @@ def _add_organization_member(
             raise DatabaseError("Failed to load organization after adding member")
         return json_response(
             201,
+            {"organization": serialize_organization_summary(loaded)},
+            event=event,
+        )
+
+
+def _update_organization_member(
+    event: Mapping[str, Any],
+    *,
+    organization_id: UUID,
+    member_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    body = parse_body(event)
+    if "is_primary_contact" not in body:
+        raise ValidationError(
+            "is_primary_contact is required",
+            field="is_primary_contact",
+        )
+    is_primary = body.get("is_primary_contact")
+    if isinstance(is_primary, bool):
+        is_primary_contact = is_primary
+    elif isinstance(is_primary, str) and is_primary.strip().lower() in {"true", "1"}:
+        is_primary_contact = True
+    elif isinstance(is_primary, str) and is_primary.strip().lower() in {"false", "0"}:
+        is_primary_contact = False
+    else:
+        raise ValidationError(
+            "is_primary_contact must be true or false",
+            field="is_primary_contact",
+        )
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
+        repository = OrganizationRepository(session)
+        org = repository.get_non_vendor_organization_by_id(organization_id)
+        if org is None:
+            raise NotFoundError("Organization", str(organization_id))
+        member = session.get(OrganizationMember, member_id)
+        if member is None or member.organization_id != organization_id:
+            raise NotFoundError("OrganizationMember", str(member_id))
+
+        if is_primary_contact:
+            for m in org.organization_members:
+                m.is_primary_contact = m.id == member_id
+        else:
+            member.is_primary_contact = False
+
+        session.commit()
+        loaded = repository.get_non_vendor_organization_by_id(organization_id)
+        if loaded is None:
+            raise DatabaseError("Failed to load organization after updating member")
+        return json_response(
+            200,
             {"organization": serialize_organization_summary(loaded)},
             event=event,
         )

--- a/backend/src/app/db/models/organization.py
+++ b/backend/src/app/db/models/organization.py
@@ -8,13 +8,18 @@ from uuid import UUID
 
 from collections.abc import Iterable
 
-from sqlalchemy import Enum, ForeignKey, Index, String, UniqueConstraint, text
+from sqlalchemy import Boolean, Enum, ForeignKey, Index, String, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import TIMESTAMP
 
 from app.db.base import Base
-from app.db.models.enums import OrganizationRole, OrganizationType, RelationshipType
+from app.db.models.enums import (
+    ContactType,
+    OrganizationRole,
+    OrganizationType,
+    RelationshipType,
+)
 
 if TYPE_CHECKING:
     from app.db.models.contact import Contact
@@ -29,6 +34,21 @@ def _enum_values(
 ) -> list[str]:
     """Return enum labels stored in PostgreSQL."""
     return [member.value for member in enum_cls]
+
+
+def organization_membership_role_from_contact_type(
+    contact_type: ContactType,
+) -> OrganizationRole:
+    """Map contact category to stored organization membership role."""
+    if contact_type is ContactType.PARENT:
+        return OrganizationRole.STAFF
+    if contact_type is ContactType.CHILD:
+        return OrganizationRole.MEMBER
+    if contact_type is ContactType.HELPER:
+        return OrganizationRole.STAFF
+    if contact_type is ContactType.PROFESSIONAL:
+        return OrganizationRole.STAFF
+    return OrganizationRole.OTHER
 
 
 class Organization(Base):
@@ -153,6 +173,11 @@ class OrganizationMember(Base):
             create_type=False,
         ),
         nullable=False,
+    )
+    is_primary_contact: Mapped[bool] = mapped_column(
+        Boolean(),
+        nullable=False,
+        server_default=text("false"),
     )
     title: Mapped[str | None] = mapped_column(String(150), nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/app/imports/entities/contacts.py
+++ b/backend/src/app/imports/entities/contacts.py
@@ -402,6 +402,7 @@ class ContactsImporter:
                                     organization_id=membership_parent,
                                     contact_id=reuse_id,
                                     role=_org_role(p.kind),
+                                    is_primary_contact=False,
                                     title=_title_trim(p.occupation),
                                 ),
                             )
@@ -525,6 +526,7 @@ class ContactsImporter:
                             organization_id=parent_uuid,
                             contact_id=contact_uuid,
                             role=_org_role(p.kind),
+                            is_primary_contact=False,
                             title=_title_trim(p.occupation),
                         ),
                     )

--- a/backend/src/app/imports/entities/link_contact_memberships.py
+++ b/backend/src/app/imports/entities/link_contact_memberships.py
@@ -323,6 +323,7 @@ class LinkContactMembershipsImporter:
                         organization_id=org_uuid,
                         contact_id=contact_uuid,
                         role=_org_role(p.kind),
+                        is_primary_contact=False,
                         title=_title_trim(p.occupation),
                     ),
                 )

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -39,6 +39,7 @@ info:
     - `GET|POST /v1/admin/organizations`
     - `GET|PATCH|DELETE /v1/admin/organizations/{id}`
     - `POST /v1/admin/organizations/{id}/members`
+    - `PATCH /v1/admin/organizations/{id}/members/{memberId}`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
     - `GET|POST /v1/admin/expenses`
     - `GET|PATCH /v1/admin/expenses/{id}`
@@ -2260,6 +2261,32 @@ paths:
     parameters:
       - $ref: "#/components/parameters/AdminOrganizationId"
       - $ref: "#/components/parameters/AdminOrganizationMemberId"
+    patch:
+      summary: Update organization member
+      description: |
+        Updates membership fields such as primary contact. Membership role is derived from the
+        linked contact's `contact_type` (see `POST /v1/admin/organizations/{id}/members`).
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateOrganizationMemberRequest"
+      responses:
+        "200":
+          description: Organization with updated members.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminOrganizationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
     delete:
       summary: Remove organization member
       security:
@@ -5310,6 +5337,16 @@ components:
           description: |
             When true, this member becomes the family's sole primary contact. When false, this
             member is cleared as primary (other members are unchanged).
+    UpdateOrganizationMemberRequest:
+      type: object
+      required:
+        - is_primary_contact
+      properties:
+        is_primary_contact:
+          type: boolean
+          description: |
+            When true, this member becomes the organisation's sole primary contact. When false, this
+            member is cleared as primary (other members are unchanged).
     AdminOrganizationMember:
       type: object
       required:
@@ -5317,6 +5354,7 @@ components:
         - contact_id
         - contact_label
         - role
+        - is_primary_contact
       properties:
         id:
           type: string
@@ -5328,6 +5366,12 @@ components:
           type: string
         role:
           $ref: "#/components/schemas/EntityOrganizationRole"
+          description: |
+            Stored organisation membership role derived from the contact's `contact_type` (parent,
+            helper, and professional map to `staff`; child maps to `member`; other maps to
+            `other`).
+        is_primary_contact:
+          type: boolean
     AdminOrganization:
       type: object
       required:
@@ -5489,13 +5533,18 @@ components:
       type: object
       required:
         - contact_id
-        - role
       properties:
         contact_id:
           type: string
           format: uuid
         role:
-          $ref: "#/components/schemas/EntityOrganizationRole"
+          type: string
+          deprecated: true
+          description: |
+            Ignored. Membership role is derived from the contact's `contact_type` (parent, helper,
+            and professional map to `staff`; child maps to `member`; other maps to `other`).
+        is_primary_contact:
+          type: boolean
     ActionMessageResponse:
       type: object
       required:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -407,7 +407,8 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   among partner rows with a non-null slug (partial unique index).
 - `organizations.location_id` optionally links an organization to a canonical
   row in `locations` for address management.
-- `organization_members` links contacts to organizations with role/title.
+- `organization_members` links contacts to organizations with role/title and an optional
+  primary-contact flag (at most one primary per organisation in normal admin use).
 - Membership rows use `ON DELETE CASCADE`.
 
 ### `tags`, `contact_tags`, `family_tags`, `organization_tags`, `asset_tags`

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -68,7 +68,9 @@ their primary responsibilities.
   `/v1/admin/organizations/picker`, `/v1/admin/organizations/*` (CRM organisations and vendor
   rows share one resource; default list excludes vendors, Finance lists vendors with
   `GET /v1/admin/organizations?relationship_type=vendor`; includes `DELETE /v1/admin/organizations/{id}`
-  for non-vendor orgs),
+  for non-vendor orgs; `POST /v1/admin/organizations/{id}/members` derives each member's role from the
+  linked contact's `contact_type`; `PATCH /v1/admin/organizations/{id}/members/{memberId}` updates
+  membership fields such as primary contact),
   `/v1/admin/leads/*`, `/v1/admin/users`, `/v1/admin/instructors`,
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for
   cross-service instance listing with optional `service_id` / `service_type`

--- a/tests/test_organization_membership_role_from_contact_type.py
+++ b/tests/test_organization_membership_role_from_contact_type.py
@@ -1,0 +1,29 @@
+"""Unit tests for organisation membership role derivation from contact type."""
+
+from __future__ import annotations
+
+from app.db.models.enums import ContactType, OrganizationRole
+from app.db.models.organization import organization_membership_role_from_contact_type
+
+
+def test_organization_role_from_contact_type_mapping() -> None:
+    assert (
+        organization_membership_role_from_contact_type(ContactType.PARENT)
+        == OrganizationRole.STAFF
+    )
+    assert (
+        organization_membership_role_from_contact_type(ContactType.HELPER)
+        == OrganizationRole.STAFF
+    )
+    assert (
+        organization_membership_role_from_contact_type(ContactType.PROFESSIONAL)
+        == OrganizationRole.STAFF
+    )
+    assert (
+        organization_membership_role_from_contact_type(ContactType.CHILD)
+        == OrganizationRole.MEMBER
+    )
+    assert (
+        organization_membership_role_from_contact_type(ContactType.OTHER)
+        == OrganizationRole.OTHER
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Admin UI (Organisations):** Members table now matches Families: icon-only remove, primary-contact checkbox, helper text that role comes from the contact record, and no role dropdown when adding members. Organisation list shows the primary contact label after the name (same pattern as families).
- **API:** `POST /v1/admin/organizations/{id}/members` no longer requires `role`; role is derived from the linked contact's `contact_type`. Optional `is_primary_contact` on add. New `PATCH /v1/admin/organizations/{id}/members/{memberId}` toggles primary contact (sole primary when checked true). Deprecated `role` on add for backward compatibility.
- **Database:** `organization_members.is_primary_contact` (boolean, default false). Migration backfills `role` from `contacts.contact_type` using the same mapping as the app (parent/helper/professional → staff, child → member, other → other).
- **Contact updates:** Changing a contact's `contact_type` refreshes stored organisation membership role(s) for that contact.
- **Infrastructure / docs:** API Gateway PATCH for org member by id; OpenAPI, lambda catalog, and database schema docs updated.

## Role mapping (contact_type → stored organisation role)

- parent, helper, professional → **staff**
- child → **member**
- other → **other**

## Testing

- `pytest tests/test_organization_membership_role_from_contact_type.py tests/test_admin_organizations_handler.py`
- `npm run test -- --run tests/components/admin/contacts/organizations-panel.test.tsx`
- `npm run lint` (admin web)

## Deploy notes

- Run Alembic migration `0031_org_member_primary` before relying on primary-contact behaviour.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9e24dd5-b3db-4c59-8071-b400d7890b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9e24dd5-b3db-4c59-8071-b400d7890b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

