### PR TITLE
Admin Tags page and tag management API

### DIFF
--- a/apps/admin_web/src/app/(dashboard)/tags/page.tsx
+++ b/apps/admin_web/src/app/(dashboard)/tags/page.tsx
@@ -1,0 +1,5 @@
+import { TagsPage } from '@/components/admin/tags/tags-page';
+
+export default function TagsRoutePage() {
+  return <TagsPage />;
+}

--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import type { FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import { AdminEditorCard } from '@/components/ui/admin-editor-card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { Textarea } from '@/components/ui/textarea';
+import { DeleteIcon } from '@/components/icons/action-icons';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
+import { formatDate } from '@/lib/format';
+import {
+  createAdminTag,
+  deleteOrArchiveAdminTag,
+  listAdminTags,
+  updateAdminTag,
+  type AdminTagRow,
+} from '@/lib/tags-api';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+
+const EDITOR_FORM_ID = 'tags-editor-form';
+
+export function TagsPage() {
+  const [confirmDialogProps, requestConfirm] = useConfirmDialog();
+  const [tags, setTags] = useState<AdminTagRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [saveError, setSaveError] = useState('');
+  const [showArchived, setShowArchived] = useState(false);
+  const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
+  const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [color, setColor] = useState('');
+  const [description, setDescription] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteBusyId, setDeleteBusyId] = useState<string | null>(null);
+
+  const loadTags = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const rows = await listAdminTags({ includeArchived: showArchived });
+      setTags(rows);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : 'Failed to load tags.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [showArchived]);
+
+  useEffect(() => {
+    void loadTags();
+  }, [loadTags]);
+
+  const resetCreateForm = () => {
+    setEditorMode('create');
+    setSelectedTagId(null);
+    setName('');
+    setColor('');
+    setDescription('');
+    setSaveError('');
+  };
+
+  const applyRowSelection = (row: AdminTagRow) => {
+    setEditorMode('edit');
+    setSelectedTagId(row.id);
+    setName(row.name);
+    setColor(row.color?.trim() ?? '');
+    setDescription(row.description?.trim() ?? '');
+    setSaveError('');
+  };
+
+  const parseColorPayload = (): string | null => {
+    const trimmed = color.trim();
+    return trimmed === '' ? null : trimmed;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSaveError('');
+    setIsSaving(true);
+    try {
+      const colorPayload = parseColorPayload();
+      const descTrimmed = description.trim();
+      if (editorMode === 'create') {
+        const body: ApiSchemas['CreateAdminTagRequest'] = {
+          name: name.trim(),
+          color: colorPayload,
+          description: descTrimmed === '' ? null : descTrimmed,
+        };
+        await createAdminTag(body);
+        resetCreateForm();
+        await loadTags();
+        return;
+      }
+      if (!selectedTagId) {
+        return;
+      }
+      const body: ApiSchemas['UpdateAdminTagRequest'] = {
+        name: name.trim(),
+        color: colorPayload,
+        description: descTrimmed === '' ? null : descTrimmed,
+      };
+      await updateAdminTag(selectedTagId, body);
+      await loadTags();
+    } catch (caught) {
+      if (caught instanceof AdminApiError && readAdminApiErrorField(caught) === 'name') {
+        setSaveError('A tag with this name already exists.');
+        return;
+      }
+      const message = caught instanceof Error ? caught.message : 'Save failed.';
+      setSaveError(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDeleteRow = async (row: AdminTagRow) => {
+    const inUse = row.usage_count > 0;
+    const confirmed = await requestConfirm(
+      inUse
+        ? {
+            title: 'Archive tag?',
+            description: `“${row.name}” is linked to ${row.usage_count} record(s). It will be hidden from pickers but stay on existing records.`,
+            confirmLabel: 'Archive',
+            variant: 'danger',
+          }
+        : {
+            title: 'Remove tag?',
+            description: `Permanently delete “${row.name}”? This cannot be undone.`,
+            confirmLabel: 'Delete',
+            variant: 'danger',
+          }
+    );
+    if (!confirmed) {
+      return;
+    }
+    setDeleteBusyId(row.id);
+    setError('');
+    try {
+      const outcome = await deleteOrArchiveAdminTag(row.id);
+      if (outcome.status === 204 && selectedTagId === row.id) {
+        resetCreateForm();
+      }
+      if (outcome.status === 200 && selectedTagId === row.id) {
+        applyRowSelection(outcome.tag);
+      }
+      await loadTags();
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : 'Delete failed.';
+      setError(message);
+    } finally {
+      setDeleteBusyId(null);
+    }
+  };
+
+  const editorIsBusy = isSaving || Boolean(deleteBusyId);
+
+  return (
+    <div className='space-y-6'>
+      <AdminEditorCard
+        title={editorMode === 'create' ? 'New tag' : 'Edit tag'}
+        description='Tags apply across contacts, families, organisations, services, instances, and assets. Archived tags stay on existing records but no longer appear in pickers.'
+        actions={
+          editorMode === 'edit' ? (
+            <>
+              <Button type='button' variant='outline' disabled={editorIsBusy} onClick={resetCreateForm}>
+                Cancel
+              </Button>
+              <Button type='submit' form={EDITOR_FORM_ID} disabled={editorIsBusy || !name.trim()}>
+                {isSaving ? 'Saving…' : 'Save changes'}
+              </Button>
+            </>
+          ) : (
+            <Button type='submit' form={EDITOR_FORM_ID} disabled={editorIsBusy || !name.trim()}>
+              {isSaving ? 'Creating…' : 'Create tag'}
+            </Button>
+          )
+        }
+      >
+        <form id={EDITOR_FORM_ID} className='space-y-4' onSubmit={(event) => void handleSubmit(event)}>
+          <div>
+            <Label htmlFor='tag-name'>Name</Label>
+            <Input
+              id='tag-name'
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              maxLength={100}
+              required
+              autoComplete='off'
+            />
+          </div>
+          <div>
+            <Label htmlFor='tag-color'>Color (#RRGGBB)</Label>
+            <Input
+              id='tag-color'
+              value={color}
+              onChange={(event) => setColor(event.target.value)}
+              placeholder='#336699'
+              maxLength={7}
+              autoComplete='off'
+            />
+          </div>
+          <div>
+            <Label htmlFor='tag-description'>Description</Label>
+            <Textarea
+              id='tag-description'
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={2}
+              maxLength={255}
+            />
+          </div>
+          {saveError ? <p className='text-sm text-red-600'>{saveError}</p> : null}
+        </form>
+      </AdminEditorCard>
+
+      <PaginatedTableCard
+        title='Tags'
+        isLoading={isLoading}
+        isLoadingMore={false}
+        hasMore={false}
+        error={error}
+        loadingLabel='Loading tags…'
+        onLoadMore={() => {}}
+        toolbar={
+          <div className='mb-3 flex flex-wrap items-end gap-3'>
+            <div className='flex min-w-[180px] items-center gap-2 pt-6'>
+              <input
+                id='tags-show-archived'
+                type='checkbox'
+                className='h-4 w-4 rounded border-slate-300 text-slate-900'
+                checked={showArchived}
+                onChange={(event) => setShowArchived(event.target.checked)}
+              />
+              <Label htmlFor='tags-show-archived' className='cursor-pointer font-normal'>
+                Show archived
+              </Label>
+            </div>
+          </div>
+        }
+      >
+        <AdminDataTable tableClassName='min-w-[720px]'>
+          <AdminDataTableHead>
+            <tr>
+              <th className='px-4 py-3 font-semibold'>Name</th>
+              <th className='px-4 py-3 font-semibold'>Color</th>
+              <th className='px-4 py-3 font-semibold'>Uses</th>
+              <th className='px-4 py-3 font-semibold'>Status</th>
+              <th className='px-4 py-3 font-semibold'>Archived</th>
+              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+            </tr>
+          </AdminDataTableHead>
+          <AdminDataTableBody>
+            {tags.map((row) => (
+              <tr
+                key={row.id}
+                className={`cursor-pointer transition ${
+                  selectedTagId === row.id ? 'bg-slate-100' : 'hover:bg-slate-50'
+                }`}
+                onClick={() => applyRowSelection(row)}
+              >
+                <td className='px-4 py-3 font-medium text-slate-900'>{row.name}</td>
+                <td className='px-4 py-3 font-mono text-sm text-slate-700'>{row.color ?? '—'}</td>
+                <td className='px-4 py-3'>{row.usage_count}</td>
+                <td className='px-4 py-3 text-sm text-slate-700'>
+                  {row.archived_at ? 'Archived' : 'Active'}
+                </td>
+                <td className='px-4 py-3 text-sm text-slate-600'>
+                  {row.archived_at ? formatDate(row.archived_at) : '—'}
+                </td>
+                <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
+                  <Button
+                    type='button'
+                    size='sm'
+                    variant='danger'
+                    disabled={editorIsBusy || deleteBusyId === row.id}
+                    onClick={() => void handleDeleteRow(row)}
+                    aria-label={row.usage_count > 0 ? 'Archive tag' : 'Delete tag'}
+                    title={row.usage_count > 0 ? 'Archive tag' : 'Delete tag'}
+                  >
+                    <DeleteIcon className='h-4 w-4' />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </AdminDataTableBody>
+        </AdminDataTable>
+      </PaginatedTableCard>
+      <ConfirmDialog {...confirmDialogProps} />
+    </div>
+  );
+}

--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -10,6 +10,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
@@ -20,6 +21,7 @@ import {
   deleteOrArchiveAdminTag,
   listAdminTags,
   updateAdminTag,
+  type AdminTagListFilter,
   type AdminTagRow,
 } from '@/lib/tags-api';
 
@@ -35,7 +37,7 @@ export function TagsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
   const [saveError, setSaveError] = useState('');
-  const [showArchived, setShowArchived] = useState(false);
+  const [listFilter, setListFilter] = useState<AdminTagListFilter>('active');
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
   const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
   const [name, setName] = useState('');
@@ -43,12 +45,18 @@ export function TagsPage() {
   const [description, setDescription] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const [deleteBusyId, setDeleteBusyId] = useState<string | null>(null);
+  const [restoreBusyId, setRestoreBusyId] = useState<string | null>(null);
+
+  const selectedRow = useMemo(
+    () => tags.find((row) => row.id === selectedTagId) ?? null,
+    [tags, selectedTagId]
+  );
 
   const loadTags = useCallback(async () => {
     setIsLoading(true);
     setError('');
     try {
-      const rows = await listAdminTags({ includeArchived: showArchived });
+      const rows = await listAdminTags({ filter: listFilter });
       setTags(rows);
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : 'Failed to load tags.';
@@ -56,7 +64,7 @@ export function TagsPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [showArchived]);
+  }, [listFilter]);
 
   useEffect(() => {
     void loadTags();
@@ -83,6 +91,23 @@ export function TagsPage() {
   const parseColorPayload = (): string | null => {
     const trimmed = color.trim();
     return trimmed === '' ? null : trimmed;
+  };
+
+  const handleRestore = async (row: AdminTagRow) => {
+    setRestoreBusyId(row.id);
+    setError('');
+    try {
+      const updated = await updateAdminTag(row.id, { archived: false });
+      await loadTags();
+      if (updated && selectedTagId === row.id) {
+        applyRowSelection(updated);
+      }
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : 'Restore failed.';
+      setError(message);
+    } finally {
+      setRestoreBusyId(null);
+    }
   };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -126,9 +151,12 @@ export function TagsPage() {
   };
 
   const handleDeleteRow = async (row: AdminTagRow) => {
-    const inUse = row.usage_count > 0;
+    if (row.is_system) {
+      return;
+    }
+    const predictedArchive = row.usage_count > 0;
     const confirmed = await requestConfirm(
-      inUse
+      predictedArchive
         ? {
             title: 'Archive tag?',
             description: `“${row.name}” is linked to ${row.usage_count} record(s). It will be hidden from pickers but stay on existing records.`,
@@ -149,10 +177,16 @@ export function TagsPage() {
     setError('');
     try {
       const outcome = await deleteOrArchiveAdminTag(row.id);
-      if (outcome.status === 204 && selectedTagId === row.id) {
+      const actualArchive = !outcome.deleted;
+      if (predictedArchive !== actualArchive) {
+        setError(
+          `The server ${actualArchive ? 'archived' : 'removed'} this tag based on current usage (${outcome.usage_count} link(s)). Refresh the list if the table looked stale.`
+        );
+      }
+      if (outcome.deleted && selectedTagId === row.id) {
         resetCreateForm();
       }
-      if (outcome.status === 200 && selectedTagId === row.id) {
+      if (!outcome.deleted && outcome.tag && selectedTagId === row.id) {
         applyRowSelection(outcome.tag);
       }
       await loadTags();
@@ -164,20 +198,38 @@ export function TagsPage() {
     }
   };
 
-  const editorIsBusy = isSaving || Boolean(deleteBusyId);
+  const editorIsBusy = isSaving || Boolean(deleteBusyId) || Boolean(restoreBusyId);
+
+  const isEditingSystemTag = editorMode === 'edit' && selectedRow?.is_system;
+  const showRestoreInEditor =
+    editorMode === 'edit' && selectedRow && Boolean(selectedRow.archived_at) && !selectedRow.is_system;
 
   return (
     <div className='space-y-6'>
       <AdminEditorCard
         title={editorMode === 'create' ? 'New tag' : 'Edit tag'}
-        description='Tags apply across contacts, families, organisations, services, instances, and assets. Archived tags stay on existing records but no longer appear in pickers.'
+        description='Tags apply across contacts, families, organisations, services, instances, and assets. Archived tags stay on existing records but no longer appear in pickers. Use Restore (below or in the table) to clear archive. System tags (expense_attachment, client_document) cannot be renamed, archived, or deleted.'
         actions={
           editorMode === 'edit' ? (
             <>
-              <Button type='button' variant='outline' disabled={editorIsBusy} onClick={resetCreateForm}>
+              {showRestoreInEditor ? (
+                <Button
+                  type='button'
+                  variant='secondary'
+                  disabled={editorIsBusy}
+                  onClick={() => selectedRow && void handleRestore(selectedRow)}
+                >
+                  {restoreBusyId === selectedTagId ? 'Restoring…' : 'Restore'}
+                </Button>
+              ) : null}
+              <Button type='button' variant='secondary' disabled={editorIsBusy} onClick={resetCreateForm}>
                 Cancel
               </Button>
-              <Button type='submit' form={EDITOR_FORM_ID} disabled={editorIsBusy || !name.trim()}>
+              <Button
+                type='submit'
+                form={EDITOR_FORM_ID}
+                disabled={editorIsBusy || !name.trim()}
+              >
                 {isSaving ? 'Saving…' : 'Save changes'}
               </Button>
             </>
@@ -198,7 +250,11 @@ export function TagsPage() {
               maxLength={100}
               required
               autoComplete='off'
+              disabled={Boolean(isEditingSystemTag)}
             />
+            {isEditingSystemTag ? (
+              <p className='mt-1 text-sm text-slate-600'>This system-managed tag name cannot be changed.</p>
+            ) : null}
           </div>
           <div>
             <Label htmlFor='tag-color'>Color (#RRGGBB)</Label>
@@ -235,22 +291,22 @@ export function TagsPage() {
         onLoadMore={() => {}}
         toolbar={
           <div className='mb-3 flex flex-wrap items-end gap-3'>
-            <div className='flex min-w-[180px] items-center gap-2 pt-6'>
-              <input
-                id='tags-show-archived'
-                type='checkbox'
-                className='h-4 w-4 rounded border-slate-300 text-slate-900'
-                checked={showArchived}
-                onChange={(event) => setShowArchived(event.target.checked)}
-              />
-              <Label htmlFor='tags-show-archived' className='cursor-pointer font-normal'>
-                Show archived
-              </Label>
+            <div className='min-w-[160px]'>
+              <Label htmlFor='tags-list-filter'>Status</Label>
+              <Select
+                id='tags-list-filter'
+                value={listFilter}
+                onChange={(event) => setListFilter(event.target.value as AdminTagListFilter)}
+              >
+                <option value='active'>Active</option>
+                <option value='archived'>Archived</option>
+                <option value='all'>All</option>
+              </Select>
             </div>
           </div>
         }
       >
-        <AdminDataTable tableClassName='min-w-[720px]'>
+        <AdminDataTable tableClassName='min-w-[800px]'>
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Name</th>
@@ -269,8 +325,20 @@ export function TagsPage() {
                   selectedTagId === row.id ? 'bg-slate-100' : 'hover:bg-slate-50'
                 }`}
                 onClick={() => applyRowSelection(row)}
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    applyRowSelection(row);
+                  }
+                }}
               >
-                <td className='px-4 py-3 font-medium text-slate-900'>{row.name}</td>
+                <td className='px-4 py-3 font-medium text-slate-900'>
+                  {row.name}
+                  {row.is_system ? (
+                    <span className='ml-2 text-xs font-normal text-slate-500'>(system)</span>
+                  ) : null}
+                </td>
                 <td className='px-4 py-3 font-mono text-sm text-slate-700'>{row.color ?? '—'}</td>
                 <td className='px-4 py-3'>{row.usage_count}</td>
                 <td className='px-4 py-3 text-sm text-slate-700'>
@@ -280,17 +348,36 @@ export function TagsPage() {
                   {row.archived_at ? formatDate(row.archived_at) : '—'}
                 </td>
                 <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
-                  <Button
-                    type='button'
-                    size='sm'
-                    variant='danger'
-                    disabled={editorIsBusy || deleteBusyId === row.id}
-                    onClick={() => void handleDeleteRow(row)}
-                    aria-label={row.usage_count > 0 ? 'Archive tag' : 'Delete tag'}
-                    title={row.usage_count > 0 ? 'Archive tag' : 'Delete tag'}
-                  >
-                    <DeleteIcon className='h-4 w-4' />
-                  </Button>
+                  <div className='flex justify-end gap-1'>
+                    {row.archived_at && !row.is_system ? (
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='secondary'
+                        disabled={editorIsBusy || restoreBusyId === row.id}
+                        onClick={() => void handleRestore(row)}
+                      >
+                        {restoreBusyId === row.id ? '…' : 'Restore'}
+                      </Button>
+                    ) : null}
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='danger'
+                      disabled={editorIsBusy || deleteBusyId === row.id || row.is_system}
+                      onClick={() => void handleDeleteRow(row)}
+                      aria-label={row.is_system ? 'System tag' : row.usage_count > 0 ? 'Archive tag' : 'Delete tag'}
+                      title={
+                        row.is_system
+                          ? 'System-managed tags cannot be removed'
+                          : row.usage_count > 0
+                            ? 'Archive tag'
+                            : 'Delete tag'
+                      }
+                    >
+                      <DeleteIcon className='h-4 w-4' />
+                    </Button>
+                  </div>
                 </td>
               </tr>
             ))}

--- a/apps/admin_web/src/lib/admin-nav.ts
+++ b/apps/admin_web/src/lib/admin-nav.ts
@@ -4,6 +4,7 @@ export const ADMIN_NAV_ITEMS = [
   { key: 'finance', label: 'Finance', href: '/finance' },
   { key: 'sales', label: 'Sales', href: '/sales' },
   { key: 'services', label: 'Services', href: '/services' },
+  { key: 'tags', label: 'Tags', href: '/tags' },
   { key: 'website', label: 'Website', href: '/website' },
 ] as const;
 

--- a/apps/admin_web/src/lib/tags-api.ts
+++ b/apps/admin_web/src/lib/tags-api.ts
@@ -1,0 +1,76 @@
+import { adminApiRequest } from './api-admin-client';
+import { unwrapPayload } from './api-payload';
+import { isRecord } from './type-guards';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+
+export type AdminTagRow = ApiSchemas['AdminTagRef'];
+
+function parseAdminTag(value: unknown): AdminTagRow {
+  const row = isRecord(value) ? value : {};
+  return row as AdminTagRow;
+}
+
+export async function listAdminTags(
+  params?: { includeArchived?: boolean },
+  signal?: AbortSignal
+): Promise<AdminTagRow[]> {
+  const query = new URLSearchParams();
+  if (params?.includeArchived) {
+    query.set('include_archived', 'true');
+  }
+  const qs = query.toString();
+  const payload = await adminApiRequest<ApiSchemas['AdminTagListResponse']>({
+    endpointPath: `/v1/admin/tags${qs ? `?${qs}` : ''}`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  return Array.isArray(root.items) ? root.items.map((t) => parseAdminTag(t)) : [];
+}
+
+export async function createAdminTag(
+  body: ApiSchemas['CreateAdminTagRequest']
+): Promise<AdminTagRow | null> {
+  const payload = await adminApiRequest<ApiSchemas['AdminTagResponse']>({
+    endpointPath: '/v1/admin/tags',
+    method: 'POST',
+    body,
+    expectedSuccessStatuses: [200, 201],
+  });
+  const root = unwrapPayload(payload);
+  return root.tag ? parseAdminTag(root.tag) : null;
+}
+
+export async function updateAdminTag(
+  tagId: string,
+  body: ApiSchemas['UpdateAdminTagRequest']
+): Promise<AdminTagRow | null> {
+  const payload = await adminApiRequest<ApiSchemas['AdminTagResponse']>({
+    endpointPath: `/v1/admin/tags/${tagId}`,
+    method: 'PATCH',
+    body,
+  });
+  const root = unwrapPayload(payload);
+  return root.tag ? parseAdminTag(root.tag) : null;
+}
+
+export async function deleteOrArchiveAdminTag(
+  tagId: string
+): Promise<{ status: 204 } | { status: 200; tag: AdminTagRow }> {
+  const payload = await adminApiRequest<unknown>({
+    endpointPath: `/v1/admin/tags/${tagId}`,
+    method: 'DELETE',
+    expectedSuccessStatuses: [200, 204],
+  });
+  if (payload === null) {
+    return { status: 204 };
+  }
+  const root = unwrapPayload(payload);
+  if (isRecord(root) && root.tag) {
+    return { status: 200, tag: parseAdminTag(root.tag) };
+  }
+  return { status: 204 };
+}

--- a/apps/admin_web/src/lib/tags-api.ts
+++ b/apps/admin_web/src/lib/tags-api.ts
@@ -8,18 +8,25 @@ type ApiSchemas = components['schemas'];
 
 export type AdminTagRow = ApiSchemas['AdminTagRef'];
 
+export type AdminTagListFilter = 'active' | 'archived' | 'all';
+
+export type AdminTagDeleteOutcome = ApiSchemas['AdminTagDeleteResponse'];
+
 function parseAdminTag(value: unknown): AdminTagRow {
   const row = isRecord(value) ? value : {};
   return row as AdminTagRow;
 }
 
 export async function listAdminTags(
-  params?: { includeArchived?: boolean },
+  params?: { filter?: AdminTagListFilter },
   signal?: AbortSignal
 ): Promise<AdminTagRow[]> {
   const query = new URLSearchParams();
-  if (params?.includeArchived) {
+  const filter = params?.filter ?? 'active';
+  if (filter === 'all') {
     query.set('include_archived', 'true');
+  } else if (filter === 'archived') {
+    query.set('archived_only', 'true');
   }
   const qs = query.toString();
   const payload = await adminApiRequest<ApiSchemas['AdminTagListResponse']>({
@@ -57,20 +64,18 @@ export async function updateAdminTag(
   return root.tag ? parseAdminTag(root.tag) : null;
 }
 
-export async function deleteOrArchiveAdminTag(
-  tagId: string
-): Promise<{ status: 204 } | { status: 200; tag: AdminTagRow }> {
-  const payload = await adminApiRequest<unknown>({
+export async function deleteOrArchiveAdminTag(tagId: string): Promise<AdminTagDeleteOutcome> {
+  const payload = await adminApiRequest<ApiSchemas['AdminTagDeleteResponse']>({
     endpointPath: `/v1/admin/tags/${tagId}`,
     method: 'DELETE',
-    expectedSuccessStatuses: [200, 204],
   });
-  if (payload === null) {
-    return { status: 204 };
-  }
   const root = unwrapPayload(payload);
-  if (isRecord(root) && root.tag) {
-    return { status: 200, tag: parseAdminTag(root.tag) };
+  if (!isRecord(root)) {
+    return { deleted: true, usage_count: 0 };
   }
-  return { status: 204 };
+  return {
+    deleted: Boolean(root.deleted),
+    usage_count: typeof root.usage_count === 'number' ? root.usage_count : 0,
+    tag: root.tag ? parseAdminTag(root.tag) : undefined,
+  };
 }

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2211,14 +2211,17 @@ export interface paths {
         };
         /**
          * List CRM tags for administration
-         * @description Returns tags sorted by name. By default only active (non-archived) tags are returned.
-         *     Pass `include_archived=true` to include archived tags (for example the Tags admin screen).
+         * @description Returns tags sorted by name. Default: active tags only (`archived_at` is null).
+         *     Use `include_archived=true` for active and archived together, or `archived_only=true`
+         *     for archived rows only. Do not pass both `include_archived` and `archived_only`.
          */
         get: {
             parameters: {
                 query?: {
                     /** @description When true, include tags with a non-null `archived_at`. */
                     include_archived?: boolean;
+                    /** @description When true, return only archived tags (mutually exclusive with `include_archived`). */
+                    archived_only?: boolean;
                 };
                 header?: never;
                 path?: never;
@@ -2320,10 +2323,13 @@ export interface paths {
         post?: never;
         /**
          * Delete or archive CRM tag
-         * @description Hard-deletes the tag when it is not linked to any contact, family, organisation, asset,
-         *     service, or service instance. When the tag is in use, sets `archived_at` instead and
-         *     returns the updated tag (same response as PATCH); repeated deletes are idempotent for
-         *     in-use tags.
+         * @description Always returns **200** with `usage_count` and `deleted`. System-managed tags
+         *     (`expense_attachment`, `client_document`) return **400** and must not be removed.
+         *     When `usage_count` is zero, the tag is **hard-deleted** (`deleted: true`), including
+         *     an archived tag with no remaining links. When `usage_count` is greater than zero,
+         *     the tag is **archived** (`deleted: false`, `tag` present); repeated calls are idempotent
+         *     for in-use tags. If the client predicted delete vs archive from a stale list, compare
+         *     `usage_count` to the prior value to detect a race.
          */
         delete: {
             parameters: {
@@ -2336,29 +2342,28 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Tag archived because it is still linked to at least one record. */
+                /** @description Delete outcome (hard delete or archive). */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["AdminTagResponse"];
+                        "application/json": components["schemas"]["AdminTagDeleteResponse"];
                     };
                 };
-                /** @description Tag removed (unused). */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
+                400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
             };
         };
         options?: never;
         head?: never;
-        /** Update CRM tag */
+        /**
+         * Update CRM tag
+         * @description Set `archived` to `false` to restore an archived tag (clear `archived_at`).
+         *     System-managed tags (`expense_attachment`, `client_document`) cannot be renamed or archived;
+         *     they may be edited for color/description only.
+         */
         patch: {
             parameters: {
                 query?: never;
@@ -4968,6 +4973,16 @@ export interface components {
             archived_at: string | null;
             /** @description Count of junction rows across contacts, families, organisations, assets, services, and service instances referencing this tag. */
             usage_count: number;
+            /** @description True for reserved asset-pipeline tags (`expense_attachment`, `client_document`). These cannot be renamed, archived, or deleted via the admin API. */
+            is_system: boolean;
+        };
+        AdminTagDeleteResponse: {
+            /** @description True when the tag row was removed from the database. */
+            deleted: boolean;
+            /** @description Junction usage count evaluated at delete time. */
+            usage_count: number;
+            /** @description Present when `deleted` is false (archived in-use tag). */
+            tag?: components["schemas"]["AdminTagRef"];
         };
         AdminTagListResponse: {
             items: components["schemas"]["AdminTagRef"][];
@@ -4985,6 +5000,8 @@ export interface components {
             name?: string;
             color?: string | null;
             description?: string | null;
+            /** @description When `false`, clears `archived_at` (restore). When `true`, sets `archived_at` unless the tag is system-managed (those reject archive). Omit when not changing archive state. */
+            archived?: boolean;
         };
         EntityTagListResponse: {
             items: components["schemas"]["EntityTagRef"][];

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2202,6 +2202,203 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List CRM tags for administration
+         * @description Returns tags sorted by name. By default only active (non-archived) tags are returned.
+         *     Pass `include_archived=true` to include archived tags (for example the Tags admin screen).
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description When true, include tags with a non-null `archived_at`. */
+                    include_archived?: boolean;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Tag list with usage counts. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminTagListResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        /** Create CRM tag */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateAdminTagRequest"];
+                };
+            };
+            responses: {
+                /** @description Tag created. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminTagResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                /** @description Duplicate tag name (case-insensitive uniqueness). */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/tags/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** Get CRM tag by id */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Tag detail. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminTagResponse"];
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Delete or archive CRM tag
+         * @description Hard-deletes the tag when it is not linked to any contact, family, organisation, asset,
+         *     service, or service instance. When the tag is in use, sets `archived_at` instead and
+         *     returns the updated tag (same response as PATCH); repeated deletes are idempotent for
+         *     in-use tags.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Tag archived because it is still linked to at least one record. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminTagResponse"];
+                    };
+                };
+                /** @description Tag removed (unused). */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update CRM tag */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateAdminTagRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated tag. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminTagResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                /** @description Duplicate tag name (case-insensitive uniqueness). */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/v1/admin/contacts/tags": {
         parameters: {
             query?: never;
@@ -4761,6 +4958,33 @@ export interface components {
             id: string;
             name: string;
             color?: string | null;
+        };
+        AdminTagRef: components["schemas"]["EntityTagRef"] & {
+            description: string | null;
+            /**
+             * Format: date-time
+             * @description When set, the tag is archived and hidden from assignment pickers.
+             */
+            archived_at: string | null;
+            /** @description Count of junction rows across contacts, families, organisations, assets, services, and service instances referencing this tag. */
+            usage_count: number;
+        };
+        AdminTagListResponse: {
+            items: components["schemas"]["AdminTagRef"][];
+        };
+        AdminTagResponse: {
+            tag: components["schemas"]["AdminTagRef"];
+        };
+        CreateAdminTagRequest: {
+            name: string;
+            /** @description Optional UI color as `#RRGGBB`. */
+            color?: string | null;
+            description?: string | null;
+        };
+        UpdateAdminTagRequest: {
+            name?: string;
+            color?: string | null;
+            description?: string | null;
         };
         EntityTagListResponse: {
             items: components["schemas"]["EntityTagRef"][];

--- a/apps/admin_web/tests/lib/admin-nav.test.ts
+++ b/apps/admin_web/tests/lib/admin-nav.test.ts
@@ -9,6 +9,7 @@ describe('adminSectionKeyFromPathname', () => {
     expect(adminSectionKeyFromPathname('/contacts')).toBe('contacts');
     expect(adminSectionKeyFromPathname('/finance')).toBe('finance');
     expect(adminSectionKeyFromPathname('/services')).toBe('services');
+    expect(adminSectionKeyFromPathname('/tags')).toBe('tags');
     expect(adminSectionKeyFromPathname('/website')).toBe('website');
   });
 
@@ -18,6 +19,7 @@ describe('adminSectionKeyFromPathname', () => {
     expect(adminSectionKeyFromPathname('/contacts/')).toBe('contacts');
     expect(adminSectionKeyFromPathname('/finance/')).toBe('finance');
     expect(adminSectionKeyFromPathname('/services/')).toBe('services');
+    expect(adminSectionKeyFromPathname('/tags/')).toBe('tags');
     expect(adminSectionKeyFromPathname('/website/')).toBe('website');
   });
 

--- a/apps/admin_web/tests/lib/tags-api.test.ts
+++ b/apps/admin_web/tests/lib/tags-api.test.ts
@@ -21,29 +21,40 @@ import {
   updateAdminTag,
 } from '@/lib/tags-api';
 
+const tagRow = {
+  id: 't1',
+  name: 'Alpha',
+  color: '#112233',
+  description: null,
+  archived_at: null,
+  usage_count: 0,
+  is_system: false,
+};
+
 describe('tags-api', () => {
   beforeEach(() => {
     mockAdminApiRequest.mockReset();
   });
 
-  it('lists tags with optional include_archived', async () => {
-    mockAdminApiRequest.mockResolvedValueOnce({
-      items: [
-        {
-          id: 't1',
-          name: 'Alpha',
-          color: '#112233',
-          description: null,
-          archived_at: null,
-          usage_count: 0,
-        },
-      ],
-    });
+  it('lists active tags by default', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({ items: [tagRow] });
 
-    const rows = await listAdminTags({ includeArchived: true });
+    const rows = await listAdminTags();
 
     expect(rows).toHaveLength(1);
-    expect(rows[0].id).toBe('t1');
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointPath: '/v1/admin/tags',
+        method: 'GET',
+      })
+    );
+  });
+
+  it('lists all tags when filter is all', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({ items: [tagRow] });
+
+    await listAdminTags({ filter: 'all' });
+
     expect(mockAdminApiRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         endpointPath: '/v1/admin/tags?include_archived=true',
@@ -52,21 +63,36 @@ describe('tags-api', () => {
     );
   });
 
-  it('deleteOrArchiveAdminTag treats empty body as hard delete', async () => {
-    mockAdminApiRequest.mockResolvedValueOnce(null);
+  it('lists archived-only when filter is archived', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({ items: [tagRow] });
+
+    await listAdminTags({ filter: 'archived' });
+
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointPath: '/v1/admin/tags?archived_only=true',
+        method: 'GET',
+      })
+    );
+  });
+
+  it('deleteOrArchiveAdminTag parses hard delete response', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      deleted: true,
+      usage_count: 0,
+    });
 
     const outcome = await deleteOrArchiveAdminTag('t1');
 
-    expect(outcome).toEqual({ status: 204 });
+    expect(outcome).toEqual({ deleted: true, usage_count: 0 });
   });
 
   it('deleteOrArchiveAdminTag parses archive response', async () => {
     mockAdminApiRequest.mockResolvedValueOnce({
+      deleted: false,
+      usage_count: 2,
       tag: {
-        id: 't1',
-        name: 'Alpha',
-        color: null,
-        description: null,
+        ...tagRow,
         archived_at: '2026-01-01T00:00:00.000Z',
         usage_count: 2,
       },
@@ -74,10 +100,9 @@ describe('tags-api', () => {
 
     const outcome = await deleteOrArchiveAdminTag('t1');
 
-    expect(outcome.status).toBe(200);
-    if (outcome.status === 200) {
-      expect(outcome.tag.archived_at).toBe('2026-01-01T00:00:00.000Z');
-    }
+    expect(outcome.deleted).toBe(false);
+    expect(outcome.usage_count).toBe(2);
+    expect(outcome.tag?.archived_at).toBe('2026-01-01T00:00:00.000Z');
   });
 
   it('createAdminTag unwraps tag payload', async () => {
@@ -89,6 +114,7 @@ describe('tags-api', () => {
         description: null,
         archived_at: null,
         usage_count: 0,
+        is_system: false,
       },
     });
 
@@ -106,6 +132,7 @@ describe('tags-api', () => {
         description: null,
         archived_at: null,
         usage_count: 0,
+        is_system: false,
       },
     });
 

--- a/apps/admin_web/tests/lib/tags-api.test.ts
+++ b/apps/admin_web/tests/lib/tags-api.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAdminApiRequest } = vi.hoisted(() => ({
+  mockAdminApiRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/api-admin-client', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api-admin-client')>(
+    '@/lib/api-admin-client'
+  );
+  return {
+    ...actual,
+    adminApiRequest: mockAdminApiRequest,
+  };
+});
+
+import {
+  createAdminTag,
+  deleteOrArchiveAdminTag,
+  listAdminTags,
+  updateAdminTag,
+} from '@/lib/tags-api';
+
+describe('tags-api', () => {
+  beforeEach(() => {
+    mockAdminApiRequest.mockReset();
+  });
+
+  it('lists tags with optional include_archived', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      items: [
+        {
+          id: 't1',
+          name: 'Alpha',
+          color: '#112233',
+          description: null,
+          archived_at: null,
+          usage_count: 0,
+        },
+      ],
+    });
+
+    const rows = await listAdminTags({ includeArchived: true });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('t1');
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointPath: '/v1/admin/tags?include_archived=true',
+        method: 'GET',
+      })
+    );
+  });
+
+  it('deleteOrArchiveAdminTag treats empty body as hard delete', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce(null);
+
+    const outcome = await deleteOrArchiveAdminTag('t1');
+
+    expect(outcome).toEqual({ status: 204 });
+  });
+
+  it('deleteOrArchiveAdminTag parses archive response', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      tag: {
+        id: 't1',
+        name: 'Alpha',
+        color: null,
+        description: null,
+        archived_at: '2026-01-01T00:00:00.000Z',
+        usage_count: 2,
+      },
+    });
+
+    const outcome = await deleteOrArchiveAdminTag('t1');
+
+    expect(outcome.status).toBe(200);
+    if (outcome.status === 200) {
+      expect(outcome.tag.archived_at).toBe('2026-01-01T00:00:00.000Z');
+    }
+  });
+
+  it('createAdminTag unwraps tag payload', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      tag: {
+        id: 'new',
+        name: 'Beta',
+        color: null,
+        description: null,
+        archived_at: null,
+        usage_count: 0,
+      },
+    });
+
+    const row = await createAdminTag({ name: 'Beta' });
+
+    expect(row?.id).toBe('new');
+  });
+
+  it('updateAdminTag sends PATCH', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      tag: {
+        id: 't1',
+        name: 'Beta',
+        color: null,
+        description: null,
+        archived_at: null,
+        usage_count: 0,
+      },
+    });
+
+    await updateAdminTag('t1', { name: 'Beta' });
+
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointPath: '/v1/admin/tags/t1',
+        method: 'PATCH',
+        body: { name: 'Beta' },
+      })
+    );
+  });
+});

--- a/backend/db/alembic/versions/0039_tags_archived_at.py
+++ b/backend/db/alembic/versions/0039_tags_archived_at.py
@@ -1,0 +1,31 @@
+"""Add tags.archived_at for soft-retiring CRM labels.
+
+1. New nullable ``tags.archived_at`` (timestamptz): null means active; set when archived.
+2. No seed changes: seed does not insert into ``tags`` beyond prior migrations; existing
+   rows default to active (null).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0039_tags_archived_at"
+down_revision = "0038_drop_inst_tag_inst_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tags",
+        sa.Column(
+            "archived_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tags", "archived_at")

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -3033,6 +3033,30 @@ export class ApiStack extends cdk.Stack {
       authorizer: adminAuthorizer,
     });
 
+    // Admin CRM tags catalog (shared across contacts, services, assets, etc.)
+    const adminTags = admin.addResource("tags");
+    adminTags.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminTags.addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    const adminTagById = adminTags.addResource("{id}");
+    adminTagById.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminTagById.addMethod("PATCH", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminTagById.addMethod("DELETE", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+
     // Admin CRM contacts / families / organizations (non-vendor)
     const adminContacts = admin.addResource("contacts");
     adminContacts.addMethod("GET", adminIntegration, {

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -23,6 +23,7 @@ from app.api.admin_users import (
     handle_admin_users_request,
 )
 from app.api.admin_contacts import handle_admin_contacts_request
+from app.api.admin_tags import handle_admin_tags_request
 from app.api.admin_families import handle_admin_families_request
 from app.api.admin_families_picker import handle_admin_families_picker_request
 from app.api.admin_organizations import handle_admin_organizations_request
@@ -166,6 +167,11 @@ _ROUTES: tuple[
         "/v1/admin/expenses",
         False,
         handle_admin_expenses_request,
+    ),
+    (
+        "/v1/admin/tags",
+        False,
+        handle_admin_tags_request,
     ),
     (
         "/v1/admin/contacts",

--- a/backend/src/app/api/admin_entities_helpers.py
+++ b/backend/src/app/api/admin_entities_helpers.py
@@ -88,6 +88,21 @@ def serialize_tag_ref(tag: Tag) -> dict[str, Any]:
     }
 
 
+def require_assignable_tag(
+    session: Session,
+    tag_id: UUID,
+    *,
+    field: str = "tag_ids",
+) -> Tag:
+    """Return a tag row that may be linked to CRM entities or services; archived tags fail."""
+    tag = session.get(Tag, tag_id)
+    if tag is None:
+        raise ValidationError("tag_id not found", field=field)
+    if tag.archived_at is not None:
+        raise ValidationError("tag is archived", field=field)
+    return tag
+
+
 def assert_contact_can_join_family(
     session: Session,
     *,
@@ -142,9 +157,7 @@ def replace_contact_tags(
 ) -> None:
     session.execute(delete(ContactTag).where(ContactTag.contact_id == contact_id))
     for tag_id in tag_ids:
-        tag = session.get(Tag, tag_id)
-        if tag is None:
-            raise ValidationError("tag_id not found", field="tag_ids")
+        require_assignable_tag(session, tag_id, field="tag_ids")
         session.add(ContactTag(contact_id=contact_id, tag_id=tag_id))
     session.flush()
 
@@ -157,9 +170,7 @@ def replace_family_tags(
 ) -> None:
     session.execute(delete(FamilyTag).where(FamilyTag.family_id == family_id))
     for tag_id in tag_ids:
-        tag = session.get(Tag, tag_id)
-        if tag is None:
-            raise ValidationError("tag_id not found", field="tag_ids")
+        require_assignable_tag(session, tag_id, field="tag_ids")
         session.add(FamilyTag(family_id=family_id, tag_id=tag_id))
     session.flush()
 
@@ -176,9 +187,7 @@ def replace_organization_tags(
         )
     )
     for tag_id in tag_ids:
-        tag = session.get(Tag, tag_id)
-        if tag is None:
-            raise ValidationError("tag_id not found", field="tag_ids")
+        require_assignable_tag(session, tag_id, field="tag_ids")
         session.add(OrganizationTag(organization_id=organization_id, tag_id=tag_id))
     session.flush()
 
@@ -199,15 +208,15 @@ def replace_service_instance_tags(
         if tag_id in seen:
             continue
         seen.add(tag_id)
-        tag = session.get(Tag, tag_id)
-        if tag is None:
-            raise ValidationError("tag_id not found", field="tag_ids")
+        require_assignable_tag(session, tag_id, field="tag_ids")
         session.add(ServiceInstanceTag(service_instance_id=instance_id, tag_id=tag_id))
     session.flush()
 
 
 def list_all_tags_for_picker(session: Session) -> list[Tag]:
-    statement = select(Tag).order_by(func.lower(Tag.name))
+    statement = (
+        select(Tag).where(Tag.archived_at.is_(None)).order_by(func.lower(Tag.name))
+    )
     return list(session.execute(statement).scalars().all())
 
 

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -26,6 +26,7 @@ from app.api.admin_services_common import (
     serialize_service_summary,
 )
 from app.api.admin_services_payload_utils import parse_service_type_details
+from app.api.admin_entities_helpers import require_assignable_tag
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
@@ -177,6 +178,8 @@ def _create_service(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, An
             parsed_details=payload["type_details"],
         )
         created = repository.create_service(service, details)
+        for tag_id in payload["tag_ids"]:
+            require_assignable_tag(session, tag_id, field="tag_ids")
         created.service_tags = [
             ServiceTag(tag_id=tag_id) for tag_id in payload["tag_ids"]
         ]
@@ -258,6 +261,8 @@ def _update_service(
         if "status" in payload:
             service.status = payload["status"]
         if "tag_ids" in payload:
+            for tag_id in payload["tag_ids"]:
+                require_assignable_tag(session, tag_id, field="tag_ids")
             service.service_tags = [
                 ServiceTag(tag_id=tag_id) for tag_id in payload["tag_ids"]
             ]

--- a/backend/src/app/api/admin_tags.py
+++ b/backend/src/app/api/admin_tags.py
@@ -8,11 +8,15 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.admin_entities_helpers import serialize_tag_ref
+from app.api.admin_entities_helpers import (
+    parse_optional_bool_body,
+    request_id,
+    serialize_tag_ref,
+)
 from app.api.admin_request import parse_body, parse_uuid, query_param
 from app.api.admin_validators import validate_string_length
 from app.api.assets.assets_common import extract_identity, split_route_parts
@@ -28,12 +32,32 @@ from app.db.models import (
     Tag,
 )
 from app.exceptions import NotFoundError, ValidationError
+from app.services.asset_expense_tagging import (
+    CLIENT_DOCUMENT_TAG_NAME,
+    EXPENSE_ATTACHMENT_TAG_NAME,
+)
 from app.utils import json_response
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 _HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+
+_SYSTEM_TAG_NAMES_LOWER: frozenset[str] = frozenset(
+    {
+        EXPENSE_ATTACHMENT_TAG_NAME.lower(),
+        CLIENT_DOCUMENT_TAG_NAME.lower(),
+    }
+)
+
+
+def _is_system_tag_name(name: str) -> bool:
+    return name.strip().lower() in _SYSTEM_TAG_NAMES_LOWER
+
+
+def _is_reserved_tag_name(name: str) -> bool:
+    """Reserved for asset pipeline behaviour; admins cannot create duplicates."""
+    return name.strip().lower() in _SYSTEM_TAG_NAMES_LOWER
 
 
 def handle_admin_tags_request(
@@ -74,30 +98,70 @@ def handle_admin_tags_request(
     return json_response(404, {"error": "Not found"}, event=event)
 
 
+def _usage_counts_by_tag_id(session: Session, tag_ids: list[UUID]) -> dict[UUID, int]:
+    """Single aggregated query per list of tag ids (avoids N×6 counts per row)."""
+    if not tag_ids:
+        return {}
+    s_contact = (
+        select(ContactTag.tag_id, func.count().label("cnt"))
+        .where(ContactTag.tag_id.in_(tag_ids))
+        .group_by(ContactTag.tag_id)
+    )
+    s_family = (
+        select(FamilyTag.tag_id, func.count().label("cnt"))
+        .where(FamilyTag.tag_id.in_(tag_ids))
+        .group_by(FamilyTag.tag_id)
+    )
+    s_org = (
+        select(OrganizationTag.tag_id, func.count().label("cnt"))
+        .where(OrganizationTag.tag_id.in_(tag_ids))
+        .group_by(OrganizationTag.tag_id)
+    )
+    s_asset = (
+        select(AssetTag.tag_id, func.count().label("cnt"))
+        .where(AssetTag.tag_id.in_(tag_ids))
+        .group_by(AssetTag.tag_id)
+    )
+    s_service = (
+        select(ServiceTag.tag_id, func.count().label("cnt"))
+        .where(ServiceTag.tag_id.in_(tag_ids))
+        .group_by(ServiceTag.tag_id)
+    )
+    s_instance = (
+        select(ServiceInstanceTag.tag_id, func.count().label("cnt"))
+        .where(ServiceInstanceTag.tag_id.in_(tag_ids))
+        .group_by(ServiceInstanceTag.tag_id)
+    )
+    combined = union_all(
+        s_contact, s_family, s_org, s_asset, s_service, s_instance
+    ).subquery()
+    stmt = select(combined.c.tag_id, func.sum(combined.c.cnt)).group_by(
+        combined.c.tag_id
+    )
+    rows = session.execute(stmt).all()
+    return {row[0]: int(row[1] or 0) for row in rows}
+
+
 def _tag_usage_count(session: Session, tag_id: UUID) -> int:
-    total = 0
-    for model in (
-        ContactTag,
-        FamilyTag,
-        OrganizationTag,
-        AssetTag,
-        ServiceTag,
-        ServiceInstanceTag,
-    ):
-        count = session.scalar(
-            select(func.count()).select_from(model).where(model.tag_id == tag_id)
-        )
-        total += int(count or 0)
-    return total
+    return _usage_counts_by_tag_id(session, [tag_id]).get(tag_id, 0)
 
 
-def _serialize_admin_tag(session: Session, tag: Tag) -> dict[str, Any]:
+def _serialize_admin_tag(
+    session: Session,
+    tag: Tag,
+    *,
+    usage_by_id: dict[UUID, int] | None = None,
+) -> dict[str, Any]:
     data = serialize_tag_ref(tag)
     data["description"] = tag.description
     data["archived_at"] = (
         tag.archived_at.isoformat() if tag.archived_at is not None else None
     )
-    data["usage_count"] = _tag_usage_count(session, tag.id)
+    data["is_system"] = _is_system_tag_name(tag.name)
+    if usage_by_id is not None:
+        data["usage_count"] = usage_by_id.get(tag.id, 0)
+    else:
+        data["usage_count"] = _tag_usage_count(session, tag.id)
     return data
 
 
@@ -113,6 +177,18 @@ def _parse_include_archived(event: Mapping[str, Any]) -> bool:
     raise ValidationError(
         "include_archived must be true or false", field="include_archived"
     )
+
+
+def _parse_archived_only(event: Mapping[str, Any]) -> bool:
+    raw = query_param(event, "archived_only")
+    if raw is None or raw.strip() == "":
+        return False
+    normalized = raw.strip().lower()
+    if normalized in {"true", "1"}:
+        return True
+    if normalized in {"false", "0"}:
+        return False
+    raise ValidationError("archived_only must be true or false", field="archived_only")
 
 
 def _parse_optional_hex_color(value: Any, *, field: str) -> str | None:
@@ -132,14 +208,29 @@ def _parse_optional_hex_color(value: Any, *, field: str) -> str | None:
 
 def _list_tags(event: Mapping[str, Any]) -> dict[str, Any]:
     include_archived = _parse_include_archived(event)
+    archived_only = _parse_archived_only(event)
+    if archived_only and include_archived:
+        raise ValidationError(
+            "use either archived_only or include_archived, not both",
+            field="archived_only",
+        )
     with Session(get_engine()) as session:
         stmt = select(Tag).order_by(func.lower(Tag.name))
-        if not include_archived:
+        if archived_only:
+            stmt = stmt.where(Tag.archived_at.is_not(None))
+        elif not include_archived:
             stmt = stmt.where(Tag.archived_at.is_(None))
         tags = list(session.execute(stmt).scalars().all())
+        tag_ids = [t.id for t in tags]
+        usage_map = _usage_counts_by_tag_id(session, tag_ids)
         return json_response(
             200,
-            {"items": [_serialize_admin_tag(session, t) for t in tags]},
+            {
+                "items": [
+                    _serialize_admin_tag(session, t, usage_by_id=usage_map)
+                    for t in tags
+                ]
+            },
             event=event,
         )
 
@@ -169,6 +260,12 @@ def _create_tag(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]:
     name_stripped = name.strip()
     if not name_stripped:
         raise ValidationError("name must not be empty", field="name")
+    if _is_reserved_tag_name(name_stripped):
+        raise ValidationError(
+            "This tag name is reserved for system use",
+            field="name",
+            status_code=400,
+        )
     color = _parse_optional_hex_color(body.get("color"), field="color")
     description = validate_string_length(
         body.get("description"),
@@ -181,7 +278,7 @@ def _create_tag(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]:
         desc_stripped = None
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         tag = Tag(
             name=name_stripped,
             color=color,
@@ -214,10 +311,27 @@ def _update_tag(
 ) -> dict[str, Any]:
     body = parse_body(event)
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         tag = session.get(Tag, tag_id)
         if tag is None:
             raise NotFoundError("Tag", str(tag_id))
+
+        if "archived" in body:
+            archived = parse_optional_bool_body(body.get("archived"), field="archived")
+            if archived is None:
+                raise ValidationError(
+                    "archived must be true or false", field="archived"
+                )
+            if archived is False:
+                tag.archived_at = None
+            elif _is_system_tag_name(tag.name):
+                raise ValidationError(
+                    "System-managed tags cannot be archived via PATCH; they stay active",
+                    field="archived",
+                    status_code=400,
+                )
+            else:
+                tag.archived_at = datetime.now(tz=UTC)
 
         if "name" in body:
             name = validate_string_length(
@@ -231,6 +345,24 @@ def _update_tag(
             name_stripped = name.strip()
             if not name_stripped:
                 raise ValidationError("name must not be empty", field="name")
+            if (
+                _is_system_tag_name(tag.name)
+                and name_stripped.lower() != tag.name.lower()
+            ):
+                raise ValidationError(
+                    "System-managed tags cannot be renamed",
+                    field="name",
+                    status_code=400,
+                )
+            if (
+                _is_reserved_tag_name(name_stripped)
+                and name_stripped.lower() != tag.name.lower()
+            ):
+                raise ValidationError(
+                    "This tag name is reserved for system use",
+                    field="name",
+                    status_code=400,
+                )
             tag.name = name_stripped
         if "color" in body:
             tag.color = _parse_optional_hex_color(body.get("color"), field="color")
@@ -270,31 +402,40 @@ def _delete_tag(
     actor_sub: str,
 ) -> dict[str, Any]:
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=_request_id(event))
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         tag = session.get(Tag, tag_id)
         if tag is None:
             raise NotFoundError("Tag", str(tag_id))
+
+        if _is_system_tag_name(tag.name):
+            raise ValidationError(
+                "System-managed tags cannot be deleted or archived",
+                field="tag",
+                status_code=400,
+            )
 
         usage = _tag_usage_count(session, tag_id)
         if usage > 0:
             if tag.archived_at is None:
                 tag.archived_at = datetime.now(tz=UTC)
-                session.commit()
+            session.commit()
+            refreshed = session.get(Tag, tag_id)
+            if refreshed is None:
+                raise NotFoundError("Tag", str(tag_id))
             return json_response(
                 200,
-                {"tag": _serialize_admin_tag(session, tag)},
+                {
+                    "deleted": False,
+                    "usage_count": usage,
+                    "tag": _serialize_admin_tag(session, refreshed),
+                },
                 event=event,
             )
 
         session.delete(tag)
         session.commit()
-        return json_response(204, {}, event=event)
-
-
-def _request_id(event: Mapping[str, Any]) -> str:
-    request_context = event.get("requestContext")
-    if isinstance(request_context, Mapping):
-        rid = request_context.get("requestId")
-        if isinstance(rid, str):
-            return rid.strip()
-    return ""
+        return json_response(
+            200,
+            {"deleted": True, "usage_count": 0},
+            event=event,
+        )

--- a/backend/src/app/api/admin_tags.py
+++ b/backend/src/app/api/admin_tags.py
@@ -102,35 +102,43 @@ def _usage_counts_by_tag_id(session: Session, tag_ids: list[UUID]) -> dict[UUID,
     """Single aggregated query per list of tag ids (avoids N×6 counts per row)."""
     if not tag_ids:
         return {}
+    # Use mapped ``__table__`` columns so static type checkers accept ``tag_id``
+    # (ORM ``.tag_id`` attributes are not always inferred on declarative classes).
+    ct = ContactTag.__table__.c
+    ft = FamilyTag.__table__.c
+    ot = OrganizationTag.__table__.c
+    at = AssetTag.__table__.c
+    st = ServiceTag.__table__.c
+    sit = ServiceInstanceTag.__table__.c
     s_contact = (
-        select(ContactTag.tag_id, func.count().label("cnt"))
-        .where(ContactTag.tag_id.in_(tag_ids))
-        .group_by(ContactTag.tag_id)
+        select(ct.tag_id, func.count().label("cnt"))
+        .where(ct.tag_id.in_(tag_ids))
+        .group_by(ct.tag_id)
     )
     s_family = (
-        select(FamilyTag.tag_id, func.count().label("cnt"))
-        .where(FamilyTag.tag_id.in_(tag_ids))
-        .group_by(FamilyTag.tag_id)
+        select(ft.tag_id, func.count().label("cnt"))
+        .where(ft.tag_id.in_(tag_ids))
+        .group_by(ft.tag_id)
     )
     s_org = (
-        select(OrganizationTag.tag_id, func.count().label("cnt"))
-        .where(OrganizationTag.tag_id.in_(tag_ids))
-        .group_by(OrganizationTag.tag_id)
+        select(ot.tag_id, func.count().label("cnt"))
+        .where(ot.tag_id.in_(tag_ids))
+        .group_by(ot.tag_id)
     )
     s_asset = (
-        select(AssetTag.tag_id, func.count().label("cnt"))
-        .where(AssetTag.tag_id.in_(tag_ids))
-        .group_by(AssetTag.tag_id)
+        select(at.tag_id, func.count().label("cnt"))
+        .where(at.tag_id.in_(tag_ids))
+        .group_by(at.tag_id)
     )
     s_service = (
-        select(ServiceTag.tag_id, func.count().label("cnt"))
-        .where(ServiceTag.tag_id.in_(tag_ids))
-        .group_by(ServiceTag.tag_id)
+        select(st.tag_id, func.count().label("cnt"))
+        .where(st.tag_id.in_(tag_ids))
+        .group_by(st.tag_id)
     )
     s_instance = (
-        select(ServiceInstanceTag.tag_id, func.count().label("cnt"))
-        .where(ServiceInstanceTag.tag_id.in_(tag_ids))
-        .group_by(ServiceInstanceTag.tag_id)
+        select(sit.tag_id, func.count().label("cnt"))
+        .where(sit.tag_id.in_(tag_ids))
+        .group_by(sit.tag_id)
     )
     combined = union_all(
         s_contact, s_family, s_org, s_asset, s_service, s_instance

--- a/backend/src/app/api/admin_tags.py
+++ b/backend/src/app/api/admin_tags.py
@@ -1,0 +1,300 @@
+"""Admin CRM tags catalog API."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.api.admin_entities_helpers import serialize_tag_ref
+from app.api.admin_request import parse_body, parse_uuid, query_param
+from app.api.admin_validators import validate_string_length
+from app.api.assets.assets_common import extract_identity, split_route_parts
+from app.db.audit import set_audit_context
+from app.db.engine import get_engine
+from app.db.models import (
+    AssetTag,
+    ContactTag,
+    FamilyTag,
+    OrganizationTag,
+    ServiceInstanceTag,
+    ServiceTag,
+    Tag,
+)
+from app.exceptions import NotFoundError, ValidationError
+from app.utils import json_response
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+
+
+def handle_admin_tags_request(
+    event: Mapping[str, Any],
+    method: str,
+    path: str,
+) -> dict[str, Any]:
+    """Handle /v1/admin/tags routes."""
+    logger.info(
+        "Handling admin tags route",
+        extra={"method": method, "path": path},
+    )
+    parts = split_route_parts(path)
+    if len(parts) < 2 or parts[0] != "admin" or parts[1] != "tags":
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    identity = extract_identity(event)
+    if not identity.user_sub:
+        raise ValidationError("Authenticated user is required", field="authorization")
+
+    if len(parts) == 2:
+        if method == "GET":
+            return _list_tags(event)
+        if method == "POST":
+            return _create_tag(event, actor_sub=identity.user_sub)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    tag_id = parse_uuid(parts[2])
+    if len(parts) == 3:
+        if method == "GET":
+            return _get_tag(event, tag_id=tag_id)
+        if method == "PATCH":
+            return _update_tag(event, tag_id=tag_id, actor_sub=identity.user_sub)
+        if method == "DELETE":
+            return _delete_tag(event, tag_id=tag_id, actor_sub=identity.user_sub)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    return json_response(404, {"error": "Not found"}, event=event)
+
+
+def _tag_usage_count(session: Session, tag_id: UUID) -> int:
+    total = 0
+    for model in (
+        ContactTag,
+        FamilyTag,
+        OrganizationTag,
+        AssetTag,
+        ServiceTag,
+        ServiceInstanceTag,
+    ):
+        count = session.scalar(
+            select(func.count()).select_from(model).where(model.tag_id == tag_id)
+        )
+        total += int(count or 0)
+    return total
+
+
+def _serialize_admin_tag(session: Session, tag: Tag) -> dict[str, Any]:
+    data = serialize_tag_ref(tag)
+    data["description"] = tag.description
+    data["archived_at"] = (
+        tag.archived_at.isoformat() if tag.archived_at is not None else None
+    )
+    data["usage_count"] = _tag_usage_count(session, tag.id)
+    return data
+
+
+def _parse_include_archived(event: Mapping[str, Any]) -> bool:
+    raw = query_param(event, "include_archived")
+    if raw is None or raw.strip() == "":
+        return False
+    normalized = raw.strip().lower()
+    if normalized in {"true", "1"}:
+        return True
+    if normalized in {"false", "0"}:
+        return False
+    raise ValidationError(
+        "include_archived must be true or false", field="include_archived"
+    )
+
+
+def _parse_optional_hex_color(value: Any, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValidationError(f"{field} must be a string or null", field=field)
+    stripped = value.strip()
+    if stripped == "":
+        return None
+    if not _HEX_COLOR_RE.match(stripped):
+        raise ValidationError(
+            f"{field} must be a #RRGGBB hex color or null", field=field
+        )
+    return stripped
+
+
+def _list_tags(event: Mapping[str, Any]) -> dict[str, Any]:
+    include_archived = _parse_include_archived(event)
+    with Session(get_engine()) as session:
+        stmt = select(Tag).order_by(func.lower(Tag.name))
+        if not include_archived:
+            stmt = stmt.where(Tag.archived_at.is_(None))
+        tags = list(session.execute(stmt).scalars().all())
+        return json_response(
+            200,
+            {"items": [_serialize_admin_tag(session, t) for t in tags]},
+            event=event,
+        )
+
+
+def _get_tag(event: Mapping[str, Any], *, tag_id: UUID) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        tag = session.get(Tag, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag", str(tag_id))
+        return json_response(
+            200,
+            {"tag": _serialize_admin_tag(session, tag)},
+            event=event,
+        )
+
+
+def _create_tag(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]:
+    body = parse_body(event)
+    name = validate_string_length(
+        body.get("name"),
+        "name",
+        max_length=100,
+        required=True,
+    )
+    if name is None:
+        raise ValidationError("name is required", field="name")
+    name_stripped = name.strip()
+    if not name_stripped:
+        raise ValidationError("name must not be empty", field="name")
+    color = _parse_optional_hex_color(body.get("color"), field="color")
+    description = validate_string_length(
+        body.get("description"),
+        "description",
+        max_length=255,
+        required=False,
+    )
+    desc_stripped = description.strip() if description else None
+    if desc_stripped == "":
+        desc_stripped = None
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=_request_id(event))
+        tag = Tag(
+            name=name_stripped,
+            color=color,
+            description=desc_stripped,
+            created_by=actor_sub,
+        )
+        session.add(tag)
+        try:
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            raise ValidationError(
+                "A tag with this name already exists",
+                field="name",
+                status_code=409,
+            ) from exc
+        session.refresh(tag)
+        return json_response(
+            201,
+            {"tag": _serialize_admin_tag(session, tag)},
+            event=event,
+        )
+
+
+def _update_tag(
+    event: Mapping[str, Any],
+    *,
+    tag_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    body = parse_body(event)
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=_request_id(event))
+        tag = session.get(Tag, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag", str(tag_id))
+
+        if "name" in body:
+            name = validate_string_length(
+                body.get("name"),
+                "name",
+                max_length=100,
+                required=True,
+            )
+            if name is None:
+                raise ValidationError("name is required", field="name")
+            name_stripped = name.strip()
+            if not name_stripped:
+                raise ValidationError("name must not be empty", field="name")
+            tag.name = name_stripped
+        if "color" in body:
+            tag.color = _parse_optional_hex_color(body.get("color"), field="color")
+        if "description" in body:
+            description = validate_string_length(
+                body.get("description"),
+                "description",
+                max_length=255,
+                required=False,
+            )
+            if description is None or description.strip() == "":
+                tag.description = None
+            else:
+                tag.description = description.strip()
+
+        try:
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            raise ValidationError(
+                "A tag with this name already exists",
+                field="name",
+                status_code=409,
+            ) from exc
+        session.refresh(tag)
+        return json_response(
+            200,
+            {"tag": _serialize_admin_tag(session, tag)},
+            event=event,
+        )
+
+
+def _delete_tag(
+    event: Mapping[str, Any],
+    *,
+    tag_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=_request_id(event))
+        tag = session.get(Tag, tag_id)
+        if tag is None:
+            raise NotFoundError("Tag", str(tag_id))
+
+        usage = _tag_usage_count(session, tag_id)
+        if usage > 0:
+            if tag.archived_at is None:
+                tag.archived_at = datetime.now(tz=UTC)
+                session.commit()
+            return json_response(
+                200,
+                {"tag": _serialize_admin_tag(session, tag)},
+                event=event,
+            )
+
+        session.delete(tag)
+        session.commit()
+        return json_response(204, {}, event=event)
+
+
+def _request_id(event: Mapping[str, Any]) -> str:
+    request_context = event.get("requestContext")
+    if isinstance(request_context, Mapping):
+        rid = request_context.get("requestId")
+        if isinstance(rid, str):
+            return rid.strip()
+    return ""

--- a/backend/src/app/db/models/tag.py
+++ b/backend/src/app/db/models/tag.py
@@ -47,6 +47,10 @@ class Tag(Base):
         nullable=False,
         server_default=text("now()"),
     )
+    archived_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+    )
 
     contact_tags: Mapped[list[ContactTag]] = relationship(
         "ContactTag",

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -24,6 +24,8 @@ info:
     - `PATCH|DELETE /v1/admin/services/{id}/instances/{instanceId}/enrollments/{enrollmentId}`
     - `GET|POST /v1/admin/discount-codes`
     - `PUT|DELETE /v1/admin/discount-codes/{id}`
+    - `GET|POST /v1/admin/tags`
+    - `GET|PATCH|DELETE /v1/admin/tags/{id}`
     - `GET /v1/admin/contacts/tags`
     - `GET /v1/admin/contacts/search`
     - `GET|POST /v1/admin/contacts`
@@ -1566,6 +1568,136 @@ paths:
                 $ref: "#/components/schemas/DiscountCodeResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/tags:
+    get:
+      summary: List CRM tags for administration
+      description: |
+        Returns tags sorted by name. By default only active (non-archived) tags are returned.
+        Pass `include_archived=true` to include archived tags (for example the Tags admin screen).
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: include_archived
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: When true, include tags with a non-null `archived_at`.
+      responses:
+        "200":
+          description: Tag list with usage counts.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminTagListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      summary: Create CRM tag
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAdminTagRequest"
+      responses:
+        "201":
+          description: Tag created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminTagResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Duplicate tag name (case-insensitive uniqueness).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/admin/tags/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get CRM tag by id
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Tag detail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminTagResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      summary: Update CRM tag
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAdminTagRequest"
+      responses:
+        "200":
+          description: Updated tag.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminTagResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Duplicate tag name (case-insensitive uniqueness).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: Delete or archive CRM tag
+      description: |
+        Hard-deletes the tag when it is not linked to any contact, family, organisation, asset,
+        service, or service instance. When the tag is in use, sets `archived_at` instead and
+        returns the updated tag (same response as PATCH); repeated deletes are idempotent for
+        in-use tags.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "204":
+          description: Tag removed (unused).
+        "200":
+          description: Tag archived because it is still linked to at least one record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminTagResponse"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
@@ -5010,6 +5142,79 @@ components:
         color:
           type: string
           nullable: true
+    AdminTagRef:
+      allOf:
+        - $ref: "#/components/schemas/EntityTagRef"
+        - type: object
+          required:
+            - description
+            - archived_at
+            - usage_count
+          properties:
+            description:
+              type: string
+              nullable: true
+              maxLength: 255
+            archived_at:
+              type: string
+              format: date-time
+              nullable: true
+              description: When set, the tag is archived and hidden from assignment pickers.
+            usage_count:
+              type: integer
+              minimum: 0
+              description: >
+                Count of junction rows across contacts, families, organisations, assets,
+                services, and service instances referencing this tag.
+    AdminTagListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminTagRef"
+    AdminTagResponse:
+      type: object
+      required:
+        - tag
+      properties:
+        tag:
+          $ref: "#/components/schemas/AdminTagRef"
+    CreateAdminTagRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        color:
+          type: string
+          nullable: true
+          pattern: "^#[0-9A-Fa-f]{6}$"
+          description: Optional UI color as `#RRGGBB`.
+        description:
+          type: string
+          nullable: true
+          maxLength: 255
+    UpdateAdminTagRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        color:
+          type: string
+          nullable: true
+          pattern: "^#[0-9A-Fa-f]{6}$"
+        description:
+          type: string
+          nullable: true
+          maxLength: 255
     EntityTagListResponse:
       type: object
       required:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -24,8 +24,8 @@ info:
     - `PATCH|DELETE /v1/admin/services/{id}/instances/{instanceId}/enrollments/{enrollmentId}`
     - `GET|POST /v1/admin/discount-codes`
     - `PUT|DELETE /v1/admin/discount-codes/{id}`
-    - `GET|POST /v1/admin/tags`
-    - `GET|PATCH|DELETE /v1/admin/tags/{id}`
+    - `GET|POST /v1/admin/tags` (optional `include_archived`, `archived_only`)
+    - `GET|PATCH|DELETE /v1/admin/tags/{id}` (DELETE returns JSON with `deleted` and `usage_count`)
     - `GET /v1/admin/contacts/tags`
     - `GET /v1/admin/contacts/search`
     - `GET|POST /v1/admin/contacts`
@@ -1577,8 +1577,9 @@ paths:
     get:
       summary: List CRM tags for administration
       description: |
-        Returns tags sorted by name. By default only active (non-archived) tags are returned.
-        Pass `include_archived=true` to include archived tags (for example the Tags admin screen).
+        Returns tags sorted by name. Default: active tags only (`archived_at` is null).
+        Use `include_archived=true` for active and archived together, or `archived_only=true`
+        for archived rows only. Do not pass both `include_archived` and `archived_only`.
       security:
         - AdminBearerAuth: []
       parameters:
@@ -1589,6 +1590,13 @@ paths:
             type: boolean
             default: false
           description: When true, include tags with a non-null `archived_at`.
+        - name: archived_only
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: When true, return only archived tags (mutually exclusive with `include_archived`).
       responses:
         "200":
           description: Tag list with usage counts.
@@ -1653,6 +1661,10 @@ paths:
           $ref: "#/components/responses/NotFound"
     patch:
       summary: Update CRM tag
+      description: |
+        Set `archived` to `false` to restore an archived tag (clear `archived_at`).
+        System-managed tags (`expense_attachment`, `client_document`) cannot be renamed or archived;
+        they may be edited for color/description only.
       security:
         - AdminBearerAuth: []
       requestBody:
@@ -1683,21 +1695,24 @@ paths:
     delete:
       summary: Delete or archive CRM tag
       description: |
-        Hard-deletes the tag when it is not linked to any contact, family, organisation, asset,
-        service, or service instance. When the tag is in use, sets `archived_at` instead and
-        returns the updated tag (same response as PATCH); repeated deletes are idempotent for
-        in-use tags.
+        Always returns **200** with `usage_count` and `deleted`. System-managed tags
+        (`expense_attachment`, `client_document`) return **400** and must not be removed.
+        When `usage_count` is zero, the tag is **hard-deleted** (`deleted: true`), including
+        an archived tag with no remaining links. When `usage_count` is greater than zero,
+        the tag is **archived** (`deleted: false`, `tag` present); repeated calls are idempotent
+        for in-use tags. If the client predicted delete vs archive from a stale list, compare
+        `usage_count` to the prior value to detect a race.
       security:
         - AdminBearerAuth: []
       responses:
-        "204":
-          description: Tag removed (unused).
         "200":
-          description: Tag archived because it is still linked to at least one record.
+          description: Delete outcome (hard delete or archive).
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AdminTagResponse"
+                $ref: "#/components/schemas/AdminTagDeleteResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
@@ -5150,6 +5165,7 @@ components:
             - description
             - archived_at
             - usage_count
+            - is_system
           properties:
             description:
               type: string
@@ -5166,6 +5182,28 @@ components:
               description: >
                 Count of junction rows across contacts, families, organisations, assets,
                 services, and service instances referencing this tag.
+            is_system:
+              type: boolean
+              description: >
+                True for reserved asset-pipeline tags (`expense_attachment`, `client_document`).
+                These cannot be renamed, archived, or deleted via the admin API.
+    AdminTagDeleteResponse:
+      type: object
+      required:
+        - deleted
+        - usage_count
+      properties:
+        deleted:
+          type: boolean
+          description: True when the tag row was removed from the database.
+        usage_count:
+          type: integer
+          minimum: 0
+          description: Junction usage count evaluated at delete time.
+        tag:
+          $ref: "#/components/schemas/AdminTagRef"
+          nullable: true
+          description: Present when `deleted` is false (archived in-use tag).
     AdminTagListResponse:
       type: object
       required:
@@ -5215,6 +5253,11 @@ components:
           type: string
           nullable: true
           maxLength: 255
+        archived:
+          type: boolean
+          description: >
+            When `false`, clears `archived_at` (restore). When `true`, sets `archived_at` unless
+            the tag is system-managed (those reject archive). Omit when not changing archive state.
     EntityTagListResponse:
       type: object
       required:

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -457,6 +457,8 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | `/v1/admin/locations` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/locations/{id}` | GET, PUT, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/users` | GET | Admin Group | `EvolvesproutsAdminFunction` | Assignee lookup for sales lead workflows |
+| `/v1/admin/tags` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | CRM tag catalog list/create |
+| `/v1/admin/tags/{id}` | GET, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | Tag detail/update; delete removes unused tags or archives in-use tags |
 | `/v1/admin/leads` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | Lead list/create |
 | `/v1/admin/leads/analytics` | GET | Admin Group | `EvolvesproutsAdminFunction` | Funnel analytics and KPI summary |
 | `/v1/admin/leads/export` | GET | Admin Group | `EvolvesproutsAdminFunction` | CSV lead export |

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -457,8 +457,8 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | `/v1/admin/locations` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/locations/{id}` | GET, PUT, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/users` | GET | Admin Group | `EvolvesproutsAdminFunction` | Assignee lookup for sales lead workflows |
-| `/v1/admin/tags` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | CRM tag catalog list/create |
-| `/v1/admin/tags/{id}` | GET, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | Tag detail/update; delete removes unused tags or archives in-use tags |
+| `/v1/admin/tags` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | CRM tag catalog; GET supports `include_archived` and `archived_only` (mutually exclusive) |
+| `/v1/admin/tags/{id}` | GET, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | Tag detail/update; DELETE returns JSON with `deleted` and `usage_count` |
 | `/v1/admin/leads` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | Lead list/create |
 | `/v1/admin/leads/analytics` | GET | Admin Group | `EvolvesproutsAdminFunction` | Funnel analytics and KPI summary |
 | `/v1/admin/leads/export` | GET | Admin Group | `EvolvesproutsAdminFunction` | CSV lead export |

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -422,6 +422,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 ### `tags`, `contact_tags`, `family_tags`, `organization_tags`, `asset_tags`
 
 - `tags` stores reusable labels.
+- `tags.archived_at` (timestamptz, nullable) soft-retires a tag: null means active; non-null
+  means archived (hidden from assignment pickers such as `GET /v1/admin/contacts/tags` while
+  existing junction rows remain valid).
 - Junction tables model many-to-many tagging across contacts/families/orgs/assets.
 - Junction rows use composite primary keys and cascade deletion.
 
@@ -491,6 +494,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 - Migration `0038_drop_inst_tag_inst_idx` drops the redundant btree index on
   `service_instance_id` (the composite primary key already leads with that column);
   the `tag_id` index remains for reverse lookups.
+
+Migration `0039_tags_archived_at` adds nullable `tags.archived_at` for soft-retiring labels
+without breaking existing junction references.
 
 ### `discount_codes`
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -56,7 +56,9 @@ their primary responsibilities.
   `/v1/admin/contacts/*` (including `GET /v1/admin/contacts` optional `contact_type` filter;
   list and single-contact responses include read-only `family_location_summary` and
   `organization_location_summary` when the contact is linked to a family or organisation that has a venue location),
-  `GET /v1/admin/contacts/tags` for tag pickers,
+  `/v1/admin/tags/*` for CRM tag catalog administration (list with optional `include_archived`,
+  create, update, delete-or-archive when in use),
+  `GET /v1/admin/contacts/tags` for tag pickers (active tags only),
   `GET /v1/admin/contacts/search` for contact picker search,
   `GET|POST /v1/admin/contacts/{id}/notes` and `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`
   for standalone CRM notes on a contact (not tied to a sales lead), and `DELETE /v1/admin/contacts/{id}`

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -56,8 +56,9 @@ their primary responsibilities.
   `/v1/admin/contacts/*` (including `GET /v1/admin/contacts` optional `contact_type` filter;
   list and single-contact responses include read-only `family_location_summary` and
   `organization_location_summary` when the contact is linked to a family or organisation that has a venue location),
-  `/v1/admin/tags/*` for CRM tag catalog administration (list with optional `include_archived`,
-  create, update, delete-or-archive when in use),
+  `/v1/admin/tags/*` for CRM tag catalog administration (list with optional `include_archived` or
+  `archived_only`, create, update, `PATCH` `archived` to restore, delete returns `deleted` +
+  `usage_count`; system tag names are protected),
   `GET /v1/admin/contacts/tags` for tag pickers (active tags only),
   `GET /v1/admin/contacts/search` for contact picker search,
   `GET|POST /v1/admin/contacts/{id}/notes` and `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`

--- a/tests/test_admin_entities_helpers.py
+++ b/tests/test_admin_entities_helpers.py
@@ -11,6 +11,7 @@ from app.api.admin_entities_helpers import (
     FAMILY_RELATIONSHIP_TYPES,
     ORGANIZATION_RELATIONSHIP_TYPES,
     replace_service_instance_tags,
+    require_assignable_tag,
     request_id,
     parse_contact_type_filter,
     parse_relationship_type,
@@ -109,9 +110,9 @@ def test_replace_service_instance_tags_dedupes_preserving_order() -> None:
 
     def fake_get(_model: type, pk: object) -> object | None:
         if pk == t1:
-            return SimpleNamespace(id=t1)
+            return SimpleNamespace(id=t1, archived_at=None)
         if pk == t2:
-            return SimpleNamespace(id=t2)
+            return SimpleNamespace(id=t2, archived_at=None)
         return None
 
     session.get.side_effect = fake_get
@@ -141,7 +142,7 @@ def test_replace_service_instance_tags_unknown_id_sets_field() -> None:
 
     def fake_get(_model: type, pk: object) -> object | None:
         if pk == known:
-            return SimpleNamespace(id=known)
+            return SimpleNamespace(id=known, archived_at=None)
         return None
 
     session.get.side_effect = fake_get
@@ -153,3 +154,37 @@ def test_replace_service_instance_tags_unknown_id_sets_field() -> None:
             tag_ids=[known, missing],
         )
     assert exc.value.field == "tag_ids"
+
+
+@pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
+def test_replace_service_instance_tags_rejects_archived_tag() -> None:
+    instance_id = uuid4()
+    active_id = uuid4()
+    archived_id = uuid4()
+    session = MagicMock()
+
+    def fake_get(_model: type, pk: object) -> object | None:
+        if pk == active_id:
+            return SimpleNamespace(id=active_id, archived_at=None)
+        if pk == archived_id:
+            return SimpleNamespace(id=archived_id, archived_at="2024-01-01")
+        return None
+
+    session.get.side_effect = fake_get
+
+    with pytest.raises(ValidationError, match="tag is archived") as exc:
+        replace_service_instance_tags(
+            session,
+            instance_id=instance_id,
+            tag_ids=[active_id, archived_id],
+        )
+    assert exc.value.field == "tag_ids"
+
+
+def test_require_assignable_tag_raises_for_archived() -> None:
+    tid = uuid4()
+    session = MagicMock()
+    session.get.return_value = SimpleNamespace(id=tid, archived_at="x")
+
+    with pytest.raises(ValidationError, match="tag is archived"):
+        require_assignable_tag(session, tid)

--- a/tests/test_admin_router.py
+++ b/tests/test_admin_router.py
@@ -29,6 +29,8 @@ def test_match_handler_routes_asset_prefix_paths() -> None:
         "/v1/admin/leads/abc",
         "/v1/admin/leads/abc/notes",
         "/v1/admin/users",
+        "/v1/admin/tags",
+        "/v1/admin/tags/abc",
         "/v1/admin/contacts",
         "/v1/admin/contacts/tags",
         "/v1/admin/contacts/abc",

--- a/tests/test_admin_tags_api.py
+++ b/tests/test_admin_tags_api.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.api import admin_tags
+from app.exceptions import ValidationError
+
+
+def test_handle_admin_tags_list_get(monkeypatch: Any, api_gateway_event: Any) -> None:
+    marker = {"statusCode": 200, "body": "{}"}
+    monkeypatch.setattr(admin_tags, "_list_tags", lambda _: marker)
+    monkeypatch.setattr(
+        admin_tags,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_tags.handle_admin_tags_request(
+        api_gateway_event(method="GET", path="/v1/admin/tags"),
+        "GET",
+        "/v1/admin/tags",
+    )
+    assert response is marker
+
+
+def test_handle_admin_tags_post(monkeypatch: Any, api_gateway_event: Any) -> None:
+    marker = {"statusCode": 201, "body": "{}"}
+    monkeypatch.setattr(admin_tags, "_create_tag", lambda _event, *, actor_sub: marker)
+    monkeypatch.setattr(
+        admin_tags,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_tags.handle_admin_tags_request(
+        api_gateway_event(method="POST", path="/v1/admin/tags", body="{}"),
+        "POST",
+        "/v1/admin/tags",
+    )
+    assert response is marker
+
+
+def test_parse_include_archived_invalid() -> None:
+    event = {
+        "queryStringParameters": {"include_archived": "maybe"},
+        "multiValueQueryStringParameters": None,
+    }
+    with pytest.raises(ValidationError, match="include_archived"):
+        admin_tags._parse_include_archived(event)
+
+
+def test_parse_optional_hex_color_rejects_bad() -> None:
+    with pytest.raises(ValidationError):
+        admin_tags._parse_optional_hex_color("red", field="color")
+
+
+def test_serialize_admin_tag_includes_usage(monkeypatch: Any) -> None:
+    tag_id = uuid4()
+    tag = SimpleNamespace(
+        id=tag_id,
+        name="Alpha",
+        color="#aabbcc",
+        description="d",
+        archived_at=None,
+    )
+    session = object()
+    monkeypatch.setattr(admin_tags, "_tag_usage_count", lambda _s, _tid: 3)
+
+    payload = admin_tags._serialize_admin_tag(session, tag)
+    assert payload["id"] == str(tag_id)
+    assert payload["name"] == "Alpha"
+    assert payload["color"] == "#aabbcc"
+    assert payload["description"] == "d"
+    assert payload["archived_at"] is None
+    assert payload["usage_count"] == 3

--- a/tests/test_admin_tags_api.py
+++ b/tests/test_admin_tags_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
@@ -77,3 +78,107 @@ def test_serialize_admin_tag_includes_usage(monkeypatch: Any) -> None:
     assert payload["description"] == "d"
     assert payload["archived_at"] is None
     assert payload["usage_count"] == 3
+    assert payload["is_system"] is False
+
+
+def test_serialize_admin_tag_marks_system_names() -> None:
+    tag_id = uuid4()
+    tag = SimpleNamespace(
+        id=tag_id,
+        name="expense_attachment",
+        color=None,
+        description=None,
+        archived_at=None,
+    )
+    session = object()
+    payload = admin_tags._serialize_admin_tag(
+        session, tag, usage_by_id={tag_id: 1}
+    )
+    assert payload["is_system"] is True
+    assert payload["usage_count"] == 1
+
+
+def test_parse_archived_only_invalid() -> None:
+    event = {
+        "queryStringParameters": {"archived_only": "maybe"},
+        "multiValueQueryStringParameters": None,
+    }
+    with pytest.raises(ValidationError, match="archived_only"):
+        admin_tags._parse_archived_only(event)
+
+
+def test_list_tags_rejects_conflicting_query_params(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    monkeypatch.setattr(
+        admin_tags,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+    event = api_gateway_event(
+        method="GET",
+        path="/v1/admin/tags",
+        query_params={"include_archived": "true", "archived_only": "true"},
+    )
+    with pytest.raises(ValidationError, match="archived_only"):
+        admin_tags.handle_admin_tags_request(event, "GET", "/v1/admin/tags")
+
+
+def test_create_tag_rejects_reserved_system_name(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    monkeypatch.setattr(
+        admin_tags,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/tags",
+        body=json.dumps({"name": "expense_attachment"}),
+    )
+    with pytest.raises(ValidationError, match="reserved"):
+        admin_tags.handle_admin_tags_request(event, "POST", "/v1/admin/tags")
+
+
+def test_delete_tag_rejects_system_tag(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    tag_id = str(uuid4())
+    monkeypatch.setattr(
+        admin_tags,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    class _SessionCtx:
+        def __init__(self, _engine: object) -> None:
+            self._inner = _Inner()
+
+        def __enter__(self) -> "_Inner":
+            return self._inner
+
+        def __exit__(self, *_a: object) -> bool:
+            return False
+
+    class _Inner:
+        def get(self, _model: type, pk: object) -> object:
+            return SimpleNamespace(
+                id=pk,
+                name="client_document",
+                archived_at=None,
+            )
+
+        def commit(self) -> None:
+            return None
+
+    monkeypatch.setattr(admin_tags, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_tags, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_tags, "set_audit_context", lambda *_a, **_k: None)
+
+    with pytest.raises(ValidationError, match="System-managed"):
+        admin_tags.handle_admin_tags_request(
+            api_gateway_event(method="DELETE", path=f"/v1/admin/tags/{tag_id}"),
+            "DELETE",
+            f"/v1/admin/tags/{tag_id}",
+        )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds admin **Tags** + `/v1/admin/tags` API with archive/restore, system tag protection, and aggregated usage counts.

## Latest fix

- **Mypy**: `_usage_counts_by_tag_id` now uses each model’s `__table__.c` for `tag_id` in the `UNION ALL` subqueries so declarative ORM types do not trip `attr-defined` on `.tag_id`.

`pre-commit run --all-files --show-diff-on-failure` passes locally.

## Deploy

Run Alembic for `0039_tags_archived_at` before relying on archive fields in production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5625349c-7d59-40be-80ce-daaa5ef503fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5625349c-7d59-40be-80ce-daaa5ef503fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

