### PR TITLE
admin web: session slot labels on first row only

### DIFF
--- a/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
+++ b/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
@@ -51,9 +51,11 @@ export function SessionSlotEditor({
           {slots.map((slot, index) => (
             <div key={`${slot.id ?? 'new'}-${index}`} className={slotGridClassName}>
               <div className='space-y-1'>
-                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-starts`}>
-                  Start time
-                </Label>
+                {index === 0 ? (
+                  <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-starts`}>
+                    Start time
+                  </Label>
+                ) : null}
                 <Input
                   id={`slot-${index}-starts`}
                   type='datetime-local'
@@ -68,9 +70,11 @@ export function SessionSlotEditor({
                 />
               </div>
               <div className='space-y-1'>
-                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-ends`}>
-                  End time
-                </Label>
+                {index === 0 ? (
+                  <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-ends`}>
+                    End time
+                  </Label>
+                ) : null}
                 <Input
                   id={`slot-${index}-ends`}
                   type='datetime-local'
@@ -85,9 +89,11 @@ export function SessionSlotEditor({
                 />
               </div>
               <div className='space-y-1'>
-                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-location`}>
-                  Location
-                </Label>
+                {index === 0 ? (
+                  <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-location`}>
+                    Location
+                  </Label>
+                ) : null}
                 {hasLocationOptions || isLoadingLocations ? (
                   <Select
                     id={`slot-${index}-location`}
@@ -129,9 +135,11 @@ export function SessionSlotEditor({
                 )}
               </div>
               <div className='space-y-1'>
-                <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-sort`}>
-                  Sort order
-                </Label>
+                {index === 0 ? (
+                  <Label className='text-xs font-medium text-slate-600' htmlFor={`slot-${index}-sort`}>
+                    Sort order
+                  </Label>
+                ) : null}
                 <Input
                   id={`slot-${index}-sort`}
                   type='number'

--- a/apps/admin_web/tests/components/admin/services/session-slot-editor.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/session-slot-editor.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { SessionSlotEditor } from '@/components/admin/services/session-slot-editor';
 
 describe('SessionSlotEditor', () => {
-  it('renders a label above each control for every slot row', () => {
+  it('renders column labels only on the first slot row', () => {
     render(
       <SessionSlotEditor
         slots={[
@@ -33,9 +33,9 @@ describe('SessionSlotEditor', () => {
     const endLabels = screen.getAllByText('End time');
     const locationLabels = screen.getAllByText('Location');
     const sortLabels = screen.getAllByText('Sort order');
-    expect(startLabels).toHaveLength(2);
-    expect(endLabels).toHaveLength(2);
-    expect(locationLabels).toHaveLength(2);
-    expect(sortLabels).toHaveLength(2);
+    expect(startLabels).toHaveLength(1);
+    expect(endLabels).toHaveLength(1);
+    expect(locationLabels).toHaveLength(1);
+    expect(sortLabels).toHaveLength(1);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Session slot editor column labels (Start time, End time, Location, Sort order) now render only above the first slot row. Additional rows keep the same controls with existing `aria-label` attributes for accessibility.

## Testing

- `npm run test -- --run tests/components/admin/services/session-slot-editor.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59d1e598-7bc0-457a-9b4e-8a041cf29b99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59d1e598-7bc0-457a-9b4e-8a041cf29b99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

