### PR TITLE
Admin web: service editor three-row layout

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -15,7 +15,8 @@ import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
 import { getServiceDiscountCodeUsageSummary } from '@/lib/services-api';
 
 import type { components } from '@/types/generated/admin-api.generated';
-import { SERVICE_TYPES } from '@/types/services';
+import { SERVICE_DELIVERY_MODES, SERVICE_STATUSES, SERVICE_TYPES } from '@/types/services';
+import type { ServiceDeliveryMode } from '@/types/services';
 import type { ServiceDetail, ServiceType } from '@/types/services';
 
 import { ConsultationFormFields, type ConsultationFormState } from './consultation-form-fields';
@@ -26,7 +27,11 @@ import {
   DEFAULT_SERVICE_FORM,
   DEFAULT_TRAINING_FORM,
 } from './form-defaults';
-import { ServiceFormFields, type ServiceFormState } from './service-form-fields';
+import {
+  ServiceFormFields,
+  ServiceReferralSlugField,
+  type ServiceFormState,
+} from './service-form-fields';
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
 type ApiSchemas = components['schemas'];
@@ -384,7 +389,7 @@ export function ServiceDetailPanel({
           </>
         }
       >
-        <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+        <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
           <div>
             <Label htmlFor='service-type'>Service type</Label>
             <Select
@@ -409,6 +414,38 @@ export function ServiceDetailPanel({
               placeholder='Service title'
             />
           </div>
+          <ServiceReferralSlugField
+            value={serviceForm.slug}
+            onChange={(next) => {
+              if (next !== serviceForm.slug) {
+                setSlugConflictError('');
+                setConflictingSlugNormalized(null);
+              }
+              setServiceForm({ ...serviceForm, slug: next });
+            }}
+            slugUsageLoadError={
+              discountUsageLoadState === 'error'
+                ? 'Could not load discount code usage. Try again later.'
+                : undefined
+            }
+            slugConflictError={slugConflictError || undefined}
+          />
+          <div>
+            <Label htmlFor='service-status'>Status</Label>
+            <Select
+              id='service-status'
+              value={serviceForm.status}
+              onChange={(event) =>
+                setServiceForm({ ...serviceForm, status: event.target.value as ServiceFormState['status'] })
+              }
+            >
+              {SERVICE_STATUSES.map((entry) => (
+                <option key={entry} value={entry}>
+                  {formatEnumLabel(entry)}
+                </option>
+              ))}
+            </Select>
+          </div>
         </div>
 
         <ServiceFormFields
@@ -421,17 +458,71 @@ export function ServiceDetailPanel({
             setServiceForm(next);
           }}
           hideTitle
-          slugUsageLoadError={
-            discountUsageLoadState === 'error'
-              ? 'Could not load discount code usage. Try again later.'
-              : undefined
-          }
-          slugConflictError={slugConflictError || undefined}
+          layout='service-detail'
         />
 
         {serviceType === 'training_course' ? (
-          <TrainingFormFields value={trainingForm} onChange={setTrainingForm} />
-        ) : null}
+          <TrainingFormFields
+            value={trainingForm}
+            onChange={setTrainingForm}
+            layout='service-detail'
+            leadingColumn={
+              <>
+                <Label htmlFor='service-delivery-mode'>Delivery mode</Label>
+                <Select
+                  id='service-delivery-mode'
+                  value={serviceForm.deliveryMode}
+                  onChange={(event) =>
+                    setServiceForm({
+                      ...serviceForm,
+                      deliveryMode: event.target.value as ServiceDeliveryMode,
+                    })
+                  }
+                >
+                  {SERVICE_DELIVERY_MODES.map((entry) => (
+                    <option key={entry} value={entry}>
+                      {formatEnumLabel(entry)}
+                    </option>
+                  ))}
+                </Select>
+              </>
+            }
+          />
+        ) : (
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <div>
+              <Label htmlFor='service-delivery-mode'>Delivery mode</Label>
+              <Select
+                id='service-delivery-mode'
+                value={serviceForm.deliveryMode}
+                onChange={(event) =>
+                  setServiceForm({
+                    ...serviceForm,
+                    deliveryMode: event.target.value as ServiceDeliveryMode,
+                  })
+                }
+              >
+                {SERVICE_DELIVERY_MODES.map((entry) => (
+                  <option key={entry} value={entry}>
+                    {formatEnumLabel(entry)}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div>
+              <Label className='text-slate-500'>Pricing unit</Label>
+              <p className='mt-2 text-sm text-slate-400'>—</p>
+            </div>
+            <div>
+              <Label className='text-slate-500'>Price</Label>
+              <p className='mt-2 text-sm text-slate-400'>—</p>
+            </div>
+            <div>
+              <Label className='text-slate-500'>Currency</Label>
+              <p className='mt-2 text-sm text-slate-400'>—</p>
+            </div>
+          </div>
+        )}
         {serviceType === 'event' ? <EventFormFields value={eventForm} onChange={setEventForm} /> : null}
         {serviceType === 'consultation' ? (
           <ConsultationFormFields value={consultationForm} onChange={setConsultationForm} />

--- a/apps/admin_web/src/components/admin/services/service-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/service-form-fields.tsx
@@ -11,6 +11,47 @@ import type { ServiceDeliveryMode, ServiceStatus } from '@/types/services';
 
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
+export interface ServiceReferralSlugFieldProps {
+  value: string;
+  onChange: (next: string) => void;
+  slugUsageLoadError?: string;
+  slugConflictError?: string;
+}
+
+export function ServiceReferralSlugField({
+  value,
+  onChange,
+  slugUsageLoadError,
+  slugConflictError,
+}: ServiceReferralSlugFieldProps) {
+  return (
+    <div>
+      <Label htmlFor='service-slug'>Referral slug</Label>
+      <Input
+        id='service-slug'
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={() => onChange(value.trim().toLowerCase())}
+        placeholder='e.g. my-best-auntie'
+        autoComplete='off'
+      />
+      <p className='mt-1 text-xs text-slate-500'>
+        Used in referral URLs. Lowercase letters, numbers, and hyphens.
+      </p>
+      {value.trim() && !SLUG_PATTERN.test(value.trim()) ? (
+        <p className='mt-1 text-xs text-red-600'>
+          Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
+          hyphen).
+        </p>
+      ) : null}
+      {slugUsageLoadError ? <p className='mt-1 text-xs text-amber-700'>{slugUsageLoadError}</p> : null}
+      {slugConflictError ? <p className='mt-1 text-xs text-red-600'>{slugConflictError}</p> : null}
+    </div>
+  );
+}
+
+export type ServiceFormFieldsLayout = 'stacked' | 'service-detail';
+
 export interface ServiceFormState {
   title: string;
   description: string;
@@ -23,6 +64,7 @@ export interface ServiceFormFieldsProps {
   value: ServiceFormState;
   onChange: (value: ServiceFormState) => void;
   hideTitle?: boolean;
+  layout?: ServiceFormFieldsLayout;
   slugUsageLoadError?: string;
   slugConflictError?: string;
 }
@@ -31,9 +73,25 @@ export function ServiceFormFields({
   value,
   onChange,
   hideTitle = false,
+  layout = 'stacked',
   slugUsageLoadError,
   slugConflictError,
 }: ServiceFormFieldsProps) {
+  if (layout === 'service-detail') {
+    return (
+      <div>
+        <Label htmlFor='service-description'>Description</Label>
+        <Textarea
+          id='service-description'
+          value={value.description}
+          onChange={(event) => onChange({ ...value, description: event.target.value })}
+          rows={3}
+          placeholder='Optional description'
+        />
+      </div>
+    );
+  }
+
   return (
     <div className='space-y-3'>
       {!hideTitle ? (
@@ -57,28 +115,12 @@ export function ServiceFormFields({
           placeholder='Optional description'
         />
       </div>
-      <div>
-        <Label htmlFor='service-slug'>Referral slug</Label>
-        <Input
-          id='service-slug'
-          value={value.slug}
-          onChange={(event) => onChange({ ...value, slug: event.target.value })}
-          onBlur={() => onChange({ ...value, slug: value.slug.trim().toLowerCase() })}
-          placeholder='e.g. my-best-auntie'
-          autoComplete='off'
-        />
-        <p className='mt-1 text-xs text-slate-500'>
-          Used in referral URLs. Lowercase letters, numbers, and hyphens.
-        </p>
-        {value.slug.trim() && !SLUG_PATTERN.test(value.slug.trim()) ? (
-          <p className='mt-1 text-xs text-red-600'>
-            Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
-            hyphen).
-          </p>
-        ) : null}
-        {slugUsageLoadError ? <p className='mt-1 text-xs text-amber-700'>{slugUsageLoadError}</p> : null}
-        {slugConflictError ? <p className='mt-1 text-xs text-red-600'>{slugConflictError}</p> : null}
-      </div>
+      <ServiceReferralSlugField
+        value={value.slug}
+        onChange={(next) => onChange({ ...value, slug: next })}
+        slugUsageLoadError={slugUsageLoadError}
+        slugConflictError={slugConflictError}
+      />
       <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
         <div>
           <Label htmlFor='service-delivery-mode'>Delivery mode</Label>

--- a/apps/admin_web/src/components/admin/services/training-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/training-form-fields.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
@@ -18,14 +20,32 @@ export interface TrainingFormFieldsProps {
   value: TrainingFormState;
   disabled?: boolean;
   onChange: (value: TrainingFormState) => void;
+  /**
+   * When set with `layout="service-detail"`, renders a single md+ row of four equal
+   * columns: leading column (e.g. delivery mode) plus pricing unit, price, currency.
+   */
+  leadingColumn?: ReactNode;
+  layout?: 'default' | 'service-detail';
 }
 
-export function TrainingFormFields({ value, disabled = false, onChange }: TrainingFormFieldsProps) {
+export function TrainingFormFields({
+  value,
+  disabled = false,
+  onChange,
+  leadingColumn,
+  layout = 'default',
+}: TrainingFormFieldsProps) {
   const currencyOptions = getCurrencyOptions();
+
+  const pricingGridClass =
+    layout === 'service-detail'
+      ? 'grid grid-cols-1 gap-3 md:grid-cols-4'
+      : 'grid grid-cols-1 gap-3 sm:grid-cols-3';
 
   return (
     <div className='space-y-3'>
-      <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
+      <div className={pricingGridClass}>
+        {layout === 'service-detail' && leadingColumn ? <div>{leadingColumn}</div> : null}
         <div>
           <Label htmlFor='training-pricing-unit'>Pricing unit</Label>
           <Select


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorganizes the Services catalog **Service** inline editor (`AdminEditorCard`) into the requested layout:

1. **Row 1** (four equal columns on `md+`): service type, title, referral slug, status.
2. **Row 2**: description only.
3. **Row 3** (four equal columns on `md+`): delivery mode, pricing unit, default price, currency for **training** services.

For **event** and **consultation** services, row 3 still shows delivery mode in the first column; the pricing columns show an em-dash placeholder because those fields are not the same as training defaults (type-specific editors follow below unchanged).

## Implementation notes

- Extracted `ServiceReferralSlugField` in `service-form-fields.tsx` so slug validation and discount-usage messaging stay in one place while the panel composes the first row.
- `ServiceFormFields` gains optional `layout="service-detail"` to render only the description block when used from `ServiceDetailPanel`.
- `TrainingFormFields` accepts `layout="service-detail"` and optional `leadingColumn` for the delivery mode cell in the four-column pricing row.

## Testing

- `npm run test -- tests/components/admin/services/service-detail-panel.test.tsx tests/components/admin/services/service-editor-slug.test.tsx`
- `npx eslint` on touched files
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92b692f6-39cd-4529-af3a-70e926b53fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92b692f6-39cd-4529-af3a-70e926b53fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

