### PR TITLE
Block deleting services that still have instances

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-list-panel.tsx
@@ -166,9 +166,17 @@ export function ServiceListPanel({
                     size='sm'
                     variant='danger'
                     onClick={(event) => void handleDeleteService(service, event)}
-                    disabled={isMutating}
-                    aria-label='Delete service'
-                    title='Delete service'
+                    disabled={isMutating || service.instancesCount > 0}
+                    aria-label={
+                      service.instancesCount > 0
+                        ? 'Cannot delete service while it has instances'
+                        : 'Delete service'
+                    }
+                    title={
+                      service.instancesCount > 0
+                        ? 'Remove all instances before deleting this service'
+                        : 'Delete service'
+                    }
                   >
                     <DeleteIcon className='h-4 w-4' />
                   </Button>

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -134,6 +134,7 @@ function parseServiceSummary(value: unknown): ServiceSummary {
   const eventRaw = isRecord(item.event_details) ? item.event_details : null;
   return {
     id: asNullableString(item.id) ?? '',
+    instancesCount: asNumber(item.instances_count, 0),
     serviceType: (asNullableString(item.service_type) ?? 'training_course') as ServiceSummary['serviceType'],
     title: asNullableString(item.title) ?? '',
     slug: asNullableString(item.slug),
@@ -214,7 +215,6 @@ function parseServiceDetail(value: unknown): ServiceDetail {
     assetIds: Array.isArray(item.asset_ids)
       ? item.asset_ids.filter((entry): entry is string => typeof entry === 'string')
       : [],
-    instancesCount: asNumber(item.instances_count, 0),
     trainingDetails,
     eventDetails,
     consultationDetails,

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -1632,6 +1632,15 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
+                /** @description Service has instances and cannot be deleted. */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
             };
         };
         options?: never;
@@ -4320,11 +4329,12 @@ export interface components {
             training_details?: components["schemas"]["ServiceTrainingDetails"] | null;
             /** @description Present for event rows when details exist. */
             event_details?: components["schemas"]["ServiceEventDetails"] | null;
+            /** @description Number of service instances for this template (list and detail payloads). */
+            instances_count: number;
         };
         Service: components["schemas"]["ServiceSummary"] & {
             tag_ids?: string[];
             asset_ids?: string[];
-            instances_count?: number;
             training_details?: components["schemas"]["ServiceTrainingDetails"];
             event_details?: components["schemas"]["ServiceEventDetails"];
             consultation_details?: components["schemas"]["ServiceConsultationDetails"];

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -96,6 +96,8 @@ export const ENROLLMENT_STATUSES = defineEnumValues<EnrollmentStatus>()(
 
 export interface ServiceSummary {
   id: string;
+  /** Number of instances for this service template (from API `instances_count`). */
+  instancesCount: number;
   serviceType: ServiceType;
   title: string;
   /** Lowercase referral slug from Aurora; null when unset. */
@@ -128,7 +130,6 @@ export interface ServiceSummary {
 export interface ServiceDetail extends ServiceSummary {
   tagIds: string[];
   assetIds: string[];
-  instancesCount: number;
   trainingDetails: {
     pricingUnit: TrainingPricingUnit;
     defaultPrice: string | null;

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/lib/entity-api', async () => {
 function buildServiceSummary(overrides: Partial<ServiceSummary> = {}): ServiceSummary {
   return {
     id: 'service-1',
+    instancesCount: 0,
     serviceType: 'training_course',
     title: 'Alpha service',
     slug: null,

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -9,6 +9,7 @@ import type { ServiceDetail } from '@/types/services';
 function buildService(overrides: Partial<ServiceDetail> = {}): ServiceDetail {
   return {
     id: 'service-1',
+    instancesCount: 0,
     serviceType: 'training_course',
     title: 'Alpha service',
     slug: null,
@@ -24,7 +25,6 @@ function buildService(overrides: Partial<ServiceDetail> = {}): ServiceDetail {
     updatedAt: '2025-01-02T00:00:00Z',
     tagIds: [],
     assetIds: [],
-    instancesCount: 0,
     trainingDetails: {
       pricingUnit: 'per_person',
       defaultPrice: null,

--- a/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
@@ -10,6 +10,7 @@ import type { ServiceDetail } from '@/types/services';
 function buildService(overrides: Partial<ServiceDetail> = {}): ServiceDetail {
   return {
     id: 'service-1',
+    instancesCount: 0,
     serviceType: 'training_course',
     title: 'Alpha service',
     slug: 'old-slug',
@@ -25,7 +26,6 @@ function buildService(overrides: Partial<ServiceDetail> = {}): ServiceDetail {
     updatedAt: '2025-01-02T00:00:00Z',
     tagIds: [],
     assetIds: [],
-    instancesCount: 0,
     trainingDetails: {
       pricingUnit: 'per_person',
       defaultPrice: null,

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -10,6 +10,7 @@ import type { DiscountCode, Enrollment, ServiceInstance, ServiceSummary } from '
 
 const SERVICE_FIXTURE: ServiceSummary = {
   id: 'service-1',
+  instancesCount: 0,
   serviceType: 'training_course',
   title: 'Service title',
   slug: null,
@@ -124,6 +125,28 @@ describe('services tables value formatting', () => {
     expect(within(table).getByText('Published')).toBeInTheDocument();
     expect(within(table).getByText('In Person')).toBeInTheDocument();
     expect(within(table).getByText(formatDate(SERVICE_FIXTURE.createdAt))).toBeInTheDocument();
+  });
+
+  it('disables delete when the service has instances', () => {
+    const withInstances: ServiceSummary = { ...SERVICE_FIXTURE, instancesCount: 2 };
+    render(
+      <ServiceListPanel
+        services={[withInstances]}
+        selectedServiceId={null}
+        filters={{ serviceType: '', status: '', search: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        hasMore={false}
+        error=''
+        isMutating={false}
+        onSelectService={vi.fn()}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onDeleteService={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /cannot delete service while it has instances/i })).toBeDisabled();
   });
 
   it('formats enum values in instance and discount tables', () => {

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -41,7 +41,11 @@ from app.db.models import (
     ServiceType,
     TrainingCourseDetails,
 )
-from app.db.repositories import DiscountCodeRepository, ServiceRepository
+from app.db.repositories import (
+    DiscountCodeRepository,
+    ServiceInstanceRepository,
+    ServiceRepository,
+)
 from app.exceptions import NotFoundError, ValidationError
 from app.services.aws_clients import get_s3_client
 from app.utils import json_response, require_env
@@ -138,10 +142,18 @@ def _list_services(event: Mapping[str, Any]) -> dict[str, Any]:
             status=filters["status"],
             search=filters["search"],
         )
+        instance_counts = repository.count_instances_by_service_ids(
+            [row.id for row in page_rows]
+        )
         return json_response(
             200,
             {
-                "items": [serialize_service_summary(row) for row in page_rows],
+                "items": [
+                    serialize_service_summary(
+                        row, instances_count=instance_counts.get(row.id, 0)
+                    )
+                    for row in page_rows
+                ],
                 "next_cursor": next_cursor,
                 "total_count": total_count,
             },
@@ -324,6 +336,13 @@ def _delete_service(
         service = repository.get_by_id(service_id)
         if service is None:
             raise NotFoundError("Service", str(service_id))
+        instance_repo = ServiceInstanceRepository(session)
+        if instance_repo.count_for_service_id(service_id) > 0:
+            raise ValidationError(
+                "Cannot delete a service that has instances. Remove all instances first.",
+                field="service",
+                status_code=409,
+            )
         repository.delete(service)
         session.commit()
         return json_response(204, {}, event=event)

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -48,7 +48,9 @@ def _event_details_summary(service: Service) -> dict[str, Any] | None:
     }
 
 
-def serialize_service_summary(service: Service) -> dict[str, Any]:
+def serialize_service_summary(
+    service: Service, *, instances_count: int
+) -> dict[str, Any]:
     """Serialize service list row payload."""
     logger.debug("Serializing service summary", extra={"service_id": str(service.id)})
     return {
@@ -66,6 +68,7 @@ def serialize_service_summary(service: Service) -> dict[str, Any]:
         "created_by": service.created_by,
         "created_at": service.created_at.isoformat() if service.created_at else None,
         "updated_at": service.updated_at.isoformat() if service.updated_at else None,
+        "instances_count": instances_count,
         "training_details": _training_details_summary(service),
         "event_details": _event_details_summary(service),
     }
@@ -73,7 +76,7 @@ def serialize_service_summary(service: Service) -> dict[str, Any]:
 
 def serialize_service_detail(service: Service) -> dict[str, Any]:
     """Serialize service detail payload with type-specific details."""
-    detail = serialize_service_summary(service)
+    detail = serialize_service_summary(service, instances_count=len(service.instances))
     detail["tag_ids"] = [str(tag.id) for tag in service.tags]
     detail["asset_ids"] = [str(asset.id) for asset in service.assets]
     detail["instances_count"] = len(service.instances)

--- a/backend/src/app/db/repositories/service.py
+++ b/backend/src/app/db/repositories/service.py
@@ -12,6 +12,7 @@ from app.db.models import (
     ConsultationDetails,
     EventDetails,
     Service,
+    ServiceInstance,
     ServiceStatus,
     ServiceType,
     TrainingCourseDetails,
@@ -109,6 +110,23 @@ class ServiceRepository(BaseRepository[Service]):
             )
         count = self._session.execute(statement).scalar_one_or_none()
         return int(count or 0)
+
+    def count_instances_by_service_ids(
+        self, service_ids: list[UUID]
+    ) -> dict[UUID, int]:
+        """Return instance counts per service id (missing ids map to 0)."""
+        if not service_ids:
+            return {}
+        statement = (
+            select(ServiceInstance.service_id, func.count(ServiceInstance.id))
+            .where(ServiceInstance.service_id.in_(service_ids))
+            .group_by(ServiceInstance.service_id)
+        )
+        rows = self._session.execute(statement).all()
+        counts = {service_id: 0 for service_id in service_ids}
+        for sid, cnt in rows:
+            counts[sid] = int(cnt)
+        return counts
 
     def get_by_id_with_details(self, service_id: UUID) -> Service | None:
         """Return a service with type details, tags, assets, and instances."""

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -38,6 +38,14 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
     def __init__(self, session: Session):
         super().__init__(session, ServiceInstance)
 
+    def count_for_service_id(self, service_id: UUID) -> int:
+        """Return how many instances exist for the given service template."""
+        statement = select(func.count(ServiceInstance.id)).where(
+            ServiceInstance.service_id == service_id
+        )
+        count = self._session.execute(statement).scalar_one_or_none()
+        return int(count or 0)
+
     def list_instances(
         self,
         *,

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1267,6 +1267,12 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: Service has instances and cannot be deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/admin/services/{id}/cover-image:
     parameters:
@@ -3567,6 +3573,7 @@ components:
         - title
         - delivery_mode
         - status
+        - instances_count
       properties:
         id:
           type: string
@@ -3634,6 +3641,10 @@ components:
             - $ref: "#/components/schemas/ServiceEventDetails"
           nullable: true
           description: Present for event rows when details exist.
+        instances_count:
+          type: integer
+          minimum: 0
+          description: Number of service instances for this template (list and detail payloads).
     Service:
       allOf:
         - $ref: "#/components/schemas/ServiceSummary"
@@ -3649,8 +3660,6 @@ components:
               items:
                 type: string
                 format: uuid
-            instances_count:
-              type: integer
             training_details:
               $ref: "#/components/schemas/ServiceTrainingDetails"
             event_details:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -84,7 +84,8 @@ their primary responsibilities.
   filters; instance create/update accepts optional `cohort`, and
   `tag_ids` with `tags` / `tag_ids` echoed on instance responses; and
   `GET /v1/admin/services/{id}/discount-code-usage-summary` for
-  aggregate discount usage before service slug changes), `/v1/admin/discount-codes/*`
+  aggregate discount usage before service slug changes; `DELETE /v1/admin/services/{id}`
+  returns `409` when the service still has instances), `/v1/admin/discount-codes/*`
   (`POST` returns `409` with `field: code` when the code collides with the
   case-insensitive unique index; `PUT` accepts `discount_value` `0` only when the
   effective discount type after the update is `referral`, otherwise `discount_value`

--- a/tests/test_admin_services_delete_guard.py
+++ b/tests/test_admin_services_delete_guard.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.api import admin_services
+from app.exceptions import ValidationError
+
+
+def test_delete_service_raises_when_instances_exist(monkeypatch: Any) -> None:
+    service_id = uuid4()
+    deleted: dict[str, bool] = {"called": False}
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeServiceRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id(self, sid: Any) -> object:
+            assert sid == service_id
+            return object()
+
+        def delete(self, _service: Any) -> None:
+            deleted["called"] = True
+
+    class _FakeInstanceRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def count_for_service_id(self, sid: Any) -> int:
+            assert sid == service_id
+            return 2
+
+    monkeypatch.setattr(admin_services, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_services, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_services, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(admin_services, "ServiceRepository", _FakeServiceRepository)
+    monkeypatch.setattr(admin_services, "ServiceInstanceRepository", _FakeInstanceRepository)
+
+    with pytest.raises(ValidationError) as exc_info:
+        admin_services._delete_service(
+            {"requestContext": {"requestId": "rid"}},
+            service_id=service_id,
+            actor_sub="actor",
+        )
+    assert exc_info.value.status_code == 409
+    assert "instances" in exc_info.value.message.lower()
+    assert deleted["called"] is False
+
+
+def test_list_services_includes_instance_counts(monkeypatch: Any, api_gateway_event: Any) -> None:
+    sid_a, sid_b = uuid4(), uuid4()
+    row_a = SimpleNamespace(id=sid_a)
+    row_b = SimpleNamespace(id=sid_b)
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeServiceRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_services(self, **_kwargs: Any) -> list[Any]:
+            return [row_a, row_b]
+
+        def count_services(self, **_kwargs: Any) -> int:
+            return 2
+
+        def count_instances_by_service_ids(self, ids: list[Any]) -> dict[Any, int]:
+            assert set(ids) == {sid_a, sid_b}
+            return {sid_a: 1, sid_b: 0}
+
+    captured: list[dict[str, Any]] = []
+
+    def _capture_summary(service: Any, *, instances_count: int) -> dict[str, Any]:
+        captured.append({"id": service.id, "instances_count": instances_count})
+        return {"id": str(service.id), "instances_count": instances_count}
+
+    monkeypatch.setattr(admin_services, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_services, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_services, "ServiceRepository", _FakeServiceRepository)
+    monkeypatch.setattr(admin_services, "encode_service_cursor", lambda _row: None)
+    monkeypatch.setattr(admin_services, "serialize_service_summary", _capture_summary)
+    monkeypatch.setattr(
+        admin_services,
+        "parse_service_filters",
+        lambda _event: {
+            "limit": 10,
+            "service_type": None,
+            "status": None,
+            "search": None,
+            "cursor_created_at": None,
+            "cursor_id": None,
+        },
+    )
+
+    response = admin_services._list_services(
+        api_gateway_event(method="GET", path="/v1/admin/services", query_params={"limit": "10"})
+    )
+    assert response["statusCode"] == 200
+    body = response["body"]
+    payload = json.loads(body) if isinstance(body, str) else body
+    assert captured == [
+        {"id": sid_a, "instances_count": 1},
+        {"id": sid_b, "instances_count": 0},
+    ]
+    assert payload["items"][0]["instances_count"] == 1
+    assert payload["items"][1]["instances_count"] == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **API:** `DELETE /v1/admin/services/{id}` now returns **409** when any `service_instances` rows exist for that service, with a clear error message (defense in depth if the UI is bypassed).
- **List payload:** Service list items now include **`instances_count`** (same field as detail summaries) via a grouped count query so the admin table can disable delete without an extra round trip per row.
- **Admin UI:** The service list **Delete** control is **disabled** when `instancesCount > 0`, with accessible label/title explaining that instances must be removed first.

## Tests

- `python3 -m pytest tests/test_admin_services_delete_guard.py`
- `npm run lint` and targeted Vitest for touched service components under `apps/admin_web/tests/components/admin/services/`

## Docs

- OpenAPI: `ServiceSummary.instances_count` (required), `DELETE` service **409** response.
- `docs/architecture/lambdas.md`: noted admin delete behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f939127-ff12-4783-83c7-283f4ece93fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f939127-ff12-4783-83c7-283f4ece93fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

