### PR TITLE
Service tier on services, default location, public calendar fallbacks

### DIFF
--- a/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
@@ -115,6 +115,32 @@ export function ConsultationServiceRowDFields({
   );
 }
 
+/** Single currency control for service-detail tier row (column-aligned with other service types). */
+export function ConsultationServiceDefaultCurrencyField({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  const currencyOptions = getCurrencyOptions();
+  return (
+    <div>
+      <Label htmlFor='service-consultation-tier-row-currency'>Default currency</Label>
+      <Select
+        id='service-consultation-tier-row-currency'
+        value={value.defaultCurrency}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
+      >
+        {currencyOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
 /** Row E: max group size, duration, package price, empty cell. */
 export function ConsultationServiceRowEFields({
   value,

--- a/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
@@ -115,32 +115,6 @@ export function ConsultationServiceRowDFields({
   );
 }
 
-/** Single currency control for service-detail tier row (column-aligned with other service types). */
-export function ConsultationServiceDefaultCurrencyField({
-  value,
-  disabled = false,
-  onChange,
-}: ConsultationServicePanelFieldsProps) {
-  const currencyOptions = getCurrencyOptions();
-  return (
-    <div>
-      <Label htmlFor='service-consultation-tier-row-currency'>Default currency</Label>
-      <Select
-        id='service-consultation-tier-row-currency'
-        value={value.defaultCurrency}
-        disabled={disabled}
-        onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
-      >
-        {currencyOptions.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </Select>
-    </div>
-  );
-}
-
 /** Row E: max group size, duration, package price, empty cell. */
 export function ConsultationServiceRowEFields({
   value,

--- a/apps/admin_web/src/components/admin/services/form-defaults.ts
+++ b/apps/admin_web/src/components/admin/services/form-defaults.ts
@@ -45,7 +45,6 @@ export const DEFAULT_INSTANCE_FORM: InstanceFormState = {
   maxCapacity: '',
   waitlistEnabled: false,
   instructorId: '',
-  ageGroup: '',
   cohort: '',
   notes: '',
   externalUrl: '',

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -184,7 +184,6 @@ export function InstanceDetailPanel({
           waitlistEnabled: instance.waitlistEnabled,
           instructorId: instance.instructorId ?? '',
           notes: instance.notes ?? '',
-          ageGroup: instance.ageGroup ?? '',
           cohort: instance.cohort ?? '',
           externalUrl: instance.externalUrl ?? '',
           partnerOrganizations: mapPartnerRefsFromInstance(instance),
@@ -284,7 +283,6 @@ export function InstanceDetailPanel({
         waitlistEnabled: instance.waitlistEnabled,
         instructorId: instance.instructorId ?? '',
         notes: instance.notes ?? '',
-        ageGroup: instance.ageGroup ?? '',
         cohort: instance.cohort ?? '',
         externalUrl: instance.externalUrl ?? '',
         partnerOrganizations: mapPartnerRefsFromInstance(instance),
@@ -329,7 +327,6 @@ export function InstanceDetailPanel({
 
   const buildCreatePayload = (): ApiSchemas['CreateInstanceRequest'] => {
     const slugTrimmed = instanceForm.slug.trim().toLowerCase();
-    const ageTrimmed = instanceForm.ageGroup.trim().toLowerCase();
     const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
       title: instanceForm.title.trim() || null,
@@ -341,7 +338,6 @@ export function InstanceDetailPanel({
       max_capacity: instanceForm.maxCapacity ? Number(instanceForm.maxCapacity) : null,
       waitlist_enabled: instanceForm.waitlistEnabled,
       instructor_id: instanceForm.instructorId.trim() || null,
-      age_group: ageTrimmed || null,
       cohort: cohortTrimmed || null,
       notes: instanceForm.notes.trim() || null,
       external_url: instanceForm.externalUrl.trim() || null,
@@ -432,10 +428,7 @@ export function InstanceDetailPanel({
   const eventPriceMissing =
     effectiveServiceType === 'event' && !eventForm.defaultPrice.trim();
 
-  const ageGroupTrimmed = instanceForm.ageGroup.trim().toLowerCase();
   const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
-  const ageGroupInvalid =
-    Boolean(ageGroupTrimmed) && !INSTANCE_SLUG_PATTERN.test(ageGroupTrimmed);
   const cohortInvalid = Boolean(cohortTrimmed) && !INSTANCE_SLUG_PATTERN.test(cohortTrimmed);
 
   return (
@@ -457,7 +450,6 @@ export function InstanceDetailPanel({
                     !instance ||
                     externalUrlInvalid ||
                     eventPriceMissing ||
-                    ageGroupInvalid ||
                     cohortInvalid
                   }
                   onClick={() => {
@@ -478,7 +470,6 @@ export function InstanceDetailPanel({
                   !selectedServiceId ||
                   externalUrlInvalid ||
                   eventPriceMissing ||
-                  ageGroupInvalid ||
                   cohortInvalid
                 }
                 onClick={() => {
@@ -608,26 +599,6 @@ export function InstanceDetailPanel({
       ) : null}
 
       <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-        <div>
-          <Label htmlFor='instance-age-group'>Age group</Label>
-          <Input
-            id='instance-age-group'
-            value={instanceForm.ageGroup}
-            disabled={typeFieldsLocked}
-            onChange={(event) => setInstanceForm((prev) => ({ ...prev, ageGroup: event.target.value }))}
-            onBlur={() =>
-              setInstanceForm((prev) => ({ ...prev, ageGroup: prev.ageGroup.trim().toLowerCase() }))
-            }
-            placeholder='e.g. ages-3-5'
-            autoComplete='off'
-          />
-          {ageGroupInvalid ? (
-            <p className='mt-1 text-xs text-red-600'>
-              Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
-              hyphen).
-            </p>
-          ) : null}
-        </div>
         <div>
           <Label htmlFor='instance-cohort'>Cohort</Label>
           <Input

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -36,7 +36,6 @@ export interface InstanceFormState {
   maxCapacity: string;
   waitlistEnabled: boolean;
   instructorId: string;
-  ageGroup: string;
   cohort: string;
   notes: string;
   externalUrl: string;

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -21,7 +21,6 @@ import type { ServiceDeliveryMode } from '@/types/services';
 import type { LocationSummary, ServiceDetail, ServiceType } from '@/types/services';
 
 import {
-  ConsultationServiceDefaultCurrencyField,
   ConsultationServiceFormatField,
   ConsultationServiceRowDFields,
   ConsultationServiceRowEFields,
@@ -238,6 +237,9 @@ export function ServiceDetailPanel({
     conflictingSlugNormalized !== null &&
     normalizedSlugInput === conflictingSlugNormalized;
 
+  const tierTrimmedForValidation = serviceTier.trim().toLowerCase();
+  const tierInvalid = Boolean(tierTrimmedForValidation) && !SLUG_PATTERN.test(tierTrimmedForValidation);
+
   const deliveryModeSelect = (
     <div>
       <Label htmlFor='service-delivery-mode'>Delivery mode</Label>
@@ -445,6 +447,7 @@ export function ServiceDetailPanel({
                     isLoading ||
                     !service ||
                     saveBlockedBySlugConflict ||
+                    tierInvalid ||
                     Boolean(serviceForm.slug.trim() && !SLUG_PATTERN.test(serviceForm.slug.trim().toLowerCase()))
                   }
                   onClick={() => void submitUpdate()}
@@ -466,6 +469,7 @@ export function ServiceDetailPanel({
                 disabled={
                   isLoading ||
                   saveBlockedBySlugConflict ||
+                  tierInvalid ||
                   !serviceForm.title.trim() ||
                   Boolean(serviceForm.slug.trim() && !SLUG_PATTERN.test(serviceForm.slug.trim().toLowerCase()))
                 }
@@ -603,7 +607,12 @@ export function ServiceDetailPanel({
 
         {serviceType === 'training_course' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            <ServiceTierControl value={serviceTier} onChange={setServiceTier} id='service-tier-training' />
+            <ServiceTierControl
+              value={serviceTier}
+              onChange={setServiceTier}
+              id='service-tier-training'
+              invalid={tierInvalid}
+            />
             <TrainingPriceControl
               value={trainingForm}
               onChange={setTrainingForm}
@@ -616,7 +625,12 @@ export function ServiceDetailPanel({
 
         {serviceType === 'event' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            <ServiceTierControl value={serviceTier} onChange={setServiceTier} id='service-tier-event' />
+            <ServiceTierControl
+              value={serviceTier}
+              onChange={setServiceTier}
+              id='service-tier-event'
+              invalid={tierInvalid}
+            />
             <EventDefaultPriceControl value={eventForm} onChange={setEventForm} />
             <EventDefaultCurrencyControl value={eventForm} onChange={setEventForm} />
             <div aria-hidden className='hidden md:block' />
@@ -632,9 +646,14 @@ export function ServiceDetailPanel({
               <ConsultationServiceRowEFields value={consultationForm} onChange={setConsultationForm} />
             </div>
             <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-              <ServiceTierControl value={serviceTier} onChange={setServiceTier} id='service-tier-consultation' />
+              <ServiceTierControl
+                value={serviceTier}
+                onChange={setServiceTier}
+                id='service-tier-consultation'
+                invalid={tierInvalid}
+              />
               <div aria-hidden className='hidden md:block' />
-              <ConsultationServiceDefaultCurrencyField value={consultationForm} onChange={setConsultationForm} />
+              <div aria-hidden className='hidden md:block' />
               <div aria-hidden className='hidden md:block' />
             </div>
           </>

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -11,16 +11,17 @@ import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
-import { formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel, formatLocationLabel } from '@/lib/format';
 import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
 import { getServiceDiscountCodeUsageSummary } from '@/lib/services-api';
 
 import type { components } from '@/types/generated/admin-api.generated';
 import { SERVICE_DELIVERY_MODES, SERVICE_STATUSES, SERVICE_TYPES } from '@/types/services';
 import type { ServiceDeliveryMode } from '@/types/services';
-import type { ServiceDetail, ServiceType } from '@/types/services';
+import type { LocationSummary, ServiceDetail, ServiceType } from '@/types/services';
 
 import {
+  ConsultationServiceDefaultCurrencyField,
   ConsultationServiceFormatField,
   ConsultationServiceRowDFields,
   ConsultationServiceRowEFields,
@@ -45,6 +46,7 @@ import {
   TrainingPricingUnitControl,
   type TrainingFormState,
 } from './training-form-fields';
+import { ServiceTierControl } from './service-tier-control';
 
 type ApiSchemas = components['schemas'];
 
@@ -52,6 +54,9 @@ const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 export interface ServiceDetailPanelProps {
   service: ServiceDetail | null;
+  locationOptions?: LocationSummary[];
+  isLoadingLocations?: boolean;
+  locationError?: string | null;
   isLoading: boolean;
   error: string;
   onCancelSelection: () => void;
@@ -64,6 +69,9 @@ type DiscountUsageLoadState = 'idle' | 'loading' | 'ok' | 'error';
 
 export function ServiceDetailPanel({
   service,
+  locationOptions = [],
+  isLoadingLocations = false,
+  locationError = null,
   isLoading,
   error,
   onCancelSelection,
@@ -119,6 +127,8 @@ export function ServiceDetailPanel({
   );
   const [coverFileName, setCoverFileName] = useState('cover-image.jpg');
   const [bookingSystem, setBookingSystem] = useState(service?.bookingSystem ?? '');
+  const [serviceTier, setServiceTier] = useState(service?.serviceTier ?? '');
+  const [locationId, setLocationId] = useState(service?.locationId ?? '');
   const [discountUsageSummary, setDiscountUsageSummary] = useState<{
     totalCurrentUses: number;
     referencingCodeCount: number;
@@ -168,12 +178,16 @@ export function ServiceDetailPanel({
         setEventForm(DEFAULT_EVENT_FORM);
         setConsultationForm(DEFAULT_CONSULTATION_FORM);
         setBookingSystem('');
+        setServiceTier('');
+        setLocationId('');
         setSlugConflictError('');
         setConflictingSlugNormalized(null);
         return;
       }
       setServiceType(service.serviceType);
       setBookingSystem(service.bookingSystem ?? '');
+      setServiceTier(service.serviceTier ?? '');
+      setLocationId(service.locationId ?? '');
       setServiceForm({
         title: service.title,
         description: service.description ?? '',
@@ -213,6 +227,10 @@ export function ServiceDetailPanel({
     const t = serviceForm.slug.trim().toLowerCase();
     return t.length ? t : null;
   }, [serviceForm.slug]);
+
+  const hasLocationOptions = locationOptions.length > 0;
+  const locationExists = locationOptions.some((entry) => entry.id === locationId);
+  const selectedLocationValue = locationExists ? locationId : locationId || '';
 
   const normalizedSlugInput = serviceForm.slug.trim().toLowerCase();
   const saveBlockedBySlugConflict =
@@ -357,6 +375,8 @@ export function ServiceDetailPanel({
         description: serviceForm.description.trim() || null,
         slug: newSlug,
         booking_system: bookingSystem.trim() || null,
+        service_tier: serviceTier.trim() || null,
+        location_id: locationId.trim() || null,
         delivery_mode: serviceForm.deliveryMode,
         status: serviceForm.status,
         ...buildTypeSpecificPayload(service.serviceType),
@@ -385,6 +405,8 @@ export function ServiceDetailPanel({
         description: serviceForm.description.trim() || null,
         slug: slugPayloadValue,
         booking_system: bookingSystem.trim() || null,
+        service_tier: serviceTier.trim() || null,
+        location_id: locationId.trim() || null,
         delivery_mode: serviceForm.deliveryMode,
         status: serviceForm.status,
         ...buildTypeSpecificPayload(serviceType),
@@ -525,6 +547,36 @@ export function ServiceDetailPanel({
           />
         </div>
 
+        <div>
+          <Label htmlFor='service-default-location'>Default location</Label>
+          {hasLocationOptions || isLoadingLocations ? (
+            <Select
+              id='service-default-location'
+              value={selectedLocationValue}
+              onChange={(event) => setLocationId(event.target.value)}
+            >
+              <option value=''>
+                {isLoadingLocations ? 'Loading locations...' : 'Select location (optional)'}
+              </option>
+              {locationId && !locationExists ? <option value={locationId}>{locationId}</option> : null}
+              {locationOptions.map((location) => (
+                <option key={location.id} value={location.id}>
+                  {formatLocationLabel(location)}
+                </option>
+              ))}
+            </Select>
+          ) : (
+            <Input
+              id='service-default-location'
+              value={locationId}
+              onChange={(event) => setLocationId(event.target.value)}
+              placeholder='Location UUID'
+              autoComplete='off'
+            />
+          )}
+          {locationError ? <p className='mt-1 text-xs text-red-600'>{locationError}</p> : null}
+        </div>
+
         {serviceType === 'training_course' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
             {deliveryModeSelect}
@@ -551,7 +603,7 @@ export function ServiceDetailPanel({
 
         {serviceType === 'training_course' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            <div aria-hidden className='hidden md:block' />
+            <ServiceTierControl value={serviceTier} onChange={setServiceTier} id='service-tier-training' />
             <TrainingPriceControl
               value={trainingForm}
               onChange={setTrainingForm}
@@ -564,7 +616,7 @@ export function ServiceDetailPanel({
 
         {serviceType === 'event' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            <div aria-hidden className='hidden md:block' />
+            <ServiceTierControl value={serviceTier} onChange={setServiceTier} id='service-tier-event' />
             <EventDefaultPriceControl value={eventForm} onChange={setEventForm} />
             <EventDefaultCurrencyControl value={eventForm} onChange={setEventForm} />
             <div aria-hidden className='hidden md:block' />
@@ -578,6 +630,12 @@ export function ServiceDetailPanel({
             </div>
             <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
               <ConsultationServiceRowEFields value={consultationForm} onChange={setConsultationForm} />
+            </div>
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+              <ServiceTierControl value={serviceTier} onChange={setServiceTier} id='service-tier-consultation' />
+              <div aria-hidden className='hidden md:block' />
+              <ConsultationServiceDefaultCurrencyField value={consultationForm} onChange={setConsultationForm} />
+              <div aria-hidden className='hidden md:block' />
             </div>
           </>
         ) : null}

--- a/apps/admin_web/src/components/admin/services/service-tier-control.tsx
+++ b/apps/admin_web/src/components/admin/services/service-tier-control.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface ServiceTierControlProps {
+  value: string;
+  onChange: (value: string) => void;
+  id?: string;
+  disabled?: boolean;
+}
+
+export function ServiceTierControl({ value, onChange, id = 'service-tier', disabled = false }: ServiceTierControlProps) {
+  return (
+    <div>
+      <Label htmlFor={id}>Service tier</Label>
+      <Input
+        id={id}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={() => onChange(value.trim().toLowerCase())}
+        placeholder='e.g. ages-3-5'
+        maxLength={128}
+        autoComplete='off'
+      />
+      <p className='mt-1 text-xs text-slate-500'>Lowercase letters, digits, and hyphens. Max 128 characters.</p>
+    </div>
+  );
+}

--- a/apps/admin_web/src/components/admin/services/service-tier-control.tsx
+++ b/apps/admin_web/src/components/admin/services/service-tier-control.tsx
@@ -8,9 +8,16 @@ export interface ServiceTierControlProps {
   onChange: (value: string) => void;
   id?: string;
   disabled?: boolean;
+  invalid?: boolean;
 }
 
-export function ServiceTierControl({ value, onChange, id = 'service-tier', disabled = false }: ServiceTierControlProps) {
+export function ServiceTierControl({
+  value,
+  onChange,
+  id = 'service-tier',
+  disabled = false,
+  invalid = false,
+}: ServiceTierControlProps) {
   return (
     <div>
       <Label htmlFor={id}>Service tier</Label>
@@ -25,6 +32,11 @@ export function ServiceTierControl({ value, onChange, id = 'service-tier', disab
         autoComplete='off'
       />
       <p className='mt-1 text-xs text-slate-500'>Lowercase letters, digits, and hyphens. Max 128 characters.</p>
+      {invalid ? (
+        <p className='mt-1 text-xs text-red-600'>
+          Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing hyphen).
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -81,6 +81,9 @@ export function ServicesPage() {
           <ServiceDetailPanel
             key={serviceDetailPanelKey}
             service={selectedServiceDetail}
+            locationOptions={state.locationList.locations}
+            isLoadingLocations={state.isLoadingLocations}
+            locationError={state.locationError || undefined}
             isLoading={state.serviceMutations.isLoading}
             error={state.serviceMutations.error}
             onCancelSelection={() => state.setSelectedServiceId(null)}

--- a/apps/admin_web/src/hooks/use-services-page.ts
+++ b/apps/admin_web/src/hooks/use-services-page.ts
@@ -171,6 +171,8 @@ export function useServicesPage() {
     enrollmentList,
     enrollmentMutations,
     locationList,
+    isLoadingLocations: locationList.isLoading,
+    locationError: locationList.error,
     discountCodes,
     venues,
   };

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -142,6 +142,8 @@ function parseServiceSummary(value: unknown): ServiceSummary {
     coverImageS3Key: asNullableString(item.cover_image_s3_key),
     deliveryMode: (asNullableString(item.delivery_mode) ?? 'online') as ServiceSummary['deliveryMode'],
     status: (asNullableString(item.status) ?? 'draft') as ServiceSummary['status'],
+    serviceTier: asNullableString(item.service_tier),
+    locationId: asNullableString(item.location_id),
     createdBy: asNullableString(item.created_by) ?? '',
     createdAt: asNullableString(item.created_at),
     updatedAt: asNullableString(item.updated_at),
@@ -245,7 +247,6 @@ function parseInstance(value: unknown): ServiceInstance {
           .filter((row): row is PartnerOrgRef => row !== null)
       : [],
     instructorId: asNullableString(item.instructor_id),
-    ageGroup: asNullableString(item.age_group),
     cohort: asNullableString(item.cohort),
     notes: asNullableString(item.notes),
     tagIds: Array.isArray(item.tag_ids)

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4304,6 +4304,13 @@ export interface components {
             cover_image_s3_key?: string | null;
             delivery_mode: components["schemas"]["ServiceDeliveryMode"];
             status: components["schemas"]["ServiceStatus"];
+            /** @description Optional slug-like tier identifier for the service template, shared across all instances. */
+            service_tier?: string | null;
+            /**
+             * Format: uuid
+             * @description Optional default venue UUID (FK to locations.id, ON DELETE SET NULL). Instances may override via service_instances.location_id.
+             */
+            location_id?: string | null;
             created_by?: string;
             /** Format: date-time */
             created_at?: string | null;
@@ -4341,6 +4348,13 @@ export interface components {
             cover_image_s3_key?: string | null;
             delivery_mode: components["schemas"]["ServiceDeliveryMode"];
             status?: components["schemas"]["ServiceStatus"];
+            /** @description Optional slug-like tier identifier for the service template, shared across all instances. */
+            service_tier?: string | null;
+            /**
+             * Format: uuid
+             * @description Optional default venue UUID (FK to locations.id, ON DELETE SET NULL). Instances may override via service_instances.location_id.
+             */
+            location_id?: string | null;
             tag_ids?: string[];
             asset_ids?: string[];
             training_details?: components["schemas"]["ServiceTrainingDetails"];
@@ -4356,6 +4370,13 @@ export interface components {
             cover_image_s3_key?: string | null;
             delivery_mode?: components["schemas"]["ServiceDeliveryMode"];
             status?: components["schemas"]["ServiceStatus"];
+            /** @description Optional slug-like tier identifier for the service template, shared across all instances. */
+            service_tier?: string | null;
+            /**
+             * Format: uuid
+             * @description Optional default venue UUID (FK to locations.id, ON DELETE SET NULL). Instances may override via service_instances.location_id.
+             */
+            location_id?: string | null;
             tag_ids?: string[];
             asset_ids?: string[];
             training_details?: components["schemas"]["ServiceTrainingDetails"];
@@ -4439,8 +4460,6 @@ export interface components {
             partner_organizations?: components["schemas"]["InstancePartnerOrganization"][];
             instructor_id?: string | null;
             /** @description Optional label using the same normalization rules as instance referral slugs (lowercase letters, digits, single hyphens between segments). */
-            age_group?: string | null;
-            /** @description Optional label using the same normalization rules as instance referral slugs (lowercase letters, digits, single hyphens between segments). */
             cohort?: string | null;
             notes?: string | null;
             tags?: components["schemas"]["EntityTagRef"][];
@@ -4498,7 +4517,6 @@ export interface components {
             /** @description Ordered partner organization ids for event instances. Unknown ids return 400. */
             partner_organization_ids?: string[];
             instructor_id?: string | null;
-            age_group?: string | null;
             cohort?: string | null;
             notes?: string | null;
             /** @description Replaces all instance tag associations when present (including on PUT). The admin web UI sends this on every instance save; omit the field only if a non-UI client must patch other fields without changing tags. */

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -106,6 +106,10 @@ export interface ServiceSummary {
   coverImageS3Key: string | null;
   deliveryMode: ServiceDeliveryMode;
   status: ServiceStatus;
+  /** Optional slug-like tier id on the service template (shared by instances). */
+  serviceTier: string | null;
+  /** Optional default venue id (FK locations). */
+  locationId: string | null;
   createdBy: string;
   createdAt: string | null;
   updatedAt: string | null;
@@ -230,7 +234,6 @@ export interface ServiceInstance {
   externalUrl: string | null;
   partnerOrganizations: PartnerOrgRef[];
   instructorId: string | null;
-  ageGroup: string | null;
   cohort: string | null;
   notes: string | null;
   tagIds: string[];

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -17,6 +17,8 @@ function buildService(overrides: Partial<ServiceDetail> = {}): ServiceDetail {
     coverImageS3Key: null,
     deliveryMode: 'online',
     status: 'draft',
+    serviceTier: null,
+    locationId: null,
     createdBy: 'admin',
     createdAt: '2025-01-01T00:00:00Z',
     updatedAt: '2025-01-02T00:00:00Z',
@@ -235,5 +237,156 @@ describe('ServiceDetailPanel', () => {
     expect(screen.getByLabelText('Pricing model')).toBeInTheDocument();
     expect(screen.getByLabelText('Max group size')).toBeInTheDocument();
     expect(screen.queryByLabelText(/Calendly/i)).not.toBeInTheDocument();
+  });
+
+  it('places service tier before default price for training and submits service_tier', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        locationOptions={[]}
+        isLoadingLocations={false}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+    await user.type(screen.getByLabelText('Title'), 'T');
+    const tierInputs = screen.getAllByLabelText('Service tier');
+    await user.type(tierInputs[0], 'ages-3-5');
+    await user.type(screen.getByLabelText('Default price'), '100');
+    await user.click(screen.getByRole('button', { name: /Add service/i }));
+    expect(onCreate).toHaveBeenCalled();
+    const body = onCreate.mock.calls[0][0] as { service_tier?: string | null };
+    expect(body.service_tier).toBe('ages-3-5');
+    const defaultPrice = screen.getByLabelText('Default price');
+    expect(tierInputs[0].compareDocumentPosition(defaultPrice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('places service tier before default price for event and submits service_tier', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        locationOptions={[]}
+        isLoadingLocations={false}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'event');
+    await user.type(screen.getByLabelText('Title'), 'E');
+    const tierInputs = screen.getAllByLabelText('Service tier');
+    await user.type(tierInputs[0], 'spring-tier');
+    await user.type(screen.getByLabelText('Default price'), '50');
+    await user.click(screen.getByRole('button', { name: /Add service/i }));
+    expect(onCreate).toHaveBeenCalled();
+    const body = onCreate.mock.calls[0][0] as { service_tier?: string | null };
+    expect(body.service_tier).toBe('spring-tier');
+    const defaultPrice = screen.getByLabelText('Default price');
+    expect(tierInputs[0].compareDocumentPosition(defaultPrice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('consultation tier row has tier, spacer column, default currency, spacer', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        locationOptions={[]}
+        isLoadingLocations={false}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
+    const tierInputs = screen.getAllByLabelText('Service tier');
+    const currencyLabels = screen.getAllByLabelText('Default currency');
+    expect(tierInputs.length).toBeGreaterThan(0);
+    expect(currencyLabels.length).toBeGreaterThan(0);
+    const tier = tierInputs[tierInputs.length - 1];
+    const defaultCurrency = currencyLabels[currencyLabels.length - 1];
+    expect(tier.compareDocumentPosition(defaultCurrency) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('submits location_id when a default location is selected', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        locationOptions={[
+          {
+            id: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+            name: 'Venue A',
+            areaId: 'a',
+            address: null,
+            lat: null,
+            lng: null,
+            createdAt: null,
+            updatedAt: null,
+            lockedFromPartnerOrg: false,
+            partnerOrganizationLabels: [],
+          },
+        ]}
+        isLoadingLocations={false}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+    await user.type(screen.getByLabelText('Title'), 'T');
+    await user.selectOptions(screen.getByLabelText('Default location'), '6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+    await user.type(screen.getByLabelText('Default price'), '10');
+    await user.click(screen.getByRole('button', { name: /Add service/i }));
+    expect(onCreate).toHaveBeenCalled();
+    const body = onCreate.mock.calls[0][0] as { location_id?: string | null };
+    expect(body.location_id).toBe('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+  });
+
+  it('shows UUID input when location list is empty and not loading, submits typed location_id', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    render(
+      <ServiceDetailPanel
+        service={null}
+        locationOptions={[]}
+        isLoadingLocations={false}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+    await user.type(screen.getByLabelText('Title'), 'T');
+    const locInput = screen.getByPlaceholderText('Location UUID');
+    expect(locInput).toBeInTheDocument();
+    await user.type(locInput, uuid);
+    await user.type(screen.getByLabelText('Default price'), '10');
+    await user.click(screen.getByRole('button', { name: /Add service/i }));
+    expect(onCreate).toHaveBeenCalled();
+    const body = onCreate.mock.calls[0][0] as { location_id?: string | null };
+    expect(body.location_id).toBe(uuid);
   });
 });

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -297,7 +297,7 @@ describe('ServiceDetailPanel', () => {
     expect(tierInputs[0].compareDocumentPosition(defaultPrice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('consultation tier row has tier, spacer column, default currency, spacer', async () => {
+  it('consultation shows one currency control (Row D) and a service tier field', async () => {
     const user = userEvent.setup();
     render(
       <ServiceDetailPanel
@@ -313,13 +313,8 @@ describe('ServiceDetailPanel', () => {
       />
     );
     await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
-    const tierInputs = screen.getAllByLabelText('Service tier');
-    const currencyLabels = screen.getAllByLabelText('Default currency');
-    expect(tierInputs.length).toBeGreaterThan(0);
-    expect(currencyLabels.length).toBeGreaterThan(0);
-    const tier = tierInputs[tierInputs.length - 1];
-    const defaultCurrency = currencyLabels[currencyLabels.length - 1];
-    expect(tier.compareDocumentPosition(defaultCurrency) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByLabelText('Currency')).toBeInTheDocument();
+    expect(document.getElementById('service-tier-consultation')).not.toBeNull();
   });
 
   it('submits location_id when a default location is selected', async () => {

--- a/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
@@ -18,6 +18,8 @@ function buildService(overrides: Partial<ServiceDetail> = {}): ServiceDetail {
     coverImageS3Key: null,
     deliveryMode: 'online',
     status: 'draft',
+    serviceTier: null,
+    locationId: null,
     createdBy: 'admin',
     createdAt: '2025-01-01T00:00:00Z',
     updatedAt: '2025-01-02T00:00:00Z',

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking.tsx
@@ -166,7 +166,7 @@ function findPreferredCohortId(
   ageGroupId: string,
 ): string {
   const ageGroupCohorts = cohorts.filter(
-    (cohort) => cohort.age_group === ageGroupId,
+    (cohort) => cohort.service_tier === ageGroupId,
   );
   const available = ageGroupCohorts.find((cohort) => !cohort.is_fully_booked);
   return available?.id ?? ageGroupCohorts[0]?.id ?? '';
@@ -238,7 +238,7 @@ export function MyBestAuntieBooking({
 
   const [selectedAgeId, setSelectedAgeId] = useState(initialAgeId);
   const cohortsForSelectedAge = sortedCohorts.filter((cohort) => {
-    return cohort.age_group === selectedAgeId;
+    return cohort.service_tier === selectedAgeId;
   });
   const dateOptions: BookingDateOption[] = cohortsForSelectedAge.map((cohort) => ({
     id: cohort.id,
@@ -321,7 +321,7 @@ export function MyBestAuntieBooking({
         sectionId: 'my-best-auntie-booking',
         ctaLocation: 'query_param',
         params: {
-          age_group: selectedCohort.age_group,
+          age_group: selectedCohort.service_tier,
           cohort_label: selectedCohort.cohort,
           cohort_date: selectedCohort.dates[0]?.start_datetime?.split('T')[0] ?? '',
         },
@@ -330,9 +330,9 @@ export function MyBestAuntieBooking({
       trackEcommerceEvent('begin_checkout', {
         value: selectedCohort.price,
         items: [{
-          item_id: `mba-${selectedCohort.age_group}`,
+          item_id: `mba-${selectedCohort.service_tier}`,
           item_name: 'My Best Auntie',
-          item_category: selectedCohort.age_group,
+          item_category: selectedCohort.service_tier,
           price: selectedCohort.price,
           quantity: 1,
         }],
@@ -600,9 +600,9 @@ export function MyBestAuntieBooking({
                   trackEcommerceEvent('begin_checkout', {
                     value: selectedCohort.price,
                     items: [{
-                      item_id: `mba-${selectedCohort.age_group}`,
+                      item_id: `mba-${selectedCohort.service_tier}`,
                       item_name: 'My Best Auntie',
-                      item_category: selectedCohort.age_group,
+                      item_category: selectedCohort.service_tier,
                       price: selectedCohort.price,
                       quantity: 1,
                     }],

--- a/apps/public_www/src/content/my-best-auntie-training-courses.json
+++ b/apps/public_www/src/content/my-best-auntie-training-courses.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "id": "my-best-auntie-0-1-04-26",
-      "age_group": "0-1",
+      "service_tier": "0-1",
       "title": "My Best Auntie Training Course 0-1 - Apr 26",
       "description": "Nurturing the Foundations. In the first year, your helper learns to create a calm, responsive environment that supports your baby's natural development. We focus on respectful caregiving routines, safe spaces for exploration, and language-rich interactions that build secure attachment.",
       "cohort": "04-26",
@@ -45,7 +45,7 @@
     },
     {
       "id": "my-best-auntie-0-1-05-26",
-      "age_group": "0-1",
+      "service_tier": "0-1",
       "title": "My Best Auntie Training Course 0-1 - May 26",
       "description": "Nurturing the Foundations. In the first year, your helper learns to create a calm, responsive environment that supports your baby's natural development. We focus on respectful caregiving routines, safe spaces for exploration, and language-rich interactions that build secure attachment.",
       "cohort": "05-26",
@@ -87,7 +87,7 @@
     },
     {
       "id": "my-best-auntie-0-1-06-26",
-      "age_group": "0-1",
+      "service_tier": "0-1",
       "title": "My Best Auntie Training Course 0-1 - Jun 26",
       "description": "Nurturing the Foundations. In the first year, your helper learns to create a calm, responsive environment that supports your baby's natural development. We focus on respectful caregiving routines, safe spaces for exploration, and language-rich interactions that build secure attachment.",
       "cohort": "06-26",
@@ -129,7 +129,7 @@
     },
     {
       "id": "my-best-auntie-1-3-04-26",
-      "age_group": "1-3",
+      "service_tier": "1-3",
       "title": "My Best Auntie Training Course 1-3 - Apr 26",
       "description": "Fostering First Independence. Toddlers are wired to do things themselves - and your helper can nurture this beautifully. This track equips helpers with practical strategies for mealtimes, dressing, and daily routines that build your child's confidence, reduce power struggles, and make \"I do it myself!\" moments a joy, not a battle.",
       "cohort": "04-26",
@@ -171,7 +171,7 @@
     },
     {
       "id": "my-best-auntie-1-3-05-26",
-      "age_group": "1-3",
+      "service_tier": "1-3",
       "title": "My Best Auntie Training Course 1-3 - May 26",
       "description": "Fostering First Independence. Toddlers are wired to do things themselves - and your helper can nurture this beautifully. This track equips helpers with practical strategies for mealtimes, dressing, and daily routines that build your child's confidence, reduce power struggles, and make \"I do it myself!\" moments a joy, not a battle.",
       "cohort": "05-26",
@@ -213,7 +213,7 @@
     },
     {
       "id": "my-best-auntie-1-3-06-26",
-      "age_group": "1-3",
+      "service_tier": "1-3",
       "title": "My Best Auntie Training Course 1-3 - Jun 26",
       "description": "Fostering First Independence. Toddlers are wired to do things themselves - and your helper can nurture this beautifully. This track equips helpers with practical strategies for mealtimes, dressing, and daily routines that build your child's confidence, reduce power struggles, and make \"I do it myself!\" moments a joy, not a battle.",
       "cohort": "06-26",
@@ -255,7 +255,7 @@
     },
     {
       "id": "my-best-auntie-3-6-04-26",
-      "age_group": "3-6",
+      "service_tier": "3-6",
       "title": "My Best Auntie Training Course 3-6 - Apr 26",
       "description": "Building Capable, Confident Kids. At this stage, children are ready to take on real responsibility and thrive with clear boundaries. Your helper will learn how to guide without over-helping, set respectful limits, and create an environment where your child develops focus, independence, and a genuine love of learning.",
       "cohort": "04-26",
@@ -297,7 +297,7 @@
     },
     {
       "id": "my-best-auntie-3-6-05-26",
-      "age_group": "3-6",
+      "service_tier": "3-6",
       "title": "My Best Auntie Training Course 3-6 - May 26",
       "description": "Building Capable, Confident Kids. At this stage, children are ready to take on real responsibility and thrive with clear boundaries. Your helper will learn how to guide without over-helping, set respectful limits, and create an environment where your child develops focus, independence, and a genuine love of learning.",
       "cohort": "05-26",
@@ -339,7 +339,7 @@
     },
     {
       "id": "my-best-auntie-3-6-06-26",
-      "age_group": "3-6",
+      "service_tier": "3-6",
       "title": "My Best Auntie Training Course 3-6 - Jun 26",
       "description": "Building Capable, Confident Kids. At this stage, children are ready to take on real responsibility and thrive with clear boundaries. Your helper will learn how to guide without over-helping, set respectful limits, and create an environment where your child develops focus, independence, and a genuine love of learning.",
       "cohort": "06-26",

--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -454,7 +454,7 @@ function buildMyBestAuntieBookingModalPayload(
   locale: Locale,
 ): MyBestAuntieBookingModalPayload | null {
   const id = readCandidateText(record, ['id', 'eventId', 'slug']) ?? '';
-  const ageGroup = readCandidateText(record, ['service_tier', 'age_group']) ?? '';
+  const ageGroup = readCandidateText(record, ['service_tier']) ?? '';
   const cohortValue = readCandidateText(record, ['cohort']) ?? '';
   if (!id || !ageGroup || !cohortValue) {
     return null;

--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -100,7 +100,8 @@ interface MyBestAuntieEventCohortDate {
 
 export interface MyBestAuntieEventCohort {
   id: string;
-  age_group: string;
+  /** Tier slug from calendar/API JSON key `service_tier` (formerly `age_group`). */
+  service_tier: string;
   title: string;
   description: string;
   cohort: string;
@@ -453,7 +454,7 @@ function buildMyBestAuntieBookingModalPayload(
   locale: Locale,
 ): MyBestAuntieBookingModalPayload | null {
   const id = readCandidateText(record, ['id', 'eventId', 'slug']) ?? '';
-  const ageGroup = readCandidateText(record, ['age_group']) ?? '';
+  const ageGroup = readCandidateText(record, ['service_tier', 'age_group']) ?? '';
   const cohortValue = readCandidateText(record, ['cohort']) ?? '';
   if (!id || !ageGroup || !cohortValue) {
     return null;
@@ -495,7 +496,7 @@ function buildMyBestAuntieBookingModalPayload(
 
   const selectedCohort: MyBestAuntieEventCohort = {
     id,
-    age_group: ageGroup,
+    service_tier: ageGroup,
     title,
     description,
     cohort: cohortValue,

--- a/apps/public_www/tests/components/sections/events.test.tsx
+++ b/apps/public_www/tests/components/sections/events.test.tsx
@@ -416,7 +416,7 @@ describe('Events section', () => {
             id: 'my-best-auntie-booking-card',
             title: 'My Best Auntie booking card',
             booking_system: 'my-best-auntie-booking',
-            age_group: '1-3',
+            service_tier: '1-3',
             cohort: '04-26',
             location: 'physical',
             address: 'PMQ, Central',

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking.test.tsx
@@ -72,7 +72,7 @@ const selectedAgeGroupTitleTemplate =
 
 function getCohortsForAge(content: BookingContent, ageGroupId: string): BookingCohort[] {
   return content.cohorts
-    .filter((cohort) => cohort.age_group === ageGroupId)
+    .filter((cohort) => cohort.service_tier === ageGroupId)
     .sort((left, right) => {
       const leftDate = Date.parse(left.dates[0]?.start_datetime ?? '');
       const rightDate = Date.parse(right.dates[0]?.start_datetime ?? '');
@@ -296,7 +296,7 @@ describe('MyBestAuntieBooking section', () => {
       JSON.stringify(bookingContent),
     ) as BookingContent;
     contentWithoutThreeToSix.cohorts = contentWithoutThreeToSix.cohorts.filter((cohort) => {
-      return cohort.age_group !== '3-6';
+      return cohort.service_tier !== '3-6';
     });
 
     render(
@@ -468,7 +468,7 @@ describe('MyBestAuntieBooking section', () => {
     extendedBookingContent.cohorts.push(
       {
         id: 'my-best-auntie-0-1-08-26',
-        age_group: '0-1',
+        service_tier: '0-1',
         title: 'My Best Auntie Training Course 0-1',
         description: 'TBD',
         cohort: '08-26',
@@ -504,7 +504,7 @@ describe('MyBestAuntieBooking section', () => {
       },
       {
         id: 'my-best-auntie-0-1-09-26',
-        age_group: '0-1',
+        service_tier: '0-1',
         title: 'My Best Auntie Training Course 0-1',
         description: 'TBD',
         cohort: '09-26',
@@ -670,7 +670,7 @@ describe('MyBestAuntieBooking section', () => {
     ) as BookingContent;
 
     const soldOutCohort = soldOutContent.cohorts.find(
-      (cohort) => cohort.age_group === '0-1',
+      (cohort) => cohort.service_tier === '0-1',
     );
     expect(soldOutCohort).toBeDefined();
     soldOutCohort!.is_fully_booked = true;

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -252,7 +252,7 @@ describe('events-data', () => {
           id: 'my-best-auntie-booking-event-1',
           title: 'My Best Auntie booking event',
           booking_system: 'my-best-auntie-booking',
-          age_group: '1-3',
+          service_tier: '1-3',
           cohort: '04-26',
           spaces_total: 8,
           spaces_left: 5,

--- a/backend/db/alembic/versions/0040_service_tier_and_location.py
+++ b/backend/db/alembic/versions/0040_service_tier_and_location.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision = "0041_service_tier_location"
+revision = "0040_service_tier_location"
 down_revision = "0039_tags_archived_at"
 branch_labels = None
 depends_on = None

--- a/backend/db/alembic/versions/0041_service_tier_and_location.py
+++ b/backend/db/alembic/versions/0041_service_tier_and_location.py
@@ -1,0 +1,44 @@
+"""Add services.service_tier and services.location_id; drop service_instances.age_group.
+
+1. Seed: does not set ``service_instances.age_group``; new service columns nullable.
+2. NOT NULL: none added.
+3. Dropped column: ``age_group`` removed from instances (no data migration per product decision).
+4. New FK: ``services.location_id`` references ``locations.id`` ON DELETE SET NULL.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0041_service_tier_location"
+down_revision = "0039_tags_archived_at"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "services",
+        sa.Column("service_tier", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "services",
+        sa.Column(
+            "location_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("locations.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.drop_column("service_instances", "age_group")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "service_instances",
+        sa.Column("age_group", sa.String(length=128), nullable=True),
+    )
+    op.drop_column("services", "location_id")
+    op.drop_column("services", "service_tier")

--- a/backend/scripts/dump_mba_instance_uuids.py
+++ b/backend/scripts/dump_mba_instance_uuids.py
@@ -2,7 +2,7 @@
 """Print My Best Auntie service instance UUIDs for public content editing.
 
 Maps each training instance to a suggested content key
-``{age_group}::{cohort}`` (aligned with ``my-best-auntie-training-courses.json``)
+``{service_tier}::{cohort}`` (aligned with ``my-best-auntie-training-courses.json``)
 when title text matches the expected pattern; otherwise uses ``unparsed::<uuid>``.
 
 Local development only: refuses to connect unless ``ATTESTATION_FAIL_CLOSED``

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -398,7 +398,6 @@ def _create_instance(
             max_capacity=payload["max_capacity"],
             waitlist_enabled=payload["waitlist_enabled"],
             instructor_id=payload["instructor_id"],
-            age_group=payload["age_group"],
             cohort=payload["cohort"],
             notes=payload["notes"],
             external_url=payload["external_url"],
@@ -524,8 +523,6 @@ def _update_instance(
             instance.waitlist_enabled = payload["waitlist_enabled"]
         if "instructor_id" in payload:
             instance.instructor_id = payload["instructor_id"]
-        if "age_group" in payload:
-            instance.age_group = payload["age_group"]
         if "cohort" in payload:
             instance.cohort = payload["cohort"]
         if "notes" in payload:

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -171,6 +171,8 @@ def _create_service(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, An
             cover_image_s3_key=payload["cover_image_s3_key"],
             delivery_mode=payload["delivery_mode"],
             status=payload["status"],
+            service_tier=payload["service_tier"],
+            location_id=payload["location_id"],
             created_by=actor_sub,
         )
         details = _build_service_type_details(
@@ -260,6 +262,10 @@ def _update_service(
             service.delivery_mode = payload["delivery_mode"]
         if "status" in payload:
             service.status = payload["status"]
+        if "service_tier" in payload:
+            service.service_tier = payload["service_tier"]
+        if "location_id" in payload:
+            service.location_id = payload["location_id"]
         if "tag_ids" in payload:
             for tag_id in payload["tag_ids"]:
                 require_assignable_tag(session, tag_id, field="tag_ids")

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -64,10 +64,19 @@ REFERRAL_DEFAULT_CURRENCY = "HKD"
 
 
 def parse_optional_service_tier(
-    value: object, *, field_name: str = "service_tier"
+    value: object, *, field: str = "service_tier"
 ) -> str | None:
     """Parse optional service tier slug; same rules as instance cohort-style labels."""
-    return parse_optional_service_instance_slug_like_text(value, field=field_name)
+    return parse_optional_service_instance_slug_like_text(value, field=field)
+
+
+def _reject_deprecated_instance_age_group(body: Mapping[str, Any]) -> None:
+    """Instance ``age_group`` was removed; tier lives on the parent service as ``service_tier``."""
+    if has_field(body, "age_group"):
+        raise ValidationError(
+            "age_group was removed; set service_tier on the parent service instead",
+            field="age_group",
+        )
 
 
 def parse_optional_service_slug(value: Any, field: str) -> str | None:
@@ -340,6 +349,7 @@ def parse_create_instance_payload(
     body: Mapping[str, Any], service: Service
 ) -> dict[str, Any]:
     """Parse and validate service-instance creation payload."""
+    _reject_deprecated_instance_age_group(body)
     return {
         "title": parse_optional_text(body.get("title"), max_length=255),
         "slug": parse_optional_service_instance_slug(body.get("slug")),
@@ -389,6 +399,7 @@ def parse_update_instance_payload(
     """Parse and validate service-instance update payload."""
     if not body:
         raise ValidationError("At least one field is required", field="body")
+    _reject_deprecated_instance_age_group(body)
     payload: dict[str, Any] = {}
     if has_field(body, "title"):
         payload["title"] = parse_optional_text(body.get("title"), max_length=255)

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -63,6 +63,13 @@ REFERRAL_DEFAULT_DISCOUNT_VALUE = Decimal("0")
 REFERRAL_DEFAULT_CURRENCY = "HKD"
 
 
+def parse_optional_service_tier(
+    value: object, *, field_name: str = "service_tier"
+) -> str | None:
+    """Parse optional service tier slug; same rules as instance cohort-style labels."""
+    return parse_optional_service_instance_slug_like_text(value, field=field_name)
+
+
 def parse_optional_service_slug(value: Any, field: str) -> str | None:
     """Parse optional referral slug: strip, lower, validate pattern; empty -> None."""
     if value is None:
@@ -243,6 +250,8 @@ def parse_create_service_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         ),
         "status": parse_optional_enum(body.get("status"), ServiceStatus, "status")
         or ServiceStatus.DRAFT,
+        "service_tier": parse_optional_service_tier(body.get("service_tier")),
+        "location_id": parse_optional_uuid(body.get("location_id"), "location_id"),
         "tag_ids": parse_uuid_list(body.get("tag_ids"), "tag_ids"),
         "asset_ids": parse_uuid_list(body.get("asset_ids"), "asset_ids"),
         "type_details": parse_service_type_details(service_type, body),
@@ -288,6 +297,12 @@ def parse_update_service_payload(
             body.get("status"),
             ServiceStatus,
             "status",
+        )
+    if has_field(body, "service_tier"):
+        payload["service_tier"] = parse_optional_service_tier(body.get("service_tier"))
+    if has_field(body, "location_id"):
+        payload["location_id"] = parse_optional_uuid(
+            body.get("location_id"), "location_id"
         )
     if has_field(body, "tag_ids"):
         payload["tag_ids"] = parse_uuid_list(body.get("tag_ids"), "tag_ids")
@@ -351,9 +366,6 @@ def parse_create_instance_payload(
         )
         or False,
         "instructor_id": parse_optional_text(body.get("instructor_id"), max_length=128),
-        "age_group": parse_optional_service_instance_slug_like_text(
-            body.get("age_group"), field="age_group"
-        ),
         "cohort": parse_optional_service_instance_slug_like_text(
             body.get("cohort"), field="cohort"
         ),
@@ -419,10 +431,6 @@ def parse_update_instance_payload(
     if has_field(body, "instructor_id"):
         payload["instructor_id"] = parse_optional_text(
             body.get("instructor_id"), max_length=128
-        )
-    if has_field(body, "age_group"):
-        payload["age_group"] = parse_optional_service_instance_slug_like_text(
-            body.get("age_group"), field="age_group"
         )
     if has_field(body, "cohort"):
         payload["cohort"] = parse_optional_service_instance_slug_like_text(

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -61,6 +61,8 @@ def serialize_service_summary(service: Service) -> dict[str, Any]:
         "cover_image_s3_key": service.cover_image_s3_key,
         "delivery_mode": service.delivery_mode.value,
         "status": service.status.value,
+        "service_tier": service.service_tier,
+        "location_id": str(service.location_id) if service.location_id else None,
         "created_by": service.created_by,
         "created_at": service.created_at.isoformat() if service.created_at else None,
         "updated_at": service.updated_at.isoformat() if service.updated_at else None,
@@ -161,7 +163,6 @@ def serialize_instance(instance: ServiceInstance) -> dict[str, Any]:
             )
         ],
         "instructor_id": instance.instructor_id,
-        "age_group": instance.age_group,
         "cohort": instance.cohort,
         "notes": instance.notes,
         "tags": [

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -112,8 +112,11 @@ def _resolve_primary_location(
         return slots[0].location
     if instance.location is not None:
         return instance.location
-    service = instance.service
-    return service.location if service is not None else None
+    # Public calendar query eagerly loads ``instance.service`` (and ``Service.location``).
+    service = getattr(instance, "service", None)
+    if service is None:
+        return None
+    return service.location
 
 
 def _resolve_primary_price(

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -110,7 +110,10 @@ def _resolve_primary_location(
 ) -> Location | None:
     if slots and slots[0].location is not None:
         return slots[0].location
-    return instance.location
+    if instance.location is not None:
+        return instance.location
+    service = instance.service
+    return service.location if service is not None else None
 
 
 def _resolve_primary_price(
@@ -264,8 +267,8 @@ def _serialize_public_event(
         payload["slug"] = instance.slug
     if instance.landing_page is not None:
         payload["landing_page"] = instance.landing_page
-    if instance.age_group is not None:
-        payload["age_group"] = instance.age_group
+    if service.service_tier is not None:
+        payload["service_tier"] = service.service_tier
     if instance.cohort is not None:
         payload["cohort"] = instance.cohort
 

--- a/backend/src/app/db/models/service.py
+++ b/backend/src/app/db/models/service.py
@@ -28,6 +28,7 @@ from app.db.models.enums import (
 if TYPE_CHECKING:
     from app.db.models.asset import Asset
     from app.db.models.discount_code import DiscountCode
+    from app.db.models.location import Location
     from app.db.models.service_instance import ServiceInstance
     from app.db.models.tag import Tag
 
@@ -105,6 +106,12 @@ class Service(Base):
         nullable=False,
         server_default=text("now()"),
     )
+    service_tier: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    location_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("locations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
     training_course_details: Mapped[TrainingCourseDetails | None] = relationship(
         "TrainingCourseDetails",
@@ -124,6 +131,7 @@ class Service(Base):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    location: Mapped["Location | None"] = relationship("Location")
     instances: Mapped[list[ServiceInstance]] = relationship(
         "ServiceInstance",
         back_populates="service",

--- a/backend/src/app/db/models/service_instance.py
+++ b/backend/src/app/db/models/service_instance.py
@@ -117,7 +117,6 @@ class ServiceInstance(Base):
         server_default=text("false"),
     )
     instructor_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
-    age_group: Mapped[str | None] = mapped_column(String(128), nullable=True)
     cohort: Mapped[str | None] = mapped_column(String(128), nullable=True)
     notes: Mapped[str | None] = mapped_column(Text(), nullable=True)
     created_by: Mapped[str] = mapped_column(String(128), nullable=False)

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -238,7 +238,10 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                 joinedload(ServiceInstance.location),
                 selectinload(ServiceInstance.ticket_tiers),
                 joinedload(ServiceInstance.training_details),
-                joinedload(ServiceInstance.service).joinedload(Service.event_details),
+                joinedload(ServiceInstance.service).options(
+                    joinedload(Service.event_details),
+                    selectinload(Service.location),
+                ),
                 selectinload(ServiceInstance.instance_tags).joinedload(
                     ServiceInstanceTag.tag
                 ),

--- a/backend/src/app/imports/entities/event_instances.py
+++ b/backend/src/app/imports/entities/event_instances.py
@@ -199,7 +199,6 @@ class EventInstancesImporter:
                 max_capacity=max_cap,
                 waitlist_enabled=False,
                 instructor_id=None,
-                age_group=None,
                 cohort=None,
                 notes=(str(ed.notes).strip() if ed.notes else None) or None,
                 external_url=(str(ed.external_url).strip() if ed.external_url else None)

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3600,6 +3600,20 @@ components:
           $ref: "#/components/schemas/ServiceDeliveryMode"
         status:
           $ref: "#/components/schemas/ServiceStatus"
+        service_tier:
+          type: string
+          nullable: true
+          maxLength: 128
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          description: >
+            Optional slug-like tier identifier for the service template, shared across all instances.
+        location_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: >
+            Optional default venue UUID (FK to locations.id, ON DELETE SET NULL). Instances may
+            override via service_instances.location_id.
         created_by:
           type: string
         created_at:
@@ -3691,6 +3705,20 @@ components:
           $ref: "#/components/schemas/ServiceDeliveryMode"
         status:
           $ref: "#/components/schemas/ServiceStatus"
+        service_tier:
+          type: string
+          nullable: true
+          maxLength: 128
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          description: >
+            Optional slug-like tier identifier for the service template, shared across all instances.
+        location_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: >
+            Optional default venue UUID (FK to locations.id, ON DELETE SET NULL). Instances may
+            override via service_instances.location_id.
         tag_ids:
           type: array
           items:
@@ -3735,6 +3763,20 @@ components:
           $ref: "#/components/schemas/ServiceDeliveryMode"
         status:
           $ref: "#/components/schemas/ServiceStatus"
+        service_tier:
+          type: string
+          nullable: true
+          maxLength: 128
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          description: >
+            Optional slug-like tier identifier for the service template, shared across all instances.
+        location_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: >
+            Optional default venue UUID (FK to locations.id, ON DELETE SET NULL). Instances may
+            override via service_instances.location_id.
         tag_ids:
           type: array
           items:
@@ -3914,14 +3956,6 @@ components:
         instructor_id:
           type: string
           nullable: true
-        age_group:
-          type: string
-          nullable: true
-          maxLength: 128
-          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
-          description: >
-            Optional label using the same normalization rules as instance referral slugs
-            (lowercase letters, digits, single hyphens between segments).
         cohort:
           type: string
           nullable: true
@@ -4073,11 +4107,6 @@ components:
         instructor_id:
           type: string
           nullable: true
-        age_group:
-          type: string
-          nullable: true
-          maxLength: 128
-          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
         cohort:
           type: string
           nullable: true

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -949,15 +949,11 @@ components:
         location_name:
           type: string
           nullable: true
-          description: >
-            Derived from the primary session slot's location when set, otherwise from the
-            instance's location, otherwise from the parent service's location.
+          description: Venue display name; derivation matches `location_url`.
         location_address:
           type: string
           nullable: true
-          description: >
-            Derived from the primary session slot's location when set, otherwise from the
-            instance's location, otherwise from the parent service's location.
+          description: Venue address line; derivation matches `location_url`.
         location_url:
           type: string
           description: >

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -949,15 +949,23 @@ components:
         location_name:
           type: string
           nullable: true
+          description: >
+            Derived from the primary session slot's location when set, otherwise from the
+            instance's location, otherwise from the parent service's location.
         location_address:
           type: string
           nullable: true
+          description: >
+            Derived from the primary session slot's location when set, otherwise from the
+            instance's location, otherwise from the parent service's location.
         location_url:
           type: string
           description: >
             Google Maps directions URL derived server-side from venue coordinates
             when available, otherwise from the URL-encoded address. Empty string
-            for virtual offerings or when no location metadata is on file.
+            for virtual offerings or when no location metadata is on file. Location fields
+            resolve from the primary session slot's location when set, otherwise from the
+            instance's location, otherwise from the parent service's location.
         external_url:
           type: string
           nullable: true
@@ -999,7 +1007,7 @@ components:
         landing_page:
           type: string
           nullable: true
-        age_group:
+        service_tier:
           type: string
           nullable: true
         cohort:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -448,7 +448,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 
 - `services` stores reusable templates (title/description/cover image, type,
   delivery mode, status, optional `slug` for public referral URLs, optional
-  `booking_system` varchar(80) for an admin-visible booking-system label).
+  `booking_system` varchar(80) for an admin-visible booking-system label,
+  optional `service_tier` varchar(128) slug-like tier id shared by all instances,
+  optional `location_id` UUID FK to `locations.id` ON DELETE SET NULL as default venue).
 - Type-specific one-to-one extension tables:
   - `training_course_details`
   - `event_details` (includes optional `default_price` numeric(10,2) and
@@ -462,9 +464,8 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   `cover_image_s3_key`, `delivery_mode`).
 - Optional public-site fields: `slug` (unique when set), `landing_page`
   (marketing route key for the public website).
-- Optional `age_group` and `cohort` varchar(128): admin labels stored with the same
-  normalization rules as instance referral slugs (lowercase letters, digits, single
-  hyphens between segments).
+- Optional `cohort` varchar(128): admin label stored with the same normalization rules as
+  instance referral slugs (lowercase letters, digits, single hyphens between segments).
 - Optional `external_url` varchar(500): operator-provided external registration/info URL
   (http/https), distinct from Eventbrite sync URLs.
 - Eventbrite sync metadata is stored on `service_instances` so DB remains source
@@ -475,7 +476,8 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   - `eventbrite_last_payload_hash`, `eventbrite_ticket_class_map`,
     `eventbrite_retry_count`
 - Scheduling/detail tables:
-  - `instance_session_slots` (time blocks + optional location)
+  - `instance_session_slots` (time blocks + optional location; public calendar location
+    display prefers slot location, then instance `location_id`, then parent `services.location_id`)
   - `training_instance_details`
   - `event_ticket_tiers`
   - `consultation_instance_details` (Calendly event URL column removed in migration

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -447,10 +447,12 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 ### `services` + type-detail tables
 
 - `services` stores reusable templates (title/description/cover image, type,
-  delivery mode, status, optional `slug` for public referral URLs, optional
-  `booking_system` varchar(80) for an admin-visible booking-system label,
-  optional `service_tier` varchar(128) slug-like tier id shared by all instances,
-  optional `location_id` UUID FK to `locations.id` ON DELETE SET NULL as default venue).
+  delivery mode, status).
+- Optional `slug` for public referral URLs.
+- Optional `booking_system` varchar(80) for an admin-visible booking-system label.
+- Optional `service_tier` varchar(128): slug-like tier id shared by all instances.
+- Optional `location_id` UUID FK to `locations.id` ON DELETE SET NULL: default venue for
+  the template (instances and session slots may override).
 - Type-specific one-to-one extension tables:
   - `training_course_details`
   - `event_details` (includes optional `default_price` numeric(10,2) and
@@ -476,8 +478,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   - `eventbrite_last_payload_hash`, `eventbrite_ticket_class_map`,
     `eventbrite_retry_count`
 - Scheduling/detail tables:
-  - `instance_session_slots` (time blocks + optional location; public calendar location
-    display prefers slot location, then instance `location_id`, then parent `services.location_id`)
+  - `instance_session_slots` (time blocks + optional location). The public calendar feed
+    eager-loads `Service.location` only in `list_public_offerings`; venue resolution is
+    slot location, then instance `location_id`, then parent `services.location_id`.
   - `training_instance_details`
   - `event_ticket_tiers`
   - `consultation_instance_details` (Calendly event URL column removed in migration

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -81,7 +81,7 @@ their primary responsibilities.
   `/v1/admin/leads/*`, `/v1/admin/users`, `/v1/admin/instructors`,
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for
   cross-service instance listing with optional `service_id` / `service_type`
-  filters; instance create/update accepts optional `age_group`, `cohort`, and
+  filters; instance create/update accepts optional `cohort`, and
   `tag_ids` with `tags` / `tag_ids` echoed on instance responses; and
   `GET /v1/admin/services/{id}/discount-code-usage-summary` for
   aggregate discount usage before service slug changes), `/v1/admin/discount-codes/*`
@@ -105,7 +105,7 @@ their primary responsibilities.
   `/www/v1/calendar/public` (public calendar feed: returns **event** and
   **training_course** `service_instances` for published services; consultation
   is intentionally excluded. Each item includes `service_type`,
-  `service_instance_id`, `partners`, optional `age_group` / `cohort`,
+  `service_instance_id`, `partners`, optional `service_tier` (from parent service) / `cohort`,
   `is_fully_booked`, and a server-derived `location_url`. `booking_system` comes
   from `services.booking_system` or defaults from service type (MBA training
   cohorts default to `my-best-auntie-booking` when `services.slug` is

--- a/tests/test_admin_services_instance_metadata.py
+++ b/tests/test_admin_services_instance_metadata.py
@@ -8,7 +8,10 @@ from uuid import uuid4
 
 import pytest
 
-from app.api.admin_services_payloads import parse_create_instance_payload
+from app.api.admin_services_payloads import (
+    parse_create_instance_payload,
+    parse_update_instance_payload,
+)
 from app.db.models import (
     Service,
     ServiceInstance,
@@ -74,6 +77,30 @@ def test_parse_create_instance_payload_rejects_invalid_cohort_field() -> None:
     with pytest.raises(ValidationError) as exc:
         parse_create_instance_payload(body, service)
     assert exc.value.field == "cohort"
+
+
+def test_parse_create_instance_payload_rejects_deprecated_age_group() -> None:
+    service = _minimal_training_service()
+    body = {
+        "age_group": "0-1",
+        "training_details": {
+            "training_format": "group",
+            "price": "10.00",
+            "currency": "HKD",
+            "pricing_unit": "per_person",
+        },
+    }
+    with pytest.raises(ValidationError) as exc:
+        parse_create_instance_payload(body, service)
+    assert exc.value.field == "age_group"
+
+
+def test_parse_update_instance_payload_rejects_deprecated_age_group() -> None:
+    service = _minimal_training_service()
+    body = {"status": "scheduled", "age_group": "0-1"}
+    with pytest.raises(ValidationError) as exc:
+        parse_update_instance_payload(body, service)
+    assert exc.value.field == "age_group"
 
 
 def test_parse_create_instance_payload_accepts_tag_ids() -> None:

--- a/tests/test_admin_services_instance_metadata.py
+++ b/tests/test_admin_services_instance_metadata.py
@@ -1,4 +1,4 @@
-"""Tests for instance age_group, cohort, and tag_ids parsing."""
+"""Tests for instance cohort and tag_ids parsing."""
 
 from __future__ import annotations
 
@@ -45,10 +45,9 @@ def _minimal_training_service() -> Service:
     )
 
 
-def test_parse_create_instance_payload_persists_age_group_and_cohort() -> None:
+def test_parse_create_instance_payload_persists_cohort() -> None:
     service = _minimal_training_service()
     body = {
-        "age_group": "  Ages-3-5  ",
         "cohort": "Spring-2026",
         "training_details": {
             "training_format": "group",
@@ -58,14 +57,13 @@ def test_parse_create_instance_payload_persists_age_group_and_cohort() -> None:
         },
     }
     parsed = parse_create_instance_payload(body, service)
-    assert parsed["age_group"] == "ages-3-5"
     assert parsed["cohort"] == "spring-2026"
 
 
-def test_parse_create_instance_payload_rejects_invalid_age_group_field() -> None:
+def test_parse_create_instance_payload_rejects_invalid_cohort_field() -> None:
     service = _minimal_training_service()
     body = {
-        "age_group": "Bad_Slug",
+        "cohort": "Bad_Slug",
         "training_details": {
             "training_format": "group",
             "price": "10.00",
@@ -75,7 +73,7 @@ def test_parse_create_instance_payload_rejects_invalid_age_group_field() -> None
     }
     with pytest.raises(ValidationError) as exc:
         parse_create_instance_payload(body, service)
-    assert exc.value.field == "age_group"
+    assert exc.value.field == "cohort"
 
 
 def test_parse_create_instance_payload_accepts_tag_ids() -> None:
@@ -94,7 +92,7 @@ def test_parse_create_instance_payload_accepts_tag_ids() -> None:
     assert parsed["tag_ids"] == [t2, t1]
 
 
-def test_training_instance_round_trip_age_cohort_tags_in_memory() -> None:
+def test_training_instance_round_trip_cohort_tags_in_memory() -> None:
     """ORM-only check: fields map and serializer ordering matches tag name (case-insensitive)."""
     from app.api.admin_services_serializers import serialize_instance
 
@@ -128,7 +126,6 @@ def test_training_instance_round_trip_age_cohort_tags_in_memory() -> None:
         max_capacity=None,
         waitlist_enabled=False,
         instructor_id=None,
-        age_group="ages-3-5",
         cohort="spring-2026",
         notes=None,
         created_by="tester",
@@ -160,7 +157,7 @@ def test_training_instance_round_trip_age_cohort_tags_in_memory() -> None:
     instance.partner_organization_links = []
 
     payload = serialize_instance(instance)
-    assert payload["age_group"] == "ages-3-5"
+    assert "age_group" not in payload
     assert payload["cohort"] == "spring-2026"
     assert [t["name"] for t in payload["tags"]] == ["alpha", "Beta"]
     assert payload["tag_ids"] == [str(tag_aa.id), str(tag_ba.id)]

--- a/tests/test_admin_services_location_payload.py
+++ b/tests/test_admin_services_location_payload.py
@@ -1,0 +1,67 @@
+"""Tests for services.location_id parsing on create/update."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from app.api.admin_services_payloads import parse_create_service_payload, parse_update_service_payload
+from app.exceptions import ValidationError
+
+
+def test_parse_create_service_payload_location_round_trip() -> None:
+    loc = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+    body = {
+        "service_type": "event",
+        "title": "E",
+        "delivery_mode": "online",
+        "location_id": loc,
+        "event_details": {
+            "event_category": "workshop",
+            "default_price": None,
+            "default_currency": "HKD",
+        },
+    }
+    parsed = parse_create_service_payload(body)
+    assert isinstance(parsed["location_id"], UUID)
+    assert str(parsed["location_id"]) == loc
+
+
+def test_parse_create_service_payload_blank_location_is_none() -> None:
+    body = {
+        "service_type": "event",
+        "title": "E",
+        "delivery_mode": "online",
+        "location_id": "  ",
+        "event_details": {
+            "event_category": "workshop",
+            "default_price": None,
+            "default_currency": "HKD",
+        },
+    }
+    parsed = parse_create_service_payload(body)
+    assert parsed["location_id"] is None
+
+
+def test_parse_create_service_payload_invalid_location_uuid() -> None:
+    body = {
+        "service_type": "event",
+        "title": "E",
+        "delivery_mode": "online",
+        "location_id": "not-a-uuid",
+        "event_details": {
+            "event_category": "workshop",
+            "default_price": None,
+            "default_currency": "HKD",
+        },
+    }
+    with pytest.raises(ValidationError) as exc:
+        parse_create_service_payload(body)
+    assert exc.value.field == "location_id"
+
+
+def test_parse_update_service_payload_partial_blank_location() -> None:
+    body = {"location_id": ""}
+    parsed = parse_update_service_payload(body, partial=True)
+    assert parsed["location_id"] is None

--- a/tests/test_admin_services_tier_payload.py
+++ b/tests/test_admin_services_tier_payload.py
@@ -1,0 +1,78 @@
+"""Tests for parse_optional_service_tier and service payload integration."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.admin_services_payloads import (
+    parse_create_service_payload,
+    parse_optional_service_tier,
+    parse_update_service_payload,
+)
+from app.db.models.enums import ServiceDeliveryMode, ServiceType
+from app.exceptions import ValidationError
+
+
+def test_parse_optional_service_tier_none_and_blank() -> None:
+    assert parse_optional_service_tier(None) is None
+    assert parse_optional_service_tier("   ") is None
+
+
+def test_parse_optional_service_tier_valid_and_normalized() -> None:
+    assert parse_optional_service_tier("  Ages-3-5  ") == "ages-3-5"
+
+
+def test_parse_optional_service_tier_rejects_bad_pattern() -> None:
+    with pytest.raises(ValidationError) as exc:
+        parse_optional_service_tier("Bad_Slug")
+    assert exc.value.field == "service_tier"
+
+
+def test_parse_optional_service_tier_rejects_too_long() -> None:
+    long_val = "a" * 129
+    with pytest.raises(ValidationError) as exc:
+        parse_optional_service_tier(long_val)
+    assert exc.value.field == "service_tier"
+
+
+def test_parse_create_service_payload_includes_service_tier_and_location() -> None:
+    loc = "550e8400-e29b-41d4-a716-446655440000"
+    body = {
+        "service_type": "training_course",
+        "title": "Course",
+        "delivery_mode": "online",
+        "service_tier": "  tier-one  ",
+        "location_id": loc,
+        "training_details": {
+            "pricing_unit": "per_person",
+            "default_price": "10.00",
+            "default_currency": "HKD",
+        },
+    }
+    parsed = parse_create_service_payload(body)
+    assert parsed["service_tier"] == "tier-one"
+    assert str(parsed["location_id"]) == loc
+    assert parsed["service_type"] == ServiceType.TRAINING_COURSE
+
+
+def test_parse_update_service_payload_partial_service_tier() -> None:
+    body = {"service_tier": ""}
+    parsed = parse_update_service_payload(body, partial=True)
+    assert parsed["service_tier"] is None
+
+
+def test_parse_update_service_payload_partial_location_id() -> None:
+    loc = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+    body = {"location_id": loc}
+    parsed = parse_update_service_payload(body, partial=True)
+    assert str(parsed["location_id"]) == loc
+
+
+def test_parse_update_service_payload_put_requires_title_and_delivery() -> None:
+    body = {
+        "title": "T",
+        "delivery_mode": ServiceDeliveryMode.IN_PERSON.value,
+        "service_tier": "abc",
+    }
+    parsed = parse_update_service_payload(body, partial=False)
+    assert parsed["service_tier"] == "abc"

--- a/tests/test_admin_validators.py
+++ b/tests/test_admin_validators.py
@@ -42,14 +42,14 @@ def test_parse_optional_service_instance_slug_like_text_matches_slug_rules() -> 
     assert parse_optional_service_instance_slug_like_text(
         "  Spring-Cohort  ", field="cohort"
     ) == "spring-cohort"
-    assert parse_optional_service_instance_slug_like_text(None, field="age_group") is None
-    assert parse_optional_service_instance_slug_like_text("   ", field="age_group") is None
+    assert parse_optional_service_instance_slug_like_text(None, field="cohort") is None
+    assert parse_optional_service_instance_slug_like_text("   ", field="cohort") is None
 
 
 def test_parse_optional_service_instance_slug_like_text_sets_field_on_error() -> None:
     with pytest.raises(ValidationError, match="lowercase letters") as excinfo:
-        parse_optional_service_instance_slug_like_text("Bad_Slug", field="age_group")
-    assert excinfo.value.field == "age_group"
+        parse_optional_service_instance_slug_like_text("Bad_Slug", field="cohort")
+    assert excinfo.value.field == "cohort"
     with pytest.raises(ValidationError, match="lowercase letters") as excinfo2:
         parse_optional_service_instance_slug_like_text("a--b", field="cohort")
     assert excinfo2.value.field == "cohort"

--- a/tests/test_public_events_api.py
+++ b/tests/test_public_events_api.py
@@ -33,6 +33,8 @@ def _instance_row(
         booking_system=None,
         event_details=SimpleNamespace(event_category=SimpleNamespace(value="workshop")),
         delivery_mode=SimpleNamespace(value=delivery_mode_value),
+        service_tier=None,
+        location=None,
     )
     return SimpleNamespace(
         id=uuid4(),
@@ -66,7 +68,6 @@ def _instance_row(
         if with_eventbrite_url
         else None,
         external_url=None,
-        age_group=None,
         cohort=None,
         instance_tags=[],
         partner_organization_links=[],

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -36,6 +36,8 @@ def test_event_ticket_tier_price_and_booking_system_default() -> None:
             default_currency="HKD",
         ),
         delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier=None,
+        location=None,
     )
     starts = datetime(2026, 5, 1, 10, 0, tzinfo=UTC)
     ends = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
@@ -50,7 +52,6 @@ def test_event_ticket_tier_price_and_booking_system_default() -> None:
         max_capacity=None,
         external_url=None,
         eventbrite_event_url=None,
-        age_group=None,
         cohort=None,
         delivery_mode=None,
         service=service,
@@ -102,6 +103,8 @@ def test_event_default_price_when_no_tiers() -> None:
             default_currency="USD",
         ),
         delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier=None,
+        location=None,
     )
     inst = _minimal_instance(service, ticket_tiers=[])
     out = public_events._serialize_public_event(inst, enrollment_counts={})
@@ -123,6 +126,8 @@ def test_event_no_price_when_no_tiers_and_no_default() -> None:
             default_currency="HKD",
         ),
         delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier=None,
+        location=None,
     )
     inst = _minimal_instance(service, ticket_tiers=[])
     out = public_events._serialize_public_event(inst, enrollment_counts={})
@@ -188,10 +193,11 @@ def test_training_mba_booking_and_category() -> None:
         booking_system=None,
         event_details=None,
         delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier="0-1",
+        location=None,
     )
     inst = _minimal_instance(
         service,
-        age_group="0-1",
         cohort="May 2026",
         training_details=SimpleNamespace(price=Decimal("350"), currency="HKD"),
     )
@@ -201,7 +207,7 @@ def test_training_mba_booking_and_category() -> None:
     assert out["categories"] == ["Training Course"]
     assert out["price"] == 350.0
     assert out["currency"] == "HKD"
-    assert out["age_group"] == "0-1"
+    assert out["service_tier"] == "0-1"
     assert out["cohort"] == "May 2026"
 
 
@@ -214,6 +220,8 @@ def test_training_non_mba_omits_booking_system() -> None:
         booking_system=None,
         event_details=None,
         delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier=None,
+        location=None,
     )
     inst = _minimal_instance(
         service,
@@ -236,6 +244,8 @@ def test_virtual_clears_location_and_url_even_with_coords() -> None:
             default_currency="HKD",
         ),
         delivery_mode=SimpleNamespace(value="online"),
+        service_tier=None,
+        location=None,
     )
     loc = SimpleNamespace(name="X", address="Y", lat=Decimal("1"), lng=Decimal("2"))
     inst = _minimal_instance(service, delivery_mode=SimpleNamespace(value="online"))
@@ -274,11 +284,59 @@ def test_physical_address_only_location_url() -> None:
 
 def test_no_location_empty_url() -> None:
     service = _event_service()
+    service.location = None
     inst = _minimal_instance(service)
     inst.session_slots[0].location = None
     inst.location = None
     out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["location_url"] == ""
+
+
+def test_primary_location_prefers_slot_over_instance_and_service() -> None:
+    service = _event_service()
+    slot_loc = SimpleNamespace(name="SlotVenue", address="S1", lat=None, lng=None)
+    inst_loc = SimpleNamespace(name="InstVenue", address="I1", lat=None, lng=None)
+    svc_loc = SimpleNamespace(name="SvcVenue", address="V1", lat=None, lng=None)
+    service.location = svc_loc
+    inst = _minimal_instance(service)
+    inst.session_slots[0].location = slot_loc
+    inst.location = inst_loc
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["location_name"] == "SlotVenue"
+
+
+def test_primary_location_falls_back_to_instance_when_slot_unset() -> None:
+    service = _event_service()
+    inst_loc = SimpleNamespace(name="InstVenue", address="I1", lat=None, lng=None)
+    svc_loc = SimpleNamespace(name="SvcVenue", address="V1", lat=None, lng=None)
+    service.location = svc_loc
+    inst = _minimal_instance(service)
+    inst.session_slots[0].location = None
+    inst.location = inst_loc
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["location_name"] == "InstVenue"
+
+
+def test_primary_location_falls_back_to_service_when_slot_and_instance_unset() -> None:
+    service = _event_service()
+    svc_loc = SimpleNamespace(name="SvcVenue", address="V1", lat=None, lng=None)
+    service.location = svc_loc
+    inst = _minimal_instance(service)
+    inst.session_slots[0].location = None
+    inst.location = None
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["location_name"] == "SvcVenue"
+
+
+def test_primary_location_all_null() -> None:
+    service = _event_service()
+    service.location = None
+    inst = _minimal_instance(service)
+    inst.session_slots[0].location = None
+    inst.location = None
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["location_name"] is None
+    assert out["location_address"] is None
 
 
 def test_max_capacity_none_omits_spaces() -> None:
@@ -330,6 +388,8 @@ def _event_service() -> Any:
             default_currency="HKD",
         ),
         delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier=None,
+        location=None,
     )
 
 
@@ -344,7 +404,6 @@ def _minimal_instance(
     external_url: str | None = None,
     eventbrite_event_url: str | None = None,
     max_capacity: int | None = 10,
-    age_group: str | None = None,
     cohort: str | None = None,
     training_details: Any = None,
     delivery_mode: Any = None,
@@ -362,7 +421,6 @@ def _minimal_instance(
         max_capacity=max_capacity,
         external_url=external_url,
         eventbrite_event_url=eventbrite_event_url,
-        age_group=age_group,
         cohort=cohort,
         delivery_mode=delivery_mode,
         service=service,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Follow-up (post-review)

- **Alembic:** Renamed migration to `0040_service_tier_and_location.py` with `revision = "0040_service_tier_location"` (≤32 chars) so numbering is contiguous after `0039` and filename matches revision id.
- **Instance `age_group`:** `parse_create_instance_payload` / `parse_update_instance_payload` now **reject** `age_group` with `ValidationError` (field `age_group`) instead of silently ignoring — tests added in `test_admin_services_instance_metadata.py`.
- **Consultation UI:** Removed duplicate currency control from the tier row; **one** `Currency` select remains in Row D; tier row is `[tier | spacer | spacer | spacer]`.
- **ServiceTierControl:** Client-side invalid pattern message + save buttons disabled when tier non-empty and invalid (same regex as slug).
- **`parse_optional_service_tier`:** Parameter renamed to `field` for consistency.
- **`public_events._resolve_primary_location`:** Uses `getattr(instance, "service", None)` and documents eager-load expectation; `database-schema.md` notes eager-load scope.
- **`docs/api/public.yaml`:** Shorter `location_name` / `location_address` descriptions (defer to `location_url` for full precedence text).
- **`events-data.ts`:** Dropped unused `age_group` read fallback for MBA modal payload.

**Note on OpenAPI `age_group`:** Current `docs/api/admin.yaml` on this branch has **no** `age_group` on `ServiceInstance` / `CreateInstanceRequest` (already removed in the initial PR). Regenerated types do not include it. If your local checkout still shows it, pull latest.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4306101-b360-433a-9805-4e35e128f08d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4306101-b360-433a-9805-4e35e128f08d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

