### PR TITLE
Add instance referral slug to admin instance editor

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -45,8 +45,10 @@ export function CreateInstanceDialog({
   );
 
   const handleSubmit = async () => {
+    const slugTrimmed = instanceForm.slug.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
       title: instanceForm.title.trim() || null,
+      slug: slugTrimmed || null,
       description: instanceForm.description.trim() || null,
       status: instanceForm.status,
       delivery_mode: instanceForm.deliveryMode || undefined,

--- a/apps/admin_web/src/components/admin/services/form-defaults.ts
+++ b/apps/admin_web/src/components/admin/services/form-defaults.ts
@@ -36,6 +36,7 @@ export const DEFAULT_CONSULTATION_FORM: ConsultationFormState = {
 
 export const DEFAULT_INSTANCE_FORM: InstanceFormState = {
   title: '',
+  slug: '',
   description: '',
   status: 'scheduled',
   deliveryMode: '',

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -103,6 +103,7 @@ export function InstanceDetailPanel({
     instance
       ? {
           title: instance.title ?? '',
+          slug: instance.slug ?? '',
           description: instance.description ?? '',
           status: instance.status,
           deliveryMode: instance.deliveryMode ?? '',
@@ -184,6 +185,46 @@ export function InstanceDetailPanel({
     });
   }, [instance, selectedServiceId, serviceOptions]);
 
+  useEffect(() => {
+    if (!instance) {
+      return;
+    }
+    queueMicrotask(() => {
+      setInstanceForm({
+        title: instance.title ?? '',
+        slug: instance.slug ?? '',
+        description: instance.description ?? '',
+        status: instance.status,
+        deliveryMode: instance.deliveryMode ?? '',
+        locationId: instance.locationId ?? '',
+        maxCapacity: instance.maxCapacity?.toString() ?? '',
+        waitlistEnabled: instance.waitlistEnabled,
+        instructorId: instance.instructorId ?? '',
+        notes: instance.notes ?? '',
+        sessionSlots: instance.sessionSlots,
+      });
+      setTrainingForm({
+        pricingUnit: instance.trainingDetails?.pricingUnit ?? 'per_person',
+        defaultPrice: instance.trainingDetails?.price ?? '',
+        defaultCurrency: instance.trainingDetails?.currency ?? defaultCurrencyCode,
+      });
+      setEventForm({
+        eventCategory: 'workshop',
+      });
+      setConsultationForm({
+        consultationFormat: 'one_on_one',
+        maxGroupSize: '',
+        durationMinutes: '60',
+        pricingModel: instance.consultationDetails?.pricingModel ?? 'free',
+        defaultHourlyRate: instance.consultationDetails?.price ?? '',
+        defaultPackagePrice: '',
+        defaultPackageSessions: instance.consultationDetails?.packageSessions?.toString() ?? '',
+        defaultCurrency: instance.consultationDetails?.currency ?? defaultCurrencyCode,
+        calendlyUrl: instance.consultationDetails?.calendlyEventUrl ?? '',
+      });
+    });
+  }, [instance]);
+
   const selectedService =
     serviceOptions.find((entry) => entry.id === selectedServiceId) ?? null;
   const effectiveServiceType = serviceType ?? selectedService?.serviceType ?? 'training_course';
@@ -191,8 +232,10 @@ export function InstanceDetailPanel({
   const typeFieldsLocked = !selectedServiceId;
 
   const buildCreatePayload = (): ApiSchemas['CreateInstanceRequest'] => {
+    const slugTrimmed = instanceForm.slug.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
       title: instanceForm.title.trim() || null,
+      slug: slugTrimmed || null,
       description: instanceForm.description.trim() || null,
       status: instanceForm.status,
       delivery_mode: instanceForm.deliveryMode || undefined,

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -13,6 +13,9 @@ import { SessionSlotEditor } from './session-slot-editor';
 
 import type { SessionSlot } from '@/types/services';
 
+/** Same pattern as service referral slugs; matches backend `SERVICE_INSTANCE_SLUG_RE`. */
+const INSTANCE_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
 export interface InstanceInstructorOption {
   sub: string;
   email: string | null;
@@ -21,6 +24,7 @@ export interface InstanceInstructorOption {
 
 export interface InstanceFormState {
   title: string;
+  slug: string;
   description: string;
   status: InstanceStatus;
   deliveryMode: ServiceDeliveryMode | '';
@@ -77,10 +81,10 @@ export function InstanceFormFields({
 
   const topRowClass =
     canSelectService && !instanceFieldsLocked
-      ? 'grid grid-cols-1 gap-3 sm:grid-cols-3'
+      ? 'grid grid-cols-1 gap-3 sm:grid-cols-4'
       : canSelectService && instanceFieldsLocked
-        ? 'grid grid-cols-1 gap-3 sm:grid-cols-3'
-        : 'grid grid-cols-1 gap-3 sm:grid-cols-2';
+        ? 'grid grid-cols-1 gap-3 sm:grid-cols-4'
+        : 'grid grid-cols-1 gap-3 sm:grid-cols-3';
 
   return (
     <div className='space-y-3'>
@@ -114,6 +118,24 @@ export function InstanceFormFields({
             onChange={(event) => onChange({ ...value, title: event.target.value })}
             placeholder='Leave empty to inherit from service'
           />
+        </div>
+        <div>
+          <Label htmlFor='instance-slug'>Referral slug</Label>
+          <Input
+            id='instance-slug'
+            value={value.slug}
+            disabled={instanceFieldsLocked}
+            onChange={(event) => onChange({ ...value, slug: event.target.value })}
+            onBlur={() => onChange({ ...value, slug: value.slug.trim().toLowerCase() })}
+            placeholder='e.g. spring-workshop'
+            autoComplete='off'
+          />
+          {value.slug.trim() && !INSTANCE_SLUG_PATTERN.test(value.slug.trim().toLowerCase()) ? (
+            <p className='mt-1 text-xs text-red-600'>
+              Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
+              hyphen).
+            </p>
+          ) : null}
         </div>
         <div>
           <Label htmlFor='instance-status'>Status</Label>

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -207,6 +207,7 @@ function parseInstance(value: unknown): ServiceInstance {
       ? (parentTypeRaw as ServiceInstance['parentServiceType'])
       : null,
     title: asNullableString(item.title),
+    slug: asNullableString(item.slug),
     description: asNullableString(item.description),
     coverImageS3Key: asNullableString(item.cover_image_s3_key),
     status: (asNullableString(item.status) ?? 'scheduled') as ServiceInstance['status'],

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4236,6 +4236,8 @@ export interface components {
         };
         CreateInstanceRequest: {
             title?: string | null;
+            /** @description Optional URL-safe slug: lowercase letters, digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized to lowercase. Must be unique among instances when set. */
+            slug?: string | null;
             description?: string | null;
             cover_image_s3_key?: string | null;
             status?: components["schemas"]["InstanceStatus"];

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -191,6 +191,8 @@ export interface ServiceInstance {
   parentServiceTitle: string | null;
   parentServiceType: ServiceType | null;
   title: string | null;
+  /** Lowercase URL slug from Aurora; null when unset. */
+  slug: string | null;
   description: string | null;
   coverImageS3Key: string | null;
   status: InstanceStatus;

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -61,6 +61,7 @@ describe('InstanceDetailPanel', () => {
 
     expect(screen.getByLabelText('Service')).toBeInTheDocument();
     expect(screen.getByLabelText('Location')).toBeInTheDocument();
+    expect(screen.getByLabelText('Referral slug')).toBeDisabled();
     expect(screen.getByLabelText('Title')).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Add instance' })).not.toBeInTheDocument();
   });

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -30,6 +30,7 @@ const INSTANCE_FIXTURE: ServiceInstance = {
   parentServiceTitle: null,
   parentServiceType: null,
   title: null,
+  slug: null,
   description: null,
   coverImageS3Key: null,
   status: 'in_progress',

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3775,6 +3775,12 @@ components:
         title:
           type: string
           nullable: true
+        slug:
+          type: string
+          nullable: true
+          description: >
+            Optional URL-safe slug: lowercase letters, digits, and single hyphens between segments
+            (e.g. spring-workshop). Stored normalized to lowercase. Must be unique among instances when set.
         description:
           type: string
           nullable: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **OpenAPI**: Document optional `slug` on `CreateInstanceRequest` (aligned with existing `ServiceInstance.slug` and backend behavior).
- **Admin web**: Add `slug` to `ServiceInstance` typing and `parseInstance`, default and form state, a **Referral slug** field between **Title** and **Status** (same validation pattern as services), include `slug` in create/update payloads, and sync the instance form when the selected instance data refreshes after save.
- **Tests**: Assert the slug field is present (disabled until a service is selected); extend `ServiceInstance` test fixture.

## Validation

- `npm run lint` (admin_web)
- `npx vitest run` on touched test files
- `bash scripts/validate-cursorrules.sh`

## Notes

Backend and DB already supported instance slugs; this change surfaces them in the admin UI and completes the request schema for generated TypeScript types.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8754a69-e0da-4823-894b-cfa6e77c7a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8754a69-e0da-4823-894b-cfa6e77c7a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

