### PR TITLE
Align service list prices with vendor spend currency formatting.

### DIFF
--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -1,4 +1,5 @@
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
+import { formatAmountInCurrency } from '@/lib/vendor-spend';
 import { CLIENT_DOCUMENT_ASSET_TAG, EXPENSE_ATTACHMENT_ASSET_TAG } from '@/types/assets';
 import type { LocationSummary, ServiceSummary } from '@/types/services';
 
@@ -126,14 +127,27 @@ export function formatEnumLabel(value: string): string {
   return toTitleCase(value.toLowerCase());
 }
 
-function appendCurrency(amount: string, currencyCode: string | null | undefined): string {
-  const cur = currencyCode?.trim() ?? '';
-  return cur ? `${amount} ${cur}` : amount;
+function parseDecimalAmountString(raw: string | null | undefined): number | null {
+  if (raw == null) {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const n = Number.parseFloat(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+function resolveIsoCurrencyCode(code: string | null | undefined): string {
+  const trimmed = code?.trim().toUpperCase() ?? '';
+  return trimmed.length === 3 ? trimmed : getAdminDefaultCurrencyCode();
 }
 
 /**
  * One-line default pricing for the admin services list (training/event default price;
- * consultation Free, hourly rate, or package price).
+ * consultation Free, hourly rate, or package price). Amounts use the same currency
+ * formatting as the Vendors total spend column ({@link formatAmountInCurrency}).
  */
 export function formatServiceListPriceLabel(service: ServiceSummary): string {
   if (service.serviceType === 'training_course') {
@@ -141,22 +155,22 @@ export function formatServiceListPriceLabel(service: ServiceSummary): string {
     if (!d) {
       return '—';
     }
-    const price = d.defaultPrice?.trim() ?? '';
-    if (!price) {
+    const amount = parseDecimalAmountString(d.defaultPrice);
+    if (amount == null) {
       return '—';
     }
-    return appendCurrency(price, d.defaultCurrency);
+    return formatAmountInCurrency(amount, resolveIsoCurrencyCode(d.defaultCurrency));
   }
   if (service.serviceType === 'event') {
     const d = service.eventDetails;
     if (!d) {
       return '—';
     }
-    const price = d.defaultPrice?.trim() ?? '';
-    if (!price) {
+    const amount = parseDecimalAmountString(d.defaultPrice);
+    if (amount == null) {
       return '—';
     }
-    return appendCurrency(price, d.defaultCurrency);
+    return formatAmountInCurrency(amount, resolveIsoCurrencyCode(d.defaultCurrency));
   }
   if (service.serviceType === 'consultation') {
     const d = service.consultationDetails;
@@ -167,23 +181,23 @@ export function formatServiceListPriceLabel(service: ServiceSummary): string {
       return 'Free';
     }
     if (d.pricingModel === 'hourly') {
-      const rate = d.defaultHourlyRate?.trim() ?? '';
-      if (!rate) {
+      const amount = parseDecimalAmountString(d.defaultHourlyRate);
+      if (amount == null) {
         return '—';
       }
-      return `${appendCurrency(rate, d.defaultCurrency)} / hr`;
+      const formatted = formatAmountInCurrency(amount, resolveIsoCurrencyCode(d.defaultCurrency));
+      return `${formatted} / hr`;
     }
     if (d.pricingModel === 'package') {
-      const pkg = d.defaultPackagePrice?.trim() ?? '';
-      if (!pkg) {
+      const amount = parseDecimalAmountString(d.defaultPackagePrice);
+      if (amount == null) {
         return '—';
       }
-      const cur = d.defaultCurrency?.trim() ?? '';
-      const base = cur ? `${pkg} ${cur}` : pkg;
+      const formatted = formatAmountInCurrency(amount, resolveIsoCurrencyCode(d.defaultCurrency));
       if (typeof d.defaultPackageSessions === 'number' && d.defaultPackageSessions > 0) {
-        return `${base} (${d.defaultPackageSessions} sessions)`;
+        return `${formatted} (${d.defaultPackageSessions} sessions)`;
       }
-      return base;
+      return formatted;
     }
     return '—';
   }

--- a/apps/admin_web/src/lib/vendor-spend.ts
+++ b/apps/admin_web/src/lib/vendor-spend.ts
@@ -68,14 +68,27 @@ export async function computeVendorSpendInDefaultCurrencyByVendorId(
   return totals;
 }
 
+const CURRENCY_AMOUNT_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
+  style: 'currency',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+};
+
+/**
+ * Format a numeric amount as currency (symbol + grouped integer part + two fraction digits).
+ * HKD uses `en-HK` like the Vendors "Total spend" column; other ISO 4217 codes use `en-GB`
+ * so USD is shown as `US$` rather than ambiguous `$` under default locale.
+ */
+export function formatAmountInCurrency(value: number, currencyCode: string): string {
+  const code = currencyCode.trim().toUpperCase();
+  const locale = code === 'HKD' ? 'en-HK' : 'en-GB';
+  return new Intl.NumberFormat(locale, {
+    ...CURRENCY_AMOUNT_FORMAT_OPTIONS,
+    currency: code,
+  }).format(value);
+}
+
 /** Format a numeric amount using the admin default display currency. */
 export function formatAmountInDefaultCurrency(value: number): string {
-  const code = getAdminDefaultCurrencyCode();
-  const locale = code === 'HKD' ? 'en-HK' : undefined;
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency: code,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value);
+  return formatAmountInCurrency(value, getAdminDefaultCurrencyCode());
 }

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -56,7 +56,7 @@ describe('format helpers', () => {
           },
         })
       )
-    ).toBe('100 HKD');
+    ).toBe('HK$100.00');
 
     expect(
       formatServiceListPriceLabel(
@@ -70,7 +70,7 @@ describe('format helpers', () => {
           },
         })
       )
-    ).toBe('50 USD');
+    ).toBe('US$50.00');
 
     expect(
       formatServiceListPriceLabel(
@@ -108,7 +108,7 @@ describe('format helpers', () => {
           },
         })
       )
-    ).toBe('200 HKD / hr');
+    ).toBe('HK$200.00 / hr');
 
     expect(
       formatServiceListPriceLabel(
@@ -127,7 +127,7 @@ describe('format helpers', () => {
           },
         })
       )
-    ).toBe('1200 HKD (6 sessions)');
+    ).toBe('HK$1,200.00 (6 sessions)');
   });
 
   it('exposes HKD, USD, EUR, GBP, CNY, and SGD in currency options with expected labels', () => {

--- a/apps/admin_web/tests/lib/vendor-spend.test.ts
+++ b/apps/admin_web/tests/lib/vendor-spend.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { clearCurrencyConversionRateCacheForTests } from '@/lib/currency-converter';
-import { computeVendorSpendInDefaultCurrencyByVendorId } from '@/lib/vendor-spend';
+import {
+  computeVendorSpendInDefaultCurrencyByVendorId,
+  formatAmountInCurrency,
+  formatAmountInDefaultCurrency,
+} from '@/lib/vendor-spend';
 import type { Expense } from '@/types/expenses';
 
 function baseExpense(overrides: Partial<Expense>): Expense {
@@ -34,6 +38,22 @@ function baseExpense(overrides: Partial<Expense>): Expense {
     ...overrides,
   };
 }
+
+describe('formatAmountInCurrency', () => {
+  it('matches HKD vendor spend style (en-HK, thousands, two decimals)', () => {
+    expect(formatAmountInCurrency(1234.56, 'HKD')).toBe('HK$1,234.56');
+  });
+
+  it('formats non-HKD ISO codes with en-GB (e.g. USD as US$)', () => {
+    expect(formatAmountInCurrency(50, 'USD')).toBe('US$50.00');
+  });
+});
+
+describe('formatAmountInDefaultCurrency', () => {
+  it('delegates to admin default currency', () => {
+    expect(formatAmountInDefaultCurrency(1234.56)).toBe('HK$1,234.56');
+  });
+});
 
 describe('computeVendorSpendInDefaultCurrencyByVendorId', () => {
   beforeEach(() => {


### PR DESCRIPTION
Export formatAmountInCurrency from vendor-spend (shared Intl options); formatAmountInDefaultCurrency delegates to it. Service list prices use the same helper for training, event, and paid consultation amounts.