### PR TITLE
Align public calendar API with DB (serializer, repository, OpenAPI)

### DIFF
--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -164,13 +164,9 @@ def _resolve_tags(instance: ServiceInstance) -> list[str]:
 
 
 def _resolve_partners(instance: ServiceInstance) -> list[str]:
-    ordered = sorted(
-        instance.partner_organization_links,
-        key=lambda link: (link.sort_order, str(link.organization_id)),
-    )
     return [
         link.organization.slug
-        for link in ordered
+        for link in instance.partner_organization_links
         if link.organization is not None and link.organization.slug
     ]
 

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.orm import Session
 
 from app.db.engine import get_engine
 from app.db.models import Service, ServiceInstance
-from app.db.models.enums import InstanceStatus
+from app.db.models.enums import InstanceStatus, ServiceType
+from app.db.models.service_instance import InstanceSessionSlot
+
+if TYPE_CHECKING:
+    from app.db.models.location import Location
 from app.db.repositories.service_instance import ServiceInstanceRepository
 from app.utils import json_response
 from app.utils.logging import get_logger
+from app.utils.maps import build_google_maps_directions_url
 
 logger = get_logger(__name__)
+
+_LANDING_PAGE_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 
 def handle_public_events(
@@ -28,11 +36,17 @@ def handle_public_events(
     if method != "GET":
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
+    query = event.get("queryStringParameters") or {}
+    landing_page = _parse_landing_page(query.get("landing_page"))
+    service_types = _parse_service_type_filter(query.get("service_type"))
+
     with Session(get_engine()) as session:
         repository = ServiceInstanceRepository(session)
-        items = _fetch_event_instances(
+        items = _fetch_public_offerings(
             repository,
             now=datetime.now(UTC),
+            service_types=service_types,
+            landing_page=landing_page,
         )
     # Keep a temporary alias for older consumers while "events" is canonical.
     return json_response(200, {"events": items, "items": items}, event=event)
@@ -46,16 +60,123 @@ def handle_public_calendar_events_request(
     return handle_public_events(event, method)
 
 
-def _fetch_event_instances(
+def _parse_landing_page(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    if len(raw) > 255:
+        return None
+    if not _LANDING_PAGE_PATTERN.fullmatch(raw):
+        return None
+    return raw
+
+
+def _parse_service_type_filter(raw: str | None) -> set[ServiceType] | None:
+    if raw is None:
+        return None
+    if raw == "event":
+        return {ServiceType.EVENT}
+    if raw == "training_course":
+        return {ServiceType.TRAINING_COURSE}
+    return None
+
+
+def _fetch_public_offerings(
     repository: ServiceInstanceRepository,
     *,
     now: datetime,
+    service_types: set[ServiceType] | None,
+    landing_page: str | None,
 ) -> list[dict[str, Any]]:
-    rows = repository.list_event_instances_for_public_feed(
+    types = (
+        service_types
+        if service_types is not None
+        else {ServiceType.EVENT, ServiceType.TRAINING_COURSE}
+    )
+    rows = repository.list_public_offerings(
         limit=100,
         now=now,
+        service_types=types,
+        landing_page=landing_page,
     )
     return [_serialize_public_event(repository, instance) for instance in rows]
+
+
+def _resolve_primary_location(
+    instance: ServiceInstance,
+    slots: list[InstanceSessionSlot],
+) -> Location | None:
+    if slots and slots[0].location is not None:
+        return slots[0].location
+    return instance.location
+
+
+def _resolve_primary_price(
+    instance: ServiceInstance,
+) -> tuple[float | None, str | None]:
+    service = instance.service
+    if service.service_type == ServiceType.EVENT:
+        if instance.ticket_tiers:
+            sorted_tiers = sorted(
+                instance.ticket_tiers,
+                key=lambda tier: (tier.sort_order, tier.created_at, tier.id),
+            )
+            selected = sorted_tiers[0]
+            return _decimal_to_float(selected.price), selected.currency
+        details = service.event_details
+        if details is not None and details.default_price is not None:
+            return _decimal_to_float(details.default_price), details.default_currency
+        return None, None
+    if service.service_type == ServiceType.TRAINING_COURSE:
+        td = instance.training_details
+        if td is not None:
+            return _decimal_to_float(td.price), td.currency
+        return None, None
+    return None, None
+
+
+def _resolve_booking_system(service: Service) -> str | None:
+    if service.booking_system:
+        return service.booking_system
+    if service.service_type == ServiceType.EVENT:
+        return "event-booking"
+    if service.service_type == ServiceType.TRAINING_COURSE:
+        if service.slug == "my-best-auntie":
+            return "my-best-auntie-booking"
+        return None
+    return None
+
+
+def _resolve_categories(service: Service) -> list[str]:
+    if service.service_type == ServiceType.EVENT:
+        details = service.event_details
+        if details is not None:
+            return [details.event_category.value]
+        return []
+    if service.service_type == ServiceType.TRAINING_COURSE:
+        return ["Training Course"]
+    return []
+
+
+def _resolve_tags(instance: ServiceInstance) -> list[str]:
+    links = instance.instance_tags
+    names = {link.tag.name for link in links if link.tag and link.tag.name}
+    return sorted(names, key=str.casefold)
+
+
+def _resolve_partners(instance: ServiceInstance) -> list[str]:
+    ordered = sorted(
+        instance.partner_organization_links,
+        key=lambda link: (link.sort_order, str(link.organization_id)),
+    )
+    return [
+        link.organization.slug
+        for link in ordered
+        if link.organization is not None and link.organization.slug
+    ]
+
+
+def _resolve_external_url(instance: ServiceInstance) -> str | None:
+    return instance.external_url or instance.eventbrite_event_url or None
 
 
 def _serialize_public_event(
@@ -63,83 +184,95 @@ def _serialize_public_event(
     instance: ServiceInstance,
 ) -> dict[str, Any]:
     service = instance.service
-    title = instance.title if instance.title else service.title
-    summary = instance.description if instance.description else service.description
+    title = instance.title or service.title
+    summary = instance.description or service.description
 
-    slots = sorted(
-        instance.session_slots, key=lambda slot: (slot.sort_order, slot.starts_at)
-    )
+    slots = sorted(instance.session_slots, key=lambda s: (s.sort_order, s.starts_at))
     dates = [
         {
-            "id": str(slot.id),
-            "start_datetime": _iso(slot.starts_at),
-            "end_datetime": _iso(slot.ends_at),
+            "id": str(s.id),
+            "start_datetime": _iso(s.starts_at),
+            "end_datetime": _iso(s.ends_at),
         }
-        for slot in slots
+        for s in slots
     ]
 
-    primary_location = (
-        slots[0].location if slots and slots[0].location else instance.location
-    )
-    location_name = _clean_text(primary_location.name if primary_location else None)
-    location_address = _clean_text(
-        primary_location.address if primary_location else None
-    )
+    primary_location = _resolve_primary_location(instance, slots)
+    is_virtual = _is_virtual_delivery_mode(instance, service)
 
-    price, currency = _resolve_primary_ticket_price(instance)
+    location_name = (
+        None
+        if is_virtual
+        else _clean_text(primary_location.name if primary_location else None)
+    )
+    location_address = (
+        None
+        if is_virtual
+        else _clean_text(primary_location.address if primary_location else None)
+    )
+    location_url = ""
+    if not is_virtual and primary_location is not None:
+        derived = build_google_maps_directions_url(
+            address=primary_location.address,
+            lat=primary_location.lat,
+            lng=primary_location.lng,
+        )
+        if derived is not None:
+            location_url = derived
+
+    price, currency = _resolve_primary_price(instance)
     booking_status = (
         "fully_booked" if instance.status == InstanceStatus.FULL else "open"
     )
-    event_status = _map_instance_status(instance.status)
 
     payload: dict[str, Any] = {
-        "id": str(instance.id),
+        "id": instance.slug or str(instance.id),
+        "service_instance_id": str(instance.id),
+        "service_type": service.service_type.value,
         "title": title,
         "summary": summary,
         "description": summary,
-        "status": event_status,
+        "status": _map_instance_status(instance.status),
         "booking_status": booking_status,
-        "booking_system": "event-booking",
-        "location": "virtual"
-        if _is_virtual_delivery_mode(instance, service)
-        else "physical",
+        "is_fully_booked": booking_status == "fully_booked",
+        "location": "virtual" if is_virtual else "physical",
         "location_name": location_name,
         "location_address": location_address,
-        "location_url": "",
+        "location_url": location_url,
         "dates": dates,
-        "tags": [],
-        "categories": [service.event_details.event_category.value]
-        if service.event_details is not None
-        else [],
+        "tags": _resolve_tags(instance),
+        "categories": _resolve_categories(service),
+        "partners": _resolve_partners(instance),
     }
+
+    booking_system = _resolve_booking_system(service)
+    if booking_system is not None:
+        payload["booking_system"] = booking_system
+
     if price is not None:
         payload["price"] = price
     if currency is not None:
         payload["currency"] = currency
-    if instance.eventbrite_event_url:
-        payload["external_url"] = instance.eventbrite_event_url
+
+    external_url = _resolve_external_url(instance)
+    if external_url:
+        payload["external_url"] = external_url
+
     if instance.slug is not None:
         payload["slug"] = instance.slug
     if instance.landing_page is not None:
         payload["landing_page"] = instance.landing_page
+    if instance.age_group is not None:
+        payload["age_group"] = instance.age_group
+    if instance.cohort is not None:
+        payload["cohort"] = instance.cohort
+
     if instance.max_capacity is not None:
         filled = repository.get_enrollment_count(instance.id)
         payload["spaces_total"] = instance.max_capacity
         payload["spaces_left"] = max(0, instance.max_capacity - filled)
+
     return payload
-
-
-def _resolve_primary_ticket_price(
-    instance: ServiceInstance,
-) -> tuple[float | None, str | None]:
-    if not instance.ticket_tiers:
-        return None, None
-    sorted_tiers = sorted(
-        instance.ticket_tiers,
-        key=lambda tier: (tier.sort_order, tier.created_at, tier.id),
-    )
-    selected = sorted_tiers[0]
-    return _decimal_to_float(selected.price), selected.currency
 
 
 def _decimal_to_float(value: Decimal | None) -> float | None:

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
@@ -87,18 +88,20 @@ def _fetch_public_offerings(
     service_types: set[ServiceType] | None,
     landing_page: str | None,
 ) -> list[dict[str, Any]]:
-    types = (
-        service_types
-        if service_types is not None
-        else {ServiceType.EVENT, ServiceType.TRAINING_COURSE}
-    )
     rows = repository.list_public_offerings(
         limit=100,
         now=now,
-        service_types=types,
+        service_types=service_types,
         landing_page=landing_page,
     )
-    return [_serialize_public_event(repository, instance) for instance in rows]
+    capacity_instance_ids = [row.id for row in rows if row.max_capacity is not None]
+    enrollment_counts = repository.get_enrollment_counts_for_instances(
+        capacity_instance_ids
+    )
+    return [
+        _serialize_public_event(instance, enrollment_counts=enrollment_counts)
+        for instance in rows
+    ]
 
 
 def _resolve_primary_location(
@@ -113,6 +116,8 @@ def _resolve_primary_location(
 def _resolve_primary_price(
     instance: ServiceInstance,
 ) -> tuple[float | None, str | None]:
+    # Consultation is not returned by list_public_offerings; if serialized elsewhere,
+    # price/currency are intentionally omitted (no training_details / ticket path).
     service = instance.service
     if service.service_type == ServiceType.EVENT:
         if instance.ticket_tiers:
@@ -176,8 +181,9 @@ def _resolve_external_url(instance: ServiceInstance) -> str | None:
 
 
 def _serialize_public_event(
-    repository: ServiceInstanceRepository,
     instance: ServiceInstance,
+    *,
+    enrollment_counts: dict[UUID, int],
 ) -> dict[str, Any]:
     service = instance.service
     title = instance.title or service.title
@@ -264,7 +270,7 @@ def _serialize_public_event(
         payload["cohort"] = instance.cohort
 
     if instance.max_capacity is not None:
-        filled = repository.get_enrollment_count(instance.id)
+        filled = enrollment_counts.get(instance.id, 0)
         payload["spaces_total"] = instance.max_capacity
         payload["spaces_left"] = max(0, instance.max_capacity - filled)
 

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -197,10 +197,11 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         landing_page: str | None = None,
     ) -> list[ServiceInstance]:
         """List public calendar rows for published event and training services."""
-        if not service_types:
-            types_tuple = (ServiceType.EVENT, ServiceType.TRAINING_COURSE)
-        else:
-            types_tuple = tuple(sorted(service_types, key=lambda t: t.value))
+        types_tuple: tuple[ServiceType, ...] = (
+            (ServiceType.EVENT, ServiceType.TRAINING_COURSE)
+            if not service_types
+            else tuple(sorted(service_types, key=lambda t: t.value))
+        )
         earliest_upcoming_slot = (
             select(func.min(InstanceSessionSlot.starts_at))
             .where(InstanceSessionSlot.instance_id == ServiceInstance.id)

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -197,11 +197,10 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         landing_page: str | None = None,
     ) -> list[ServiceInstance]:
         """List public calendar rows for published event and training services."""
-        types = (
-            service_types
-            if service_types is not None
-            else {ServiceType.EVENT, ServiceType.TRAINING_COURSE}
-        )
+        if not service_types:
+            types_tuple = (ServiceType.EVENT, ServiceType.TRAINING_COURSE)
+        else:
+            types_tuple = tuple(sorted(service_types, key=lambda t: t.value))
         earliest_upcoming_slot = (
             select(func.min(InstanceSessionSlot.starts_at))
             .where(InstanceSessionSlot.instance_id == ServiceInstance.id)
@@ -212,7 +211,7 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         statement = (
             select(ServiceInstance)
             .join(Service, ServiceInstance.service_id == Service.id)
-            .where(Service.service_type.in_(types))
+            .where(Service.service_type.in_(types_tuple))
             .where(Service.status == ServiceStatus.PUBLISHED)
             .where(ServiceInstance.status != InstanceStatus.CANCELLED)
             .where(
@@ -338,6 +337,21 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         )
         count = self._session.execute(statement).scalar_one_or_none()
         return int(count or 0)
+
+    def get_enrollment_counts_for_instances(
+        self, instance_ids: list[UUID]
+    ) -> dict[UUID, int]:
+        """Return capacity enrollment counts keyed by instance (one query)."""
+        if not instance_ids:
+            return {}
+        statement = (
+            select(Enrollment.instance_id, func.count(Enrollment.id))
+            .where(Enrollment.instance_id.in_(instance_ids))
+            .where(Enrollment.status.in_(CAPACITY_ENROLLMENT_STATUSES))
+            .group_by(Enrollment.instance_id)
+        )
+        rows = self._session.execute(statement).all()
+        return {row[0]: int(row[1]) for row in rows}
 
     def get_waitlist_count(self, instance_id: UUID) -> int:
         """Return waitlist count for an instance."""

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -188,17 +188,31 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         )
         return self._session.execute(statement).scalar_one_or_none()
 
-    def list_event_instances_for_public_feed(
+    def list_public_offerings(
         self,
         *,
         limit: int,
         now: datetime,
+        service_types: set[ServiceType] | None = None,
+        landing_page: str | None = None,
     ) -> list[ServiceInstance]:
-        """List upcoming/past public event instances for calendar feed."""
+        """List public calendar rows for published event and training services."""
+        types = (
+            service_types
+            if service_types is not None
+            else {ServiceType.EVENT, ServiceType.TRAINING_COURSE}
+        )
+        earliest_upcoming_slot = (
+            select(func.min(InstanceSessionSlot.starts_at))
+            .where(InstanceSessionSlot.instance_id == ServiceInstance.id)
+            .where(InstanceSessionSlot.ends_at >= now - datetime.resolution)
+            .correlate(ServiceInstance)
+            .scalar_subquery()
+        )
         statement = (
             select(ServiceInstance)
             .join(Service, ServiceInstance.service_id == Service.id)
-            .where(Service.service_type == ServiceType.EVENT)
+            .where(Service.service_type.in_(types))
             .where(Service.status == ServiceStatus.PUBLISHED)
             .where(ServiceInstance.status != InstanceStatus.CANCELLED)
             .where(
@@ -218,15 +232,43 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                 )
             )
             .options(
-                selectinload(ServiceInstance.session_slots),
-                selectinload(ServiceInstance.ticket_tiers),
+                selectinload(ServiceInstance.session_slots).joinedload(
+                    InstanceSessionSlot.location
+                ),
                 joinedload(ServiceInstance.location),
-                joinedload(ServiceInstance.service),
+                selectinload(ServiceInstance.ticket_tiers),
+                joinedload(ServiceInstance.training_details),
+                joinedload(ServiceInstance.service).joinedload(Service.event_details),
+                selectinload(ServiceInstance.instance_tags).joinedload(
+                    ServiceInstanceTag.tag
+                ),
+                selectinload(ServiceInstance.partner_organization_links).joinedload(
+                    ServiceInstancePartnerOrganization.organization
+                ),
             )
-            .order_by(ServiceInstance.created_at.desc(), ServiceInstance.id.desc())
+            .order_by(earliest_upcoming_slot.asc(), ServiceInstance.id.asc())
             .limit(limit)
         )
+        if landing_page:
+            statement = statement.where(ServiceInstance.landing_page == landing_page)
         return list(self._session.execute(statement).unique().scalars().all())
+
+    def list_event_instances_for_public_feed(
+        self,
+        *,
+        limit: int,
+        now: datetime,
+    ) -> list[ServiceInstance]:
+        """List upcoming/past public event instances for calendar feed.
+
+        .. deprecated::
+            Use :meth:`list_public_offerings` with ``service_types={ServiceType.EVENT}``.
+        """
+        return self.list_public_offerings(
+            limit=limit,
+            now=now,
+            service_types={ServiceType.EVENT},
+        )
 
     def list_instances_pending_eventbrite_sync(
         self, *, limit: int

--- a/backend/src/app/utils/maps.py
+++ b/backend/src/app/utils/maps.py
@@ -1,0 +1,41 @@
+"""Derive Google Maps directions URLs from venue data."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from urllib.parse import quote_plus
+
+_BASE = "https://www.google.com/maps/dir/?api=1&destination="
+
+
+def _format_coord_component(value: Decimal) -> str:
+    quantized = value.quantize(Decimal("0.000001"))
+    text = format(quantized, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text
+
+
+def build_google_maps_directions_url(
+    *,
+    address: str | None,
+    lat: Decimal | None,
+    lng: Decimal | None,
+) -> str | None:
+    """Return a Google Maps directions URL or None.
+
+    Preference order:
+    1. Coordinates when both lat and lng are present (precise pin).
+    2. Non-empty address encoded with quote_plus (matches existing JSON format).
+    3. None when nothing usable is available.
+    """
+    if lat is not None and lng is not None:
+        pair = f"{_format_coord_component(lat)},{_format_coord_component(lng)}"
+        return f"{_BASE}{quote_plus(pair)}"
+
+    if address is not None:
+        stripped = address.strip()
+        if stripped:
+            return f"{_BASE}{quote_plus(stripped)}"
+
+    return None

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -243,11 +243,34 @@ paths:
     get:
       summary: List public calendar events
       description: |
-        Event feed for public consumers (direct API).
+        Calendar feed for public consumers (direct API).
         Source of truth is the backend `service_instances` projection for
-        `service_type=event` services.
+        published `event` and `training_course` services (consultation is never
+        included). Results are ordered by the earliest upcoming session slot,
+        then `service_instances.id` for a stable tie-break.
       security:
         - ApiKeyAuth: []
+      parameters:
+        - name: service_type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [event, training_course]
+          description: >
+            Restrict feed to one service type. Omitted = both event and
+            training_course are returned. Consultation is never exposed.
+        - name: landing_page
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 255
+            pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          description: >
+            Filter results to at most one instance whose
+            `service_instances.landing_page` matches the provided slug.
+            Invalid or empty values are silently ignored.
       responses:
         "200":
           description: Event list response.
@@ -268,9 +291,32 @@ paths:
       description: |
         Same as `GET /v1/calendar/public` for same-origin calls from `public_www`.
         Source of truth is the backend `service_instances` projection for
-        `service_type=event` services.
+        published `event` and `training_course` services (consultation is never
+        included). Results are ordered by the earliest upcoming session slot,
+        then `service_instances.id` for a stable tie-break.
       security:
         - ApiKeyAuth: []
+      parameters:
+        - name: service_type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [event, training_course]
+          description: >
+            Restrict feed to one service type. Omitted = both event and
+            training_course are returned. Consultation is never exposed.
+        - name: landing_page
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 255
+            pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          description: >
+            Filter results to at most one instance whose
+            `service_instances.landing_page` matches the provided slug.
+            Invalid or empty values are silently ignored.
       responses:
         "200":
           description: Event list response.
@@ -848,15 +894,31 @@ components:
       type: object
       required:
         - id
+        - service_instance_id
+        - service_type
         - title
         - status
         - booking_status
-        - booking_system
+        - is_fully_booked
         - location
+        - location_url
         - dates
+        - tags
+        - categories
+        - partners
       properties:
         id:
           type: string
+          description: >
+            Public slug when `service_instances.slug` is set, otherwise the
+            instance UUID as string.
+        service_instance_id:
+          type: string
+          format: uuid
+          description: Aurora `service_instances.id`. Stable even when the `id` alias changes.
+        service_type:
+          type: string
+          enum: [event, training_course]
         title:
           type: string
         summary:
@@ -871,8 +933,17 @@ components:
         booking_status:
           type: string
           enum: [open, fully_booked]
+        is_fully_booked:
+          type: boolean
+          description: Mirrors `booking_status == "fully_booked"`.
         booking_system:
           type: string
+          nullable: true
+          description: >
+            Resolved booking-system key. Derived from `services.booking_system` when
+            set; otherwise defaults to `event-booking` for events and
+            `my-best-auntie-booking` for the My Best Auntie training course service.
+            Omitted when no default applies.
         location:
           type: string
           enum: [virtual, physical]
@@ -884,9 +955,17 @@ components:
           nullable: true
         location_url:
           type: string
+          description: >
+            Google Maps directions URL derived server-side from venue coordinates
+            when available, otherwise from the URL-encoded address. Empty string
+            for virtual offerings or when no location metadata is on file.
         external_url:
           type: string
           nullable: true
+          description: >
+            Optional external registration URL. Uses
+            `service_instances.external_url` when set, falling back to
+            `service_instances.eventbrite_event_url` for backward compatibility.
         price:
           type: number
           nullable: true
@@ -897,14 +976,33 @@ components:
           type: array
           items:
             type: string
+          description: >
+            Alphabetically ordered display tag names from
+            `service_instance_tags`. Does not include service-level CRM tags.
         categories:
           type: array
           items:
             type: string
+          description: >
+            Single-element for events (derived from `event_details.event_category`)
+            or `["Training Course"]` for training courses.
+        partners:
+          type: array
+          items:
+            type: string
+          description: >
+            Partner organization slugs linked via
+            `service_instance_organizations`, ordered by `sort_order`.
         slug:
           type: string
           nullable: true
         landing_page:
+          type: string
+          nullable: true
+        age_group:
+          type: string
+          nullable: true
+        cohort:
           type: string
           nullable: true
         spaces_total:
@@ -924,6 +1022,13 @@ components:
       properties:
         events:
           type: array
+          items:
+            $ref: "#/components/schemas/PublicCalendarEvent"
+        items:
+          type: array
+          deprecated: true
+          description: >
+            Deprecated alias of `events` for older clients. Prefer `events`.
           items:
             $ref: "#/components/schemas/PublicCalendarEvent"
     DiscountValidationRequest:

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -938,12 +938,11 @@ components:
           description: Mirrors `booking_status == "fully_booked"`.
         booking_system:
           type: string
-          nullable: true
           description: >
             Resolved booking-system key. Derived from `services.booking_system` when
             set; otherwise defaults to `event-booking` for events and
             `my-best-auntie-booking` for the My Best Auntie training course service.
-            Omitted when no default applies.
+            Omitted from the JSON object when no default applies (not `null`).
         location:
           type: string
           enum: [virtual, physical]
@@ -985,7 +984,8 @@ components:
             type: string
           description: >
             Single-element for events (derived from `event_details.event_category`)
-            or `["Training Course"]` for training courses.
+            or `["Training Course"]` for training courses. May be an empty array for
+            events when `event_details` has not been set (unexpected in normal data).
         partners:
           type: array
           items:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -33,7 +33,8 @@ their primary responsibilities.
 - Trigger: API Gateway — currently wired for
   `/v1/assets/free/request`, `/v1/reservations`,
   `/v1/reservations/payment-intent`,
-  `/v1/calendar/public`,
+  `/v1/calendar/public` (same public calendar feed and contract as
+  `/www/v1/calendar/public`; see that entry below for payload, ordering, and query filters),
   `/v1/discounts/validate`,
   `/v1/contact-us`,
   `/v1/admin/geographic-areas`,

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -101,10 +101,19 @@ their primary responsibilities.
   `Public discount validate rejected` entry with `rejection_reason`, `code_hash`,
   and `code_prefix`—never the full code),
   `/www/v1/contact-us`, `/www/v1/reservations`,
-  `/www/v1/calendar/public` (event instances include optional `slug` and
-  `landing_page` from `service_instances`, and `spaces_total` / `spaces_left`
-  when `max_capacity` is set, using the same enrollment statuses as capacity
-  checks: registered, confirmed, completed),
+  `/www/v1/calendar/public` (public calendar feed: returns **event** and
+  **training_course** `service_instances` for published services; consultation
+  is intentionally excluded. Each item includes `service_type`,
+  `service_instance_id`, `partners`, optional `age_group` / `cohort`,
+  `is_fully_booked`, and a server-derived `location_url`. `booking_system` comes
+  from `services.booking_system` or defaults from service type (MBA training
+  cohorts default to `my-best-auntie-booking` when `services.slug` is
+  `my-best-auntie`). Results order by earliest upcoming session slot ascending
+  with `service_instances.id` as tie-break. Optional query filters:
+  `landing_page`, `service_type`. Optional `slug` and `landing_page` echo from
+  `service_instances`; `spaces_total` / `spaces_left` when `max_capacity` is set,
+  using the same enrollment statuses as capacity checks: registered, confirmed,
+  completed),
   `/www/v1/assets/free` (lists public assets tagged `client_document`;
   optional `language` query filters on `assets.content_language` using any valid
   BCP 47-style tag; admin asset writes restrict `content_language` to `en`,

--- a/tests/test_maps_helper.py
+++ b/tests/test_maps_helper.py
@@ -1,0 +1,63 @@
+"""Tests for Google Maps directions URL helper."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from urllib.parse import quote_plus
+
+from app.utils.maps import _BASE, build_google_maps_directions_url
+
+
+def test_coord_preferred_over_address() -> None:
+    url = build_google_maps_directions_url(
+        address="123 Main St",
+        lat=Decimal("22.319300"),
+        lng=Decimal("114.169400"),
+    )
+    assert url is not None
+    assert url.startswith(_BASE)
+    assert "22.3193%2C114.1694" in url
+
+
+def test_coord_strips_trailing_zeros() -> None:
+    url = build_google_maps_directions_url(
+        address=None,
+        lat=Decimal("1.000000"),
+        lng=Decimal("2.000000"),
+    )
+    assert url == f"{_BASE}{quote_plus('1,2')}"
+
+
+def test_partial_coords_falls_back_to_address() -> None:
+    url = build_google_maps_directions_url(
+        address="Foo Bar",
+        lat=Decimal("1"),
+        lng=None,
+    )
+    assert url == f"{_BASE}{quote_plus('Foo Bar')}"
+
+
+def test_address_apostrophe_and_space_byte_shape() -> None:
+    addr = "Queen's Rd Central"
+    url = build_google_maps_directions_url(address=addr, lat=None, lng=None)
+    assert url == f"{_BASE}{quote_plus(addr)}"
+
+
+def test_empty_address_no_coords_returns_none() -> None:
+    assert build_google_maps_directions_url(address="   ", lat=None, lng=None) is None
+    assert build_google_maps_directions_url(address=None, lat=None, lng=None) is None
+
+
+def test_high_precision_decimal_quantized_to_six_places() -> None:
+    url = build_google_maps_directions_url(
+        address=None,
+        lat=Decimal("1.234567891234"),
+        lng=Decimal("5"),
+    )
+    assert url == f"{_BASE}{quote_plus('1.234568,5')}"
+
+
+def test_unicode_address_uses_quote_plus() -> None:
+    addr = "中環"
+    url = build_google_maps_directions_url(address=addr, lat=None, lng=None)
+    assert url == f"{_BASE}{quote_plus(addr)}"

--- a/tests/test_public_events_api.py
+++ b/tests/test_public_events_api.py
@@ -111,14 +111,15 @@ def test_handle_public_events_returns_items(monkeypatch: Any, api_gateway_event:
             assert limit == 100
             assert isinstance(now, datetime)
             assert landing_page is None
-            assert service_types == {ServiceType.EVENT, ServiceType.TRAINING_COURSE}
+            assert service_types is None
             return [
                 _instance_row(status=public_events.InstanceStatus.OPEN, with_eventbrite_url=True),
                 _instance_row(status=public_events.InstanceStatus.FULL),
             ]
 
-        def get_enrollment_count(self, instance_id: Any) -> int:
-            return 1
+        def get_enrollment_counts_for_instances(self, instance_ids: list[Any]) -> dict[Any, int]:
+            assert len(instance_ids) == 2
+            return {iid: 1 for iid in instance_ids}
 
     monkeypatch.setattr(public_events, "Session", _SessionCtx)
     monkeypatch.setattr(public_events, "get_engine", lambda: object())
@@ -176,8 +177,9 @@ def test_handle_public_events_landing_page_filter(
             captured["service_types"] = service_types
             return [_instance_row(status=public_events.InstanceStatus.OPEN)]
 
-        def get_enrollment_count(self, _instance_id: Any) -> int:
-            return 0
+        def get_enrollment_counts_for_instances(self, instance_ids: list[Any]) -> dict[Any, int]:
+            assert len(instance_ids) == 1
+            return {instance_ids[0]: 0}
 
     monkeypatch.setattr(public_events, "Session", _SessionCtx)
     monkeypatch.setattr(public_events, "get_engine", lambda: object())
@@ -231,8 +233,8 @@ def test_handle_public_events_invalid_landing_page_ignored(
             captured["landing_page"] = landing_page
             return []
 
-        def get_enrollment_count(self, _instance_id: Any) -> int:
-            return 0
+        def get_enrollment_counts_for_instances(self, _instance_ids: list[Any]) -> dict[Any, int]:
+            return {}
 
     monkeypatch.setattr(public_events, "Session", _SessionCtx)
     monkeypatch.setattr(public_events, "get_engine", lambda: object())
@@ -281,8 +283,8 @@ def test_handle_public_events_service_type_training_course(
             captured["service_types"] = service_types
             return []
 
-        def get_enrollment_count(self, _instance_id: Any) -> int:
-            return 0
+        def get_enrollment_counts_for_instances(self, _instance_ids: list[Any]) -> dict[Any, int]:
+            return {}
 
     monkeypatch.setattr(public_events, "Session", _SessionCtx)
     monkeypatch.setattr(public_events, "get_engine", lambda: object())
@@ -331,8 +333,8 @@ def test_handle_public_events_invalid_service_type_defaults(
             captured["service_types"] = service_types
             return []
 
-        def get_enrollment_count(self, _instance_id: Any) -> int:
-            return 0
+        def get_enrollment_counts_for_instances(self, _instance_ids: list[Any]) -> dict[Any, int]:
+            return {}
 
     monkeypatch.setattr(public_events, "Session", _SessionCtx)
     monkeypatch.setattr(public_events, "get_engine", lambda: object())
@@ -345,7 +347,4 @@ def test_handle_public_events_invalid_service_type_defaults(
         ),
         "GET",
     )
-    assert captured["service_types"] == {
-        ServiceType.EVENT,
-        ServiceType.TRAINING_COURSE,
-    }
+    assert captured["service_types"] is None

--- a/tests/test_public_events_api.py
+++ b/tests/test_public_events_api.py
@@ -22,11 +22,15 @@ def _instance_row(
 ) -> Any:
     starts = datetime(2026, 4, 20, 18, 0, tzinfo=UTC)
     ends = datetime(2026, 4, 20, 20, 0, tzinfo=UTC)
-    location = SimpleNamespace(name="Central Studio", address="123 Main St")
+    location = SimpleNamespace(
+        name="Central Studio", address="123 Main St", lat=None, lng=None
+    )
     service = SimpleNamespace(
         title="Parent Service",
         description="Parent description",
         service_type=ServiceType.EVENT,
+        slug=None,
+        booking_system=None,
         event_details=SimpleNamespace(event_category=SimpleNamespace(value="workshop")),
         delivery_mode=SimpleNamespace(value=delivery_mode_value),
     )
@@ -61,6 +65,11 @@ def _instance_row(
         eventbrite_event_url="https://www.eventbrite.com/e/demo"
         if with_eventbrite_url
         else None,
+        external_url=None,
+        age_group=None,
+        cohort=None,
+        instance_tags=[],
+        partner_organization_links=[],
         delivery_mode=SimpleNamespace(value=delivery_mode_value),
     )
 
@@ -91,9 +100,18 @@ def test_handle_public_events_returns_items(monkeypatch: Any, api_gateway_event:
         def __init__(self, _session: Any) -> None:
             pass
 
-        def list_event_instances_for_public_feed(self, *, limit: int, now: datetime) -> list[Any]:
+        def list_public_offerings(
+            self,
+            *,
+            limit: int,
+            now: datetime,
+            service_types: Any,
+            landing_page: str | None,
+        ) -> list[Any]:
             assert limit == 100
             assert isinstance(now, datetime)
+            assert landing_page is None
+            assert service_types == {ServiceType.EVENT, ServiceType.TRAINING_COURSE}
             return [
                 _instance_row(status=public_events.InstanceStatus.OPEN, with_eventbrite_url=True),
                 _instance_row(status=public_events.InstanceStatus.FULL),
@@ -120,3 +138,214 @@ def test_handle_public_events_returns_items(monkeypatch: Any, api_gateway_event:
     assert body["items"][0]["spaces_total"] == 10
     assert body["items"][0]["spaces_left"] == 9
     assert body["items"][1]["booking_status"] == "fully_booked"
+    assert body["items"][0]["service_type"] == "event"
+    assert "service_instance_id" in body["items"][0]
+
+
+def test_handle_public_events_landing_page_filter(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_public_offerings(
+            self,
+            *,
+            limit: int,
+            now: datetime,
+            service_types: Any,
+            landing_page: str | None,
+        ) -> list[Any]:
+            captured["landing_page"] = landing_page
+            captured["service_types"] = service_types
+            return [_instance_row(status=public_events.InstanceStatus.OPEN)]
+
+        def get_enrollment_count(self, _instance_id: Any) -> int:
+            return 0
+
+    monkeypatch.setattr(public_events, "Session", _SessionCtx)
+    monkeypatch.setattr(public_events, "get_engine", lambda: object())
+    monkeypatch.setattr(public_events, "ServiceInstanceRepository", _FakeRepository)
+
+    slug = "may-2026-the-missing-piece"
+    response = public_events.handle_public_events(
+        api_gateway_event(
+            method="GET",
+            path="/v1/calendar/public",
+            query_params={"landing_page": slug},
+        ),
+        "GET",
+    )
+    assert response["statusCode"] == 200
+    assert captured["landing_page"] == slug
+    body = json.loads(response["body"])
+    assert len(body["events"]) == 1
+
+
+def test_handle_public_events_invalid_landing_page_ignored(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_public_offerings(
+            self,
+            *,
+            limit: int,
+            now: datetime,
+            service_types: Any,
+            landing_page: str | None,
+        ) -> list[Any]:
+            captured["landing_page"] = landing_page
+            return []
+
+        def get_enrollment_count(self, _instance_id: Any) -> int:
+            return 0
+
+    monkeypatch.setattr(public_events, "Session", _SessionCtx)
+    monkeypatch.setattr(public_events, "get_engine", lambda: object())
+    monkeypatch.setattr(public_events, "ServiceInstanceRepository", _FakeRepository)
+
+    public_events.handle_public_events(
+        api_gateway_event(
+            method="GET",
+            query_params={"landing_page": "Invalid.Slug"},
+        ),
+        "GET",
+    )
+    assert captured["landing_page"] is None
+
+
+def test_handle_public_events_service_type_training_course(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_public_offerings(
+            self,
+            *,
+            limit: int,
+            now: datetime,
+            service_types: Any,
+            landing_page: str | None,
+        ) -> list[Any]:
+            captured["service_types"] = service_types
+            return []
+
+        def get_enrollment_count(self, _instance_id: Any) -> int:
+            return 0
+
+    monkeypatch.setattr(public_events, "Session", _SessionCtx)
+    monkeypatch.setattr(public_events, "get_engine", lambda: object())
+    monkeypatch.setattr(public_events, "ServiceInstanceRepository", _FakeRepository)
+
+    public_events.handle_public_events(
+        api_gateway_event(
+            method="GET",
+            query_params={"service_type": "training_course"},
+        ),
+        "GET",
+    )
+    assert captured["service_types"] == {ServiceType.TRAINING_COURSE}
+
+
+def test_handle_public_events_invalid_service_type_defaults(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_public_offerings(
+            self,
+            *,
+            limit: int,
+            now: datetime,
+            service_types: Any,
+            landing_page: str | None,
+        ) -> list[Any]:
+            captured["service_types"] = service_types
+            return []
+
+        def get_enrollment_count(self, _instance_id: Any) -> int:
+            return 0
+
+    monkeypatch.setattr(public_events, "Session", _SessionCtx)
+    monkeypatch.setattr(public_events, "get_engine", lambda: object())
+    monkeypatch.setattr(public_events, "ServiceInstanceRepository", _FakeRepository)
+
+    public_events.handle_public_events(
+        api_gateway_event(
+            method="GET",
+            query_params={"service_type": "consultation"},
+        ),
+        "GET",
+    )
+    assert captured["service_types"] == {
+        ServiceType.EVENT,
+        ServiceType.TRAINING_COURSE,
+    }

--- a/tests/test_public_events_repository.py
+++ b/tests/test_public_events_repository.py
@@ -1,0 +1,116 @@
+"""Tests for public calendar repository query (list_public_offerings)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from sqlalchemy.dialects import postgresql
+
+from app.db.models.enums import ServiceType
+from app.db.repositories.service_instance import ServiceInstanceRepository
+
+
+def _compiled_sql(stmt: object) -> str:
+    return str(
+        stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+    )
+
+
+def test_list_public_offerings_default_types_and_ordering_sql() -> None:
+    mock_session = MagicMock()
+    exec_result = MagicMock()
+    exec_result.unique.return_value.scalars.return_value.all.return_value = []
+    mock_session.execute.return_value = exec_result
+
+    repo = ServiceInstanceRepository(mock_session)
+    now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    repo.list_public_offerings(limit=50, now=now)
+
+    stmt = mock_session.execute.call_args[0][0]
+    sql = _compiled_sql(stmt)
+
+    assert "services.service_type IN" in sql
+    assert "'event'" in sql
+    assert "'training_course'" in sql
+    assert "services.status = 'published'" in sql
+    assert "service_instances.status != 'cancelled'" in sql
+    assert "service_instances.status IN" in sql
+    assert "min(instance_session_slots.starts_at)" in sql.lower()
+    assert "instance_session_slots.ends_at >=" in sql
+    assert "ORDER BY" in sql.upper()
+    assert "service_instances.id ASC" in sql
+
+
+def test_list_public_offerings_service_type_event_only() -> None:
+    mock_session = MagicMock()
+    exec_result = MagicMock()
+    exec_result.unique.return_value.scalars.return_value.all.return_value = []
+    mock_session.execute.return_value = exec_result
+
+    repo = ServiceInstanceRepository(mock_session)
+    now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    repo.list_public_offerings(
+        limit=10,
+        now=now,
+        service_types={ServiceType.EVENT},
+    )
+    stmt = mock_session.execute.call_args[0][0]
+    sql = _compiled_sql(stmt)
+    assert "services.service_type IN ('event')" in sql
+
+
+def test_list_public_offerings_landing_page_filter() -> None:
+    mock_session = MagicMock()
+    exec_result = MagicMock()
+    exec_result.unique.return_value.scalars.return_value.all.return_value = []
+    mock_session.execute.return_value = exec_result
+
+    repo = ServiceInstanceRepository(mock_session)
+    now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    slug = "may-2026-the-missing-piece"
+    repo.list_public_offerings(limit=5, now=now, landing_page=slug)
+
+    stmt = mock_session.execute.call_args[0][0]
+    sql = _compiled_sql(stmt)
+    assert f"service_instances.landing_page = '{slug}'" in sql
+
+
+def test_list_event_instances_for_public_feed_wraps_list_public_offerings() -> None:
+    mock_session = MagicMock()
+    exec_result = MagicMock()
+    exec_result.unique.return_value.scalars.return_value.all.return_value = []
+    mock_session.execute.return_value = exec_result
+
+    repo = ServiceInstanceRepository(mock_session)
+    now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    repo.list_event_instances_for_public_feed(limit=7, now=now)
+
+    stmt = mock_session.execute.call_args[0][0]
+    sql = _compiled_sql(stmt)
+    assert "'event'" in sql
+    assert "'training_course'" not in sql
+
+
+def test_list_public_offerings_eager_load_paths() -> None:
+    mock_session = MagicMock()
+    exec_result = MagicMock()
+    exec_result.unique.return_value.scalars.return_value.all.return_value = []
+    mock_session.execute.return_value = exec_result
+
+    repo = ServiceInstanceRepository(mock_session)
+    now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    repo.list_public_offerings(limit=1, now=now)
+
+    stmt = mock_session.execute.call_args[0][0]
+    path_text = " ".join(str(opt.path) for opt in stmt._with_options)
+    assert "ServiceInstance.session_slots" in path_text
+    assert "InstanceSessionSlot.location" in path_text
+    assert "ServiceInstance.location" in path_text
+    assert "ServiceInstance.ticket_tiers" in path_text
+    assert "ServiceInstance.training_details" in path_text
+    assert "Service.event_details" in path_text
+    assert "ServiceInstance.instance_tags" in path_text
+    assert "ServiceInstanceTag.tag" in path_text
+    assert "ServiceInstance.partner_organization_links" in path_text
+    assert "ServiceInstancePartnerOrganization.organization" in path_text

--- a/tests/test_public_events_repository.py
+++ b/tests/test_public_events_repository.py
@@ -30,9 +30,7 @@ def test_list_public_offerings_default_types_and_ordering_sql() -> None:
     stmt = mock_session.execute.call_args[0][0]
     sql = _compiled_sql(stmt)
 
-    assert "services.service_type IN" in sql
-    assert "'event'" in sql
-    assert "'training_course'" in sql
+    assert "services.service_type IN ('event', 'training_course')" in sql
     assert "services.status = 'published'" in sql
     assert "service_instances.status != 'cancelled'" in sql
     assert "service_instances.status IN" in sql
@@ -92,7 +90,7 @@ def test_list_event_instances_for_public_feed_wraps_list_public_offerings() -> N
     assert "'training_course'" not in sql
 
 
-def test_list_public_offerings_eager_load_paths() -> None:
+def test_list_public_offerings_empty_service_types_uses_default_in_order() -> None:
     mock_session = MagicMock()
     exec_result = MagicMock()
     exec_result.unique.return_value.scalars.return_value.all.return_value = []
@@ -100,17 +98,33 @@ def test_list_public_offerings_eager_load_paths() -> None:
 
     repo = ServiceInstanceRepository(mock_session)
     now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
-    repo.list_public_offerings(limit=1, now=now)
+    repo.list_public_offerings(limit=1, now=now, service_types=set())
 
     stmt = mock_session.execute.call_args[0][0]
-    path_text = " ".join(str(opt.path) for opt in stmt._with_options)
-    assert "ServiceInstance.session_slots" in path_text
-    assert "InstanceSessionSlot.location" in path_text
-    assert "ServiceInstance.location" in path_text
-    assert "ServiceInstance.ticket_tiers" in path_text
-    assert "ServiceInstance.training_details" in path_text
-    assert "Service.event_details" in path_text
-    assert "ServiceInstance.instance_tags" in path_text
-    assert "ServiceInstanceTag.tag" in path_text
-    assert "ServiceInstance.partner_organization_links" in path_text
-    assert "ServiceInstancePartnerOrganization.organization" in path_text
+    sql = _compiled_sql(stmt)
+    assert "services.service_type IN ('event', 'training_course')" in sql
+
+
+def test_get_enrollment_counts_for_instances_empty_returns_empty() -> None:
+    mock_session = MagicMock()
+    repo = ServiceInstanceRepository(mock_session)
+    assert repo.get_enrollment_counts_for_instances([]) == {}
+    mock_session.execute.assert_not_called()
+
+
+def test_get_enrollment_counts_for_instances_groups_by_instance() -> None:
+    from uuid import UUID
+
+    mock_session = MagicMock()
+    row_a = (UUID(int=1), 3)
+    row_b = (UUID(int=2), 1)
+    mock_session.execute.return_value.all.return_value = [row_a, row_b]
+
+    repo = ServiceInstanceRepository(mock_session)
+    counts = repo.get_enrollment_counts_for_instances([UUID(int=1), UUID(int=2)])
+
+    assert counts == {UUID(int=1): 3, UUID(int=2): 1}
+    stmt = mock_session.execute.call_args[0][0]
+    sql = _compiled_sql(stmt)
+    assert "GROUP BY" in sql.upper()
+    assert "enrollments.instance_id" in sql

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -1,0 +1,406 @@
+"""Unit tests for public calendar event serialization."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID, uuid4
+
+from app.api import public_events
+from app.db.models.enums import InstanceStatus, ServiceType
+
+
+def _tag_link(name: str) -> Any:
+    return SimpleNamespace(tag=SimpleNamespace(name=name))
+
+
+def _partner_link(slug: str, sort_order: int, org_id: UUID | None = None) -> Any:
+    oid = org_id or uuid4()
+    return SimpleNamespace(
+        sort_order=sort_order,
+        organization_id=oid,
+        organization=SimpleNamespace(slug=slug),
+    )
+
+
+def _repo() -> Any:
+    class _R:
+        def get_enrollment_count(self, _instance_id: UUID) -> int:
+            return 2
+
+    return _R()
+
+
+def test_event_ticket_tier_price_and_booking_system_default() -> None:
+    service = SimpleNamespace(
+        title="Svc",
+        description="Desc",
+        service_type=ServiceType.EVENT,
+        slug=None,
+        booking_system=None,
+        event_details=SimpleNamespace(
+            event_category=SimpleNamespace(value="workshop"),
+            default_price=Decimal("99"),
+            default_currency="HKD",
+        ),
+        delivery_mode=SimpleNamespace(value="in_person"),
+    )
+    starts = datetime(2026, 5, 1, 10, 0, tzinfo=UTC)
+    ends = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    loc = SimpleNamespace(name="Venue", address="1 Rd", lat=None, lng=None)
+    inst = SimpleNamespace(
+        id=uuid4(),
+        slug="my-event",
+        landing_page=None,
+        title=None,
+        description=None,
+        status=InstanceStatus.OPEN,
+        max_capacity=None,
+        external_url=None,
+        eventbrite_event_url=None,
+        age_group=None,
+        cohort=None,
+        delivery_mode=None,
+        service=service,
+        session_slots=[
+            SimpleNamespace(
+                id=uuid4(),
+                sort_order=0,
+                starts_at=starts,
+                ends_at=ends,
+                location=loc,
+            )
+        ],
+        location=loc,
+        ticket_tiers=[
+            SimpleNamespace(
+                id=uuid4(),
+                sort_order=0,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                price=Decimal("250.00"),
+                currency="HKD",
+            )
+        ],
+        instance_tags=[],
+        partner_organization_links=[],
+    )
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["id"] == "my-event"
+    assert out["service_instance_id"] == str(inst.id)
+    assert out["service_type"] == "event"
+    assert out["booking_system"] == "event-booking"
+    assert out["categories"] == ["workshop"]
+    assert out["price"] == 250.0
+    assert out["currency"] == "HKD"
+    assert out["tags"] == []
+    assert out["partners"] == []
+    assert out["is_fully_booked"] is False
+
+
+def test_event_default_price_when_no_tiers() -> None:
+    service = SimpleNamespace(
+        title="Svc",
+        description="Desc",
+        service_type=ServiceType.EVENT,
+        slug="x",
+        booking_system=None,
+        event_details=SimpleNamespace(
+            event_category=SimpleNamespace(value="seminar"),
+            default_price=Decimal("10.50"),
+            default_currency="USD",
+        ),
+        delivery_mode=SimpleNamespace(value="in_person"),
+    )
+    inst = _minimal_instance(service, ticket_tiers=[])
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["price"] == 10.5
+    assert out["currency"] == "USD"
+    assert "booking_system" in out
+
+
+def test_event_no_price_when_no_tiers_and_no_default() -> None:
+    service = SimpleNamespace(
+        title="Svc",
+        description="Desc",
+        service_type=ServiceType.EVENT,
+        slug="x",
+        booking_system=None,
+        event_details=SimpleNamespace(
+            event_category=SimpleNamespace(value="seminar"),
+            default_price=None,
+            default_currency="HKD",
+        ),
+        delivery_mode=SimpleNamespace(value="in_person"),
+    )
+    inst = _minimal_instance(service, ticket_tiers=[])
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert "price" not in out
+    assert "currency" not in out
+
+
+def test_external_url_precedence() -> None:
+    service = _event_service()
+    inst = _minimal_instance(
+        service,
+        external_url="https://example.com/new",
+        eventbrite_event_url="https://eventbrite.com/old",
+    )
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["external_url"] == "https://example.com/new"
+
+
+def test_external_url_eventbrite_only() -> None:
+    service = _event_service()
+    inst = _minimal_instance(
+        service,
+        external_url=None,
+        eventbrite_event_url="https://eventbrite.com/e/1",
+    )
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["external_url"] == "https://eventbrite.com/e/1"
+
+
+def test_instance_tags_sorted_case_insensitive() -> None:
+    service = _event_service()
+    inst = _minimal_instance(
+        service,
+        instance_tags=[
+            _tag_link("zebra"),
+            _tag_link("Alpha"),
+            _tag_link("beta"),
+        ],
+    )
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["tags"] == ["Alpha", "beta", "zebra"]
+
+
+def test_partners_follow_link_order() -> None:
+    service = _event_service()
+    inst = _minimal_instance(
+        service,
+        partner_organization_links=[
+            _partner_link("second", 1, uuid4()),
+            _partner_link("first", 0, uuid4()),
+        ],
+    )
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["partners"] == ["first", "second"]
+
+
+def test_training_mba_booking_and_category() -> None:
+    service = SimpleNamespace(
+        title="MBA",
+        description="Course",
+        service_type=ServiceType.TRAINING_COURSE,
+        slug="my-best-auntie",
+        booking_system=None,
+        event_details=None,
+        delivery_mode=SimpleNamespace(value="in_person"),
+    )
+    inst = _minimal_instance(
+        service,
+        age_group="0-1",
+        cohort="May 2026",
+        training_details=SimpleNamespace(price=Decimal("350"), currency="HKD"),
+    )
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["service_type"] == "training_course"
+    assert out["booking_system"] == "my-best-auntie-booking"
+    assert out["categories"] == ["Training Course"]
+    assert out["price"] == 350.0
+    assert out["currency"] == "HKD"
+    assert out["age_group"] == "0-1"
+    assert out["cohort"] == "May 2026"
+
+
+def test_training_non_mba_omits_booking_system() -> None:
+    service = SimpleNamespace(
+        title="Other",
+        description="Course",
+        service_type=ServiceType.TRAINING_COURSE,
+        slug="other-course",
+        booking_system=None,
+        event_details=None,
+        delivery_mode=SimpleNamespace(value="in_person"),
+    )
+    inst = _minimal_instance(
+        service,
+        training_details=SimpleNamespace(price=Decimal("1"), currency="HKD"),
+    )
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert "booking_system" not in out
+
+
+def test_virtual_clears_location_and_url_even_with_coords() -> None:
+    service = SimpleNamespace(
+        title="Svc",
+        description="D",
+        service_type=ServiceType.EVENT,
+        slug="e",
+        booking_system=None,
+        event_details=SimpleNamespace(
+            event_category=SimpleNamespace(value="workshop"),
+            default_price=None,
+            default_currency="HKD",
+        ),
+        delivery_mode=SimpleNamespace(value="online"),
+    )
+    loc = SimpleNamespace(name="X", address="Y", lat=Decimal("1"), lng=Decimal("2"))
+    inst = _minimal_instance(service, delivery_mode=SimpleNamespace(value="online"))
+    inst.session_slots[0].location = loc
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["location"] == "virtual"
+    assert out["location_name"] is None
+    assert out["location_address"] is None
+    assert out["location_url"] == ""
+
+
+def test_physical_coord_location_url() -> None:
+    service = _event_service()
+    loc = SimpleNamespace(name="V", address="A", lat=Decimal("22.3"), lng=Decimal("114.1"))
+    inst = _minimal_instance(service)
+    inst.session_slots[0].location = loc
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["location"] == "physical"
+    assert out["location_url"].startswith("https://www.google.com/maps/dir/")
+    assert "%2C" in out["location_url"]
+
+
+def test_physical_address_only_location_url() -> None:
+    from urllib.parse import quote_plus
+
+    from app.utils.maps import _BASE
+
+    service = _event_service()
+    addr = "Queen's Rd Central"
+    loc = SimpleNamespace(name="V", address=addr, lat=None, lng=None)
+    inst = _minimal_instance(service)
+    inst.session_slots[0].location = loc
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["location_url"] == f"{_BASE}{quote_plus(addr)}"
+
+
+def test_no_location_empty_url() -> None:
+    service = _event_service()
+    inst = _minimal_instance(service)
+    inst.session_slots[0].location = None
+    inst.location = None
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["location_url"] == ""
+
+
+def test_max_capacity_none_omits_spaces() -> None:
+    service = _event_service()
+    inst = _minimal_instance(service, max_capacity=None)
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert "spaces_total" not in out
+    assert "spaces_left" not in out
+
+
+def test_max_capacity_with_enrollments() -> None:
+    service = _event_service()
+    inst = _minimal_instance(service, max_capacity=8)
+
+    class _R:
+        def get_enrollment_count(self, _instance_id: UUID) -> int:
+            return 10
+
+    out = public_events._serialize_public_event(_R(), inst)
+    assert out["spaces_total"] == 8
+    assert out["spaces_left"] == 0
+
+
+def test_id_uuid_when_no_slug() -> None:
+    service = _event_service()
+    iid = uuid4()
+    inst = _minimal_instance(service, slug=None)
+    inst.id = iid
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["id"] == str(iid)
+    assert out["service_instance_id"] == str(iid)
+
+
+def test_fully_booked_flag() -> None:
+    service = _event_service()
+    inst = _minimal_instance(service, status=InstanceStatus.FULL)
+    out = public_events._serialize_public_event(_repo(), inst)
+    assert out["booking_status"] == "fully_booked"
+    assert out["is_fully_booked"] is True
+
+
+def _event_service() -> Any:
+    return SimpleNamespace(
+        title="Svc",
+        description="Desc",
+        service_type=ServiceType.EVENT,
+        slug="slug",
+        booking_system=None,
+        event_details=SimpleNamespace(
+            event_category=SimpleNamespace(value="workshop"),
+            default_price=None,
+            default_currency="HKD",
+        ),
+        delivery_mode=SimpleNamespace(value="in_person"),
+    )
+
+
+def _minimal_instance(
+    service: Any,
+    *,
+    status: InstanceStatus = InstanceStatus.OPEN,
+    slug: str | None = "slug",
+    ticket_tiers: list[Any] | None = None,
+    instance_tags: list[Any] | None = None,
+    partner_organization_links: list[Any] | None = None,
+    external_url: str | None = None,
+    eventbrite_event_url: str | None = None,
+    max_capacity: int | None = 10,
+    age_group: str | None = None,
+    cohort: str | None = None,
+    training_details: Any = None,
+    delivery_mode: Any = None,
+) -> Any:
+    starts = datetime(2026, 5, 1, 10, 0, tzinfo=UTC)
+    ends = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    loc = SimpleNamespace(name="V", address="1 St", lat=None, lng=None)
+    return SimpleNamespace(
+        id=uuid4(),
+        slug=slug,
+        landing_page=None,
+        title=None,
+        description=None,
+        status=status,
+        max_capacity=max_capacity,
+        external_url=external_url,
+        eventbrite_event_url=eventbrite_event_url,
+        age_group=age_group,
+        cohort=cohort,
+        delivery_mode=delivery_mode,
+        service=service,
+        session_slots=[
+            SimpleNamespace(
+                id=uuid4(),
+                sort_order=0,
+                starts_at=starts,
+                ends_at=ends,
+                location=loc,
+            )
+        ],
+        location=loc,
+        ticket_tiers=ticket_tiers
+        if ticket_tiers is not None
+        else [
+            SimpleNamespace(
+                id=uuid4(),
+                sort_order=0,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                price=Decimal("1"),
+                currency="HKD",
+            )
+        ],
+        training_details=training_details,
+        instance_tags=instance_tags or [],
+        partner_organization_links=partner_organization_links or [],
+    )

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -16,11 +16,9 @@ def _tag_link(name: str) -> Any:
     return SimpleNamespace(tag=SimpleNamespace(name=name))
 
 
-def _partner_link(slug: str, sort_order: int, org_id: UUID | None = None) -> Any:
-    oid = org_id or uuid4()
+def _partner_link(slug: str, sort_order: int) -> Any:
     return SimpleNamespace(
         sort_order=sort_order,
-        organization_id=oid,
         organization=SimpleNamespace(slug=slug),
     )
 
@@ -181,8 +179,8 @@ def test_partners_follow_link_order() -> None:
     inst = _minimal_instance(
         service,
         partner_organization_links=[
-            _partner_link("second", 1, uuid4()),
-            _partner_link("first", 0, uuid4()),
+            _partner_link("first", 0),
+            _partner_link("second", 1),
         ],
     )
     out = public_events._serialize_public_event(_repo(), inst)

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from app.api import public_events
 from app.db.models.enums import InstanceStatus, ServiceType
@@ -21,14 +21,6 @@ def _partner_link(slug: str, sort_order: int) -> Any:
         sort_order=sort_order,
         organization=SimpleNamespace(slug=slug),
     )
-
-
-def _repo() -> Any:
-    class _R:
-        def get_enrollment_count(self, _instance_id: UUID) -> int:
-            return 2
-
-    return _R()
 
 
 def test_event_ticket_tier_price_and_booking_system_default() -> None:
@@ -84,7 +76,7 @@ def test_event_ticket_tier_price_and_booking_system_default() -> None:
         instance_tags=[],
         partner_organization_links=[],
     )
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["id"] == "my-event"
     assert out["service_instance_id"] == str(inst.id)
     assert out["service_type"] == "event"
@@ -112,7 +104,7 @@ def test_event_default_price_when_no_tiers() -> None:
         delivery_mode=SimpleNamespace(value="in_person"),
     )
     inst = _minimal_instance(service, ticket_tiers=[])
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["price"] == 10.5
     assert out["currency"] == "USD"
     assert "booking_system" in out
@@ -133,7 +125,7 @@ def test_event_no_price_when_no_tiers_and_no_default() -> None:
         delivery_mode=SimpleNamespace(value="in_person"),
     )
     inst = _minimal_instance(service, ticket_tiers=[])
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert "price" not in out
     assert "currency" not in out
 
@@ -145,7 +137,7 @@ def test_external_url_precedence() -> None:
         external_url="https://example.com/new",
         eventbrite_event_url="https://eventbrite.com/old",
     )
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["external_url"] == "https://example.com/new"
 
 
@@ -156,7 +148,7 @@ def test_external_url_eventbrite_only() -> None:
         external_url=None,
         eventbrite_event_url="https://eventbrite.com/e/1",
     )
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["external_url"] == "https://eventbrite.com/e/1"
 
 
@@ -170,7 +162,7 @@ def test_instance_tags_sorted_case_insensitive() -> None:
             _tag_link("beta"),
         ],
     )
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["tags"] == ["Alpha", "beta", "zebra"]
 
 
@@ -183,7 +175,7 @@ def test_partners_follow_link_order() -> None:
             _partner_link("second", 1),
         ],
     )
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["partners"] == ["first", "second"]
 
 
@@ -203,7 +195,7 @@ def test_training_mba_booking_and_category() -> None:
         cohort="May 2026",
         training_details=SimpleNamespace(price=Decimal("350"), currency="HKD"),
     )
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["service_type"] == "training_course"
     assert out["booking_system"] == "my-best-auntie-booking"
     assert out["categories"] == ["Training Course"]
@@ -227,7 +219,7 @@ def test_training_non_mba_omits_booking_system() -> None:
         service,
         training_details=SimpleNamespace(price=Decimal("1"), currency="HKD"),
     )
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert "booking_system" not in out
 
 
@@ -248,7 +240,7 @@ def test_virtual_clears_location_and_url_even_with_coords() -> None:
     loc = SimpleNamespace(name="X", address="Y", lat=Decimal("1"), lng=Decimal("2"))
     inst = _minimal_instance(service, delivery_mode=SimpleNamespace(value="online"))
     inst.session_slots[0].location = loc
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["location"] == "virtual"
     assert out["location_name"] is None
     assert out["location_address"] is None
@@ -260,7 +252,7 @@ def test_physical_coord_location_url() -> None:
     loc = SimpleNamespace(name="V", address="A", lat=Decimal("22.3"), lng=Decimal("114.1"))
     inst = _minimal_instance(service)
     inst.session_slots[0].location = loc
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["location"] == "physical"
     assert out["location_url"].startswith("https://www.google.com/maps/dir/")
     assert "%2C" in out["location_url"]
@@ -276,7 +268,7 @@ def test_physical_address_only_location_url() -> None:
     loc = SimpleNamespace(name="V", address=addr, lat=None, lng=None)
     inst = _minimal_instance(service)
     inst.session_slots[0].location = loc
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["location_url"] == f"{_BASE}{quote_plus(addr)}"
 
 
@@ -285,14 +277,14 @@ def test_no_location_empty_url() -> None:
     inst = _minimal_instance(service)
     inst.session_slots[0].location = None
     inst.location = None
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["location_url"] == ""
 
 
 def test_max_capacity_none_omits_spaces() -> None:
     service = _event_service()
     inst = _minimal_instance(service, max_capacity=None)
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert "spaces_total" not in out
     assert "spaces_left" not in out
 
@@ -300,12 +292,9 @@ def test_max_capacity_none_omits_spaces() -> None:
 def test_max_capacity_with_enrollments() -> None:
     service = _event_service()
     inst = _minimal_instance(service, max_capacity=8)
-
-    class _R:
-        def get_enrollment_count(self, _instance_id: UUID) -> int:
-            return 10
-
-    out = public_events._serialize_public_event(_R(), inst)
+    out = public_events._serialize_public_event(
+        inst, enrollment_counts={inst.id: 10}
+    )
     assert out["spaces_total"] == 8
     assert out["spaces_left"] == 0
 
@@ -315,7 +304,7 @@ def test_id_uuid_when_no_slug() -> None:
     iid = uuid4()
     inst = _minimal_instance(service, slug=None)
     inst.id = iid
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["id"] == str(iid)
     assert out["service_instance_id"] == str(iid)
 
@@ -323,7 +312,7 @@ def test_id_uuid_when_no_slug() -> None:
 def test_fully_booked_flag() -> None:
     service = _event_service()
     inst = _minimal_instance(service, status=InstanceStatus.FULL)
-    out = public_events._serialize_public_event(_repo(), inst)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["booking_status"] == "fully_booked"
     assert out["is_fully_booked"] is True
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change widens the public calendar feed to published **event** and **training_course** instances (consultation excluded), orders rows by **earliest upcoming session slot** (then `service_instances.id`), and aligns the JSON payload with the agreed field contract.

## Backend

- **`ServiceInstanceRepository.list_public_offerings`**: optional `service_types` and `landing_page`, correlated `MIN(starts_at)` subquery for ordering (with `.correlate(ServiceInstance)`), expanded `selectinload` / `joinedload` for slots+locations, tags, partners, tiers, training details, and `service.event_details`.
- **`list_event_instances_for_public_feed`**: thin wrapper calling the new method with `{ServiceType.EVENT}` only; docstring marks deprecated.
- **`public_events.handle_public_events`**: parses optional `service_type` (`event` | `training_course`) and `landing_page` (kebab-case, max 255); invalid values are ignored. Passes resolved `service_types` into the repository (default both types).
- **`_serialize_public_event`**: required fields per spec (`service_type`, `service_instance_id`, `is_fully_booked`, `tags`, `categories`, `partners`, `location_url`, virtual clears venue + forces empty `location_url`), price resolution by service type, `booking_system` defaulting, `external_url` precedence, Google Maps URL via new helper.
- **`app.utils.maps.build_google_maps_directions_url`**: coordinates preferred over address; Decimal formatting to six fractional places with trailing zeros stripped.

## Docs

- **`docs/api/public.yaml`**: `PublicCalendarEvent` required set updated; query params on both calendar paths; deprecated `items` on response documented.
- **`docs/architecture/lambdas.md`**: public calendar bullet updated for behavior and filters.

## Tests

- Maps URL builder, serializer branches, repository SQL / loader paths, handler query parsing and 405.

## Notes / risks

- OpenAPI **required** additions are a breaking change for strict schema validators; in-repo consumer updates are expected separately.
- Default list **order** is no longer `created_at` DESC; the website re-sorts client-side today, but any consumer relying on API order will see a change.
- Partners are emitted in **`sort_order` then `organization_id`** order so output is deterministic even if the ORM collection order differs from the relationship `order_by` in edge cases.

## Validation

- `pytest` on touched test modules
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f65869da-1fe5-4b9f-9d0f-f90496dbfe46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f65869da-1fe5-4b9f-9d0f-f90496dbfe46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

