### PR TITLE
Admin: service detail panel field layout and consultation controls

### DIFF
--- a/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
@@ -52,106 +52,144 @@ export function ConsultationServiceFormatField({
   );
 }
 
-/** Row D: pricing model, hourly rate, currency, package sessions. */
-export function ConsultationServiceRowDFields({
+export function ConsultationPricingModelControl({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  return (
+    <div>
+      <Label htmlFor='consultation-pricing-model'>Pricing model</Label>
+      <Select
+        id='consultation-pricing-model'
+        value={value.pricingModel}
+        disabled={disabled}
+        onChange={(event) =>
+          onChange({ ...value, pricingModel: event.target.value as ConsultationPricingModel })
+        }
+      >
+        {CONSULTATION_PRICING_MODELS.map((entry) => (
+          <option key={entry} value={entry}>
+            {formatEnumLabel(entry)}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
+export function ConsultationHourlyRateControl({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  return (
+    <div>
+      <Label htmlFor='consultation-hourly-rate'>Hourly rate</Label>
+      <Input
+        id='consultation-hourly-rate'
+        value={value.defaultHourlyRate}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultHourlyRate: event.target.value })}
+      />
+    </div>
+  );
+}
+
+export function ConsultationPackagePriceControl({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  return (
+    <div>
+      <Label htmlFor='consultation-package-price'>Package price</Label>
+      <Input
+        id='consultation-package-price'
+        value={value.defaultPackagePrice}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultPackagePrice: event.target.value })}
+      />
+    </div>
+  );
+}
+
+export function ConsultationPackageSessionsControl({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  return (
+    <div>
+      <Label htmlFor='consultation-package-sessions'>Package sessions</Label>
+      <Input
+        id='consultation-package-sessions'
+        value={value.defaultPackageSessions}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultPackageSessions: event.target.value })}
+      />
+    </div>
+  );
+}
+
+export function ConsultationCurrencyControl({
   value,
   disabled = false,
   onChange,
 }: ConsultationServicePanelFieldsProps) {
   const currencyOptions = getCurrencyOptions();
   return (
-    <>
-      <div>
-        <Label htmlFor='consultation-pricing-model'>Pricing model</Label>
-        <Select
-          id='consultation-pricing-model'
-          value={value.pricingModel}
-          disabled={disabled}
-          onChange={(event) =>
-            onChange({ ...value, pricingModel: event.target.value as ConsultationPricingModel })
-          }
-        >
-          {CONSULTATION_PRICING_MODELS.map((entry) => (
-            <option key={entry} value={entry}>
-              {formatEnumLabel(entry)}
-            </option>
-          ))}
-        </Select>
-      </div>
-      <div>
-        <Label htmlFor='consultation-hourly-rate'>Hourly rate</Label>
-        <Input
-          id='consultation-hourly-rate'
-          value={value.defaultHourlyRate}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, defaultHourlyRate: event.target.value })}
-        />
-      </div>
-      <div>
-        <Label htmlFor='consultation-currency'>Currency</Label>
-        <Select
-          id='consultation-currency'
-          value={value.defaultCurrency}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
-        >
-          {currencyOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </Select>
-      </div>
-      <div>
-        <Label htmlFor='consultation-package-sessions'>Package sessions</Label>
-        <Input
-          id='consultation-package-sessions'
-          value={value.defaultPackageSessions}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, defaultPackageSessions: event.target.value })}
-        />
-      </div>
-    </>
+    <div>
+      <Label htmlFor='consultation-currency'>Currency</Label>
+      <Select
+        id='consultation-currency'
+        value={value.defaultCurrency}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, defaultCurrency: event.target.value })}
+      >
+        {currencyOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </Select>
+    </div>
   );
 }
 
-/** Row E: max group size, duration, package price, empty cell. */
-export function ConsultationServiceRowEFields({
+export function ConsultationDurationControl({
   value,
   disabled = false,
   onChange,
 }: ConsultationServicePanelFieldsProps) {
   return (
-    <>
-      <div>
-        <Label htmlFor='consultation-max-group-size'>Max group size</Label>
-        <Input
-          id='consultation-max-group-size'
-          value={value.maxGroupSize}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, maxGroupSize: event.target.value })}
-        />
-      </div>
-      <div>
-        <Label htmlFor='consultation-duration-minutes'>Duration (minutes)</Label>
-        <Input
-          id='consultation-duration-minutes'
-          value={value.durationMinutes}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, durationMinutes: event.target.value })}
-        />
-      </div>
-      <div>
-        <Label htmlFor='consultation-package-price'>Package price</Label>
-        <Input
-          id='consultation-package-price'
-          value={value.defaultPackagePrice}
-          disabled={disabled}
-          onChange={(event) => onChange({ ...value, defaultPackagePrice: event.target.value })}
-        />
-      </div>
-      <div aria-hidden className='hidden md:block' />
-    </>
+    <div>
+      <Label htmlFor='consultation-duration-minutes'>Duration (minutes)</Label>
+      <Input
+        id='consultation-duration-minutes'
+        value={value.durationMinutes}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, durationMinutes: event.target.value })}
+      />
+    </div>
+  );
+}
+
+export function ConsultationMaxGroupSizeControl({
+  value,
+  disabled = false,
+  onChange,
+}: ConsultationServicePanelFieldsProps) {
+  return (
+    <div>
+      <Label htmlFor='consultation-max-group-size'>Max group size</Label>
+      <Input
+        id='consultation-max-group-size'
+        value={value.maxGroupSize}
+        disabled={disabled}
+        onChange={(event) => onChange({ ...value, maxGroupSize: event.target.value })}
+      />
+    </div>
   );
 }
 
@@ -163,10 +201,16 @@ export function ConsultationServicePanelFields(props: ConsultationServicePanelFi
         <ConsultationServiceFormatField {...props} />
       </div>
       <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-        <ConsultationServiceRowDFields {...props} />
+        <ConsultationPricingModelControl {...props} />
+        <ConsultationHourlyRateControl {...props} />
+        <ConsultationCurrencyControl {...props} />
+        <ConsultationPackageSessionsControl {...props} />
       </div>
       <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-        <ConsultationServiceRowEFields {...props} />
+        <ConsultationMaxGroupSizeControl {...props} />
+        <ConsultationDurationControl {...props} />
+        <ConsultationPackagePriceControl {...props} />
+        <div aria-hidden className='hidden md:block' />
       </div>
     </div>
   );

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -21,9 +21,14 @@ import type { ServiceDeliveryMode } from '@/types/services';
 import type { LocationSummary, ServiceDetail, ServiceType } from '@/types/services';
 
 import {
+  ConsultationCurrencyControl,
+  ConsultationDurationControl,
+  ConsultationHourlyRateControl,
+  ConsultationMaxGroupSizeControl,
+  ConsultationPackagePriceControl,
+  ConsultationPackageSessionsControl,
+  ConsultationPricingModelControl,
   ConsultationServiceFormatField,
-  ConsultationServiceRowDFields,
-  ConsultationServiceRowEFields,
   type ConsultationFormState,
 } from './consultation-form-fields';
 import {
@@ -338,6 +343,36 @@ export function ServiceDetailPanel({
     </>
   );
 
+  const defaultLocationField = (
+    <div>
+      <Label htmlFor='service-default-location'>Default location</Label>
+      {hasLocationOptions || isLoadingLocations ? (
+        <Select
+          id='service-default-location'
+          value={selectedLocationValue}
+          onChange={(event) => setLocationId(event.target.value)}
+        >
+          <option value=''>{isLoadingLocations ? 'Loading locations...' : 'Select location'}</option>
+          {locationId && !locationExists ? <option value={locationId}>{locationId}</option> : null}
+          {locationOptions.map((location) => (
+            <option key={location.id} value={location.id}>
+              {formatLocationLabel(location)}
+            </option>
+          ))}
+        </Select>
+      ) : (
+        <Input
+          id='service-default-location'
+          value={locationId}
+          onChange={(event) => setLocationId(event.target.value)}
+          placeholder='Location UUID'
+          autoComplete='off'
+        />
+      )}
+      {locationError ? <p className='mt-1 text-xs text-red-600'>{locationError}</p> : null}
+    </div>
+  );
+
   const buildTypeSpecificPayload = (
     currentServiceType: ServiceType
   ):
@@ -603,110 +638,91 @@ export function ServiceDetailPanel({
           />
         </div>
 
-        <div>
-          <Label htmlFor='service-default-location'>Default location</Label>
-          {hasLocationOptions || isLoadingLocations ? (
-            <Select
-              id='service-default-location'
-              value={selectedLocationValue}
-              onChange={(event) => setLocationId(event.target.value)}
-            >
-              <option value=''>
-                {isLoadingLocations ? 'Loading locations...' : 'Select location (optional)'}
-              </option>
-              {locationId && !locationExists ? <option value={locationId}>{locationId}</option> : null}
-              {locationOptions.map((location) => (
-                <option key={location.id} value={location.id}>
-                  {formatLocationLabel(location)}
-                </option>
-              ))}
-            </Select>
-          ) : (
-            <Input
-              id='service-default-location'
-              value={locationId}
-              onChange={(event) => setLocationId(event.target.value)}
-              placeholder='Location UUID'
-              autoComplete='off'
-            />
-          )}
-          {locationError ? <p className='mt-1 text-xs text-red-600'>{locationError}</p> : null}
-        </div>
-
         {serviceType === 'training_course' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
             {deliveryModeSelect}
-            <TrainingPricingUnitControl value={trainingForm} onChange={setTrainingForm} />
-            {bookingAndCover}
-          </div>
-        ) : null}
-
-        {serviceType === 'event' ? (
-          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            {deliveryModeSelect}
-            <EventCategoryControl value={eventForm} onChange={setEventForm} categoryFieldId='service-event-category' />
-            {bookingAndCover}
-          </div>
-        ) : null}
-
-        {serviceType === 'consultation' ? (
-          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-            {deliveryModeSelect}
-            <ConsultationServiceFormatField value={consultationForm} onChange={setConsultationForm} />
-            {bookingAndCover}
-          </div>
-        ) : null}
-
-        {serviceType === 'training_course' ? (
-          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
             <ServiceTierControl
               value={serviceTier}
               onChange={setServiceTier}
               id='service-tier-training'
               invalid={tierInvalid}
             />
+            {bookingAndCover}
+          </div>
+        ) : null}
+
+        {serviceType === 'training_course' ? (
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <TrainingPricingUnitControl value={trainingForm} onChange={setTrainingForm} />
             <TrainingPriceControl
               value={trainingForm}
               onChange={setTrainingForm}
               priceLabel='Default price'
             />
             <TrainingCurrencyControl value={trainingForm} onChange={setTrainingForm} />
-            <div aria-hidden className='hidden md:block' />
+            {defaultLocationField}
           </div>
         ) : null}
 
         {serviceType === 'event' ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            {deliveryModeSelect}
             <ServiceTierControl
               value={serviceTier}
               onChange={setServiceTier}
               id='service-tier-event'
               invalid={tierInvalid}
             />
+            {bookingAndCover}
+          </div>
+        ) : null}
+
+        {serviceType === 'event' ? (
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            <EventCategoryControl value={eventForm} onChange={setEventForm} categoryFieldId='service-event-category' />
             <EventDefaultPriceControl value={eventForm} onChange={setEventForm} />
             <EventDefaultCurrencyControl value={eventForm} onChange={setEventForm} />
-            <div aria-hidden className='hidden md:block' />
+            {defaultLocationField}
+          </div>
+        ) : null}
+
+        {serviceType === 'consultation' ? (
+          <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+            {deliveryModeSelect}
+            <ServiceTierControl
+              value={serviceTier}
+              onChange={setServiceTier}
+              id='service-tier-consultation'
+              invalid={tierInvalid}
+            />
+            {bookingAndCover}
           </div>
         ) : null}
 
         {serviceType === 'consultation' ? (
           <>
-            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-              <ConsultationServiceRowDFields value={consultationForm} onChange={setConsultationForm} />
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-5'>
+              <ConsultationServiceFormatField value={consultationForm} onChange={setConsultationForm} />
+              <ConsultationPricingModelControl value={consultationForm} onChange={setConsultationForm} />
+              {consultationForm.pricingModel === 'hourly' ? (
+                <ConsultationHourlyRateControl value={consultationForm} onChange={setConsultationForm} />
+              ) : null}
+              {consultationForm.pricingModel === 'package' ? (
+                <ConsultationPackagePriceControl value={consultationForm} onChange={setConsultationForm} />
+              ) : null}
+              {consultationForm.pricingModel !== 'free' ? (
+                <ConsultationCurrencyControl value={consultationForm} onChange={setConsultationForm} />
+              ) : null}
+              {defaultLocationField}
             </div>
-            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-              <ConsultationServiceRowEFields value={consultationForm} onChange={setConsultationForm} />
-            </div>
-            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-              <ServiceTierControl
-                value={serviceTier}
-                onChange={setServiceTier}
-                id='service-tier-consultation'
-                invalid={tierInvalid}
-              />
-              <div aria-hidden className='hidden md:block' />
-              <div aria-hidden className='hidden md:block' />
-              <div aria-hidden className='hidden md:block' />
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-3'>
+              <ConsultationDurationControl value={consultationForm} onChange={setConsultationForm} />
+              {consultationForm.pricingModel === 'package' ? (
+                <ConsultationPackageSessionsControl value={consultationForm} onChange={setConsultationForm} />
+              ) : null}
+              {consultationForm.consultationFormat !== 'one_on_one' ? (
+                <ConsultationMaxGroupSizeControl value={consultationForm} onChange={setConsultationForm} />
+              ) : null}
             </div>
           </>
         ) : null}

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -207,34 +207,41 @@ describe('ServiceDetailPanel', () => {
     expect(editModeServiceType).toHaveValue('consultation');
   });
 
-  it('lays out event fields in one row with delivery mode and omits placeholder pricing', async () => {
+  it('lays out event fields: Row1 delivery/tier/booking/cover; Row2 category/price/currency/location', async () => {
     const user = userEvent.setup();
-    const onUpdate = vi.fn();
-    const onCreate = vi.fn();
-    const onUploadCover = vi.fn();
-    const onCancelSelection = vi.fn();
 
     render(
       <ServiceDetailPanel
         service={null}
         isLoading={false}
         error=''
-        onCancelSelection={onCancelSelection}
-        onCreate={onCreate}
-        onUpdate={onUpdate}
-        onUploadCover={onUploadCover}
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
       />
     );
 
     await user.selectOptions(screen.getByLabelText('Type'), 'event');
 
-    expect(screen.getByLabelText('Delivery mode')).toBeInTheDocument();
-    expect(screen.getByLabelText('Event category')).toBeInTheDocument();
-    expect(screen.getByLabelText('Booking system')).toBeInTheDocument();
-    expect(screen.getByLabelText('Cover file name')).toBeInTheDocument();
+    const delivery = screen.getByLabelText('Delivery mode');
+    const tier = screen.getByLabelText('Service tier');
+    const booking = screen.getByLabelText('Booking system');
+    const cover = screen.getByLabelText('Cover file name');
+    expect(delivery.compareDocumentPosition(tier) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(tier.compareDocumentPosition(booking) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(booking.compareDocumentPosition(cover) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    const category = screen.getByLabelText('Event category');
+    const defaultPrice = screen.getByLabelText('Default price');
+    const currency = screen.getByLabelText('Currency');
+    const location = screen.getByLabelText('Default location');
+    expect(category.compareDocumentPosition(defaultPrice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(defaultPrice.compareDocumentPosition(currency) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(currency.compareDocumentPosition(location) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
     expect(screen.queryAllByLabelText('Booking system')).toHaveLength(1);
     expect(screen.queryByText('Pricing unit')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Default price')).toBeInTheDocument();
   });
 
   it('labels training course default amount as Default price', async () => {
@@ -256,7 +263,7 @@ describe('ServiceDetailPanel', () => {
     expect(screen.getByLabelText('Default price')).toBeInTheDocument();
   });
 
-  it('shows consultation Row D/E fields without Calendly', async () => {
+  it('shows consultation fields without Calendly; max group size after group format', async () => {
     const user = userEvent.setup();
     render(
       <ServiceDetailPanel
@@ -272,6 +279,8 @@ describe('ServiceDetailPanel', () => {
     await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
     expect(screen.getByLabelText('Consultation format')).toBeInTheDocument();
     expect(screen.getByLabelText('Pricing model')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Max group size')).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Consultation format'), 'group');
     expect(screen.getByLabelText('Max group size')).toBeInTheDocument();
     expect(screen.queryByLabelText(/Calendly/i)).not.toBeInTheDocument();
   });
@@ -303,6 +312,8 @@ describe('ServiceDetailPanel', () => {
     expect(body.service_tier).toBe('ages-3-5');
     const defaultPrice = screen.getByLabelText('Default price');
     expect(tierInputs[0].compareDocumentPosition(defaultPrice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const defaultLocation = screen.getByLabelText('Default location');
+    expect(defaultPrice.compareDocumentPosition(defaultLocation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('places service tier before default price for event and submits service_tier', async () => {
@@ -332,9 +343,11 @@ describe('ServiceDetailPanel', () => {
     expect(body.service_tier).toBe('spring-tier');
     const defaultPrice = screen.getByLabelText('Default price');
     expect(tierInputs[0].compareDocumentPosition(defaultPrice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const defaultLocation = screen.getByLabelText('Default location');
+    expect(defaultPrice.compareDocumentPosition(defaultLocation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('consultation shows one currency control (Row D) and a service tier field', async () => {
+  it('consultation shows currency when hourly and a service tier field in Row1', async () => {
     const user = userEvent.setup();
     render(
       <ServiceDetailPanel
@@ -350,6 +363,8 @@ describe('ServiceDetailPanel', () => {
       />
     );
     await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
+    expect(screen.queryByLabelText('Currency')).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Pricing model'), 'hourly');
     expect(screen.getByLabelText('Currency')).toBeInTheDocument();
     expect(document.getElementById('service-tier-consultation')).not.toBeNull();
   });
@@ -420,5 +435,160 @@ describe('ServiceDetailPanel', () => {
     expect(onCreate).toHaveBeenCalled();
     const body = onCreate.mock.calls[0][0] as { location_id?: string | null };
     expect(body.location_id).toBe(uuid);
+  });
+
+  it('lays out training Row1/Row2 with expected fields and order', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+
+    const delivery = screen.getByLabelText('Delivery mode');
+    const tier = screen.getByLabelText('Service tier');
+    const booking = screen.getByLabelText('Booking system');
+    const cover = screen.getByLabelText('Cover file name');
+    expect(delivery.compareDocumentPosition(tier) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(tier.compareDocumentPosition(booking) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(booking.compareDocumentPosition(cover) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    const pricingUnit = screen.getByLabelText('Pricing unit');
+    const defaultPrice = screen.getByLabelText('Default price');
+    const currency = screen.getByLabelText('Currency');
+    const location = screen.getByLabelText('Default location');
+    expect(pricingUnit.compareDocumentPosition(defaultPrice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(defaultPrice.compareDocumentPosition(currency) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(currency.compareDocumentPosition(location) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('lays out consultation Row1 with delivery, tier, booking, cover', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
+
+    const delivery = screen.getByLabelText('Delivery mode');
+    const tier = document.getElementById('service-tier-consultation');
+    expect(tier).not.toBeNull();
+    const booking = screen.getByLabelText('Booking system');
+    const cover = screen.getByLabelText('Cover file name');
+    expect(delivery.compareDocumentPosition(tier!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(tier!.compareDocumentPosition(booking) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(booking.compareDocumentPosition(cover) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('consultation pricing free hides price/currency/package sessions', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
+    await user.selectOptions(screen.getByLabelText('Pricing model'), 'free');
+    expect(screen.queryByLabelText('Hourly rate')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Package price')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Currency')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Package sessions')).not.toBeInTheDocument();
+  });
+
+  it('consultation pricing hourly shows hourly rate and currency; hides package fields', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
+    await user.selectOptions(screen.getByLabelText('Pricing model'), 'hourly');
+    expect(screen.getByLabelText('Hourly rate')).toBeInTheDocument();
+    expect(screen.getByLabelText('Currency')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Package price')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Package sessions')).not.toBeInTheDocument();
+  });
+
+  it('consultation pricing package shows package price, currency, sessions; hides hourly', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
+    await user.selectOptions(screen.getByLabelText('Pricing model'), 'package');
+    expect(screen.getByLabelText('Package price')).toBeInTheDocument();
+    expect(screen.getByLabelText('Currency')).toBeInTheDocument();
+    expect(screen.getByLabelText('Package sessions')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Hourly rate')).not.toBeInTheDocument();
+  });
+
+  it('default location select uses Select location placeholder', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        locationOptions={[
+          {
+            id: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+            name: 'Venue A',
+            areaId: 'a',
+            address: null,
+            lat: null,
+            lng: null,
+            createdAt: null,
+            updatedAt: null,
+            lockedFromPartnerOrg: false,
+            partnerOrganizationLabels: [],
+          },
+        ]}
+        isLoadingLocations={false}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+    const select = screen.getByLabelText('Default location') as HTMLSelectElement;
+    const placeholder = Array.from(select.options).find((o) => o.value === '');
+    expect(placeholder?.textContent).toBe('Select location');
+    expect(placeholder?.textContent).not.toContain('optional');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders the admin **Service** detail panel so **Default location** sits in each service type’s second row (no standalone block under Description). **Service tier** moves to **Row 1** beside delivery mode, booking system, and cover file name for training, event, and consultation.

## Consultation

- **Row 2** uses `md:grid-cols-5` with conditional cells: hourly rate vs package price, currency when pricing ≠ free, default location last; no placeholder cells when fields are omitted.
- **Row 3** uses `md:grid-cols-3`: duration, package sessions (package only), max group size (hidden for one-on-one).

## Other

- Default location `<select>` placeholder option text: **Select location** (was “Select location (optional)”).
- `consultation-form-fields.tsx`: named exports for each service-level consultation control; `ConsultationServicePanelFields` updated to use them; removed unused `ConsultationServiceRowDFields` / `ConsultationServiceRowEFields`.

## Tests

- Updated and expanded `service-detail-panel.test.tsx` for layout, conditionals, and placeholder copy.

## Validation

- `npm run test -- --run tests/components/admin/services/service-detail-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cb92ee7-70f9-4d9a-ad25-d8c8b789b41f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cb92ee7-70f9-4d9a-ad25-d8c8b789b41f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

