### PR TITLE
Admin web: tags page title, inline name/color row, and name search

### DIFF
--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -216,7 +216,7 @@ export function TagsPage() {
   return (
     <div className='space-y-6'>
       <AdminEditorCard
-        title={editorMode === 'create' ? 'Tag' : 'Edit tag'}
+        title='Tag'
         description='Tags apply across contacts, families, organisations, services, instances, and assets. Archived tags stay on existing records but no longer appear in pickers. Use Restore (below or in the table) to clear archive. System tags (expense_attachment, client_document) cannot be renamed, archived, or deleted.'
         actions={
           editorMode === 'edit' ? (

--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -46,11 +46,20 @@ export function TagsPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [deleteBusyId, setDeleteBusyId] = useState<string | null>(null);
   const [restoreBusyId, setRestoreBusyId] = useState<string | null>(null);
+  const [listSearchQuery, setListSearchQuery] = useState('');
 
   const selectedRow = useMemo(
     () => tags.find((row) => row.id === selectedTagId) ?? null,
     [tags, selectedTagId]
   );
+
+  const filteredTags = useMemo(() => {
+    const q = listSearchQuery.trim().toLowerCase();
+    if (!q) {
+      return tags;
+    }
+    return tags.filter((row) => row.name.toLowerCase().includes(q));
+  }, [tags, listSearchQuery]);
 
   const loadTags = useCallback(async () => {
     setIsLoading(true);
@@ -207,7 +216,7 @@ export function TagsPage() {
   return (
     <div className='space-y-6'>
       <AdminEditorCard
-        title={editorMode === 'create' ? 'New tag' : 'Edit tag'}
+        title={editorMode === 'create' ? 'Tag' : 'Edit tag'}
         description='Tags apply across contacts, families, organisations, services, instances, and assets. Archived tags stay on existing records but no longer appear in pickers. Use Restore (below or in the table) to clear archive. System tags (expense_attachment, client_document) cannot be renamed, archived, or deleted.'
         actions={
           editorMode === 'edit' ? (
@@ -241,31 +250,33 @@ export function TagsPage() {
         }
       >
         <form id={EDITOR_FORM_ID} className='space-y-4' onSubmit={(event) => void handleSubmit(event)}>
-          <div>
-            <Label htmlFor='tag-name'>Name</Label>
-            <Input
-              id='tag-name'
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              maxLength={100}
-              required
-              autoComplete='off'
-              disabled={Boolean(isEditingSystemTag)}
-            />
-            {isEditingSystemTag ? (
-              <p className='mt-1 text-sm text-slate-600'>This system-managed tag name cannot be changed.</p>
-            ) : null}
-          </div>
-          <div>
-            <Label htmlFor='tag-color'>Color (#RRGGBB)</Label>
-            <Input
-              id='tag-color'
-              value={color}
-              onChange={(event) => setColor(event.target.value)}
-              placeholder='#336699'
-              maxLength={7}
-              autoComplete='off'
-            />
+          <div className='flex flex-col gap-4 sm:flex-row sm:items-start'>
+            <div className='min-w-0 flex-1'>
+              <Label htmlFor='tag-name'>Name</Label>
+              <Input
+                id='tag-name'
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                maxLength={100}
+                required
+                autoComplete='off'
+                disabled={Boolean(isEditingSystemTag)}
+              />
+              {isEditingSystemTag ? (
+                <p className='mt-1 text-sm text-slate-600'>This system-managed tag name cannot be changed.</p>
+              ) : null}
+            </div>
+            <div className='min-w-0 flex-1 sm:max-w-[220px]'>
+              <Label htmlFor='tag-color'>Color (#RRGGBB)</Label>
+              <Input
+                id='tag-color'
+                value={color}
+                onChange={(event) => setColor(event.target.value)}
+                placeholder='#336699'
+                maxLength={7}
+                autoComplete='off'
+              />
+            </div>
           </div>
           <div>
             <Label htmlFor='tag-description'>Description</Label>
@@ -291,6 +302,16 @@ export function TagsPage() {
         onLoadMore={() => {}}
         toolbar={
           <div className='mb-3 flex flex-wrap items-end gap-3'>
+            <div className='min-w-[200px] flex-1'>
+              <Label htmlFor='tags-list-search'>Search</Label>
+              <Input
+                id='tags-list-search'
+                value={listSearchQuery}
+                onChange={(event) => setListSearchQuery(event.target.value)}
+                placeholder='Name'
+                autoComplete='off'
+              />
+            </div>
             <div className='min-w-[160px]'>
               <Label htmlFor='tags-list-filter'>Status</Label>
               <Select
@@ -318,7 +339,7 @@ export function TagsPage() {
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
-            {tags.map((row) => (
+            {filteredTags.map((row) => (
               <tr
                 key={row.id}
                 className={`cursor-pointer transition ${

--- a/apps/admin_web/tests/components/admin/tags/tags-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/tags/tags-page.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockListAdminTags } = vi.hoisted(() => ({
+  mockListAdminTags: vi.fn(),
+}));
+
+vi.mock('@/lib/tags-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/tags-api')>();
+  return {
+    ...actual,
+    listAdminTags: mockListAdminTags,
+  };
+});
+
+import { TagsPage } from '@/components/admin/tags/tags-page';
+
+const tagAlpha = {
+  id: 't-alpha',
+  name: 'Alpha',
+  color: '#112233',
+  description: null,
+  archived_at: null,
+  usage_count: 0,
+  is_system: false,
+};
+
+const tagBeta = {
+  id: 't-beta',
+  name: 'Beta',
+  color: null,
+  description: null,
+  archived_at: null,
+  usage_count: 1,
+  is_system: false,
+};
+
+describe('TagsPage', () => {
+  beforeEach(() => {
+    mockListAdminTags.mockReset();
+    mockListAdminTags.mockResolvedValue([tagAlpha, tagBeta]);
+  });
+
+  it('shows Tag as the create editor title and filters rows by name search', async () => {
+    const user = userEvent.setup();
+    render(<TagsPage />);
+
+    expect(await screen.findByRole('heading', { name: 'Tag' })).toBeInTheDocument();
+
+    const tagsCard = screen.getByRole('heading', { name: 'Tags' }).closest('section');
+    expect(tagsCard).toBeTruthy();
+    const tagsSection = tagsCard as HTMLElement;
+
+    expect(within(tagsSection).getByRole('cell', { name: 'Alpha' })).toBeInTheDocument();
+    expect(within(tagsSection).getByRole('cell', { name: 'Beta' })).toBeInTheDocument();
+
+    const searchInput = within(tagsSection).getByPlaceholderText('Name');
+    await user.type(searchInput, 'alp');
+
+    expect(within(tagsSection).getByRole('cell', { name: 'Alpha' })).toBeInTheDocument();
+    expect(within(tagsSection).queryByRole('cell', { name: 'Beta' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin_web/tests/components/admin/tags/tags-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/tags/tags-page.test.tsx
@@ -42,7 +42,7 @@ describe('TagsPage', () => {
     mockListAdminTags.mockResolvedValue([tagAlpha, tagBeta]);
   });
 
-  it('shows Tag as the create editor title and filters rows by name search', async () => {
+  it('shows Tag as the editor title and filters rows by name search', async () => {
     const user = userEvent.setup();
     render(<TagsPage />);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Editor card**: Title is always **Tag** (create and edit).
- **Form layout**: **Name** and **Color (#RRGGBB)** sit on one row from the `sm` breakpoint up (`flex-row`), stacked on narrow viewports.
- **Tags table**: Toolbar includes a **Search** field (placeholder **Name**) that filters loaded tags by case-insensitive substring match on `name`, alongside the existing Status filter.

## Tests

- `npm run test -- tests/components/admin/tags/tags-page.test.tsx`
- `npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad4d9e47-2645-4a8d-9b0f-3ec910dddf4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad4d9e47-2645-4a8d-9b0f-3ec910dddf4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

