### PR TITLE
Public calendar API: integer price, remove id, service_tier always set

### DIFF
--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -461,7 +461,10 @@ function buildMyBestAuntieBookingModalPayload(
   record: Record<string, unknown>,
   locale: Locale,
 ): MyBestAuntieBookingModalPayload | null {
-  const id = readCandidateText(record, ['id', 'eventId', 'slug']) ?? '';
+  const id =
+    readCandidateText(record, ['id', 'eventId', 'slug']) ??
+    readCandidateText(record, ['service_instance_id', 'service_instance_uuid']) ??
+    '';
   const ageGroup = readCandidateText(record, ['service_tier']) ?? '';
   const cohortValue = readCandidateText(record, ['cohort']) ?? '';
   if (!id || !ageGroup || !cohortValue) {

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -286,6 +286,49 @@ describe('events-data', () => {
     }
   });
 
+  it('resolves my-best-auntie cohort id from service_instance_id when id is absent', () => {
+    const payload = {
+      data: [
+        {
+          service_instance_id: 'e2d0ad6b-70df-4385-873f-bdfc628d59c9',
+          title: 'My Best Auntie 1-3',
+          booking_system: 'my-best-auntie-booking',
+          service_tier: '1-3',
+          cohort: 'apr-26',
+          spaces_total: 8,
+          spaces_left: 8,
+          price: 9000,
+          currency: 'HKD',
+          location: 'physical',
+          location_name: 'Evolve Sprouts',
+          location_address: '507, 5/F',
+          location_url: 'https://www.google.com/maps/dir/?api=1&destination=22.286209%2C114.148303',
+          dates: [
+            {
+              id: 'da6bcd38-0a63-481b-830f-31de835b9369',
+              start_datetime: '2026-04-18T09:00:00+00:00',
+              end_datetime: '2026-04-18T11:00:00+00:00',
+            },
+          ],
+          is_fully_booked: false,
+        },
+      ],
+    };
+
+    const events = normalizeEvents(payload, enContent.events, 'en');
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.bookingModalPayload?.variant).toBe('my-best-auntie');
+    if (events[0]?.bookingModalPayload?.variant === 'my-best-auntie') {
+      expect(events[0].bookingModalPayload.selectedCohort.id).toBe(
+        'e2d0ad6b-70df-4385-873f-bdfc628d59c9',
+      );
+      expect(events[0].bookingModalPayload.selectedCohort.service_instance_id).toBe(
+        'e2d0ad6b-70df-4385-873f-bdfc628d59c9',
+      );
+    }
+  });
+
   it('normalizes event-booking records with in-page modal payload', () => {
     const payload = {
       data: [

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -166,7 +166,7 @@ def _resolve_primary_location(
 
 def _resolve_primary_price(
     instance: ServiceInstance,
-) -> tuple[float | None, str | None]:
+) -> tuple[int | None, str | None]:
     # Consultation is not returned by list_public_offerings; if serialized elsewhere,
     # price/currency are intentionally omitted (no training_details / ticket path).
     service = instance.service
@@ -177,15 +177,17 @@ def _resolve_primary_price(
                 key=lambda tier: (tier.sort_order, tier.created_at, tier.id),
             )
             selected = sorted_tiers[0]
-            return _decimal_to_float(selected.price), selected.currency
+            return _decimal_to_int_price(selected.price), selected.currency
         details = service.event_details
         if details is not None and details.default_price is not None:
-            return _decimal_to_float(details.default_price), details.default_currency
+            return _decimal_to_int_price(
+                details.default_price
+            ), details.default_currency
         return None, None
     if service.service_type == ServiceType.TRAINING_COURSE:
         td = instance.training_details
         if td is not None:
-            return _decimal_to_float(td.price), td.currency
+            return _decimal_to_int_price(td.price), td.currency
         return None, None
     return None, None
 
@@ -229,6 +231,33 @@ def _resolve_partners(instance: ServiceInstance) -> list[str]:
 
 def _resolve_external_url(instance: ServiceInstance) -> str | None:
     return instance.external_url or instance.eventbrite_event_url or None
+
+
+def _derive_training_service_tier_from_instance_slug(
+    instance_slug: str | None,
+    service_slug: str | None,
+) -> str | None:
+    """Infer age tier from instance slug when parent ``services.service_tier`` is unset."""
+    if not instance_slug or service_slug != "my-best-auntie":
+        return None
+    prefix = "my-best-auntie-"
+    if not instance_slug.startswith(prefix):
+        return None
+    rest = instance_slug[len(prefix) :]
+    for tier in ("0-1", "1-3", "3-6"):
+        if rest.startswith(f"{tier}-"):
+            return tier
+    return None
+
+
+def _resolve_public_calendar_service_tier(instance: ServiceInstance) -> str | None:
+    service = instance.service
+    if service.service_tier is not None:
+        return service.service_tier
+    return _derive_training_service_tier_from_instance_slug(
+        instance.slug,
+        getattr(service, "slug", None),
+    )
 
 
 def _serialize_public_event(
@@ -279,7 +308,6 @@ def _serialize_public_event(
     )
 
     payload: dict[str, Any] = {
-        "id": instance.slug or str(instance.id),
         "service_instance_id": str(instance.id),
         "service_type": service.service_type.value,
         "title": title,
@@ -315,8 +343,7 @@ def _serialize_public_event(
         payload["slug"] = instance.slug
     if instance.landing_page is not None:
         payload["landing_page"] = instance.landing_page
-    if service.service_tier is not None:
-        payload["service_tier"] = service.service_tier
+    payload["service_tier"] = _resolve_public_calendar_service_tier(instance)
     if instance.cohort is not None:
         payload["cohort"] = instance.cohort
 
@@ -328,10 +355,11 @@ def _serialize_public_event(
     return payload
 
 
-def _decimal_to_float(value: Decimal | None) -> float | None:
+def _decimal_to_int_price(value: Decimal | None) -> int | None:
     if value is None:
         return None
-    return float(value)
+    quantized = value.quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    return int(quantized)
 
 
 def _clean_text(value: str | None) -> str | None:

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -933,7 +933,6 @@ components:
     PublicCalendarEvent:
       type: object
       required:
-        - id
         - service_instance_id
         - service_type
         - title
@@ -946,16 +945,12 @@ components:
         - tags
         - categories
         - partners
+        - service_tier
       properties:
-        id:
-          type: string
-          description: >
-            Public slug when `service_instances.slug` is set, otherwise the
-            instance UUID as string.
         service_instance_id:
           type: string
           format: uuid
-          description: Aurora `service_instances.id`. Stable even when the `id` alias changes.
+          description: Aurora `service_instances.id`. Stable public identifier for the offering.
         service_type:
           type: string
           enum: [event, training_course]
@@ -1010,8 +1005,11 @@ components:
             `service_instances.external_url` when set, falling back to
             `service_instances.eventbrite_event_url` for backward compatibility.
         price:
-          type: number
+          type: integer
           nullable: true
+          description: >
+            Whole currency units; fractional DB amounts are rounded half-up to the
+            nearest integer.
         currency:
           type: string
           nullable: true
@@ -1046,6 +1044,10 @@ components:
         service_tier:
           type: string
           nullable: true
+          description: >
+            From `services.service_tier` when set; for My Best Auntie training
+            cohorts, inferred from `service_instances.slug` (e.g. `my-best-auntie-1-3-04-26`)
+            when the parent service tier is unset. `null` when not applicable.
         cohort:
           type: string
           nullable: true

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -109,7 +109,8 @@ their primary responsibilities.
   `/www/v1/calendar/public` (public calendar feed: returns **event** and
   **training_course** `service_instances` for published services; consultation
   is intentionally excluded. Each item includes `service_type`,
-  `service_instance_id`, `partners`, optional `service_tier` (from parent service) / `cohort`,
+  `service_instance_id` (stable id; no separate `id` field), `partners`, `service_tier`
+  (from parent service, or inferred from instance slug for My Best Auntie) / `cohort`,
   `is_fully_booked`, and a server-derived `location_url`. `booking_system` comes
   from `services.booking_system` or defaults from service type (MBA training
   cohorts default to `my-best-auntie-booking` when `services.slug` is

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -78,12 +78,12 @@ def test_event_ticket_tier_price_and_booking_system_default() -> None:
         partner_organization_links=[],
     )
     out = public_events._serialize_public_event(inst, enrollment_counts={})
-    assert out["id"] == "my-event"
+    assert "id" not in out
     assert out["service_instance_id"] == str(inst.id)
     assert out["service_type"] == "event"
     assert out["booking_system"] == "event-booking"
     assert out["categories"] == ["workshop"]
-    assert out["price"] == 250.0
+    assert out["price"] == 250
     assert out["currency"] == "HKD"
     assert out["tags"] == []
     assert out["partners"] == []
@@ -108,7 +108,7 @@ def test_event_default_price_when_no_tiers() -> None:
     )
     inst = _minimal_instance(service, ticket_tiers=[])
     out = public_events._serialize_public_event(inst, enrollment_counts={})
-    assert out["price"] == 10.5
+    assert out["price"] == 11
     assert out["currency"] == "USD"
     assert "booking_system" in out
 
@@ -205,7 +205,7 @@ def test_training_mba_booking_and_category() -> None:
     assert out["service_type"] == "training_course"
     assert out["booking_system"] == "my-best-auntie-booking"
     assert out["categories"] == ["Training Course"]
-    assert out["price"] == 350.0
+    assert out["price"] == 350
     assert out["currency"] == "HKD"
     assert out["service_tier"] == "0-1"
     assert out["cohort"] == "May 2026"
@@ -229,6 +229,30 @@ def test_training_non_mba_omits_booking_system() -> None:
     )
     out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert "booking_system" not in out
+    assert out["service_tier"] is None
+
+
+def test_training_mba_infers_service_tier_from_instance_slug() -> None:
+    service = SimpleNamespace(
+        title="MBA",
+        description="Course",
+        service_type=ServiceType.TRAINING_COURSE,
+        slug="my-best-auntie",
+        booking_system=None,
+        event_details=None,
+        delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier=None,
+        location=None,
+    )
+    inst = _minimal_instance(
+        service,
+        slug="my-best-auntie-1-3-04-26",
+        cohort="apr-26",
+        training_details=SimpleNamespace(price=Decimal("9000"), currency="HKD"),
+    )
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["service_tier"] == "1-3"
+    assert "id" not in out
 
 
 def test_virtual_clears_location_and_url_even_with_coords() -> None:
@@ -357,13 +381,13 @@ def test_max_capacity_with_enrollments() -> None:
     assert out["spaces_left"] == 0
 
 
-def test_id_uuid_when_no_slug() -> None:
+def test_omits_id_when_no_slug() -> None:
     service = _event_service()
     iid = uuid4()
     inst = _minimal_instance(service, slug=None)
     inst.id = iid
     out = public_events._serialize_public_event(inst, enrollment_counts={})
-    assert out["id"] == str(iid)
+    assert "id" not in out
     assert out["service_instance_id"] == str(iid)
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the public calendar feed (`GET /v1/calendar/public` and `/www/v1/calendar/public`) serialization and contract:

1. **`price`** is now a JSON **integer**, using half-up rounding from `Decimal` (ticket tiers, event default price, training details).
2. **`id`** is **removed** from each calendar item; **`service_instance_id`** remains the stable identifier.
3. **`service_tier`** is **always present**: from `services.service_tier` when set, otherwise inferred for My Best Auntie from `service_instances.slug` (e.g. `my-best-auntie-1-3-04-26` → `1-3`), or `null` when not applicable.

## Also

- **`docs/api/public.yaml`**: `PublicCalendarEvent` schema updated (required fields, `price` type, removed `id`).
- **`docs/architecture/lambdas.md`**: Calendar feed bullet aligned with behavior.
- **`apps/public_www`**: My Best Auntie booking modal resolves cohort `id` from `service_instance_id` when `id`/`slug` are absent (with a focused Vitest case).

## Tests

- `python3 -m pytest tests/test_public_events_api.py tests/test_public_events_serializer.py`
- `npm test -- --run tests/lib/events-data.test.ts` (public_www)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd498883-8e87-4062-b34a-c8a5a3809c73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd498883-8e87-4062-b34a-c8a5a3809c73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

