### PR TITLE
Admin: match session slots box to CRM collapsible location style

### DIFF
--- a/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
+++ b/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { DeleteIcon } from '@/components/icons/action-icons';
+import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -38,133 +39,134 @@ export function SessionSlotEditor({
   const hasLocationOptions = locationOptions.length > 0;
 
   return (
-    <div className='space-y-2'>
-      <div className='flex items-center justify-between'>
-        <Label>Session slots</Label>
-        <Button
-          type='button'
-          variant='secondary'
-          size='sm'
-          disabled={disabled}
-          onClick={() => onChange([...slots, emptySlot(slots.length)])}
-        >
-          Add slot
-        </Button>
-      </div>
-      {slots.length === 0 ? <p className='text-sm text-slate-500'>No slots configured.</p> : null}
-      <div className='space-y-3'>
-        {slots.map((slot, index) => (
-          <div
-            key={`${slot.id ?? 'new'}-${index}`}
-            className='grid grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-[1fr_1fr_1fr_minmax(0,5.5rem)_auto] sm:items-end'
+    <AdminCollapsibleSection id='service-instance-session-slots' title='Session slots' disabled={disabled}>
+      <div className='space-y-2'>
+        <div className='flex justify-end'>
+          <Button
+            type='button'
+            variant='secondary'
+            size='sm'
+            disabled={disabled}
+            onClick={() => onChange([...slots, emptySlot(slots.length)])}
           >
-            <div className='space-y-1'>
-              <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-starts`}>
-                Start time
-              </Label>
-              <Input
-                id={`slot-${index}-starts`}
-                type='datetime-local'
-                disabled={disabled}
-                value={(slot.startsAt ?? '').slice(0, 16)}
-                onChange={(event) => {
-                  const next = [...slots];
-                  next[index] = { ...slot, startsAt: event.target.value || null };
-                  onChange(next);
-                }}
-              />
-            </div>
-            <div className='space-y-1'>
-              <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-ends`}>
-                End time
-              </Label>
-              <Input
-                id={`slot-${index}-ends`}
-                type='datetime-local'
-                disabled={disabled}
-                value={(slot.endsAt ?? '').slice(0, 16)}
-                onChange={(event) => {
-                  const next = [...slots];
-                  next[index] = { ...slot, endsAt: event.target.value || null };
-                  onChange(next);
-                }}
-              />
-            </div>
-            <div className='space-y-1'>
-              <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-location`}>
-                Location
-              </Label>
-              {hasLocationOptions || isLoadingLocations ? (
-                <Select
-                  id={`slot-${index}-location`}
-                  disabled={disabled}
-                  value={slot.locationId ?? ''}
-                  onChange={(event) => {
-                    const next = [...slots];
-                    next[index] = { ...slot, locationId: event.target.value || null };
-                    onChange(next);
-                  }}
-                >
-                  <option value=''>
-                    {isLoadingLocations ? 'Loading locations...' : 'None'}
-                  </option>
-                  {slot.locationId &&
-                  !locationOptions.some((loc) => loc.id === slot.locationId) ? (
-                    <option value={slot.locationId}>{slot.locationId}</option>
-                  ) : null}
-                  {locationOptions.map((location) => (
-                    <option key={location.id} value={location.id}>
-                      {formatLocationLabel(location)}
-                    </option>
-                  ))}
-                </Select>
-              ) : (
+            Add slot
+          </Button>
+        </div>
+        {slots.length === 0 ? <p className='text-sm text-slate-500'>No slots configured.</p> : null}
+        <div className='space-y-3'>
+          {slots.map((slot, index) => (
+            <div
+              key={`${slot.id ?? 'new'}-${index}`}
+              className='grid grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-[1fr_1fr_1fr_minmax(0,5.5rem)_auto] sm:items-end'
+            >
+              <div className='space-y-1'>
+                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-starts`}>
+                  Start time
+                </Label>
                 <Input
-                  id={`slot-${index}-location`}
+                  id={`slot-${index}-starts`}
+                  type='datetime-local'
                   disabled={disabled}
-                  value={slot.locationId ?? ''}
+                  value={(slot.startsAt ?? '').slice(0, 16)}
                   onChange={(event) => {
                     const next = [...slots];
-                    next[index] = { ...slot, locationId: event.target.value || null };
+                    next[index] = { ...slot, startsAt: event.target.value || null };
                     onChange(next);
                   }}
-                  placeholder='Location UUID'
                 />
-              )}
+              </div>
+              <div className='space-y-1'>
+                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-ends`}>
+                  End time
+                </Label>
+                <Input
+                  id={`slot-${index}-ends`}
+                  type='datetime-local'
+                  disabled={disabled}
+                  value={(slot.endsAt ?? '').slice(0, 16)}
+                  onChange={(event) => {
+                    const next = [...slots];
+                    next[index] = { ...slot, endsAt: event.target.value || null };
+                    onChange(next);
+                  }}
+                />
+              </div>
+              <div className='space-y-1'>
+                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-location`}>
+                  Location
+                </Label>
+                {hasLocationOptions || isLoadingLocations ? (
+                  <Select
+                    id={`slot-${index}-location`}
+                    disabled={disabled}
+                    value={slot.locationId ?? ''}
+                    onChange={(event) => {
+                      const next = [...slots];
+                      next[index] = { ...slot, locationId: event.target.value || null };
+                      onChange(next);
+                    }}
+                  >
+                    <option value=''>
+                      {isLoadingLocations ? 'Loading locations...' : 'None'}
+                    </option>
+                    {slot.locationId &&
+                    !locationOptions.some((loc) => loc.id === slot.locationId) ? (
+                      <option value={slot.locationId}>{slot.locationId}</option>
+                    ) : null}
+                    {locationOptions.map((location) => (
+                      <option key={location.id} value={location.id}>
+                        {formatLocationLabel(location)}
+                      </option>
+                    ))}
+                  </Select>
+                ) : (
+                  <Input
+                    id={`slot-${index}-location`}
+                    disabled={disabled}
+                    value={slot.locationId ?? ''}
+                    onChange={(event) => {
+                      const next = [...slots];
+                      next[index] = { ...slot, locationId: event.target.value || null };
+                      onChange(next);
+                    }}
+                    placeholder='Location UUID'
+                  />
+                )}
+              </div>
+              <div className='space-y-1'>
+                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-sort`}>
+                  Sort order
+                </Label>
+                <Input
+                  id={`slot-${index}-sort`}
+                  type='number'
+                  disabled={disabled}
+                  value={slot.sortOrder ?? index}
+                  onChange={(event) => {
+                    const next = [...slots];
+                    next[index] = { ...slot, sortOrder: Number(event.target.value) };
+                    onChange(next);
+                  }}
+                />
+              </div>
+              <div className='flex justify-end pb-0.5 sm:justify-start'>
+                <Button
+                  type='button'
+                  variant='danger'
+                  size='sm'
+                  disabled={disabled}
+                  className='min-w-8 px-2'
+                  aria-label='Delete session slot'
+                  title='Delete session slot'
+                  onClick={() => onChange(slots.filter((_, itemIndex) => itemIndex !== index))}
+                >
+                  <DeleteIcon className='h-4 w-4' />
+                </Button>
+              </div>
             </div>
-            <div className='space-y-1'>
-              <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-sort`}>
-                Sort order
-              </Label>
-              <Input
-                id={`slot-${index}-sort`}
-                type='number'
-                disabled={disabled}
-                value={slot.sortOrder ?? index}
-                onChange={(event) => {
-                  const next = [...slots];
-                  next[index] = { ...slot, sortOrder: Number(event.target.value) };
-                  onChange(next);
-                }}
-              />
-            </div>
-            <div className='flex justify-end pb-0.5 sm:justify-start'>
-              <Button
-                type='button'
-                variant='danger'
-                size='sm'
-                disabled={disabled}
-                className='min-w-8 px-2'
-                aria-label='Delete session slot'
-                title='Delete session slot'
-                onClick={() => onChange(slots.filter((_, itemIndex) => itemIndex !== index))}
-              >
-                <DeleteIcon className='h-4 w-4' />
-              </Button>
-            </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
-    </div>
+    </AdminCollapsibleSection>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wraps the service instance **Session slots** editor in `AdminCollapsibleSection`, the same primitive used for **Location** on Contacts / Families (bold title, bordered panel, `bg-slate-50/40`, collapsible `<details>`).

## Changes

- `apps/admin_web/src/components/admin/services/session-slot-editor.tsx`: import `AdminCollapsibleSection`, wrap editor content with `id='service-instance-session-slots'` and `title='Session slots'`. Pass `disabled` through to the section so the fieldset behavior matches other collapsible editors when the instance form is locked.

## Testing

- `npm run lint` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d866f89-06d3-4cd7-82b9-d8319f7052b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d866f89-06d3-4cd7-82b9-d8319f7052b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

