### PR TITLE
Admin services: duplicate-as-draft button shows brief copy-style success

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -35,7 +35,8 @@ export interface InstanceListPanelProps {
   isMutating: boolean;
   onSelectInstance: (instanceId: string) => void;
   onLoadMore: () => Promise<void> | void;
-  onDuplicateInstance: (instance: ServiceInstance) => Promise<void> | void;
+  /** Resolve true when the draft flow started (e.g. instance loaded); omit feedback on failure. */
+  onDuplicateInstance: (instance: ServiceInstance) => Promise<boolean> | boolean | void;
   onDeleteInstance: (instanceId: string, serviceId: string) => Promise<void>;
   /** When set, show a service filter above the table (empty value = all services). */
   serviceFilter?: {
@@ -78,6 +79,7 @@ export function InstanceListPanel({
 }: InstanceListPanelProps) {
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
   const { copiedKey: copiedInstanceId, markCopied: markInstanceIdCopied } = useCopyFeedback(1000);
+  const { copiedKey: duplicateDraftFeedbackId, markCopied: markDuplicateDraftFeedback } = useCopyFeedback(1000);
 
   const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, instanceId: string) => {
     if (event.target !== event.currentTarget) {
@@ -89,9 +91,12 @@ export function InstanceListPanel({
     }
   };
 
-  const handleDuplicateInstance = (instance: ServiceInstance, event: MouseEvent<HTMLButtonElement>) => {
+  const handleDuplicateInstance = async (instance: ServiceInstance, event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    void onDuplicateInstance(instance);
+    const started = await onDuplicateInstance(instance);
+    if (started === true) {
+      markDuplicateDraftFeedback(instance.id);
+    }
   };
 
   const handleDeleteInstance = async (
@@ -240,17 +245,17 @@ export function InstanceListPanel({
                       idleTitle='Copy instance UUID'
                       copiedTitle='Copied'
                     />
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant='outline'
-                      onClick={(event) => handleDuplicateInstance(instance, event)}
+                    <CopyFeedbackIconButton
+                      copied={duplicateDraftFeedbackId === instance.id}
+                      idleVariant='outline'
+                      idleIcon={<DuplicateIcon className='h-4 w-4' />}
                       disabled={isMutating}
-                      aria-label='Duplicate instance as new row'
-                      title='Duplicate instance as new row'
-                    >
-                      <DuplicateIcon className='h-4 w-4' />
-                    </Button>
+                      onClick={(event) => void handleDuplicateInstance(instance, event)}
+                      idleLabel='Duplicate instance as new row'
+                      copiedLabel='Draft copy ready'
+                      idleTitle='Duplicate instance as new row'
+                      copiedTitle='Copied'
+                    />
                     <Button
                       type='button'
                       size='sm'

--- a/apps/admin_web/src/components/admin/services/service-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-list-panel.tsx
@@ -8,9 +8,11 @@ import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { CopyFeedbackIconButton } from '@/components/ui/copy-feedback-icon-button';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { DeleteIcon, DuplicateIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import { formatDate, formatEnumLabel } from '@/lib/format';
 
 import { SERVICE_STATUSES, SERVICE_TYPES } from '@/types/services';
@@ -31,7 +33,8 @@ export interface ServiceListPanelProps {
     value: ServiceListFilters[TKey]
   ) => void;
   onLoadMore: () => Promise<void> | void;
-  onDuplicateService: (serviceId: string) => Promise<void> | void;
+  /** Resolve true when the draft flow started (e.g. service loaded); omit feedback on failure. */
+  onDuplicateService: (serviceId: string) => Promise<boolean> | boolean | void;
   onDeleteService: (serviceId: string) => Promise<void>;
 }
 
@@ -51,6 +54,7 @@ export function ServiceListPanel({
   onDeleteService,
 }: ServiceListPanelProps) {
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
+  const { copiedKey: duplicateDraftFeedbackId, markCopied: markDuplicateDraftFeedback } = useCopyFeedback(1000);
 
   const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, serviceId: string) => {
     if (event.target !== event.currentTarget) {
@@ -62,9 +66,12 @@ export function ServiceListPanel({
     }
   };
 
-  const handleDuplicateService = (service: ServiceSummary, event: MouseEvent<HTMLButtonElement>) => {
+  const handleDuplicateService = async (service: ServiceSummary, event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    void onDuplicateService(service.id);
+    const started = await onDuplicateService(service.id);
+    if (started === true) {
+      markDuplicateDraftFeedback(service.id);
+    }
   };
 
   const handleDeleteService = async (service: ServiceSummary, event: MouseEvent<HTMLButtonElement>) => {
@@ -169,17 +176,17 @@ export function ServiceListPanel({
                 <td className='px-4 py-3'>{formatDate(service.createdAt)}</td>
                 <td className='px-4 py-3 text-right'>
                   <div className='flex justify-end gap-2'>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant='outline'
-                      onClick={(event) => handleDuplicateService(service, event)}
+                    <CopyFeedbackIconButton
+                      copied={duplicateDraftFeedbackId === service.id}
+                      idleVariant='outline'
+                      idleIcon={<DuplicateIcon className='h-4 w-4' />}
                       disabled={isMutating}
-                      aria-label='Duplicate service as new draft'
-                      title='Duplicate service as new draft'
-                    >
-                      <DuplicateIcon className='h-4 w-4' />
-                    </Button>
+                      onClick={(event) => void handleDuplicateService(service, event)}
+                      idleLabel='Duplicate service as new draft'
+                      copiedLabel='Draft copy ready'
+                      idleTitle='Duplicate service as new draft'
+                      copiedTitle='Copied'
+                    />
                     <Button
                       type='button'
                       size='sm'

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -32,12 +32,13 @@ export function ServicesPage() {
   const handleDuplicateService = useCallback(async (serviceId: string) => {
     const detail = await getService(serviceId);
     if (!detail) {
-      return;
+      return false;
     }
     setDuplicateInstanceTemplate(null);
     setDuplicateServiceTemplate(detail);
     state.setSelectedServiceId(null);
     bumpServicesEditorKey();
+    return true;
   }, [bumpServicesEditorKey, state]);
 
   const handleDuplicateInstance = useCallback(
@@ -48,6 +49,7 @@ export function ServicesPage() {
       setDuplicateInstanceTemplate(row);
       state.setSelectedServiceId(row.serviceId);
       bumpServicesEditorKey();
+      return true;
     },
     [bumpServicesEditorKey, state]
   );

--- a/apps/admin_web/src/components/ui/copy-feedback-icon-button.tsx
+++ b/apps/admin_web/src/components/ui/copy-feedback-icon-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { MouseEvent } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 
 import { CheckIcon, CopyIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
@@ -15,11 +15,13 @@ export interface CopyFeedbackIconButtonProps {
   copiedTitle?: string;
   /** Visual variant when not showing success (default `secondary`). */
   idleVariant?: 'secondary' | 'outline';
+  /** Replaces the copy icon while idle (success still shows a check). */
+  idleIcon?: ReactNode;
   className?: string;
 }
 
 /**
- * Icon-only copy control: shows a green check briefly after `copied` is true,
+ * Icon-only control: shows a green check briefly after `copied` is true,
  * then callers clear via {@link useCopyFeedback}.
  */
 export function CopyFeedbackIconButton({
@@ -31,6 +33,7 @@ export function CopyFeedbackIconButton({
   idleTitle,
   copiedTitle,
   idleVariant = 'secondary',
+  idleIcon,
   className,
 }: CopyFeedbackIconButtonProps) {
   return (
@@ -48,7 +51,7 @@ export function CopyFeedbackIconButton({
       title={copied ? (copiedTitle ?? copiedLabel) : (idleTitle ?? idleLabel)}
       onClick={onClick}
     >
-      {copied ? <CheckIcon className='h-4 w-4' /> : <CopyIcon className='h-4 w-4' />}
+      {copied ? <CheckIcon className='h-4 w-4' /> : (idleIcon ?? <CopyIcon className='h-4 w-4' />)}
     </Button>
   );
 }

--- a/apps/admin_web/src/hooks/use-copy-feedback.ts
+++ b/apps/admin_web/src/hooks/use-copy-feedback.ts
@@ -3,8 +3,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
- * Tracks which item key was last copied successfully, clearing after `durationMs`.
- * Use with row-scoped copy buttons that show a brief success state.
+ * Tracks which item key last completed a brief-success action (copy, draft duplicate, etc.),
+ * clearing after `durationMs`. Use with row-scoped icon buttons that show a brief success state.
  */
 export function useCopyFeedback(durationMs = 1000) {
   const [copiedKey, setCopiedKey] = useState<string | null>(null);

--- a/apps/admin_web/tests/components/admin/services/duplicate-draft-feedback-buttons.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/duplicate-draft-feedback-buttons.test.tsx
@@ -1,0 +1,139 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { InstanceListPanel } from '@/components/admin/services/instance-list-panel';
+import { ServiceListPanel } from '@/components/admin/services/service-list-panel';
+import type { ServiceInstance, ServiceSummary } from '@/types/services';
+
+vi.mock('@/lib/clipboard', () => ({
+  tryCopyTextToClipboard: vi.fn().mockResolvedValue(false),
+}));
+
+const SERVICE_ROW: ServiceSummary = {
+  id: 'service-1',
+  instancesCount: 0,
+  serviceType: 'training_course',
+  title: 'Yoga',
+  slug: 'yoga',
+  bookingSystem: null,
+  description: null,
+  coverImageS3Key: null,
+  deliveryMode: 'in_person',
+  status: 'published',
+  createdBy: 'admin-sub',
+  createdAt: '2026-03-01T10:00:00Z',
+  updatedAt: '2026-03-01T10:00:00Z',
+  trainingDetails: null,
+  eventDetails: null,
+};
+
+const INSTANCE_ROW: ServiceInstance = {
+  id: 'instance-1',
+  serviceId: 'service-1',
+  parentServiceTitle: null,
+  parentServiceType: null,
+  title: null,
+  slug: null,
+  description: null,
+  coverImageS3Key: null,
+  status: 'in_progress',
+  deliveryMode: null,
+  locationId: null,
+  maxCapacity: null,
+  waitlistEnabled: false,
+  instructorId: null,
+  notes: null,
+  createdBy: 'admin-sub',
+  createdAt: '2026-03-01T10:00:00Z',
+  updatedAt: '2026-03-01T10:00:00Z',
+  resolvedTitle: 'Spring cohort',
+  resolvedDescription: null,
+  resolvedCoverImageS3Key: null,
+  resolvedDeliveryMode: null,
+  sessionSlots: [],
+  trainingDetails: null,
+  eventTicketTiers: [],
+  consultationDetails: null,
+};
+
+describe('duplicate-as-draft feedback (services tables)', () => {
+  it('shows brief success on service duplicate when handler returns true', async () => {
+    vi.useFakeTimers();
+    const onDuplicateService = vi.fn().mockResolvedValue(true);
+
+    try {
+      render(
+        <ServiceListPanel
+          services={[SERVICE_ROW]}
+          selectedServiceId={null}
+          filters={{ serviceType: '', status: '', search: '' }}
+          isLoading={false}
+          isLoadingMore={false}
+          hasMore={false}
+          error=''
+          isMutating={false}
+          onSelectService={vi.fn()}
+          onFilterChange={vi.fn()}
+          onLoadMore={vi.fn()}
+          onDuplicateService={onDuplicateService}
+          onDeleteService={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Duplicate service as new draft' }));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Draft copy ready' })).toBeInTheDocument();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Duplicate service as new draft' })).toBeInTheDocument();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows brief success on instance duplicate when handler returns true', async () => {
+    vi.useFakeTimers();
+    const onDuplicateInstance = vi.fn().mockResolvedValue(true);
+
+    try {
+      render(
+        <InstanceListPanel
+          instances={[INSTANCE_ROW]}
+          selectedInstanceId={null}
+          isLoading={false}
+          isLoadingMore={false}
+          hasMore={false}
+          error=''
+          isMutating={false}
+          onSelectInstance={vi.fn()}
+          onLoadMore={vi.fn()}
+          onDuplicateInstance={onDuplicateInstance}
+          onDeleteInstance={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Duplicate instance as new row' }));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Draft copy ready' })).toBeInTheDocument();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Duplicate instance as new row' })).toBeInTheDocument();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -143,6 +143,7 @@ describe('services tables value formatting', () => {
         onSelectService={vi.fn()}
         onFilterChange={vi.fn()}
         onLoadMore={vi.fn()}
+        onDuplicateService={vi.fn()}
         onDeleteService={vi.fn()}
       />
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The duplicate (draft a copy) icon buttons on the **Services** and **Instances** list tables now use the same brief success pattern as the UUID **copy** buttons: green success variant and check icon for ~1s, driven by `useCopyFeedback` and `CopyFeedbackIconButton`.

## Changes

- Extended `CopyFeedbackIconButton` with optional `idleIcon` so duplicate can keep the duplicate glyph while idle and still show the check when successful.
- `ServiceListPanel` / `InstanceListPanel`: duplicate handlers call `markCopied` only when the parent handler resolves `true`.
- `ServicesPage`: `handleDuplicateService` returns `false` when `getService` returns null; otherwise returns `true` after opening the draft flow.

## Tests

- New Vitest coverage for duplicate feedback on both panels.
- Fixed missing `onDuplicateService` in an existing `ServiceListPanel` table formatting test.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fb8f74f-a2c0-4f24-ba02-7cceb1f39e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fb8f74f-a2c0-4f24-ba02-7cceb1f39e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

