### PR TITLE
Service instances: age group, cohort, and tags

### DIFF
--- a/apps/admin_web/src/components/admin/services/form-defaults.ts
+++ b/apps/admin_web/src/components/admin/services/form-defaults.ts
@@ -45,6 +45,8 @@ export const DEFAULT_INSTANCE_FORM: InstanceFormState = {
   maxCapacity: '',
   waitlistEnabled: false,
   instructorId: '',
+  ageGroup: '',
+  cohort: '',
   notes: '',
   externalUrl: '',
   partnerOrganizations: [],

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -21,6 +21,7 @@ import {
 } from './form-defaults';
 import { EventInstancePartnersField } from './event-instance-partners-field';
 import {
+  INSTANCE_SLUG_PATTERN,
   InstanceFormFields,
   InstanceInstructorField,
   type InstanceFormState,
@@ -44,6 +45,7 @@ import {
   type ServiceType,
 } from '@/types/services';
 
+import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Button } from '@/components/ui/button';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
@@ -52,12 +54,16 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
+import type { EntityTagRef } from '@/lib/entity-api';
 
 type ApiSchemas = components['schemas'];
 const defaultCurrencyCode = getAdminDefaultCurrencyCode();
 
 export interface InstanceDetailPanelProps {
   instance: ServiceInstance | null;
+  entityTags: EntityTagRef[];
+  entityTagsLoading: boolean;
+  entityTagsError: string;
   selectedServiceId: string | null;
   serviceOptions: ServiceSummary[];
   locationOptions: LocationSummary[];
@@ -141,6 +147,9 @@ function mapPartnerRefsFromInstance(instance: ServiceInstance): PartnerOrgRef[] 
 
 export function InstanceDetailPanel({
   instance,
+  entityTags,
+  entityTagsLoading,
+  entityTagsError,
   selectedServiceId,
   serviceOptions,
   locationOptions,
@@ -160,6 +169,8 @@ export function InstanceDetailPanel({
     Boolean(selectedServiceId)
   );
 
+  const [tagIds, setTagIds] = useState<string[]>(() => instance?.tagIds ?? []);
+
   const [instanceForm, setInstanceForm] = useState<InstanceFormState>(
     instance
       ? {
@@ -173,6 +184,8 @@ export function InstanceDetailPanel({
           waitlistEnabled: instance.waitlistEnabled,
           instructorId: instance.instructorId ?? '',
           notes: instance.notes ?? '',
+          ageGroup: instance.ageGroup ?? '',
+          cohort: instance.cohort ?? '',
           externalUrl: instance.externalUrl ?? '',
           partnerOrganizations: mapPartnerRefsFromInstance(instance),
           sessionSlots: instance.sessionSlots,
@@ -253,9 +266,13 @@ export function InstanceDetailPanel({
 
   useEffect(() => {
     if (!instance) {
+      queueMicrotask(() => {
+        setTagIds([]);
+      });
       return;
     }
     queueMicrotask(() => {
+      setTagIds(instance.tagIds);
       setInstanceForm({
         title: instance.title ?? '',
         slug: instance.slug ?? '',
@@ -267,6 +284,8 @@ export function InstanceDetailPanel({
         waitlistEnabled: instance.waitlistEnabled,
         instructorId: instance.instructorId ?? '',
         notes: instance.notes ?? '',
+        ageGroup: instance.ageGroup ?? '',
+        cohort: instance.cohort ?? '',
         externalUrl: instance.externalUrl ?? '',
         partnerOrganizations: mapPartnerRefsFromInstance(instance),
         sessionSlots: instance.sessionSlots,
@@ -310,6 +329,8 @@ export function InstanceDetailPanel({
 
   const buildCreatePayload = (): ApiSchemas['CreateInstanceRequest'] => {
     const slugTrimmed = instanceForm.slug.trim().toLowerCase();
+    const ageTrimmed = instanceForm.ageGroup.trim().toLowerCase();
+    const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
       title: instanceForm.title.trim() || null,
       slug: slugTrimmed || null,
@@ -320,9 +341,12 @@ export function InstanceDetailPanel({
       max_capacity: instanceForm.maxCapacity ? Number(instanceForm.maxCapacity) : null,
       waitlist_enabled: instanceForm.waitlistEnabled,
       instructor_id: instanceForm.instructorId.trim() || null,
+      age_group: ageTrimmed || null,
+      cohort: cohortTrimmed || null,
       notes: instanceForm.notes.trim() || null,
       external_url: instanceForm.externalUrl.trim() || null,
       partner_organization_ids: instanceForm.partnerOrganizations.map((row) => row.id),
+      tag_ids: tagIds,
       session_slots: instanceForm.sessionSlots.map((slot, index) => ({
         location_id: slot.locationId,
         starts_at: slot.startsAt,
@@ -408,6 +432,12 @@ export function InstanceDetailPanel({
   const eventPriceMissing =
     effectiveServiceType === 'event' && !eventForm.defaultPrice.trim();
 
+  const ageGroupTrimmed = instanceForm.ageGroup.trim().toLowerCase();
+  const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
+  const ageGroupInvalid =
+    Boolean(ageGroupTrimmed) && !INSTANCE_SLUG_PATTERN.test(ageGroupTrimmed);
+  const cohortInvalid = Boolean(cohortTrimmed) && !INSTANCE_SLUG_PATTERN.test(cohortTrimmed);
+
   return (
     <AdminEditorCard
       title='Instance'
@@ -422,7 +452,14 @@ export function InstanceDetailPanel({
                 </Button>
                 <Button
                   type='button'
-                  disabled={isLoading || !instance || externalUrlInvalid || eventPriceMissing}
+                  disabled={
+                    isLoading ||
+                    !instance ||
+                    externalUrlInvalid ||
+                    eventPriceMissing ||
+                    ageGroupInvalid ||
+                    cohortInvalid
+                  }
                   onClick={() => {
                     if (!instance || !selectedServiceId) {
                       return;
@@ -436,7 +473,14 @@ export function InstanceDetailPanel({
             ) : (
               <Button
                 type='button'
-                disabled={isLoading || !selectedServiceId || externalUrlInvalid || eventPriceMissing}
+                disabled={
+                  isLoading ||
+                  !selectedServiceId ||
+                  externalUrlInvalid ||
+                  eventPriceMissing ||
+                  ageGroupInvalid ||
+                  cohortInvalid
+                }
                 onClick={() => {
                   if (!selectedServiceId) {
                     return;
@@ -563,6 +607,49 @@ export function InstanceDetailPanel({
         </>
       ) : null}
 
+      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+        <div>
+          <Label htmlFor='instance-age-group'>Age group</Label>
+          <Input
+            id='instance-age-group'
+            value={instanceForm.ageGroup}
+            disabled={typeFieldsLocked}
+            onChange={(event) => setInstanceForm((prev) => ({ ...prev, ageGroup: event.target.value }))}
+            onBlur={() =>
+              setInstanceForm((prev) => ({ ...prev, ageGroup: prev.ageGroup.trim().toLowerCase() }))
+            }
+            placeholder='e.g. ages-3-5'
+            autoComplete='off'
+          />
+          {ageGroupInvalid ? (
+            <p className='mt-1 text-xs text-red-600'>
+              Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
+              hyphen).
+            </p>
+          ) : null}
+        </div>
+        <div>
+          <Label htmlFor='instance-cohort'>Cohort</Label>
+          <Input
+            id='instance-cohort'
+            value={instanceForm.cohort}
+            disabled={typeFieldsLocked}
+            onChange={(event) => setInstanceForm((prev) => ({ ...prev, cohort: event.target.value }))}
+            onBlur={() =>
+              setInstanceForm((prev) => ({ ...prev, cohort: prev.cohort.trim().toLowerCase() }))
+            }
+            placeholder='e.g. spring-2026'
+            autoComplete='off'
+          />
+          {cohortInvalid ? (
+            <p className='mt-1 text-xs text-red-600'>
+              Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
+              hyphen).
+            </p>
+          ) : null}
+        </div>
+      </div>
+
       <div>
         <Label htmlFor='instance-notes'>Notes</Label>
         <Textarea
@@ -573,6 +660,16 @@ export function InstanceDetailPanel({
           rows={2}
         />
       </div>
+
+      <EntityTagPicker
+        id='service-instance-tags'
+        label='Tags'
+        tags={entityTags}
+        selectedIds={tagIds}
+        onChange={setTagIds}
+        disabled={isLoading || entityTagsLoading || typeFieldsLocked}
+        variant='collapsible'
+      />
 
       <SessionSlotEditor
         slots={instanceForm.sessionSlots}
@@ -585,6 +682,7 @@ export function InstanceDetailPanel({
       {effectiveServiceType === 'event' && eventPriceMissing ? (
         <AdminInlineError>Enter a price for this event instance.</AdminInlineError>
       ) : null}
+      {entityTagsError ? <AdminInlineError>{entityTagsError}</AdminInlineError> : null}
       {locationError ? <AdminInlineError>{locationError}</AdminInlineError> : null}
       {error ? <AdminInlineError>{error}</AdminInlineError> : null}
     </AdminEditorCard>

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -18,7 +18,7 @@ import type {
 import type { SessionSlot } from '@/types/services';
 
 /** Same pattern as service referral slugs; matches backend `SERVICE_INSTANCE_SLUG_RE`. */
-const INSTANCE_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+export const INSTANCE_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 export interface InstanceInstructorOption {
   sub: string;
@@ -36,6 +36,8 @@ export interface InstanceFormState {
   maxCapacity: string;
   waitlistEnabled: boolean;
   instructorId: string;
+  ageGroup: string;
+  cohort: string;
   notes: string;
   externalUrl: string;
   partnerOrganizations: PartnerOrgRef[];

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -128,6 +128,9 @@ export function ServicesPage() {
           <InstanceDetailPanel
             key={`${state.selectedInstanceId ?? 'create-instance'}-${state.selectedService?.serviceType ?? 'none'}`}
             instance={state.selectedInstance}
+            entityTags={state.entityTags}
+            entityTagsLoading={state.entityTagsLoading}
+            entityTagsError={state.entityTagsError}
             selectedServiceId={instancesContextServiceId}
             serviceOptions={allServiceOptions}
             locationOptions={state.locationList.locations}

--- a/apps/admin_web/src/hooks/use-services-page.ts
+++ b/apps/admin_web/src/hooks/use-services-page.ts
@@ -1,6 +1,9 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { toErrorMessage } from '@/hooks/hook-errors';
+import { listEntityTags, type EntityTagRef } from '@/lib/entity-api';
 
 import { useDiscountCodes } from './use-discount-codes';
 import { useVenues } from './use-venues';
@@ -35,6 +38,9 @@ export function useServicesPage() {
   const [instancesServiceFilter, setInstancesServiceFilter] = useState<string>('');
   const [instancesServiceTypeFilter, setInstancesServiceTypeFilter] = useState<string>('');
   const [instancesSearchQuery, setInstancesSearchQuery] = useState<string>('');
+  const [entityTags, setEntityTags] = useState<EntityTagRef[]>([]);
+  const [entityTagsLoading, setEntityTagsLoading] = useState(false);
+  const [entityTagsError, setEntityTagsError] = useState('');
 
   const serviceList = useServiceList();
   const selectedServiceId = selectedServiceIdState;
@@ -43,6 +49,34 @@ export function useServicesPage() {
     setSelectedServiceIdState(serviceId);
     setSelectedInstanceId(null);
   }, []);
+
+  useEffect(() => {
+    if (activeView !== 'instances') {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      setEntityTagsLoading(true);
+      try {
+        const tagList = await listEntityTags();
+        if (!cancelled) {
+          setEntityTags(tagList);
+          setEntityTagsError('');
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setEntityTagsError(toErrorMessage(error, 'Failed to load tags.'));
+        }
+      } finally {
+        if (!cancelled) {
+          setEntityTagsLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeView]);
 
   const serviceDetail = useServiceDetail(selectedServiceId);
   const instanceList = useInstanceList(
@@ -125,6 +159,9 @@ export function useServicesPage() {
     setInstancesServiceTypeFilter,
     instancesSearchQuery,
     setInstancesSearchQuery,
+    entityTags,
+    entityTagsLoading,
+    entityTagsError,
     serviceList,
     serviceDetail,
     serviceMutations,

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -245,7 +245,12 @@ function parseInstance(value: unknown): ServiceInstance {
           .filter((row): row is PartnerOrgRef => row !== null)
       : [],
     instructorId: asNullableString(item.instructor_id),
+    ageGroup: asNullableString(item.age_group),
+    cohort: asNullableString(item.cohort),
     notes: asNullableString(item.notes),
+    tagIds: Array.isArray(item.tag_ids)
+      ? item.tag_ids.filter((entry): entry is string => typeof entry === 'string')
+      : [],
     createdBy: asNullableString(item.created_by) ?? '',
     createdAt: asNullableString(item.created_at),
     updatedAt: asNullableString(item.updated_at),

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4233,7 +4233,13 @@ export interface components {
             external_url?: string | null;
             partner_organizations?: components["schemas"]["InstancePartnerOrganization"][];
             instructor_id?: string | null;
+            /** @description Optional label using the same normalization rules as instance referral slugs (lowercase letters, digits, single hyphens between segments). */
+            age_group?: string | null;
+            /** @description Optional label using the same normalization rules as instance referral slugs (lowercase letters, digits, single hyphens between segments). */
+            cohort?: string | null;
             notes?: string | null;
+            tags?: components["schemas"]["EntityTagRef"][];
+            tag_ids?: string[];
             created_by?: string;
             /** Format: date-time */
             created_at?: string | null;
@@ -4287,7 +4293,10 @@ export interface components {
             /** @description Ordered partner organization ids for event instances. Unknown ids return 400. */
             partner_organization_ids?: string[];
             instructor_id?: string | null;
+            age_group?: string | null;
+            cohort?: string | null;
             notes?: string | null;
+            tag_ids?: string[];
             session_slots?: components["schemas"]["SessionSlot"][];
             training_details?: {
                 training_format?: components["schemas"]["TrainingFormat"];

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4296,6 +4296,7 @@ export interface components {
             age_group?: string | null;
             cohort?: string | null;
             notes?: string | null;
+            /** @description Replaces all instance tag associations when present (including on PUT). The admin web UI sends this on every instance save; omit the field only if a non-UI client must patch other fields without changing tags. */
             tag_ids?: string[];
             session_slots?: components["schemas"]["SessionSlot"][];
             training_details?: {

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -230,7 +230,10 @@ export interface ServiceInstance {
   externalUrl: string | null;
   partnerOrganizations: PartnerOrgRef[];
   instructorId: string | null;
+  ageGroup: string | null;
+  cohort: string | null;
   notes: string | null;
+  tagIds: string[];
   createdBy: string;
   createdAt: string | null;
   updatedAt: string | null;

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -34,6 +34,12 @@ function buildServiceSummary(overrides: Partial<ServiceSummary> = {}): ServiceSu
   };
 }
 
+const defaultEntityTagProps = {
+  entityTags: [] as import('@/lib/entity-api').EntityTagRef[],
+  entityTagsLoading: false,
+  entityTagsError: '',
+};
+
 function buildLocationSummary(overrides: Partial<LocationSummary> = {}): LocationSummary {
   return {
     id: 'location-1',
@@ -58,6 +64,7 @@ describe('InstanceDetailPanel', () => {
   it('renders service and location selectors in create mode', () => {
     render(
       <InstanceDetailPanel
+        {...defaultEntityTagProps}
         instance={null}
         selectedServiceId={null}
         serviceOptions={[buildServiceSummary()]}
@@ -87,6 +94,7 @@ describe('InstanceDetailPanel', () => {
 
     render(
       <InstanceDetailPanel
+        {...defaultEntityTagProps}
         instance={null}
         selectedServiceId='service-1'
         serviceOptions={[buildServiceSummary()]}
@@ -109,6 +117,7 @@ describe('InstanceDetailPanel', () => {
       expect.objectContaining({
         status: 'scheduled',
         partner_organization_ids: [],
+        tag_ids: [],
       })
     );
   });
@@ -119,6 +128,7 @@ describe('InstanceDetailPanel', () => {
 
     render(
       <InstanceDetailPanel
+        {...defaultEntityTagProps}
         instance={null}
         selectedServiceId='service-1'
         serviceOptions={[
@@ -152,6 +162,7 @@ describe('InstanceDetailPanel', () => {
 
     render(
       <InstanceDetailPanel
+        {...defaultEntityTagProps}
         instance={null}
         selectedServiceId={null}
         serviceOptions={[
@@ -194,6 +205,7 @@ describe('InstanceDetailPanel', () => {
 
     render(
       <InstanceDetailPanel
+        {...defaultEntityTagProps}
         instance={null}
         selectedServiceId='evt-svc'
         serviceOptions={[
@@ -244,6 +256,7 @@ describe('InstanceDetailPanel', () => {
           }),
         ],
         partner_organization_ids: [],
+        tag_ids: [],
       })
     );
   });

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -122,6 +122,42 @@ describe('InstanceDetailPanel', () => {
     );
   });
 
+  it('includes selected tag ids when Tags picker is used', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InstanceDetailPanel
+        entityTags={[{ id: 'tag-alpha', name: 'Alpha', color: null }]}
+        entityTagsLoading={false}
+        entityTagsError=''
+        instance={null}
+        selectedServiceId='service-1'
+        serviceOptions={[buildServiceSummary()]}
+        locationOptions={[buildLocationSummary()]}
+        isLoadingLocations={false}
+        serviceType='training_course'
+        isLoading={false}
+        error=''
+        onSelectService={vi.fn()}
+        onCancelSelection={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByText('Tags'));
+    await user.click(screen.getByRole('checkbox', { name: 'Alpha' }));
+    await user.click(screen.getByRole('button', { name: 'Add instance' }));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      'service-1',
+      expect.objectContaining({
+        tag_ids: ['tag-alpha'],
+      })
+    );
+  });
+
   it('forwards service dropdown changes', async () => {
     const user = userEvent.setup();
     const onSelectService = vi.fn();

--- a/apps/admin_web/tests/components/admin/services/services-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/services-page.test.tsx
@@ -18,6 +18,9 @@ const { mockUseServicesPage, state } = vi.hoisted(() => {
     setInstancesServiceTypeFilter: vi.fn(),
     instancesSearchQuery: '',
     setInstancesSearchQuery: vi.fn(),
+    entityTags: [],
+    entityTagsLoading: false,
+    entityTagsError: '',
     serviceList: {
       services: [],
       filters: { serviceType: '', status: 'published', search: '' },

--- a/backend/db/alembic/versions/0037_instance_age_cohort_tags.py
+++ b/backend/db/alembic/versions/0037_instance_age_cohort_tags.py
@@ -1,0 +1,71 @@
+"""Add age_group, cohort, and service_instance_tags.
+
+1. Compatibility: seed does not insert into ``service_instances``; new columns nullable.
+2. New NOT NULL: none.
+3. Renamed/dropped: n/a.
+4. New table ``service_instance_tags``: empty at migration time; no seed rows.
+5. Enum: n/a.
+6. FK: ``service_instance_tags`` references ``service_instances`` and ``tags`` (existing).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0037_instance_age_cohort_tags"
+down_revision = "0036_instance_partners_ext_url"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "service_instances",
+        sa.Column("age_group", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "service_instances",
+        sa.Column("cohort", sa.String(length=128), nullable=True),
+    )
+    op.create_table(
+        "service_instance_tags",
+        sa.Column(
+            "service_instance_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("service_instances.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tag_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tags.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("service_instance_id", "tag_id"),
+    )
+    op.create_index(
+        "svc_instance_tags_instance_idx",
+        "service_instance_tags",
+        ["service_instance_id"],
+    )
+    op.create_index(
+        "svc_instance_tags_tag_idx",
+        "service_instance_tags",
+        ["tag_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("svc_instance_tags_tag_idx", table_name="service_instance_tags")
+    op.drop_index("svc_instance_tags_instance_idx", table_name="service_instance_tags")
+    op.drop_table("service_instance_tags")
+    op.drop_column("service_instances", "cohort")
+    op.drop_column("service_instances", "age_group")

--- a/backend/db/alembic/versions/0038_drop_redundant_svc_instance_tag_idx.py
+++ b/backend/db/alembic/versions/0038_drop_redundant_svc_instance_tag_idx.py
@@ -1,0 +1,26 @@
+"""Drop redundant index on service_instance_tags(service_instance_id).
+
+The composite primary key already begins with ``service_instance_id``; keep the
+``tag_id`` index for reverse lookups.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0038_drop_inst_tag_inst_idx"
+down_revision = "0037_instance_age_cohort_tags"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("svc_instance_tags_instance_idx", table_name="service_instance_tags")
+
+
+def downgrade() -> None:
+    op.create_index(
+        "svc_instance_tags_instance_idx",
+        "service_instance_tags",
+        ["service_instance_id"],
+    )

--- a/backend/src/app/api/admin_entities_helpers.py
+++ b/backend/src/app/api/admin_entities_helpers.py
@@ -194,7 +194,11 @@ def replace_service_instance_tags(
             ServiceInstanceTag.service_instance_id == instance_id
         )
     )
+    seen: set[UUID] = set()
     for tag_id in tag_ids:
+        if tag_id in seen:
+            continue
+        seen.add(tag_id)
         tag = session.get(Tag, tag_id)
         if tag is None:
             raise ValidationError("tag_id not found", field="tag_ids")

--- a/backend/src/app/api/admin_entities_helpers.py
+++ b/backend/src/app/api/admin_entities_helpers.py
@@ -19,6 +19,7 @@ from app.db.models import (
     OrganizationMember,
     OrganizationTag,
     RelationshipType,
+    ServiceInstanceTag,
     Tag,
 )
 from app.db.models.enums import ContactType
@@ -179,6 +180,25 @@ def replace_organization_tags(
         if tag is None:
             raise ValidationError("tag_id not found", field="tag_ids")
         session.add(OrganizationTag(organization_id=organization_id, tag_id=tag_id))
+    session.flush()
+
+
+def replace_service_instance_tags(
+    session: Session,
+    *,
+    instance_id: UUID,
+    tag_ids: list[UUID],
+) -> None:
+    session.execute(
+        delete(ServiceInstanceTag).where(
+            ServiceInstanceTag.service_instance_id == instance_id
+        )
+    )
+    for tag_id in tag_ids:
+        tag = session.get(Tag, tag_id)
+        if tag is None:
+            raise ValidationError("tag_id not found", field="tag_ids")
+        session.add(ServiceInstanceTag(service_instance_id=instance_id, tag_id=tag_id))
     session.flush()
 
 

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -14,6 +14,7 @@ from app.api.admin_service_instance_partners import (
     reconcile_instance_partner_organizations,
     validate_partner_organization_ids,
 )
+from app.api.admin_entities_helpers import replace_service_instance_tags
 from app.api.admin_services_common import (
     encode_instance_cursor,
     parse_create_instance_payload,
@@ -397,6 +398,8 @@ def _create_instance(
             max_capacity=payload["max_capacity"],
             waitlist_enabled=payload["waitlist_enabled"],
             instructor_id=payload["instructor_id"],
+            age_group=payload["age_group"],
+            cohort=payload["cohort"],
             notes=payload["notes"],
             external_url=payload["external_url"],
             created_by=actor_sub,
@@ -429,6 +432,11 @@ def _create_instance(
             session,
             instance_id=created.id,
             ordered_org_ids=payload["partner_organization_ids"],
+        )
+        replace_service_instance_tags(
+            session,
+            instance_id=created.id,
+            tag_ids=payload["tag_ids"],
         )
         session.commit()
         if service.service_type == ServiceType.EVENT:
@@ -516,6 +524,10 @@ def _update_instance(
             instance.waitlist_enabled = payload["waitlist_enabled"]
         if "instructor_id" in payload:
             instance.instructor_id = payload["instructor_id"]
+        if "age_group" in payload:
+            instance.age_group = payload["age_group"]
+        if "cohort" in payload:
+            instance.cohort = payload["cohort"]
         if "notes" in payload:
             instance.notes = payload["notes"]
         if "external_url" in payload:
@@ -550,6 +562,12 @@ def _update_instance(
                 session,
                 instance_id=instance.id,
                 ordered_org_ids=payload["partner_organization_ids"],
+            )
+        if "tag_ids" in payload:
+            replace_service_instance_tags(
+                session,
+                instance_id=instance.id,
+                tag_ids=payload["tag_ids"],
             )
 
         updated = instance_repository.update_instance(instance)

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -12,6 +12,7 @@ from app.api.admin_request import query_param
 from app.api.admin_validators import (
     MAX_DESCRIPTION_LENGTH,
     parse_optional_service_instance_slug,
+    parse_optional_service_instance_slug_like_text,
 )
 from app.api.admin_services_cursor import parse_created_cursor
 from app.api.admin_service_instance_partners import parse_partner_organization_ids
@@ -350,6 +351,12 @@ def parse_create_instance_payload(
         )
         or False,
         "instructor_id": parse_optional_text(body.get("instructor_id"), max_length=128),
+        "age_group": parse_optional_service_instance_slug_like_text(
+            body.get("age_group"), field="age_group"
+        ),
+        "cohort": parse_optional_service_instance_slug_like_text(
+            body.get("cohort"), field="cohort"
+        ),
         "notes": parse_optional_text(
             body.get("notes"), max_length=MAX_DESCRIPTION_LENGTH
         ),
@@ -358,6 +365,7 @@ def parse_create_instance_payload(
         ),
         "partner_organization_ids": parse_partner_organization_ids(body),
         "session_slots": parse_session_slots(body.get("session_slots")),
+        "tag_ids": parse_uuid_list(body.get("tag_ids"), "tag_ids"),
         "type_details": parse_instance_type_details(service.service_type, body),
     }
 
@@ -412,6 +420,14 @@ def parse_update_instance_payload(
         payload["instructor_id"] = parse_optional_text(
             body.get("instructor_id"), max_length=128
         )
+    if has_field(body, "age_group"):
+        payload["age_group"] = parse_optional_service_instance_slug_like_text(
+            body.get("age_group"), field="age_group"
+        )
+    if has_field(body, "cohort"):
+        payload["cohort"] = parse_optional_service_instance_slug_like_text(
+            body.get("cohort"), field="cohort"
+        )
     if has_field(body, "notes"):
         payload["notes"] = parse_optional_text(
             body.get("notes"), max_length=MAX_DESCRIPTION_LENGTH
@@ -424,6 +440,8 @@ def parse_update_instance_payload(
         payload["partner_organization_ids"] = parse_partner_organization_ids(body)
     if has_field(body, "session_slots"):
         payload["session_slots"] = parse_session_slots(body.get("session_slots"))
+    if has_field(body, "tag_ids"):
+        payload["tag_ids"] = parse_uuid_list(body.get("tag_ids"), "tag_ids")
     if has_any_field(
         body,
         "training_details",

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
+from app.api.admin_entities_helpers import serialize_tag_ref
+
 from app.db.models import (
     DiscountCode,
     Enrollment,
@@ -152,7 +154,21 @@ def serialize_instance(instance: ServiceInstance) -> dict[str, Any]:
             )
         ],
         "instructor_id": instance.instructor_id,
+        "age_group": instance.age_group,
+        "cohort": instance.cohort,
         "notes": instance.notes,
+        "tags": [
+            serialize_tag_ref(link.tag)
+            for link in sorted(
+                instance.instance_tags,
+                key=lambda row: (
+                    row.tag.name.lower() if row.tag else "",
+                    str(row.tag_id),
+                ),
+            )
+            if link.tag
+        ],
+        "tag_ids": [str(link.tag_id) for link in instance.instance_tags],
         "created_by": instance.created_by,
         "created_at": instance.created_at.isoformat() if instance.created_at else None,
         "updated_at": instance.updated_at.isoformat() if instance.updated_at else None,

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -124,6 +124,13 @@ def serialize_instance(instance: ServiceInstance) -> dict[str, Any]:
         if instance.delivery_mode is not None
         else service.delivery_mode.value
     )
+    sorted_instance_tags = sorted(
+        instance.instance_tags,
+        key=lambda row: (
+            row.tag.name.lower() if row.tag else "",
+            str(row.tag_id),
+        ),
+    )
     return {
         "id": str(instance.id),
         "service_id": str(instance.service_id),
@@ -158,17 +165,9 @@ def serialize_instance(instance: ServiceInstance) -> dict[str, Any]:
         "cohort": instance.cohort,
         "notes": instance.notes,
         "tags": [
-            serialize_tag_ref(link.tag)
-            for link in sorted(
-                instance.instance_tags,
-                key=lambda row: (
-                    row.tag.name.lower() if row.tag else "",
-                    str(row.tag_id),
-                ),
-            )
-            if link.tag
+            serialize_tag_ref(link.tag) for link in sorted_instance_tags if link.tag
         ],
-        "tag_ids": [str(link.tag_id) for link in instance.instance_tags],
+        "tag_ids": [str(link.tag_id) for link in sorted_instance_tags],
         "created_by": instance.created_by,
         "created_at": instance.created_at.isoformat() if instance.created_at else None,
         "updated_at": instance.updated_at.isoformat() if instance.updated_at else None,

--- a/backend/src/app/api/admin_validators.py
+++ b/backend/src/app/api/admin_validators.py
@@ -108,6 +108,13 @@ def parse_optional_service_instance_slug(
     return trimmed
 
 
+def parse_optional_service_instance_slug_like_text(
+    value: Any, *, field: str
+) -> str | None:
+    """Same character rules and normalization as instance slug; for free-text labels."""
+    return parse_optional_service_instance_slug(value, field=field)
+
+
 def validate_string_length(
     value: Any,
     field_name: str,

--- a/backend/src/app/db/models/__init__.py
+++ b/backend/src/app/db/models/__init__.py
@@ -58,6 +58,7 @@ from app.db.models.service_instance import (
     InstanceSessionSlot,
     ServiceInstance,
     ServiceInstancePartnerOrganization,
+    ServiceInstanceTag,
     TrainingInstanceDetails,
 )
 from app.db.models.tag import AssetTag, ContactTag, FamilyTag, OrganizationTag, Tag
@@ -120,6 +121,7 @@ __all__ = [
     "ServiceDeliveryMode",
     "ServiceInstance",
     "ServiceInstancePartnerOrganization",
+    "ServiceInstanceTag",
     "ServiceStatus",
     "ServiceTag",
     "ServiceType",

--- a/backend/src/app/db/models/service_instance.py
+++ b/backend/src/app/db/models/service_instance.py
@@ -201,11 +201,6 @@ class ServiceInstance(Base):
         back_populates="instance",
         cascade="all, delete-orphan",
     )
-    tags: Mapped[list["Tag"]] = relationship(
-        "Tag",
-        secondary="service_instance_tags",
-        viewonly=True,
-    )
     partner_organization_links: Mapped[list[ServiceInstancePartnerOrganization]] = (
         relationship(
             "ServiceInstancePartnerOrganization",
@@ -220,10 +215,7 @@ class ServiceInstanceTag(Base):
     """Many-to-many link between service instances and CRM tags."""
 
     __tablename__ = "service_instance_tags"
-    __table_args__ = (
-        Index("svc_instance_tags_instance_idx", "service_instance_id"),
-        Index("svc_instance_tags_tag_idx", "tag_id"),
-    )
+    __table_args__ = (Index("svc_instance_tags_tag_idx", "tag_id"),)
 
     service_instance_id: Mapped[UUID] = mapped_column(
         PG_UUID(as_uuid=True),

--- a/backend/src/app/db/models/service_instance.py
+++ b/backend/src/app/db/models/service_instance.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from app.db.models.location import Location
     from app.db.models.organization import Organization
     from app.db.models.service import Service
+    from app.db.models.tag import Tag
 
 
 def _enum_values(
@@ -116,6 +117,8 @@ class ServiceInstance(Base):
         server_default=text("false"),
     )
     instructor_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    age_group: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    cohort: Mapped[str | None] = mapped_column(String(128), nullable=True)
     notes: Mapped[str | None] = mapped_column(Text(), nullable=True)
     created_by: Mapped[str] = mapped_column(String(128), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -193,6 +196,16 @@ class ServiceInstance(Base):
         "DiscountCode",
         back_populates="instance",
     )
+    instance_tags: Mapped[list[ServiceInstanceTag]] = relationship(
+        "ServiceInstanceTag",
+        back_populates="instance",
+        cascade="all, delete-orphan",
+    )
+    tags: Mapped[list["Tag"]] = relationship(
+        "Tag",
+        secondary="service_instance_tags",
+        viewonly=True,
+    )
     partner_organization_links: Mapped[list[ServiceInstancePartnerOrganization]] = (
         relationship(
             "ServiceInstancePartnerOrganization",
@@ -200,6 +213,41 @@ class ServiceInstance(Base):
             cascade="all, delete-orphan",
             order_by="ServiceInstancePartnerOrganization.sort_order.asc()",
         )
+    )
+
+
+class ServiceInstanceTag(Base):
+    """Many-to-many link between service instances and CRM tags."""
+
+    __tablename__ = "service_instance_tags"
+    __table_args__ = (
+        Index("svc_instance_tags_instance_idx", "service_instance_id"),
+        Index("svc_instance_tags_tag_idx", "tag_id"),
+    )
+
+    service_instance_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("service_instances.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    tag_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    instance: Mapped[ServiceInstance] = relationship(
+        "ServiceInstance",
+        back_populates="instance_tags",
+    )
+    tag: Mapped["Tag"] = relationship(
+        "Tag",
+        back_populates="service_instance_tags",
     )
 
 

--- a/backend/src/app/db/models/tag.py
+++ b/backend/src/app/db/models/tag.py
@@ -67,6 +67,11 @@ class Tag(Base):
         back_populates="tag",
         cascade="all, delete-orphan",
     )
+    service_instance_tags: Mapped[list["ServiceInstanceTag"]] = relationship(
+        "ServiceInstanceTag",
+        back_populates="tag",
+        cascade="all, delete-orphan",
+    )
 
 
 class ContactTag(Base):

--- a/backend/src/app/db/models/tag.py
+++ b/backend/src/app/db/models/tag.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from app.db.models.contact import Contact
     from app.db.models.family import Family
     from app.db.models.organization import Organization
+    from app.db.models.service_instance import ServiceInstanceTag
 
 
 class Tag(Base):

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -18,6 +18,7 @@ from app.db.models import (
     InstanceStatus,
     Service,
     ServiceInstancePartnerOrganization,
+    ServiceInstanceTag,
     ServiceStatus,
     ServiceInstance,
     ServiceType,
@@ -57,6 +58,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                 selectinload(ServiceInstance.ticket_tiers),
                 selectinload(ServiceInstance.partner_organization_links).joinedload(
                     ServiceInstancePartnerOrganization.organization
+                ),
+                selectinload(ServiceInstance.instance_tags).selectinload(
+                    ServiceInstanceTag.tag
                 ),
             )
         )
@@ -110,6 +114,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             selectinload(ServiceInstance.ticket_tiers),
             selectinload(ServiceInstance.partner_organization_links).joinedload(
                 ServiceInstancePartnerOrganization.organization
+            ),
+            selectinload(ServiceInstance.instance_tags).selectinload(
+                ServiceInstanceTag.tag
             ),
             joinedload(ServiceInstance.service),
         )
@@ -172,6 +179,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                 selectinload(ServiceInstance.ticket_tiers),
                 selectinload(ServiceInstance.partner_organization_links).joinedload(
                     ServiceInstancePartnerOrganization.organization
+                ),
+                selectinload(ServiceInstance.instance_tags).selectinload(
+                    ServiceInstanceTag.tag
                 ),
                 selectinload(ServiceInstance.enrollments),
             )

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3941,6 +3941,10 @@ components:
           items:
             type: string
             format: uuid
+          description: >
+            Replaces all instance tag associations when present (including on PUT).
+            The admin web UI sends this on every instance save; omit the field only if
+            a non-UI client must patch other fields without changing tags.
         session_slots:
           type: array
           items:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3764,9 +3764,34 @@ components:
         instructor_id:
           type: string
           nullable: true
+        age_group:
+          type: string
+          nullable: true
+          maxLength: 128
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          description: >
+            Optional label using the same normalization rules as instance referral slugs
+            (lowercase letters, digits, single hyphens between segments).
+        cohort:
+          type: string
+          nullable: true
+          maxLength: 128
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          description: >
+            Optional label using the same normalization rules as instance referral slugs
+            (lowercase letters, digits, single hyphens between segments).
         notes:
           type: string
           nullable: true
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/EntityTagRef"
+        tag_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
         created_by:
           type: string
         created_at:
@@ -3898,9 +3923,24 @@ components:
         instructor_id:
           type: string
           nullable: true
+        age_group:
+          type: string
+          nullable: true
+          maxLength: 128
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        cohort:
+          type: string
+          nullable: true
+          maxLength: 128
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
         notes:
           type: string
           nullable: true
+        tag_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
         session_slots:
           type: array
           items:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -457,6 +457,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   `cover_image_s3_key`, `delivery_mode`).
 - Optional public-site fields: `slug` (unique when set), `landing_page`
   (marketing route key for the public website).
+- Optional `age_group` and `cohort` varchar(128): admin labels stored with the same
+  normalization rules as instance referral slugs (lowercase letters, digits, single
+  hyphens between segments).
 - Optional `external_url` varchar(500): operator-provided external registration/info URL
   (http/https), distinct from Eventbrite sync URLs.
 - Eventbrite sync metadata is stored on `service_instances` so DB remains source
@@ -479,6 +482,12 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   (`service_instance_id`, `organization_id`, `sort_order`, `created_at`), added in
   migration `0036_instance_partners_ext_url`. Used by the admin API for event instance
   partner multi-select; ordering follows `sort_order`.
+
+### `service_instance_tags`
+
+- Junction table linking `service_instances` to CRM `tags` rows (`service_instance_id`,
+  `tag_id`, `created_at`), added in migration `0037_instance_age_cohort_tags`. Used by
+  the admin API for instance tag multi-select (same tag catalog as contacts).
 
 ### `discount_codes`
 

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -488,6 +488,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 - Junction table linking `service_instances` to CRM `tags` rows (`service_instance_id`,
   `tag_id`, `created_at`), added in migration `0037_instance_age_cohort_tags`. Used by
   the admin API for instance tag multi-select (same tag catalog as contacts).
+- Migration `0038_drop_inst_tag_inst_idx` drops the redundant btree index on
+  `service_instance_id` (the composite primary key already leads with that column);
+  the `tag_id` index remains for reverse lookups.
 
 ### `discount_codes`
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -76,7 +76,9 @@ their primary responsibilities.
   `/v1/admin/leads/*`, `/v1/admin/users`, `/v1/admin/instructors`,
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for
   cross-service instance listing with optional `service_id` / `service_type`
-  filters and `GET /v1/admin/services/{id}/discount-code-usage-summary` for
+  filters; instance create/update accepts optional `age_group`, `cohort`, and
+  `tag_ids` with `tags` / `tag_ids` echoed on instance responses; and
+  `GET /v1/admin/services/{id}/discount-code-usage-summary` for
   aggregate discount usage before service slug changes), `/v1/admin/discount-codes/*`
   (`POST` returns `409` with `field: code` when the code collides with the
   case-insensitive unique index; `PUT` accepts `discount_value` `0` only when the

--- a/tests/test_admin_entities_helpers.py
+++ b/tests/test_admin_entities_helpers.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 
 from app.api.admin_entities_helpers import (
     FAMILY_RELATIONSHIP_TYPES,
     ORGANIZATION_RELATIONSHIP_TYPES,
+    replace_service_instance_tags,
     request_id,
     parse_contact_type_filter,
     parse_relationship_type,
 )
-from app.db.models import RelationshipType
+from app.db.models import RelationshipType, ServiceInstanceTag
 from app.db.models.enums import ContactType
 from app.exceptions import ValidationError
 
@@ -94,3 +98,58 @@ def test_parse_contact_type_filter_accepts_known_values() -> None:
 def test_parse_contact_type_filter_rejects_unknown() -> None:
     with pytest.raises(ValidationError, match="contact_type"):
         parse_contact_type_filter("not_a_type")
+
+
+@pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
+def test_replace_service_instance_tags_dedupes_preserving_order() -> None:
+    instance_id = uuid4()
+    t1, t2 = uuid4(), uuid4()
+    session = MagicMock()
+    added: list[ServiceInstanceTag] = []
+
+    def fake_get(_model: type, pk: object) -> object | None:
+        if pk == t1:
+            return SimpleNamespace(id=t1)
+        if pk == t2:
+            return SimpleNamespace(id=t2)
+        return None
+
+    session.get.side_effect = fake_get
+    session.add.side_effect = lambda row: added.append(row)
+
+    replace_service_instance_tags(
+        session,
+        instance_id=instance_id,
+        tag_ids=[t2, t1, t2],
+    )
+
+    assert len(added) == 2
+    assert isinstance(added[0], ServiceInstanceTag)
+    assert added[0].service_instance_id == instance_id
+    assert added[0].tag_id == t2
+    assert added[1].tag_id == t1
+    session.execute.assert_called_once()
+    session.flush.assert_called_once()
+
+
+@pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
+def test_replace_service_instance_tags_unknown_id_sets_field() -> None:
+    instance_id = uuid4()
+    known = uuid4()
+    missing = uuid4()
+    session = MagicMock()
+
+    def fake_get(_model: type, pk: object) -> object | None:
+        if pk == known:
+            return SimpleNamespace(id=known)
+        return None
+
+    session.get.side_effect = fake_get
+
+    with pytest.raises(ValidationError, match="tag_id not found") as exc:
+        replace_service_instance_tags(
+            session,
+            instance_id=instance_id,
+            tag_ids=[known, missing],
+        )
+    assert exc.value.field == "tag_ids"

--- a/tests/test_admin_services_instance_metadata.py
+++ b/tests/test_admin_services_instance_metadata.py
@@ -1,0 +1,166 @@
+"""Tests for instance age_group, cohort, and tag_ids parsing."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from app.api.admin_services_payloads import parse_create_instance_payload
+from app.db.models import (
+    Service,
+    ServiceInstance,
+    ServiceInstanceTag,
+    Tag,
+    TrainingInstanceDetails,
+)
+from app.db.models.enums import (
+    InstanceStatus,
+    ServiceDeliveryMode,
+    ServiceStatus,
+    ServiceType,
+    TrainingFormat,
+    TrainingPricingUnit,
+)
+from app.exceptions import ValidationError
+
+pytestmark = pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
+
+
+def _minimal_training_service() -> Service:
+    sid = uuid4()
+    return Service(
+        id=sid,
+        service_type=ServiceType.TRAINING_COURSE,
+        title="Course",
+        slug=None,
+        booking_system=None,
+        description=None,
+        cover_image_s3_key=None,
+        delivery_mode=ServiceDeliveryMode.ONLINE,
+        status=ServiceStatus.PUBLISHED,
+        created_by="tester",
+    )
+
+
+def test_parse_create_instance_payload_persists_age_group_and_cohort() -> None:
+    service = _minimal_training_service()
+    body = {
+        "age_group": "  Ages-3-5  ",
+        "cohort": "Spring-2026",
+        "training_details": {
+            "training_format": "group",
+            "price": "10.00",
+            "currency": "HKD",
+            "pricing_unit": "per_person",
+        },
+    }
+    parsed = parse_create_instance_payload(body, service)
+    assert parsed["age_group"] == "ages-3-5"
+    assert parsed["cohort"] == "spring-2026"
+
+
+def test_parse_create_instance_payload_rejects_invalid_age_group_field() -> None:
+    service = _minimal_training_service()
+    body = {
+        "age_group": "Bad_Slug",
+        "training_details": {
+            "training_format": "group",
+            "price": "10.00",
+            "currency": "HKD",
+            "pricing_unit": "per_person",
+        },
+    }
+    with pytest.raises(ValidationError) as exc:
+        parse_create_instance_payload(body, service)
+    assert exc.value.field == "age_group"
+
+
+def test_parse_create_instance_payload_accepts_tag_ids() -> None:
+    service = _minimal_training_service()
+    t1, t2 = uuid4(), uuid4()
+    body = {
+        "tag_ids": [str(t2), str(t1)],
+        "training_details": {
+            "training_format": "group",
+            "price": "10.00",
+            "currency": "HKD",
+            "pricing_unit": "per_person",
+        },
+    }
+    parsed = parse_create_instance_payload(body, service)
+    assert parsed["tag_ids"] == [t2, t1]
+
+
+def test_training_instance_round_trip_age_cohort_tags_in_memory() -> None:
+    """ORM-only check: fields map and serializer ordering matches tag name (case-insensitive)."""
+    from app.api.admin_services_serializers import serialize_instance
+
+    service = _minimal_training_service()
+    inst_id = uuid4()
+    tag_ba = Tag(
+        id=uuid4(),
+        name="Beta",
+        color=None,
+        description=None,
+        created_by="t",
+    )
+    tag_aa = Tag(
+        id=uuid4(),
+        name="alpha",
+        color=None,
+        description=None,
+        created_by="t",
+    )
+    instance = ServiceInstance(
+        id=inst_id,
+        service_id=service.id,
+        title=None,
+        slug=None,
+        landing_page=None,
+        description=None,
+        cover_image_s3_key=None,
+        status=InstanceStatus.SCHEDULED,
+        delivery_mode=None,
+        location_id=None,
+        max_capacity=None,
+        waitlist_enabled=False,
+        instructor_id=None,
+        age_group="ages-3-5",
+        cohort="spring-2026",
+        notes=None,
+        created_by="tester",
+        external_url=None,
+    )
+    instance.service = service
+    link_ba = ServiceInstanceTag(
+        service_instance_id=inst_id,
+        tag_id=tag_ba.id,
+        created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+    link_ba.tag = tag_ba
+    link_aa = ServiceInstanceTag(
+        service_instance_id=inst_id,
+        tag_id=tag_aa.id,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    link_aa.tag = tag_aa
+    instance.instance_tags = [link_ba, link_aa]
+    instance.training_details = TrainingInstanceDetails(
+        instance_id=inst_id,
+        training_format=TrainingFormat.GROUP,
+        price=Decimal("10.00"),
+        currency="HKD",
+        pricing_unit=TrainingPricingUnit.PER_PERSON,
+    )
+    instance.session_slots = []
+    instance.ticket_tiers = []
+    instance.partner_organization_links = []
+
+    payload = serialize_instance(instance)
+    assert payload["age_group"] == "ages-3-5"
+    assert payload["cohort"] == "spring-2026"
+    assert [t["name"] for t in payload["tags"]] == ["alpha", "Beta"]
+    assert payload["tag_ids"] == [str(tag_aa.id), str(tag_ba.id)]

--- a/tests/test_admin_validators.py
+++ b/tests/test_admin_validators.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.api.admin_validators import (
     parse_optional_service_instance_slug,
+    parse_optional_service_instance_slug_like_text,
     validate_email,
     validate_string_length,
 )
@@ -35,3 +36,20 @@ def test_parse_optional_service_instance_slug_rejects_invalid() -> None:
         parse_optional_service_instance_slug("Bad_Slug")
     with pytest.raises(ValidationError, match="lowercase letters"):
         parse_optional_service_instance_slug("double--hyphen")
+
+
+def test_parse_optional_service_instance_slug_like_text_matches_slug_rules() -> None:
+    assert parse_optional_service_instance_slug_like_text(
+        "  Spring-Cohort  ", field="cohort"
+    ) == "spring-cohort"
+    assert parse_optional_service_instance_slug_like_text(None, field="age_group") is None
+    assert parse_optional_service_instance_slug_like_text("   ", field="age_group") is None
+
+
+def test_parse_optional_service_instance_slug_like_text_sets_field_on_error() -> None:
+    with pytest.raises(ValidationError, match="lowercase letters") as excinfo:
+        parse_optional_service_instance_slug_like_text("Bad_Slug", field="age_group")
+    assert excinfo.value.field == "age_group"
+    with pytest.raises(ValidationError, match="lowercase letters") as excinfo2:
+        parse_optional_service_instance_slug_like_text("a--b", field="cohort")
+    assert excinfo2.value.field == "cohort"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds optional `age_group` and `cohort` on `service_instances` (varchar 128), validated and stored with the same normalization rules as instance referral slugs (lowercase, digits, single hyphens).
- Adds `service_instance_tags` junction so instances can use the same CRM `tags` catalog as contacts; create/update accepts `tag_ids`; responses include `tags` and `tag_ids` (sorted case-insensitively by tag name, with `tag_ids` matching that order). Duplicate `tag_id` values in a request are deduped while preserving first-seen order.
- Admin Services → Instances: age group and cohort inputs above Notes; collapsible tag picker below Notes (same pattern as contacts).

## Notes

- Run Alembic through `0038_drop_inst_tag_inst_idx` before deploying (adds instance fields/tags in `0037`, drops redundant `service_instance_id` index in `0038`).
- Regenerated `apps/admin_web/src/types/generated/admin-api.generated.ts` from `docs/api/admin.yaml`.
- **PUT semantics:** when `tag_ids` is present on instance create/update, it **replaces** all instance tag rows (admin web always sends it). Non-UI clients that must patch other fields without changing tags should omit `tag_ids` (documented on the OpenAPI field).

## Testing

- `pre-commit run --all-files --show-diff-on-failure`
- `bash scripts/validate-cursorrules.sh`
- `python3 -m pytest tests/test_admin_validators.py tests/test_admin_entities_helpers.py tests/test_admin_services_instance_metadata.py tests/test_admin_service_instances_api.py`
- `npm run check:admin-api-types && npm run lint` (admin_web)
- `npx vitest run tests/components/admin/services/instance-detail-panel.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56c99b0f-11ef-4bdc-aeb5-74a0aa83439c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56c99b0f-11ef-4bdc-aeb5-74a0aa83439c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

