### PR TITLE
Admin services: event type row layout without pricing placeholders

### DIFF
--- a/apps/admin_web/src/components/admin/services/event-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/event-form-fields.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { formatEnumLabel } from '@/lib/format';
@@ -15,10 +17,24 @@ export interface EventFormFieldsProps {
   value: EventFormState;
   disabled?: boolean;
   onChange: (value: EventFormState) => void;
+  /**
+   * With `layout="service-detail"`, renders one md+ row: optional `leadingColumn`,
+   * event category, then `trailingSlot` (typically booking + cover as two grid cells).
+   */
+  layout?: 'default' | 'service-detail';
+  leadingColumn?: ReactNode;
+  trailingSlot?: ReactNode;
 }
 
-export function EventFormFields({ value, disabled = false, onChange }: EventFormFieldsProps) {
-  return (
+export function EventFormFields({
+  value,
+  disabled = false,
+  onChange,
+  layout = 'default',
+  leadingColumn,
+  trailingSlot,
+}: EventFormFieldsProps) {
+  const categoryField = (
     <div>
       <Label htmlFor='event-category'>Event category</Label>
       <Select
@@ -35,4 +51,16 @@ export function EventFormFields({ value, disabled = false, onChange }: EventForm
       </Select>
     </div>
   );
+
+  if (layout === 'service-detail') {
+    return (
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+        {leadingColumn ? <div>{leadingColumn}</div> : null}
+        {categoryField}
+        {trailingSlot}
+      </div>
+    );
+  }
+
+  return categoryField;
 }

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -493,6 +493,56 @@ export function ServiceDetailPanel({
               </>
             }
           />
+        ) : serviceType === 'event' ? (
+          <EventFormFields
+            value={eventForm}
+            onChange={setEventForm}
+            layout='service-detail'
+            leadingColumn={
+              <>
+                <Label htmlFor='service-delivery-mode'>Delivery mode</Label>
+                <Select
+                  id='service-delivery-mode'
+                  value={serviceForm.deliveryMode}
+                  onChange={(event) =>
+                    setServiceForm({
+                      ...serviceForm,
+                      deliveryMode: event.target.value as ServiceDeliveryMode,
+                    })
+                  }
+                >
+                  {SERVICE_DELIVERY_MODES.map((entry) => (
+                    <option key={entry} value={entry}>
+                      {formatEnumLabel(entry)}
+                    </option>
+                  ))}
+                </Select>
+              </>
+            }
+            trailingSlot={
+              <>
+                <div>
+                  <Label htmlFor='service-booking-system'>Booking system</Label>
+                  <Input
+                    id='service-booking-system'
+                    value={bookingSystem}
+                    onChange={(event) => setBookingSystem(event.target.value)}
+                    placeholder='e.g. calendly'
+                    maxLength={80}
+                    autoComplete='off'
+                  />
+                </div>
+                <div>
+                  <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
+                  <Input
+                    id='service-detail-cover-file-name'
+                    value={coverFileName}
+                    onChange={(event) => setCoverFileName(event.target.value)}
+                  />
+                </div>
+              </>
+            }
+          />
         ) : (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
             <div>
@@ -528,33 +578,34 @@ export function ServiceDetailPanel({
             </div>
           </div>
         )}
-        {serviceType === 'event' ? <EventFormFields value={eventForm} onChange={setEventForm} /> : null}
         {serviceType === 'consultation' ? (
           <ConsultationFormFields value={consultationForm} onChange={setConsultationForm} />
         ) : null}
 
-        <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-          <div>
-            <Label htmlFor='service-booking-system'>Booking system</Label>
-            <Input
-              id='service-booking-system'
-              value={bookingSystem}
-              onChange={(event) => setBookingSystem(event.target.value)}
-              placeholder='e.g. calendly'
-              maxLength={80}
-              autoComplete='off'
-            />
+        {serviceType === 'event' ? null : (
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <div>
+              <Label htmlFor='service-booking-system'>Booking system</Label>
+              <Input
+                id='service-booking-system'
+                value={bookingSystem}
+                onChange={(event) => setBookingSystem(event.target.value)}
+                placeholder='e.g. calendly'
+                maxLength={80}
+                autoComplete='off'
+              />
+            </div>
+            <div>
+              <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
+              <Input
+                id='service-detail-cover-file-name'
+                value={coverFileName}
+                onChange={(event) => setCoverFileName(event.target.value)}
+              />
+            </div>
+            <div className='hidden md:block md:col-span-2' aria-hidden />
           </div>
-          <div>
-            <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
-            <Input
-              id='service-detail-cover-file-name'
-              value={coverFileName}
-              onChange={(event) => setCoverFileName(event.target.value)}
-            />
-          </div>
-          <div className='hidden md:block md:col-span-2' aria-hidden />
-        </div>
+        )}
 
         {error ? <AdminInlineError>{error}</AdminInlineError> : null}
       </AdminEditorCard>

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -167,4 +167,33 @@ describe('ServiceDetailPanel', () => {
     expect(editModeServiceType).toBeDisabled();
     expect(editModeServiceType).toHaveValue('consultation');
   });
+
+  it('lays out event fields in one row with delivery mode and omits placeholder pricing', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    const onCreate = vi.fn();
+    const onUploadCover = vi.fn();
+    const onCancelSelection = vi.fn();
+
+    render(
+      <ServiceDetailPanel
+        service={null}
+        isLoading={false}
+        error=''
+        onCancelSelection={onCancelSelection}
+        onCreate={onCreate}
+        onUpdate={onUpdate}
+        onUploadCover={onUploadCover}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText('Service type'), 'event');
+
+    expect(screen.getByLabelText('Delivery mode')).toBeInTheDocument();
+    expect(screen.getByLabelText('Event category')).toBeInTheDocument();
+    expect(screen.getByLabelText('Booking system')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cover image file name')).toBeInTheDocument();
+    expect(screen.queryAllByLabelText('Booking system')).toHaveLength(1);
+    expect(screen.queryByText('Pricing unit')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- For **Event** service type on the admin Services catalog editor, removed the row that showed disabled-looking pricing placeholders (pricing unit, price, currency).
- **Delivery mode**, **event category**, **booking system**, and **cover image file name** now share one responsive grid row on `md+` (same four-column pattern as training + delivery).
- Extended `EventFormFields` with an optional `service-detail` layout (`leadingColumn` + `trailingSlot`) so instance/create flows keep the default single-field layout.

## Testing

- `npm run lint` (admin_web)
- `npx vitest run tests/components/admin/services/service-detail-panel.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e4e89dc-0d96-44bb-b009-7188f25153a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e4e89dc-0d96-44bb-b009-7188f25153a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

