### PR TITLE
Admin services: remove referral slug hint; half-width cover file name

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -529,13 +529,15 @@ export function ServiceDetailPanel({
         ) : null}
 
         {isEditMode ? (
-          <div>
-            <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
-            <Input
-              id='service-detail-cover-file-name'
-              value={coverFileName}
-              onChange={(event) => setCoverFileName(event.target.value)}
-            />
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <div className='md:col-span-2'>
+              <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
+              <Input
+                id='service-detail-cover-file-name'
+                value={coverFileName}
+                onChange={(event) => setCoverFileName(event.target.value)}
+              />
+            </div>
           </div>
         ) : null}
 

--- a/apps/admin_web/src/components/admin/services/service-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/service-form-fields.tsx
@@ -35,9 +35,6 @@ export function ServiceReferralSlugField({
         placeholder='e.g. my-best-auntie'
         autoComplete='off'
       />
-      <p className='mt-1 text-xs text-slate-500'>
-        Used in referral URLs. Lowercase letters, numbers, and hyphens.
-      </p>
       {value.trim() && !SLUG_PATTERN.test(value.trim()) ? (
         <p className='mt-1 text-xs text-red-600'>
           Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removes the helper text under the Referral slug field on the admin Services editor (`ServiceReferralSlugField`).
- Constrains the Cover image file name input to half width on medium+ breakpoints by placing it in a four-column grid with `md:col-span-2` (still full width on small screens).

## Testing

- `npm run test -- --run tests/components/admin/services/service-editor-slug.test.tsx tests/components/admin/services/service-detail-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c89a84a-d5ea-4482-9a80-2d8cd47128d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c89a84a-d5ea-4482-9a80-2d8cd47128d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

