### PR TITLE
Admin web: session slot end +2h and location from instance

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -179,6 +179,7 @@ export function CreateInstanceDialog({
       <div className='mt-3'>
         <SessionSlotEditor
           slots={instanceForm.sessionSlots}
+          defaultLocationId={instanceForm.locationId.trim() || null}
           onChange={(sessionSlots) => setInstanceForm((prev) => ({ ...prev, sessionSlots }))}
         />
       </div>

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -434,6 +434,9 @@ export function InstanceDetailPanel({
   const canSubmit = Boolean(selectedServiceId);
   const typeFieldsLocked = !selectedServiceId;
 
+  const effectiveSessionSlotDefaultLocationId =
+    instanceForm.locationId.trim() || selectedService?.locationId?.trim() || null;
+
   const resolvedEventCategory = useMemo(
     () => resolveInheritedEventCategory(selectedService, instance),
     [selectedService, instance]
@@ -743,6 +746,7 @@ export function InstanceDetailPanel({
         disabled={typeFieldsLocked}
         locationOptions={locationOptions}
         isLoadingLocations={isLoadingLocations}
+        defaultLocationId={effectiveSessionSlotDefaultLocationId}
         onChange={(sessionSlots) => setInstanceForm((prev) => ({ ...prev, sessionSlots }))}
       />
 

--- a/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
+++ b/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { formatLocationLabel } from '@/lib/format';
+import { addHoursToDatetimeLocal } from '@/lib/session-slot-datetime';
 
 import type { LocationSummary, SessionSlot } from '@/types/services';
 
@@ -15,14 +16,17 @@ export interface SessionSlotEditorProps {
   disabled?: boolean;
   locationOptions?: LocationSummary[];
   isLoadingLocations?: boolean;
+  /** Instance (or inherited service) venue id used to prefill slot locations. */
+  defaultLocationId?: string | null;
   onChange: (slots: SessionSlot[]) => void;
 }
 
-function emptySlot(sortOrder: number): SessionSlot {
+function emptySlot(sortOrder: number, defaultLocationId?: string | null): SessionSlot {
+  const locationId = defaultLocationId?.trim() || null;
   return {
     id: null,
     instanceId: null,
-    locationId: null,
+    locationId,
     startsAt: null,
     endsAt: null,
     sortOrder,
@@ -34,9 +38,11 @@ export function SessionSlotEditor({
   disabled = false,
   locationOptions = [],
   isLoadingLocations = false,
+  defaultLocationId = null,
   onChange,
 }: SessionSlotEditorProps) {
   const hasLocationOptions = locationOptions.length > 0;
+  const trimmedDefaultLocation = defaultLocationId?.trim() || null;
 
   const slotGridClassName =
     'grid grid-cols-1 gap-x-3 gap-y-3 sm:grid-cols-[1fr_1fr_1fr_minmax(0,5.5rem)_auto] sm:items-end';
@@ -64,7 +70,20 @@ export function SessionSlotEditor({
                   value={(slot.startsAt ?? '').slice(0, 16)}
                   onChange={(event) => {
                     const next = [...slots];
-                    next[index] = { ...slot, startsAt: event.target.value || null };
+                    const startsAt = event.target.value || null;
+                    const startComplete = Boolean(startsAt && startsAt.length === 16);
+                    let { endsAt } = slot;
+                    if (!startsAt) {
+                      endsAt = null;
+                    } else if (startComplete) {
+                      const computedEnd = addHoursToDatetimeLocal(startsAt, 2);
+                      endsAt = computedEnd ?? endsAt;
+                    }
+                    let { locationId } = slot;
+                    if (startComplete && trimmedDefaultLocation && !locationId?.trim()) {
+                      locationId = trimmedDefaultLocation;
+                    }
+                    next[index] = { ...slot, startsAt, endsAt, locationId };
                     onChange(next);
                   }}
                 />
@@ -176,7 +195,7 @@ export function SessionSlotEditor({
             variant='secondary'
             size='sm'
             disabled={disabled}
-            onClick={() => onChange([...slots, emptySlot(slots.length)])}
+            onClick={() => onChange([...slots, emptySlot(slots.length, trimmedDefaultLocation)])}
           >
             Add slot
           </Button>

--- a/apps/admin_web/src/lib/session-slot-datetime.ts
+++ b/apps/admin_web/src/lib/session-slot-datetime.ts
@@ -1,0 +1,13 @@
+/** `datetime-local` values are `YYYY-MM-DDTHH:mm` in local time (no timezone). */
+export function addHoursToDatetimeLocal(value: string, hours: number): string | null {
+  if (!value) {
+    return null;
+  }
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    return null;
+  }
+  d.setTime(d.getTime() + hours * 60 * 60 * 1000);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/apps/admin_web/tests/components/admin/services/session-slot-editor.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/session-slot-editor.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SessionSlotEditor } from '@/components/admin/services/session-slot-editor';
@@ -37,5 +38,88 @@ describe('SessionSlotEditor', () => {
     expect(endLabels).toHaveLength(1);
     expect(locationLabels).toHaveLength(1);
     expect(sortLabels).toHaveLength(1);
+  });
+
+  it('sets end time two hours after start when start is entered', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SessionSlotEditor
+        slots={[
+          {
+            id: null,
+            instanceId: null,
+            locationId: null,
+            startsAt: null,
+            endsAt: null,
+            sortOrder: 0,
+          },
+        ]}
+        onChange={onChange}
+      />
+    );
+
+    const startInput = screen.getByLabelText('Start time');
+    await user.type(startInput, '2026-04-24T10:00');
+
+    expect(onChange).toHaveBeenCalled();
+    const last = onChange.mock.calls.at(-1)?.[0]?.[0];
+    expect(last?.startsAt).toBe('2026-04-24T10:00');
+    expect(last?.endsAt).toBe('2026-04-24T12:00');
+  });
+
+  it('prefills slot location from defaultLocationId when start is set and slot has no location', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const venueId = '11111111-1111-1111-1111-111111111111';
+    render(
+      <SessionSlotEditor
+        defaultLocationId={venueId}
+        slots={[
+          {
+            id: null,
+            instanceId: null,
+            locationId: null,
+            startsAt: null,
+            endsAt: null,
+            sortOrder: 0,
+          },
+        ]}
+        onChange={onChange}
+      />
+    );
+
+    const startInput = screen.getByLabelText('Start time');
+    await user.type(startInput, '2026-04-24T09:00');
+
+    const last = onChange.mock.calls.at(-1)?.[0]?.[0];
+    expect(last?.locationId).toBe(venueId);
+    expect(last?.endsAt).toBe('2026-04-24T11:00');
+  });
+
+  it('add slot uses defaultLocationId for new row location', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const venueId = '22222222-2222-2222-2222-222222222222';
+    render(
+      <SessionSlotEditor
+        defaultLocationId={venueId}
+        slots={[]}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /add slot/i }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        id: null,
+        instanceId: null,
+        locationId: venueId,
+        startsAt: null,
+        endsAt: null,
+        sortOrder: 0,
+      },
+    ]);
   });
 });

--- a/apps/admin_web/tests/lib/session-slot-datetime.test.ts
+++ b/apps/admin_web/tests/lib/session-slot-datetime.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { addHoursToDatetimeLocal } from '@/lib/session-slot-datetime';
+
+describe('addHoursToDatetimeLocal', () => {
+  it('adds hours in local wall time', () => {
+    expect(addHoursToDatetimeLocal('2026-04-24T10:00', 2)).toBe('2026-04-24T12:00');
+  });
+
+  it('returns null for empty input', () => {
+    expect(addHoursToDatetimeLocal('', 2)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- When a session slot **start** is fully entered (`datetime-local`), the **end** time is set automatically to **two hours later** (local wall time).
- Session slot **location** is prefilled from the instance’s location when the slot has no location yet; on create, the **service default location** is used if the instance field is still empty.
- **Add slot** seeds new rows with that default location id.

## Implementation notes

- End time and location prefill run only once the start value is complete (16-character `YYYY-MM-DDTHH:mm`) so partial typing does not produce bad dates.
- Manually edited end times are preserved until the user changes start again (then end is recomputed from the new start).

## Tests

- `npm run test` for `session-slot-datetime` and `SessionSlotEditor` specs.
- `npm run lint` in `apps/admin_web`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fa5e833-17db-44a2-82f8-d4a9989670dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fa5e833-17db-44a2-82f8-d4a9989670dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

