### PR TITLE
feat(admin_web): compact PhoneField for contacts grid

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -635,6 +635,19 @@ export function ContactsPanel({
               />
             </div>
             <div>
+              <PhoneField
+                variant='compact'
+                combinedLabel='Phone number'
+                regionLabel='Phone country / region'
+                nationalLabel='Phone number (national digits)'
+                region={phoneRegion}
+                national={phoneNational}
+                onRegionChange={setPhoneRegion}
+                onNationalChange={setPhoneNational}
+                nationalInputId='crm-contact-phone-national'
+              />
+            </div>
+            <div>
               <Label htmlFor='crm-contact-ig'>Instagram</Label>
               <Input
                 id='crm-contact-ig'
@@ -653,16 +666,6 @@ export function ContactsPanel({
               />
             </div>
           </div>
-
-          <PhoneField
-            region={phoneRegion}
-            national={phoneNational}
-            onRegionChange={setPhoneRegion}
-            onNationalChange={setPhoneNational}
-            regionLabel='Phone country / region'
-            nationalLabel='Phone number (national digits)'
-            nationalInputId='crm-contact-phone-national'
-          />
 
           <div className='space-y-4'>
             <div className='grid grid-cols-1 gap-4 lg:grid-cols-4 lg:items-end'>

--- a/apps/admin_web/src/components/ui/phone-field.tsx
+++ b/apps/admin_web/src/components/ui/phone-field.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { useId } from 'react';
+import { useId, useMemo } from 'react';
+import { clsx } from 'clsx';
 
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { PHONE_COUNTRIES } from '@/lib/phone-countries.generated';
+
+type PhoneCountryRow = (typeof PHONE_COUNTRIES)[number];
 
 export interface PhoneFieldProps {
   region: string;
@@ -15,6 +18,41 @@ export interface PhoneFieldProps {
   regionLabel: string;
   nationalLabel: string;
   nationalInputId?: string;
+  variant?: 'default' | 'compact';
+  combinedLabel?: string;
+  className?: string;
+}
+
+function buildDedupedByDialCode(): PhoneCountryRow[] {
+  const seenDial = new Set<string>();
+  const out: PhoneCountryRow[] = [];
+  for (const row of PHONE_COUNTRIES) {
+    if (seenDial.has(row.dialCode)) {
+      continue;
+    }
+    seenDial.add(row.dialCode);
+    out.push(row);
+  }
+  return out;
+}
+
+function buildCompactSelectRows(region: string): PhoneCountryRow[] {
+  const deduped = buildDedupedByDialCode();
+  const canonicalRegions = new Set(deduped.map((r) => r.region));
+
+  if (!region || canonicalRegions.has(region)) {
+    return deduped;
+  }
+
+  const direct = PHONE_COUNTRIES.find((r) => r.region === region);
+  if (direct) {
+    return [direct, ...deduped];
+  }
+
+  if (typeof console !== 'undefined' && console.warn) {
+    console.warn('PhoneField: unknown phone_region not found in PHONE_COUNTRIES', region);
+  }
+  return [{ region, dialCode: '', englishName: region }, ...deduped];
 }
 
 export function PhoneField({
@@ -25,31 +63,75 @@ export function PhoneField({
   regionLabel,
   nationalLabel,
   nationalInputId,
+  variant = 'default',
+  combinedLabel,
+  className,
 }: PhoneFieldProps) {
   const autoId = useId();
   const regionId = `${autoId}-region`;
   const nationalId = nationalInputId ?? `${autoId}-national`;
 
+  const compactSelectRows = useMemo((): PhoneCountryRow[] => {
+    if (variant !== 'compact') {
+      return [];
+    }
+    return buildCompactSelectRows(region);
+  }, [variant, region]);
+
+  if (variant === 'default') {
+    return (
+      <div className={clsx('grid gap-3 sm:grid-cols-2 sm:gap-4', className)}>
+        <div className='space-y-1.5'>
+          <Label htmlFor={regionId}>{regionLabel}</Label>
+          <Select id={regionId} value={region} onChange={(event) => onRegionChange(event.target.value)}>
+            {PHONE_COUNTRIES.map((row) => (
+              <option key={row.region} value={row.region}>
+                {row.englishName} (+{row.dialCode})
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className='space-y-1.5'>
+          <Label htmlFor={nationalId}>{nationalLabel}</Label>
+          <Input
+            id={nationalId}
+            type='tel'
+            inputMode='numeric'
+            autoComplete='tel-national'
+            value={national}
+            onChange={(event) => onNationalChange(event.target.value)}
+            onBlur={() => onNationalChange(national.replace(/\D/g, ''))}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const visibleLabel = combinedLabel ?? nationalLabel;
+
   return (
-    <div className='grid gap-3 sm:grid-cols-2 sm:gap-4'>
-      <div className='space-y-1.5'>
-        <Label htmlFor={regionId}>{regionLabel}</Label>
+    <div className={clsx('space-y-1.5', className)}>
+      <Label htmlFor={nationalId}>{visibleLabel}</Label>
+      <div className='flex items-stretch gap-2'>
         <Select
-          id={regionId}
+          aria-label={regionLabel}
           value={region}
           onChange={(event) => onRegionChange(event.target.value)}
+          className='basis-1/4 shrink-0 min-w-0'
         >
-          {PHONE_COUNTRIES.map((row) => (
-            <option key={row.region} value={row.region}>
-              {row.englishName} (+{row.dialCode})
-            </option>
-          ))}
+          {compactSelectRows.map((row) => {
+            const isDrift = row.dialCode === '' && !PHONE_COUNTRIES.some((p) => p.region === row.region);
+            const label = isDrift ? row.region : `+${row.dialCode}`;
+            return (
+              <option key={`${row.region}-${row.dialCode}`} value={row.region} title={row.englishName}>
+                {label}
+              </option>
+            );
+          })}
         </Select>
-      </div>
-      <div className='space-y-1.5'>
-        <Label htmlFor={nationalId}>{nationalLabel}</Label>
         <Input
           id={nationalId}
+          className='flex-1 min-w-0'
           type='tel'
           inputMode='numeric'
           autoComplete='tel-national'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add an opt-in `compact` variant to `PhoneField` with deduped dial-code options (first occurrence in `PHONE_COUNTRIES` wins), `+{dialCode}` option text, `title` for full English name, `aria-label` on the country select, and synthetic options when the saved `region` is not in the deduped list or missing from generated data (with `console.warn` for unknown regions).
- Reorder the contacts editor grid to **Email → Phone → Instagram → Date of birth** and embed the compact phone field in the second cell; remove the standalone phone block.

## Testing

- `npm run lint` (admin_web)
- `npx vitest run tests/components/admin/contacts/`
- `bash scripts/validate-cursorrules.sh`

## Notes

- Default `PhoneField` behavior is unchanged for other consumers (e.g. sales flows).
- No API or backend changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50d8c302-4070-409a-84a3-337d73ec645f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50d8c302-4070-409a-84a3-337d73ec645f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

