### PR TITLE
Admin: instances toolbar — search first, 3/4 width

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -123,43 +123,15 @@ export function InstanceListPanel({
         onLoadMore={onLoadMore}
         toolbar={
           serviceFilter || serviceTypeFilter || searchFilter ? (
-            <div className='mb-3 flex flex-wrap items-end gap-3'>
-              {serviceTypeFilter ? (
-                <div className='min-w-[180px] flex-1'>
-                  <Label htmlFor='instances-filter-service-type'>Type</Label>
-                  <Select
-                    id='instances-filter-service-type'
-                    value={serviceTypeFilter.value}
-                    onChange={(event) => serviceTypeFilter.onChange(event.target.value)}
-                  >
-                    <option value=''>All types</option>
-                    {SERVICE_TYPES.map((serviceType) => (
-                      <option key={serviceType} value={serviceType}>
-                        {formatEnumLabel(serviceType)}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-              ) : null}
-              {serviceFilter ? (
-                <div className='min-w-[220px] flex-1'>
-                  <Label htmlFor='instances-filter-service'>Service</Label>
-                  <Select
-                    id='instances-filter-service'
-                    value={serviceFilter.value}
-                    onChange={(event) => serviceFilter.onChange(event.target.value)}
-                  >
-                    <option value=''>All services</option>
-                    {serviceFilter.options.map((entry) => (
-                      <option key={entry.id} value={entry.id}>
-                        {entry.title}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-              ) : null}
+            <div className='mb-3 flex w-full flex-wrap items-end gap-3'>
               {searchFilter ? (
-                <div className='min-w-[220px] flex-1'>
+                <div
+                  className={
+                    serviceTypeFilter || serviceFilter
+                      ? 'min-w-0 basis-full sm:basis-0 sm:flex-[3]'
+                      : 'min-w-[220px] flex-1'
+                  }
+                >
                   <Label htmlFor='instances-filter-search'>Search instances</Label>
                   <Input
                     id='instances-filter-search'
@@ -167,6 +139,50 @@ export function InstanceListPanel({
                     onChange={(event) => searchFilter.onChange(event.target.value)}
                     placeholder='Cohort, service, instructor, status'
                   />
+                </div>
+              ) : null}
+              {serviceTypeFilter || serviceFilter ? (
+                <div
+                  className={
+                    searchFilter
+                      ? 'flex min-w-0 basis-full flex-wrap items-end gap-3 sm:basis-0 sm:flex-1'
+                      : 'contents'
+                  }
+                >
+                  {serviceTypeFilter ? (
+                    <div className='min-w-0 flex-1 sm:min-w-[180px]'>
+                      <Label htmlFor='instances-filter-service-type'>Type</Label>
+                      <Select
+                        id='instances-filter-service-type'
+                        value={serviceTypeFilter.value}
+                        onChange={(event) => serviceTypeFilter.onChange(event.target.value)}
+                      >
+                        <option value=''>All types</option>
+                        {SERVICE_TYPES.map((serviceType) => (
+                          <option key={serviceType} value={serviceType}>
+                            {formatEnumLabel(serviceType)}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                  ) : null}
+                  {serviceFilter ? (
+                    <div className='min-w-0 flex-1 sm:min-w-[220px]'>
+                      <Label htmlFor='instances-filter-service'>Service</Label>
+                      <Select
+                        id='instances-filter-service'
+                        value={serviceFilter.value}
+                        onChange={(event) => serviceFilter.onChange(event.target.value)}
+                      >
+                        <option value=''>All services</option>
+                        {serviceFilter.options.map((entry) => (
+                          <option key={entry.id} value={entry.id}>
+                            {entry.title}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders the Instances table toolbar so **Search instances** is the first control and uses a **3:1 flex split** with the combined Type + Service filter group on `sm` and up. On narrow viewports the toolbar stacks in logical order (search row, then type/service row).

## Changes

- `apps/admin_web/src/components/admin/services/instance-list-panel.tsx`: toolbar JSX order and responsive flex classes.

## Testing

- `npm run test -- --run` on affected services tests (services-page, table-value-formatting, duplicate-draft-feedback-buttons)
- `npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59b15de7-39ae-49bc-b355-2e671b4b6971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59b15de7-39ae-49bc-b355-2e671b4b6971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

