### PR TITLE
Admin services: remove tier hint, add duplicate-to-create

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -38,11 +38,13 @@ import type { components } from '@/types/generated/admin-api.generated';
 import {
   normalizeEventCategoryFromApi,
   type EventCategory,
+  type EventTicketTier,
   type LocationSummary,
   type PartnerOrgRef,
   type ServiceInstance,
   type ServiceSummary,
   type ServiceType,
+  type SessionSlot,
 } from '@/types/services';
 
 import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
@@ -61,6 +63,8 @@ const defaultCurrencyCode = getAdminDefaultCurrencyCode();
 
 export interface InstanceDetailPanelProps {
   instance: ServiceInstance | null;
+  /** When set with `instance` null, seed the create form from this row (UI-only duplicate). */
+  createPrefillInstance?: ServiceInstance | null;
   entityTags: EntityTagRef[];
   entityTagsLoading: boolean;
   entityTagsError: string;
@@ -145,8 +149,33 @@ function mapPartnerRefsFromInstance(instance: ServiceInstance): PartnerOrgRef[] 
   }));
 }
 
+function cloneSessionSlotsForCreate(slots: SessionSlot[]): SessionSlot[] {
+  return slots.map((slot) => ({
+    id: null,
+    instanceId: null,
+    locationId: slot.locationId,
+    startsAt: slot.startsAt,
+    endsAt: slot.endsAt,
+    sortOrder: slot.sortOrder,
+  }));
+}
+
+function cloneEventTiersForCreate(tiers: EventTicketTier[]): EventTicketTier[] {
+  return tiers.map((tier, index) => ({
+    id: null,
+    instanceId: null,
+    name: tier.name,
+    description: tier.description,
+    price: tier.price,
+    currency: tier.currency,
+    maxQuantity: tier.maxQuantity,
+    sortOrder: tier.sortOrder ?? index,
+  }));
+}
+
 export function InstanceDetailPanel({
   instance,
+  createPrefillInstance = null,
   entityTags,
   entityTagsLoading,
   entityTagsError,
@@ -165,6 +194,8 @@ export function InstanceDetailPanel({
 }: InstanceDetailPanelProps) {
   const isEditMode = Boolean(instance);
   const lastMergedServiceIdForCreateRef = useRef<string | null>(null);
+  const duplicateCreateHydratedRef = useRef(false);
+  const duplicateEventTiersTemplateRef = useRef<EventTicketTier[] | null>(null);
   const { users: instructorUsers, isLoading: isLoadingInstructors } = useInstructorUsers(
     Boolean(selectedServiceId)
   );
@@ -224,6 +255,71 @@ export function InstanceDetailPanel({
       : DEFAULT_CONSULTATION_FORM
   );
 
+  useEffect(() => {
+    if (!createPrefillInstance) {
+      duplicateCreateHydratedRef.current = false;
+      duplicateEventTiersTemplateRef.current = null;
+    }
+  }, [createPrefillInstance]);
+
+  useEffect(() => {
+    if (instance || !createPrefillInstance || !selectedServiceId) {
+      return;
+    }
+    if (selectedServiceId !== createPrefillInstance.serviceId) {
+      return;
+    }
+    if (duplicateCreateHydratedRef.current) {
+      return;
+    }
+    duplicateCreateHydratedRef.current = true;
+    lastMergedServiceIdForCreateRef.current = selectedServiceId;
+    duplicateEventTiersTemplateRef.current = cloneEventTiersForCreate(createPrefillInstance.eventTicketTiers);
+    const source = createPrefillInstance;
+    queueMicrotask(() => {
+      setTagIds([...source.tagIds]);
+      setInstanceForm({
+        title: source.title ?? '',
+        slug: '',
+        description: source.description ?? '',
+        status: source.status,
+        deliveryMode: source.deliveryMode ?? '',
+        locationId: source.locationId ?? '',
+        maxCapacity: source.maxCapacity?.toString() ?? '',
+        waitlistEnabled: source.waitlistEnabled,
+        instructorId: source.instructorId ?? '',
+        notes: source.notes ?? '',
+        cohort: source.cohort ?? '',
+        externalUrl: source.externalUrl ?? '',
+        partnerOrganizations: mapPartnerRefsFromInstance(source),
+        sessionSlots: cloneSessionSlotsForCreate(source.sessionSlots),
+      });
+      setTrainingForm({
+        pricingUnit: source.trainingDetails?.pricingUnit ?? 'per_person',
+        defaultPrice: source.trainingDetails?.price ?? '',
+        defaultCurrency: source.trainingDetails?.currency ?? defaultCurrencyCode,
+      });
+      setEventForm({
+        eventCategory: resolveInheritedEventCategory(
+          serviceOptions.find((entry) => entry.id === source.serviceId) ?? null,
+          source
+        ),
+        defaultPrice: source.eventTicketTiers?.[0]?.price ?? '',
+        defaultCurrency: source.eventTicketTiers?.[0]?.currency ?? defaultCurrencyCode,
+      });
+      setConsultationForm({
+        consultationFormat: 'one_on_one',
+        maxGroupSize: '',
+        durationMinutes: '60',
+        pricingModel: source.consultationDetails?.pricingModel ?? 'free',
+        defaultHourlyRate: source.consultationDetails?.price ?? '',
+        defaultPackagePrice: '',
+        defaultPackageSessions: source.consultationDetails?.packageSessions?.toString() ?? '',
+        defaultCurrency: source.consultationDetails?.currency ?? defaultCurrencyCode,
+      });
+    });
+  }, [instance, createPrefillInstance, selectedServiceId, serviceOptions]);
+
   const handleSelectService = useCallback(
     (serviceId: string | null) => {
       onSelectService(serviceId);
@@ -245,7 +341,11 @@ export function InstanceDetailPanel({
   );
 
   useEffect(() => {
-    if (instance || !selectedServiceId) {
+    if (
+      instance ||
+      !selectedServiceId ||
+      (createPrefillInstance && createPrefillInstance.serviceId === selectedServiceId)
+    ) {
       return;
     }
     const svc = serviceOptions.find((entry) => entry.id === selectedServiceId);
@@ -261,7 +361,7 @@ export function InstanceDetailPanel({
       setTrainingForm((prev) => mergeServiceIntoTrainingForm(prev, svc));
       setEventForm((prev) => mergeServiceIntoEventForm(prev, svc));
     });
-  }, [instance, selectedServiceId, serviceOptions]);
+  }, [instance, selectedServiceId, serviceOptions, createPrefillInstance]);
 
   useEffect(() => {
     if (!instance) {
@@ -361,7 +461,10 @@ export function InstanceDetailPanel({
     } else if (effectiveServiceType === 'event') {
       const priceStr = eventForm.defaultPrice.trim();
       const currencyStr = (eventForm.defaultCurrency || defaultCurrencyCode).trim();
-      const tiers = instance?.eventTicketTiers ?? [];
+      const tiers =
+        (instance?.eventTicketTiers?.length ? instance.eventTicketTiers : null) ??
+        duplicateEventTiersTemplateRef.current ??
+        [];
       if (tiers.length > 1) {
         payload.event_ticket_tiers = tiers.map((tier, index) => ({
           name: tier.name,

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -5,7 +5,7 @@ import type { KeyboardEvent, MouseEvent } from 'react';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
-import { DeleteIcon } from '@/components/icons/action-icons';
+import { DeleteIcon, DuplicateIcon } from '@/components/icons/action-icons';
 import { CopyFeedbackIconButton } from '@/components/ui/copy-feedback-icon-button';
 import { trackAdminAnalyticsEvent } from '@/lib/admin-analytics';
 import { tryCopyTextToClipboard } from '@/lib/clipboard';
@@ -35,6 +35,7 @@ export interface InstanceListPanelProps {
   isMutating: boolean;
   onSelectInstance: (instanceId: string) => void;
   onLoadMore: () => Promise<void> | void;
+  onDuplicateInstance: (instance: ServiceInstance) => Promise<void> | void;
   onDeleteInstance: (instanceId: string, serviceId: string) => Promise<void>;
   /** When set, show a service filter above the table (empty value = all services). */
   serviceFilter?: {
@@ -67,6 +68,7 @@ export function InstanceListPanel({
   isMutating,
   onSelectInstance,
   onLoadMore,
+  onDuplicateInstance,
   onDeleteInstance,
   serviceFilter,
   serviceTypeFilter,
@@ -85,6 +87,11 @@ export function InstanceListPanel({
       event.preventDefault();
       onSelectInstance(instanceId);
     }
+  };
+
+  const handleDuplicateInstance = (instance: ServiceInstance, event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    void onDuplicateInstance(instance);
   };
 
   const handleDeleteInstance = async (
@@ -233,6 +240,17 @@ export function InstanceListPanel({
                       idleTitle='Copy instance UUID'
                       copiedTitle='Copied'
                     />
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='outline'
+                      onClick={(event) => handleDuplicateInstance(instance, event)}
+                      disabled={isMutating}
+                      aria-label='Duplicate instance as new row'
+                      title='Duplicate instance as new row'
+                    >
+                      <DuplicateIcon className='h-4 w-4' />
+                    </Button>
                     <Button
                       type='button'
                       size='sm'

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -53,6 +53,8 @@ const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 export interface ServiceDetailPanelProps {
   service: ServiceDetail | null;
+  /** When set with `service` null, seed the create form from this template (UI-only duplicate). */
+  createPrefillFromService?: ServiceDetail | null;
   locationOptions?: LocationSummary[];
   isLoadingLocations?: boolean;
   locationError?: string | null;
@@ -68,6 +70,7 @@ type DiscountUsageLoadState = 'idle' | 'loading' | 'ok' | 'error';
 
 export function ServiceDetailPanel({
   service,
+  createPrefillFromService = null,
   locationOptions = [],
   isLoadingLocations = false,
   locationError = null,
@@ -170,6 +173,55 @@ export function ServiceDetailPanel({
       if (cancelled) {
         return;
       }
+      if (!service && createPrefillFromService) {
+        const p = createPrefillFromService;
+        setServiceType(p.serviceType);
+        setBookingSystem(p.bookingSystem ?? '');
+        setServiceTier(p.serviceTier ?? '');
+        setLocationId(p.locationId ?? '');
+        setServiceForm({
+          title: `${p.title} (copy)`,
+          description: p.description ?? '',
+          slug: '',
+          deliveryMode: p.deliveryMode,
+          status: 'draft',
+        });
+        setTrainingForm(
+          p.trainingDetails
+            ? {
+                pricingUnit: p.trainingDetails.pricingUnit,
+                defaultPrice: p.trainingDetails.defaultPrice ?? '',
+                defaultCurrency: p.trainingDetails.defaultCurrency ?? 'HKD',
+              }
+            : DEFAULT_TRAINING_FORM
+        );
+        setEventForm(
+          p.eventDetails
+            ? {
+                eventCategory: p.eventDetails.eventCategory,
+                defaultPrice: p.eventDetails.defaultPrice ?? '',
+                defaultCurrency: p.eventDetails.defaultCurrency ?? 'HKD',
+              }
+            : DEFAULT_EVENT_FORM
+        );
+        setConsultationForm(
+          p.consultationDetails
+            ? {
+                consultationFormat: p.consultationDetails.consultationFormat,
+                maxGroupSize: p.consultationDetails.maxGroupSize?.toString() ?? '',
+                durationMinutes: p.consultationDetails.durationMinutes?.toString() ?? '60',
+                pricingModel: p.consultationDetails.pricingModel,
+                defaultHourlyRate: p.consultationDetails.defaultHourlyRate ?? '',
+                defaultPackagePrice: p.consultationDetails.defaultPackagePrice ?? '',
+                defaultPackageSessions: p.consultationDetails.defaultPackageSessions?.toString() ?? '',
+                defaultCurrency: p.consultationDetails.defaultCurrency ?? 'HKD',
+              }
+            : DEFAULT_CONSULTATION_FORM
+        );
+        setSlugConflictError('');
+        setConflictingSlugNormalized(null);
+        return;
+      }
       if (!service) {
         setServiceType('training_course');
         setServiceForm(DEFAULT_SERVICE_FORM);
@@ -220,7 +272,7 @@ export function ServiceDetailPanel({
     return () => {
       cancelled = true;
     };
-  }, [service]);
+  }, [service, createPrefillFromService]);
 
   const slugPayloadValue = useMemo(() => {
     const t = serviceForm.slug.trim().toLowerCase();

--- a/apps/admin_web/src/components/admin/services/service-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-list-panel.tsx
@@ -9,7 +9,7 @@ import { Select } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
-import { DeleteIcon } from '@/components/icons/action-icons';
+import { DeleteIcon, DuplicateIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { formatDate, formatEnumLabel } from '@/lib/format';
 
@@ -31,6 +31,7 @@ export interface ServiceListPanelProps {
     value: ServiceListFilters[TKey]
   ) => void;
   onLoadMore: () => Promise<void> | void;
+  onDuplicateService: (serviceId: string) => Promise<void> | void;
   onDeleteService: (serviceId: string) => Promise<void>;
 }
 
@@ -46,6 +47,7 @@ export function ServiceListPanel({
   onSelectService,
   onFilterChange,
   onLoadMore,
+  onDuplicateService,
   onDeleteService,
 }: ServiceListPanelProps) {
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
@@ -58,6 +60,11 @@ export function ServiceListPanel({
       event.preventDefault();
       onSelectService(serviceId);
     }
+  };
+
+  const handleDuplicateService = (service: ServiceSummary, event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    void onDuplicateService(service.id);
   };
 
   const handleDeleteService = async (service: ServiceSummary, event: MouseEvent<HTMLButtonElement>) => {
@@ -161,17 +168,30 @@ export function ServiceListPanel({
                 <td className='px-4 py-3'>{formatEnumLabel(service.deliveryMode)}</td>
                 <td className='px-4 py-3'>{formatDate(service.createdAt)}</td>
                 <td className='px-4 py-3 text-right'>
-                  <Button
-                    type='button'
-                    size='sm'
-                    variant='danger'
-                    onClick={(event) => void handleDeleteService(service, event)}
-                    disabled={isMutating}
-                    aria-label='Delete service'
-                    title='Delete service'
-                  >
-                    <DeleteIcon className='h-4 w-4' />
-                  </Button>
+                  <div className='flex justify-end gap-2'>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='outline'
+                      onClick={(event) => handleDuplicateService(service, event)}
+                      disabled={isMutating}
+                      aria-label='Duplicate service as new draft'
+                      title='Duplicate service as new draft'
+                    >
+                      <DuplicateIcon className='h-4 w-4' />
+                    </Button>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='danger'
+                      onClick={(event) => void handleDeleteService(service, event)}
+                      disabled={isMutating}
+                      aria-label='Delete service'
+                      title='Delete service'
+                    >
+                      <DeleteIcon className='h-4 w-4' />
+                    </Button>
+                  </div>
                 </td>
               </tr>
             ))}

--- a/apps/admin_web/src/components/admin/services/service-tier-control.tsx
+++ b/apps/admin_web/src/components/admin/services/service-tier-control.tsx
@@ -31,7 +31,6 @@ export function ServiceTierControl({
         maxLength={128}
         autoComplete='off'
       />
-      <p className='mt-1 text-xs text-slate-500'>Lowercase letters, digits, and hyphens. Max 128 characters.</p>
       {invalid ? (
         <p className='mt-1 text-xs text-red-600'>
           Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing hyphen).

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { StatusBanner } from '@/components/status-banner';
 
-import { useServicesPage } from '@/hooks/use-services-page';
+import { useServicesPage, type ServicesView } from '@/hooks/use-services-page';
+import { getInstance, getService } from '@/lib/services-api';
+import type { ServiceDetail, ServiceInstance } from '@/types/services';
 
 import { DiscountCodesPanel } from './discount-codes-panel';
 import { VenuesPanel } from './venues-panel';
@@ -19,6 +21,49 @@ import { ServicesHeader } from './services-header';
 export function ServicesPage() {
   const state = useServicesPage();
   const [showArchivedDiscountServices, setShowArchivedDiscountServices] = useState(false);
+  const [duplicateServiceTemplate, setDuplicateServiceTemplate] = useState<ServiceDetail | null>(null);
+  const [duplicateInstanceTemplate, setDuplicateInstanceTemplate] = useState<ServiceInstance | null>(null);
+  const [servicesEditorRemountKey, setServicesEditorRemountKey] = useState(0);
+
+  const bumpServicesEditorKey = useCallback(() => {
+    setServicesEditorRemountKey((key) => key + 1);
+  }, []);
+
+  const handleDuplicateService = useCallback(async (serviceId: string) => {
+    const detail = await getService(serviceId);
+    if (!detail) {
+      return;
+    }
+    setDuplicateInstanceTemplate(null);
+    setDuplicateServiceTemplate(detail);
+    state.setSelectedServiceId(null);
+    bumpServicesEditorKey();
+  }, [bumpServicesEditorKey, state]);
+
+  const handleDuplicateInstance = useCallback(
+    async (instance: ServiceInstance) => {
+      const full = await getInstance(instance.serviceId, instance.id);
+      const row = full ?? instance;
+      setDuplicateServiceTemplate(null);
+      setDuplicateInstanceTemplate(row);
+      state.setSelectedServiceId(row.serviceId);
+      bumpServicesEditorKey();
+    },
+    [bumpServicesEditorKey, state]
+  );
+
+  const handleSetActiveView = useCallback(
+    (view: ServicesView) => {
+      if (view !== 'catalog') {
+        setDuplicateServiceTemplate(null);
+      }
+      if (view !== 'instances') {
+        setDuplicateInstanceTemplate(null);
+      }
+      state.setActiveView(view);
+    },
+    [state]
+  );
   const allServiceOptionsIncludingArchived = state.serviceList.services;
   const pickerServiceOptions = useMemo(() => {
     if (showArchivedDiscountServices) {
@@ -54,7 +99,10 @@ export function ServicesPage() {
       : null;
   const serviceDetailPanelKey = `${state.selectedServiceId ?? 'create-service'}-${
     selectedServiceDetail ? 'loaded' : 'empty'
-  }`;
+  }-${servicesEditorRemountKey}-${duplicateServiceTemplate?.id ?? ''}`;
+  const instanceDetailPanelKey = `${state.selectedInstanceId ?? 'create-instance'}-${
+    state.selectedService?.serviceType ?? 'none'
+  }-${servicesEditorRemountKey}-${duplicateInstanceTemplate?.id ?? ''}`;
   const hasAnyError =
     state.serviceList.error ||
     state.serviceDetail.error ||
@@ -74,21 +122,26 @@ export function ServicesPage() {
         </StatusBanner>
       ) : null}
 
-      <ServicesHeader activeView={state.activeView} onSetView={state.setActiveView} />
+      <ServicesHeader activeView={state.activeView} onSetView={handleSetActiveView} />
 
       {state.activeView === 'catalog' ? (
         <>
           <ServiceDetailPanel
             key={serviceDetailPanelKey}
             service={selectedServiceDetail}
+            createPrefillFromService={duplicateServiceTemplate}
             locationOptions={state.locationList.locations}
             isLoadingLocations={state.isLoadingLocations}
             locationError={state.locationError || undefined}
             isLoading={state.serviceMutations.isLoading}
             error={state.serviceMutations.error}
-            onCancelSelection={() => state.setSelectedServiceId(null)}
+            onCancelSelection={() => {
+              setDuplicateServiceTemplate(null);
+              state.setSelectedServiceId(null);
+            }}
             onCreate={async (payload) => {
               await state.serviceMutations.createServiceEntry(payload);
+              setDuplicateServiceTemplate(null);
               state.setSelectedServiceId(null);
             }}
             onUpdate={async (payload) => {
@@ -116,11 +169,16 @@ export function ServicesPage() {
             hasMore={state.serviceList.hasMore}
             error={state.serviceList.error}
             isMutating={state.serviceMutations.isLoading}
-            onSelectService={state.setSelectedServiceId}
+            onSelectService={(serviceId) => {
+              setDuplicateServiceTemplate(null);
+              state.setSelectedServiceId(serviceId);
+            }}
             onFilterChange={state.serviceList.setFilter}
             onLoadMore={state.serviceList.loadMore}
+            onDuplicateService={handleDuplicateService}
             onDeleteService={async (serviceId) => {
               if (state.selectedServiceId === serviceId) {
+                setDuplicateServiceTemplate(null);
                 state.setSelectedServiceId(null);
               }
               await state.serviceMutations.deleteServiceEntry(serviceId);
@@ -130,8 +188,9 @@ export function ServicesPage() {
       ) : state.activeView === 'instances' ? (
         <>
           <InstanceDetailPanel
-            key={`${state.selectedInstanceId ?? 'create-instance'}-${state.selectedService?.serviceType ?? 'none'}`}
+            key={instanceDetailPanelKey}
             instance={state.selectedInstance}
+            createPrefillInstance={duplicateInstanceTemplate}
             entityTags={state.entityTags}
             entityTagsLoading={state.entityTagsLoading}
             entityTagsError={state.entityTagsError}
@@ -147,13 +206,20 @@ export function ServicesPage() {
             isLoading={state.instanceMutations.isLoading}
             error={state.instanceMutations.error}
             locationError={state.locationList.error}
-            onSelectService={state.setSelectedServiceId}
-            onCancelSelection={() => state.setSelectedInstanceId(null)}
+            onSelectService={(serviceId) => {
+              setDuplicateInstanceTemplate(null);
+              state.setSelectedServiceId(serviceId);
+            }}
+            onCancelSelection={() => {
+              setDuplicateInstanceTemplate(null);
+              state.setSelectedInstanceId(null);
+            }}
             onCreate={async (serviceId, payload) => {
               if (!serviceId) {
                 return;
               }
               await state.instanceMutations.createInstanceEntry(serviceId, payload);
+              setDuplicateInstanceTemplate(null);
               state.setSelectedInstanceId(null);
             }}
             onUpdate={async (serviceId, instanceId, payload) => {
@@ -171,7 +237,10 @@ export function ServicesPage() {
             hasMore={state.instanceList.hasMore}
             error={state.instanceList.error}
             isMutating={state.instanceMutations.isLoading}
-            onSelectInstance={state.setSelectedInstanceId}
+            onSelectInstance={(instanceId) => {
+              setDuplicateInstanceTemplate(null);
+              state.setSelectedInstanceId(instanceId);
+            }}
             onLoadMore={state.instanceList.loadMore}
             showServiceColumn
             showTypeColumn
@@ -188,8 +257,10 @@ export function ServicesPage() {
               options: allServiceOptions.map((s) => ({ id: s.id, title: s.title })),
               onChange: state.setInstancesServiceFilter,
             }}
+            onDuplicateInstance={handleDuplicateInstance}
             onDeleteInstance={async (instanceId, serviceId) => {
               if (state.selectedInstanceId === instanceId) {
+                setDuplicateInstanceTemplate(null);
                 state.setSelectedInstanceId(null);
               }
               await state.instanceMutations.deleteInstanceEntry(serviceId, instanceId);

--- a/apps/admin_web/src/components/icons/action-icons.tsx
+++ b/apps/admin_web/src/components/icons/action-icons.tsx
@@ -1,6 +1,7 @@
 export { default as GoogleIcon } from './svg/google-icon.svg';
 export { default as EmailIcon } from './svg/email-icon.svg';
 export { default as CopyIcon } from './svg/copy-icon.svg';
+export { default as DuplicateIcon } from './svg/duplicate-icon.svg';
 export { default as CheckIcon } from './svg/check-icon.svg';
 export { default as RotateIcon } from './svg/rotate-icon.svg';
 export { default as DeleteIcon } from './svg/delete-icon.svg';

--- a/apps/admin_web/src/components/icons/svg/duplicate-icon.svg
+++ b/apps/admin_web/src/components/icons/svg/duplicate-icon.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.8"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <rect x="8" y="8" width="13" height="13" rx="2" />
+  <path d="M4 16H3a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h11a2 2 0 0 1 2 2v1" />
+</svg>

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { InstanceDetailPanel } from '@/components/admin/services/instance-detail-panel';
 import * as entityApi from '@/lib/entity-api';
-import type { LocationSummary, ServiceSummary } from '@/types/services';
+import type { LocationSummary, ServiceInstance, ServiceSummary } from '@/types/services';
 
 vi.mock('@/lib/entity-api', async () => {
   const actual = await vi.importActual<typeof import('@/lib/entity-api')>('@/lib/entity-api');
@@ -295,5 +295,84 @@ describe('InstanceDetailPanel', () => {
         tag_ids: [],
       })
     );
+  });
+
+  it('prefills create form from createPrefillInstance with cleared slug', async () => {
+    const prefill: ServiceInstance = {
+      id: 'old-inst',
+      serviceId: 'service-1',
+      parentServiceTitle: null,
+      parentServiceType: 'training_course',
+      title: 'Workshop A',
+      slug: 'workshop-a',
+      description: 'Body',
+      coverImageS3Key: null,
+      status: 'open',
+      deliveryMode: 'hybrid',
+      locationId: 'location-1',
+      maxCapacity: 12,
+      waitlistEnabled: true,
+      externalUrl: null,
+      partnerOrganizations: [],
+      instructorId: 'inst-1',
+      cohort: 'spring-2026',
+      notes: 'Note text',
+      tagIds: ['tag-1'],
+      createdBy: 'admin',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      resolvedTitle: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      sessionSlots: [
+        {
+          id: 'slot-1',
+          instanceId: 'old-inst',
+          locationId: 'location-1',
+          startsAt: '2026-06-01T10:00:00Z',
+          endsAt: '2026-06-01T11:00:00Z',
+          sortOrder: 0,
+        },
+      ],
+      trainingDetails: {
+        trainingFormat: 'group',
+        price: '99',
+        currency: 'USD',
+        pricingUnit: 'per_family',
+      },
+      eventTicketTiers: [],
+      consultationDetails: null,
+    };
+
+    render(
+      <InstanceDetailPanel
+        {...defaultEntityTagProps}
+        instance={null}
+        createPrefillInstance={prefill}
+        selectedServiceId='service-1'
+        serviceOptions={[buildServiceSummary()]}
+        locationOptions={[buildLocationSummary()]}
+        isLoadingLocations={false}
+        serviceType='training_course'
+        isLoading={false}
+        error=''
+        onSelectService={vi.fn()}
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Title')).toHaveValue('Workshop A');
+    });
+    expect(screen.getByLabelText('Referral slug')).toHaveValue('');
+    expect(screen.getByLabelText('Description')).toHaveValue('Body');
+    expect(screen.getByLabelText('Delivery mode')).toHaveValue('hybrid');
+    expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
+    expect(screen.getByLabelText('Price')).toHaveValue('99');
+    expect(screen.getByLabelText('Currency')).toHaveValue('USD');
+    expect(screen.getByLabelText('Cohort')).toHaveValue('spring-2026');
   });
 });

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -42,6 +42,43 @@ describe('ServiceDetailPanel', () => {
       summary: { totalCurrentUses: 0, referencingCodeCount: 0 },
       error: null,
     });
+  });
+
+  it('prefills create form from createPrefillFromService with draft title suffix and empty slug', async () => {
+    const template = buildService({
+      title: 'Original',
+      slug: 'original-slug',
+      status: 'published',
+      serviceTier: 'tier-a',
+      trainingDetails: {
+        pricingUnit: 'per_family',
+        defaultPrice: '88',
+        defaultCurrency: 'USD',
+      },
+    });
+
+    render(
+      <ServiceDetailPanel
+        service={null}
+        createPrefillFromService={template}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Title')).toHaveValue('Original (copy)');
+    });
+    expect(screen.getByLabelText('Service tier')).toHaveValue('tier-a');
+    expect(screen.getByLabelText('Referral slug')).toHaveValue('');
+    expect(screen.getByLabelText('Status')).toHaveValue('draft');
+    expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
+    expect(screen.getByLabelText('Default price')).toHaveValue('88');
+    expect(screen.getByLabelText('Currency')).toHaveValue('USD');
   });
 
   afterEach(() => {

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -115,6 +115,7 @@ describe('services tables value formatting', () => {
         onSelectService={vi.fn()}
         onFilterChange={vi.fn()}
         onLoadMore={vi.fn()}
+        onDuplicateService={vi.fn()}
         onDeleteService={vi.fn()}
       />
     );
@@ -139,6 +140,7 @@ describe('services tables value formatting', () => {
           isMutating={false}
           onSelectInstance={vi.fn()}
           onLoadMore={vi.fn()}
+          onDuplicateInstance={vi.fn()}
           onDeleteInstance={vi.fn()}
         />
         <DiscountCodesPanel


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removes the always-visible grey hint under the Service tier field (invalid tier validation copy is unchanged).
- Adds a duplicate (outline icon) control before delete in the Services and Instances table Operations columns.
- Duplicate is UI-only: loads full `getService` / `getInstance` data, clears referral slug, opens the inline create editor prefilled (service title gets ` (copy)` and status defaults to draft). Switching away from Service Catalogue or Instances via the tab strip clears any in-progress duplicate draft.

## Merge with main

Merged latest `main`; resolved `service-list-panel` conflict by keeping the duplicate button and `main`'s delete-disable logic when `instancesCount > 0`.

## Tests

- `npm run lint`
- `npm run test -- --run` on touched service component tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06570e2f-0265-4469-8ec9-b3a375162365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06570e2f-0265-4469-8ec9-b3a375162365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

