### PR TITLE
Services admin table: sort by title, remove Created, draft warning icon

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-list-panel.tsx
@@ -10,10 +10,10 @@ import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { CopyFeedbackIconButton } from '@/components/ui/copy-feedback-icon-button';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
-import { DeleteIcon, DuplicateIcon } from '@/components/icons/action-icons';
+import { DeleteIcon, DuplicateIcon, WarningTriangleIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
-import { formatDate, formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel } from '@/lib/format';
 
 import { SERVICE_STATUSES, SERVICE_TYPES } from '@/types/services';
 import type { ServiceListFilters, ServiceSummary } from '@/types/services';
@@ -145,14 +145,13 @@ export function ServiceListPanel({
           </div>
         }
       >
-        <AdminDataTable tableClassName='min-w-[840px]'>
+        <AdminDataTable tableClassName='min-w-[720px]'>
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Title</th>
               <th className='px-4 py-3 font-semibold'>Type</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Delivery</th>
-              <th className='px-4 py-3 font-semibold'>Created</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
           </AdminDataTableHead>
@@ -171,9 +170,17 @@ export function ServiceListPanel({
               >
                 <td className='px-4 py-3'>{service.title}</td>
                 <td className='px-4 py-3'>{formatEnumLabel(service.serviceType)}</td>
-                <td className='px-4 py-3'>{formatEnumLabel(service.status)}</td>
+                <td className='px-4 py-3'>
+                  <span className='inline-flex items-center gap-1.5'>
+                    {formatEnumLabel(service.status)}
+                    {service.status === 'draft' ? (
+                      <span className='inline-flex' role='img' aria-label='Draft status'>
+                        <WarningTriangleIcon className='h-4 w-4 shrink-0 text-amber-600' aria-hidden />
+                      </span>
+                    ) : null}
+                  </span>
+                </td>
                 <td className='px-4 py-3'>{formatEnumLabel(service.deliveryMode)}</td>
-                <td className='px-4 py-3'>{formatDate(service.createdAt)}</td>
                 <td className='px-4 py-3 text-right'>
                   <div className='flex justify-end gap-2'>
                     <CopyFeedbackIconButton

--- a/apps/admin_web/src/components/icons/action-icons.tsx
+++ b/apps/admin_web/src/components/icons/action-icons.tsx
@@ -14,3 +14,4 @@ export { default as PencilIcon } from './svg/pencil-icon.svg';
 export { default as ArrowRightIcon } from './svg/arrow-right-icon.svg';
 export { default as VendorInactiveIcon } from './svg/vendor-inactive-icon.svg';
 export { default as QrLinkIcon } from './svg/qr-link-icon.svg';
+export { default as WarningTriangleIcon } from './svg/warning-triangle-icon.svg';

--- a/apps/admin_web/src/components/icons/svg/warning-triangle-icon.svg
+++ b/apps/admin_web/src/components/icons/svg/warning-triangle-icon.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+  <line x1="12" y1="9" x2="12" y2="13" />
+  <line x1="12" y1="17" x2="12.01" y2="17" />
+</svg>

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -1363,6 +1363,11 @@ export interface paths {
             parameters: {
                 query?: {
                     limit?: number;
+                    /**
+                     * @description Opaque continuation token from `next_cursor` on the previous page.
+                     *     Service list results are ordered by title ascending, then id ascending;
+                     *     the cursor encodes the last row's title and id for that ordering.
+                     */
                     cursor?: string;
                     service_type?: components["schemas"]["ServiceType"];
                     status?: components["schemas"]["ServiceStatus"];

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -19,6 +19,8 @@ const SERVICE_FIXTURE: ServiceSummary = {
   coverImageS3Key: null,
   deliveryMode: 'in_person',
   status: 'published',
+  serviceTier: null,
+  locationId: null,
   createdBy: 'admin-sub',
   createdAt: '2026-03-01T10:00:00Z',
   updatedAt: '2026-03-01T10:00:00Z',
@@ -102,7 +104,7 @@ const DISCOUNT_REFERRAL_FIXTURE: DiscountCode = {
 };
 
 describe('services tables value formatting', () => {
-  it('formats enum and date values in service list table rows', () => {
+  it('formats enum values in service list table rows', () => {
     render(
       <ServiceListPanel
         services={[SERVICE_FIXTURE]}
@@ -125,7 +127,31 @@ describe('services tables value formatting', () => {
     expect(within(table).getByText('Training Course')).toBeInTheDocument();
     expect(within(table).getByText('Published')).toBeInTheDocument();
     expect(within(table).getByText('In Person')).toBeInTheDocument();
-    expect(within(table).getByText(formatDate(SERVICE_FIXTURE.createdAt))).toBeInTheDocument();
+  });
+
+  it('shows a warning icon next to status when the service is a draft', () => {
+    const draft: ServiceSummary = { ...SERVICE_FIXTURE, status: 'draft' };
+    render(
+      <ServiceListPanel
+        services={[draft]}
+        selectedServiceId={null}
+        filters={{ serviceType: '', status: '', search: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        hasMore={false}
+        error=''
+        isMutating={false}
+        onSelectService={vi.fn()}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onDuplicateService={vi.fn()}
+        onDeleteService={vi.fn()}
+      />
+    );
+
+    const table = screen.getByRole('table');
+    expect(within(table).getByRole('img', { name: 'Draft status' })).toBeInTheDocument();
+    expect(within(table).getByText('Draft')).toBeInTheDocument();
   });
 
   it('disables delete when the service has instances', () => {

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -129,7 +129,7 @@ def _list_services(event: Mapping[str, Any]) -> dict[str, Any]:
             service_type=filters["service_type"],
             status=filters["status"],
             search=filters["search"],
-            cursor_created_at=filters["cursor_created_at"],
+            cursor_title=filters["cursor_title"],
             cursor_id=filters["cursor_id"],
         )
         has_more = len(rows) > limit

--- a/backend/src/app/api/admin_services_common.py
+++ b/backend/src/app/api/admin_services_common.py
@@ -10,6 +10,7 @@ from app.api.admin_services_cursor import (
     encode_instance_cursor,
     encode_service_cursor,
     parse_created_cursor,
+    parse_service_list_cursor,
     request_id,
 )
 from app.api.admin_services_payloads import (
@@ -43,6 +44,7 @@ __all__ = [
     "encode_instance_cursor",
     "encode_service_cursor",
     "parse_created_cursor",
+    "parse_service_list_cursor",
     "parse_create_discount_code_payload",
     "parse_create_enrollment_payload",
     "parse_create_instance_payload",

--- a/backend/src/app/api/admin_services_cursor.py
+++ b/backend/src/app/api/admin_services_cursor.py
@@ -27,8 +27,33 @@ def request_id(event: Mapping[str, Any]) -> str:
 
 
 def encode_service_cursor(service: Service) -> str | None:
-    """Encode service cursor for pagination."""
-    return encode_created_cursor(service.created_at, service.id)
+    """Encode service list cursor (title sort, ascending)."""
+    return encode_service_list_cursor(service.title, service.id)
+
+
+def encode_service_list_cursor(title: str, row_id: UUID) -> str | None:
+    """Encode title/id cursor for service template list pagination."""
+    payload = json.dumps({"title": title, "id": str(row_id)}).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
+
+
+def parse_service_list_cursor(cursor: str | None) -> tuple[str | None, UUID | None]:
+    """Parse service list cursor (title + id); empty input returns (None, None)."""
+    if not cursor:
+        return None, None
+    try:
+        padded = cursor + ("=" * (-len(cursor) % 4))
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+        title_raw = payload["title"]
+        row_id_raw = payload["id"]
+        if not isinstance(title_raw, str):
+            raise ValueError("title must be a string")
+        return title_raw, UUID(str(row_id_raw))
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Invalid pagination cursor", extra={"cursor_length": len(cursor)}
+        )
+        raise ValidationError("Invalid cursor", field="cursor") from exc
 
 
 def encode_instance_cursor(instance: ServiceInstance) -> str | None:

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -14,7 +14,10 @@ from app.api.admin_validators import (
     parse_optional_service_instance_slug,
     parse_optional_service_instance_slug_like_text,
 )
-from app.api.admin_services_cursor import parse_created_cursor
+from app.api.admin_services_cursor import (
+    parse_created_cursor,
+    parse_service_list_cursor,
+)
 from app.api.admin_service_instance_partners import parse_partner_organization_ids
 from app.api.admin_services_payload_utils import (
     has_any_field,
@@ -122,10 +125,10 @@ def parse_service_filters(event: Mapping[str, Any]) -> dict[str, Any]:
     """Parse query filters for service list endpoint."""
     logger.debug("Parsing service list filters")
     limit = _parse_limit(query_param(event, "limit"))
-    cursor_created_at, cursor_id = parse_created_cursor(query_param(event, "cursor"))
+    cursor_title, cursor_id = parse_service_list_cursor(query_param(event, "cursor"))
     return {
         "limit": limit,
-        "cursor_created_at": cursor_created_at,
+        "cursor_title": cursor_title,
         "cursor_id": cursor_id,
         "service_type": parse_optional_enum(
             query_param(event, "service_type"),

--- a/backend/src/app/db/repositories/service.py
+++ b/backend/src/app/db/repositories/service.py
@@ -48,10 +48,10 @@ class ServiceRepository(BaseRepository[Service]):
         service_type: ServiceType | None = None,
         status: ServiceStatus | None = None,
         search: str | None = None,
-        cursor_created_at: datetime | None = None,
+        cursor_title: str | None = None,
         cursor_id: UUID | None = None,
     ) -> list[Service]:
-        """List services with filters and stable cursor pagination."""
+        """List services with filters and stable cursor pagination (title asc, id asc)."""
         statement = select(Service).options(
             joinedload(Service.training_course_details),
             joinedload(Service.event_details),
@@ -71,19 +71,16 @@ class ServiceRepository(BaseRepository[Service]):
                     Service.description.ilike(pattern, escape="\\"),
                 )
             )
-        if cursor_created_at is not None and cursor_id is not None:
+        if cursor_title is not None and cursor_id is not None:
             statement = statement.where(
                 or_(
-                    Service.created_at < cursor_created_at,
-                    and_(
-                        Service.created_at == cursor_created_at,
-                        Service.id < cursor_id,
-                    ),
+                    Service.title > cursor_title,
+                    and_(Service.title == cursor_title, Service.id > cursor_id),
                 )
             )
-        statement = statement.order_by(
-            Service.created_at.desc(), Service.id.desc()
-        ).limit(limit)
+        statement = statement.order_by(Service.title.asc(), Service.id.asc()).limit(
+            limit
+        )
         return list(self._session.execute(statement).unique().scalars().all())
 
     def count_services(

--- a/backend/src/app/db/repositories/service.py
+++ b/backend/src/app/db/repositories/service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1037,6 +1037,10 @@ paths:
         - name: cursor
           in: query
           required: false
+          description: |
+            Opaque continuation token from `next_cursor` on the previous page.
+            Service list results are ordered by title ascending, then id ascending;
+            the cursor encodes the last row's title and id for that ordering.
           schema:
             type: string
         - name: service_type

--- a/tests/test_admin_service_list_cursor.py
+++ b/tests/test_admin_service_list_cursor.py
@@ -1,0 +1,41 @@
+"""Tests for service list pagination cursor (title + id)."""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from app.api.admin_services_cursor import encode_service_list_cursor, parse_service_list_cursor
+from app.exceptions import ValidationError
+
+
+def test_parse_service_list_cursor_round_trip() -> None:
+    title = "Alpha Course"
+    row_id = uuid4()
+    token = encode_service_list_cursor(title, row_id)
+    assert token is not None
+    parsed_title, parsed_id = parse_service_list_cursor(token)
+    assert parsed_title == title
+    assert parsed_id == row_id
+
+
+def test_parse_service_list_cursor_empty() -> None:
+    assert parse_service_list_cursor(None) == (None, None)
+    assert parse_service_list_cursor("") == (None, None)
+
+
+def test_parse_service_list_cursor_rejects_legacy_created_cursor() -> None:
+    """Previous API used created_at + id in the cursor payload."""
+    payload = json.dumps(
+        {
+            "created_at": datetime(2026, 1, 1, tzinfo=UTC).isoformat(),
+            "id": str(uuid4()),
+        }
+    ).encode("utf-8")
+    token = base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
+    with pytest.raises(ValidationError):
+        parse_service_list_cursor(token)

--- a/tests/test_admin_services_delete_guard.py
+++ b/tests/test_admin_services_delete_guard.py
@@ -115,7 +115,7 @@ def test_list_services_includes_instance_counts(monkeypatch: Any, api_gateway_ev
             "service_type": None,
             "status": None,
             "search": None,
-            "cursor_created_at": None,
+            "cursor_title": None,
             "cursor_id": None,
         },
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Services list API** (`GET /v1/admin/services`): results are ordered by **title ascending**, then **id ascending**. Pagination `cursor` / `next_cursor` now encode **title + id** (replacing the previous created-at cursor). Clients using an old cursor receive **400 Invalid cursor** and should restart from the first page.
- **Admin Services table**: removed the **Created** column. **Draft** rows show an amber **warning triangle** beside the status label (SVGR icon + `role="img"` for accessibility).
- **OpenAPI**: documented cursor semantics for the services list endpoint.

## Tests

- `python3 -m pytest tests/test_admin_service_list_cursor.py tests/test_admin_services_delete_guard.py`
- `npm test -- --run tests/components/admin/services/table-value-formatting.test.tsx` (admin_web)
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b93bddd-8bc4-4b63-aa4a-8b664fa5f008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b93bddd-8bc4-4b63-aa4a-8b664fa5f008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

