### PR TITLE
Admin: instance editor cohort field and service location default

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -22,6 +22,7 @@ import {
 } from './form-defaults';
 import { EventInstancePartnersField } from './event-instance-partners-field';
 import {
+  INSTANCE_SLUG_PATTERN,
   InstanceFormFields,
   InstanceInstructorField,
   type InstanceFormState,
@@ -56,6 +57,8 @@ export function CreateInstanceDialog({
   );
 
   const eventPriceMissing = serviceType === 'event' && !eventForm.defaultPrice.trim();
+  const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
+  const cohortInvalid = Boolean(cohortTrimmed) && !INSTANCE_SLUG_PATTERN.test(cohortTrimmed);
 
   const handleSubmit = async () => {
     const slugTrimmed = instanceForm.slug.trim().toLowerCase();
@@ -69,6 +72,7 @@ export function CreateInstanceDialog({
       max_capacity: instanceForm.maxCapacity ? Number(instanceForm.maxCapacity) : null,
       waitlist_enabled: instanceForm.waitlistEnabled,
       instructor_id: instanceForm.instructorId.trim() || null,
+      cohort: cohortTrimmed || null,
       notes: instanceForm.notes.trim() || null,
       external_url: instanceForm.externalUrl.trim() || null,
       partner_organization_ids:
@@ -121,7 +125,7 @@ export function CreateInstanceDialog({
       isLoading={isLoading}
       error={error}
       submitLabel='Create instance'
-      submitDisabled={eventPriceMissing}
+      submitDisabled={eventPriceMissing || cohortInvalid}
       onClose={onClose}
       onSubmit={handleSubmit}
     >

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -95,6 +95,7 @@ function mergeServiceIntoInstanceForm(
     title: service.title,
     description: service.description ?? '',
     deliveryMode: service.deliveryMode,
+    locationId: service.locationId ?? '',
   };
 }
 
@@ -606,6 +607,7 @@ export function InstanceDetailPanel({
       <InstanceFormFields
         value={instanceForm}
         serviceId={selectedServiceId}
+        serviceLocationId={selectedService?.locationId ?? null}
         serviceOptions={serviceOptions}
         locationOptions={locationOptions}
         isLoadingLocations={isLoadingLocations}
@@ -711,29 +713,6 @@ export function InstanceDetailPanel({
           </div>
         </>
       ) : null}
-
-      <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
-        <div>
-          <Label htmlFor='instance-cohort'>Cohort</Label>
-          <Input
-            id='instance-cohort'
-            value={instanceForm.cohort}
-            disabled={typeFieldsLocked}
-            onChange={(event) => setInstanceForm((prev) => ({ ...prev, cohort: event.target.value }))}
-            onBlur={() =>
-              setInstanceForm((prev) => ({ ...prev, cohort: prev.cohort.trim().toLowerCase() }))
-            }
-            placeholder='e.g. spring-2026'
-            autoComplete='off'
-          />
-          {cohortInvalid ? (
-            <p className='mt-1 text-xs text-red-600'>
-              Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
-              hyphen).
-            </p>
-          ) : null}
-        </div>
-      </div>
 
       <div>
         <Label htmlFor='instance-notes'>Notes</Label>

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -18,7 +18,7 @@ import type {
 
 import type { SessionSlot } from '@/types/services';
 
-/** Same pattern as service referral slugs; matches backend `SERVICE_INSTANCE_SLUG_RE`. */
+/** Same pattern as service instance cohorts; matches backend `SERVICE_INSTANCE_SLUG_RE`. */
 export const INSTANCE_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 export interface InstanceInstructorOption {
@@ -47,6 +47,8 @@ export interface InstanceFormState {
 export interface InstanceFormFieldsProps {
   value: InstanceFormState;
   serviceId?: string | null;
+  /** Service default location; used to show the correct option when the form `locationId` is still empty. */
+  serviceLocationId?: string | null;
   serviceOptions?: ServiceSummary[];
   locationOptions?: LocationSummary[];
   isLoadingLocations?: boolean;
@@ -111,6 +113,7 @@ export function InstanceInstructorField({
 export function InstanceFormFields({
   value,
   serviceId = null,
+  serviceLocationId = null,
   serviceOptions = [],
   locationOptions = [],
   isLoadingLocations = false,
@@ -121,10 +124,13 @@ export function InstanceFormFields({
 }: InstanceFormFieldsProps) {
   const canSelectService = Boolean(onSelectService);
   const serviceExists = serviceOptions.some((entry) => entry.id === serviceId);
-  const locationExists = locationOptions.some((entry) => entry.id === value.locationId);
-  const selectedLocationValue = locationExists ? value.locationId : value.locationId || '';
+  const effectiveLocationId = value.locationId || (serviceLocationId ?? '');
+  const locationExists = locationOptions.some((entry) => entry.id === effectiveLocationId);
+  const selectedLocationValue = locationExists ? effectiveLocationId : effectiveLocationId || '';
   const hasLocationOptions = locationOptions.length > 0;
   const instanceFieldsLocked = canSelectService && !serviceId;
+  const cohortTrimmed = value.cohort.trim().toLowerCase();
+  const cohortInvalid = Boolean(cohortTrimmed) && !INSTANCE_SLUG_PATTERN.test(cohortTrimmed);
 
   const topRowClass =
     canSelectService && !instanceFieldsLocked
@@ -167,17 +173,17 @@ export function InstanceFormFields({
           />
         </div>
         <div>
-          <Label htmlFor='instance-slug'>Slug</Label>
+          <Label htmlFor='instance-cohort'>Cohort</Label>
           <Input
-            id='instance-slug'
-            value={value.slug}
+            id='instance-cohort'
+            value={value.cohort}
             disabled={instanceFieldsLocked}
-            onChange={(event) => onChange({ ...value, slug: event.target.value })}
-            onBlur={() => onChange({ ...value, slug: value.slug.trim().toLowerCase() })}
-            placeholder='e.g. spring-workshop'
+            onChange={(event) => onChange({ ...value, cohort: event.target.value })}
+            onBlur={() => onChange({ ...value, cohort: value.cohort.trim().toLowerCase() })}
+            placeholder='e.g. spring-2026'
             autoComplete='off'
           />
-          {value.slug.trim() && !INSTANCE_SLUG_PATTERN.test(value.slug.trim().toLowerCase()) ? (
+          {cohortInvalid ? (
             <p className='mt-1 text-xs text-red-600'>
               Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
               hyphen).
@@ -254,8 +260,8 @@ export function InstanceFormFields({
               <option value=''>
                 {isLoadingLocations ? 'Loading locations...' : 'Select location'}
               </option>
-              {value.locationId && !locationExists ? (
-                <option value={value.locationId}>{value.locationId}</option>
+              {effectiveLocationId && !locationExists ? (
+                <option value={effectiveLocationId}>{effectiveLocationId}</option>
               ) : null}
               {locationOptions.map((location) => (
                 <option key={location.id} value={location.id}>
@@ -266,7 +272,7 @@ export function InstanceFormFields({
           ) : (
             <Input
               id='instance-location-id'
-              value={value.locationId}
+              value={effectiveLocationId}
               disabled={instanceFieldsLocked}
               onChange={(event) => onChange({ ...value, locationId: event.target.value })}
               placeholder='Location UUID'

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -86,7 +86,7 @@ describe('InstanceDetailPanel', () => {
 
     expect(screen.getByLabelText('Service')).toBeInTheDocument();
     expect(screen.getByLabelText('Location')).toBeInTheDocument();
-    expect(screen.getByLabelText('Slug')).toBeDisabled();
+    expect(screen.getByLabelText('Cohort')).toBeDisabled();
     expect(screen.getByLabelText('Title')).toBeDisabled();
     expect(screen.getByLabelText('Waitlist')).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Add instance' })).not.toBeInTheDocument();
@@ -209,6 +209,7 @@ describe('InstanceDetailPanel', () => {
           buildServiceSummary({
             description: 'Service body',
             deliveryMode: 'hybrid',
+            locationId: 'location-1',
             trainingDetails: {
               pricingUnit: 'per_family',
               defaultPrice: '199.00',
@@ -237,6 +238,7 @@ describe('InstanceDetailPanel', () => {
     expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
     expect(screen.getByLabelText('Price')).toHaveValue('199.00');
     expect(screen.getByLabelText('Currency')).toHaveValue('USD');
+    expect(screen.getByLabelText('Location')).toHaveValue('location-1');
   });
 
   it('inherits event category from the selected service and omits category select for event instances', async () => {
@@ -301,7 +303,9 @@ describe('InstanceDetailPanel', () => {
     );
   });
 
-  it('prefills create form from createPrefillInstance with cleared slug', async () => {
+  it('prefills duplicate create from createPrefillInstance and sends null slug with cohort', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
     const prefill: ServiceInstance = {
       id: 'old-inst',
       serviceId: 'service-1',
@@ -373,7 +377,7 @@ describe('InstanceDetailPanel', () => {
         error=''
         onSelectService={vi.fn()}
         onCancelSelection={vi.fn()}
-        onCreate={vi.fn()}
+        onCreate={onCreate}
         onUpdate={vi.fn()}
       />
     );
@@ -381,12 +385,21 @@ describe('InstanceDetailPanel', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Title')).toHaveValue('Workshop A');
     });
-    expect(screen.getByLabelText('Slug')).toHaveValue('');
+    expect(screen.queryByLabelText('Slug')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Description')).toHaveValue('Body');
     expect(screen.getByLabelText('Delivery mode')).toHaveValue('hybrid');
     expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
     expect(screen.getByLabelText('Price')).toHaveValue('99');
     expect(screen.getByLabelText('Currency')).toHaveValue('USD');
     expect(screen.getByLabelText('Cohort')).toHaveValue('spring-2026');
+
+    await user.click(screen.getByRole('button', { name: 'Add instance' }));
+    expect(onCreate).toHaveBeenCalledWith(
+      'service-1',
+      expect.objectContaining({
+        slug: null,
+        cohort: 'spring-2026',
+      })
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaced the instance **Slug** field in `InstanceFormFields` with **Cohort** (same validation pattern as before for cohort values).
- When a service is selected for a new instance, `mergeServiceIntoInstanceForm` now copies `service.locationId` into the form so the **Location** dropdown defaults to the service’s location (with a fallback display via `serviceLocationId` when options load after state).
- Removed the duplicate cohort block from `InstanceDetailPanel` (cohort is edited in the top form row).
- `CreateInstanceDialog` now sends `cohort` in the create payload and disables submit when cohort format is invalid.

## Testing

- `npm run test -- --run tests/components/admin/services/instance-detail-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d7d0d26-fa6e-4f68-a9f9-d44d791f7aed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d7d0d26-fa6e-4f68-a9f9-d44d791f7aed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

