### PR TITLE
Admin services: default status Published; booking and cover layout

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -534,18 +534,6 @@ export function ServiceDetailPanel({
         ) : null}
 
         <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-          {isEditMode ? (
-            <div className='md:col-span-3'>
-              <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
-              <Input
-                id='service-detail-cover-file-name'
-                value={coverFileName}
-                onChange={(event) => setCoverFileName(event.target.value)}
-              />
-            </div>
-          ) : (
-            <div className='hidden md:block md:col-span-3' aria-hidden />
-          )}
           <div>
             <Label htmlFor='service-booking-system'>Booking system</Label>
             <Input
@@ -557,6 +545,15 @@ export function ServiceDetailPanel({
               autoComplete='off'
             />
           </div>
+          <div>
+            <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
+            <Input
+              id='service-detail-cover-file-name'
+              value={coverFileName}
+              onChange={(event) => setCoverFileName(event.target.value)}
+            />
+          </div>
+          <div className='hidden md:block md:col-span-2' aria-hidden />
         </div>
 
         {error ? <AdminInlineError>{error}</AdminInlineError> : null}

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -270,7 +270,7 @@ export interface ServiceListFilters {
 
 export const DEFAULT_SERVICE_LIST_FILTERS: ServiceListFilters = {
   serviceType: '',
-  status: '',
+  status: 'published',
   search: '',
 };
 

--- a/apps/admin_web/tests/components/admin/services/services-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/services-page.test.tsx
@@ -20,7 +20,7 @@ const { mockUseServicesPage, state } = vi.hoisted(() => {
     setInstancesSearchQuery: vi.fn(),
     serviceList: {
       services: [],
-      filters: { serviceType: '', status: '', search: '' },
+      filters: { serviceType: '', status: 'published', search: '' },
       setFilter: vi.fn(),
       clearFilters: vi.fn(),
       isLoading: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Default the Services table status filter to **Published** so the catalog list opens focused on live services (`DEFAULT_SERVICE_LIST_FILTERS` in `apps/admin_web/src/types/services.ts`).
- In the Service inline editor, place **Booking system** first and **Cover image file name** immediately next on the same row; each uses one column of the existing `md:grid-cols-4` layout (quarter width each on desktop). Remaining columns are reserved as spacer on `md+` for alignment.

## Testing

- `npm run test -- tests/components/admin/services/` (admin_web)

## Notes

- Cover filename remains editable in create mode; **Generate cover upload URL** stays disabled until a service exists (unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-734acf8f-8b55-42bb-8589-015c711976f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-734acf8f-8b55-42bb-8589-015c711976f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

