### PR TITLE
Services admin: event defaults, partners, external URL, Calendly removal

### DIFF
--- a/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
@@ -17,37 +17,50 @@ export interface ConsultationFormState {
   defaultPackagePrice: string;
   defaultPackageSessions: string;
   defaultCurrency: string;
-  calendlyUrl: string;
 }
 
-export interface ConsultationFormFieldsProps {
+export interface ConsultationServicePanelFieldsProps {
   value: ConsultationFormState;
   disabled?: boolean;
   onChange: (value: ConsultationFormState) => void;
 }
 
-export function ConsultationFormFields({ value, disabled = false, onChange }: ConsultationFormFieldsProps) {
-  const currencyOptions = getCurrencyOptions();
-
+/** Row C type anchor: consultation format only. */
+export function ConsultationServiceFormatField({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
   return (
-    <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
-      <div>
-        <Label htmlFor='consultation-format'>Consultation format</Label>
-        <Select
-          id='consultation-format'
-          value={value.consultationFormat}
-          disabled={disabled}
-          onChange={(event) =>
-            onChange({ ...value, consultationFormat: event.target.value as ConsultationFormat })
-          }
-        >
-          {CONSULTATION_FORMATS.map((entry) => (
-            <option key={entry} value={entry}>
-              {formatEnumLabel(entry)}
-            </option>
-          ))}
-        </Select>
-      </div>
+    <div>
+      <Label htmlFor='consultation-format'>Consultation format</Label>
+      <Select
+        id='consultation-format'
+        value={value.consultationFormat}
+        disabled={disabled}
+        onChange={(event) =>
+          onChange({ ...value, consultationFormat: event.target.value as ConsultationFormat })
+        }
+      >
+        {CONSULTATION_FORMATS.map((entry) => (
+          <option key={entry} value={entry}>
+            {formatEnumLabel(entry)}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
+/** Row D: pricing model, hourly rate, currency, package sessions. */
+export function ConsultationServiceRowDFields({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  const currencyOptions = getCurrencyOptions();
+  return (
+    <>
       <div>
         <Label htmlFor='consultation-pricing-model'>Pricing model</Label>
         <Select
@@ -66,48 +79,12 @@ export function ConsultationFormFields({ value, disabled = false, onChange }: Co
         </Select>
       </div>
       <div>
-        <Label htmlFor='consultation-max-group-size'>Max group size</Label>
-        <Input
-          id='consultation-max-group-size'
-          value={value.maxGroupSize}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, maxGroupSize: event.target.value })}
-        />
-      </div>
-      <div>
-        <Label htmlFor='consultation-duration-minutes'>Duration minutes</Label>
-        <Input
-          id='consultation-duration-minutes'
-          value={value.durationMinutes}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, durationMinutes: event.target.value })}
-        />
-      </div>
-      <div>
-        <Label htmlFor='consultation-hourly-rate'>Default hourly rate</Label>
+        <Label htmlFor='consultation-hourly-rate'>Hourly rate</Label>
         <Input
           id='consultation-hourly-rate'
           value={value.defaultHourlyRate}
           disabled={disabled}
           onChange={(event) => onChange({ ...value, defaultHourlyRate: event.target.value })}
-        />
-      </div>
-      <div>
-        <Label htmlFor='consultation-package-price'>Default package price</Label>
-        <Input
-          id='consultation-package-price'
-          value={value.defaultPackagePrice}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, defaultPackagePrice: event.target.value })}
-        />
-      </div>
-      <div>
-        <Label htmlFor='consultation-package-sessions'>Default package sessions</Label>
-        <Input
-          id='consultation-package-sessions'
-          value={value.defaultPackageSessions}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, defaultPackageSessions: event.target.value })}
         />
       </div>
       <div>
@@ -125,15 +102,260 @@ export function ConsultationFormFields({ value, disabled = false, onChange }: Co
           ))}
         </Select>
       </div>
-      <div className='sm:col-span-2'>
-        <Label htmlFor='consultation-calendly-url'>Calendly URL</Label>
+      <div>
+        <Label htmlFor='consultation-package-sessions'>Package sessions</Label>
         <Input
-          id='consultation-calendly-url'
-          value={value.calendlyUrl}
+          id='consultation-package-sessions'
+          value={value.defaultPackageSessions}
           disabled={disabled}
-          onChange={(event) => onChange({ ...value, calendlyUrl: event.target.value })}
+          onChange={(event) => onChange({ ...value, defaultPackageSessions: event.target.value })}
         />
+      </div>
+    </>
+  );
+}
+
+/** Row E: max group size, duration, package price, empty cell. */
+export function ConsultationServiceRowEFields({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  return (
+    <>
+      <div>
+        <Label htmlFor='consultation-max-group-size'>Max group size</Label>
+        <Input
+          id='consultation-max-group-size'
+          value={value.maxGroupSize}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, maxGroupSize: event.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor='consultation-duration-minutes'>Duration (minutes)</Label>
+        <Input
+          id='consultation-duration-minutes'
+          value={value.durationMinutes}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, durationMinutes: event.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor='consultation-package-price'>Package price</Label>
+        <Input
+          id='consultation-package-price'
+          value={value.defaultPackagePrice}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, defaultPackagePrice: event.target.value })}
+        />
+      </div>
+      <div aria-hidden className='hidden md:block' />
+    </>
+  );
+}
+
+/** Per-row grids for service detail panel (parent supplies Row C booking + cover). */
+export function ConsultationServicePanelFields(props: ConsultationServicePanelFieldsProps) {
+  return (
+    <div className='space-y-3'>
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+        <ConsultationServiceFormatField {...props} />
+      </div>
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+        <ConsultationServiceRowDFields {...props} />
+      </div>
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+        <ConsultationServiceRowEFields {...props} />
       </div>
     </div>
   );
 }
+
+/** Full stacked form for create-instance dialog and similar. */
+export function ConsultationFormFieldsStacked({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  const currencyOptions = getCurrencyOptions();
+  return (
+    <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+      <ConsultationServiceFormatField value={value} disabled={disabled} onChange={onChange} />
+      <div>
+        <Label htmlFor='dialog-consultation-pricing-model'>Pricing model</Label>
+        <Select
+          id='dialog-consultation-pricing-model'
+          value={value.pricingModel}
+          disabled={disabled}
+          onChange={(event) =>
+            onChange({ ...value, pricingModel: event.target.value as ConsultationPricingModel })
+          }
+        >
+          {CONSULTATION_PRICING_MODELS.map((entry) => (
+            <option key={entry} value={entry}>
+              {formatEnumLabel(entry)}
+            </option>
+          ))}
+        </Select>
+      </div>
+      <div>
+        <Label htmlFor='dialog-consultation-max-group'>Max group size</Label>
+        <Input
+          id='dialog-consultation-max-group'
+          value={value.maxGroupSize}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, maxGroupSize: event.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor='dialog-consultation-duration'>Duration (minutes)</Label>
+        <Input
+          id='dialog-consultation-duration'
+          value={value.durationMinutes}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, durationMinutes: event.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor='dialog-consultation-hourly'>Hourly rate</Label>
+        <Input
+          id='dialog-consultation-hourly'
+          value={value.defaultHourlyRate}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, defaultHourlyRate: event.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor='dialog-consultation-pkg-price'>Package price</Label>
+        <Input
+          id='dialog-consultation-pkg-price'
+          value={value.defaultPackagePrice}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, defaultPackagePrice: event.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor='dialog-consultation-pkg-sessions'>Package sessions</Label>
+        <Input
+          id='dialog-consultation-pkg-sessions'
+          value={value.defaultPackageSessions}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, defaultPackageSessions: event.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor='dialog-consultation-currency'>Currency</Label>
+        <Select
+          id='dialog-consultation-currency'
+          value={value.defaultCurrency}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
+        >
+          {currencyOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+export interface ConsultationInstancePanelFieldsProps {
+  value: ConsultationFormState;
+  disabled?: boolean;
+  onChange: (value: ConsultationFormState) => void;
+}
+
+/** Instance Row D: pricing model, hourly rate, currency (parent adds instructor as col 1). */
+export function ConsultationInstanceRowDFields({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationInstancePanelFieldsProps) {
+  const currencyOptions = getCurrencyOptions();
+  return (
+    <>
+      <div>
+        <Label htmlFor='instance-consultation-pricing-model'>Pricing model</Label>
+        <Select
+          id='instance-consultation-pricing-model'
+          value={value.pricingModel}
+          disabled={disabled}
+          onChange={(event) =>
+            onChange({ ...value, pricingModel: event.target.value as ConsultationPricingModel })
+          }
+        >
+          {CONSULTATION_PRICING_MODELS.map((entry) => (
+            <option key={entry} value={entry}>
+              {formatEnumLabel(entry)}
+            </option>
+          ))}
+        </Select>
+      </div>
+      <div>
+        <Label htmlFor='instance-consultation-hourly-rate'>Hourly rate</Label>
+        <Input
+          id='instance-consultation-hourly-rate'
+          value={value.defaultHourlyRate}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, defaultHourlyRate: event.target.value })}
+        />
+      </div>
+      <div>
+        <Label htmlFor='instance-consultation-currency'>Currency</Label>
+        <Select
+          id='instance-consultation-currency'
+          value={value.defaultCurrency}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
+        >
+          {currencyOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </div>
+    </>
+  );
+}
+
+/** Instance Row E: package sessions only. */
+export function ConsultationInstanceRowEFields({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationInstancePanelFieldsProps) {
+  return (
+    <>
+      <div>
+        <Label htmlFor='instance-consultation-package-sessions'>Package sessions</Label>
+        <Input
+          id='instance-consultation-package-sessions'
+          value={value.defaultPackageSessions}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, defaultPackageSessions: event.target.value })}
+        />
+      </div>
+      <div aria-hidden className='hidden md:col-span-3 md:block' />
+    </>
+  );
+}
+
+export function ConsultationInstancePanelFields(props: ConsultationInstancePanelFieldsProps) {
+  return (
+    <div className='space-y-3'>
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+        <ConsultationInstanceRowDFields {...props} />
+      </div>
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+        <ConsultationInstanceRowEFields {...props} />
+      </div>
+    </div>
+  );
+}
+
+export const ConsultationFormFields = ConsultationFormFieldsStacked;

--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -8,7 +8,12 @@ import type { components } from '@/types/generated/admin-api.generated';
 import type { ServiceType } from '@/types/services';
 
 import { ConsultationFormFields, type ConsultationFormState } from './consultation-form-fields';
-import { EventFormFields, type EventFormState } from './event-form-fields';
+import {
+  EventCategoryControl,
+  EventDefaultCurrencyControl,
+  EventDefaultPriceControl,
+  type EventFormState,
+} from './event-form-fields';
 import {
   DEFAULT_CONSULTATION_FORM,
   DEFAULT_EVENT_FORM,
@@ -50,6 +55,8 @@ export function CreateInstanceDialog({
     DEFAULT_CONSULTATION_FORM
   );
 
+  const eventPriceMissing = serviceType === 'event' && !eventForm.defaultPrice.trim();
+
   const handleSubmit = async () => {
     const slugTrimmed = instanceForm.slug.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
@@ -88,8 +95,8 @@ export function CreateInstanceDialog({
         {
           name: eventForm.eventCategory,
           description: null,
-          price: priceStr.length ? priceStr : null,
-          currency: currencyStr.length ? currencyStr : null,
+          price: priceStr,
+          currency: currencyStr || 'HKD',
           max_quantity: null,
           sort_order: 0,
         },
@@ -114,6 +121,7 @@ export function CreateInstanceDialog({
       isLoading={isLoading}
       error={error}
       submitLabel='Create instance'
+      submitDisabled={eventPriceMissing}
       onClose={onClose}
       onSubmit={handleSubmit}
     >
@@ -129,14 +137,26 @@ export function CreateInstanceDialog({
           <div className='sm:col-span-1' />
         </div>
       ) : null}
+      {serviceType === 'consultation' || serviceType === 'event' ? (
+        <div className='mt-3'>
+          <InstanceInstructorField
+            value={instanceForm.instructorId}
+            onChange={(instructorId) =>
+              setInstanceForm((prev) => ({ ...prev, instructorId }))
+            }
+          />
+        </div>
+      ) : null}
       {serviceType === 'training_course' ? (
         <div className='mt-3'>
           <TrainingFormFields value={trainingForm} onChange={setTrainingForm} />
         </div>
       ) : null}
       {serviceType === 'event' ? (
-        <div className='mt-3'>
-          <EventFormFields value={eventForm} onChange={setEventForm} />
+        <div className='mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3'>
+          <EventCategoryControl value={eventForm} onChange={setEventForm} categoryFieldId='dialog-event-category' />
+          <EventDefaultPriceControl value={eventForm} onChange={setEventForm} />
+          <EventDefaultCurrencyControl value={eventForm} onChange={setEventForm} />
         </div>
       ) : null}
       {serviceType === 'event' ? (

--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -15,11 +15,13 @@ import {
   DEFAULT_INSTANCE_FORM,
   DEFAULT_TRAINING_FORM,
 } from './form-defaults';
+import { EventInstancePartnersField } from './event-instance-partners-field';
 import {
   InstanceFormFields,
   InstanceInstructorField,
   type InstanceFormState,
 } from './instance-form-fields';
+import { SessionSlotEditor } from './session-slot-editor';
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
 type ApiSchemas = components['schemas'];
@@ -61,6 +63,9 @@ export function CreateInstanceDialog({
       waitlist_enabled: instanceForm.waitlistEnabled,
       instructor_id: instanceForm.instructorId.trim() || null,
       notes: instanceForm.notes.trim() || null,
+      external_url: instanceForm.externalUrl.trim() || null,
+      partner_organization_ids:
+        serviceType === 'event' ? instanceForm.partnerOrganizations.map((row) => row.id) : [],
       session_slots: instanceForm.sessionSlots.map((slot, index) => ({
         location_id: slot.locationId,
         starts_at: slot.startsAt,
@@ -77,12 +82,14 @@ export function CreateInstanceDialog({
         pricing_unit: trainingForm.pricingUnit,
       };
     } else if (serviceType === 'event') {
+      const priceStr = eventForm.defaultPrice.trim();
+      const currencyStr = (eventForm.defaultCurrency || 'HKD').trim();
       payload.event_ticket_tiers = [
         {
           name: eventForm.eventCategory,
           description: null,
-          price: '0',
-          currency: 'HKD',
+          price: priceStr.length ? priceStr : null,
+          currency: currencyStr.length ? currencyStr : null,
           max_quantity: null,
           sort_order: 0,
         },
@@ -95,7 +102,6 @@ export function CreateInstanceDialog({
         package_sessions: consultationForm.defaultPackageSessions
           ? Number(consultationForm.defaultPackageSessions)
           : null,
-        calendly_event_url: consultationForm.calendlyUrl || null,
       };
     }
     await onCreate(payload);
@@ -111,30 +117,47 @@ export function CreateInstanceDialog({
       onClose={onClose}
       onSubmit={handleSubmit}
     >
-      <InstanceFormFields
-        value={instanceForm}
-        hideInstructorField={serviceType === 'training_course'}
-        onChange={setInstanceForm}
-      />
+      <InstanceFormFields value={instanceForm} onChange={setInstanceForm} />
       {serviceType === 'training_course' ? (
-        <TrainingFormFields
-          value={trainingForm}
-          onChange={setTrainingForm}
-          layout='service-detail'
-          prePricingUnitColumn={
-            <InstanceInstructorField
-              value={instanceForm.instructorId}
-              onChange={(instructorId) =>
-                setInstanceForm((prev) => ({ ...prev, instructorId }))
-              }
-            />
-          }
-        />
+        <div className='mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2'>
+          <InstanceInstructorField
+            value={instanceForm.instructorId}
+            onChange={(instructorId) =>
+              setInstanceForm((prev) => ({ ...prev, instructorId }))
+            }
+          />
+          <div className='sm:col-span-1' />
+        </div>
       ) : null}
-      {serviceType === 'event' ? <EventFormFields value={eventForm} onChange={setEventForm} /> : null}
+      {serviceType === 'training_course' ? (
+        <div className='mt-3'>
+          <TrainingFormFields value={trainingForm} onChange={setTrainingForm} />
+        </div>
+      ) : null}
+      {serviceType === 'event' ? (
+        <div className='mt-3'>
+          <EventFormFields value={eventForm} onChange={setEventForm} />
+        </div>
+      ) : null}
+      {serviceType === 'event' ? (
+        <div className='mt-3'>
+          <EventInstancePartnersField
+            value={instanceForm.partnerOrganizations}
+            onChange={(next) => setInstanceForm((prev) => ({ ...prev, partnerOrganizations: next }))}
+          />
+        </div>
+      ) : null}
       {serviceType === 'consultation' ? (
-        <ConsultationFormFields value={consultationForm} onChange={setConsultationForm} />
+        <div className='mt-3'>
+          <ConsultationFormFields value={consultationForm} onChange={setConsultationForm} />
+        </div>
       ) : null}
+      <div className='mt-3'>
+        <SessionSlotEditor
+          slots={instanceForm.sessionSlots}
+          onChange={(sessionSlots) => setInstanceForm((prev) => ({ ...prev, sessionSlots }))}
+        />
+      </div>
     </FormDialog>
   );
 }

--- a/apps/admin_web/src/components/admin/services/event-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/event-form-fields.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import type { ReactNode } from 'react';
-
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
-import { formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel, getCurrencyOptions } from '@/lib/format';
 
 import { EVENT_CATEGORIES } from '@/types/services';
 import type { EventCategory } from '@/types/services';
 
 export interface EventFormState {
   eventCategory: EventCategory;
+  defaultPrice: string;
+  defaultCurrency: string;
 }
 
 export interface EventFormFieldsProps {
@@ -22,44 +22,36 @@ export interface EventFormFieldsProps {
   categoryReadOnly?: boolean;
   /** Optional id for the category control (read-only input or select). */
   categoryFieldId?: string;
-  /**
-   * With `layout="service-detail"`, renders one md+ row: optional `leadingColumn`,
-   * event category, then `trailingSlot` (typically booking + cover as two grid cells).
-   * With `layout="instance-detail"`, category spans three quarters and `trailingSlot` one quarter on large screens.
-   */
-  layout?: 'default' | 'service-detail' | 'instance-detail';
-  leadingColumn?: ReactNode;
-  trailingSlot?: ReactNode;
 }
 
-export function EventFormFields({
+export function EventCategoryControl({
   value,
   disabled = false,
   onChange,
   categoryReadOnly = false,
   categoryFieldId = 'event-category',
-  layout = 'default',
-  leadingColumn,
-  trailingSlot,
 }: EventFormFieldsProps) {
-  const categoryField = categoryReadOnly ? (
-    <div>
-      <Label htmlFor={categoryFieldId}>Event category</Label>
-      <Input
-        id={categoryFieldId}
-        readOnly
-        value={formatEnumLabel(value.eventCategory)}
-        className='bg-slate-50 text-slate-700'
-      />
-    </div>
-  ) : (
+  if (categoryReadOnly) {
+    return (
+      <div>
+        <Label htmlFor={categoryFieldId}>Event category</Label>
+        <Input
+          id={categoryFieldId}
+          readOnly
+          value={formatEnumLabel(value.eventCategory)}
+          className='bg-slate-50 text-slate-700'
+        />
+      </div>
+    );
+  }
+  return (
     <div>
       <Label htmlFor={categoryFieldId}>Event category</Label>
       <Select
         id={categoryFieldId}
         value={value.eventCategory}
         disabled={disabled}
-        onChange={(event) => onChange({ eventCategory: event.target.value as EventCategory })}
+        onChange={(event) => onChange({ ...value, eventCategory: event.target.value as EventCategory })}
       >
         {EVENT_CATEGORIES.map((entry) => (
           <option key={entry} value={entry}>
@@ -69,26 +61,74 @@ export function EventFormFields({
       </Select>
     </div>
   );
+}
 
-  if (layout === 'service-detail') {
-    return (
-      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-        {leadingColumn ? <div>{leadingColumn}</div> : null}
-        {categoryField}
-        {trailingSlot}
+export function EventDefaultPriceControl({
+  value,
+  disabled = false,
+  onChange,
+  priceLabel = 'Default price',
+}: Pick<EventFormFieldsProps, 'value' | 'disabled' | 'onChange'> & { priceLabel?: string }) {
+  return (
+    <div>
+      <Label htmlFor='event-default-price'>{priceLabel}</Label>
+      <Input
+        id='event-default-price'
+        value={value.defaultPrice}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultPrice: event.target.value })}
+        placeholder='0.00'
+      />
+    </div>
+  );
+}
+
+export function EventDefaultCurrencyControl({
+  value,
+  disabled = false,
+  onChange,
+}: Pick<EventFormFieldsProps, 'value' | 'disabled' | 'onChange'>) {
+  const currencyOptions = getCurrencyOptions();
+  return (
+    <div>
+      <Label htmlFor='event-default-currency'>Currency</Label>
+      <Select
+        id='event-default-currency'
+        value={value.defaultCurrency}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
+      >
+        {currencyOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
+/** Stacked layout for dialogs and non-detail flows. */
+export function EventFormFields({
+  value,
+  disabled = false,
+  onChange,
+  categoryReadOnly = false,
+  categoryFieldId = 'event-category',
+}: EventFormFieldsProps) {
+  return (
+    <div className='space-y-3'>
+      <EventCategoryControl
+        value={value}
+        disabled={disabled}
+        onChange={onChange}
+        categoryReadOnly={categoryReadOnly}
+        categoryFieldId={categoryFieldId}
+      />
+      <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+        <EventDefaultPriceControl value={value} disabled={disabled} onChange={onChange} />
+        <EventDefaultCurrencyControl value={value} disabled={disabled} onChange={onChange} />
       </div>
-    );
-  }
-
-  if (layout === 'instance-detail') {
-    return (
-      <div className='grid grid-cols-1 gap-3 lg:grid-cols-12'>
-        {leadingColumn ? <div className='lg:col-span-12'>{leadingColumn}</div> : null}
-        <div className='lg:col-span-9'>{categoryField}</div>
-        {trailingSlot ? <div className='lg:col-span-3'>{trailingSlot}</div> : null}
-      </div>
-    );
-  }
-
-  return categoryField;
+    </div>
+  );
 }

--- a/apps/admin_web/src/components/admin/services/event-instance-partners-field.tsx
+++ b/apps/admin_web/src/components/admin/services/event-instance-partners-field.tsx
@@ -65,7 +65,10 @@ export function EventInstancePartnersField({
     <div className='space-y-2'>
       <Label htmlFor='event-instance-partner-orgs'>Partner organisations</Label>
       {loadError ? <p className='text-xs text-amber-700'>{loadError}</p> : null}
-      <div className='flex min-h-8 flex-wrap gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-1'>
+      <div
+        className='flex min-h-8 flex-wrap gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-1'
+        aria-label='Selected partner organisations'
+      >
         {value.length === 0 ? (
           <span className='text-xs text-slate-500'>None selected</span>
         ) : (
@@ -84,17 +87,27 @@ export function EventInstancePartnersField({
         id='event-instance-partner-orgs'
         multiple
         disabled={disabled}
+        aria-describedby='event-instance-partner-orgs-hint'
         className='min-h-28 w-full rounded-md border border-slate-200 bg-white px-2 py-1 text-sm'
         value={selectedIds}
         onChange={(event) => {
           const selected = new Set(
             Array.from(event.target.selectedOptions, (option) => option.value)
           );
+          const stickyKeep = value.filter((row) => !row.active);
           const next: PartnerOrgRef[] = [];
+          for (const ref of stickyKeep) {
+            next.push(ref);
+          }
           for (const id of selected) {
+            if (stickyKeep.some((row) => row.id === id)) {
+              continue;
+            }
             const fromValue = value.find((row) => row.id === id);
             if (fromValue) {
-              next.push(fromValue);
+              if (!next.some((row) => row.id === fromValue.id)) {
+                next.push(fromValue);
+              }
               continue;
             }
             const fromPicker = pickerItems.find((row) => row.id === id);
@@ -111,7 +124,10 @@ export function EventInstancePartnersField({
           </option>
         ))}
       </select>
-      <p className='text-xs text-slate-500'>Hold Ctrl or Cmd to select multiple partners.</p>
+      <p id='event-instance-partner-orgs-hint' className='text-xs text-slate-500'>
+        Selected partners are listed above. Hold Ctrl or Cmd in the list below to add or remove active
+        partners; archived partners stay linked until you remove them from the list.
+      </p>
     </div>
   );
 }

--- a/apps/admin_web/src/components/admin/services/event-instance-partners-field.tsx
+++ b/apps/admin_web/src/components/admin/services/event-instance-partners-field.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { Label } from '@/components/ui/label';
+import { listEntityPartnerOrganizationPicker } from '@/lib/entity-api';
+
+import type { PartnerOrgRef } from '@/types/services';
+
+export interface EventInstancePartnersFieldProps {
+  value: PartnerOrgRef[];
+  onChange: (next: PartnerOrgRef[]) => void;
+  disabled?: boolean;
+}
+
+export function EventInstancePartnersField({
+  value,
+  onChange,
+  disabled = false,
+}: EventInstancePartnersFieldProps) {
+  const [pickerItems, setPickerItems] = useState<{ id: string; label: string }[]>([]);
+  const [loadError, setLoadError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    void listEntityPartnerOrganizationPicker()
+      .then((items) => {
+        if (!cancelled) {
+          setPickerItems(items.map((row) => ({ id: row.id, label: row.label })));
+          setLoadError('');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLoadError('Could not load partner organisations.');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const pickerIdSet = useMemo(() => new Set(pickerItems.map((row) => row.id)), [pickerItems]);
+
+  const selectedIds = useMemo(() => value.map((row) => row.id), [value]);
+
+  const optionRows = useMemo(() => {
+    const rows: { id: string; label: string; disabled: boolean; sticky: boolean }[] = pickerItems.map(
+      (row) => ({ id: row.id, label: row.label, disabled: false, sticky: false })
+    );
+    for (const ref of value) {
+      if (!pickerIdSet.has(ref.id)) {
+        rows.push({
+          id: ref.id,
+          label: `${ref.name} (archived)`,
+          disabled: true,
+          sticky: true,
+        });
+      }
+    }
+    return rows;
+  }, [pickerItems, pickerIdSet, value]);
+
+  return (
+    <div className='space-y-2'>
+      <Label htmlFor='event-instance-partner-orgs'>Partner organisations</Label>
+      {loadError ? <p className='text-xs text-amber-700'>{loadError}</p> : null}
+      <div className='flex min-h-8 flex-wrap gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-1'>
+        {value.length === 0 ? (
+          <span className='text-xs text-slate-500'>None selected</span>
+        ) : (
+          value.map((ref) => (
+            <span
+              key={ref.id}
+              className='inline-flex items-center rounded-full bg-slate-200 px-2 py-0.5 text-xs text-slate-800'
+            >
+              {ref.name}
+              {!ref.active ? ' (archived)' : ''}
+            </span>
+          ))
+        )}
+      </div>
+      <select
+        id='event-instance-partner-orgs'
+        multiple
+        disabled={disabled}
+        className='min-h-28 w-full rounded-md border border-slate-200 bg-white px-2 py-1 text-sm'
+        value={selectedIds}
+        onChange={(event) => {
+          const selected = new Set(
+            Array.from(event.target.selectedOptions, (option) => option.value)
+          );
+          const next: PartnerOrgRef[] = [];
+          for (const id of selected) {
+            const fromValue = value.find((row) => row.id === id);
+            if (fromValue) {
+              next.push(fromValue);
+              continue;
+            }
+            const fromPicker = pickerItems.find((row) => row.id === id);
+            if (fromPicker) {
+              next.push({ id: fromPicker.id, name: fromPicker.label, active: true });
+            }
+          }
+          onChange(next);
+        }}
+      >
+        {optionRows.map((row) => (
+          <option key={`${row.id}-${row.sticky ? 'sticky' : 'live'}`} value={row.id} disabled={row.disabled}>
+            {row.label}
+          </option>
+        ))}
+      </select>
+      <p className='text-xs text-slate-500'>Hold Ctrl or Cmd to select multiple partners.</p>
+    </div>
+  );
+}

--- a/apps/admin_web/src/components/admin/services/form-defaults.ts
+++ b/apps/admin_web/src/components/admin/services/form-defaults.ts
@@ -20,6 +20,8 @@ export const DEFAULT_TRAINING_FORM: TrainingFormState = {
 
 export const DEFAULT_EVENT_FORM: EventFormState = {
   eventCategory: 'workshop',
+  defaultPrice: '',
+  defaultCurrency: 'HKD',
 };
 
 export const DEFAULT_CONSULTATION_FORM: ConsultationFormState = {
@@ -31,7 +33,6 @@ export const DEFAULT_CONSULTATION_FORM: ConsultationFormState = {
   defaultPackagePrice: '',
   defaultPackageSessions: '',
   defaultCurrency: 'HKD',
-  calendlyUrl: '',
 };
 
 export const DEFAULT_INSTANCE_FORM: InstanceFormState = {
@@ -45,5 +46,7 @@ export const DEFAULT_INSTANCE_FORM: InstanceFormState = {
   waitlistEnabled: false,
   instructorId: '',
   notes: '',
+  externalUrl: '',
+  partnerOrganizations: [],
   sessionSlots: [],
 };

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   ConsultationInstanceRowDFields,
@@ -303,6 +303,11 @@ export function InstanceDetailPanel({
   const canSubmit = Boolean(selectedServiceId);
   const typeFieldsLocked = !selectedServiceId;
 
+  const resolvedEventCategory = useMemo(
+    () => resolveInheritedEventCategory(selectedService, instance),
+    [selectedService, instance]
+  );
+
   const buildCreatePayload = (): ApiSchemas['CreateInstanceRequest'] => {
     const slugTrimmed = instanceForm.slug.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
@@ -334,19 +339,48 @@ export function InstanceDetailPanel({
         pricing_unit: trainingForm.pricingUnit,
       };
     } else if (effectiveServiceType === 'event') {
-      const eventCategory = resolveInheritedEventCategory(selectedService, instance);
       const priceStr = eventForm.defaultPrice.trim();
       const currencyStr = (eventForm.defaultCurrency || defaultCurrencyCode).trim();
-      payload.event_ticket_tiers = [
-        {
-          name: eventCategory,
-          description: null,
-          price: priceStr.length ? priceStr : null,
-          currency: currencyStr.length ? currencyStr : null,
-          max_quantity: null,
-          sort_order: 0,
-        },
-      ];
+      const tiers = instance?.eventTicketTiers ?? [];
+      if (tiers.length > 1) {
+        payload.event_ticket_tiers = tiers.map((tier, index) => ({
+          name: tier.name,
+          description: tier.description,
+          price:
+            tier.name === resolvedEventCategory
+              ? priceStr
+              : (tier.price ?? '0'),
+          currency:
+            tier.name === resolvedEventCategory
+              ? (currencyStr || defaultCurrencyCode)
+              : (tier.currency ?? defaultCurrencyCode),
+          max_quantity: tier.maxQuantity,
+          sort_order: tier.sortOrder ?? index,
+        }));
+      } else if (tiers.length === 1) {
+        const t = tiers[0];
+        payload.event_ticket_tiers = [
+          {
+            name: t.name,
+            description: t.description,
+            price: priceStr,
+            currency: currencyStr || defaultCurrencyCode,
+            max_quantity: t.maxQuantity,
+            sort_order: t.sortOrder ?? 0,
+          },
+        ];
+      } else {
+        payload.event_ticket_tiers = [
+          {
+            name: resolvedEventCategory,
+            description: null,
+            price: priceStr,
+            currency: currencyStr || defaultCurrencyCode,
+            max_quantity: null,
+            sort_order: 0,
+          },
+        ];
+      }
     } else {
       payload.consultation_details = {
         pricing_model: consultationForm.pricingModel,
@@ -371,6 +405,9 @@ export function InstanceDetailPanel({
     Boolean(instanceForm.externalUrl.trim()) &&
     !/^https?:\/\//i.test(instanceForm.externalUrl.trim());
 
+  const eventPriceMissing =
+    effectiveServiceType === 'event' && !eventForm.defaultPrice.trim();
+
   return (
     <AdminEditorCard
       title='Instance'
@@ -385,7 +422,7 @@ export function InstanceDetailPanel({
                 </Button>
                 <Button
                   type='button'
-                  disabled={isLoading || !instance || externalUrlInvalid}
+                  disabled={isLoading || !instance || externalUrlInvalid || eventPriceMissing}
                   onClick={() => {
                     if (!instance || !selectedServiceId) {
                       return;
@@ -399,7 +436,7 @@ export function InstanceDetailPanel({
             ) : (
               <Button
                 type='button'
-                disabled={isLoading || !selectedServiceId || externalUrlInvalid}
+                disabled={isLoading || !selectedServiceId || externalUrlInvalid || eventPriceMissing}
                 onClick={() => {
                   if (!selectedServiceId) {
                     return;
@@ -457,10 +494,12 @@ export function InstanceDetailPanel({
             <EventCategoryControl
               value={{
                 ...eventForm,
-                eventCategory: resolveInheritedEventCategory(selectedService, instance),
+                eventCategory: resolvedEventCategory,
               }}
               disabled={typeFieldsLocked}
-              onChange={setEventForm}
+              onChange={(next) =>
+                setEventForm({ ...next, eventCategory: resolvedEventCategory })
+              }
               categoryReadOnly
               categoryFieldId='instance-event-category'
             />
@@ -543,6 +582,9 @@ export function InstanceDetailPanel({
         onChange={(sessionSlots) => setInstanceForm((prev) => ({ ...prev, sessionSlots }))}
       />
 
+      {effectiveServiceType === 'event' && eventPriceMissing ? (
+        <AdminInlineError>Enter a price for this event instance.</AdminInlineError>
+      ) : null}
       {locationError ? <AdminInlineError>{locationError}</AdminInlineError> : null}
       {error ? <AdminInlineError>{error}</AdminInlineError> : null}
     </AdminEditorCard>

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -2,26 +2,43 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { ConsultationFormFields, type ConsultationFormState } from './consultation-form-fields';
-import { EventFormFields, type EventFormState } from './event-form-fields';
+import {
+  ConsultationInstanceRowDFields,
+  ConsultationInstanceRowEFields,
+  type ConsultationFormState,
+} from './consultation-form-fields';
+import {
+  EventCategoryControl,
+  EventDefaultCurrencyControl,
+  EventDefaultPriceControl,
+  type EventFormState,
+} from './event-form-fields';
 import {
   DEFAULT_CONSULTATION_FORM,
   DEFAULT_EVENT_FORM,
   DEFAULT_INSTANCE_FORM,
   DEFAULT_TRAINING_FORM,
 } from './form-defaults';
+import { EventInstancePartnersField } from './event-instance-partners-field';
 import {
   InstanceFormFields,
   InstanceInstructorField,
   type InstanceFormState,
 } from './instance-form-fields';
-import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
+import { SessionSlotEditor } from './session-slot-editor';
+import {
+  TrainingCurrencyControl,
+  TrainingPriceControl,
+  TrainingPricingUnitControl,
+  type TrainingFormState,
+} from './training-form-fields';
 
 import type { components } from '@/types/generated/admin-api.generated';
 import {
   normalizeEventCategoryFromApi,
   type EventCategory,
   type LocationSummary,
+  type PartnerOrgRef,
   type ServiceInstance,
   type ServiceSummary,
   type ServiceType,
@@ -30,6 +47,9 @@ import {
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Button } from '@/components/ui/button';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 
@@ -68,13 +88,15 @@ function mergeServiceIntoInstanceForm(
   };
 }
 
-function mergeServiceIntoEventForm(prev: EventFormState, service: ServiceSummary): EventFormState {
+function mergeServiceIntoEventForm(_prev: EventFormState, service: ServiceSummary): EventFormState {
   if (service.serviceType !== 'event') {
-    return prev;
+    return DEFAULT_EVENT_FORM;
   }
+  const ed = service.eventDetails;
   return {
-    ...prev,
-    eventCategory: service.eventDetails?.eventCategory ?? 'workshop',
+    eventCategory: ed?.eventCategory ?? 'workshop',
+    defaultPrice: ed?.defaultPrice ?? '',
+    defaultCurrency: ed?.defaultCurrency ?? defaultCurrencyCode,
   };
 }
 
@@ -107,6 +129,14 @@ function mergeServiceIntoTrainingForm(
     defaultPrice: td.defaultPrice ?? '',
     defaultCurrency: td.defaultCurrency ?? defaultCurrencyCode,
   };
+}
+
+function mapPartnerRefsFromInstance(instance: ServiceInstance): PartnerOrgRef[] {
+  return instance.partnerOrganizations.map((row) => ({
+    id: row.id,
+    name: row.name,
+    active: row.active,
+  }));
 }
 
 export function InstanceDetailPanel({
@@ -143,6 +173,8 @@ export function InstanceDetailPanel({
           waitlistEnabled: instance.waitlistEnabled,
           instructorId: instance.instructorId ?? '',
           notes: instance.notes ?? '',
+          externalUrl: instance.externalUrl ?? '',
+          partnerOrganizations: mapPartnerRefsFromInstance(instance),
           sessionSlots: instance.sessionSlots,
         }
       : DEFAULT_INSTANCE_FORM
@@ -160,6 +192,8 @@ export function InstanceDetailPanel({
     instance
       ? {
           eventCategory: 'workshop',
+          defaultPrice: instance.eventTicketTiers?.[0]?.price ?? '',
+          defaultCurrency: instance.eventTicketTiers?.[0]?.currency ?? defaultCurrencyCode,
         }
       : DEFAULT_EVENT_FORM
   );
@@ -173,9 +207,7 @@ export function InstanceDetailPanel({
           defaultHourlyRate: instance.consultationDetails?.price ?? '',
           defaultPackagePrice: '',
           defaultPackageSessions: instance.consultationDetails?.packageSessions?.toString() ?? '',
-          defaultCurrency:
-            instance.consultationDetails?.currency ?? defaultCurrencyCode,
-          calendlyUrl: instance.consultationDetails?.calendlyEventUrl ?? '',
+          defaultCurrency: instance.consultationDetails?.currency ?? defaultCurrencyCode,
         }
       : DEFAULT_CONSULTATION_FORM
   );
@@ -235,6 +267,8 @@ export function InstanceDetailPanel({
         waitlistEnabled: instance.waitlistEnabled,
         instructorId: instance.instructorId ?? '',
         notes: instance.notes ?? '',
+        externalUrl: instance.externalUrl ?? '',
+        partnerOrganizations: mapPartnerRefsFromInstance(instance),
         sessionSlots: instance.sessionSlots,
       });
       setTrainingForm({
@@ -247,6 +281,8 @@ export function InstanceDetailPanel({
           serviceOptions.find((entry) => entry.id === instance.serviceId) ?? null,
           instance
         ),
+        defaultPrice: instance.eventTicketTiers?.[0]?.price ?? '',
+        defaultCurrency: instance.eventTicketTiers?.[0]?.currency ?? defaultCurrencyCode,
       });
       setConsultationForm({
         consultationFormat: 'one_on_one',
@@ -257,7 +293,6 @@ export function InstanceDetailPanel({
         defaultPackagePrice: '',
         defaultPackageSessions: instance.consultationDetails?.packageSessions?.toString() ?? '',
         defaultCurrency: instance.consultationDetails?.currency ?? defaultCurrencyCode,
-        calendlyUrl: instance.consultationDetails?.calendlyEventUrl ?? '',
       });
     });
   }, [instance, serviceOptions]);
@@ -281,6 +316,8 @@ export function InstanceDetailPanel({
       waitlist_enabled: instanceForm.waitlistEnabled,
       instructor_id: instanceForm.instructorId.trim() || null,
       notes: instanceForm.notes.trim() || null,
+      external_url: instanceForm.externalUrl.trim() || null,
+      partner_organization_ids: instanceForm.partnerOrganizations.map((row) => row.id),
       session_slots: instanceForm.sessionSlots.map((slot, index) => ({
         location_id: slot.locationId,
         starts_at: slot.startsAt,
@@ -298,12 +335,14 @@ export function InstanceDetailPanel({
       };
     } else if (effectiveServiceType === 'event') {
       const eventCategory = resolveInheritedEventCategory(selectedService, instance);
+      const priceStr = eventForm.defaultPrice.trim();
+      const currencyStr = (eventForm.defaultCurrency || defaultCurrencyCode).trim();
       payload.event_ticket_tiers = [
         {
           name: eventCategory,
           description: null,
-          price: '0',
-          currency: defaultCurrencyCode,
+          price: priceStr.length ? priceStr : null,
+          currency: currencyStr.length ? currencyStr : null,
           max_quantity: null,
           sort_order: 0,
         },
@@ -316,7 +355,6 @@ export function InstanceDetailPanel({
         package_sessions: consultationForm.defaultPackageSessions
           ? Number(consultationForm.defaultPackageSessions)
           : null,
-        calendly_event_url: consultationForm.calendlyUrl || null,
       };
     }
 
@@ -327,6 +365,11 @@ export function InstanceDetailPanel({
     ...buildCreatePayload(),
     status: instanceForm.status,
   });
+
+  const externalUrlInvalid =
+    effectiveServiceType === 'event' &&
+    Boolean(instanceForm.externalUrl.trim()) &&
+    !/^https?:\/\//i.test(instanceForm.externalUrl.trim());
 
   return (
     <AdminEditorCard
@@ -342,7 +385,7 @@ export function InstanceDetailPanel({
                 </Button>
                 <Button
                   type='button'
-                  disabled={isLoading || !instance}
+                  disabled={isLoading || !instance || externalUrlInvalid}
                   onClick={() => {
                     if (!instance || !selectedServiceId) {
                       return;
@@ -356,7 +399,7 @@ export function InstanceDetailPanel({
             ) : (
               <Button
                 type='button'
-                disabled={isLoading || !selectedServiceId}
+                disabled={isLoading || !selectedServiceId || externalUrlInvalid}
                 onClick={() => {
                   if (!selectedServiceId) {
                     return;
@@ -380,61 +423,125 @@ export function InstanceDetailPanel({
         serviceOptions={serviceOptions}
         locationOptions={locationOptions}
         isLoadingLocations={isLoadingLocations}
-        hideInstructorField={
-          effectiveServiceType === 'training_course' || effectiveServiceType === 'event'
-        }
         instructorOptions={instructorUsers}
         isLoadingInstructors={isLoadingInstructors}
         onSelectService={handleSelectService}
         onChange={setInstanceForm}
       />
+
       {effectiveServiceType === 'training_course' ? (
-        <TrainingFormFields
-          disabled={typeFieldsLocked}
-          value={trainingForm}
-          onChange={setTrainingForm}
-          layout='service-detail'
-          prePricingUnitColumn={
-            <InstanceInstructorField
-              value={instanceForm.instructorId}
-              disabled={typeFieldsLocked}
-              instructorOptions={instructorUsers}
-              isLoadingInstructors={isLoadingInstructors}
-              onChange={(instructorId) =>
-                setInstanceForm((prev) => ({ ...prev, instructorId }))
-              }
-            />
-          }
-        />
+        <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+          <InstanceInstructorField
+            value={instanceForm.instructorId}
+            disabled={typeFieldsLocked}
+            instructorOptions={instructorUsers}
+            isLoadingInstructors={isLoadingInstructors}
+            onChange={(instructorId) => setInstanceForm((prev) => ({ ...prev, instructorId }))}
+          />
+          <TrainingPricingUnitControl value={trainingForm} disabled={typeFieldsLocked} onChange={setTrainingForm} />
+          <TrainingPriceControl value={trainingForm} disabled={typeFieldsLocked} onChange={setTrainingForm} />
+          <TrainingCurrencyControl value={trainingForm} disabled={typeFieldsLocked} onChange={setTrainingForm} />
+        </div>
       ) : null}
+
       {effectiveServiceType === 'event' ? (
-        <EventFormFields
-          disabled={typeFieldsLocked}
-          value={eventForm}
-          onChange={setEventForm}
-          categoryReadOnly
-          categoryFieldId='instance-event-category'
-          layout='instance-detail'
-          trailingSlot={
+        <>
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
             <InstanceInstructorField
               value={instanceForm.instructorId}
               disabled={typeFieldsLocked}
               instructorOptions={instructorUsers}
               isLoadingInstructors={isLoadingInstructors}
-              onChange={(instructorId) =>
-                setInstanceForm((prev) => ({ ...prev, instructorId }))
-              }
+              onChange={(instructorId) => setInstanceForm((prev) => ({ ...prev, instructorId }))}
             />
-          }
-        />
+            <EventCategoryControl
+              value={{
+                ...eventForm,
+                eventCategory: resolveInheritedEventCategory(selectedService, instance),
+              }}
+              disabled={typeFieldsLocked}
+              onChange={setEventForm}
+              categoryReadOnly
+              categoryFieldId='instance-event-category'
+            />
+            <EventDefaultPriceControl
+              value={eventForm}
+              disabled={typeFieldsLocked}
+              onChange={setEventForm}
+              priceLabel='Price'
+            />
+            <EventDefaultCurrencyControl value={eventForm} disabled={typeFieldsLocked} onChange={setEventForm} />
+          </div>
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <div className='md:col-span-2'>
+              <EventInstancePartnersField
+                value={instanceForm.partnerOrganizations}
+                disabled={typeFieldsLocked}
+                onChange={(next) => setInstanceForm((prev) => ({ ...prev, partnerOrganizations: next }))}
+              />
+            </div>
+            <div className='md:col-span-2'>
+              <Label htmlFor='instance-external-url'>External URL</Label>
+              <Input
+                id='instance-external-url'
+                value={instanceForm.externalUrl}
+                disabled={typeFieldsLocked}
+                onChange={(event) => setInstanceForm((prev) => ({ ...prev, externalUrl: event.target.value }))}
+                placeholder='https://…'
+                autoComplete='off'
+              />
+              {externalUrlInvalid ? (
+                <p className='mt-1 text-xs text-red-600'>URL must start with http:// or https://</p>
+              ) : null}
+            </div>
+          </div>
+        </>
       ) : null}
+
       {effectiveServiceType === 'consultation' ? (
-        <ConsultationFormFields
-          disabled={typeFieldsLocked}
-          value={consultationForm}
-          onChange={setConsultationForm}
-        />
+        <>
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <InstanceInstructorField
+              value={instanceForm.instructorId}
+              disabled={typeFieldsLocked}
+              instructorOptions={instructorUsers}
+              isLoadingInstructors={isLoadingInstructors}
+              onChange={(instructorId) => setInstanceForm((prev) => ({ ...prev, instructorId }))}
+            />
+            <ConsultationInstanceRowDFields
+              value={consultationForm}
+              disabled={typeFieldsLocked}
+              onChange={setConsultationForm}
+            />
+          </div>
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <ConsultationInstanceRowEFields
+              value={consultationForm}
+              disabled={typeFieldsLocked}
+              onChange={setConsultationForm}
+            />
+          </div>
+        </>
       ) : null}
+
+      <div>
+        <Label htmlFor='instance-notes'>Notes</Label>
+        <Textarea
+          id='instance-notes'
+          value={instanceForm.notes}
+          disabled={typeFieldsLocked}
+          onChange={(event) => setInstanceForm((prev) => ({ ...prev, notes: event.target.value }))}
+          rows={2}
+        />
+      </div>
+
+      <SessionSlotEditor
+        slots={instanceForm.sessionSlots}
+        disabled={typeFieldsLocked}
+        locationOptions={locationOptions}
+        isLoadingLocations={isLoadingLocations}
+        onChange={(sessionSlots) => setInstanceForm((prev) => ({ ...prev, sessionSlots }))}
+      />
 
       {locationError ? <AdminInlineError>{locationError}</AdminInlineError> : null}
       {error ? <AdminInlineError>{error}</AdminInlineError> : null}

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -7,9 +7,13 @@ import { Textarea } from '@/components/ui/textarea';
 import { formatEnumLabel, formatLocationLabel } from '@/lib/format';
 
 import { INSTANCE_STATUSES, SERVICE_DELIVERY_MODES } from '@/types/services';
-import type { InstanceStatus, LocationSummary, ServiceDeliveryMode, ServiceSummary } from '@/types/services';
-
-import { SessionSlotEditor } from './session-slot-editor';
+import type {
+  InstanceStatus,
+  LocationSummary,
+  PartnerOrgRef,
+  ServiceDeliveryMode,
+  ServiceSummary,
+} from '@/types/services';
 
 import type { SessionSlot } from '@/types/services';
 
@@ -33,6 +37,8 @@ export interface InstanceFormState {
   waitlistEnabled: boolean;
   instructorId: string;
   notes: string;
+  externalUrl: string;
+  partnerOrganizations: PartnerOrgRef[];
   sessionSlots: SessionSlot[];
 }
 
@@ -42,8 +48,6 @@ export interface InstanceFormFieldsProps {
   serviceOptions?: ServiceSummary[];
   locationOptions?: LocationSummary[];
   isLoadingLocations?: boolean;
-  /** When true, omit the instructor field (shown beside training pricing instead). */
-  hideInstructorField?: boolean;
   instructorOptions?: InstanceInstructorOption[];
   isLoadingInstructors?: boolean;
   onSelectService?: (serviceId: string | null) => void;
@@ -71,7 +75,7 @@ export interface InstanceInstructorFieldProps {
   onChange: (instructorId: string) => void;
 }
 
-/** Instructor select for instance flows; pairs with `TrainingFormFields` `prePricingUnitColumn`. */
+/** Instructor select for instance flows; composed in instance detail Row D. */
 export function InstanceInstructorField({
   value,
   disabled = false,
@@ -108,7 +112,6 @@ export function InstanceFormFields({
   serviceOptions = [],
   locationOptions = [],
   isLoadingLocations = false,
-  hideInstructorField = false,
   instructorOptions = [],
   isLoadingInstructors = false,
   onSelectService,
@@ -266,7 +269,7 @@ export function InstanceFormFields({
           />
         </div>
         <div>
-          <Label htmlFor='instance-waitlist'>Whitelist</Label>
+          <Label htmlFor='instance-waitlist'>Waitlist</Label>
           <Select
             id='instance-waitlist'
             value={value.waitlistEnabled ? 'true' : 'false'}
@@ -280,32 +283,6 @@ export function InstanceFormFields({
           </Select>
         </div>
       </div>
-      {!hideInstructorField ? (
-        <InstanceInstructorField
-          value={value.instructorId}
-          disabled={instanceFieldsLocked}
-          instructorOptions={instructorOptions}
-          isLoadingInstructors={isLoadingInstructors}
-          onChange={(instructorId) => onChange({ ...value, instructorId })}
-        />
-      ) : null}
-      <div>
-        <Label htmlFor='instance-notes'>Notes</Label>
-        <Textarea
-          id='instance-notes'
-          value={value.notes}
-          disabled={instanceFieldsLocked}
-          onChange={(event) => onChange({ ...value, notes: event.target.value })}
-          rows={2}
-        />
-      </div>
-      <SessionSlotEditor
-        slots={value.sessionSlots}
-        disabled={instanceFieldsLocked}
-        locationOptions={locationOptions}
-        isLoadingLocations={isLoadingLocations}
-        onChange={(sessionSlots) => onChange({ ...value, sessionSlots })}
-      />
     </div>
   );
 }

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -9,6 +9,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { formatEnumLabel } from '@/lib/format';
 import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
@@ -19,20 +20,31 @@ import { SERVICE_DELIVERY_MODES, SERVICE_STATUSES, SERVICE_TYPES } from '@/types
 import type { ServiceDeliveryMode } from '@/types/services';
 import type { ServiceDetail, ServiceType } from '@/types/services';
 
-import { ConsultationFormFields, type ConsultationFormState } from './consultation-form-fields';
-import { EventFormFields, type EventFormState } from './event-form-fields';
+import {
+  ConsultationServiceFormatField,
+  ConsultationServiceRowDFields,
+  ConsultationServiceRowEFields,
+  type ConsultationFormState,
+} from './consultation-form-fields';
+import {
+  EventCategoryControl,
+  EventDefaultCurrencyControl,
+  EventDefaultPriceControl,
+  type EventFormState,
+} from './event-form-fields';
 import {
   DEFAULT_CONSULTATION_FORM,
   DEFAULT_EVENT_FORM,
   DEFAULT_SERVICE_FORM,
   DEFAULT_TRAINING_FORM,
 } from './form-defaults';
+import { ServiceReferralSlugField, type ServiceFormState } from './service-form-fields';
 import {
-  ServiceFormFields,
-  ServiceReferralSlugField,
-  type ServiceFormState,
-} from './service-form-fields';
-import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
+  TrainingCurrencyControl,
+  TrainingPriceControl,
+  TrainingPricingUnitControl,
+  type TrainingFormState,
+} from './training-form-fields';
 
 type ApiSchemas = components['schemas'];
 
@@ -86,6 +98,8 @@ export function ServiceDetailPanel({
     service
       ? {
           eventCategory: service.eventDetails?.eventCategory ?? 'workshop',
+          defaultPrice: service.eventDetails?.defaultPrice ?? '',
+          defaultCurrency: service.eventDetails?.defaultCurrency ?? 'HKD',
         }
       : DEFAULT_EVENT_FORM
   );
@@ -100,7 +114,6 @@ export function ServiceDetailPanel({
           defaultPackagePrice: service.consultationDetails?.defaultPackagePrice ?? '',
           defaultPackageSessions: service.consultationDetails?.defaultPackageSessions?.toString() ?? '',
           defaultCurrency: service.consultationDetails?.defaultCurrency ?? 'HKD',
-          calendlyUrl: service.consultationDetails?.calendlyUrl ?? '',
         }
       : DEFAULT_CONSULTATION_FORM
   );
@@ -175,6 +188,8 @@ export function ServiceDetailPanel({
       });
       setEventForm({
         eventCategory: service.eventDetails?.eventCategory ?? 'workshop',
+        defaultPrice: service.eventDetails?.defaultPrice ?? '',
+        defaultCurrency: service.eventDetails?.defaultCurrency ?? 'HKD',
       });
       setConsultationForm({
         consultationFormat: service.consultationDetails?.consultationFormat ?? 'one_on_one',
@@ -185,7 +200,6 @@ export function ServiceDetailPanel({
         defaultPackagePrice: service.consultationDetails?.defaultPackagePrice ?? '',
         defaultPackageSessions: service.consultationDetails?.defaultPackageSessions?.toString() ?? '',
         defaultCurrency: service.consultationDetails?.defaultCurrency ?? 'HKD',
-        calendlyUrl: service.consultationDetails?.calendlyUrl ?? '',
       });
       setSlugConflictError('');
       setConflictingSlugNormalized(null);
@@ -206,6 +220,52 @@ export function ServiceDetailPanel({
     conflictingSlugNormalized !== null &&
     normalizedSlugInput === conflictingSlugNormalized;
 
+  const deliveryModeSelect = (
+    <div>
+      <Label htmlFor='service-delivery-mode'>Delivery mode</Label>
+      <Select
+        id='service-delivery-mode'
+        value={serviceForm.deliveryMode}
+        onChange={(event) =>
+          setServiceForm({
+            ...serviceForm,
+            deliveryMode: event.target.value as ServiceDeliveryMode,
+          })
+        }
+      >
+        {SERVICE_DELIVERY_MODES.map((entry) => (
+          <option key={entry} value={entry}>
+            {formatEnumLabel(entry)}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+
+  const bookingAndCover = (
+    <>
+      <div>
+        <Label htmlFor='service-booking-system'>Booking system</Label>
+        <Input
+          id='service-booking-system'
+          value={bookingSystem}
+          onChange={(event) => setBookingSystem(event.target.value)}
+          placeholder='Optional label'
+          maxLength={80}
+          autoComplete='off'
+        />
+      </div>
+      <div>
+        <Label htmlFor='service-detail-cover-file-name'>Cover file name</Label>
+        <Input
+          id='service-detail-cover-file-name'
+          value={coverFileName}
+          onChange={(event) => setCoverFileName(event.target.value)}
+        />
+      </div>
+    </>
+  );
+
   const buildTypeSpecificPayload = (
     currentServiceType: ServiceType
   ):
@@ -225,6 +285,8 @@ export function ServiceDetailPanel({
       return {
         event_details: {
           event_category: eventForm.eventCategory,
+          default_price: eventForm.defaultPrice.trim() || null,
+          default_currency: eventForm.defaultCurrency.trim() || 'HKD',
         },
       };
     }
@@ -242,7 +304,6 @@ export function ServiceDetailPanel({
           ? Number(consultationForm.defaultPackageSessions)
           : null,
         default_currency: consultationForm.defaultCurrency.trim() || 'HKD',
-        calendly_url: consultationForm.calendlyUrl.trim() || null,
       },
     };
   };
@@ -396,7 +457,7 @@ export function ServiceDetailPanel({
       >
         <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
           <div>
-            <Label htmlFor='service-type'>Service type</Label>
+            <Label htmlFor='service-type'>Type</Label>
             <Select
               id='service-type'
               value={serviceType}
@@ -453,159 +514,69 @@ export function ServiceDetailPanel({
           </div>
         </div>
 
-        <ServiceFormFields
-          value={serviceForm}
-          onChange={(next) => {
-            if (next.slug !== serviceForm.slug) {
-              setSlugConflictError('');
-              setConflictingSlugNormalized(null);
-            }
-            setServiceForm(next);
-          }}
-          hideTitle
-          layout='service-detail'
-        />
+        <div>
+          <Label htmlFor='service-description'>Description</Label>
+          <Textarea
+            id='service-description'
+            value={serviceForm.description}
+            onChange={(event) => setServiceForm({ ...serviceForm, description: event.target.value })}
+            rows={3}
+            placeholder='Optional description'
+          />
+        </div>
 
         {serviceType === 'training_course' ? (
-          <TrainingFormFields
-            value={trainingForm}
-            onChange={setTrainingForm}
-            layout='service-detail'
-            leadingColumn={
-              <>
-                <Label htmlFor='service-delivery-mode'>Delivery mode</Label>
-                <Select
-                  id='service-delivery-mode'
-                  value={serviceForm.deliveryMode}
-                  onChange={(event) =>
-                    setServiceForm({
-                      ...serviceForm,
-                      deliveryMode: event.target.value as ServiceDeliveryMode,
-                    })
-                  }
-                >
-                  {SERVICE_DELIVERY_MODES.map((entry) => (
-                    <option key={entry} value={entry}>
-                      {formatEnumLabel(entry)}
-                    </option>
-                  ))}
-                </Select>
-              </>
-            }
-          />
-        ) : serviceType === 'event' ? (
-          <EventFormFields
-            value={eventForm}
-            onChange={setEventForm}
-            layout='service-detail'
-            leadingColumn={
-              <>
-                <Label htmlFor='service-delivery-mode'>Delivery mode</Label>
-                <Select
-                  id='service-delivery-mode'
-                  value={serviceForm.deliveryMode}
-                  onChange={(event) =>
-                    setServiceForm({
-                      ...serviceForm,
-                      deliveryMode: event.target.value as ServiceDeliveryMode,
-                    })
-                  }
-                >
-                  {SERVICE_DELIVERY_MODES.map((entry) => (
-                    <option key={entry} value={entry}>
-                      {formatEnumLabel(entry)}
-                    </option>
-                  ))}
-                </Select>
-              </>
-            }
-            trailingSlot={
-              <>
-                <div>
-                  <Label htmlFor='service-booking-system'>Booking system</Label>
-                  <Input
-                    id='service-booking-system'
-                    value={bookingSystem}
-                    onChange={(event) => setBookingSystem(event.target.value)}
-                    placeholder='e.g. calendly'
-                    maxLength={80}
-                    autoComplete='off'
-                  />
-                </div>
-                <div>
-                  <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
-                  <Input
-                    id='service-detail-cover-file-name'
-                    value={coverFileName}
-                    onChange={(event) => setCoverFileName(event.target.value)}
-                  />
-                </div>
-              </>
-            }
-          />
-        ) : (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            <div>
-              <Label htmlFor='service-delivery-mode'>Delivery mode</Label>
-              <Select
-                id='service-delivery-mode'
-                value={serviceForm.deliveryMode}
-                onChange={(event) =>
-                  setServiceForm({
-                    ...serviceForm,
-                    deliveryMode: event.target.value as ServiceDeliveryMode,
-                  })
-                }
-              >
-                {SERVICE_DELIVERY_MODES.map((entry) => (
-                  <option key={entry} value={entry}>
-                    {formatEnumLabel(entry)}
-                  </option>
-                ))}
-              </Select>
-            </div>
-            <div>
-              <Label className='text-slate-500'>Pricing unit</Label>
-              <p className='mt-2 text-sm text-slate-400'>—</p>
-            </div>
-            <div>
-              <Label className='text-slate-500'>Price</Label>
-              <p className='mt-2 text-sm text-slate-400'>—</p>
-            </div>
-            <div>
-              <Label className='text-slate-500'>Currency</Label>
-              <p className='mt-2 text-sm text-slate-400'>—</p>
-            </div>
+            {deliveryModeSelect}
+            <TrainingPricingUnitControl value={trainingForm} onChange={setTrainingForm} />
+            {bookingAndCover}
           </div>
-        )}
-        {serviceType === 'consultation' ? (
-          <ConsultationFormFields value={consultationForm} onChange={setConsultationForm} />
         ) : null}
 
-        {serviceType === 'event' ? null : (
+        {serviceType === 'event' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            <div>
-              <Label htmlFor='service-booking-system'>Booking system</Label>
-              <Input
-                id='service-booking-system'
-                value={bookingSystem}
-                onChange={(event) => setBookingSystem(event.target.value)}
-                placeholder='e.g. calendly'
-                maxLength={80}
-                autoComplete='off'
-              />
-            </div>
-            <div>
-              <Label htmlFor='service-detail-cover-file-name'>Cover image file name</Label>
-              <Input
-                id='service-detail-cover-file-name'
-                value={coverFileName}
-                onChange={(event) => setCoverFileName(event.target.value)}
-              />
-            </div>
-            <div className='hidden md:block md:col-span-2' aria-hidden />
+            {deliveryModeSelect}
+            <EventCategoryControl value={eventForm} onChange={setEventForm} categoryFieldId='service-event-category' />
+            {bookingAndCover}
           </div>
-        )}
+        ) : null}
+
+        {serviceType === 'consultation' ? (
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            {deliveryModeSelect}
+            <ConsultationServiceFormatField value={consultationForm} onChange={setConsultationForm} />
+            {bookingAndCover}
+          </div>
+        ) : null}
+
+        {serviceType === 'training_course' ? (
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <div aria-hidden className='hidden md:block' />
+            <TrainingPriceControl value={trainingForm} onChange={setTrainingForm} />
+            <TrainingCurrencyControl value={trainingForm} onChange={setTrainingForm} />
+            <div aria-hidden className='hidden md:block' />
+          </div>
+        ) : null}
+
+        {serviceType === 'event' ? (
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <div aria-hidden className='hidden md:block' />
+            <EventDefaultPriceControl value={eventForm} onChange={setEventForm} />
+            <EventDefaultCurrencyControl value={eventForm} onChange={setEventForm} />
+            <div aria-hidden className='hidden md:block' />
+          </div>
+        ) : null}
+
+        {serviceType === 'consultation' ? (
+          <>
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+              <ConsultationServiceRowDFields value={consultationForm} onChange={setConsultationForm} />
+            </div>
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+              <ConsultationServiceRowEFields value={consultationForm} onChange={setConsultationForm} />
+            </div>
+          </>
+        ) : null}
 
         {error ? <AdminInlineError>{error}</AdminInlineError> : null}
       </AdminEditorCard>

--- a/apps/admin_web/src/components/admin/services/service-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/service-form-fields.tsx
@@ -47,8 +47,6 @@ export function ServiceReferralSlugField({
   );
 }
 
-export type ServiceFormFieldsLayout = 'stacked' | 'service-detail';
-
 export interface ServiceFormState {
   title: string;
   description: string;
@@ -61,7 +59,6 @@ export interface ServiceFormFieldsProps {
   value: ServiceFormState;
   onChange: (value: ServiceFormState) => void;
   hideTitle?: boolean;
-  layout?: ServiceFormFieldsLayout;
   slugUsageLoadError?: string;
   slugConflictError?: string;
 }
@@ -70,25 +67,9 @@ export function ServiceFormFields({
   value,
   onChange,
   hideTitle = false,
-  layout = 'stacked',
   slugUsageLoadError,
   slugConflictError,
 }: ServiceFormFieldsProps) {
-  if (layout === 'service-detail') {
-    return (
-      <div>
-        <Label htmlFor='service-description'>Description</Label>
-        <Textarea
-          id='service-description'
-          value={value.description}
-          onChange={(event) => onChange({ ...value, description: event.target.value })}
-          rows={3}
-          placeholder='Optional description'
-        />
-      </div>
-    );
-  }
-
   return (
     <div className='space-y-3'>
       {!hideTitle ? (

--- a/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
+++ b/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
@@ -39,35 +39,21 @@ export function SessionSlotEditor({
   const hasLocationOptions = locationOptions.length > 0;
 
   const slotGridClassName =
-    'grid grid-cols-1 gap-x-3 gap-y-2 sm:grid-cols-[1fr_1fr_1fr_minmax(0,5.5rem)_auto] sm:items-end';
+    'grid grid-cols-1 gap-x-3 gap-y-3 sm:grid-cols-[1fr_1fr_1fr_minmax(0,5.5rem)_auto] sm:items-end';
 
   return (
     <AdminCollapsibleSection id='service-instance-session-slots' title='Session slots' disabled={disabled}>
       <div className='grid grid-rows-[auto_1fr_auto] gap-3'>
         <div className='min-h-0'>
           {slots.length === 0 ? <p className='text-sm text-slate-500'>No slots configured.</p> : null}
-          {slots.length > 0 ? (
-            <div className={`hidden ${slotGridClassName} sm:grid`}>
-              <div className='text-xs font-medium text-slate-600'>Start time</div>
-              <div className='text-xs font-medium text-slate-600'>End time</div>
-              <div className='text-xs font-medium text-slate-600'>Location</div>
-              <div className='text-xs font-medium text-slate-600'>Sort order</div>
-              <div className='min-h-5' aria-hidden='true' />
-            </div>
-          ) : null}
         </div>
         <div className='flex min-h-0 flex-col gap-3 overflow-y-auto'>
           {slots.map((slot, index) => (
             <div key={`${slot.id ?? 'new'}-${index}`} className={slotGridClassName}>
               <div className='space-y-1'>
-                {index === 0 ? (
-                  <Label
-                    className='text-xs font-medium text-slate-600 sm:hidden'
-                    htmlFor={`slot-${index}-starts`}
-                  >
-                    Start time
-                  </Label>
-                ) : null}
+                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-starts`}>
+                  Start time
+                </Label>
                 <Input
                   id={`slot-${index}-starts`}
                   type='datetime-local'
@@ -82,11 +68,9 @@ export function SessionSlotEditor({
                 />
               </div>
               <div className='space-y-1'>
-                {index === 0 ? (
-                  <Label className='text-xs font-medium text-slate-600 sm:hidden' htmlFor={`slot-${index}-ends`}>
-                    End time
-                  </Label>
-                ) : null}
+                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-ends`}>
+                  End time
+                </Label>
                 <Input
                   id={`slot-${index}-ends`}
                   type='datetime-local'
@@ -101,14 +85,9 @@ export function SessionSlotEditor({
                 />
               </div>
               <div className='space-y-1'>
-                {index === 0 ? (
-                  <Label
-                    className='text-xs font-medium text-slate-600 sm:hidden'
-                    htmlFor={`slot-${index}-location`}
-                  >
-                    Location
-                  </Label>
-                ) : null}
+                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-location`}>
+                  Location
+                </Label>
                 {hasLocationOptions || isLoadingLocations ? (
                   <Select
                     id={`slot-${index}-location`}
@@ -150,11 +129,9 @@ export function SessionSlotEditor({
                 )}
               </div>
               <div className='space-y-1'>
-                {index === 0 ? (
-                  <Label className='text-xs font-medium text-slate-600 sm:hidden' htmlFor={`slot-${index}-sort`}>
-                    Sort order
-                  </Label>
-                ) : null}
+                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-sort`}>
+                  Sort order
+                </Label>
                 <Input
                   id={`slot-${index}-sort`}
                   type='number'

--- a/apps/admin_web/src/components/admin/services/training-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/training-form-fields.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import type { ReactNode } from 'react';
-
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
@@ -20,106 +18,84 @@ export interface TrainingFormFieldsProps {
   value: TrainingFormState;
   disabled?: boolean;
   onChange: (value: TrainingFormState) => void;
-  /**
-   * When set with `layout="service-detail"`, renders a single md+ row of equal
-   * columns: optional leading column (e.g. delivery mode), optional column before
-   * pricing unit (e.g. instance instructor), then pricing unit, price, and currency.
-   */
-  leadingColumn?: ReactNode;
-  /** Renders immediately before the pricing unit column when `layout="service-detail"`. */
-  prePricingUnitColumn?: ReactNode;
-  layout?: 'default' | 'service-detail';
 }
 
-export function TrainingFormFields({
+export function TrainingPricingUnitControl({
   value,
   disabled = false,
   onChange,
-  leadingColumn,
-  prePricingUnitColumn,
-  layout = 'default',
-}: TrainingFormFieldsProps) {
-  const currencyOptions = getCurrencyOptions();
-
-  const hasLeading = layout === 'service-detail' && Boolean(leadingColumn);
-  const hasPrePricing = layout === 'service-detail' && Boolean(prePricingUnitColumn);
-  const serviceDetailColumnCount = (hasLeading ? 1 : 0) + (hasPrePricing ? 1 : 0) + 3;
-  const useQuarterInstructorRow =
-    layout === 'service-detail' && hasPrePricing && !hasLeading;
-
-  const pricingGridClass =
-    layout === 'service-detail'
-      ? useQuarterInstructorRow
-        ? 'grid grid-cols-1 gap-3 lg:grid-cols-12'
-        : serviceDetailColumnCount <= 3
-          ? 'grid grid-cols-1 gap-3 sm:grid-cols-3'
-          : serviceDetailColumnCount === 4
-            ? 'grid grid-cols-1 gap-3 md:grid-cols-4'
-            : serviceDetailColumnCount === 5
-              ? 'grid grid-cols-1 gap-3 md:grid-cols-5'
-              : 'grid grid-cols-1 gap-3 md:grid-cols-6'
-      : 'grid grid-cols-1 gap-3 sm:grid-cols-3';
-
-  const pricingFieldsWrapperClass = useQuarterInstructorRow ? 'lg:col-span-9' : undefined;
-  const prePricingWrapperClass = useQuarterInstructorRow ? 'lg:col-span-3' : undefined;
-  const innerThreeColClass = useQuarterInstructorRow
-    ? 'grid grid-cols-1 gap-3 sm:grid-cols-3 lg:contents'
-    : undefined;
-
+}: Pick<TrainingFormFieldsProps, 'value' | 'disabled' | 'onChange'>) {
   return (
-    <div className='space-y-3'>
-      <div className={pricingGridClass}>
-        {hasLeading ? <div>{leadingColumn}</div> : null}
-        {hasPrePricing ? (
-          <div className={prePricingWrapperClass}>{prePricingUnitColumn}</div>
-        ) : null}
-        <div className={pricingFieldsWrapperClass}>
-          <div className={innerThreeColClass}>
-        <div>
-          <Label htmlFor='training-pricing-unit'>Pricing unit</Label>
-          <Select
-            id='training-pricing-unit'
-            value={value.pricingUnit}
-            disabled={disabled}
-            onChange={(event) =>
-              onChange({ ...value, pricingUnit: event.target.value as TrainingPricingUnit })
-            }
-          >
-            {TRAINING_PRICING_UNITS.map((entry) => (
-              <option key={entry} value={entry}>
-                {formatEnumLabel(entry)}
-              </option>
-            ))}
-          </Select>
-        </div>
-        <div>
-          <Label htmlFor='training-default-price'>Price</Label>
-          <Input
-            id='training-default-price'
-            value={value.defaultPrice}
-            disabled={disabled}
-            onChange={(event) => onChange({ ...value, defaultPrice: event.target.value })}
-            placeholder='0.00'
-          />
-        </div>
-        <div>
-          <Label htmlFor='training-default-currency'>Currency</Label>
-          <Select
-            id='training-default-currency'
-            value={value.defaultCurrency}
-            disabled={disabled}
-            onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
-          >
-            {currencyOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </Select>
-        </div>
-          </div>
-        </div>
-      </div>
+    <div>
+      <Label htmlFor='training-pricing-unit'>Pricing unit</Label>
+      <Select
+        id='training-pricing-unit'
+        value={value.pricingUnit}
+        disabled={disabled}
+        onChange={(event) =>
+          onChange({ ...value, pricingUnit: event.target.value as TrainingPricingUnit })
+        }
+      >
+        {TRAINING_PRICING_UNITS.map((entry) => (
+          <option key={entry} value={entry}>
+            {formatEnumLabel(entry)}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
+export function TrainingPriceControl({
+  value,
+  disabled = false,
+  onChange,
+}: Pick<TrainingFormFieldsProps, 'value' | 'disabled' | 'onChange'>) {
+  return (
+    <div>
+      <Label htmlFor='training-default-price'>Price</Label>
+      <Input
+        id='training-default-price'
+        value={value.defaultPrice}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultPrice: event.target.value })}
+        placeholder='0.00'
+      />
+    </div>
+  );
+}
+
+export function TrainingCurrencyControl({
+  value,
+  disabled = false,
+  onChange,
+}: Pick<TrainingFormFieldsProps, 'value' | 'disabled' | 'onChange'>) {
+  const currencyOptions = getCurrencyOptions();
+  return (
+    <div>
+      <Label htmlFor='training-default-currency'>Currency</Label>
+      <Select
+        id='training-default-currency'
+        value={value.defaultCurrency}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
+      >
+        {currencyOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
+export function TrainingFormFields({ value, disabled = false, onChange }: TrainingFormFieldsProps) {
+  return (
+    <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
+      <TrainingPricingUnitControl value={value} disabled={disabled} onChange={onChange} />
+      <TrainingPriceControl value={value} disabled={disabled} onChange={onChange} />
+      <TrainingCurrencyControl value={value} disabled={disabled} onChange={onChange} />
     </div>
   );
 }

--- a/apps/admin_web/src/lib/entity-api.ts
+++ b/apps/admin_web/src/lib/entity-api.ts
@@ -80,15 +80,27 @@ export async function listEntityFamilyPicker(
 }
 
 export async function listEntityOrganizationPicker(
+  params?: { relationshipType?: string },
   signal?: AbortSignal
 ): Promise<EntityPickerListItem[]> {
+  const query = new URLSearchParams();
+  query.set('limit', '100');
+  if (params?.relationshipType?.trim()) {
+    query.set('relationship_type', params.relationshipType.trim());
+  }
   const payload = await adminApiRequest<ApiEntityPickerList>({
-    endpointPath: '/v1/admin/organizations/picker?limit=100',
+    endpointPath: `/v1/admin/organizations/picker?${query.toString()}`,
     method: 'GET',
     signal,
   });
   const root = unwrapPayload(payload);
   return Array.isArray(root.items) ? root.items.map((e) => parsePickerItem(e)) : [];
+}
+
+export async function listEntityPartnerOrganizationPicker(
+  signal?: AbortSignal
+): Promise<EntityPickerListItem[]> {
+  return listEntityOrganizationPicker({ relationshipType: 'partner' }, signal);
 }
 
 export async function searchEntityContactsForPicker(

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -18,6 +18,7 @@ import {
   type Enrollment,
   type EnrollmentListFilters,
   type EventTicketTier,
+  type PartnerOrgRef,
   type GeographicAreaSummary,
   type LocationSummary,
   type ServiceDetail,
@@ -84,6 +85,19 @@ function parseTicketTier(value: unknown): EventTicketTier {
   };
 }
 
+function parsePartnerOrganization(value: unknown): PartnerOrgRef | null {
+  const item = isRecord(value) ? value : {};
+  const id = asNullableString(item.id);
+  if (!id) {
+    return null;
+  }
+  return {
+    id,
+    name: asNullableString(item.name) ?? '',
+    active: !asBoolean(item.archived, false),
+  };
+}
+
 function parseLocationSummary(value: unknown): LocationSummary {
   const item = isRecord(value) ? value : {};
   return {
@@ -142,6 +156,8 @@ function parseServiceSummary(value: unknown): ServiceSummary {
     eventDetails: eventRaw
       ? {
           eventCategory: normalizeEventCategoryFromApi(eventRaw.event_category),
+          defaultPrice: asNullableString(eventRaw.default_price),
+          defaultCurrency: asNullableString(eventRaw.default_currency) ?? 'HKD',
         }
       : null,
   };
@@ -161,6 +177,8 @@ function parseServiceDetail(value: unknown): ServiceDetail {
   const eventDetails = isRecord(item.event_details)
     ? {
         eventCategory: normalizeEventCategoryFromApi(item.event_details.event_category),
+        defaultPrice: asNullableString(item.event_details.default_price),
+        defaultCurrency: asNullableString(item.event_details.default_currency) ?? 'HKD',
       }
     : null;
   const consultationDetails = isRecord(item.consultation_details)
@@ -184,7 +202,6 @@ function parseServiceDetail(value: unknown): ServiceDetail {
             ? item.consultation_details.default_package_sessions
             : null,
         defaultCurrency: asNullableString(item.consultation_details.default_currency),
-        calendlyUrl: asNullableString(item.consultation_details.calendly_url),
       }
     : null;
   return {
@@ -221,6 +238,12 @@ function parseInstance(value: unknown): ServiceInstance {
     locationId: asNullableString(item.location_id),
     maxCapacity: typeof item.max_capacity === 'number' ? item.max_capacity : null,
     waitlistEnabled: asBoolean(item.waitlist_enabled, false),
+    externalUrl: asNullableString(item.external_url),
+    partnerOrganizations: Array.isArray(item.partner_organizations)
+      ? item.partner_organizations
+          .map((entry) => parsePartnerOrganization(entry))
+          .filter((row): row is PartnerOrgRef => row !== null)
+      : [],
     instructorId: asNullableString(item.instructor_id),
     notes: asNullableString(item.notes),
     createdBy: asNullableString(item.created_by) ?? '',
@@ -256,7 +279,6 @@ function parseInstance(value: unknown): ServiceInstance {
             typeof item.consultation_details.package_sessions === 'number'
               ? item.consultation_details.package_sessions
               : null,
-          calendlyEventUrl: asNullableString(item.consultation_details.calendly_event_url),
         }
       : null,
   };

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2994,12 +2994,17 @@ export interface paths {
         };
         /**
          * List active CRM organisations for pickers
-         * @description Returns active non-vendor organisations ordered by name for admin UI dropdowns.
-         *     At most 100 rows unless `limit` is set lower.
+         * @description Returns active organisations ordered by name for admin UI dropdowns.
+         *     When `relationship_type` is omitted, vendor rows are excluded (same default as
+         *     organization list). When `relationship_type` is set (e.g. `partner`), only
+         *     organisations with that relationship type are returned. At most 100 rows unless
+         *     `limit` is set lower.
          */
         get: {
             parameters: {
                 query?: {
+                    /** @description When set, only organizations with this CRM relationship type are returned. When omitted, vendors are excluded (non-vendor default). */
+                    relationship_type?: components["schemas"]["EntityRelationshipType"];
                     limit?: number;
                 };
                 header?: never;
@@ -4062,6 +4067,10 @@ export interface components {
         };
         ServiceEventDetails: {
             event_category?: components["schemas"]["EventCategory"];
+            /** @description Optional default ticket price for new event instances. */
+            default_price?: string | null;
+            /** @description ISO 4217 currency code for default_price (defaults to HKD). */
+            default_currency?: string;
         };
         ServiceConsultationDetails: {
             consultation_format?: components["schemas"]["ConsultationFormat"];
@@ -4072,7 +4081,6 @@ export interface components {
             default_package_price?: string | null;
             default_package_sessions?: number | null;
             default_currency?: string | null;
-            calendly_url?: string | null;
         };
         DiscountCodeUsageSummaryResponse: {
             total_current_uses: number;
@@ -4187,12 +4195,19 @@ export interface components {
             id?: string | null;
             /** Format: uuid */
             instance_id?: string | null;
-            name?: string;
+            name?: string | null;
             description?: string | null;
-            price?: string;
-            currency?: string;
+            price?: string | null;
+            currency?: string | null;
             max_quantity?: number | null;
             sort_order?: number | null;
+        };
+        InstancePartnerOrganization: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** @description True when the organization is archived (omitted from active pickers). */
+            archived: boolean;
         };
         ServiceInstance: {
             /** Format: uuid */
@@ -4211,6 +4226,12 @@ export interface components {
             location_id?: string | null;
             max_capacity?: number | null;
             waitlist_enabled?: boolean;
+            /**
+             * Format: uri
+             * @description Optional external registration or info URL (http/https only). Distinct from Eventbrite sync URLs on the instance.
+             */
+            external_url?: string | null;
+            partner_organizations?: components["schemas"]["InstancePartnerOrganization"][];
             instructor_id?: string | null;
             notes?: string | null;
             created_by?: string;
@@ -4235,7 +4256,6 @@ export interface components {
                 price?: string | null;
                 currency?: string;
                 package_sessions?: number | null;
-                calendly_event_url?: string | null;
             } | null;
             /** @description Parent service title (present on cross-service list responses). */
             parent_service_title?: string | null;
@@ -4262,6 +4282,10 @@ export interface components {
             location_id?: string | null;
             max_capacity?: number | null;
             waitlist_enabled?: boolean;
+            /** Format: uri */
+            external_url?: string | null;
+            /** @description Ordered partner organization ids for event instances. Unknown ids return 400. */
+            partner_organization_ids?: string[];
             instructor_id?: string | null;
             notes?: string | null;
             session_slots?: components["schemas"]["SessionSlot"][];
@@ -4277,7 +4301,6 @@ export interface components {
                 price?: string | null;
                 currency?: string;
                 package_sessions?: number | null;
-                calendly_event_url?: string | null;
             } | null;
         };
         UpdateInstanceRequest: WithRequired<components["schemas"]["CreateInstanceRequest"], "status">;

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -116,6 +116,8 @@ export interface ServiceSummary {
   } | null;
   eventDetails: {
     eventCategory: EventCategory;
+    defaultPrice: string | null;
+    defaultCurrency: string;
   } | null;
 }
 
@@ -130,6 +132,8 @@ export interface ServiceDetail extends ServiceSummary {
   } | null;
   eventDetails: {
     eventCategory: EventCategory;
+    defaultPrice: string | null;
+    defaultCurrency: string;
   } | null;
   consultationDetails: {
     consultationFormat: ConsultationFormat;
@@ -140,7 +144,6 @@ export interface ServiceDetail extends ServiceSummary {
     defaultPackagePrice: string | null;
     defaultPackageSessions: number | null;
     defaultCurrency: string | null;
-    calendlyUrl: string | null;
   } | null;
 }
 
@@ -202,6 +205,13 @@ export interface EventTicketTier {
   sortOrder: number | null;
 }
 
+/** Partner org on an event instance (`active` is false when archived in CRM). */
+export interface PartnerOrgRef {
+  id: string;
+  name: string;
+  active: boolean;
+}
+
 export interface ServiceInstance {
   id: string;
   serviceId: string;
@@ -217,6 +227,8 @@ export interface ServiceInstance {
   locationId: string | null;
   maxCapacity: number | null;
   waitlistEnabled: boolean;
+  externalUrl: string | null;
+  partnerOrganizations: PartnerOrgRef[];
   instructorId: string | null;
   notes: string | null;
   createdBy: string;
@@ -239,7 +251,6 @@ export interface ServiceInstance {
     price: string | null;
     currency: string;
     packageSessions: number | null;
-    calendlyEventUrl: string | null;
   } | null;
 }
 

--- a/apps/admin_web/tests/components/admin/services/event-instance-partners-field.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/event-instance-partners-field.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EventInstancePartnersField } from '@/components/admin/services/event-instance-partners-field';
+import * as entityApi from '@/lib/entity-api';
+
+vi.mock('@/lib/entity-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/entity-api')>('@/lib/entity-api');
+  return {
+    ...actual,
+    listEntityPartnerOrganizationPicker: vi.fn(),
+  };
+});
+
+describe('EventInstancePartnersField', () => {
+  beforeEach(() => {
+    vi.mocked(entityApi.listEntityPartnerOrganizationPicker).mockResolvedValue([
+      { id: 'live-1', label: 'Live Org' },
+    ]);
+  });
+
+  it('keeps inactive (archived) partners when adding a picker org', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <EventInstancePartnersField
+        value={[{ id: 'arch-1', name: 'Archived Co', active: false }]}
+        onChange={onChange}
+      />
+    );
+
+    const select = await screen.findByLabelText('Partner organisations');
+    await user.selectOptions(select, 'live-1');
+
+    expect(onChange).toHaveBeenCalled();
+    const next = onChange.mock.calls[0][0] as { id: string; active: boolean }[];
+    expect(next).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'arch-1', active: false }),
+        expect.objectContaining({ id: 'live-1', active: true }),
+      ])
+    );
+    expect(next).toHaveLength(2);
+  });
+});

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -3,7 +3,16 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { InstanceDetailPanel } from '@/components/admin/services/instance-detail-panel';
+import * as entityApi from '@/lib/entity-api';
 import type { LocationSummary, ServiceSummary } from '@/types/services';
+
+vi.mock('@/lib/entity-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/entity-api')>('@/lib/entity-api');
+  return {
+    ...actual,
+    listEntityPartnerOrganizationPicker: vi.fn().mockResolvedValue([]),
+  };
+});
 
 function buildServiceSummary(overrides: Partial<ServiceSummary> = {}): ServiceSummary {
   return {
@@ -42,6 +51,10 @@ function buildLocationSummary(overrides: Partial<LocationSummary> = {}): Locatio
 }
 
 describe('InstanceDetailPanel', () => {
+  beforeEach(() => {
+    vi.mocked(entityApi.listEntityPartnerOrganizationPicker).mockResolvedValue([]);
+  });
+
   it('renders service and location selectors in create mode', () => {
     render(
       <InstanceDetailPanel
@@ -64,6 +77,7 @@ describe('InstanceDetailPanel', () => {
     expect(screen.getByLabelText('Location')).toBeInTheDocument();
     expect(screen.getByLabelText('Referral slug')).toBeDisabled();
     expect(screen.getByLabelText('Title')).toBeDisabled();
+    expect(screen.getByLabelText('Waitlist')).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Add instance' })).not.toBeInTheDocument();
   });
 
@@ -94,6 +108,7 @@ describe('InstanceDetailPanel', () => {
       'service-1',
       expect.objectContaining({
         status: 'scheduled',
+        partner_organization_ids: [],
       })
     );
   });
@@ -187,7 +202,11 @@ describe('InstanceDetailPanel', () => {
             serviceType: 'event',
             title: 'Spring open house',
             trainingDetails: null,
-            eventDetails: { eventCategory: 'open_house' },
+            eventDetails: {
+              eventCategory: 'open_house',
+              defaultPrice: '50.00',
+              defaultCurrency: 'HKD',
+            },
           }),
         ]}
         locationOptions={[buildLocationSummary()]}
@@ -207,6 +226,10 @@ describe('InstanceDetailPanel', () => {
     });
     expect(screen.queryByRole('combobox', { name: 'Event category' })).not.toBeInTheDocument();
     expect(screen.getByLabelText('Instructor')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Price')).toHaveValue('50.00');
+    });
+    expect(screen.getByLabelText('External URL')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Add instance' }));
 
@@ -216,8 +239,11 @@ describe('InstanceDetailPanel', () => {
         event_ticket_tiers: [
           expect.objectContaining({
             name: 'open_house',
+            price: '50.00',
+            currency: 'HKD',
           }),
         ],
+        partner_organization_ids: [],
       })
     );
   });

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -145,7 +145,7 @@ describe('ServiceDetailPanel', () => {
       />
     );
 
-    const createModeServiceType = screen.getByLabelText('Service type');
+    const createModeServiceType = screen.getByLabelText('Type');
     expect(createModeServiceType).toBeEnabled();
 
     rerender(
@@ -163,7 +163,7 @@ describe('ServiceDetailPanel', () => {
       />
     );
 
-    const editModeServiceType = screen.getByLabelText('Service type');
+    const editModeServiceType = screen.getByLabelText('Type');
     expect(editModeServiceType).toBeDisabled();
     expect(editModeServiceType).toHaveValue('consultation');
   });
@@ -187,13 +187,34 @@ describe('ServiceDetailPanel', () => {
       />
     );
 
-    await user.selectOptions(screen.getByLabelText('Service type'), 'event');
+    await user.selectOptions(screen.getByLabelText('Type'), 'event');
 
     expect(screen.getByLabelText('Delivery mode')).toBeInTheDocument();
     expect(screen.getByLabelText('Event category')).toBeInTheDocument();
     expect(screen.getByLabelText('Booking system')).toBeInTheDocument();
-    expect(screen.getByLabelText('Cover image file name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cover file name')).toBeInTheDocument();
     expect(screen.queryAllByLabelText('Booking system')).toHaveLength(1);
     expect(screen.queryByText('Pricing unit')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Default price')).toBeInTheDocument();
+  });
+
+  it('shows consultation Row D/E fields without Calendly', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
+    expect(screen.getByLabelText('Consultation format')).toBeInTheDocument();
+    expect(screen.getByLabelText('Pricing model')).toBeInTheDocument();
+    expect(screen.getByLabelText('Max group size')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Calendly/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/admin_web/tests/components/admin/services/session-slot-editor.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/session-slot-editor.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionSlotEditor } from '@/components/admin/services/session-slot-editor';
+
+describe('SessionSlotEditor', () => {
+  it('renders a label above each control for every slot row', () => {
+    render(
+      <SessionSlotEditor
+        slots={[
+          {
+            id: null,
+            instanceId: null,
+            locationId: null,
+            startsAt: null,
+            endsAt: null,
+            sortOrder: 0,
+          },
+          {
+            id: null,
+            instanceId: null,
+            locationId: null,
+            startsAt: null,
+            endsAt: null,
+            sortOrder: 1,
+          },
+        ]}
+        onChange={vi.fn()}
+      />
+    );
+
+    const startLabels = screen.getAllByText('Start time');
+    const endLabels = screen.getAllByText('End time');
+    const locationLabels = screen.getAllByText('Location');
+    const sortLabels = screen.getAllByText('Sort order');
+    expect(startLabels).toHaveLength(2);
+    expect(endLabels).toHaveLength(2);
+    expect(locationLabels).toHaveLength(2);
+    expect(sortLabels).toHaveLength(2);
+  });
+});

--- a/apps/admin_web/tests/lib/services-api.test.ts
+++ b/apps/admin_web/tests/lib/services-api.test.ts
@@ -106,7 +106,11 @@ describe('services-api', () => {
             created_at: '2026-03-01T00:00:00.000Z',
             updated_at: '2026-03-01T00:00:00.000Z',
             training_details: null,
-            event_details: { event_category: 'open_house' },
+            event_details: {
+              event_category: 'open_house',
+              default_price: '25.00',
+              default_currency: 'USD',
+            },
           },
         ],
         next_cursor: null,
@@ -125,7 +129,11 @@ describe('services-api', () => {
     expect(result.items[0]).toMatchObject({
       id: 'service-event-1',
       serviceType: 'event',
-      eventDetails: { eventCategory: 'open_house' },
+      eventDetails: {
+        eventCategory: 'open_house',
+        defaultPrice: '25.00',
+        defaultCurrency: 'USD',
+      },
     });
   });
 

--- a/backend/db/alembic/versions/0034_drop_calendly_fields.py
+++ b/backend/db/alembic/versions/0034_drop_calendly_fields.py
@@ -1,0 +1,41 @@
+"""Drop Calendly URL columns from consultation service and instance details.
+
+Seed-data assessment (``backend/db/seed/seed_data.sql``):
+1. Compatibility: seed does not reference ``calendly_url`` / ``calendly_event_url``; no seed update required.
+2. NOT NULL: N/A (dropped columns were nullable).
+3. Renamed/dropped: columns removed; seed unaffected.
+4. New tables: N/A.
+5. Enum: N/A.
+6. FK order: N/A.
+
+**Irreversible data:** Upgrade permanently drops stored Calendly URLs. Downgrade re-adds
+the columns as NULL; previous values cannot be recovered.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0034_drop_calendly_fields"
+down_revision: Union[str, None] = "0033_phone_region"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column("consultation_details", "calendly_url")
+    op.drop_column("consultation_instance_details", "calendly_event_url")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "consultation_details",
+        sa.Column("calendly_url", sa.String(length=500), nullable=True),
+    )
+    op.add_column(
+        "consultation_instance_details",
+        sa.Column("calendly_event_url", sa.String(length=500), nullable=True),
+    )

--- a/backend/db/alembic/versions/0035_event_default_price.py
+++ b/backend/db/alembic/versions/0035_event_default_price.py
@@ -1,0 +1,44 @@
+"""Add default price and currency columns to event_details.
+
+Seed-data assessment (``backend/db/seed/seed_data.sql``):
+1. Compatibility: seed inserts into ``event_details`` gain server defaults for
+   ``default_currency``; ``default_price`` remains NULL unless seed is extended.
+2. NOT NULL: ``default_currency`` is NOT NULL with server default ``HKD``; existing rows OK.
+3. Renamed/dropped: N/A.
+4. New tables: N/A.
+5. Enum: N/A.
+6. FK order: N/A.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0035_event_default_price"
+down_revision: Union[str, None] = "0034_drop_calendly_fields"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "event_details",
+        sa.Column("default_price", sa.Numeric(10, 2), nullable=True),
+    )
+    op.add_column(
+        "event_details",
+        sa.Column(
+            "default_currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default="HKD",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("event_details", "default_currency")
+    op.drop_column("event_details", "default_price")

--- a/backend/db/alembic/versions/0036_instance_partners_ext_url.py
+++ b/backend/db/alembic/versions/0036_instance_partners_ext_url.py
@@ -1,0 +1,81 @@
+"""Add external_url to service_instances and partner-org M2M table.
+
+Seed-data assessment (``backend/db/seed/seed_data.sql``):
+1. Compatibility: seed unaffected (no references to new columns/table).
+2. NOT NULL: ``external_url`` is nullable; M2M table empty by default.
+3. Renamed/dropped: N/A.
+4. New tables: ``service_instance_organizations`` starts empty; no seed rows required.
+5. Enum: N/A.
+6. FK order: table references ``service_instances`` and ``organizations`` (already seeded).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+revision: str = "0036_instance_partners_ext_url"
+down_revision: Union[str, None] = "0035_event_default_price"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "service_instances",
+        sa.Column("external_url", sa.String(length=500), nullable=True),
+    )
+    op.create_table(
+        "service_instance_organizations",
+        sa.Column(
+            "service_instance_id",
+            PG_UUID(as_uuid=True),
+            sa.ForeignKey("service_instances.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "organization_id",
+            PG_UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "sort_order",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("service_instance_id", "organization_id"),
+    )
+    op.create_index(
+        "svc_instance_org_instance_idx",
+        "service_instance_organizations",
+        ["service_instance_id"],
+    )
+    op.create_index(
+        "svc_instance_org_organization_idx",
+        "service_instance_organizations",
+        ["organization_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "svc_instance_org_organization_idx",
+        table_name="service_instance_organizations",
+    )
+    op.drop_index(
+        "svc_instance_org_instance_idx",
+        table_name="service_instance_organizations",
+    )
+    op.drop_table("service_instance_organizations")
+    op.drop_column("service_instances", "external_url")

--- a/backend/src/app/api/admin_organizations_picker.py
+++ b/backend/src/app/api/admin_organizations_picker.py
@@ -53,21 +53,22 @@ def _list_organization_picker(event: Mapping[str, Any]) -> dict[str, Any]:
     limit = parse_limit(event, default=_DEFAULT_LIMIT)
     relationship_filter = query_param(event, "relationship_type")
     with Session(get_engine()) as session:
-        filters = [Organization.archived_at.is_(None)]
+        statement = select(Organization.id, Organization.name).where(
+            Organization.archived_at.is_(None)
+        )
         if relationship_filter:
             rel_type = parse_relationship_type(
                 relationship_filter,
                 field="relationship_type",
             )
-            filters.append(Organization.relationship_type == rel_type)
+            statement = statement.where(Organization.relationship_type == rel_type)
         else:
-            filters.append(Organization.relationship_type != RelationshipType.VENDOR)
-        statement = (
-            select(Organization.id, Organization.name)
-            .where(*filters)
-            .order_by(Organization.name.asc(), Organization.id.asc())
-            .limit(limit)
-        )
+            statement = statement.where(
+                Organization.relationship_type != RelationshipType.VENDOR
+            )
+        statement = statement.order_by(
+            Organization.name.asc(), Organization.id.asc()
+        ).limit(limit)
         rows = session.execute(statement).all()
         items = [{"id": str(r[0]), "label": r[1]} for r in rows]
         return json_response(200, {"items": items}, event=event)

--- a/backend/src/app/api/admin_organizations_picker.py
+++ b/backend/src/app/api/admin_organizations_picker.py
@@ -1,14 +1,15 @@
-"""Lightweight organization picker list for admin UI (excludes vendors)."""
+"""Lightweight organization picker list for admin UI."""
 
 from __future__ import annotations
 
-from typing import Any
 from collections.abc import Mapping
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.admin_entities_helpers import parse_limit
+from app.api.admin_entities_helpers import parse_limit, parse_relationship_type
+from app.api.admin_request import query_param
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.engine import get_engine
 from app.db.models import Organization, RelationshipType
@@ -50,13 +51,20 @@ def handle_admin_organizations_picker_request(
 
 def _list_organization_picker(event: Mapping[str, Any]) -> dict[str, Any]:
     limit = parse_limit(event, default=_DEFAULT_LIMIT)
+    relationship_filter = query_param(event, "relationship_type")
     with Session(get_engine()) as session:
+        filters = [Organization.archived_at.is_(None)]
+        if relationship_filter:
+            rel_type = parse_relationship_type(
+                relationship_filter,
+                field="relationship_type",
+            )
+            filters.append(Organization.relationship_type == rel_type)
+        else:
+            filters.append(Organization.relationship_type != RelationshipType.VENDOR)
         statement = (
             select(Organization.id, Organization.name)
-            .where(
-                Organization.archived_at.is_(None),
-                Organization.relationship_type != RelationshipType.VENDOR,
-            )
+            .where(*filters)
             .order_by(Organization.name.asc(), Organization.id.asc())
             .limit(limit)
         )

--- a/backend/src/app/api/admin_service_instance_partners.py
+++ b/backend/src/app/api/admin_service_instance_partners.py
@@ -20,7 +20,9 @@ logger = get_logger(__name__)
 
 def parse_partner_organization_ids(body: Mapping[str, Any]) -> list[UUID]:
     """Parse partner_organization_ids; dedupe while preserving order."""
-    raw = parse_uuid_list(body.get("partner_organization_ids"), "partner_organization_ids")
+    raw = parse_uuid_list(
+        body.get("partner_organization_ids"), "partner_organization_ids"
+    )
     seen: set[UUID] = set()
     ordered: list[UUID] = []
     for org_id in raw:
@@ -30,9 +32,7 @@ def parse_partner_organization_ids(body: Mapping[str, Any]) -> list[UUID]:
     return ordered
 
 
-def validate_partner_organization_ids(
-    session: Session, org_ids: list[UUID]
-) -> None:
+def validate_partner_organization_ids(session: Session, org_ids: list[UUID]) -> None:
     """Raise ValidationError if any organization id does not exist."""
     if not org_ids:
         return

--- a/backend/src/app/api/admin_service_instance_partners.py
+++ b/backend/src/app/api/admin_service_instance_partners.py
@@ -1,0 +1,72 @@
+"""Partner organization links for admin service instances."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.db.models import Organization, ServiceInstancePartnerOrganization
+from app.exceptions import ValidationError
+from app.utils.logging import get_logger
+
+from .admin_services_payload_utils import parse_uuid_list
+
+logger = get_logger(__name__)
+
+
+def parse_partner_organization_ids(body: Mapping[str, Any]) -> list[UUID]:
+    """Parse partner_organization_ids; dedupe while preserving order."""
+    raw = parse_uuid_list(body.get("partner_organization_ids"), "partner_organization_ids")
+    seen: set[UUID] = set()
+    ordered: list[UUID] = []
+    for org_id in raw:
+        if org_id not in seen:
+            seen.add(org_id)
+            ordered.append(org_id)
+    return ordered
+
+
+def validate_partner_organization_ids(
+    session: Session, org_ids: list[UUID]
+) -> None:
+    """Raise ValidationError if any organization id does not exist."""
+    if not org_ids:
+        return
+    statement = select(Organization.id).where(Organization.id.in_(org_ids))
+    found = {row[0] for row in session.execute(statement).all()}
+    missing = [str(i) for i in org_ids if i not in found]
+    if missing:
+        raise ValidationError(
+            "Unknown partner_organization_ids",
+            field="partner_organization_ids",
+        )
+
+
+def reconcile_instance_partner_organizations(
+    session: Session,
+    *,
+    instance_id: UUID,
+    ordered_org_ids: list[UUID],
+) -> None:
+    """Replace M2M rows for the instance with the given ordered org ids."""
+    logger.debug(
+        "Reconciling instance partner organizations",
+        extra={"instance_id": str(instance_id), "count": len(ordered_org_ids)},
+    )
+    session.execute(
+        delete(ServiceInstancePartnerOrganization).where(
+            ServiceInstancePartnerOrganization.service_instance_id == instance_id
+        )
+    )
+    for sort_order, org_id in enumerate(ordered_org_ids):
+        session.add(
+            ServiceInstancePartnerOrganization(
+                service_instance_id=instance_id,
+                organization_id=org_id,
+                sort_order=sort_order,
+            )
+        )

--- a/backend/src/app/api/admin_service_instance_partners.py
+++ b/backend/src/app/api/admin_service_instance_partners.py
@@ -21,7 +21,9 @@ logger = get_logger(__name__)
 def parse_partner_organization_ids(body: Mapping[str, Any]) -> list[UUID]:
     """Parse partner_organization_ids; dedupe while preserving order."""
     raw = parse_uuid_list(
-        body.get("partner_organization_ids"), "partner_organization_ids"
+        body.get("partner_organization_ids"),
+        "partner_organization_ids",
+        reject_empty_members=True,
     )
     seen: set[UUID] = set()
     ordered: list[UUID] = []

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
@@ -10,6 +11,10 @@ from sqlalchemy.orm import Session
 
 from app.api.admin_enrollments import handle_admin_enrollments_request
 from app.api.admin_request import parse_body, parse_uuid
+from app.api.admin_service_instance_partners import (
+    reconcile_instance_partner_organizations,
+    validate_partner_organization_ids,
+)
 from app.api.admin_services_common import (
     encode_instance_cursor,
     parse_create_instance_payload,
@@ -24,8 +29,10 @@ from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.models import (
     ConsultationInstanceDetails,
+    EventCategory,
     EventTicketTier,
     InstanceSessionSlot,
+    Service,
     ServiceInstance,
     ServiceType,
     TrainingFormat,
@@ -38,6 +45,44 @@ from app.utils import json_response
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def _resolve_event_ticket_tiers_for_persist(
+    service: Service, parsed_tiers: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Fill missing tier price/currency from service event defaults; default name from category."""
+    if not parsed_tiers:
+        parsed_tiers = [{}]
+    event_details = service.event_details
+    default_price = event_details.default_price if event_details is not None else None
+    default_currency = (
+        event_details.default_currency if event_details is not None else "HKD"
+    )
+    category_name = (
+        event_details.event_category.value
+        if event_details is not None
+        else EventCategory.WORKSHOP.value
+    )
+    resolved: list[dict[str, Any]] = []
+    for idx, tier in enumerate(parsed_tiers):
+        price = tier.get("price")
+        if price is None:
+            price = default_price if default_price is not None else Decimal("0")
+        currency = tier.get("currency") or default_currency
+        name = tier.get("name") or category_name
+        resolved.append(
+            {
+                "name": name,
+                "description": tier.get("description"),
+                "price": price,
+                "currency": currency,
+                "max_quantity": tier.get("max_quantity"),
+                "sort_order": tier.get("sort_order")
+                if tier.get("sort_order") is not None
+                else idx,
+            }
+        )
+    return resolved
 
 
 def handle_admin_all_service_instances_request(
@@ -225,10 +270,11 @@ def _create_instance(
         service_repository = ServiceRepository(session)
         instance_repository = ServiceInstanceRepository(session)
 
-        service = service_repository.get_by_id(service_id)
+        service = service_repository.get_by_id_with_details(service_id)
         if service is None:
             raise NotFoundError("Service", str(service_id))
         payload = parse_create_instance_payload(body, service)
+        validate_partner_organization_ids(session, payload["partner_organization_ids"])
 
         instance = ServiceInstance(
             service_id=service_id,
@@ -244,10 +290,19 @@ def _create_instance(
             waitlist_enabled=payload["waitlist_enabled"],
             instructor_id=payload["instructor_id"],
             notes=payload["notes"],
+            external_url=payload["external_url"],
             created_by=actor_sub,
         )
+        type_details_raw = payload["type_details"]
+        if service.service_type == ServiceType.EVENT:
+            type_details_raw = {
+                **type_details_raw,
+                "event_ticket_tiers": _resolve_event_ticket_tiers_for_persist(
+                    service, type_details_raw["event_ticket_tiers"]
+                ),
+            }
         type_details = _build_instance_type_details(
-            service.service_type, payload["type_details"]
+            service.service_type, type_details_raw
         )
         slots = [
             InstanceSessionSlot(
@@ -259,6 +314,11 @@ def _create_instance(
             for item in payload["session_slots"]
         ]
         created = instance_repository.create_instance(instance, type_details, slots)
+        reconcile_instance_partner_organizations(
+            session,
+            instance_id=created.id,
+            ordered_org_ids=payload["partner_organization_ids"],
+        )
         session.commit()
         if service.service_type == ServiceType.EVENT:
             enqueue_eventbrite_instance_sync_by_id(created.id)
@@ -311,13 +371,17 @@ def _update_instance(
         service_repository = ServiceRepository(session)
         instance_repository = ServiceInstanceRepository(session)
 
-        service = service_repository.get_by_id(service_id)
+        service = service_repository.get_by_id_with_details(service_id)
         if service is None:
             raise NotFoundError("Service", str(service_id))
         instance = instance_repository.get_by_id_with_details(instance_id)
         if instance is None or instance.service_id != service_id:
             raise NotFoundError("ServiceInstance", str(instance_id))
         payload = parse_update_instance_payload(body, service)
+        if "partner_organization_ids" in payload:
+            validate_partner_organization_ids(
+                session, payload["partner_organization_ids"]
+            )
 
         if "title" in payload:
             instance.title = payload["title"]
@@ -343,6 +407,8 @@ def _update_instance(
             instance.instructor_id = payload["instructor_id"]
         if "notes" in payload:
             instance.notes = payload["notes"]
+        if "external_url" in payload:
+            instance.external_url = payload["external_url"]
         if "session_slots" in payload:
             instance.session_slots.clear()
             for item in payload["session_slots"]:
@@ -355,10 +421,24 @@ def _update_instance(
                     )
                 )
         if "type_details" in payload:
+            type_details_raw = payload["type_details"]
+            if service.service_type == ServiceType.EVENT:
+                type_details_raw = {
+                    **type_details_raw,
+                    "event_ticket_tiers": _resolve_event_ticket_tiers_for_persist(
+                        service, type_details_raw["event_ticket_tiers"]
+                    ),
+                }
             _apply_instance_type_details(
                 instance=instance,
                 service_type=service.service_type,
-                parsed_details=payload["type_details"],
+                parsed_details=type_details_raw,
+            )
+        if "partner_organization_ids" in payload:
+            reconcile_instance_partner_organizations(
+                session,
+                instance_id=instance.id,
+                ordered_org_ids=payload["partner_organization_ids"],
             )
 
         updated = instance_repository.update_instance(instance)
@@ -430,7 +510,6 @@ def _build_instance_type_details(
         price=parsed["price"],
         currency=parsed["currency"],
         package_sessions=parsed["package_sessions"],
-        calendly_event_url=parsed["calendly_event_url"],
     )
 
 

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
@@ -47,10 +46,20 @@ from app.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+def _event_category_name(service: Service) -> str:
+    if service.event_details is not None:
+        return service.event_details.event_category.value
+    return EventCategory.WORKSHOP.value
+
+
 def _resolve_event_ticket_tiers_for_persist(
     service: Service, parsed_tiers: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    """Fill missing tier price/currency from service event defaults; default name from category."""
+    """Fill missing tier currency from service event defaults; default name from category.
+
+    Missing ``price`` uses the service-level ``default_price`` when set; otherwise
+    callers must supply an explicit price (no silent zero).
+    """
     if not parsed_tiers:
         parsed_tiers = [{}]
     event_details = service.event_details
@@ -58,16 +67,19 @@ def _resolve_event_ticket_tiers_for_persist(
     default_currency = (
         event_details.default_currency if event_details is not None else "HKD"
     )
-    category_name = (
-        event_details.event_category.value
-        if event_details is not None
-        else EventCategory.WORKSHOP.value
-    )
+    category_name = _event_category_name(service)
     resolved: list[dict[str, Any]] = []
     for idx, tier in enumerate(parsed_tiers):
         price = tier.get("price")
         if price is None:
-            price = default_price if default_price is not None else Decimal("0")
+            if default_price is not None:
+                price = default_price
+            else:
+                raise ValidationError(
+                    "Each event_ticket_tiers entry must include price, or the service "
+                    "must define event_details.default_price",
+                    field="event_ticket_tiers",
+                )
         currency = tier.get("currency") or default_currency
         name = tier.get("name") or category_name
         resolved.append(
@@ -83,6 +95,102 @@ def _resolve_event_ticket_tiers_for_persist(
             }
         )
     return resolved
+
+
+def _merge_event_ticket_tiers_with_existing(
+    service: Service,
+    instance: ServiceInstance | None,
+    resolved_tiers: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Preserve multi-tier rows and non-category tier metadata when the UI sends one tier.
+
+    When the instance already has ticket tiers and the client sends a single tier
+    object (admin Row D), merge price/currency into the tier whose ``name`` matches
+    the service event category, or the sole tier, and keep other tiers unchanged.
+    When the client sends N tiers for an instance with N tiers, zip-merge by
+    ``sort_order`` and preserve each existing tier's name, description, max_quantity,
+    and sort_order while applying payload price/currency per row.
+    """
+    if instance is None or not instance.ticket_tiers:
+        return resolved_tiers
+    existing = sorted(
+        instance.ticket_tiers,
+        key=lambda row: (row.sort_order, str(getattr(row, "id", ""))),
+    )
+    category_name = _event_category_name(service)
+
+    if len(resolved_tiers) == 1:
+        patch = resolved_tiers[0]
+        if len(existing) == 1:
+            t = existing[0]
+            return [
+                {
+                    **patch,
+                    "name": t.name,
+                    "description": t.description,
+                    "max_quantity": t.max_quantity,
+                    "sort_order": t.sort_order,
+                }
+            ]
+        match_index = next(
+            (i for i, t in enumerate(existing) if t.name == category_name), None
+        )
+        if match_index is None:
+            raise ValidationError(
+                "This instance has multiple ticket tiers; none matches the service "
+                f"event category ({category_name!r}). Send a full event_ticket_tiers "
+                "array with one entry per tier to update prices.",
+                field="event_ticket_tiers",
+            )
+        merged: list[dict[str, Any]] = []
+        for t in existing:
+            if t.name == category_name:
+                merged.append(
+                    {
+                        **patch,
+                        "name": t.name,
+                        "description": t.description,
+                        "max_quantity": t.max_quantity,
+                        "sort_order": t.sort_order,
+                    }
+                )
+            else:
+                merged.append(
+                    {
+                        "name": t.name,
+                        "description": t.description,
+                        "price": t.price,
+                        "currency": t.currency,
+                        "max_quantity": t.max_quantity,
+                        "sort_order": t.sort_order,
+                    }
+                )
+        return merged
+
+    if len(resolved_tiers) != len(existing):
+        raise ValidationError(
+            "event_ticket_tiers length must match the number of existing tiers "
+            f"({len(existing)}); send {len(existing)} tier objects or a single tier "
+            "for category-scoped price updates.",
+            field="event_ticket_tiers",
+        )
+    res_sorted = sorted(
+        resolved_tiers,
+        key=lambda row: row.get("sort_order", 0),
+    )
+    out: list[dict[str, Any]] = []
+    for t, p in zip(existing, res_sorted, strict=True):
+        out.append(
+            {
+                "name": t.name,
+                "description": t.description,
+                "price": p["price"],
+                "currency": p.get("currency") or t.currency,
+                "max_quantity": t.max_quantity,
+                "sort_order": t.sort_order,
+            }
+        )
+    return out
 
 
 def handle_admin_all_service_instances_request(
@@ -295,10 +403,13 @@ def _create_instance(
         )
         type_details_raw = payload["type_details"]
         if service.service_type == ServiceType.EVENT:
+            resolved = _resolve_event_ticket_tiers_for_persist(
+                service, type_details_raw["event_ticket_tiers"]
+            )
             type_details_raw = {
                 **type_details_raw,
-                "event_ticket_tiers": _resolve_event_ticket_tiers_for_persist(
-                    service, type_details_raw["event_ticket_tiers"]
+                "event_ticket_tiers": _merge_event_ticket_tiers_with_existing(
+                    service, instance, resolved
                 ),
             }
         type_details = _build_instance_type_details(
@@ -519,17 +630,48 @@ def _apply_instance_type_details(
     service_type: ServiceType,
     parsed_details: Mapping[str, Any],
 ) -> None:
+    if service_type == ServiceType.EVENT:
+        raw_tiers = parsed_details.get("event_ticket_tiers")
+        if not isinstance(raw_tiers, list):
+            raise ValidationError(
+                "event_ticket_tiers must be an array", field="event_ticket_tiers"
+            )
+        tiers_data: list[dict[str, Any]] = list(raw_tiers)
+        tiers_sorted = sorted(tiers_data, key=lambda d: d["sort_order"])
+        existing_sorted = sorted(
+            instance.ticket_tiers,
+            key=lambda t: (t.sort_order, str(t.id)),
+        )
+        if existing_sorted and len(tiers_sorted) == len(existing_sorted):
+            for tier_row, data in zip(existing_sorted, tiers_sorted, strict=True):
+                tier_row.name = data["name"]
+                tier_row.description = data.get("description")
+                tier_row.price = data["price"]
+                tier_row.currency = data["currency"]
+                tier_row.max_quantity = data.get("max_quantity")
+                tier_row.sort_order = data["sort_order"]
+        else:
+            instance.ticket_tiers.clear()
+            for data in tiers_sorted:
+                instance.ticket_tiers.append(
+                    EventTicketTier(
+                        name=data["name"],
+                        description=data.get("description"),
+                        price=data["price"],
+                        currency=data["currency"],
+                        max_quantity=data.get("max_quantity"),
+                        sort_order=data["sort_order"],
+                    )
+                )
+        instance.training_details = None
+        instance.consultation_details = None
+        return
+
     details = _build_instance_type_details(service_type, parsed_details)
     if service_type == ServiceType.TRAINING_COURSE:
         instance.training_details = details
         instance.consultation_details = None
         instance.ticket_tiers.clear()
-    elif service_type == ServiceType.EVENT:
-        instance.ticket_tiers.clear()
-        for tier in details:
-            instance.ticket_tiers.append(tier)
-        instance.training_details = None
-        instance.consultation_details = None
     else:
         instance.consultation_details = details
         instance.training_details = None

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -450,35 +450,35 @@ def _apply_service_type_details(*, service: Service, details: Any) -> None:
         if service.training_course_details is None:
             service.training_course_details = details
         else:
-            existing = service.training_course_details
-            existing.pricing_unit = details.pricing_unit
-            existing.default_price = details.default_price
-            existing.default_currency = details.default_currency
+            training_row = service.training_course_details
+            training_row.pricing_unit = details.pricing_unit
+            training_row.default_price = details.default_price
+            training_row.default_currency = details.default_currency
         service.event_details = None
         service.consultation_details = None
     elif isinstance(details, EventDetails):
         if service.event_details is None:
             service.event_details = details
         else:
-            existing = service.event_details
-            existing.event_category = details.event_category
-            existing.default_price = details.default_price
-            existing.default_currency = details.default_currency
+            event_row = service.event_details
+            event_row.event_category = details.event_category
+            event_row.default_price = details.default_price
+            event_row.default_currency = details.default_currency
         service.training_course_details = None
         service.consultation_details = None
     else:
         if service.consultation_details is None:
             service.consultation_details = details
         else:
-            existing = service.consultation_details
-            existing.consultation_format = details.consultation_format
-            existing.max_group_size = details.max_group_size
-            existing.duration_minutes = details.duration_minutes
-            existing.pricing_model = details.pricing_model
-            existing.default_hourly_rate = details.default_hourly_rate
-            existing.default_package_price = details.default_package_price
-            existing.default_package_sessions = details.default_package_sessions
-            existing.default_currency = details.default_currency
+            consultation_row = service.consultation_details
+            consultation_row.consultation_format = details.consultation_format
+            consultation_row.max_group_size = details.max_group_size
+            consultation_row.duration_minutes = details.duration_minutes
+            consultation_row.pricing_model = details.pricing_model
+            consultation_row.default_hourly_rate = details.default_hourly_rate
+            consultation_row.default_package_price = details.default_package_price
+            consultation_row.default_package_sessions = details.default_package_sessions
+            consultation_row.default_currency = details.default_currency
         service.training_course_details = None
         service.event_details = None
 

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -388,7 +388,9 @@ def _build_service_type_details(
         )
     if service_type == ServiceType.EVENT:
         return EventDetails(
-            event_category=EventCategory(parsed_details["event_category"].value)
+            event_category=EventCategory(parsed_details["event_category"].value),
+            default_price=parsed_details["default_price"],
+            default_currency=parsed_details["default_currency"],
         )
     return ConsultationDetails(
         consultation_format=ConsultationFormat(
@@ -401,7 +403,6 @@ def _build_service_type_details(
         default_package_price=parsed_details["default_package_price"],
         default_package_sessions=parsed_details["default_package_sessions"],
         default_currency=parsed_details["default_currency"],
-        calendly_url=parsed_details["calendly_url"],
     )
 
 
@@ -446,15 +447,38 @@ def _is_services_slug_unique_violation(exc: IntegrityError) -> bool:
 
 def _apply_service_type_details(*, service: Service, details: Any) -> None:
     if isinstance(details, TrainingCourseDetails):
-        service.training_course_details = details
+        if service.training_course_details is None:
+            service.training_course_details = details
+        else:
+            existing = service.training_course_details
+            existing.pricing_unit = details.pricing_unit
+            existing.default_price = details.default_price
+            existing.default_currency = details.default_currency
         service.event_details = None
         service.consultation_details = None
     elif isinstance(details, EventDetails):
-        service.event_details = details
+        if service.event_details is None:
+            service.event_details = details
+        else:
+            existing = service.event_details
+            existing.event_category = details.event_category
+            existing.default_price = details.default_price
+            existing.default_currency = details.default_currency
         service.training_course_details = None
         service.consultation_details = None
     else:
-        service.consultation_details = details
+        if service.consultation_details is None:
+            service.consultation_details = details
+        else:
+            existing = service.consultation_details
+            existing.consultation_format = details.consultation_format
+            existing.max_group_size = details.max_group_size
+            existing.duration_minutes = details.duration_minutes
+            existing.pricing_model = details.pricing_model
+            existing.default_hourly_rate = details.default_hourly_rate
+            existing.default_package_price = details.default_package_price
+            existing.default_package_sessions = details.default_package_sessions
+            existing.default_currency = details.default_currency
         service.training_course_details = None
         service.event_details = None
 

--- a/backend/src/app/api/admin_services_payload_utils.py
+++ b/backend/src/app/api/admin_services_payload_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
@@ -68,7 +69,20 @@ def parse_service_type_details(
                 source.get("event_category") or body.get("event_category"),
                 EventCategory,
                 "event_category",
+            ),
+            "default_price": parse_optional_decimal(
+                source.get("default_price")
+                if "default_price" in source
+                else body.get("default_price"),
+                "default_price",
+            ),
+            "default_currency": parse_optional_currency(
+                source.get("default_currency")
+                if "default_currency" in source
+                else body.get("default_currency"),
+                "default_currency",
             )
+            or "HKD",
         }
 
     source = extract_obj(body, "consultation_details")
@@ -130,12 +144,6 @@ def parse_service_type_details(
             "default_currency",
         )
         or "HKD",
-        "calendly_url": parse_optional_text(
-            source.get("calendly_url")
-            if "calendly_url" in source
-            else body.get("calendly_url"),
-            max_length=500,
-        ),
     }
 
 
@@ -191,19 +199,17 @@ def parse_instance_type_details(
                     f"event_ticket_tiers[{idx}] must be an object",
                     field="event_ticket_tiers",
                 )
+            name_raw = parse_optional_text(entry.get("name"), max_length=100)
             tiers.append(
                 {
-                    "name": parse_required_text(
-                        entry.get("name"), "name", max_length=100
-                    ),
+                    "name": (name_raw or "").strip(),
                     "description": parse_optional_text(
                         entry.get("description"), max_length=MAX_DESCRIPTION_LENGTH
                     ),
-                    "price": parse_required_decimal(entry.get("price"), "price"),
+                    "price": parse_optional_decimal(entry.get("price"), "price"),
                     "currency": parse_optional_currency(
                         entry.get("currency"), "currency"
-                    )
-                    or "HKD",
+                    ),
                     "max_quantity": parse_optional_int(
                         entry.get("max_quantity"), "max_quantity", minimum=1
                     ),
@@ -237,12 +243,6 @@ def parse_instance_type_details(
             else body.get("package_sessions"),
             "package_sessions",
             minimum=1,
-        ),
-        "calendly_event_url": parse_optional_text(
-            source.get("calendly_event_url")
-            if "calendly_event_url" in source
-            else body.get("calendly_event_url"),
-            max_length=500,
         ),
     }
 
@@ -400,6 +400,26 @@ def parse_required_decimal(value: Any, field: str) -> Decimal:
     if parsed <= Decimal("0"):
         raise ValidationError(f"{field} must be greater than 0", field=field)
     return parsed
+
+
+_EXTERNAL_URL_PATTERN = re.compile(r"^https?://", re.IGNORECASE)
+
+
+def parse_optional_external_url(value: Any, field: str) -> str | None:
+    """Parse optional external URL: trim, max 500, http(s) only."""
+    if value is None or str(value).strip() == "":
+        return None
+    if not isinstance(value, str):
+        raise ValidationError(f"{field} must be a string", field=field)
+    trimmed = value.strip()
+    if len(trimmed) > 500:
+        raise ValidationError(f"{field} must be at most 500 characters", field=field)
+    if not _EXTERNAL_URL_PATTERN.match(trimmed):
+        raise ValidationError(
+            f"{field} must start with http:// or https://",
+            field=field,
+        )
+    return trimmed
 
 
 def parse_required_non_negative_decimal(value: Any, field: str) -> Decimal:

--- a/backend/src/app/api/admin_services_payload_utils.py
+++ b/backend/src/app/api/admin_services_payload_utils.py
@@ -307,13 +307,22 @@ def parse_optional_uuid(value: Any, field: str) -> UUID | None:
         raise ValidationError(f"{field} must be a valid UUID", field=field) from exc
 
 
-def parse_uuid_list(value: Any, field: str) -> list[UUID]:
+def parse_uuid_list(
+    value: Any, field: str, *, reject_empty_members: bool = False
+) -> list[UUID]:
     if value is None:
         return []
     if not isinstance(value, list):
         raise ValidationError(f"{field} must be a list of UUID strings", field=field)
     parsed: list[UUID] = []
     for idx, entry in enumerate(value):
+        if reject_empty_members and (
+            entry is None or (isinstance(entry, str) and entry.strip() == "")
+        ):
+            raise ValidationError(
+                f"{field}[{idx}] must be a non-empty UUID string",
+                field=field,
+            )
         parsed_value = parse_optional_uuid(entry, f"{field}[{idx}]")
         if parsed_value is not None:
             parsed.append(parsed_value)

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -14,6 +14,7 @@ from app.api.admin_validators import (
     parse_optional_service_instance_slug,
 )
 from app.api.admin_services_cursor import parse_created_cursor
+from app.api.admin_service_instance_partners import parse_partner_organization_ids
 from app.api.admin_services_payload_utils import (
     has_any_field,
     has_field,
@@ -24,6 +25,7 @@ from app.api.admin_services_payload_utils import (
     parse_optional_decimal,
     parse_optional_enum,
     parse_optional_int,
+    parse_optional_external_url,
     parse_optional_text,
     parse_optional_uuid,
     parse_required_bool,
@@ -297,6 +299,8 @@ def parse_update_service_payload(
         "consultation_details",
         "pricing_unit",
         "event_category",
+        "default_price",
+        "default_currency",
         "consultation_format",
         "pricing_model",
     ):
@@ -349,6 +353,10 @@ def parse_create_instance_payload(
         "notes": parse_optional_text(
             body.get("notes"), max_length=MAX_DESCRIPTION_LENGTH
         ),
+        "external_url": parse_optional_external_url(
+            body.get("external_url"), "external_url"
+        ),
+        "partner_organization_ids": parse_partner_organization_ids(body),
         "session_slots": parse_session_slots(body.get("session_slots")),
         "type_details": parse_instance_type_details(service.service_type, body),
     }
@@ -408,6 +416,12 @@ def parse_update_instance_payload(
         payload["notes"] = parse_optional_text(
             body.get("notes"), max_length=MAX_DESCRIPTION_LENGTH
         )
+    if has_field(body, "external_url"):
+        payload["external_url"] = parse_optional_external_url(
+            body.get("external_url"), "external_url"
+        )
+    if has_field(body, "partner_organization_ids"):
+        payload["partner_organization_ids"] = parse_partner_organization_ids(body)
     if has_field(body, "session_slots"):
         payload["session_slots"] = parse_session_slots(body.get("session_slots"))
     if has_any_field(

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -440,6 +440,14 @@ def parse_update_instance_payload(
         raise ValidationError("status is required for PUT", field="status")
     if not payload:
         raise ValidationError("At least one updatable field is required", field="body")
+    if service.service_type == ServiceType.EVENT and "type_details" not in payload:
+        non_status = {key for key in payload if key != "status"}
+        if non_status:
+            raise ValidationError(
+                "event_ticket_tiers (or nested event tier fields) is required when "
+                "updating other fields on an event instance",
+                field="event_ticket_tiers",
+            )
     return payload
 
 

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -39,7 +39,11 @@ def _event_details_summary(service: Service) -> dict[str, Any] | None:
     details = service.event_details
     if details is None:
         return None
-    return {"event_category": details.event_category.value}
+    return {
+        "event_category": details.event_category.value,
+        "default_price": _decimal_to_string(details.default_price),
+        "default_currency": details.default_currency,
+    }
 
 
 def serialize_service_summary(service: Service) -> dict[str, Any]:
@@ -75,7 +79,12 @@ def serialize_service_detail(service: Service) -> dict[str, Any]:
     if service.training_course_details is not None:
         detail["training_details"] = _training_details_summary(service)
     if service.event_details is not None:
-        detail["event_details"] = _event_details_summary(service)
+        ed = service.event_details
+        detail["event_details"] = {
+            "event_category": ed.event_category.value,
+            "default_price": _decimal_to_string(ed.default_price),
+            "default_currency": ed.default_currency,
+        }
     if service.consultation_details is not None:
         detail["consultation_details"] = {
             "consultation_format": service.consultation_details.consultation_format.value,
@@ -90,7 +99,6 @@ def serialize_service_detail(service: Service) -> dict[str, Any]:
             ),
             "default_package_sessions": service.consultation_details.default_package_sessions,
             "default_currency": service.consultation_details.default_currency,
-            "calendly_url": service.consultation_details.calendly_url,
         }
     return detail
 
@@ -131,6 +139,18 @@ def serialize_instance(instance: ServiceInstance) -> dict[str, Any]:
         "location_id": str(instance.location_id) if instance.location_id else None,
         "max_capacity": instance.max_capacity,
         "waitlist_enabled": instance.waitlist_enabled,
+        "external_url": instance.external_url,
+        "partner_organizations": [
+            {
+                "id": str(link.organization_id),
+                "name": link.organization.name,
+                "archived": link.organization.archived_at is not None,
+            }
+            for link in sorted(
+                instance.partner_organization_links,
+                key=lambda row: row.sort_order,
+            )
+        ],
         "instructor_id": instance.instructor_id,
         "notes": instance.notes,
         "created_by": instance.created_by,
@@ -162,7 +182,6 @@ def serialize_instance(instance: ServiceInstance) -> dict[str, Any]:
                 "price": _decimal_to_string(instance.consultation_details.price),
                 "currency": instance.consultation_details.currency,
                 "package_sessions": instance.consultation_details.package_sessions,
-                "calendly_event_url": instance.consultation_details.calendly_event_url,
             }
             if instance.consultation_details is not None
             else None

--- a/backend/src/app/db/models/__init__.py
+++ b/backend/src/app/db/models/__init__.py
@@ -57,6 +57,7 @@ from app.db.models.service_instance import (
     EventTicketTier,
     InstanceSessionSlot,
     ServiceInstance,
+    ServiceInstancePartnerOrganization,
     TrainingInstanceDetails,
 )
 from app.db.models.tag import AssetTag, ContactTag, FamilyTag, OrganizationTag, Tag
@@ -118,6 +119,7 @@ __all__ = [
     "ServiceAsset",
     "ServiceDeliveryMode",
     "ServiceInstance",
+    "ServiceInstancePartnerOrganization",
     "ServiceStatus",
     "ServiceTag",
     "ServiceType",

--- a/backend/src/app/db/models/service.py
+++ b/backend/src/app/db/models/service.py
@@ -207,6 +207,12 @@ class EventDetails(Base):
         ),
         nullable=False,
     )
+    default_price: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
+    default_currency: Mapped[str] = mapped_column(
+        String(3),
+        nullable=False,
+        server_default=text("'HKD'"),
+    )
 
     service: Mapped[Service] = relationship(
         "Service",
@@ -258,7 +264,6 @@ class ConsultationDetails(Base):
         nullable=False,
         server_default=text("'HKD'"),
     )
-    calendly_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     service: Mapped[Service] = relationship(
         "Service",

--- a/backend/src/app/db/models/service_instance.py
+++ b/backend/src/app/db/models/service_instance.py
@@ -9,7 +9,16 @@ from uuid import UUID
 
 from collections.abc import Iterable
 
-from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, String, Text, text
+from sqlalchemy import (
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -29,6 +38,7 @@ if TYPE_CHECKING:
     from app.db.models.discount_code import DiscountCode
     from app.db.models.enrollment import Enrollment
     from app.db.models.location import Location
+    from app.db.models.organization import Organization
     from app.db.models.service import Service
 
 
@@ -146,6 +156,7 @@ class ServiceInstance(Base):
         nullable=False,
         server_default=text("0"),
     )
+    external_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     service: Mapped[Service] = relationship(
         "Service",
@@ -182,6 +193,51 @@ class ServiceInstance(Base):
         "DiscountCode",
         back_populates="instance",
     )
+    partner_organization_links: Mapped[list[ServiceInstancePartnerOrganization]] = (
+        relationship(
+            "ServiceInstancePartnerOrganization",
+            back_populates="instance",
+            cascade="all, delete-orphan",
+            order_by="ServiceInstancePartnerOrganization.sort_order.asc()",
+        )
+    )
+
+
+class ServiceInstancePartnerOrganization(Base):
+    """Many-to-many link between event instances and partner organizations."""
+
+    __tablename__ = "service_instance_organizations"
+    __table_args__ = (
+        Index("svc_instance_org_instance_idx", "service_instance_id"),
+        Index("svc_instance_org_organization_idx", "organization_id"),
+    )
+
+    service_instance_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("service_instances.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    organization_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    sort_order: Mapped[int] = mapped_column(
+        Integer(),
+        nullable=False,
+        server_default=text("0"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    instance: Mapped[ServiceInstance] = relationship(
+        "ServiceInstance",
+        back_populates="partner_organization_links",
+    )
+    organization: Mapped[Organization] = relationship("Organization")
 
 
 class InstanceSessionSlot(Base):
@@ -343,7 +399,6 @@ class ConsultationInstanceDetails(Base):
         server_default=text("'HKD'"),
     )
     package_sessions: Mapped[int | None] = mapped_column(nullable=True)
-    calendly_event_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     instance: Mapped[ServiceInstance] = relationship(
         "ServiceInstance",

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -17,6 +17,7 @@ from app.db.models import (
     InstanceSessionSlot,
     InstanceStatus,
     Service,
+    ServiceInstancePartnerOrganization,
     ServiceStatus,
     ServiceInstance,
     ServiceType,
@@ -54,6 +55,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                 joinedload(ServiceInstance.training_details),
                 joinedload(ServiceInstance.consultation_details),
                 selectinload(ServiceInstance.ticket_tiers),
+                selectinload(ServiceInstance.partner_organization_links).joinedload(
+                    ServiceInstancePartnerOrganization.organization
+                ),
             )
         )
         if status is not None:
@@ -104,6 +108,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             joinedload(ServiceInstance.training_details),
             joinedload(ServiceInstance.consultation_details),
             selectinload(ServiceInstance.ticket_tiers),
+            selectinload(ServiceInstance.partner_organization_links).joinedload(
+                ServiceInstancePartnerOrganization.organization
+            ),
             joinedload(ServiceInstance.service),
         )
         if service_type is not None:
@@ -163,6 +170,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                 joinedload(ServiceInstance.training_details),
                 joinedload(ServiceInstance.consultation_details),
                 selectinload(ServiceInstance.ticket_tiers),
+                selectinload(ServiceInstance.partner_organization_links).joinedload(
+                    ServiceInstancePartnerOrganization.organization
+                ),
                 selectinload(ServiceInstance.enrollments),
             )
         )

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Admin API
-  version: 0.2.1
+  version: 0.3.0
   description: |
     API contract for routes currently wired in
     `backend/infrastructure/lib/api-stack.ts`.
@@ -2078,11 +2078,21 @@ paths:
     get:
       summary: List active CRM organisations for pickers
       description: |
-        Returns active non-vendor organisations ordered by name for admin UI dropdowns.
-        At most 100 rows unless `limit` is set lower.
+        Returns active organisations ordered by name for admin UI dropdowns.
+        When `relationship_type` is omitted, vendor rows are excluded (same default as
+        organization list). When `relationship_type` is set (e.g. `partner`), only
+        organisations with that relationship type are returned. At most 100 rows unless
+        `limit` is set lower.
       security:
         - AdminBearerAuth: []
       parameters:
+        - name: relationship_type
+          in: query
+          description: >
+            When set, only organizations with this CRM relationship type are returned.
+            When omitted, vendors are excluded (non-vendor default).
+          schema:
+            $ref: "#/components/schemas/EntityRelationshipType"
         - name: limit
           in: query
           schema:
@@ -3351,6 +3361,17 @@ components:
       properties:
         event_category:
           $ref: "#/components/schemas/EventCategory"
+        default_price:
+          type: string
+          nullable: true
+          pattern: ^-?\d+(\.\d{1,2})?$
+          description: Optional default ticket price for new event instances.
+        default_currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+          pattern: ^[A-Z]{3}$
+          description: ISO 4217 currency code for default_price (defaults to HKD).
     ServiceConsultationDetails:
       type: object
       properties:
@@ -3374,9 +3395,6 @@ components:
           type: integer
           nullable: true
         default_currency:
-          type: string
-          nullable: true
-        calendly_url:
           type: string
           nullable: true
     DiscountCodeUsageSummaryResponse:
@@ -3657,19 +3675,38 @@ components:
           nullable: true
         name:
           type: string
+          nullable: true
         description:
           type: string
           nullable: true
         price:
           type: string
+          nullable: true
+          pattern: ^-?\d+(\.\d{1,2})?$
         currency:
           type: string
+          nullable: true
+          minLength: 3
+          maxLength: 3
+          pattern: ^[A-Z]{3}$
         max_quantity:
           type: integer
           nullable: true
         sort_order:
           type: integer
           nullable: true
+    InstancePartnerOrganization:
+      type: object
+      required: [id, name, archived]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        archived:
+          type: boolean
+          description: True when the organization is archived (omitted from active pickers).
     ServiceInstance:
       type: object
       required: [id, service_id, status]
@@ -3711,6 +3748,18 @@ components:
           nullable: true
         waitlist_enabled:
           type: boolean
+        external_url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 500
+          description: >
+            Optional external registration or info URL (http/https only).
+            Distinct from Eventbrite sync URLs on the instance.
+        partner_organizations:
+          type: array
+          items:
+            $ref: "#/components/schemas/InstancePartnerOrganization"
         instructor_id:
           type: string
           nullable: true
@@ -3773,9 +3822,6 @@ components:
             package_sessions:
               type: integer
               nullable: true
-            calendly_event_url:
-              type: string
-              nullable: true
         parent_service_title:
           type: string
           nullable: true
@@ -3835,6 +3881,18 @@ components:
           nullable: true
         waitlist_enabled:
           type: boolean
+        external_url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 500
+        partner_organization_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: >
+            Ordered partner organization ids for event instances. Unknown ids return 400.
         instructor_id:
           type: string
           nullable: true
@@ -3874,9 +3932,6 @@ components:
               type: string
             package_sessions:
               type: integer
-              nullable: true
-            calendly_event_url:
-              type: string
               nullable: true
     UpdateInstanceRequest:
       allOf:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3751,6 +3751,7 @@ components:
         external_url:
           type: string
           format: uri
+          pattern: ^https?://
           nullable: true
           maxLength: 500
           description: >
@@ -3884,6 +3885,7 @@ components:
         external_url:
           type: string
           format: uri
+          pattern: ^https?://
           nullable: true
           maxLength: 500
         partner_organization_ids:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -446,8 +446,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   `booking_system` varchar(80) for an admin-visible booking-system label).
 - Type-specific one-to-one extension tables:
   - `training_course_details`
-  - `event_details`
-  - `consultation_details`
+  - `event_details` (includes optional `default_price` numeric(10,2) and
+    `default_currency` varchar(3), default `HKD`, for admin defaults on new event instances)
+  - `consultation_details` (Calendly URL column removed in migration `0034_drop_calendly_fields`)
 
 ### `service_instances` + schedule/detail tables
 
@@ -456,6 +457,8 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   `cover_image_s3_key`, `delivery_mode`).
 - Optional public-site fields: `slug` (unique when set), `landing_page`
   (marketing route key for the public website).
+- Optional `external_url` varchar(500): operator-provided external registration/info URL
+  (http/https), distinct from Eventbrite sync URLs.
 - Eventbrite sync metadata is stored on `service_instances` so DB remains source
   of truth while tracking downstream publish state:
   - `eventbrite_event_id`, `eventbrite_event_url`
@@ -467,7 +470,15 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   - `instance_session_slots` (time blocks + optional location)
   - `training_instance_details`
   - `event_ticket_tiers`
-  - `consultation_instance_details`
+  - `consultation_instance_details` (Calendly event URL column removed in migration
+    `0034_drop_calendly_fields`)
+
+### `service_instance_organizations`
+
+- Junction table linking event `service_instances` to partner `organizations`
+  (`service_instance_id`, `organization_id`, `sort_order`, `created_at`), added in
+  migration `0036_instance_partners_ext_url`. Used by the admin API for event instance
+  partner multi-select; ordering follows `sort_order`.
 
 ### `discount_codes`
 

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -525,6 +525,14 @@ and strip the corresponding fields from the admin OpenAPI contract (version bump
 simplifies consultation services/instances and avoids maintaining unused PII-adjacent
 URLs. **Data loss:** upgrade drops stored values; downgrade re-adds nullable columns only.
 
+**Same contract bump (0.3.0):** Admin instance ``event_ticket_tiers`` request entries may
+omit ``price`` / ``currency`` / ``name`` when the server fills from ``event_details``
+defaults; ``PUT`` updates that touch other fields on an event instance must still
+include ``event_ticket_tiers`` (or nested tier fields) so tier rows are not skipped
+silently. Multi-tier instances accept a single-tier payload only when one tier's
+``name`` matches the service event category (otherwise the client must send the full
+array, one object per tier).
+
 ## Keeping Documentation Up to Date
 
 **Decision:** Architecture documentation in `docs/architecture/` describes

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -499,6 +499,32 @@ and the legacy ``phone`` string is gone; downgrade cannot reconstruct them.
 match and anchored-prefix ``ILIKE``; substring ``ILIKE '%…%'`` remains a sequential
 scan at CRM scale (by design).
 
+## Partner organisations on event instances
+
+**Decision:** Store ordered partner organisation links for event-type
+`service_instances` in a dedicated junction table `service_instance_organizations`
+(`service_instance_id`, `organization_id`, `sort_order`). Admin create/update sends
+`partner_organization_ids` (UUID array); the API rejects unknown organisation ids with
+HTTP 400. The admin organisation picker may filter with `relationship_type=partner`
+while still listing only active (non-archived) organisations; already-linked partners
+remain visible in the UI when archived because the instance response includes
+`partner_organizations` with an `archived` flag.
+
+**Why:** Event instances need explicit partner attribution without overloading
+Eventbrite fields; a normalised M2M table supports ordering and future relationship
+metadata without schema churn today.
+
+## Drop Calendly integration from services schema
+
+**Decision:** Remove `consultation_details.calendly_url` and
+`consultation_instance_details.calendly_event_url` (migration `0034_drop_calendly_fields`)
+and strip the corresponding fields from the admin OpenAPI contract (version bump to
+0.3.0). Product no longer persists Calendly URLs in Aurora.
+
+**Why:** Calendly-specific columns coupled the data model to one vendor; dropping them
+simplifies consultation services/instances and avoids maintaining unused PII-adjacent
+URLs. **Data loss:** upgrade drops stored values; downgrade re-adds nullable columns only.
+
 ## Keeping Documentation Up to Date
 
 **Decision:** Architecture documentation in `docs/architecture/` describes

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -65,7 +65,9 @@ their primary responsibilities.
   for hard-deleting a family after clearing blocking CRM rows; `POST /v1/admin/families/{id}/members`
   derives each member's role from the linked contact's `contact_type`; `PATCH /v1/admin/families/{id}/members/{memberId}`
   updates membership fields such as primary contact),
-  `/v1/admin/organizations/picker`, `/v1/admin/organizations/*` (CRM organisations and vendor
+  `/v1/admin/organizations/picker` (optional `relationship_type` query mirrors organisation list
+  semantics; default still excludes vendors; pass `relationship_type=partner` for partner-only
+  admin pickers), `/v1/admin/organizations/*` (CRM organisations and vendor
   rows share one resource; default list excludes vendors, Finance lists vendors with
   `GET /v1/admin/organizations?relationship_type=vendor`; includes `DELETE /v1/admin/organizations/{id}`
   for non-vendor orgs; `POST /v1/admin/organizations/{id}/members` derives each member's role from the

--- a/tests/test_admin_event_ticket_tier_merge.py
+++ b/tests/test_admin_event_ticket_tier_merge.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.api import admin_service_instances
+from app.api.admin_services_payload_utils import parse_uuid_list
+from app.api.admin_services_payloads import parse_update_instance_payload
+from app.db.models import EventCategory, ServiceType
+from app.exceptions import ValidationError
+
+
+def test_parse_uuid_list_reject_empty_members() -> None:
+    with pytest.raises(ValidationError):
+        parse_uuid_list(["", str(uuid4())], "ids", reject_empty_members=True)
+
+
+def test_merge_single_tier_patch_preserves_extra_tier_rows() -> None:
+    """Row D sends one tier; instance has two tiers — non-category tier unchanged."""
+    service = SimpleNamespace(
+        event_details=SimpleNamespace(
+            event_category=EventCategory.WORKSHOP,
+            default_price=Decimal("10.00"),
+            default_currency="HKD",
+        )
+    )
+    tier_cat = SimpleNamespace(
+        name="workshop",
+        description="d1",
+        price=Decimal("5.00"),
+        currency="HKD",
+        max_quantity=10,
+        sort_order=0,
+    )
+    tier_other = SimpleNamespace(
+        name="vip",
+        description="d2",
+        price=Decimal("99.00"),
+        currency="USD",
+        max_quantity=2,
+        sort_order=1,
+    )
+    instance = SimpleNamespace(ticket_tiers=[tier_cat, tier_other])
+    resolved = [{"name": "workshop", "price": Decimal("25.00"), "currency": "EUR"}]
+    merged = admin_service_instances._merge_event_ticket_tiers_with_existing(
+        service, instance, resolved  # type: ignore[arg-type]
+    )
+    assert len(merged) == 2
+    by_name = {m["name"]: m for m in merged}
+    assert by_name["workshop"]["price"] == Decimal("25.00")
+    assert by_name["workshop"]["currency"] == "EUR"
+    assert by_name["vip"]["price"] == Decimal("99.00")
+    assert by_name["vip"]["currency"] == "USD"
+
+
+def test_merge_multi_tier_requires_category_match() -> None:
+    service = SimpleNamespace(
+        event_details=SimpleNamespace(
+            event_category=EventCategory.WORKSHOP,
+            default_price=None,
+            default_currency="HKD",
+        )
+    )
+    instance = SimpleNamespace(
+        ticket_tiers=[
+            SimpleNamespace(
+                name="alpha",
+                description=None,
+                price=Decimal("1"),
+                currency="HKD",
+                max_quantity=None,
+                sort_order=0,
+            ),
+            SimpleNamespace(
+                name="beta",
+                description=None,
+                price=Decimal("2"),
+                currency="HKD",
+                max_quantity=None,
+                sort_order=1,
+            ),
+        ]
+    )
+    with pytest.raises(ValidationError) as exc:
+        admin_service_instances._merge_event_ticket_tiers_with_existing(
+            service, instance, [{"name": "workshop", "price": Decimal("5")}]
+        )
+    assert "event_ticket_tiers" in (exc.value.field or "")
+
+
+def test_parse_update_event_instance_requires_tiers_with_other_fields() -> None:
+    service = SimpleNamespace(service_type=ServiceType.EVENT)
+    body = {"status": "scheduled", "title": "Updated title only"}
+    with pytest.raises(ValidationError) as exc:
+        parse_update_instance_payload(body, service)  # type: ignore[arg-type]
+    assert exc.value.field == "event_ticket_tiers"

--- a/tests/test_admin_organizations_picker.py
+++ b/tests/test_admin_organizations_picker.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.api import admin_organizations_picker
+from app.api.assets.assets_common import RequestIdentity
+from app.db.models import RelationshipType
+
+
+def _admin_identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_sub="admin-sub",
+        groups={"admin"},
+        organization_ids=set(),
+    )
+
+
+@pytest.fixture
+def picker_session(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    session = MagicMock()
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> MagicMock:
+            return session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    monkeypatch.setattr(admin_organizations_picker, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_organizations_picker, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        admin_organizations_picker,
+        "extract_identity",
+        lambda _event: _admin_identity(),
+    )
+    return session
+
+
+def test_picker_default_excludes_vendors(
+    api_gateway_event: Any,
+    picker_session: MagicMock,
+) -> None:
+    org_id = uuid4()
+    picker_session.execute.return_value.all.return_value = [(org_id, "Alpha Org")]
+
+    path = "/v1/admin/organizations/picker"
+    response = admin_organizations_picker.handle_admin_organizations_picker_request(
+        api_gateway_event(method="GET", path=path),
+        "GET",
+        path,
+    )
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["items"] == [{"id": str(org_id), "label": "Alpha Org"}]
+
+
+def test_picker_relationship_type_partner_calls_parser(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    picker_session: MagicMock,
+) -> None:
+    org_id = uuid4()
+    picker_session.execute.return_value.all.return_value = [(org_id, "Partner Org")]
+    captured: list[Any] = []
+
+    def _capture(value: Any, *, field: str, allowed: Any = None) -> RelationshipType:
+        captured.append((value, field))
+        return RelationshipType.PARTNER
+
+    monkeypatch.setattr(
+        admin_organizations_picker,
+        "parse_relationship_type",
+        _capture,
+    )
+
+    path = "/v1/admin/organizations/picker"
+    response = admin_organizations_picker.handle_admin_organizations_picker_request(
+        api_gateway_event(
+            method="GET",
+            path=path,
+            query_params={"relationship_type": "partner", "limit": "50"},
+        ),
+        "GET",
+        path,
+    )
+
+    assert response["statusCode"] == 200
+    assert captured == [("partner", "relationship_type")]
+    body = json.loads(response["body"])
+    assert body["items"] == [{"id": str(org_id), "label": "Partner Org"}]

--- a/tests/test_admin_services_instance_payload.py
+++ b/tests/test_admin_services_instance_payload.py
@@ -29,3 +29,11 @@ def test_parse_partner_organization_ids_dedupes_preserving_order() -> None:
         {"partner_organization_ids": [str(a), str(b), str(a), str(b)]}
     )
     assert raw == [a, b]
+
+
+def test_parse_partner_organization_ids_rejects_empty_string_entry() -> None:
+    with pytest.raises(ValidationError) as exc:
+        parse_partner_organization_ids(
+            {"partner_organization_ids": [str(uuid4()), "  "]}
+        )
+    assert exc.value.field == "partner_organization_ids"

--- a/tests/test_admin_services_instance_payload.py
+++ b/tests/test_admin_services_instance_payload.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.api.admin_service_instance_partners import parse_partner_organization_ids
+from app.api.admin_services_payload_utils import parse_optional_external_url
+from app.exceptions import ValidationError
+
+
+def test_parse_optional_external_url_accepts_http_https() -> None:
+    assert parse_optional_external_url("  https://example.com/path  ", "external_url") == (
+        "https://example.com/path"
+    )
+    assert parse_optional_external_url("http://a.example/x", "external_url") == "http://a.example/x"
+
+
+def test_parse_optional_external_url_rejects_non_http_scheme() -> None:
+    with pytest.raises(ValidationError) as exc:
+        parse_optional_external_url("ftp://example.com", "external_url")
+    assert exc.value.field == "external_url"
+
+
+def test_parse_partner_organization_ids_dedupes_preserving_order() -> None:
+    a = uuid4()
+    b = uuid4()
+    raw = parse_partner_organization_ids(
+        {"partner_organization_ids": [str(a), str(b), str(a), str(b)]}
+    )
+    assert raw == [a, b]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Services admin rework (migrations 0034–0036, OpenAPI 0.3.0, admin UI) plus follow-up **correctness** fixes:

### Correctness (this push)

- **Event ticket tiers:** Single-tier payloads from Row D no longer wipe extra tiers or non-category tier metadata. `_merge_event_ticket_tiers_with_existing` merges price/currency onto the tier whose `name` matches the service event category (or the sole tier); multi-tier instances without a category match return **400**. When the client sends N tiers matching N existing rows, **in-place** `EventTicketTier` updates preserve tier **ids** (better for Eventbrite `eventbrite_ticket_class_map`).
- **Price:** `_resolve_event_ticket_tiers_for_persist` no longer falls back to silent `0` when `price` is omitted — requires explicit `price` unless `event_details.default_price` is set.
- **PUT contract:** Event instance `PUT` that changes fields other than `status` without `event_ticket_tiers` (or nested tier fields) now returns **400** (`event_ticket_tiers`).
- **`partner_organization_ids`:** Empty string entries are rejected (strict list parsing).
- **UI:** Event Row D requires a typed price (disable save + inline error). **Create instance dialog:** instructor for consultation + event; event uses category + price + currency controls (not full service default row); submit disabled until event price set. **Partners field:** archived/inactive refs are re-unioned on change so they are not dropped when editing live partners.
- **OpenAPI:** `external_url` includes `pattern: ^https?://` (aligned with backend).
- **ADR:** Documents nullable tier request semantics and PUT tier requirement.

### Tests

- Backend: `tests/test_admin_event_ticket_tier_merge.py`, extended `test_admin_services_instance_payload.py`.
- Frontend: `event-instance-partners-field.test.tsx`, `session-slot-editor.test.tsx`.

Commits on branch include prior work + `93bfcba2` (this batch).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8174f53b-f66f-4408-ac0a-8ae80daf6e49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8174f53b-f66f-4408-ac0a-8ae80daf6e49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

