### PR TITLE
fix(admin): return 409 for duplicate service referral slug on create

### DIFF
--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -191,17 +191,17 @@ def _create_service(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, An
             service_type=payload["service_type"],
             parsed_details=payload["type_details"],
         )
-        created = repository.create_service(service, details)
-        for tag_id in payload["tag_ids"]:
-            require_assignable_tag(session, tag_id, field="tag_ids")
-        created.service_tags = [
-            ServiceTag(tag_id=tag_id) for tag_id in payload["tag_ids"]
-        ]
-        created.service_assets = [
-            ServiceAsset(asset_id=asset_id) for asset_id in payload["asset_ids"]
-        ]
-        repository.update_service(created)
         try:
+            created = repository.create_service(service, details)
+            for tag_id in payload["tag_ids"]:
+                require_assignable_tag(session, tag_id, field="tag_ids")
+            created.service_tags = [
+                ServiceTag(tag_id=tag_id) for tag_id in payload["tag_ids"]
+            ]
+            created.service_assets = [
+                ServiceAsset(asset_id=asset_id) for asset_id in payload["asset_ids"]
+            ]
+            repository.update_service(created)
             session.commit()
         except IntegrityError as exc:
             session.rollback()
@@ -298,8 +298,8 @@ def _update_service(
             )
             _apply_service_type_details(service=service, details=parsed_details)
 
-        updated = repository.update_service(service)
         try:
+            updated = repository.update_service(service)
             session.commit()
         except IntegrityError as exc:
             session.rollback()

--- a/tests/test_admin_services_create_slug_duplicate.py
+++ b/tests/test_admin_services_create_slug_duplicate.py
@@ -1,0 +1,89 @@
+"""Regression: duplicate referral slug must return 409, not 500."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.api import admin_services
+from app.db.models import Service, TrainingCourseDetails
+from app.exceptions import ValidationError
+
+
+def _make_services_slug_integrity_error() -> IntegrityError:
+    class _Diag:
+        constraint_name = "services_slug_unique_idx"
+
+    class _Orig:
+        diag = _Diag()
+
+    return IntegrityError("duplicate key", None, _Orig())
+
+
+def test_create_service_duplicate_slug_maps_to_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.committed = False
+
+        def commit(self) -> None:
+            self.committed = True
+
+        def rollback(self) -> None:
+            pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeServiceRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def create_service(self, _service: Service, _details: TrainingCourseDetails) -> Service:
+            raise _make_services_slug_integrity_error()
+
+    monkeypatch.setattr(admin_services, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_services, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_services, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(admin_services, "ServiceRepository", _FakeServiceRepository)
+    monkeypatch.setattr(admin_services, "require_assignable_tag", lambda *_a, **_k: None)
+
+    body = {
+        "service_type": "training_course",
+        "title": "Another course",
+        "slug": "existing-slug",
+        "delivery_mode": "online",
+        "status": "draft",
+        "tag_ids": [],
+        "asset_ids": [],
+        "training_details": {
+            "pricing_unit": "per_person",
+            "default_price": "10.00",
+            "default_currency": "HKD",
+        },
+    }
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/services",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        admin_services._create_service(event, actor_sub="actor")
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.field == "slug"
+    assert "slug" in exc_info.value.message.lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Duplicate `services.slug` values triggered a database unique constraint on SQLAlchemy **flush** inside `ServiceRepository.create_service()` (and similarly on update flush), before `session.commit()`. The admin handler only caught `IntegrityError` around `commit()`, so the exception bubbled to the Lambda generic handler and the UI saw **500 Internal server error**.

## Changes

- Wrap the full create and update persistence blocks in `IntegrityError` handling so slug unique violations are converted to `ValidationError` with HTTP **409**, `field: slug`, and message **Referral slug already in use** (unchanged contract).
- Add a regression test that simulates flush-time slug violation.

## Notes

The admin web `ServiceDetailPanel` already maps 409 + `field === 'slug'` to inline copy under the referral slug field; it only needed the API to return the structured error instead of 500.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0b2f710-4398-4e59-9631-4b9424b892da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0b2f710-4398-4e59-9631-4b9424b892da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

