### PR TITLE
Admin web: Default price label for training courses in service catalogue

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -552,7 +552,11 @@ export function ServiceDetailPanel({
         {serviceType === 'training_course' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
             <div aria-hidden className='hidden md:block' />
-            <TrainingPriceControl value={trainingForm} onChange={setTrainingForm} />
+            <TrainingPriceControl
+              value={trainingForm}
+              onChange={setTrainingForm}
+              priceLabel='Default price'
+            />
             <TrainingCurrencyControl value={trainingForm} onChange={setTrainingForm} />
             <div aria-hidden className='hidden md:block' />
           </div>

--- a/apps/admin_web/src/components/admin/services/training-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/training-form-fields.tsx
@@ -50,10 +50,11 @@ export function TrainingPriceControl({
   value,
   disabled = false,
   onChange,
-}: Pick<TrainingFormFieldsProps, 'value' | 'disabled' | 'onChange'>) {
+  priceLabel = 'Price',
+}: Pick<TrainingFormFieldsProps, 'value' | 'disabled' | 'onChange'> & { priceLabel?: string }) {
   return (
     <div>
-      <Label htmlFor='training-default-price'>Price</Label>
+      <Label htmlFor='training-default-price'>{priceLabel}</Label>
       <Input
         id='training-default-price'
         value={value.defaultPrice}

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -198,6 +198,25 @@ describe('ServiceDetailPanel', () => {
     expect(screen.getByLabelText('Default price')).toBeInTheDocument();
   });
 
+  it('labels training course default amount as Default price', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+
+    expect(screen.getByLabelText('Default price')).toBeInTheDocument();
+  });
+
   it('shows consultation Row D/E fields without Calendly', async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add an optional `priceLabel` prop to `TrainingPriceControl` (default remains `Price` for other surfaces).
- Pass `priceLabel="Default price"` from `ServiceDetailPanel` only, so the Service Catalogue tab shows the new label for training course services while Instances and create-instance dialog keep `Price`.
- Add a focused unit test in `service-detail-panel.test.tsx`.

## Testing

- `npx vitest run tests/components/admin/services/service-detail-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-159673fe-bd77-4e58-9f4a-72c3de84673f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-159673fe-bd77-4e58-9f4a-72c3de84673f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

