### PR TITLE
Admin web: instance form row layout (delivery, location, capacity, Whitelist)

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -3,8 +3,6 @@
 import { useState } from 'react';
 
 import { FormDialog } from '@/components/ui/form-dialog';
-import { Label } from '@/components/ui/label';
-import { Select } from '@/components/ui/select';
 
 import type { components } from '@/types/generated/admin-api.generated';
 import type { ServiceType } from '@/types/services';
@@ -112,31 +110,12 @@ export function CreateInstanceDialog({
       <InstanceFormFields
         value={instanceForm}
         onChange={setInstanceForm}
-        omitWaitlistField={serviceType === 'training_course'}
       />
       {serviceType === 'training_course' ? (
         <TrainingFormFields
           value={trainingForm}
           onChange={setTrainingForm}
           layout='service-detail'
-          prePricingUnitColumn={
-            <>
-              <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
-              <Select
-                id='instance-waitlist'
-                value={instanceForm.waitlistEnabled ? 'true' : 'false'}
-                onChange={(event) =>
-                  setInstanceForm((prev) => ({
-                    ...prev,
-                    waitlistEnabled: event.target.value === 'true',
-                  }))
-                }
-              >
-                <option value='false'>Disabled</option>
-                <option value='true'>Enabled</option>
-              </Select>
-            </>
-          }
         />
       ) : null}
       {serviceType === 'event' ? <EventFormFields value={eventForm} onChange={setEventForm} /> : null}

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -24,8 +24,6 @@ import type {
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Button } from '@/components/ui/button';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
-import { Label } from '@/components/ui/label';
-import { Select } from '@/components/ui/select';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 
@@ -346,7 +344,6 @@ export function InstanceDetailPanel({
         isLoadingLocations={isLoadingLocations}
         instructorOptions={instructorUsers}
         isLoadingInstructors={isLoadingInstructors}
-        omitWaitlistField={effectiveServiceType === 'training_course'}
         onSelectService={handleSelectService}
         onChange={setInstanceForm}
       />
@@ -356,25 +353,6 @@ export function InstanceDetailPanel({
           value={trainingForm}
           onChange={setTrainingForm}
           layout='service-detail'
-          prePricingUnitColumn={
-            <>
-              <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
-              <Select
-                id='instance-waitlist'
-                value={instanceForm.waitlistEnabled ? 'true' : 'false'}
-                disabled={typeFieldsLocked}
-                onChange={(event) =>
-                  setInstanceForm((prev) => ({
-                    ...prev,
-                    waitlistEnabled: event.target.value === 'true',
-                  }))
-                }
-              >
-                <option value='false'>Disabled</option>
-                <option value='true'>Enabled</option>
-              </Select>
-            </>
-          }
         />
       ) : null}
       {effectiveServiceType === 'event' ? (

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -44,8 +44,6 @@ export interface InstanceFormFieldsProps {
   isLoadingLocations?: boolean;
   instructorOptions?: InstanceInstructorOption[];
   isLoadingInstructors?: boolean;
-  /** When true, the waitlist control is omitted (shown next to training pricing instead). */
-  omitWaitlistField?: boolean;
   onSelectService?: (serviceId: string | null) => void;
   onChange: (value: InstanceFormState) => void;
 }
@@ -70,7 +68,6 @@ export function InstanceFormFields({
   isLoadingLocations = false,
   instructorOptions = [],
   isLoadingInstructors = false,
-  omitWaitlistField = false,
   onSelectService,
   onChange,
 }: InstanceFormFieldsProps) {
@@ -167,7 +164,7 @@ export function InstanceFormFields({
           placeholder='Leave empty to inherit from service'
         />
       </div>
-      <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
+      <div className='grid grid-cols-1 gap-3 sm:grid-cols-4'>
         <div>
           <Label htmlFor='instance-delivery-mode'>Delivery mode</Label>
           <Select
@@ -180,27 +177,6 @@ export function InstanceFormFields({
             {SERVICE_DELIVERY_MODES.map((entry) => (
               <option key={entry} value={entry}>
                 {formatEnumLabel(entry)}
-              </option>
-            ))}
-          </Select>
-        </div>
-        <div>
-          <Label htmlFor='instance-instructor-id'>Instructor</Label>
-          <Select
-            id='instance-instructor-id'
-            value={value.instructorId}
-            disabled={instanceFieldsLocked || isLoadingInstructors}
-            onChange={(event) => onChange({ ...value, instructorId: event.target.value })}
-          >
-            <option value=''>
-              {isLoadingInstructors ? 'Loading instructors...' : 'None'}
-            </option>
-            {value.instructorId.trim() && !instructorExists ? (
-              <option value={value.instructorId}>{value.instructorId}</option>
-            ) : null}
-            {instructorOptions.map((entry) => (
-              <option key={entry.sub} value={entry.sub}>
-                {getInstructorOptionLabel(entry)}
               </option>
             ))}
           </Select>
@@ -236,8 +212,6 @@ export function InstanceFormFields({
             />
           )}
         </div>
-      </div>
-      <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
         <div>
           <Label htmlFor='instance-max-capacity'>Max capacity</Label>
           <Input
@@ -249,22 +223,41 @@ export function InstanceFormFields({
             placeholder='Unlimited if empty'
           />
         </div>
-        {omitWaitlistField ? null : (
-          <div>
-            <Label htmlFor='instance-waitlist'>Waitlist enabled</Label>
-            <Select
-              id='instance-waitlist'
-              value={value.waitlistEnabled ? 'true' : 'false'}
-              disabled={instanceFieldsLocked}
-              onChange={(event) =>
-                onChange({ ...value, waitlistEnabled: event.target.value === 'true' })
-              }
-            >
-              <option value='false'>Disabled</option>
-              <option value='true'>Enabled</option>
-            </Select>
-          </div>
-        )}
+        <div>
+          <Label htmlFor='instance-waitlist'>Whitelist</Label>
+          <Select
+            id='instance-waitlist'
+            value={value.waitlistEnabled ? 'true' : 'false'}
+            disabled={instanceFieldsLocked}
+            onChange={(event) =>
+              onChange({ ...value, waitlistEnabled: event.target.value === 'true' })
+            }
+          >
+            <option value='false'>Disabled</option>
+            <option value='true'>Enabled</option>
+          </Select>
+        </div>
+      </div>
+      <div>
+        <Label htmlFor='instance-instructor-id'>Instructor</Label>
+        <Select
+          id='instance-instructor-id'
+          value={value.instructorId}
+          disabled={instanceFieldsLocked || isLoadingInstructors}
+          onChange={(event) => onChange({ ...value, instructorId: event.target.value })}
+        >
+          <option value=''>
+            {isLoadingInstructors ? 'Loading instructors...' : 'None'}
+          </option>
+          {value.instructorId.trim() && !instructorExists ? (
+            <option value={value.instructorId}>{value.instructorId}</option>
+          ) : null}
+          {instructorOptions.map((entry) => (
+            <option key={entry.sub} value={entry.sub}>
+              {getInstructorOptionLabel(entry)}
+            </option>
+          ))}
+        </Select>
       </div>
       <div>
         <Label htmlFor='instance-notes'>Notes</Label>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Instance form** (`InstanceFormFields`): One `sm:grid-cols-4` row with **Delivery mode**, **Location**, **Max capacity**, and the waitlist toggle labeled **Whitelist** (same `instance-waitlist` id for tests/accessibility).
- **Instructor** moved to its own full-width row below that row (swapped with the former waitlist row position relative to the four-field row).
- **Training instances**: Removed the duplicate waitlist control from `TrainingFormFields` `prePricingUnitColumn` in both `InstanceDetailPanel` and `CreateInstanceDialog`; waitlist is only in `InstanceFormFields` now.
- Removed the `omitWaitlistField` prop (no longer needed).

## Validation

- `npm run test -- tests/components/admin/services/instance-detail-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9f85489-e4fd-4ffc-bf38-5fb76e5f735f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9f85489-e4fd-4ffc-bf38-5fb76e5f735f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

