### PR TITLE
Optional childAgeGroup on public reservation POST

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -1217,7 +1217,9 @@ export function BookingReservationForm({
       attendeeEmail: reservationSummary.attendeeEmail,
       attendeePhone: reservationSummary.attendeePhone,
       attendeeCountry: reservationSummary.attendeeCountry,
-      childAgeGroup: reservationSummary.ageGroup ?? '',
+      ...(reservationSummary.ageGroup
+        ? { childAgeGroup: reservationSummary.ageGroup }
+        : {}),
       cohortDate: normalizedCohortDate,
       interestedTopics: sanitizeSingleLineValue(interestedTopics) || undefined,
       discountCode: discountRule?.code || undefined,

--- a/apps/public_www/src/lib/reservations-data.ts
+++ b/apps/public_www/src/lib/reservations-data.ts
@@ -15,7 +15,11 @@ export interface ReservationSubmissionPayload {
   attendeePhone: string;
   /** ISO 3166-1 alpha-2; optional — server defaults when omitted. */
   attendeeCountry?: string;
-  childAgeGroup: string;
+  /**
+   * Child age group label; optional. Omit for flows without an age selector (e.g. events);
+   * age-gated flows (MBA, consultation) send the selected label.
+   */
+  childAgeGroup?: string;
   cohortDate: string;
   interestedTopics?: string;
   discountCode?: string;

--- a/apps/public_www/tests/components/sections/event-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/event-booking-modal.test.tsx
@@ -251,6 +251,8 @@ describe('EventBookingModal', () => {
         }),
       }),
     );
+    const call = requestSpy.mock.calls[0]?.[0] as { body: Record<string, unknown> };
+    expect(call.body).not.toHaveProperty('childAgeGroup');
   });
 
   it('omits payment UI for a zero-priced event and submits paymentMethod free', async () => {

--- a/apps/public_www/tests/lib/reservations-data.test.ts
+++ b/apps/public_www/tests/lib/reservations-data.test.ts
@@ -45,4 +45,26 @@ describe('reservations-data', () => {
       expectedSuccessStatuses: [200, 202],
     });
   });
+
+  it('submits reservation without childAgeGroup when omitted from payload', async () => {
+    const requestSpy = vi.fn().mockResolvedValue({ status: 'ok' });
+    const client = { request: requestSpy };
+
+    await submitReservation(client, {
+      payload: {
+        attendeeName: 'Test User',
+        attendeeEmail: 'test@example.com',
+        attendeePhone: '91234567',
+        cohortDate: '2026-04-08',
+        totalAmount: 100,
+        reservationPendingUntilPaymentConfirmed: false,
+        agreedToTermsAndConditions: true,
+        paymentMethod: 'free',
+      },
+      turnstileToken: 'mock-turnstile-token',
+    });
+
+    const call = requestSpy.mock.calls[0]?.[0] as { body: Record<string, unknown> };
+    expect(call.body).not.toHaveProperty('childAgeGroup');
+  });
 });

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -343,7 +343,7 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
     phone_region, phone_national_number = validate_phone_fields(
         parse_region, attendee_phone
     )
-    child_age_group = _require_text(
+    child_age_group = _optional_text(
         body.get("childAgeGroup"),
         "childAgeGroup",
         _MAX_LABEL_LENGTH,

--- a/backend/src/app/services/public_form_internal_notifications.py
+++ b/backend/src/app/services/public_form_internal_notifications.py
@@ -340,13 +340,19 @@ def build_reservation_recap_lines(*, payload: Mapping[str, Any]) -> list[str]:
         f"Attendee name: {payload.get('attendee_name', '')}",
         f"Attendee email: {payload.get('attendee_email', '')}",
         f"Telephone: {phone_display or '(not provided)'}",
-        f"Child age group: {payload.get('child_age_group', '')}",
-        f"Package: {payload.get('package_label', '') or '(not set)'}",
-        f"Month: {payload.get('month_label', '') or '(not set)'}",
-        f"Course: {payload.get('course_label', '')}",
-        f"Payment method: {payment_recap}",
-        f"Total amount: {total_recap}",
     ]
+    child_age_recap = str(payload.get("child_age_group") or "").strip()
+    if child_age_recap:
+        lines.append(f"Child age group: {child_age_recap}")
+    lines.extend(
+        [
+            f"Package: {payload.get('package_label', '') or '(not set)'}",
+            f"Month: {payload.get('month_label', '') or '(not set)'}",
+            f"Course: {payload.get('course_label', '')}",
+            f"Payment method: {payment_recap}",
+            f"Total amount: {total_recap}",
+        ]
+    )
     if payload.get("cohort_date"):
         lines.append(f"Cohort date: {payload['cohort_date']}")
     if payload.get("discount_code"):

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1265,7 +1265,6 @@ components:
         - attendeeName
         - attendeeEmail
         - attendeePhone
-        - childAgeGroup
         - paymentMethod
         - totalAmount
         - courseLabel
@@ -1292,6 +1291,9 @@ components:
         childAgeGroup:
           type: string
           maxLength: 200
+          description: >
+            Optional; event flows without an age selector may omit it. Age-gated flows
+            (for example My Best Auntie or consultation) should send the selected label.
         packageLabel:
           type: string
           maxLength: 200

--- a/tests/test_public_form_hooks.py
+++ b/tests/test_public_form_hooks.py
@@ -179,3 +179,46 @@ def test_run_reservation_post_success_hooks_stripe_zero_total_not_is_free(
     )
 
     assert captured["is_free"] is False
+
+
+def test_run_reservation_post_success_hooks_accepts_null_child_age_group(
+    monkeypatch: Any,
+) -> None:
+    """Confirmation email path accepts optional age group (event bookings)."""
+    from decimal import Decimal
+
+    from app.api import public_reservations as pr
+
+    captured: dict[str, object] = {}
+
+    def _fake_send(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "hello@example.com")
+    monkeypatch.setattr(
+        "app.api.public_reservations.send_booking_confirmation_email",
+        _fake_send,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.maybe_subscribe_booking_marketing",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.send_sales_form_recap_email",
+        MagicMock(),
+    )
+
+    pr._run_reservation_post_success_hooks(
+        {
+            "attendee_email": "j@example.com",
+            "attendee_name": "Jane Doe",
+            "child_age_group": None,
+            "payment_method": "bank_transfer",
+            "total_amount": Decimal("100"),
+            "course_label": "Course",
+            "locale": "en",
+            "stripe_payment_intent_id": None,
+        }
+    )
+
+    assert captured.get("age_group_label") is None

--- a/tests/test_public_form_internal_notifications.py
+++ b/tests/test_public_form_internal_notifications.py
@@ -226,6 +226,24 @@ def test_sales_recap_display_timezone_invalid_env_falls_back(
     assert "Submitted at: 2026-03-03 11:14:00 HKT" in "\n".join(lines)
 
 
+def test_build_reservation_recap_lines_omits_child_age_group_when_empty() -> None:
+    lines = n.build_reservation_recap_lines(
+        payload={
+            "attendee_name": "N",
+            "attendee_email": "n@example.com",
+            "attendee_phone": "1",
+            "child_age_group": None,
+            "package_label": "P",
+            "month_label": "M",
+            "course_label": "C",
+            "payment_method": "fps",
+            "total_amount": "100",
+        }
+    )
+    body = "\n".join(lines)
+    assert "Child age group" not in body
+
+
 def test_build_reservation_recap_lines_optional_fields() -> None:
     lines = n.build_reservation_recap_lines(
         payload={

--- a/tests/test_public_reservations_extended.py
+++ b/tests/test_public_reservations_extended.py
@@ -333,6 +333,91 @@ def test_handle_public_reservation_runs_hooks_after_persist(
     assert payload["payment_method"] == "bank_transfer"
 
 
+def test_handle_public_reservation_accepts_missing_child_age_group(
+    api_gateway_event: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Event-style bookings omit childAgeGroup; persistence and hooks still succeed."""
+    monkeypatch.setattr(
+        "app.api.public_reservations.verify_turnstile_token",
+        lambda *_a, **_k: True,
+    )
+    hooks = MagicMock()
+    monkeypatch.setattr(
+        "app.api.public_reservations._run_reservation_post_success_hooks",
+        hooks,
+    )
+
+    contact_id = uuid4()
+
+    class _FakeContactRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def upsert_by_email(self, _email: str, **kwargs: object) -> tuple[object, bool]:
+            c = MagicMock()
+            c.id = contact_id
+            c.phone_region = None
+            c.phone_national_number = None
+            return c, True
+
+        def update(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _FakeLeadRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def create_with_event(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _FakeSalesLead:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLead",
+        _FakeSalesLead,
+    )
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+    class _FakeSessionCM:
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_a: object) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.ContactRepository",
+        _FakeContactRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLeadRepository",
+        _FakeLeadRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.Session",
+        lambda _e: _FakeSessionCM(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.get_engine",
+        lambda: object(),
+    )
+
+    body = _reservation_body()
+    del body["childAgeGroup"]
+    event = _post_event(api_gateway_event, body)
+    resp = _handle_public_reservation(event, "POST")
+    assert resp["statusCode"] == 202
+    hooks.assert_called_once()
+    payload = hooks.call_args[0][0]
+    assert payload.get("child_age_group") is None
+
+
 def test_handle_public_reservation_validation_rejects_missing_terms(
     api_gateway_event: Any,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **OpenAPI (`docs/api/public.yaml`)**: `childAgeGroup` removed from `PublicReservationSubmissionRequest.required`; property stays `string` / `maxLength: 200` with description noting optional use for event flows without an age selector.
- **Backend (`public_reservations.py`)**: `_validate_reservation_payload` uses `_optional_text` for `childAgeGroup`; normalized dict still exposes `child_age_group` as `str | None`.
- **Sales recap (`public_form_internal_notifications.py`)**: `Child age group:` line is omitted when `child_age_group` is empty/null after strip.
- **Tests**: Extended reservation handler test without `childAgeGroup`; hook test with `"child_age_group": None`; recap test for omitted line.
- **`public_www`**: `ReservationSubmissionPayload.childAgeGroup` optional; reservation form spreads the key only when `reservationSummary.ageGroup` is truthy; Vitest for `reservations-data` and event booking modal assert `childAgeGroup` absent on the wire.

## Validation

- `pytest` (focused new/changed cases)
- `npm test` in `apps/public_www` for touched test files
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`

## Notes

Deploy order: backend should land before or with the frontend change so omitted `childAgeGroup` is accepted in all environments.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fffb6573-d92d-4caf-bc92-5bd1c239ab4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fffb6573-d92d-4caf-bc92-5bd1c239ab4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

