### PR TITLE
Admin: inherit event category on instances; 1/4-width instructor

### DIFF
--- a/apps/admin_web/src/components/admin/services/event-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/event-form-fields.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { formatEnumLabel } from '@/lib/format';
@@ -17,11 +18,16 @@ export interface EventFormFieldsProps {
   value: EventFormState;
   disabled?: boolean;
   onChange: (value: EventFormState) => void;
+  /** When true, category is shown read-only (inherited from parent service). */
+  categoryReadOnly?: boolean;
+  /** Optional id for the category control (read-only input or select). */
+  categoryFieldId?: string;
   /**
    * With `layout="service-detail"`, renders one md+ row: optional `leadingColumn`,
    * event category, then `trailingSlot` (typically booking + cover as two grid cells).
+   * With `layout="instance-detail"`, category spans three quarters and `trailingSlot` one quarter on large screens.
    */
-  layout?: 'default' | 'service-detail';
+  layout?: 'default' | 'service-detail' | 'instance-detail';
   leadingColumn?: ReactNode;
   trailingSlot?: ReactNode;
 }
@@ -30,15 +36,27 @@ export function EventFormFields({
   value,
   disabled = false,
   onChange,
+  categoryReadOnly = false,
+  categoryFieldId = 'event-category',
   layout = 'default',
   leadingColumn,
   trailingSlot,
 }: EventFormFieldsProps) {
-  const categoryField = (
+  const categoryField = categoryReadOnly ? (
     <div>
-      <Label htmlFor='event-category'>Event category</Label>
+      <Label htmlFor={categoryFieldId}>Event category</Label>
+      <Input
+        id={categoryFieldId}
+        readOnly
+        value={formatEnumLabel(value.eventCategory)}
+        className='bg-slate-50 text-slate-700'
+      />
+    </div>
+  ) : (
+    <div>
+      <Label htmlFor={categoryFieldId}>Event category</Label>
       <Select
-        id='event-category'
+        id={categoryFieldId}
         value={value.eventCategory}
         disabled={disabled}
         onChange={(event) => onChange({ eventCategory: event.target.value as EventCategory })}
@@ -58,6 +76,16 @@ export function EventFormFields({
         {leadingColumn ? <div>{leadingColumn}</div> : null}
         {categoryField}
         {trailingSlot}
+      </div>
+    );
+  }
+
+  if (layout === 'instance-detail') {
+    return (
+      <div className='grid grid-cols-1 gap-3 lg:grid-cols-12'>
+        {leadingColumn ? <div className='lg:col-span-12'>{leadingColumn}</div> : null}
+        <div className='lg:col-span-9'>{categoryField}</div>
+        {trailingSlot ? <div className='lg:col-span-3'>{trailingSlot}</div> : null}
       </div>
     );
   }

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -18,11 +18,13 @@ import {
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
 import type { components } from '@/types/generated/admin-api.generated';
-import type {
-  LocationSummary,
-  ServiceInstance,
-  ServiceSummary,
-  ServiceType,
+import {
+  normalizeEventCategoryFromApi,
+  type EventCategory,
+  type LocationSummary,
+  type ServiceInstance,
+  type ServiceSummary,
+  type ServiceType,
 } from '@/types/services';
 
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -64,6 +66,31 @@ function mergeServiceIntoInstanceForm(
     description: service.description ?? '',
     deliveryMode: service.deliveryMode,
   };
+}
+
+function mergeServiceIntoEventForm(prev: EventFormState, service: ServiceSummary): EventFormState {
+  if (service.serviceType !== 'event') {
+    return prev;
+  }
+  return {
+    ...prev,
+    eventCategory: service.eventDetails?.eventCategory ?? 'workshop',
+  };
+}
+
+function resolveInheritedEventCategory(
+  selectedService: ServiceSummary | null,
+  instance: ServiceInstance | null
+): EventCategory {
+  const fromService = selectedService?.eventDetails?.eventCategory;
+  if (fromService) {
+    return fromService;
+  }
+  const tierName = instance?.eventTicketTiers?.[0]?.name;
+  if (tierName) {
+    return normalizeEventCategoryFromApi(tierName);
+  }
+  return 'workshop';
 }
 
 function mergeServiceIntoTrainingForm(
@@ -158,6 +185,7 @@ export function InstanceDetailPanel({
       onSelectService(serviceId);
       if (!serviceId) {
         lastMergedServiceIdForCreateRef.current = null;
+        setEventForm(DEFAULT_EVENT_FORM);
         return;
       }
       const svc = serviceOptions.find((entry) => entry.id === serviceId);
@@ -167,6 +195,7 @@ export function InstanceDetailPanel({
       lastMergedServiceIdForCreateRef.current = serviceId;
       setInstanceForm((prev) => mergeServiceIntoInstanceForm(prev, svc));
       setTrainingForm((prev) => mergeServiceIntoTrainingForm(prev, svc));
+      setEventForm((prev) => mergeServiceIntoEventForm(prev, svc));
     },
     [onSelectService, serviceOptions]
   );
@@ -186,6 +215,7 @@ export function InstanceDetailPanel({
     queueMicrotask(() => {
       setInstanceForm((prev) => mergeServiceIntoInstanceForm(prev, svc));
       setTrainingForm((prev) => mergeServiceIntoTrainingForm(prev, svc));
+      setEventForm((prev) => mergeServiceIntoEventForm(prev, svc));
     });
   }, [instance, selectedServiceId, serviceOptions]);
 
@@ -213,7 +243,10 @@ export function InstanceDetailPanel({
         defaultCurrency: instance.trainingDetails?.currency ?? defaultCurrencyCode,
       });
       setEventForm({
-        eventCategory: 'workshop',
+        eventCategory: resolveInheritedEventCategory(
+          serviceOptions.find((entry) => entry.id === instance.serviceId) ?? null,
+          instance
+        ),
       });
       setConsultationForm({
         consultationFormat: 'one_on_one',
@@ -227,7 +260,7 @@ export function InstanceDetailPanel({
         calendlyUrl: instance.consultationDetails?.calendlyEventUrl ?? '',
       });
     });
-  }, [instance]);
+  }, [instance, serviceOptions]);
 
   const selectedService =
     serviceOptions.find((entry) => entry.id === selectedServiceId) ?? null;
@@ -264,9 +297,10 @@ export function InstanceDetailPanel({
         pricing_unit: trainingForm.pricingUnit,
       };
     } else if (effectiveServiceType === 'event') {
+      const eventCategory = resolveInheritedEventCategory(selectedService, instance);
       payload.event_ticket_tiers = [
         {
-          name: eventForm.eventCategory,
+          name: eventCategory,
           description: null,
           price: '0',
           currency: defaultCurrencyCode,
@@ -346,7 +380,9 @@ export function InstanceDetailPanel({
         serviceOptions={serviceOptions}
         locationOptions={locationOptions}
         isLoadingLocations={isLoadingLocations}
-        hideInstructorField={effectiveServiceType === 'training_course'}
+        hideInstructorField={
+          effectiveServiceType === 'training_course' || effectiveServiceType === 'event'
+        }
         instructorOptions={instructorUsers}
         isLoadingInstructors={isLoadingInstructors}
         onSelectService={handleSelectService}
@@ -372,7 +408,25 @@ export function InstanceDetailPanel({
         />
       ) : null}
       {effectiveServiceType === 'event' ? (
-        <EventFormFields disabled={typeFieldsLocked} value={eventForm} onChange={setEventForm} />
+        <EventFormFields
+          disabled={typeFieldsLocked}
+          value={eventForm}
+          onChange={setEventForm}
+          categoryReadOnly
+          categoryFieldId='instance-event-category'
+          layout='instance-detail'
+          trailingSlot={
+            <InstanceInstructorField
+              value={instanceForm.instructorId}
+              disabled={typeFieldsLocked}
+              instructorOptions={instructorUsers}
+              isLoadingInstructors={isLoadingInstructors}
+              onChange={(instructorId) =>
+                setInstanceForm((prev) => ({ ...prev, instructorId }))
+              }
+            />
+          }
+        />
       ) : null}
       {effectiveServiceType === 'consultation' ? (
         <ConsultationFormFields

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -65,6 +65,7 @@ function getInstructorOptionLabel(entry: InstanceInstructorOption): string {
 export interface InstanceInstructorFieldProps {
   value: string;
   disabled?: boolean;
+  className?: string;
   instructorOptions?: InstanceInstructorOption[];
   isLoadingInstructors?: boolean;
   onChange: (instructorId: string) => void;
@@ -74,13 +75,14 @@ export interface InstanceInstructorFieldProps {
 export function InstanceInstructorField({
   value,
   disabled = false,
+  className,
   instructorOptions = [],
   isLoadingInstructors = false,
   onChange,
 }: InstanceInstructorFieldProps) {
   const instructorExists = instructorOptions.some((entry) => entry.sub === value);
   return (
-    <div>
+    <div className={className}>
       <Label htmlFor='instance-instructor-id'>Instructor</Label>
       <Select
         id='instance-instructor-id'

--- a/apps/admin_web/src/components/admin/services/training-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/training-form-fields.tsx
@@ -44,23 +44,37 @@ export function TrainingFormFields({
   const hasLeading = layout === 'service-detail' && Boolean(leadingColumn);
   const hasPrePricing = layout === 'service-detail' && Boolean(prePricingUnitColumn);
   const serviceDetailColumnCount = (hasLeading ? 1 : 0) + (hasPrePricing ? 1 : 0) + 3;
+  const useQuarterInstructorRow =
+    layout === 'service-detail' && hasPrePricing && !hasLeading;
 
   const pricingGridClass =
     layout === 'service-detail'
-      ? serviceDetailColumnCount <= 3
-        ? 'grid grid-cols-1 gap-3 sm:grid-cols-3'
-        : serviceDetailColumnCount === 4
-          ? 'grid grid-cols-1 gap-3 md:grid-cols-4'
-          : serviceDetailColumnCount === 5
-            ? 'grid grid-cols-1 gap-3 md:grid-cols-5'
-            : 'grid grid-cols-1 gap-3 md:grid-cols-6'
+      ? useQuarterInstructorRow
+        ? 'grid grid-cols-1 gap-3 lg:grid-cols-12'
+        : serviceDetailColumnCount <= 3
+          ? 'grid grid-cols-1 gap-3 sm:grid-cols-3'
+          : serviceDetailColumnCount === 4
+            ? 'grid grid-cols-1 gap-3 md:grid-cols-4'
+            : serviceDetailColumnCount === 5
+              ? 'grid grid-cols-1 gap-3 md:grid-cols-5'
+              : 'grid grid-cols-1 gap-3 md:grid-cols-6'
       : 'grid grid-cols-1 gap-3 sm:grid-cols-3';
+
+  const pricingFieldsWrapperClass = useQuarterInstructorRow ? 'lg:col-span-9' : undefined;
+  const prePricingWrapperClass = useQuarterInstructorRow ? 'lg:col-span-3' : undefined;
+  const innerThreeColClass = useQuarterInstructorRow
+    ? 'grid grid-cols-1 gap-3 sm:grid-cols-3 lg:contents'
+    : undefined;
 
   return (
     <div className='space-y-3'>
       <div className={pricingGridClass}>
         {hasLeading ? <div>{leadingColumn}</div> : null}
-        {hasPrePricing ? <div>{prePricingUnitColumn}</div> : null}
+        {hasPrePricing ? (
+          <div className={prePricingWrapperClass}>{prePricingUnitColumn}</div>
+        ) : null}
+        <div className={pricingFieldsWrapperClass}>
+          <div className={innerThreeColClass}>
         <div>
           <Label htmlFor='training-pricing-unit'>Pricing unit</Label>
           <Select
@@ -102,6 +116,8 @@ export function TrainingFormFields({
               </option>
             ))}
           </Select>
+        </div>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -12,6 +12,7 @@ import { isRecord } from './type-guards';
 import type { components } from '@/types/generated/admin-api.generated';
 import {
   normalizeDiscountTypeFromApi,
+  normalizeEventCategoryFromApi,
   type DiscountCode,
   type DiscountCodeFilters,
   type Enrollment,
@@ -116,6 +117,7 @@ function parseGeographicAreaSummary(value: unknown): GeographicAreaSummary {
 function parseServiceSummary(value: unknown): ServiceSummary {
   const item = isRecord(value) ? value : {};
   const trainingRaw = isRecord(item.training_details) ? item.training_details : null;
+  const eventRaw = isRecord(item.event_details) ? item.event_details : null;
   return {
     id: asNullableString(item.id) ?? '',
     serviceType: (asNullableString(item.service_type) ?? 'training_course') as ServiceSummary['serviceType'],
@@ -137,6 +139,11 @@ function parseServiceSummary(value: unknown): ServiceSummary {
           defaultCurrency: asNullableString(trainingRaw.default_currency),
         }
       : null,
+    eventDetails: eventRaw
+      ? {
+          eventCategory: normalizeEventCategoryFromApi(eventRaw.event_category),
+        }
+      : null,
   };
 }
 
@@ -153,8 +160,7 @@ function parseServiceDetail(value: unknown): ServiceDetail {
     : null;
   const eventDetails = isRecord(item.event_details)
     ? {
-        eventCategory: (asNullableString(item.event_details.event_category) ??
-          'workshop') as NonNullable<ServiceDetail['eventDetails']>['eventCategory'],
+        eventCategory: normalizeEventCategoryFromApi(item.event_details.event_category),
       }
     : null;
   const consultationDetails = isRecord(item.consultation_details)

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4084,6 +4084,8 @@ export interface components {
             updated_at?: string | null;
             /** @description Present for training_course rows when details exist. */
             training_details?: components["schemas"]["ServiceTrainingDetails"] | null;
+            /** @description Present for event rows when details exist. */
+            event_details?: components["schemas"]["ServiceEventDetails"] | null;
         };
         Service: components["schemas"]["ServiceSummary"] & {
             tag_ids?: string[];

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -36,6 +36,20 @@ export const EVENT_CATEGORIES = defineEnumValues<EventCategory>()(
   ['workshop', 'webinar', 'open_house', 'community_meetup', 'other'] as const satisfies readonly EventCategory[]
 );
 
+const EVENT_CATEGORY_SET = new Set<string>(EVENT_CATEGORIES);
+
+/**
+ * Map API `event_category` to a value that matches `<option value>` entries.
+ * Unknown values fall back to `workshop`.
+ */
+export function normalizeEventCategoryFromApi(raw: unknown): EventCategory {
+  if (typeof raw !== 'string') {
+    return 'workshop';
+  }
+  const normalized = raw.trim().toLowerCase();
+  return EVENT_CATEGORY_SET.has(normalized) ? (normalized as EventCategory) : 'workshop';
+}
+
 export type ConsultationFormat = ApiSchemas['ConsultationFormat'];
 export const CONSULTATION_FORMATS = defineEnumValues<ConsultationFormat>()(
   ['one_on_one', 'group'] as const satisfies readonly ConsultationFormat[]
@@ -99,6 +113,9 @@ export interface ServiceSummary {
     pricingUnit: TrainingPricingUnit;
     defaultPrice: string | null;
     defaultCurrency: string | null;
+  } | null;
+  eventDetails: {
+    eventCategory: EventCategory;
   } | null;
 }
 

--- a/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
@@ -59,6 +59,7 @@ describe('DiscountCodesPanel', () => {
       defaultPrice: '100',
       defaultCurrency: 'HKD',
     },
+    eventDetails: null,
   };
 
   it('includes service and instance selects and sends scope in create payload', async () => {

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -20,6 +20,7 @@ function buildServiceSummary(overrides: Partial<ServiceSummary> = {}): ServiceSu
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     trainingDetails: null,
+    eventDetails: null,
     ...overrides,
   };
 }
@@ -170,5 +171,54 @@ describe('InstanceDetailPanel', () => {
     expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
     expect(screen.getByLabelText('Price')).toHaveValue('199.00');
     expect(screen.getByLabelText('Currency')).toHaveValue('USD');
+  });
+
+  it('inherits event category from the selected service and omits category select for event instances', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InstanceDetailPanel
+        instance={null}
+        selectedServiceId='evt-svc'
+        serviceOptions={[
+          buildServiceSummary({
+            id: 'evt-svc',
+            serviceType: 'event',
+            title: 'Spring open house',
+            trainingDetails: null,
+            eventDetails: { eventCategory: 'open_house' },
+          }),
+        ]}
+        locationOptions={[buildLocationSummary()]}
+        isLoadingLocations={false}
+        serviceType='event'
+        isLoading={false}
+        error=''
+        onSelectService={vi.fn()}
+        onCancelSelection={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Event category')).toHaveValue('Open House');
+    });
+    expect(screen.queryByRole('combobox', { name: 'Event category' })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Instructor')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Add instance' }));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      'evt-svc',
+      expect.objectContaining({
+        event_ticket_tiers: [
+          expect.objectContaining({
+            name: 'open_house',
+          }),
+        ],
+      })
+    );
   });
 });

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -22,6 +22,7 @@ const SERVICE_FIXTURE: ServiceSummary = {
   createdAt: '2026-03-01T10:00:00Z',
   updatedAt: '2026-03-01T10:00:00Z',
   trainingDetails: null,
+  eventDetails: null,
 };
 
 const INSTANCE_FIXTURE: ServiceInstance = {

--- a/apps/admin_web/tests/lib/services-api.test.ts
+++ b/apps/admin_web/tests/lib/services-api.test.ts
@@ -89,6 +89,45 @@ describe('services-api', () => {
     expect(request.endpointPath).toContain('limit=10');
   });
 
+  it('maps event_details on service list rows when present', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: 'service-event-1',
+            service_type: 'event',
+            title: 'Open day',
+            description: null,
+            cover_image_s3_key: null,
+            delivery_mode: 'in_person',
+            status: 'published',
+            created_by: 'admin-1',
+            created_at: '2026-03-01T00:00:00.000Z',
+            updated_at: '2026-03-01T00:00:00.000Z',
+            training_details: null,
+            event_details: { event_category: 'open_house' },
+          },
+        ],
+        next_cursor: null,
+        total_count: 1,
+      },
+    });
+
+    const result = await listServices({
+      serviceType: 'event',
+      status: 'published',
+      search: '',
+      cursor: null,
+      limit: 20,
+    });
+
+    expect(result.items[0]).toMatchObject({
+      id: 'service-event-1',
+      serviceType: 'event',
+      eventDetails: { eventCategory: 'open_house' },
+    });
+  });
+
   it('creates cover-image upload URL and maps response', async () => {
     mockAdminApiRequest.mockResolvedValueOnce({
       data: {

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -34,6 +34,14 @@ def _training_details_summary(service: Service) -> dict[str, Any] | None:
     }
 
 
+def _event_details_summary(service: Service) -> dict[str, Any] | None:
+    """Return event category for list/summary payloads when present."""
+    details = service.event_details
+    if details is None:
+        return None
+    return {"event_category": details.event_category.value}
+
+
 def serialize_service_summary(service: Service) -> dict[str, Any]:
     """Serialize service list row payload."""
     logger.debug("Serializing service summary", extra={"service_id": str(service.id)})
@@ -51,6 +59,7 @@ def serialize_service_summary(service: Service) -> dict[str, Any]:
         "created_at": service.created_at.isoformat() if service.created_at else None,
         "updated_at": service.updated_at.isoformat() if service.updated_at else None,
         "training_details": _training_details_summary(service),
+        "event_details": _event_details_summary(service),
     }
 
 
@@ -66,9 +75,7 @@ def serialize_service_detail(service: Service) -> dict[str, Any]:
     if service.training_course_details is not None:
         detail["training_details"] = _training_details_summary(service)
     if service.event_details is not None:
-        detail["event_details"] = {
-            "event_category": service.event_details.event_category.value
-        }
+        detail["event_details"] = _event_details_summary(service)
     if service.consultation_details is not None:
         detail["consultation_details"] = {
             "consultation_format": service.consultation_details.consultation_format.value,

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3417,6 +3417,11 @@ components:
             - $ref: "#/components/schemas/ServiceTrainingDetails"
           nullable: true
           description: Present for training_course rows when details exist.
+        event_details:
+          allOf:
+            - $ref: "#/components/schemas/ServiceEventDetails"
+          nullable: true
+          description: Present for event rows when details exist.
     Service:
       allOf:
         - $ref: "#/components/schemas/ServiceSummary"

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -137,7 +137,8 @@ their primary responsibilities.
   vendor management, expense invoice ingestion/listing/amendment/void/pay flows
   (mark-paid requires vendor, invoice date, currency, and total), and admin-user
   listing for lead assignment and instructor-group listing for service instances
-  (service list items may include nullable `training_details` for training courses),
+  (service list items may include nullable `training_details` for training courses
+  and nullable `event_details` for events),
   grant management,
   stable share-link lifecycle (read/create/rotate/revoke + domain allowlist
   policy), share-link source-domain enforcement, conditional JWT


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Event instances:** Event category is no longer user-selectable. It is shown read-only and comes from the parent service’s `event_details.event_category`. Create/update payloads use that value for the default `event_ticket_tiers[0].name` (same behavior as before, but always aligned with the service).
- **API:** `GET /v1/admin/services` list rows now include optional `event_details` for event services so the admin client can read the category without fetching full service detail.
- **Layout:** For event instances, instructor sits in **one quarter** of the row (large screens) next to the read-only category. Training instances with instructor beside pricing use the same **1/4 instructor + 3/4 pricing** split when there is no delivery-mode column in that row.

## Tests

- `npm run check:admin-api-types && npm run lint && npm test` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
- `pre-commit run ruff-format` on the touched Python file

## Notes

- If `event_details` is missing on a legacy list response, edit mode falls back to normalizing the first ticket tier `name` when possible, otherwise `workshop`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d588685c-d252-46bb-9eb3-1709e4b7236f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d588685c-d252-46bb-9eb3-1709e4b7236f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

