### PR TITLE
Admin: instance table slots column and sort by first slot

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -13,7 +13,12 @@ import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
-import { formatEnumLabel, formatInstanceCohortDisplay } from '@/lib/format';
+import {
+  formatEnumLabel,
+  formatInstanceCohortDisplay,
+  formatSessionSlotStartsAtDisplay,
+  orderSessionSlotsForDisplay,
+} from '@/lib/format';
 
 import type { ServiceInstance, ServiceType } from '@/types/services';
 import { SERVICE_TYPES } from '@/types/services';
@@ -177,7 +182,7 @@ export function InstanceListPanel({
           ) : undefined
         }
       >
-        <AdminDataTable tableClassName='min-w-[820px]'>
+        <AdminDataTable tableClassName='min-w-[960px]'>
           <AdminDataTableHead>
             <tr>
               {showServiceColumn ? (
@@ -185,6 +190,9 @@ export function InstanceListPanel({
               ) : null}
               {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Cohort</th>
+              ) : null}
+              {showServiceColumn ? (
+                <th className='px-4 py-3 font-semibold'>Slots</th>
               ) : null}
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Capacity</th>
@@ -210,6 +218,21 @@ export function InstanceListPanel({
                 ) : null}
                 {showServiceColumn ? (
                   <td className='px-4 py-3'>{formatInstanceCohortDisplay(instance.cohort)}</td>
+                ) : null}
+                {showServiceColumn ? (
+                  <td className='px-4 py-3 align-top'>
+                    {instance.sessionSlots.length === 0 ? (
+                      '-'
+                    ) : (
+                      <ul className='m-0 max-w-[11rem] list-none space-y-0.5 p-0'>
+                        {orderSessionSlotsForDisplay(instance.sessionSlots).map((slot, slotIndex) => (
+                          <li key={slot.id ?? `${instance.id}-slot-${slotIndex}`}>
+                            {formatSessionSlotStartsAtDisplay(slot.startsAt)}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </td>
                 ) : null}
                 <td className='px-4 py-3'>{formatEnumLabel(instance.status)}</td>
                 <td className='px-4 py-3'>{instance.maxCapacity ?? 'Unlimited'}</td>

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -5,7 +5,10 @@ import { useCallback, useMemo, useState } from 'react';
 import { StatusBanner } from '@/components/status-banner';
 
 import { useServicesPage, type ServicesView } from '@/hooks/use-services-page';
-import { formatInstanceCohortDisplay } from '@/lib/format';
+import {
+  compareInstancesByFirstSlotStartsDesc,
+  formatInstanceCohortDisplay,
+} from '@/lib/format';
 import { getInstance, getService } from '@/lib/services-api';
 import type { ServiceDetail, ServiceInstance } from '@/types/services';
 
@@ -75,24 +78,32 @@ export function ServicesPage() {
     return allServiceOptionsIncludingArchived.filter((svc) => svc.status !== 'archived');
   }, [showArchivedDiscountServices, allServiceOptionsIncludingArchived]);
   const normalizedInstanceSearch = state.instancesSearchQuery.trim().toLowerCase();
-  const filteredInstances =
-    state.activeView === 'instances' && normalizedInstanceSearch
-      ? state.instanceList.instances.filter((instance) => {
-          const parts: string[] = [
-            instance.resolvedTitle,
-            instance.title,
-            instance.parentServiceTitle,
-            instance.instructorId,
-            instance.status,
-          ].filter((value): value is string => Boolean(value));
-          const cohortTrimmed = instance.cohort?.trim();
-          if (cohortTrimmed) {
-            parts.push(cohortTrimmed, formatInstanceCohortDisplay(instance.cohort));
-          }
-          const searchable = parts.join(' ').toLowerCase();
-          return searchable.includes(normalizedInstanceSearch);
-        })
-      : state.instanceList.instances;
+  const filteredInstances = useMemo(() => {
+    if (state.activeView !== 'instances' || !normalizedInstanceSearch) {
+      return state.instanceList.instances;
+    }
+    return state.instanceList.instances.filter((instance) => {
+      const parts: string[] = [
+        instance.resolvedTitle,
+        instance.title,
+        instance.parentServiceTitle,
+        instance.instructorId,
+        instance.status,
+      ].filter((value): value is string => Boolean(value));
+      const cohortTrimmed = instance.cohort?.trim();
+      if (cohortTrimmed) {
+        parts.push(cohortTrimmed, formatInstanceCohortDisplay(instance.cohort));
+      }
+      const searchable = parts.join(' ').toLowerCase();
+      return searchable.includes(normalizedInstanceSearch);
+    });
+  }, [normalizedInstanceSearch, state.activeView, state.instanceList.instances]);
+  const instancesTableRows = useMemo(() => {
+    if (state.activeView !== 'instances') {
+      return filteredInstances;
+    }
+    return [...filteredInstances].sort(compareInstancesByFirstSlotStartsDesc);
+  }, [filteredInstances, state.activeView]);
   const instancesContextServiceId =
     state.activeView === 'instances'
       ? (state.selectedInstance?.serviceId ?? state.selectedServiceId)
@@ -235,7 +246,7 @@ export function ServicesPage() {
             }}
           />
           <InstanceListPanel
-            instances={filteredInstances}
+            instances={instancesTableRows}
             selectedInstanceId={state.selectedInstanceId}
             isLoading={state.instanceList.isLoading}
             isLoadingMore={state.instanceList.isLoadingMore}

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -1,7 +1,7 @@
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { formatAmountInCurrency } from '@/lib/vendor-spend';
 import { CLIENT_DOCUMENT_ASSET_TAG, EXPENSE_ATTACHMENT_ASSET_TAG } from '@/types/assets';
-import type { LocationSummary, ServiceSummary } from '@/types/services';
+import type { LocationSummary, ServiceInstance, ServiceSummary, SessionSlot } from '@/types/services';
 
 import adminSelectableCurrency from '@shared-config/admin-selectable-currency-codes.json';
 
@@ -149,6 +149,113 @@ export function formatInstanceCohortDisplay(cohort: string | null | undefined): 
   return words
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ');
+}
+
+const SESSION_SLOT_TABLE_DATETIME_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  day: '2-digit',
+  month: 'short',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+/**
+ * Session slot start for instances table: `dd Mmm @ HH:mm` in local time (en-GB parts).
+ */
+export function formatSessionSlotStartsAtDisplay(iso: string | null | undefined): string {
+  if (iso == null) {
+    return '-';
+  }
+  const trimmed = iso.trim();
+  if (!trimmed) {
+    return '-';
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return '-';
+  }
+  const parts = SESSION_SLOT_TABLE_DATETIME_FORMATTER.formatToParts(parsed);
+  const day = parts.find((p) => p.type === 'day')?.value ?? '';
+  const month = parts.find((p) => p.type === 'month')?.value ?? '';
+  const hour = parts.find((p) => p.type === 'hour')?.value ?? '';
+  const minute = parts.find((p) => p.type === 'minute')?.value ?? '';
+  if (!day || !month || !hour || !minute) {
+    return '-';
+  }
+  const monthNorm = month.replace(/\.$/, '');
+  return `${day} ${monthNorm} @ ${hour}:${minute}`;
+}
+
+function sessionSlotSortKey(slot: SessionSlot, index: number): number {
+  const o = slot.sortOrder;
+  if (typeof o === 'number' && Number.isFinite(o)) {
+    return o;
+  }
+  return index;
+}
+
+/** Same ordering as the instances table slot column: `sort_order`, then start time, then index. */
+export function orderSessionSlotsForDisplay(slots: SessionSlot[]): SessionSlot[] {
+  return slots
+    .map((slot, index) => ({ slot, index }))
+    .sort((a, b) => {
+      const ko = sessionSlotSortKey(a.slot, a.index) - sessionSlotSortKey(b.slot, b.index);
+      if (ko !== 0) {
+        return ko;
+      }
+      const ra = a.slot.startsAt?.trim() ?? '';
+      const rb = b.slot.startsAt?.trim() ?? '';
+      const ta = ra ? new Date(ra).getTime() : NaN;
+      const tb = rb ? new Date(rb).getTime() : NaN;
+      const fa = Number.isFinite(ta);
+      const fb = Number.isFinite(tb);
+      if (fa && fb && ta !== tb) {
+        return ta - tb;
+      }
+      if (fa !== fb) {
+        return fa ? -1 : 1;
+      }
+      return a.index - b.index;
+    })
+    .map(({ slot }) => slot);
+}
+
+/** Timestamp of the earliest slot with a valid `startsAt`, or `null` if none. */
+export function getFirstSessionSlotStartTimeMs(slots: SessionSlot[]): number | null {
+  const ordered = orderSessionSlotsForDisplay(slots);
+  for (const slot of ordered) {
+    const raw = slot.startsAt?.trim() ?? '';
+    if (!raw) {
+      continue;
+    }
+    const ms = new Date(raw).getTime();
+    if (Number.isFinite(ms)) {
+      return ms;
+    }
+  }
+  return null;
+}
+
+/**
+ * Sort instances for the admin table: latest first session start first; instances
+ * without slot times last (stable tie-break on id).
+ */
+export function compareInstancesByFirstSlotStartsDesc(a: ServiceInstance, b: ServiceInstance): number {
+  const ta = getFirstSessionSlotStartTimeMs(a.sessionSlots);
+  const tb = getFirstSessionSlotStartTimeMs(b.sessionSlots);
+  if (ta == null && tb == null) {
+    return a.id.localeCompare(b.id);
+  }
+  if (ta == null) {
+    return 1;
+  }
+  if (tb == null) {
+    return -1;
+  }
+  if (tb !== ta) {
+    return tb - ta;
+  }
+  return a.id.localeCompare(b.id);
 }
 
 function parseDecimalAmountString(raw: string | null | undefined): number | null {

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  compareInstancesByFirstSlotStartsDesc,
   formatAssetContentLanguageLabel,
   formatDate,
   formatDateOnly,
@@ -8,12 +9,15 @@ import {
   formatInstanceCohortDisplay,
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
+  formatSessionSlotStartsAtDisplay,
+  getFirstSessionSlotStartTimeMs,
   getContentLanguageOptions,
   getCurrencyOptions,
   matchAdminSelectableContentLanguage,
+  orderSessionSlotsForDisplay,
   parseDatetimeLocalToIsoUtc,
 } from '@/lib/format';
-import type { ServiceSummary } from '@/types/services';
+import type { ServiceInstance, ServiceSummary, SessionSlot } from '@/types/services';
 
 function baseSummary(overrides: Partial<ServiceSummary> = {}): ServiceSummary {
   return {
@@ -50,6 +54,87 @@ describe('format helpers', () => {
     expect(formatInstanceCohortDisplay('')).toBe('-');
     expect(formatInstanceCohortDisplay('spring-2024')).toBe('Spring 2024');
     expect(formatInstanceCohortDisplay('MY-BEST-AUNTIE')).toBe('My Best Auntie');
+  });
+
+  it('formats session slot starts for instances table', () => {
+    expect(formatSessionSlotStartsAtDisplay(null)).toBe('-');
+    expect(formatSessionSlotStartsAtDisplay('')).toBe('-');
+    expect(formatSessionSlotStartsAtDisplay('not-a-date')).toBe('-');
+    const line = formatSessionSlotStartsAtDisplay('2026-06-15T14:30:00Z');
+    expect(line).toMatch(/^\d{2} \w+ @ \d{2}:\d{2}$/);
+  });
+
+  it('orders session slots by sort_order then starts_at', () => {
+    const slots: SessionSlot[] = [
+      { id: 'a', instanceId: null, locationId: null, startsAt: '2026-01-10T10:00:00Z', endsAt: null, sortOrder: 2 },
+      { id: 'b', instanceId: null, locationId: null, startsAt: '2026-01-05T10:00:00Z', endsAt: null, sortOrder: 1 },
+    ];
+    const ordered = orderSessionSlotsForDisplay(slots);
+    expect(ordered.map((s) => s.id)).toEqual(['b', 'a']);
+  });
+
+  it('uses earliest ordered slot time for instance sort key', () => {
+    const slots: SessionSlot[] = [
+      { id: 'late', instanceId: null, locationId: null, startsAt: '2026-02-01T10:00:00Z', endsAt: null, sortOrder: 2 },
+      { id: 'early', instanceId: null, locationId: null, startsAt: '2026-01-01T10:00:00Z', endsAt: null, sortOrder: 1 },
+    ];
+    expect(getFirstSessionSlotStartTimeMs(slots)).toBe(new Date('2026-01-01T10:00:00Z').getTime());
+  });
+
+  it('sorts instances by first slot start descending', () => {
+    const mk = (id: string, startsAt: string | null): ServiceInstance => ({
+      id,
+      serviceId: 'svc',
+      parentServiceTitle: null,
+      parentServiceType: null,
+      title: null,
+      slug: null,
+      description: null,
+      coverImageS3Key: null,
+      status: 'scheduled',
+      deliveryMode: null,
+      locationId: null,
+      maxCapacity: null,
+      waitlistEnabled: false,
+      externalUrl: null,
+      partnerOrganizations: [],
+      instructorId: null,
+      cohort: null,
+      notes: null,
+      tagIds: [],
+      createdBy: 'u',
+      createdAt: null,
+      updatedAt: null,
+      resolvedTitle: null,
+      resolvedSlug: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      resolvedLocationId: null,
+      sessionSlots: startsAt
+        ? [
+            {
+              id: 's',
+              instanceId: id,
+              locationId: null,
+              startsAt,
+              endsAt: null,
+              sortOrder: 0,
+            },
+          ]
+        : [],
+      trainingDetails: null,
+      resolvedTrainingDetails: null,
+      eventTicketTiers: [],
+      resolvedEventTicketTiers: [],
+      consultationDetails: null,
+      resolvedConsultationDetails: null,
+    });
+    const later = mk('b', '2026-06-01T12:00:00Z');
+    const earlier = mk('a', '2026-05-01T12:00:00Z');
+    const noSlots = mk('c', null);
+    const sorted = [earlier, noSlots, later].sort(compareInstancesByFirstSlotStartsDesc);
+    expect(sorted.map((i) => i.id)).toEqual(['b', 'a', 'c']);
   });
 
   it('formats service list price labels by service type', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a **Slots** column immediately after **Cohort** on the Services → Instances table (cross-service list). Each session slot’s start is shown on its own line as `dd Mmm @ HH:mm` in the viewer’s local timezone (24-hour clock).
- **Sorts** the table by the instance’s **earliest** slot start time **descending** (newest first). Instances with no parseable slot times appear last; order within ties is stable by instance id.

## Implementation notes

- Slot display order matches `sort_order` then `starts_at` (aligned with session slot editor semantics).
- Client-side sort applies to the loaded page of instances (same pagination model as before).

## Testing

- `npm run lint` (admin_web)
- `npx vitest run tests/lib/format.test.ts tests/components/admin/services/table-value-formatting.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c65f17ce-59d3-4ab2-a767-346956fe123b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65f17ce-59d3-4ab2-a767-346956fe123b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

