### PR TITLE
Admin web: reorder instance fields and waitlist with pricing

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 
 import { FormDialog } from '@/components/ui/form-dialog';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
 
 import type { components } from '@/types/generated/admin-api.generated';
 import type { ServiceType } from '@/types/services';
@@ -107,9 +109,35 @@ export function CreateInstanceDialog({
       onClose={onClose}
       onSubmit={handleSubmit}
     >
-      <InstanceFormFields value={instanceForm} onChange={setInstanceForm} />
+      <InstanceFormFields
+        value={instanceForm}
+        onChange={setInstanceForm}
+        omitWaitlistField={serviceType === 'training_course'}
+      />
       {serviceType === 'training_course' ? (
-        <TrainingFormFields value={trainingForm} onChange={setTrainingForm} />
+        <TrainingFormFields
+          value={trainingForm}
+          onChange={setTrainingForm}
+          layout='service-detail'
+          prePricingUnitColumn={
+            <>
+              <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
+              <Select
+                id='instance-waitlist'
+                value={instanceForm.waitlistEnabled ? 'true' : 'false'}
+                onChange={(event) =>
+                  setInstanceForm((prev) => ({
+                    ...prev,
+                    waitlistEnabled: event.target.value === 'true',
+                  }))
+                }
+              >
+                <option value='false'>Disabled</option>
+                <option value='true'>Enabled</option>
+              </Select>
+            </>
+          }
+        />
       ) : null}
       {serviceType === 'event' ? <EventFormFields value={eventForm} onChange={setEventForm} /> : null}
       {serviceType === 'consultation' ? (

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -24,6 +24,8 @@ import type {
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Button } from '@/components/ui/button';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 
@@ -344,11 +346,36 @@ export function InstanceDetailPanel({
         isLoadingLocations={isLoadingLocations}
         instructorOptions={instructorUsers}
         isLoadingInstructors={isLoadingInstructors}
+        omitWaitlistField={effectiveServiceType === 'training_course'}
         onSelectService={handleSelectService}
         onChange={setInstanceForm}
       />
       {effectiveServiceType === 'training_course' ? (
-        <TrainingFormFields disabled={typeFieldsLocked} value={trainingForm} onChange={setTrainingForm} />
+        <TrainingFormFields
+          disabled={typeFieldsLocked}
+          value={trainingForm}
+          onChange={setTrainingForm}
+          layout='service-detail'
+          prePricingUnitColumn={
+            <>
+              <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
+              <Select
+                id='instance-waitlist'
+                value={instanceForm.waitlistEnabled ? 'true' : 'false'}
+                disabled={typeFieldsLocked}
+                onChange={(event) =>
+                  setInstanceForm((prev) => ({
+                    ...prev,
+                    waitlistEnabled: event.target.value === 'true',
+                  }))
+                }
+              >
+                <option value='false'>Disabled</option>
+                <option value='true'>Enabled</option>
+              </Select>
+            </>
+          }
+        />
       ) : null}
       {effectiveServiceType === 'event' ? (
         <EventFormFields disabled={typeFieldsLocked} value={eventForm} onChange={setEventForm} />

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -44,6 +44,8 @@ export interface InstanceFormFieldsProps {
   isLoadingLocations?: boolean;
   instructorOptions?: InstanceInstructorOption[];
   isLoadingInstructors?: boolean;
+  /** When true, the waitlist control is omitted (shown next to training pricing instead). */
+  omitWaitlistField?: boolean;
   onSelectService?: (serviceId: string | null) => void;
   onChange: (value: InstanceFormState) => void;
 }
@@ -68,6 +70,7 @@ export function InstanceFormFields({
   isLoadingLocations = false,
   instructorOptions = [],
   isLoadingInstructors = false,
+  omitWaitlistField = false,
   onSelectService,
   onChange,
 }: InstanceFormFieldsProps) {
@@ -182,6 +185,27 @@ export function InstanceFormFields({
           </Select>
         </div>
         <div>
+          <Label htmlFor='instance-instructor-id'>Instructor</Label>
+          <Select
+            id='instance-instructor-id'
+            value={value.instructorId}
+            disabled={instanceFieldsLocked || isLoadingInstructors}
+            onChange={(event) => onChange({ ...value, instructorId: event.target.value })}
+          >
+            <option value=''>
+              {isLoadingInstructors ? 'Loading instructors...' : 'None'}
+            </option>
+            {value.instructorId.trim() && !instructorExists ? (
+              <option value={value.instructorId}>{value.instructorId}</option>
+            ) : null}
+            {instructorOptions.map((entry) => (
+              <option key={entry.sub} value={entry.sub}>
+                {getInstructorOptionLabel(entry)}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div>
           <Label htmlFor='instance-location-id'>Location</Label>
           {hasLocationOptions || isLoadingLocations ? (
             <Select
@@ -212,6 +236,8 @@ export function InstanceFormFields({
             />
           )}
         </div>
+      </div>
+      <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
         <div>
           <Label htmlFor='instance-max-capacity'>Max capacity</Label>
           <Input
@@ -223,43 +249,22 @@ export function InstanceFormFields({
             placeholder='Unlimited if empty'
           />
         </div>
-      </div>
-      <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
-        <div>
-          <Label htmlFor='instance-instructor-id'>Instructor</Label>
-          <Select
-            id='instance-instructor-id'
-            value={value.instructorId}
-            disabled={instanceFieldsLocked || isLoadingInstructors}
-            onChange={(event) => onChange({ ...value, instructorId: event.target.value })}
-          >
-            <option value=''>
-              {isLoadingInstructors ? 'Loading instructors...' : 'None'}
-            </option>
-            {value.instructorId.trim() && !instructorExists ? (
-              <option value={value.instructorId}>{value.instructorId}</option>
-            ) : null}
-            {instructorOptions.map((entry) => (
-              <option key={entry.sub} value={entry.sub}>
-                {getInstructorOptionLabel(entry)}
-              </option>
-            ))}
-          </Select>
-        </div>
-        <div>
-          <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
-          <Select
-            id='instance-waitlist'
-            value={value.waitlistEnabled ? 'true' : 'false'}
-            disabled={instanceFieldsLocked}
-            onChange={(event) =>
-              onChange({ ...value, waitlistEnabled: event.target.value === 'true' })
-            }
-          >
-            <option value='false'>Disabled</option>
-            <option value='true'>Enabled</option>
-          </Select>
-        </div>
+        {omitWaitlistField ? null : (
+          <div>
+            <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
+            <Select
+              id='instance-waitlist'
+              value={value.waitlistEnabled ? 'true' : 'false'}
+              disabled={instanceFieldsLocked}
+              onChange={(event) =>
+                onChange({ ...value, waitlistEnabled: event.target.value === 'true' })
+              }
+            >
+              <option value='false'>Disabled</option>
+              <option value='true'>Enabled</option>
+            </Select>
+          </div>
+        )}
       </div>
       <div>
         <Label htmlFor='instance-notes'>Notes</Label>

--- a/apps/admin_web/src/components/admin/services/training-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/training-form-fields.tsx
@@ -21,10 +21,13 @@ export interface TrainingFormFieldsProps {
   disabled?: boolean;
   onChange: (value: TrainingFormState) => void;
   /**
-   * When set with `layout="service-detail"`, renders a single md+ row of four equal
-   * columns: leading column (e.g. delivery mode) plus pricing unit, price, currency.
+   * When set with `layout="service-detail"`, renders a single md+ row of equal
+   * columns: optional leading column (e.g. delivery mode), optional column before
+   * pricing unit, then pricing unit, default price, and currency.
    */
   leadingColumn?: ReactNode;
+  /** Renders immediately before the pricing unit column when `layout="service-detail"`. */
+  prePricingUnitColumn?: ReactNode;
   layout?: 'default' | 'service-detail';
 }
 
@@ -33,19 +36,29 @@ export function TrainingFormFields({
   disabled = false,
   onChange,
   leadingColumn,
+  prePricingUnitColumn,
   layout = 'default',
 }: TrainingFormFieldsProps) {
   const currencyOptions = getCurrencyOptions();
 
+  const hasLeading = layout === 'service-detail' && Boolean(leadingColumn);
+  const hasPrePricing = layout === 'service-detail' && Boolean(prePricingUnitColumn);
+  const serviceDetailColumnCount = (hasLeading ? 1 : 0) + (hasPrePricing ? 1 : 0) + 3;
+
   const pricingGridClass =
     layout === 'service-detail'
-      ? 'grid grid-cols-1 gap-3 md:grid-cols-4'
+      ? serviceDetailColumnCount <= 3
+        ? 'grid grid-cols-1 gap-3 sm:grid-cols-3'
+        : serviceDetailColumnCount === 4
+          ? 'grid grid-cols-1 gap-3 md:grid-cols-4'
+          : 'grid grid-cols-1 gap-3 md:grid-cols-5'
       : 'grid grid-cols-1 gap-3 sm:grid-cols-3';
 
   return (
     <div className='space-y-3'>
       <div className={pricingGridClass}>
-        {layout === 'service-detail' && leadingColumn ? <div>{leadingColumn}</div> : null}
+        {hasLeading ? <div>{leadingColumn}</div> : null}
+        {hasPrePricing ? <div>{prePricingUnitColumn}</div> : null}
         <div>
           <Label htmlFor='training-pricing-unit'>Pricing unit</Label>
           <Select


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Places **Instructor** between **Delivery mode** and **Location** on the instance form.
- For **training** instances, moves **Waitlist enabled** into the same responsive row as **Pricing unit** (and default price/currency) by extending `TrainingFormFields` with an optional column before pricing.
- **Event** and **consultation** instances keep waitlist with max capacity in a two-column row (waitlist was removed from its old position next to instructor).

## Testing

- `npm run lint` (admin_web)
- `npx vitest run tests/components/admin/services/instance-detail-panel.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-997e03cf-2db3-479c-b3a7-6773528e6b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-997e03cf-2db3-479c-b3a7-6773528e6b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

