### PR TITLE
fix(public_www): resolve vulnerable uuid from @lhci/cli via override

### DIFF
--- a/apps/public_www/package-lock.json
+++ b/apps/public_www/package-lock.json
@@ -11034,13 +11034,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/apps/public_www/package.json
+++ b/apps/public_www/package.json
@@ -66,6 +66,9 @@
   "overrides": {
     "tmp": "^0.2.4",
     "yauzl": "^3.2.1",
-    "flatted": "^3.4.0"
+    "flatted": "^3.4.0",
+    "@lhci/cli": {
+      "uuid": "^14.0.0"
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dependabot reported GHSA for `uuid` (&lt; 14.0.0) pulled in by `@lhci/cli@0.15.1` (`uuid@^8.3.1`). There is no newer `@lhci/cli` release that widens the range.

## Change

- Add an npm `overrides` entry so `@lhci/cli` resolves `uuid` to `^14.0.0` (patched).
- Regenerate `apps/public_www/package-lock.json`.

## Risk / compatibility

`@lhci/cli` only uses `uuid.v4()` with default arguments (no caller-supplied buffer), so the semver jump from 8.x to 14.x for that usage path is expected to remain compatible.

## Validation

- `npm test` and `npm run lint` in `apps/public_www`
- `bash scripts/validate-cursorrules.sh`

Note: `npm audit` still reports unrelated highs (`basic-ftp`, `path-to-regexp`); not addressed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-910b3fea-276c-4c35-99ae-e2b7a5a6a40d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-910b3fea-276c-4c35-99ae-e2b7a5a6a40d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

