### PR TITLE
Remove Partner organisations column from admin Venues table

### DIFF
--- a/apps/admin_web/src/components/admin/services/venues-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/venues-panel.tsx
@@ -394,7 +394,6 @@ export function VenuesPanel({
             <tr>
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Address</th>
-              <th className='px-4 py-3 font-semibold'>Partner organisations</th>
               <th className='px-4 py-3 font-semibold'>Area</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
@@ -412,11 +411,6 @@ export function VenuesPanel({
                 >
                   <td className='px-4 py-3'>{row.name?.trim() || '—'}</td>
                   <td className='px-4 py-3'>{row.address?.trim() || '—'}</td>
-                  <td className='px-4 py-3'>
-                    {row.partnerOrganizationLabels.length > 0
-                      ? row.partnerOrganizationLabels.join(', ')
-                      : '—'}
-                  </td>
                   <td className='px-4 py-3'>{area?.name ?? row.areaId}</td>
                   <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
                     <Button

--- a/apps/admin_web/tests/components/admin/services/venues-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/venues-panel.test.tsx
@@ -72,7 +72,7 @@ describe('VenuesPanel', () => {
     });
   });
 
-  it('lists name, address, area, and operations columns without coordinates or updated', () => {
+  it('lists name, address, area, and operations columns without partner organisations, coordinates, or updated', () => {
     render(
       <VenuesPanel
         venues={[
@@ -119,7 +119,7 @@ describe('VenuesPanel', () => {
 
     expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Address' })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: 'Partner organisations' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Partner organisations' })).not.toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Area' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Operations' })).toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Coordinates' })).not.toBeInTheDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Services → Venues table no longer shows a **Partner organisations** column. Partner context remains in the inline editor (name lock messaging) where it affects editing.

## Changes

- `venues-panel.tsx`: removed table header and cell for partner organisation labels.
- `venues-panel.test.tsx`: updated column expectations.

## Testing

- `npx vitest run tests/components/admin/services/venues-panel.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e7ca285-2dd4-4f0d-81ca-e207b9723122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e7ca285-2dd4-4f0d-81ca-e207b9723122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

