### PR TITLE
fix(admin_web): copy referral slug when duplicating a service

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -187,7 +187,7 @@ export function ServiceDetailPanel({
         setServiceForm({
           title: `${p.title} (copy)`,
           description: p.description ?? '',
-          slug: '',
+          slug: p.slug ?? '',
           deliveryMode: p.deliveryMode,
           status: 'draft',
         });

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -44,7 +44,7 @@ describe('ServiceDetailPanel', () => {
     });
   });
 
-  it('prefills create form from createPrefillFromService with draft title suffix and empty slug', async () => {
+  it('prefills create form from createPrefillFromService with draft title suffix and copied slug', async () => {
     const template = buildService({
       title: 'Original',
       slug: 'original-slug',
@@ -74,7 +74,7 @@ describe('ServiceDetailPanel', () => {
       expect(screen.getByLabelText('Title')).toHaveValue('Original (copy)');
     });
     expect(screen.getByLabelText('Service tier')).toHaveValue('tier-a');
-    expect(screen.getByLabelText('Referral slug')).toHaveValue('');
+    expect(screen.getByLabelText('Referral slug')).toHaveValue('original-slug');
     expect(screen.getByLabelText('Status')).toHaveValue('draft');
     expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
     expect(screen.getByLabelText('Default price')).toHaveValue('88');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When duplicating a service as a new draft, the inline create form cleared the referral slug. The duplicate flow now prefills the slug from the source service (same as title, tier, and type-specific fields).

## Testing

- `npm test -- --run tests/components/admin/services/service-detail-panel.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0b8162f-5f34-4b78-a43c-7c39724be030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0b8162f-5f34-4b78-a43c-7c39724be030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

