### PR TITLE
Admin web: website QR src defaults and download filenames

### DIFF
--- a/apps/admin_web/src/components/admin/website/website-qr-page.tsx
+++ b/apps/admin_web/src/components/admin/website/website-qr-page.tsx
@@ -13,6 +13,8 @@ import { PUBLIC_SITE_PAGE_PRESETS } from '@/lib/public-site-page-presets';
 import {
   buildLocalizedPublicPageUrl,
   normalizePublicSitePathInput,
+  normalizePublicSiteSrcValue,
+  sanitizePublicSiteSrcQueryInput,
 } from '@/lib/public-site-page-urls';
 import {
   MY_BEST_AUNTIE_REFERRAL_LOCALES,
@@ -36,8 +38,13 @@ export function WebsiteQrPage() {
   const [presetValue, setPresetValue] = useState<string>(PUBLIC_SITE_PAGE_PRESETS[0]?.pathInput ?? '/');
   const [customPathInput, setCustomPathInput] = useState('');
   const [appendSrcQuery, setAppendSrcQuery] = useState(false);
-  const [srcQueryValue, setSrcQueryValue] = useState('qr');
+  const [srcQueryValue, setSrcQueryValue] = useState('');
   const isCustom = presetValue === CUSTOM_PRESET_VALUE;
+
+  const normalizedSrcForQuery = useMemo(
+    () => (appendSrcQuery ? normalizePublicSiteSrcValue(srcQueryValue) : ''),
+    [appendSrcQuery, srcQueryValue],
+  );
 
   const normalizedPathResult = useMemo(() => {
     if (isCustom && !customPathInput.trim()) {
@@ -65,18 +72,17 @@ export function WebsiteQrPage() {
     if (!appendSrcQuery) {
       return builtUrl;
     }
-    const trimmed = srcQueryValue.trim();
-    if (!trimmed) {
+    if (!normalizedSrcForQuery) {
       return builtUrl;
     }
     try {
       const url = new URL(builtUrl);
-      url.searchParams.set('src', trimmed);
+      url.searchParams.set('src', normalizedSrcForQuery);
       return url.toString();
     } catch {
       return builtUrl;
     }
-  }, [appendSrcQuery, builtUrl, srcQueryValue]);
+  }, [appendSrcQuery, builtUrl, normalizedSrcForQuery]);
 
   const pathForAnalytics = normalizedPathResult.path || '';
 
@@ -96,7 +102,7 @@ export function WebsiteQrPage() {
 
   const pathError = normalizedPathResult.error;
 
-  const downloadBase = `public-page-${pathToDownloadBase(normalizedPathResult.path || '/')}-${locale}`;
+  const downloadBase = `${normalizedSrcForQuery ? `${normalizedSrcForQuery}-` : ''}page-${pathToDownloadBase(normalizedPathResult.path || '/')}-${locale}`;
 
   return (
     <div className='space-y-6'>
@@ -166,11 +172,7 @@ export function WebsiteQrPage() {
               className='h-4 w-4 rounded border-slate-300 text-slate-900'
               checked={appendSrcQuery}
               onChange={(event) => {
-                const next = event.target.checked;
-                setAppendSrcQuery(next);
-                if (next && !srcQueryValue.trim()) {
-                  setSrcQueryValue('qr');
-                }
+                setAppendSrcQuery(event.target.checked);
               }}
               disabled={Boolean(configError) || Boolean(pathError) || !builtUrl}
             />
@@ -185,7 +187,7 @@ export function WebsiteQrPage() {
               <Input
                 id='website-qr-src-value'
                 value={srcQueryValue}
-                onChange={(event) => setSrcQueryValue(event.target.value)}
+                onChange={(event) => setSrcQueryValue(sanitizePublicSiteSrcQueryInput(event.target.value))}
                 placeholder='e.g. qr'
                 disabled={Boolean(configError) || Boolean(pathError) || !builtUrl}
                 autoComplete='off'
@@ -193,7 +195,8 @@ export function WebsiteQrPage() {
               <p className='mt-1 text-xs text-slate-500'>
                 Adds <code className='rounded bg-slate-100 px-1'>?src=…</code> (or{' '}
                 <code className='rounded bg-slate-100 px-1'>&amp;src=…</code>) for attribution. Leave
-                blank to omit.
+                blank to omit. Use lowercase letters, numbers, and hyphens only (same slug rules as
+                site paths).
               </p>
             </div>
           ) : null}

--- a/apps/admin_web/src/lib/public-site-page-urls.ts
+++ b/apps/admin_web/src/lib/public-site-page-urls.ts
@@ -7,6 +7,38 @@ function trimTrailingSlashes(value: string): string {
 /** Segments are normalized to lowercase before validation. */
 const PATH_SEGMENT = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
+const SLUG_SEGMENT = PATH_SEGMENT;
+
+/**
+ * Sanitizes typing/paste for the `src` field: lowercase, map disallowed characters to `-`,
+ * collapse repeated hyphens, trim leading hyphens only (trailing `-` is kept so users can
+ * compose multi-part slugs like `a-b`).
+ */
+export function sanitizePublicSiteSrcQueryInput(raw: string): string {
+  const lower = raw.toLowerCase();
+  const replaced = lower.replace(/[^a-z0-9-]+/g, '-');
+  return replaced.replace(/-+/g, '-').replace(/^-+/, '');
+}
+
+/**
+ * Normalizes a single `src` query token to the same kebab-case slug rules as public path
+ * segments (lowercase letters, numbers, hyphens; no leading/trailing or repeated hyphens).
+ * Returns empty when nothing valid remains.
+ */
+export function normalizePublicSiteSrcValue(raw: string): string {
+  const lower = raw.trim().toLowerCase();
+  if (!lower) {
+    return '';
+  }
+  const replaced = lower.replace(/[^a-z0-9-]+/g, '-');
+  const collapsed = replaced.replace(/-+/g, '-');
+  const trimmed = collapsed.replace(/^-+|-+$/g, '');
+  if (!trimmed || !SLUG_SEGMENT.test(trimmed)) {
+    return '';
+  }
+  return trimmed;
+}
+
 export interface NormalizePublicSitePathResult {
   /** Normalized path starting with `/`, ending with `/`, or `/` for site home. */
   path: string;

--- a/apps/admin_web/tests/components/admin/website/website-qr-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/website/website-qr-page.test.tsx
@@ -59,10 +59,16 @@ describe('WebsiteQrPage', () => {
     });
   });
 
-  it('appends src query when enabled', async () => {
+  it('does not append src until a valid slug value is entered', async () => {
     render(<WebsiteQrPage />);
 
     fireEvent.click(screen.getByRole('checkbox', { name: /Append .*src.* query parameter/i }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'https://www.example.com/en/' })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('src value'), { target: { value: 'qr' } });
 
     await vi.waitFor(() => {
       expect(
@@ -84,6 +90,52 @@ describe('WebsiteQrPage', () => {
       expect(
         screen.getByRole('link', { name: 'https://www.example.com/en/?src=poster' }),
       ).toBeInTheDocument();
+    });
+  });
+
+  it('uses page- prefixed download filename and prepends normalized src when set', async () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const createdAnchors: HTMLAnchorElement[] = [];
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string, options?: unknown) => {
+      if (tag !== 'a') {
+        return originalCreateElement(tag, options as DocumentCreateElementOptions | undefined);
+      }
+      const anchor = originalCreateElement('a', options as DocumentCreateElementOptions | undefined);
+      createdAnchors.push(anchor);
+      vi.spyOn(anchor, 'click').mockImplementation(() => {});
+      return anchor;
+    });
+
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    }) as typeof fetch;
+
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    render(<WebsiteQrPage />);
+
+    await vi.waitFor(() => {
+      expect(generateSpy).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PNG (512)' }));
+    await vi.waitFor(() => {
+      expect(createdAnchors.at(-1)?.download).toBe('page-home-en-512.png');
+    });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Append .*src.* query parameter/i }));
+    fireEvent.change(screen.getByLabelText('src value'), { target: { value: 'poster' } });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'https://www.example.com/en/?src=poster' }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PNG (512)' }));
+    await vi.waitFor(() => {
+      expect(createdAnchors.at(-1)?.download).toBe('poster-page-home-en-512.png');
     });
   });
 });

--- a/apps/admin_web/tests/lib/public-site-page-urls.test.ts
+++ b/apps/admin_web/tests/lib/public-site-page-urls.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   buildLocalizedPublicPageUrl,
   normalizePublicSitePathInput,
+  normalizePublicSiteSrcValue,
+  sanitizePublicSiteSrcQueryInput,
 } from '@/lib/public-site-page-urls';
 
 describe('normalizePublicSitePathInput', () => {
@@ -33,6 +35,23 @@ describe('normalizePublicSitePathInput', () => {
 
   it('rejects uppercase segments', () => {
     expect(normalizePublicSitePathInput('/About-Us').error).toBeTruthy();
+  });
+});
+
+describe('normalizePublicSiteSrcValue', () => {
+  it('returns kebab-case slugs and empty for invalid', () => {
+    expect(normalizePublicSiteSrcValue('  QR_Poster  ')).toBe('qr-poster');
+    expect(normalizePublicSiteSrcValue('a--b')).toBe('a-b');
+    expect(normalizePublicSiteSrcValue('')).toBe('');
+    expect(normalizePublicSiteSrcValue('-')).toBe('');
+    expect(normalizePublicSiteSrcValue('Bad_Slug')).toBe('bad-slug');
+  });
+});
+
+describe('sanitizePublicSiteSrcQueryInput', () => {
+  it('lowercases and maps invalid characters to hyphens', () => {
+    expect(sanitizePublicSiteSrcQueryInput('Foo Bar')).toBe('foo-bar');
+    expect(sanitizePublicSiteSrcQueryInput('a--')).toBe('a-');
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **src field**: Removed the default `qr` value and the behavior that re-filled `qr` when enabling "Append src". The helper text under the field is unchanged except for an added line clarifying slug rules (lowercase letters, numbers, hyphens—same as public site paths).
- **Slug rules**: Introduced `normalizePublicSiteSrcValue` and `sanitizePublicSiteSrcQueryInput` in `public-site-page-urls.ts`. The preview/download URL only adds `src` when the normalized value is non-empty and matches path-segment slug rules. Input is sanitized on change so invalid characters cannot be entered.
- **Download filenames**: Replaced the `public-page-` prefix with `page-`. When a valid `src` is set, the filename is prefixed with `{src}-` (e.g. `poster-page-home-en-512.png`).

## Tests

- `npm run test -- --run tests/components/admin/website/website-qr-page.test.tsx tests/lib/public-site-page-urls.test.ts`
- `npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1f6bd79-06d4-4ea8-b326-e4ed876bd23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1f6bd79-06d4-4ea8-b326-e4ed876bd23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

