### PR TITLE
Admin web: instances table cohort column; remove type and title

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -13,7 +13,7 @@ import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
-import { formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel, formatInstanceCohortDisplay } from '@/lib/format';
 
 import type { ServiceInstance, ServiceType } from '@/types/services';
 import { SERVICE_TYPES } from '@/types/services';
@@ -53,8 +53,6 @@ export interface InstanceListPanelProps {
   };
   /** When true, add a Service column (e.g. cross-service instance list). */
   showServiceColumn?: boolean;
-  /** When true, add a Type column showing the parent service type. */
-  showTypeColumn?: boolean;
 }
 
 export function InstanceListPanel({
@@ -73,7 +71,6 @@ export function InstanceListPanel({
   serviceTypeFilter,
   searchFilter,
   showServiceColumn = false,
-  showTypeColumn = false,
 }: InstanceListPanelProps) {
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
   const { copiedKey: duplicateDraftFeedbackId, markCopied: markDuplicateDraftFeedback } = useCopyFeedback(1000);
@@ -168,7 +165,7 @@ export function InstanceListPanel({
                     id='instances-filter-search'
                     value={searchFilter.value}
                     onChange={(event) => searchFilter.onChange(event.target.value)}
-                    placeholder='Title, service, instructor, status'
+                    placeholder='Cohort, service, instructor, status'
                   />
                 </div>
               ) : null}
@@ -179,13 +176,12 @@ export function InstanceListPanel({
         <AdminDataTable tableClassName='min-w-[820px]'>
           <AdminDataTableHead>
             <tr>
-              {showTypeColumn ? (
-                <th className='px-4 py-3 font-semibold'>Type</th>
-              ) : null}
               {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Service</th>
               ) : null}
-              <th className='px-4 py-3 font-semibold'>Title</th>
+              {showServiceColumn ? (
+                <th className='px-4 py-3 font-semibold'>Cohort</th>
+              ) : null}
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Capacity</th>
               <th className='px-4 py-3 font-semibold'>Instructor</th>
@@ -205,15 +201,12 @@ export function InstanceListPanel({
                 role='row'
                 aria-selected={selectedInstanceId === instance.id}
               >
-                {showTypeColumn ? (
-                  <td className='px-4 py-3'>
-                    {instance.parentServiceType ? formatEnumLabel(instance.parentServiceType) : '-'}
-                  </td>
-                ) : null}
                 {showServiceColumn ? (
                   <td className='px-4 py-3'>{instance.parentServiceTitle ?? '-'}</td>
                 ) : null}
-                <td className='px-4 py-3'>{instance.resolvedTitle ?? '-'}</td>
+                {showServiceColumn ? (
+                  <td className='px-4 py-3'>{formatInstanceCohortDisplay(instance.cohort)}</td>
+                ) : null}
                 <td className='px-4 py-3'>{formatEnumLabel(instance.status)}</td>
                 <td className='px-4 py-3'>{instance.maxCapacity ?? 'unlimited'}</td>
                 <td className='px-4 py-3'>{instance.instructorId ?? '-'}</td>

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { StatusBanner } from '@/components/status-banner';
 
 import { useServicesPage, type ServicesView } from '@/hooks/use-services-page';
+import { formatInstanceCohortDisplay } from '@/lib/format';
 import { getInstance, getService } from '@/lib/services-api';
 import type { ServiceDetail, ServiceInstance } from '@/types/services';
 
@@ -77,16 +78,18 @@ export function ServicesPage() {
   const filteredInstances =
     state.activeView === 'instances' && normalizedInstanceSearch
       ? state.instanceList.instances.filter((instance) => {
-          const searchable = [
+          const parts: string[] = [
             instance.resolvedTitle,
             instance.title,
             instance.parentServiceTitle,
             instance.instructorId,
             instance.status,
-          ]
-            .filter((value): value is string => Boolean(value))
-            .join(' ')
-            .toLowerCase();
+          ].filter((value): value is string => Boolean(value));
+          const cohortTrimmed = instance.cohort?.trim();
+          if (cohortTrimmed) {
+            parts.push(cohortTrimmed, formatInstanceCohortDisplay(instance.cohort));
+          }
+          const searchable = parts.join(' ').toLowerCase();
           return searchable.includes(normalizedInstanceSearch);
         })
       : state.instanceList.instances;
@@ -245,7 +248,6 @@ export function ServicesPage() {
             }}
             onLoadMore={state.instanceList.loadMore}
             showServiceColumn
-            showTypeColumn
             searchFilter={{
               value: state.instancesSearchQuery,
               onChange: state.setInstancesSearchQuery,

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -127,6 +127,30 @@ export function formatEnumLabel(value: string): string {
   return toTitleCase(value.toLowerCase());
 }
 
+/**
+ * Service instance cohort slugs use hyphens (e.g. `spring-2024`); show each segment
+ * as a word with a capitalized first letter.
+ */
+export function formatInstanceCohortDisplay(cohort: string | null | undefined): string {
+  if (cohort == null) {
+    return '-';
+  }
+  const trimmed = cohort.trim();
+  if (!trimmed) {
+    return '-';
+  }
+  const words = trimmed
+    .split('-')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  if (words.length === 0) {
+    return '-';
+  }
+  return words
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
 function parseDecimalAmountString(raw: string | null | undefined): number | null {
   if (raw == null) {
     return null;

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -53,6 +53,7 @@ const INSTANCE_FIXTURE: ServiceInstance = {
   createdAt: '2026-03-01T10:00:00Z',
   updatedAt: '2026-03-01T10:00:00Z',
   resolvedTitle: 'Resolved title',
+  cohort: 'spring-2024',
   resolvedSlug: null,
   resolvedDescription: null,
   resolvedCoverImageS3Key: null,
@@ -167,7 +168,7 @@ describe('services tables value formatting', () => {
     render(
       <>
         <InstanceListPanel
-          instances={[INSTANCE_FIXTURE]}
+          instances={[{ ...INSTANCE_FIXTURE, parentServiceTitle: 'Yoga' }]}
           selectedInstanceId={null}
           isLoading={false}
           isLoadingMore={false}
@@ -178,6 +179,7 @@ describe('services tables value formatting', () => {
           onLoadMore={vi.fn()}
           onDuplicateInstance={vi.fn()}
           onDeleteInstance={vi.fn()}
+          showServiceColumn
         />
         <DiscountCodesPanel
           codes={[DISCOUNT_CODE_FIXTURE, DISCOUNT_REFERRAL_FIXTURE]}
@@ -198,7 +200,9 @@ describe('services tables value formatting', () => {
     );
 
     const tables = screen.getAllByRole('table');
-    expect(within(tables[0] as HTMLElement).getByText('In Progress')).toBeInTheDocument();
+    const instanceTable = tables[0] as HTMLElement;
+    expect(within(instanceTable).getByText('In Progress')).toBeInTheDocument();
+    expect(within(instanceTable).getByText('Spring 2024')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('SAVE10')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('10%')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('Referral')).toBeInTheDocument();

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -5,6 +5,7 @@ import {
   formatDate,
   formatDateOnly,
   formatEnumLabel,
+  formatInstanceCohortDisplay,
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
   getContentLanguageOptions,
@@ -42,6 +43,13 @@ describe('format helpers', () => {
   it('formats snake_case values into title case labels', () => {
     expect(formatEnumLabel('training_course')).toBe('Training Course');
     expect(formatEnumLabel('in_person')).toBe('In Person');
+  });
+
+  it('formats instance cohort slugs for table display', () => {
+    expect(formatInstanceCohortDisplay(null)).toBe('-');
+    expect(formatInstanceCohortDisplay('')).toBe('-');
+    expect(formatInstanceCohortDisplay('spring-2024')).toBe('Spring 2024');
+    expect(formatInstanceCohortDisplay('MY-BEST-AUNTIE')).toBe('My Best Auntie');
   });
 
   it('formats service list price labels by service type', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Services **Instances** table (cross-service list) to remove the **Type** and **Title** columns, add **Cohort** immediately after **Service**, and display cohort values by replacing hyphens with spaces and capitalizing the first letter of each word (for example `spring-2024` → `Spring 2024`).

## Implementation notes

- New helper `formatInstanceCohortDisplay` in `apps/admin_web/src/lib/format.ts` (empty/null cohort shows `-`).
- Instance search on the instances view now also matches cohort slug and the formatted display string.
- Search placeholder text updated to mention cohort instead of title.

## Tests

- `npm run lint` (admin_web)
- Vitest: `format.test.ts`, `table-value-formatting.test.tsx`, and related instance panel tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-279b53ee-9b36-4fa4-b046-7e798052de5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-279b53ee-9b36-4fa4-b046-7e798052de5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

