### PR TITLE
Admin web: instructor on same row as instance training pricing

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -15,7 +15,11 @@ import {
   DEFAULT_INSTANCE_FORM,
   DEFAULT_TRAINING_FORM,
 } from './form-defaults';
-import { InstanceFormFields, type InstanceFormState } from './instance-form-fields';
+import {
+  InstanceFormFields,
+  InstanceInstructorField,
+  type InstanceFormState,
+} from './instance-form-fields';
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
 type ApiSchemas = components['schemas'];
@@ -109,6 +113,7 @@ export function CreateInstanceDialog({
     >
       <InstanceFormFields
         value={instanceForm}
+        hideInstructorField={serviceType === 'training_course'}
         onChange={setInstanceForm}
       />
       {serviceType === 'training_course' ? (
@@ -116,6 +121,14 @@ export function CreateInstanceDialog({
           value={trainingForm}
           onChange={setTrainingForm}
           layout='service-detail'
+          prePricingUnitColumn={
+            <InstanceInstructorField
+              value={instanceForm.instructorId}
+              onChange={(instructorId) =>
+                setInstanceForm((prev) => ({ ...prev, instructorId }))
+              }
+            />
+          }
         />
       ) : null}
       {serviceType === 'event' ? <EventFormFields value={eventForm} onChange={setEventForm} /> : null}

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -10,7 +10,11 @@ import {
   DEFAULT_INSTANCE_FORM,
   DEFAULT_TRAINING_FORM,
 } from './form-defaults';
-import { InstanceFormFields, type InstanceFormState } from './instance-form-fields';
+import {
+  InstanceFormFields,
+  InstanceInstructorField,
+  type InstanceFormState,
+} from './instance-form-fields';
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -342,6 +346,7 @@ export function InstanceDetailPanel({
         serviceOptions={serviceOptions}
         locationOptions={locationOptions}
         isLoadingLocations={isLoadingLocations}
+        hideInstructorField={effectiveServiceType === 'training_course'}
         instructorOptions={instructorUsers}
         isLoadingInstructors={isLoadingInstructors}
         onSelectService={handleSelectService}
@@ -353,6 +358,17 @@ export function InstanceDetailPanel({
           value={trainingForm}
           onChange={setTrainingForm}
           layout='service-detail'
+          prePricingUnitColumn={
+            <InstanceInstructorField
+              value={instanceForm.instructorId}
+              disabled={typeFieldsLocked}
+              instructorOptions={instructorUsers}
+              isLoadingInstructors={isLoadingInstructors}
+              onChange={(instructorId) =>
+                setInstanceForm((prev) => ({ ...prev, instructorId }))
+              }
+            />
+          }
         />
       ) : null}
       {effectiveServiceType === 'event' ? (

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -42,6 +42,8 @@ export interface InstanceFormFieldsProps {
   serviceOptions?: ServiceSummary[];
   locationOptions?: LocationSummary[];
   isLoadingLocations?: boolean;
+  /** When true, omit the instructor field (shown beside training pricing instead). */
+  hideInstructorField?: boolean;
   instructorOptions?: InstanceInstructorOption[];
   isLoadingInstructors?: boolean;
   onSelectService?: (serviceId: string | null) => void;
@@ -60,12 +62,51 @@ function getInstructorOptionLabel(entry: InstanceInstructorOption): string {
   return entry.sub;
 }
 
+export interface InstanceInstructorFieldProps {
+  value: string;
+  disabled?: boolean;
+  instructorOptions?: InstanceInstructorOption[];
+  isLoadingInstructors?: boolean;
+  onChange: (instructorId: string) => void;
+}
+
+/** Instructor select for instance flows; pairs with `TrainingFormFields` `prePricingUnitColumn`. */
+export function InstanceInstructorField({
+  value,
+  disabled = false,
+  instructorOptions = [],
+  isLoadingInstructors = false,
+  onChange,
+}: InstanceInstructorFieldProps) {
+  const instructorExists = instructorOptions.some((entry) => entry.sub === value);
+  return (
+    <div>
+      <Label htmlFor='instance-instructor-id'>Instructor</Label>
+      <Select
+        id='instance-instructor-id'
+        value={value}
+        disabled={disabled || isLoadingInstructors}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        <option value=''>{isLoadingInstructors ? 'Loading instructors...' : 'None'}</option>
+        {value.trim() && !instructorExists ? <option value={value}>{value}</option> : null}
+        {instructorOptions.map((entry) => (
+          <option key={entry.sub} value={entry.sub}>
+            {getInstructorOptionLabel(entry)}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
 export function InstanceFormFields({
   value,
   serviceId = null,
   serviceOptions = [],
   locationOptions = [],
   isLoadingLocations = false,
+  hideInstructorField = false,
   instructorOptions = [],
   isLoadingInstructors = false,
   onSelectService,
@@ -77,7 +118,6 @@ export function InstanceFormFields({
   const selectedLocationValue = locationExists ? value.locationId : value.locationId || '';
   const hasLocationOptions = locationOptions.length > 0;
   const instanceFieldsLocked = canSelectService && !serviceId;
-  const instructorExists = instructorOptions.some((entry) => entry.sub === value.instructorId);
 
   const topRowClass =
     canSelectService && !instanceFieldsLocked
@@ -238,27 +278,15 @@ export function InstanceFormFields({
           </Select>
         </div>
       </div>
-      <div>
-        <Label htmlFor='instance-instructor-id'>Instructor</Label>
-        <Select
-          id='instance-instructor-id'
+      {!hideInstructorField ? (
+        <InstanceInstructorField
           value={value.instructorId}
-          disabled={instanceFieldsLocked || isLoadingInstructors}
-          onChange={(event) => onChange({ ...value, instructorId: event.target.value })}
-        >
-          <option value=''>
-            {isLoadingInstructors ? 'Loading instructors...' : 'None'}
-          </option>
-          {value.instructorId.trim() && !instructorExists ? (
-            <option value={value.instructorId}>{value.instructorId}</option>
-          ) : null}
-          {instructorOptions.map((entry) => (
-            <option key={entry.sub} value={entry.sub}>
-              {getInstructorOptionLabel(entry)}
-            </option>
-          ))}
-        </Select>
-      </div>
+          disabled={instanceFieldsLocked}
+          instructorOptions={instructorOptions}
+          isLoadingInstructors={isLoadingInstructors}
+          onChange={(instructorId) => onChange({ ...value, instructorId })}
+        />
+      ) : null}
       <div>
         <Label htmlFor='instance-notes'>Notes</Label>
         <Textarea

--- a/apps/admin_web/src/components/admin/services/training-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/training-form-fields.tsx
@@ -23,7 +23,7 @@ export interface TrainingFormFieldsProps {
   /**
    * When set with `layout="service-detail"`, renders a single md+ row of equal
    * columns: optional leading column (e.g. delivery mode), optional column before
-   * pricing unit, then pricing unit, default price, and currency.
+   * pricing unit (e.g. instance instructor), then pricing unit, price, and currency.
    */
   leadingColumn?: ReactNode;
   /** Renders immediately before the pricing unit column when `layout="service-detail"`. */
@@ -51,7 +51,9 @@ export function TrainingFormFields({
         ? 'grid grid-cols-1 gap-3 sm:grid-cols-3'
         : serviceDetailColumnCount === 4
           ? 'grid grid-cols-1 gap-3 md:grid-cols-4'
-          : 'grid grid-cols-1 gap-3 md:grid-cols-5'
+          : serviceDetailColumnCount === 5
+            ? 'grid grid-cols-1 gap-3 md:grid-cols-5'
+            : 'grid grid-cols-1 gap-3 md:grid-cols-6'
       : 'grid grid-cols-1 gap-3 sm:grid-cols-3';
 
   return (
@@ -77,7 +79,7 @@ export function TrainingFormFields({
           </Select>
         </div>
         <div>
-          <Label htmlFor='training-default-price'>Default price</Label>
+          <Label htmlFor='training-default-price'>Price</Label>
           <Input
             id='training-default-price'
             value={value.defaultPrice}

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -168,7 +168,7 @@ describe('InstanceDetailPanel', () => {
     expect(screen.getByLabelText('Description')).toHaveValue('Service body');
     expect(screen.getByLabelText('Delivery mode')).toHaveValue('hybrid');
     expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
-    expect(screen.getByLabelText('Default price')).toHaveValue('199.00');
+    expect(screen.getByLabelText('Price')).toHaveValue('199.00');
     expect(screen.getByLabelText('Currency')).toHaveValue('USD');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- For training-course instances, the instructor select is rendered in the same responsive grid row as Pricing unit, Price (renamed from Default price), and Currency, using `TrainingFormFields` `prePricingUnitColumn` with a shared `InstanceInstructorField` component.
- Event and consultation instances keep the instructor field in `InstanceFormFields` (with `hideInstructorField` when training pricing row owns instructor).
- `TrainingFormFields` service-detail layout supports six columns when both `leadingColumn` and `prePricingUnitColumn` are set (unchanged for service editor; instances use instructor + three pricing columns).

## Testing

- `npm run lint` (admin_web)
- `npx vitest run tests/components/admin/services/instance-detail-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b8a7723-df4d-4871-bb52-53da99eeea7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b8a7723-df4d-4871-bb52-53da99eeea7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

