### PR TITLE
Admin web: instance location dropdown shows venues and partner locations only

### DIFF
--- a/apps/admin_web/src/hooks/use-location-list.ts
+++ b/apps/admin_web/src/hooks/use-location-list.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { listAllLocations } from '@/lib/services-api';
+import { listAllVenueAndPartnerLocations } from '@/lib/services-api';
 
 import type { LocationSummary } from '@/types/services';
 
@@ -17,7 +17,7 @@ export function useLocationList() {
     setIsLoading(true);
     setError('');
     try {
-      const items = await listAllLocations();
+      const items = await listAllVenueAndPartnerLocations();
       setLocations(items);
     } catch (err) {
       setError(toErrorMessage(err, 'Failed to load locations.'));

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -375,6 +375,50 @@ export async function listAllLocations(signal?: AbortSignal): Promise<LocationSu
   return all;
 }
 
+/**
+ * Locations suitable for service instances: standalone venues (not used as a
+ * family or non-partner org address) plus any location linked to an active
+ * partner organisation (those may be excluded from the venue-only query).
+ */
+export async function listAllVenueAndPartnerLocations(signal?: AbortSignal): Promise<LocationSummary[]> {
+  const byId = new Map<string, LocationSummary>();
+
+  let venueCursor: string | null = null;
+  do {
+    const page = await listLocations(
+      {
+        cursor: venueCursor,
+        limit: 100,
+        excludeAddresses: true,
+      },
+      signal
+    );
+    for (const loc of page.items) {
+      byId.set(loc.id, loc);
+    }
+    venueCursor = page.nextCursor;
+  } while (venueCursor);
+
+  let allCursor: string | null = null;
+  do {
+    const page = await listLocations(
+      {
+        cursor: allCursor,
+        limit: 100,
+      },
+      signal
+    );
+    for (const loc of page.items) {
+      if (loc.partnerOrganizationLabels.length > 0) {
+        byId.set(loc.id, loc);
+      }
+    }
+    allCursor = page.nextCursor;
+  } while (allCursor);
+
+  return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
 export interface GeocodeLocationResult {
   lat: number;
   lng: number;

--- a/apps/admin_web/tests/lib/services-api.test.ts
+++ b/apps/admin_web/tests/lib/services-api.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/lib/api-admin-client', async () => {
 import {
   createServiceCoverImageUpload,
   listDiscountCodes,
+  listAllVenueAndPartnerLocations,
   listLocations,
   listServices,
 } from '@/lib/services-api';
@@ -235,5 +236,67 @@ describe('services-api', () => {
         endpointPath: '/v1/admin/locations?limit=50&exclude_addresses=true',
       })
     );
+  });
+
+  it('listAllVenueAndPartnerLocations merges exclude_addresses pages with partner-labelled locations', async () => {
+    const venueRow = {
+      id: '00000000-0000-0000-0000-000000000002',
+      name: 'Hall',
+      area_id: '00000000-0000-0000-0000-000000000001',
+      address: '2 Rd',
+      lat: null,
+      lng: null,
+      created_at: null,
+      updated_at: null,
+      locked_from_partner_org: false,
+      partner_organization_labels: [],
+    };
+    const partnerOnlyRow = {
+      id: '00000000-0000-0000-0000-000000000003',
+      name: 'Partner HQ',
+      area_id: '00000000-0000-0000-0000-000000000001',
+      address: '3 Rd',
+      lat: null,
+      lng: null,
+      created_at: null,
+      updated_at: null,
+      locked_from_partner_org: true,
+      partner_organization_labels: ['Acme Partner'],
+    };
+
+    mockAdminApiRequest
+      .mockResolvedValueOnce({
+        data: {
+          items: [venueRow],
+          next_cursor: null,
+          total_count: 1,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          items: [partnerOnlyRow, venueRow],
+          next_cursor: null,
+          total_count: 2,
+        },
+      });
+
+    const merged = await listAllVenueAndPartnerLocations();
+
+    expect(mockAdminApiRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        endpointPath: '/v1/admin/locations?limit=100&exclude_addresses=true',
+      })
+    );
+    expect(mockAdminApiRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        endpointPath: '/v1/admin/locations?limit=100',
+      })
+    );
+    expect(merged.map((l) => l.id)).toEqual([
+      '00000000-0000-0000-0000-000000000002',
+      '00000000-0000-0000-0000-000000000003',
+    ]);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Services **Instances** editor loads locations through `useLocationList`, which previously called `listAllLocations` and listed every location in the system.

## Change

- Added `listAllVenueAndPartnerLocations` in `apps/admin_web/src/lib/services-api.ts`, which:
  - Pages through `GET /v1/admin/locations` with `exclude_addresses=true` (same definition as the Venues tab: not used as venue by a non-archived family or organisation).
  - Merges in any location from a full list pass that has non-empty `partner_organization_labels` (active partner CRM organisations), so partner-linked venues still appear even when they are excluded from the venue-only query.
- `useLocationList` now uses this helper so **Instance** and **Session slots** location dropdowns share the filtered set.

## Tests

- Extended `tests/lib/services-api.test.ts` with a focused case for the merge behaviour.

## Notes

`listAllLocations` is unchanged for other callers (e.g. contacts).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-292c7ace-098d-491a-9101-3f3a02ad76b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-292c7ace-098d-491a-9101-3f3a02ad76b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

