### PR TITLE
fix(admin_web): default consultation instance pricing to package

### DIFF
--- a/apps/admin_web/src/components/admin/services/form-defaults.ts
+++ b/apps/admin_web/src/components/admin/services/form-defaults.ts
@@ -35,6 +35,12 @@ export const DEFAULT_CONSULTATION_FORM: ConsultationFormState = {
   defaultCurrency: 'HKD',
 };
 
+/** Instance create/edit panel: default new consultation instances to package pricing. */
+export const DEFAULT_CONSULTATION_INSTANCE_FORM: ConsultationFormState = {
+  ...DEFAULT_CONSULTATION_FORM,
+  pricingModel: 'package',
+};
+
 export const DEFAULT_INSTANCE_FORM: InstanceFormState = {
   title: '',
   slug: '',

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -14,7 +14,7 @@ import {
   type EventFormState,
 } from './event-form-fields';
 import {
-  DEFAULT_CONSULTATION_FORM,
+  DEFAULT_CONSULTATION_INSTANCE_FORM,
   DEFAULT_EVENT_FORM,
   DEFAULT_INSTANCE_FORM,
   DEFAULT_TRAINING_FORM,
@@ -146,8 +146,11 @@ function mergeServiceIntoConsultationForm(
   prev: ConsultationFormState,
   service: ServiceSummary
 ): ConsultationFormState {
-  if (service.serviceType !== 'consultation' || !service.consultationDetails) {
+  if (service.serviceType !== 'consultation') {
     return prev;
+  }
+  if (!service.consultationDetails) {
+    return DEFAULT_CONSULTATION_INSTANCE_FORM;
   }
   const cd = service.consultationDetails;
   const pm = cd.pricingModel;
@@ -164,7 +167,7 @@ function mergeServiceIntoConsultationForm(
 function consultationFormFromInstanceResolved(instance: ServiceInstance): ConsultationFormState {
   const r = instance.resolvedConsultationDetails;
   if (!r) {
-    return DEFAULT_CONSULTATION_FORM;
+    return DEFAULT_CONSULTATION_INSTANCE_FORM;
   }
   const pm = r.pricingModel;
   return {
@@ -279,7 +282,7 @@ export function InstanceDetailPanel({
       : DEFAULT_EVENT_FORM
   );
   const [consultationForm, setConsultationForm] = useState<ConsultationFormState>(
-    instance ? consultationFormFromInstanceResolved(instance) : DEFAULT_CONSULTATION_FORM
+    instance ? consultationFormFromInstanceResolved(instance) : DEFAULT_CONSULTATION_INSTANCE_FORM
   );
 
   useEffect(() => {

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -196,6 +196,36 @@ describe('InstanceDetailPanel', () => {
     expect(onSelectService).toHaveBeenCalledWith('service-2');
   });
 
+  it('defaults consultation instance pricing model to package when the service has no consultation details', async () => {
+    render(
+      <InstanceDetailPanel
+        {...defaultEntityTagProps}
+        instance={null}
+        selectedServiceId='service-1'
+        serviceOptions={[
+          buildServiceSummary({
+            serviceType: 'consultation',
+            trainingDetails: null,
+            consultationDetails: null,
+          }),
+        ]}
+        locationOptions={[buildLocationSummary()]}
+        isLoadingLocations={false}
+        serviceType='consultation'
+        isLoading={false}
+        error=''
+        onSelectService={vi.fn()}
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Pricing model')).toHaveValue('package');
+    });
+  });
+
   it('prefills title, description, delivery, and training pricing from the selected service', async () => {
     const user = userEvent.setup();
     const onSelectService = vi.fn();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consultation instances on the admin Services instance panel now default the **Pricing model** to **Package** instead of **Free** when there is no inherited consultation pricing (new create flow, duplicate/prefill without resolved details, or a consultation service row with `consultationDetails: null`).

The service definition panel and create-instance dialog still use `DEFAULT_CONSULTATION_FORM` with **Free** as the service-level default.

## Changes

- Added `DEFAULT_CONSULTATION_INSTANCE_FORM` in `form-defaults.ts` (package pricing).
- `instance-detail-panel.tsx`: use the instance default for initial state, missing `resolvedConsultationDetails`, and `mergeServiceIntoConsultationForm` when the service has no `consultationDetails`.
- Unit test for the package default on the instance panel.

## Testing

- `npm test -- --run tests/components/admin/services/instance-detail-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f98e6d1f-1768-4e5e-9bb6-594b8346e940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f98e6d1f-1768-4e5e-9bb6-594b8346e940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

