### PR TITLE
Admin web: hide default location when delivery mode is Online

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -287,6 +287,7 @@ export function ServiceDetailPanel({
   const hasLocationOptions = locationOptions.length > 0;
   const locationExists = locationOptions.some((entry) => entry.id === locationId);
   const selectedLocationValue = locationExists ? locationId : locationId || '';
+  const showDefaultLocationField = serviceForm.deliveryMode !== 'online';
 
   const normalizedSlugInput = serviceForm.slug.trim().toLowerCase();
   const saveBlockedBySlugConflict =
@@ -303,12 +304,13 @@ export function ServiceDetailPanel({
       <Select
         id='service-delivery-mode'
         value={serviceForm.deliveryMode}
-        onChange={(event) =>
-          setServiceForm({
-            ...serviceForm,
-            deliveryMode: event.target.value as ServiceDeliveryMode,
-          })
-        }
+        onChange={(event) => {
+          const nextMode = event.target.value as ServiceDeliveryMode;
+          setServiceForm({ ...serviceForm, deliveryMode: nextMode });
+          if (nextMode === 'online') {
+            setLocationId('');
+          }
+        }}
       >
         {SERVICE_DELIVERY_MODES.map((entry) => (
           <option key={entry} value={entry}>
@@ -466,7 +468,7 @@ export function ServiceDetailPanel({
         slug: newSlug,
         booking_system: bookingSystem.trim() || null,
         service_tier: serviceTier.trim() || null,
-        location_id: locationId.trim() || null,
+        location_id: serviceForm.deliveryMode === 'online' ? null : locationId.trim() || null,
         delivery_mode: serviceForm.deliveryMode,
         status: serviceForm.status,
         ...buildTypeSpecificPayload(service.serviceType),
@@ -496,7 +498,7 @@ export function ServiceDetailPanel({
         slug: slugPayloadValue,
         booking_system: bookingSystem.trim() || null,
         service_tier: serviceTier.trim() || null,
-        location_id: locationId.trim() || null,
+        location_id: serviceForm.deliveryMode === 'online' ? null : locationId.trim() || null,
         delivery_mode: serviceForm.deliveryMode,
         status: serviceForm.status,
         ...buildTypeSpecificPayload(serviceType),
@@ -659,7 +661,7 @@ export function ServiceDetailPanel({
               priceLabel='Default price'
             />
             <TrainingCurrencyControl value={trainingForm} onChange={setTrainingForm} />
-            {defaultLocationField}
+            {showDefaultLocationField ? defaultLocationField : null}
           </div>
         ) : null}
 
@@ -681,7 +683,7 @@ export function ServiceDetailPanel({
             <EventCategoryControl value={eventForm} onChange={setEventForm} categoryFieldId='service-event-category' />
             <EventDefaultPriceControl value={eventForm} onChange={setEventForm} />
             <EventDefaultCurrencyControl value={eventForm} onChange={setEventForm} />
-            {defaultLocationField}
+            {showDefaultLocationField ? defaultLocationField : null}
           </div>
         ) : null}
 
@@ -711,7 +713,7 @@ export function ServiceDetailPanel({
               {consultationForm.pricingModel !== 'free' ? (
                 <ConsultationCurrencyControl value={consultationForm} onChange={setConsultationForm} />
               ) : null}
-              {defaultLocationField}
+              {showDefaultLocationField ? defaultLocationField : null}
             </div>
             <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
               <ConsultationServiceFormatField value={consultationForm} onChange={setConsultationForm} />

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -240,6 +240,7 @@ describe('ServiceDetailPanel', () => {
     const category = screen.getByLabelText('Event category');
     const defaultPrice = screen.getByLabelText('Default price');
     const currency = screen.getByLabelText('Currency');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
     const location = screen.getByLabelText('Default location');
     expect(category.compareDocumentPosition(defaultPrice) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(defaultPrice.compareDocumentPosition(currency) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -313,6 +314,7 @@ describe('ServiceDetailPanel', () => {
     const tierInputs = screen.getAllByLabelText('Service tier');
     await user.type(tierInputs[0], 'ages-3-5');
     await user.type(screen.getByLabelText('Default price'), '100');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
     await user.click(screen.getByRole('button', { name: /Add service/i }));
     expect(onCreate).toHaveBeenCalled();
     const body = onCreate.mock.calls[0][0] as { service_tier?: string | null };
@@ -344,6 +346,7 @@ describe('ServiceDetailPanel', () => {
     const tierInputs = screen.getAllByLabelText('Service tier');
     await user.type(tierInputs[0], 'spring-tier');
     await user.type(screen.getByLabelText('Default price'), '50');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
     await user.click(screen.getByRole('button', { name: /Add service/i }));
     expect(onCreate).toHaveBeenCalled();
     const body = onCreate.mock.calls[0][0] as { service_tier?: string | null };
@@ -407,6 +410,7 @@ describe('ServiceDetailPanel', () => {
     );
     await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
     await user.type(screen.getByLabelText('Title'), 'T');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
     await user.selectOptions(screen.getByLabelText('Default location'), '6ba7b810-9dad-11d1-80b4-00c04fd430c8');
     await user.type(screen.getByLabelText('Default price'), '10');
     await user.click(screen.getByRole('button', { name: /Add service/i }));
@@ -434,6 +438,7 @@ describe('ServiceDetailPanel', () => {
     );
     await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
     await user.type(screen.getByLabelText('Title'), 'T');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
     const locInput = screen.getByPlaceholderText('Location UUID');
     expect(locInput).toBeInTheDocument();
     await user.type(locInput, uuid);
@@ -458,6 +463,7 @@ describe('ServiceDetailPanel', () => {
       />
     );
     await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
 
     const delivery = screen.getByLabelText('Delivery mode');
     const tier = screen.getByLabelText('Service tier');
@@ -571,6 +577,72 @@ describe('ServiceDetailPanel', () => {
     expect(screen.queryByLabelText('Hourly rate')).not.toBeInTheDocument();
   });
 
+  it('hides default location when delivery mode is Online for all service types', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        locationOptions={[
+          {
+            id: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+            name: 'Venue A',
+            areaId: 'a',
+            address: null,
+            lat: null,
+            lng: null,
+            createdAt: null,
+            updatedAt: null,
+            lockedFromPartnerOrg: false,
+            partnerOrganizationLabels: [],
+          },
+        ]}
+        isLoadingLocations={false}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+
+    for (const typeLabel of ['training_course', 'event', 'consultation'] as const) {
+      await user.selectOptions(screen.getByLabelText('Type'), typeLabel);
+      await user.selectOptions(screen.getByLabelText('Delivery mode'), 'Online');
+      expect(screen.queryByLabelText('Default location')).not.toBeInTheDocument();
+      await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
+      expect(screen.getByLabelText('Default location')).toBeInTheDocument();
+    }
+  });
+
+  it('clears default location and submits null when switching to Online before save', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+    render(
+      <ServiceDetailPanel
+        service={null}
+        locationOptions={[]}
+        isLoadingLocations={false}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+    await user.type(screen.getByLabelText('Title'), 'T');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
+    await user.type(screen.getByPlaceholderText('Location UUID'), '550e8400-e29b-41d4-a716-446655440000');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'Online');
+    expect(screen.queryByLabelText('Default location')).not.toBeInTheDocument();
+    await user.type(screen.getByLabelText('Default price'), '10');
+    await user.click(screen.getByRole('button', { name: /Add service/i }));
+    const body = onCreate.mock.calls[0][0] as { location_id?: string | null };
+    expect(body.location_id).toBeNull();
+  });
+
   it('default location select uses Select location placeholder', async () => {
     const user = userEvent.setup();
     render(
@@ -600,6 +672,7 @@ describe('ServiceDetailPanel', () => {
       />
     );
     await user.selectOptions(screen.getByLabelText('Type'), 'training_course');
+    await user.selectOptions(screen.getByLabelText('Delivery mode'), 'In Person');
     const select = screen.getByLabelText('Default location') as HTMLSelectElement;
     const placeholder = Array.from(select.options).find((o) => o.value === '');
     expect(placeholder?.textContent).toBe('Select location');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the admin Services editor (`ServiceDetailPanel`), the **Default location** field (dropdown or UUID input) is hidden when **Delivery mode** is **Online**, for training courses, events, and consultations.

## Behavior

- **Online**: no default location UI; `location_id` is sent as `null` on create/update so the API state matches the form.
- **In person / Hybrid**: default location behaves as before.
- Switching delivery mode to **Online** clears any previously entered default location in the form.

## Tests

- Updated existing layout and location tests to use **In person** when asserting on the default location field.
- Added coverage for Online hiding across all three service types and for clearing location when switching back to Online before save.

## How to verify

1. Open Admin → Services, create or edit a service.
2. Set delivery mode to **Online** → default location should not appear.
3. Switch to **In person** or **Hybrid** → default location should appear again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b82c7f15-44c2-46b4-9b64-4d39dd492199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b82c7f15-44c2-46b4-9b64-4d39dd492199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

