### PR TITLE
Add booking_system field to services and admin UI

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -105,6 +105,7 @@ export function ServiceDetailPanel({
       : DEFAULT_CONSULTATION_FORM
   );
   const [coverFileName, setCoverFileName] = useState('cover-image.jpg');
+  const [bookingSystem, setBookingSystem] = useState(service?.bookingSystem ?? '');
   const [discountUsageSummary, setDiscountUsageSummary] = useState<{
     totalCurrentUses: number;
     referencingCodeCount: number;
@@ -153,11 +154,13 @@ export function ServiceDetailPanel({
         setTrainingForm(DEFAULT_TRAINING_FORM);
         setEventForm(DEFAULT_EVENT_FORM);
         setConsultationForm(DEFAULT_CONSULTATION_FORM);
+        setBookingSystem('');
         setSlugConflictError('');
         setConflictingSlugNormalized(null);
         return;
       }
       setServiceType(service.serviceType);
+      setBookingSystem(service.bookingSystem ?? '');
       setServiceForm({
         title: service.title,
         description: service.description ?? '',
@@ -292,6 +295,7 @@ export function ServiceDetailPanel({
         title: serviceForm.title.trim(),
         description: serviceForm.description.trim() || null,
         slug: newSlug,
+        booking_system: bookingSystem.trim() || null,
         delivery_mode: serviceForm.deliveryMode,
         status: serviceForm.status,
         ...buildTypeSpecificPayload(service.serviceType),
@@ -319,6 +323,7 @@ export function ServiceDetailPanel({
         title: serviceForm.title.trim(),
         description: serviceForm.description.trim() || null,
         slug: slugPayloadValue,
+        booking_system: bookingSystem.trim() || null,
         delivery_mode: serviceForm.deliveryMode,
         status: serviceForm.status,
         ...buildTypeSpecificPayload(serviceType),
@@ -528,9 +533,9 @@ export function ServiceDetailPanel({
           <ConsultationFormFields value={consultationForm} onChange={setConsultationForm} />
         ) : null}
 
-        {isEditMode ? (
-          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            <div className='md:col-span-2'>
+        <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+          {isEditMode ? (
+            <div className='md:col-span-3'>
               <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
               <Input
                 id='service-detail-cover-file-name'
@@ -538,8 +543,21 @@ export function ServiceDetailPanel({
                 onChange={(event) => setCoverFileName(event.target.value)}
               />
             </div>
+          ) : (
+            <div className='hidden md:block md:col-span-3' aria-hidden />
+          )}
+          <div>
+            <Label htmlFor='service-booking-system'>Booking system</Label>
+            <Input
+              id='service-booking-system'
+              value={bookingSystem}
+              onChange={(event) => setBookingSystem(event.target.value)}
+              placeholder='e.g. calendly'
+              maxLength={80}
+              autoComplete='off'
+            />
           </div>
-        ) : null}
+        </div>
 
         {error ? <AdminInlineError>{error}</AdminInlineError> : null}
       </AdminEditorCard>

--- a/apps/admin_web/src/components/admin/services/service-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-list-panel.tsx
@@ -87,6 +87,15 @@ export function ServiceListPanel({
         onLoadMore={onLoadMore}
         toolbar={
           <div className='mb-3 flex flex-wrap items-end gap-3'>
+            <div className='min-w-[200px] flex-1'>
+              <Label htmlFor='services-filter-search'>Search</Label>
+              <Input
+                id='services-filter-search'
+                value={filters.search}
+                onChange={(event) => onFilterChange('search', event.target.value)}
+                placeholder='Title or description'
+              />
+            </div>
             <div className='min-w-[140px]'>
               <Label htmlFor='services-filter-type'>Type</Label>
               <Select
@@ -118,15 +127,6 @@ export function ServiceListPanel({
                   </option>
                 ))}
               </Select>
-            </div>
-            <div className='min-w-[200px] flex-1'>
-              <Label htmlFor='services-filter-search'>Search</Label>
-              <Input
-                id='services-filter-search'
-                value={filters.search}
-                onChange={(event) => onFilterChange('search', event.target.value)}
-                placeholder='Title or description'
-              />
             </div>
           </div>
         }

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -121,6 +121,7 @@ function parseServiceSummary(value: unknown): ServiceSummary {
     serviceType: (asNullableString(item.service_type) ?? 'training_course') as ServiceSummary['serviceType'],
     title: asNullableString(item.title) ?? '',
     slug: asNullableString(item.slug),
+    bookingSystem: asNullableString(item.booking_system),
     description: asNullableString(item.description),
     coverImageS3Key: asNullableString(item.cover_image_s3_key),
     deliveryMode: (asNullableString(item.delivery_mode) ?? 'online') as ServiceSummary['deliveryMode'],

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4071,6 +4071,8 @@ export interface components {
             title: string;
             /** @description Optional lowercase referral slug for public URLs (e.g. `my-best-auntie`). Uniqueness is enforced case-insensitively in Aurora. */
             slug?: string | null;
+            /** @description Optional label for which booking system or flow applies to this service (free-form text, same max length as referral slug). */
+            booking_system?: string | null;
             description?: string | null;
             cover_image_s3_key?: string | null;
             delivery_mode: components["schemas"]["ServiceDeliveryMode"];
@@ -4104,6 +4106,8 @@ export interface components {
             title: string;
             /** @description Optional referral slug (lowercase letters, numbers, hyphens). */
             slug?: string | null;
+            /** @description Optional booking system label (free-form text). */
+            booking_system?: string | null;
             description?: string | null;
             cover_image_s3_key?: string | null;
             delivery_mode: components["schemas"]["ServiceDeliveryMode"];
@@ -4118,6 +4122,7 @@ export interface components {
         PartialUpdateServiceRequest: {
             title?: string;
             slug?: string | null;
+            booking_system?: string | null;
             description?: string | null;
             cover_image_s3_key?: string | null;
             delivery_mode?: components["schemas"]["ServiceDeliveryMode"];

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -86,6 +86,8 @@ export interface ServiceSummary {
   title: string;
   /** Lowercase referral slug from Aurora; null when unset. */
   slug: string | null;
+  /** Optional admin label for booking system or flow (free-form text). */
+  bookingSystem: string | null;
   description: string | null;
   coverImageS3Key: string | null;
   deliveryMode: ServiceDeliveryMode;

--- a/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
@@ -46,6 +46,7 @@ describe('DiscountCodesPanel', () => {
     serviceType: 'training_course' as const,
     title: 'My Best Auntie',
     slug: 'my-best-auntie' as string | null,
+    bookingSystem: null,
     description: null,
     coverImageS3Key: null,
     deliveryMode: 'in_person' as const,

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -11,6 +11,7 @@ function buildServiceSummary(overrides: Partial<ServiceSummary> = {}): ServiceSu
     serviceType: 'training_course',
     title: 'Alpha service',
     slug: null,
+    bookingSystem: null,
     description: null,
     coverImageS3Key: null,
     deliveryMode: 'online',

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -12,6 +12,7 @@ function buildService(overrides: Partial<ServiceDetail> = {}): ServiceDetail {
     serviceType: 'training_course',
     title: 'Alpha service',
     slug: null,
+    bookingSystem: null,
     description: 'Alpha description',
     coverImageS3Key: null,
     deliveryMode: 'online',

--- a/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
@@ -13,6 +13,7 @@ function buildService(overrides: Partial<ServiceDetail> = {}): ServiceDetail {
     serviceType: 'training_course',
     title: 'Alpha service',
     slug: 'old-slug',
+    bookingSystem: null,
     description: null,
     coverImageS3Key: null,
     deliveryMode: 'online',

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -13,6 +13,7 @@ const SERVICE_FIXTURE: ServiceSummary = {
   serviceType: 'training_course',
   title: 'Service title',
   slug: null,
+  bookingSystem: null,
   description: null,
   coverImageS3Key: null,
   deliveryMode: 'in_person',

--- a/backend/db/alembic/versions/0032_services_booking_system.py
+++ b/backend/db/alembic/versions/0032_services_booking_system.py
@@ -1,0 +1,36 @@
+"""Add nullable ``booking_system`` text column on ``services``.
+
+Seed-data assessment:
+1. Compatibility: ``backend/db/seed/seed_data.sql`` inserts into ``services``;
+   new column is nullable with no default required.
+2. NOT NULL: N/A (nullable).
+3. Renamed/dropped: N/A.
+4. New tables: N/A.
+5. Enum: N/A.
+6. FK order: N/A.
+
+Result: No seed update required.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0032_services_booking"
+down_revision: Union[str, None] = "0031_org_member_primary"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "services",
+        sa.Column("booking_system", sa.String(length=80), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("services", "booking_system")

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -165,6 +165,7 @@ def _create_service(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, An
             service_type=payload["service_type"],
             title=payload["title"],
             slug=payload["slug"],
+            booking_system=payload["booking_system"],
             description=payload["description"],
             cover_image_s3_key=payload["cover_image_s3_key"],
             delivery_mode=payload["delivery_mode"],
@@ -246,6 +247,8 @@ def _update_service(
             service.title = payload["title"]
         if "slug" in payload:
             service.slug = payload["slug"]
+        if "booking_system" in payload:
+            service.booking_system = payload["booking_system"]
         if "description" in payload:
             service.description = payload["description"]
         if "cover_image_s3_key" in payload:

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -52,6 +52,7 @@ _LIST_MAX_LIMIT = 100
 _MAX_CODE_LENGTH = 50
 _SERVICE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _MAX_SERVICE_SLUG_LENGTH = 80
+_MAX_BOOKING_SYSTEM_LENGTH = 80
 logger = get_logger(__name__)
 
 # Sibling defaults: admin_web `REFERRAL_DEFAULT_*` in `apps/admin_web/src/types/services.ts`.
@@ -76,6 +77,23 @@ def parse_optional_service_slug(value: Any, field: str) -> str | None:
     if not _SERVICE_SLUG_PATTERN.fullmatch(trimmed):
         raise ValidationError(
             f"{field} must use lowercase letters, numbers, and single hyphens between segments",
+            field=field,
+        )
+    return trimmed
+
+
+def parse_optional_booking_system(value: Any, field: str) -> str | None:
+    """Parse optional booking system label; strip; empty -> None."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValidationError(f"{field} must be a string", field=field)
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    if len(trimmed) > _MAX_BOOKING_SYSTEM_LENGTH:
+        raise ValidationError(
+            f"{field} must be at most {_MAX_BOOKING_SYSTEM_LENGTH} characters",
             field=field,
         )
     return trimmed
@@ -206,6 +224,9 @@ def parse_create_service_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         "service_type": service_type,
         "title": parse_required_text(body.get("title"), "title", max_length=255),
         "slug": parse_optional_service_slug(body.get("slug"), "slug"),
+        "booking_system": parse_optional_booking_system(
+            body.get("booking_system"), "booking_system"
+        ),
         "description": parse_optional_text(
             body.get("description"), max_length=MAX_DESCRIPTION_LENGTH
         ),
@@ -241,6 +262,10 @@ def parse_update_service_payload(
         )
     if has_field(body, "slug"):
         payload["slug"] = parse_optional_service_slug(body.get("slug"), "slug")
+    if has_field(body, "booking_system"):
+        payload["booking_system"] = parse_optional_booking_system(
+            body.get("booking_system"), "booking_system"
+        )
     if has_field(body, "description"):
         payload["description"] = parse_optional_text(
             body.get("description"), max_length=MAX_DESCRIPTION_LENGTH

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -43,6 +43,7 @@ def serialize_service_summary(service: Service) -> dict[str, Any]:
         "title": service.title,
         "description": service.description,
         "slug": service.slug,
+        "booking_system": service.booking_system,
         "cover_image_s3_key": service.cover_image_s3_key,
         "delivery_mode": service.delivery_mode.value,
         "status": service.status.value,

--- a/backend/src/app/db/models/service.py
+++ b/backend/src/app/db/models/service.py
@@ -72,6 +72,7 @@ class Service(Base):
     )
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    booking_system: Mapped[str | None] = mapped_column(String(80), nullable=True)
     description: Mapped[str | None] = mapped_column(Text(), nullable=True)
     cover_image_s3_key: Mapped[str | None] = mapped_column(String(), nullable=True)
     delivery_mode: Mapped[ServiceDeliveryMode] = mapped_column(

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3385,6 +3385,13 @@ components:
           description: >
             Optional lowercase referral slug for public URLs (e.g. `my-best-auntie`).
             Uniqueness is enforced case-insensitively in Aurora.
+        booking_system:
+          type: string
+          nullable: true
+          maxLength: 80
+          description: >
+            Optional label for which booking system or flow applies to this service
+            (free-form text, same max length as referral slug).
         description:
           type: string
           nullable: true
@@ -3466,6 +3473,11 @@ components:
           maxLength: 80
           pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
           description: Optional referral slug (lowercase letters, numbers, hyphens).
+        booking_system:
+          type: string
+          nullable: true
+          maxLength: 80
+          description: Optional booking system label (free-form text).
         description:
           type: string
           nullable: true
@@ -3506,6 +3518,10 @@ components:
           nullable: true
           maxLength: 80
           pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        booking_system:
+          type: string
+          nullable: true
+          maxLength: 80
         description:
           type: string
           nullable: true

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -62,6 +62,9 @@ Migration `0023_services_add_slug` adds nullable `services.slug` (varchar(80)) w
 unique partial index `services_slug_unique_idx` on `lower(slug)` where `slug` is not
 null (case-insensitive uniqueness for public referral URLs).
 
+Migration `0032_services_booking` adds nullable `services.booking_system` (varchar(80))
+for an optional admin-visible booking-system label.
+
 ## Table: assets
 
 Purpose: Stores asset metadata for files in S3.
@@ -434,7 +437,8 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 ### `services` + type-detail tables
 
 - `services` stores reusable templates (title/description/cover image, type,
-  delivery mode, status, optional `slug` for public referral URLs).
+  delivery mode, status, optional `slug` for public referral URLs, optional
+  `booking_system` varchar(80) for an admin-visible booking-system label).
 - Type-specific one-to-one extension tables:
   - `training_course_details`
   - `event_details`

--- a/tests/test_admin_services_booking_system_payload.py
+++ b/tests/test_admin_services_booking_system_payload.py
@@ -1,0 +1,26 @@
+"""Tests for optional ``booking_system`` field on admin service payloads."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.admin_services_payloads import parse_optional_booking_system
+from app.exceptions import ValidationError
+
+
+def test_parse_optional_booking_system_strips_and_none_for_blank() -> None:
+    assert parse_optional_booking_system(None, "booking_system") is None
+    assert parse_optional_booking_system("   ", "booking_system") is None
+    assert parse_optional_booking_system("  calendly  ", "booking_system") == "calendly"
+
+
+def test_parse_optional_booking_system_rejects_non_string() -> None:
+    with pytest.raises(ValidationError, match="must be a string"):
+        parse_optional_booking_system(123, "booking_system")
+
+
+def test_parse_optional_booking_system_max_length() -> None:
+    ok = "a" * 80
+    assert parse_optional_booking_system(ok, "booking_system") == ok
+    with pytest.raises(ValidationError, match="at most 80"):
+        parse_optional_booking_system("a" * 81, "booking_system")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds nullable `services.booking_system` (`varchar(80)`) via Alembic migration `0032_services_booking`, aligned with referral slug length.
- Wires the field through the admin services API: create/update payloads, persistence, and list/detail JSON as `booking_system`.
- Updates `docs/api/admin.yaml` and regenerates `apps/admin_web/src/types/generated/admin-api.generated.ts`.
- Admin Services screen: **Booking system** text input on the same grid row as cover image, using `md:col-span-3` for cover and one column (1/4) for booking system. The field is shown for both create and edit; cover file name remains edit-only.
- **Services list toolbar:** search input is placed **before** the Type and Status filters (same flex row).
- Documents the column in `docs/architecture/database-schema.md`.
- Adds a small pytest module for payload parsing.

## Testing

- `python3 -m pytest tests/test_admin_services_booking_system_payload.py -q`
- `npm run lint` and `npm run test -- --run tests/components/admin/services/` in `apps/admin_web`

## Notes

- `booking_system` is optional free-form text (no slug pattern); empty input is stored as null.
- No seed SQL change: new column is nullable and existing inserts do not require it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f828ef09-46da-4daf-a63d-a3aad8607dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f828ef09-46da-4daf-a63d-a3aad8607dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

