### PR TITLE
Rename finance vendors table column to Total Spend

### DIFF
--- a/apps/admin_web/src/components/admin/finance/vendors-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/vendors-panel.tsx
@@ -10,7 +10,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
-import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { formatAmountInDefaultCurrency } from '@/lib/vendor-spend';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -51,7 +50,6 @@ export function VendorsPanel({
   isVendorSpendLoading,
   vendorSpendError,
 }: VendorsPanelProps) {
-  const spendColumnLabel = `Total spend (${getAdminDefaultCurrencyCode()})`;
   const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
   const [selectedVendorId, setSelectedVendorId] = useState<string | null>(null);
   const [name, setName] = useState('');
@@ -196,7 +194,7 @@ export function VendorsPanel({
             <tr>
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 font-semibold text-right'>{spendColumnLabel}</th>
+              <th className='px-4 py-3 font-semibold text-right'>Total Spend</th>
               <th className='px-4 py-3 font-semibold text-right'>Operations</th>
             </tr>
           </AdminDataTableHead>

--- a/apps/admin_web/tests/components/admin/finance/vendors-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/vendors-panel.test.tsx
@@ -36,7 +36,7 @@ describe('VendorsPanel', () => {
 
     expect(screen.getByRole('heading', { name: 'Vendors' })).toBeInTheDocument();
     const columnHeaders = screen.getAllByRole('columnheader').map((el) => el.textContent?.trim() ?? '');
-    expect(columnHeaders).toEqual(['Name', 'Status', 'Total spend (HKD)', 'Operations']);
+    expect(columnHeaders).toEqual(['Name', 'Status', 'Total Spend', 'Operations']);
     expect(screen.getByText('HK$1,234.56')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Make vendor inactive' })).toBeInTheDocument();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Finance → Vendors table previously used a dynamic header `Total spend ({currency})` (for example `Total spend (HKD)` when HKD is the admin default). The column header is now fixed as **Total Spend**.

Spend cells are unchanged: they still use `formatAmountInDefaultCurrency`, so amounts continue to reflect `NEXT_PUBLIC_ADMIN_DEFAULT_CURRENCY` in their formatting.

## Testing

- `npx vitest run tests/components/admin/finance/vendors-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc3a291c-309f-4cce-927b-dfda3e38d41c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc3a291c-309f-4cce-927b-dfda3e38d41c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

