### PR TITLE
Admin web: reorder instance form fields and locations section

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -10,7 +10,12 @@ import {
   DEFAULT_INSTANCE_FORM,
   DEFAULT_TRAINING_FORM,
 } from './form-defaults';
-import { InstanceFormFields, type InstanceFormState } from './instance-form-fields';
+import {
+  InstanceFormFields,
+  InstancePrimaryLocationField,
+  type InstanceFormState,
+} from './instance-form-fields';
+import { SessionSlotEditor } from './session-slot-editor';
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -24,6 +29,8 @@ import type {
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Button } from '@/components/ui/button';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 
@@ -346,9 +353,54 @@ export function InstanceDetailPanel({
         isLoadingInstructors={isLoadingInstructors}
         onSelectService={handleSelectService}
         onChange={setInstanceForm}
+        primaryLocationPlacement='omit'
+        sessionSlotsPlacement='omit'
       />
+      {effectiveServiceType !== 'training_course' ? (
+        <div>
+          <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
+          <Select
+            id='instance-waitlist'
+            value={instanceForm.waitlistEnabled ? 'true' : 'false'}
+            disabled={typeFieldsLocked}
+            onChange={(event) =>
+              setInstanceForm({
+                ...instanceForm,
+                waitlistEnabled: event.target.value === 'true',
+              })
+            }
+          >
+            <option value='false'>Disabled</option>
+            <option value='true'>Enabled</option>
+          </Select>
+        </div>
+      ) : null}
       {effectiveServiceType === 'training_course' ? (
-        <TrainingFormFields disabled={typeFieldsLocked} value={trainingForm} onChange={setTrainingForm} />
+        <TrainingFormFields
+          disabled={typeFieldsLocked}
+          value={trainingForm}
+          onChange={setTrainingForm}
+          layout='instance-detail'
+          leadingColumn={
+            <>
+              <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
+              <Select
+                id='instance-waitlist'
+                value={instanceForm.waitlistEnabled ? 'true' : 'false'}
+                disabled={typeFieldsLocked}
+                onChange={(event) =>
+                  setInstanceForm({
+                    ...instanceForm,
+                    waitlistEnabled: event.target.value === 'true',
+                  })
+                }
+              >
+                <option value='false'>Disabled</option>
+                <option value='true'>Enabled</option>
+              </Select>
+            </>
+          }
+        />
       ) : null}
       {effectiveServiceType === 'event' ? (
         <EventFormFields disabled={typeFieldsLocked} value={eventForm} onChange={setEventForm} />
@@ -360,6 +412,23 @@ export function InstanceDetailPanel({
           onChange={setConsultationForm}
         />
       ) : null}
+
+      <div className='space-y-3'>
+        <InstancePrimaryLocationField
+          value={instanceForm}
+          locationOptions={locationOptions}
+          isLoadingLocations={isLoadingLocations}
+          disabled={typeFieldsLocked}
+          onChange={setInstanceForm}
+        />
+        <SessionSlotEditor
+          slots={instanceForm.sessionSlots}
+          disabled={typeFieldsLocked}
+          locationOptions={locationOptions}
+          isLoadingLocations={isLoadingLocations}
+          onChange={(sessionSlots) => setInstanceForm({ ...instanceForm, sessionSlots })}
+        />
+      </div>
 
       {locationError ? <AdminInlineError>{locationError}</AdminInlineError> : null}
       {error ? <AdminInlineError>{error}</AdminInlineError> : null}

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
@@ -46,6 +48,69 @@ export interface InstanceFormFieldsProps {
   isLoadingInstructors?: boolean;
   onSelectService?: (serviceId: string | null) => void;
   onChange: (value: InstanceFormState) => void;
+  /**
+   * When `'omit'`, the primary instance location is not shown here; render
+   * `InstancePrimaryLocationField` from the parent where the locations section should appear.
+   * @default 'with-delivery'
+   */
+  primaryLocationPlacement?: 'with-delivery' | 'omit';
+  /**
+   * When `'omit'`, session slots are not shown here; render `SessionSlotEditor` from the parent.
+   * @default 'inline'
+   */
+  sessionSlotsPlacement?: 'inline' | 'omit';
+}
+
+export interface InstancePrimaryLocationFieldProps {
+  value: InstanceFormState;
+  locationOptions?: LocationSummary[];
+  isLoadingLocations?: boolean;
+  disabled?: boolean;
+  onChange: (value: InstanceFormState) => void;
+}
+
+export function InstancePrimaryLocationField({
+  value,
+  locationOptions = [],
+  isLoadingLocations = false,
+  disabled = false,
+  onChange,
+}: InstancePrimaryLocationFieldProps) {
+  const locationExists = locationOptions.some((entry) => entry.id === value.locationId);
+  const selectedLocationValue = locationExists ? value.locationId : value.locationId || '';
+  const hasLocationOptions = locationOptions.length > 0;
+
+  return (
+    <div>
+      <Label htmlFor='instance-location-id'>Location</Label>
+      {hasLocationOptions || isLoadingLocations ? (
+        <Select
+          id='instance-location-id'
+          value={selectedLocationValue}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, locationId: event.target.value })}
+        >
+          <option value=''>
+            {isLoadingLocations ? 'Loading locations...' : 'Select location (optional)'}
+          </option>
+          {value.locationId && !locationExists ? <option value={value.locationId}>{value.locationId}</option> : null}
+          {locationOptions.map((location) => (
+            <option key={location.id} value={location.id}>
+              {formatLocationLabel(location)}
+            </option>
+          ))}
+        </Select>
+      ) : (
+        <Input
+          id='instance-location-id'
+          value={value.locationId}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, locationId: event.target.value })}
+          placeholder='Location UUID'
+        />
+      )}
+    </div>
+  );
 }
 
 function getInstructorOptionLabel(entry: InstanceInstructorOption): string {
@@ -70,12 +135,11 @@ export function InstanceFormFields({
   isLoadingInstructors = false,
   onSelectService,
   onChange,
+  primaryLocationPlacement = 'with-delivery',
+  sessionSlotsPlacement = 'inline',
 }: InstanceFormFieldsProps) {
   const canSelectService = Boolean(onSelectService);
   const serviceExists = serviceOptions.some((entry) => entry.id === serviceId);
-  const locationExists = locationOptions.some((entry) => entry.id === value.locationId);
-  const selectedLocationValue = locationExists ? value.locationId : value.locationId || '';
-  const hasLocationOptions = locationOptions.length > 0;
   const instanceFieldsLocked = canSelectService && !serviceId;
   const instructorExists = instructorOptions.some((entry) => entry.sub === value.instructorId);
 
@@ -164,7 +228,13 @@ export function InstanceFormFields({
           placeholder='Leave empty to inherit from service'
         />
       </div>
-      <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
+      <div
+        className={
+          primaryLocationPlacement === 'with-delivery'
+            ? 'grid grid-cols-1 gap-3 sm:grid-cols-3'
+            : 'grid grid-cols-1 gap-3 sm:grid-cols-2'
+        }
+      >
         <div>
           <Label htmlFor='instance-delivery-mode'>Delivery mode</Label>
           <Select
@@ -181,50 +251,6 @@ export function InstanceFormFields({
             ))}
           </Select>
         </div>
-        <div>
-          <Label htmlFor='instance-location-id'>Location</Label>
-          {hasLocationOptions || isLoadingLocations ? (
-            <Select
-              id='instance-location-id'
-              value={selectedLocationValue}
-              disabled={instanceFieldsLocked}
-              onChange={(event) => onChange({ ...value, locationId: event.target.value })}
-            >
-              <option value=''>
-                {isLoadingLocations ? 'Loading locations...' : 'Select location (optional)'}
-              </option>
-              {value.locationId && !locationExists ? (
-                <option value={value.locationId}>{value.locationId}</option>
-              ) : null}
-              {locationOptions.map((location) => (
-                <option key={location.id} value={location.id}>
-                  {formatLocationLabel(location)}
-                </option>
-              ))}
-            </Select>
-          ) : (
-            <Input
-              id='instance-location-id'
-              value={value.locationId}
-              disabled={instanceFieldsLocked}
-              onChange={(event) => onChange({ ...value, locationId: event.target.value })}
-              placeholder='Location UUID'
-            />
-          )}
-        </div>
-        <div>
-          <Label htmlFor='instance-max-capacity'>Max capacity</Label>
-          <Input
-            id='instance-max-capacity'
-            value={value.maxCapacity}
-            disabled={instanceFieldsLocked}
-            onChange={(event) => onChange({ ...value, maxCapacity: event.target.value })}
-            type='number'
-            placeholder='Unlimited if empty'
-          />
-        </div>
-      </div>
-      <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
         <div>
           <Label htmlFor='instance-instructor-id'>Instructor</Label>
           <Select
@@ -246,20 +272,26 @@ export function InstanceFormFields({
             ))}
           </Select>
         </div>
-        <div>
-          <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
-          <Select
-            id='instance-waitlist'
-            value={value.waitlistEnabled ? 'true' : 'false'}
+        {primaryLocationPlacement === 'with-delivery' ? (
+          <InstancePrimaryLocationField
+            value={value}
+            locationOptions={locationOptions}
+            isLoadingLocations={isLoadingLocations}
             disabled={instanceFieldsLocked}
-            onChange={(event) =>
-              onChange({ ...value, waitlistEnabled: event.target.value === 'true' })
-            }
-          >
-            <option value='false'>Disabled</option>
-            <option value='true'>Enabled</option>
-          </Select>
-        </div>
+            onChange={onChange}
+          />
+        ) : null}
+      </div>
+      <div>
+        <Label htmlFor='instance-max-capacity'>Max capacity</Label>
+        <Input
+          id='instance-max-capacity'
+          value={value.maxCapacity}
+          disabled={instanceFieldsLocked}
+          onChange={(event) => onChange({ ...value, maxCapacity: event.target.value })}
+          type='number'
+          placeholder='Unlimited if empty'
+        />
       </div>
       <div>
         <Label htmlFor='instance-notes'>Notes</Label>
@@ -271,13 +303,15 @@ export function InstanceFormFields({
           rows={2}
         />
       </div>
-      <SessionSlotEditor
-        slots={value.sessionSlots}
-        disabled={instanceFieldsLocked}
-        locationOptions={locationOptions}
-        isLoadingLocations={isLoadingLocations}
-        onChange={(sessionSlots) => onChange({ ...value, sessionSlots })}
-      />
+      {sessionSlotsPlacement === 'inline' ? (
+        <SessionSlotEditor
+          slots={value.sessionSlots}
+          disabled={instanceFieldsLocked}
+          locationOptions={locationOptions}
+          isLoadingLocations={isLoadingLocations}
+          onChange={(sessionSlots) => onChange({ ...value, sessionSlots })}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/admin_web/src/components/admin/services/training-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/training-form-fields.tsx
@@ -21,11 +21,11 @@ export interface TrainingFormFieldsProps {
   disabled?: boolean;
   onChange: (value: TrainingFormState) => void;
   /**
-   * When set with `layout="service-detail"`, renders a single md+ row of four equal
-   * columns: leading column (e.g. delivery mode) plus pricing unit, price, currency.
+   * When set with `layout="service-detail"` or `layout="instance-detail"`, renders a
+   * single md+ row of four equal columns: leading column plus pricing unit, price, currency.
    */
   leadingColumn?: ReactNode;
-  layout?: 'default' | 'service-detail';
+  layout?: 'default' | 'service-detail' | 'instance-detail';
 }
 
 export function TrainingFormFields({
@@ -38,14 +38,16 @@ export function TrainingFormFields({
   const currencyOptions = getCurrencyOptions();
 
   const pricingGridClass =
-    layout === 'service-detail'
+    layout === 'service-detail' || layout === 'instance-detail'
       ? 'grid grid-cols-1 gap-3 md:grid-cols-4'
       : 'grid grid-cols-1 gap-3 sm:grid-cols-3';
 
   return (
     <div className='space-y-3'>
       <div className={pricingGridClass}>
-        {layout === 'service-detail' && leadingColumn ? <div>{leadingColumn}</div> : null}
+        {(layout === 'service-detail' || layout === 'instance-detail') && leadingColumn ? (
+          <div>{leadingColumn}</div>
+        ) : null}
         <div>
           <Label htmlFor='training-pricing-unit'>Pricing unit</Label>
           <Select


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Puts **Instructor** between **Delivery mode** and **Location** in the shared instance form grid.
- On the **Instance** editor card (`InstanceDetailPanel`), moves the **locations** block (primary **Location** plus **Session slots**) to the **bottom of the card**, immediately before the Cancel / Add / Update actions.
- For **training** instances, places **Waitlist enabled** in the **same row** as **Pricing unit** (and default price/currency) using a new `TrainingFormFields` `layout="instance-detail"`.
- For **event** and **consultation** instances, keeps **Waitlist enabled** as its own row after the main instance fields (unchanged behavior aside from locations at the bottom).

## Testing

- `npm run test -- --run tests/components/admin/services/instance-detail-panel.test.tsx`
- `npm run lint`
- `bash scripts/validate-cursorrules.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e02b74f-95e5-45aa-a18c-2f792f8abb94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e02b74f-95e5-45aa-a18c-2f792f8abb94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

