### PR TITLE
Admin web: service form field hints and empty defaults

### DIFF
--- a/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/consultation-form-fields.tsx
@@ -170,6 +170,7 @@ export function ConsultationDurationControl({
         value={value.durationMinutes}
         disabled={disabled}
         onChange={(event) => onChange({ ...value, durationMinutes: event.target.value })}
+        title='e.g. 60'
       />
     </div>
   );
@@ -259,6 +260,7 @@ export function ConsultationFormFieldsStacked({
           value={value.durationMinutes}
           disabled={disabled}
           onChange={(event) => onChange({ ...value, durationMinutes: event.target.value })}
+          title='e.g. 60'
         />
       </div>
       <div>

--- a/apps/admin_web/src/components/admin/services/form-defaults.ts
+++ b/apps/admin_web/src/components/admin/services/form-defaults.ts
@@ -27,7 +27,7 @@ export const DEFAULT_EVENT_FORM: EventFormState = {
 export const DEFAULT_CONSULTATION_FORM: ConsultationFormState = {
   consultationFormat: 'one_on_one',
   maxGroupSize: '',
-  durationMinutes: '60',
+  durationMinutes: '',
   pricingModel: 'free',
   defaultHourlyRate: '',
   defaultPackagePrice: '',

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -245,7 +245,7 @@ export function InstanceDetailPanel({
       ? {
           consultationFormat: 'one_on_one',
           maxGroupSize: '',
-          durationMinutes: '60',
+          durationMinutes: '',
           pricingModel: instance.consultationDetails?.pricingModel ?? 'free',
           defaultHourlyRate: instance.consultationDetails?.price ?? '',
           defaultPackagePrice: '',
@@ -310,7 +310,7 @@ export function InstanceDetailPanel({
       setConsultationForm({
         consultationFormat: 'one_on_one',
         maxGroupSize: '',
-        durationMinutes: '60',
+        durationMinutes: '',
         pricingModel: source.consultationDetails?.pricingModel ?? 'free',
         defaultHourlyRate: source.consultationDetails?.price ?? '',
         defaultPackagePrice: '',
@@ -404,7 +404,7 @@ export function InstanceDetailPanel({
       setConsultationForm({
         consultationFormat: 'one_on_one',
         maxGroupSize: '',
-        durationMinutes: '60',
+        durationMinutes: '',
         pricingModel: instance.consultationDetails?.pricingModel ?? 'free',
         defaultHourlyRate: instance.consultationDetails?.price ?? '',
         defaultPackagePrice: '',

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -700,8 +700,10 @@ export function ServiceDetailPanel({
 
         {serviceType === 'consultation' ? (
           <>
-            <div className='grid grid-cols-1 gap-3 md:grid-cols-5'>
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
               <ConsultationServiceFormatField value={consultationForm} onChange={setConsultationForm} />
+            </div>
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
               <ConsultationPricingModelControl value={consultationForm} onChange={setConsultationForm} />
               {consultationForm.pricingModel === 'hourly' ? (
                 <ConsultationHourlyRateControl value={consultationForm} onChange={setConsultationForm} />
@@ -714,7 +716,7 @@ export function ServiceDetailPanel({
               ) : null}
               {defaultLocationField}
             </div>
-            <div className='grid grid-cols-1 gap-3 md:grid-cols-3'>
+            <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
               <ConsultationDurationControl value={consultationForm} onChange={setConsultationForm} />
               {consultationForm.pricingModel === 'package' ? (
                 <ConsultationPackageSessionsControl value={consultationForm} onChange={setConsultationForm} />

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -123,7 +123,7 @@ export function ServiceDetailPanel({
       ? {
           consultationFormat: service.consultationDetails?.consultationFormat ?? 'one_on_one',
           maxGroupSize: service.consultationDetails?.maxGroupSize?.toString() ?? '',
-          durationMinutes: service.consultationDetails?.durationMinutes?.toString() ?? '60',
+          durationMinutes: service.consultationDetails?.durationMinutes?.toString() ?? '',
           pricingModel: service.consultationDetails?.pricingModel ?? 'free',
           defaultHourlyRate: service.consultationDetails?.defaultHourlyRate ?? '',
           defaultPackagePrice: service.consultationDetails?.defaultPackagePrice ?? '',
@@ -132,7 +132,7 @@ export function ServiceDetailPanel({
         }
       : DEFAULT_CONSULTATION_FORM
   );
-  const [coverFileName, setCoverFileName] = useState('cover-image.jpg');
+  const [coverFileName, setCoverFileName] = useState('');
   const [bookingSystem, setBookingSystem] = useState(service?.bookingSystem ?? '');
   const [serviceTier, setServiceTier] = useState(service?.serviceTier ?? '');
   const [locationId, setLocationId] = useState(service?.locationId ?? '');
@@ -214,7 +214,7 @@ export function ServiceDetailPanel({
             ? {
                 consultationFormat: p.consultationDetails.consultationFormat,
                 maxGroupSize: p.consultationDetails.maxGroupSize?.toString() ?? '',
-                durationMinutes: p.consultationDetails.durationMinutes?.toString() ?? '60',
+                durationMinutes: p.consultationDetails.durationMinutes?.toString() ?? '',
                 pricingModel: p.consultationDetails.pricingModel,
                 defaultHourlyRate: p.consultationDetails.defaultHourlyRate ?? '',
                 defaultPackagePrice: p.consultationDetails.defaultPackagePrice ?? '',
@@ -264,7 +264,7 @@ export function ServiceDetailPanel({
       setConsultationForm({
         consultationFormat: service.consultationDetails?.consultationFormat ?? 'one_on_one',
         maxGroupSize: service.consultationDetails?.maxGroupSize?.toString() ?? '',
-        durationMinutes: service.consultationDetails?.durationMinutes?.toString() ?? '60',
+        durationMinutes: service.consultationDetails?.durationMinutes?.toString() ?? '',
         pricingModel: service.consultationDetails?.pricingModel ?? 'free',
         defaultHourlyRate: service.consultationDetails?.defaultHourlyRate ?? '',
         defaultPackagePrice: service.consultationDetails?.defaultPackagePrice ?? '',
@@ -327,7 +327,7 @@ export function ServiceDetailPanel({
           id='service-booking-system'
           value={bookingSystem}
           onChange={(event) => setBookingSystem(event.target.value)}
-          placeholder='Optional label'
+          title='e.g. training-booking'
           maxLength={80}
           autoComplete='off'
         />
@@ -338,6 +338,7 @@ export function ServiceDetailPanel({
           id='service-detail-cover-file-name'
           value={coverFileName}
           onChange={(event) => setCoverFileName(event.target.value)}
+          title='e.g. cover-image.jpg'
         />
       </div>
     </>
@@ -590,7 +591,6 @@ export function ServiceDetailPanel({
               id='service-title'
               value={serviceForm.title}
               onChange={(event) => setServiceForm({ ...serviceForm, title: event.target.value })}
-              placeholder='Service title'
             />
           </div>
           <ServiceReferralSlugField
@@ -634,7 +634,6 @@ export function ServiceDetailPanel({
             value={serviceForm.description}
             onChange={(event) => setServiceForm({ ...serviceForm, description: event.target.value })}
             rows={3}
-            placeholder='Optional description'
           />
         </div>
 

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -476,7 +476,7 @@ describe('ServiceDetailPanel', () => {
     expect(currency.compareDocumentPosition(location) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('lays out consultation Row1 with delivery, tier, booking, cover', async () => {
+  it('lays out consultation Row1 with delivery, tier, booking, cover; format on next row', async () => {
     const user = userEvent.setup();
     render(
       <ServiceDetailPanel
@@ -499,6 +499,11 @@ describe('ServiceDetailPanel', () => {
     expect(delivery.compareDocumentPosition(tier!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(tier!.compareDocumentPosition(booking) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(booking.compareDocumentPosition(cover) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    const format = screen.getByLabelText('Consultation format');
+    const pricingModel = screen.getByLabelText('Pricing model');
+    expect(cover.compareDocumentPosition(format) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(format.compareDocumentPosition(pricingModel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('consultation pricing free hides price/currency/package sessions', async () => {

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -107,6 +107,11 @@ describe('ServiceDetailPanel', () => {
     expect(screen.getByLabelText('Title')).toHaveValue('');
     expect(screen.getByLabelText('Description')).toHaveValue('');
     expect(screen.getByLabelText('Status')).toHaveValue('draft');
+    expect(screen.getByLabelText('Cover file name')).toHaveValue('');
+    expect(screen.getByLabelText('Cover file name')).toHaveAttribute('title', 'e.g. cover-image.jpg');
+    expect(screen.getByLabelText('Booking system')).toHaveAttribute('title', 'e.g. training-booking');
+    expect(screen.getByLabelText('Title')).not.toHaveAttribute('placeholder');
+    expect(screen.getByLabelText('Description')).not.toHaveAttribute('placeholder');
 
     rerender(
       <ServiceDetailPanel
@@ -277,6 +282,8 @@ describe('ServiceDetailPanel', () => {
       />
     );
     await user.selectOptions(screen.getByLabelText('Type'), 'consultation');
+    expect(screen.getByLabelText('Duration (minutes)')).toHaveValue('');
+    expect(screen.getByLabelText('Duration (minutes)')).toHaveAttribute('title', 'e.g. 60');
     expect(screen.getByLabelText('Consultation format')).toBeInTheDocument();
     expect(screen.getByLabelText('Pricing model')).toBeInTheDocument();
     expect(screen.queryByLabelText('Max group size')).not.toBeInTheDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Services admin editor so cover file name and consultation duration start empty, example text moves to native browser tooltips (`title`) where requested, and title/description no longer use placeholder hints.

Consultation services: **Consultation format** sits on its own row below delivery / tier / booking / cover, with consultation-specific grids using **four columns** (`md:grid-cols-4`) so each visible field occupies a quarter-width slot on desktop.

## Changes

- **Cover file name**: Initial value is empty; `title="e.g. cover-image.jpg"` on the input.
- **Booking system**: Replaced placeholder with `title="e.g. training-booking"`.
- **Title / description**: Removed `placeholder` from the service detail panel inputs.
- **Duration (minutes)**: Default empty for new services and shared `DEFAULT_CONSULTATION_FORM`; `title="e.g. 60"` on duration inputs (detail panel and stacked consultation dialog fields). Instance detail panel consultation stubs updated to match empty default.
- **Consultation layout**: Row 1 — delivery, tier, booking, cover. Row 2 — consultation format only (full-width first cell in a 4-col grid). Row 3 — pricing model, conditional rate/price/currency, default location. Row 4 — duration, optional package sessions, optional max group size (also `md:grid-cols-4`).

## Testing

- `npm run lint` (admin_web)
- `npx vitest run tests/components/admin/services/service-detail-panel.test.tsx`
- `npx vitest run tests/components/admin/services/instance-detail-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72496793-ec6d-4531-89ad-b0262b4b7899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72496793-ec6d-4531-89ad-b0262b4b7899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

