### PR TITLE
fix(admin_web): convert instance session slot times to UTC for API

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
 import { FormDialog } from '@/components/ui/form-dialog';
@@ -38,6 +38,8 @@ type ApiSchemas = components['schemas'];
 export interface CreateInstanceDialogProps {
   open: boolean;
   serviceType: ServiceType;
+  /** Parent service default venue when the instance row has no location yet (matches instance panel). */
+  serviceDefaultLocationId?: string | null;
   isLoading: boolean;
   error: string;
   onClose: () => void;
@@ -47,6 +49,7 @@ export interface CreateInstanceDialogProps {
 export function CreateInstanceDialog({
   open,
   serviceType,
+  serviceDefaultLocationId = null,
   isLoading,
   error,
   onClose,
@@ -59,6 +62,11 @@ export function CreateInstanceDialog({
     DEFAULT_CONSULTATION_FORM
   );
   const [sessionSlotsError, setSessionSlotsError] = useState('');
+
+  const effectiveSessionSlotDefaultLocationId = useMemo(
+    () => instanceForm.locationId.trim() || serviceDefaultLocationId?.trim() || null,
+    [instanceForm.locationId, serviceDefaultLocationId]
+  );
 
   const eventPriceMissing = serviceType === 'event' && !eventForm.defaultPrice.trim();
   const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
@@ -184,7 +192,7 @@ export function CreateInstanceDialog({
       <div className='mt-3'>
         <SessionSlotEditor
           slots={instanceForm.sessionSlots}
-          defaultLocationId={instanceForm.locationId.trim() || null}
+          defaultLocationId={effectiveSessionSlotDefaultLocationId}
           onChange={(sessionSlots) => {
             setSessionSlotsError('');
             setInstanceForm((prev) => ({ ...prev, sessionSlots }));

--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -30,6 +30,8 @@ import {
 import { SessionSlotEditor } from './session-slot-editor';
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
+import { sessionSlotsToUtcApiPayload } from '@/lib/format';
+
 type ApiSchemas = components['schemas'];
 
 export interface CreateInstanceDialogProps {
@@ -77,12 +79,7 @@ export function CreateInstanceDialog({
       external_url: instanceForm.externalUrl.trim() || null,
       partner_organization_ids:
         serviceType === 'event' ? instanceForm.partnerOrganizations.map((row) => row.id) : [],
-      session_slots: instanceForm.sessionSlots.map((slot, index) => ({
-        location_id: slot.locationId,
-        starts_at: slot.startsAt,
-        ends_at: slot.endsAt,
-        sort_order: slot.sortOrder ?? index,
-      })),
+      session_slots: sessionSlotsToUtcApiPayload(instanceForm.sessionSlots),
     };
 
     if (serviceType === 'training_course') {

--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { AdminInlineError } from '@/components/ui/admin-inline-error';
 import { FormDialog } from '@/components/ui/form-dialog';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -30,7 +31,7 @@ import {
 import { SessionSlotEditor } from './session-slot-editor';
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
-import { sessionSlotsToUtcApiPayload } from '@/lib/format';
+import { buildSessionSlotsUtcPayload } from '@/lib/format';
 
 type ApiSchemas = components['schemas'];
 
@@ -57,12 +58,19 @@ export function CreateInstanceDialog({
   const [consultationForm, setConsultationForm] = useState<ConsultationFormState>(
     DEFAULT_CONSULTATION_FORM
   );
+  const [sessionSlotsError, setSessionSlotsError] = useState('');
 
   const eventPriceMissing = serviceType === 'event' && !eventForm.defaultPrice.trim();
   const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
   const cohortInvalid = Boolean(cohortTrimmed) && !INSTANCE_SLUG_PATTERN.test(cohortTrimmed);
 
   const handleSubmit = async () => {
+    const slotsPayload = buildSessionSlotsUtcPayload(instanceForm.sessionSlots);
+    if (!slotsPayload.ok) {
+      setSessionSlotsError(slotsPayload.message);
+      return;
+    }
+    setSessionSlotsError('');
     const slugTrimmed = instanceForm.slug.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
       title: instanceForm.title.trim() || null,
@@ -79,7 +87,7 @@ export function CreateInstanceDialog({
       external_url: instanceForm.externalUrl.trim() || null,
       partner_organization_ids:
         serviceType === 'event' ? instanceForm.partnerOrganizations.map((row) => row.id) : [],
-      session_slots: sessionSlotsToUtcApiPayload(instanceForm.sessionSlots),
+      session_slots: slotsPayload.session_slots,
     };
 
     if (serviceType === 'training_course') {
@@ -177,8 +185,12 @@ export function CreateInstanceDialog({
         <SessionSlotEditor
           slots={instanceForm.sessionSlots}
           defaultLocationId={instanceForm.locationId.trim() || null}
-          onChange={(sessionSlots) => setInstanceForm((prev) => ({ ...prev, sessionSlots }))}
+          onChange={(sessionSlots) => {
+            setSessionSlotsError('');
+            setInstanceForm((prev) => ({ ...prev, sessionSlots }));
+          }}
         />
+        {sessionSlotsError ? <AdminInlineError>{sessionSlotsError}</AdminInlineError> : null}
       </div>
     </FormDialog>
   );

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -34,7 +34,7 @@ import {
   formatEnumLabel,
   formatIsoForDatetimeLocalInput,
   getCurrencyOptions,
-  parseDatetimeLocalToIsoUtc,
+  parseAdminDateTimeInputToIsoUtc,
 } from '@/lib/format';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -213,8 +213,8 @@ export function DiscountCodesPanel({
     }
     setValidityRangeError('');
     setSaveError('');
-    const validFromIso = parseDatetimeLocalToIsoUtc(validFromLocal);
-    const validUntilIso = parseDatetimeLocalToIsoUtc(validUntilLocal);
+    const validFromIso = parseAdminDateTimeInputToIsoUtc(validFromLocal);
+    const validUntilIso = parseAdminDateTimeInputToIsoUtc(validUntilLocal);
     const serviceUuid = serviceId.trim() || null;
     const instanceUuid = serviceUuid && instanceId.trim() ? instanceId.trim() : null;
     const createPayload: ApiSchemas['CreateDiscountCodeRequest'] = {

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -45,6 +45,7 @@ import {
   type ServiceSummary,
   type ServiceType,
   type SessionSlot,
+  type SessionSlotFormRow,
 } from '@/types/services';
 
 import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
@@ -56,7 +57,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
-import { mapSessionSlotsFromApiToForm, sessionSlotsToUtcApiPayload } from '@/lib/format';
+import { buildSessionSlotsUtcPayload, mapSessionSlotsFromApiToForm } from '@/lib/format';
 import type { EntityTagRef } from '@/lib/entity-api';
 
 type ApiSchemas = components['schemas'];
@@ -191,14 +192,14 @@ function mapPartnerRefsFromInstance(instance: ServiceInstance): PartnerOrgRef[] 
   }));
 }
 
-function cloneSessionSlotsForCreate(slots: SessionSlot[]): SessionSlot[] {
-  return mapSessionSlotsFromApiToForm(slots).map((slot) => ({
+function cloneSessionSlotsForCreate(slots: SessionSlot[]): SessionSlotFormRow[] {
+  return mapSessionSlotsFromApiToForm(slots).map((row) => ({
     id: null,
     instanceId: null,
-    locationId: slot.locationId,
-    startsAt: slot.startsAt,
-    endsAt: slot.endsAt,
-    sortOrder: slot.sortOrder,
+    locationId: row.locationId,
+    startsAtLocal: row.startsAtLocal,
+    endsAtLocal: row.endsAtLocal,
+    sortOrder: row.sortOrder,
   }));
 }
 
@@ -243,6 +244,7 @@ export function InstanceDetailPanel({
   );
 
   const [tagIds, setTagIds] = useState<string[]>(() => instance?.tagIds ?? []);
+  const [sessionSlotsError, setSessionSlotsError] = useState('');
 
   const [instanceForm, setInstanceForm] = useState<InstanceFormState>(
     instance
@@ -443,7 +445,13 @@ export function InstanceDetailPanel({
     [selectedService, instance]
   );
 
-  const buildCreatePayload = (): ApiSchemas['CreateInstanceRequest'] => {
+  const buildCreatePayload = (): ApiSchemas['CreateInstanceRequest'] | null => {
+    const slotsPayload = buildSessionSlotsUtcPayload(instanceForm.sessionSlots);
+    if (!slotsPayload.ok) {
+      setSessionSlotsError(slotsPayload.message);
+      return null;
+    }
+    setSessionSlotsError('');
     const slugTrimmed = instanceForm.slug.trim().toLowerCase();
     const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
@@ -461,7 +469,7 @@ export function InstanceDetailPanel({
       external_url: instanceForm.externalUrl.trim() || null,
       partner_organization_ids: instanceForm.partnerOrganizations.map((row) => row.id),
       tag_ids: tagIds,
-      session_slots: sessionSlotsToUtcApiPayload(instanceForm.sessionSlots),
+      session_slots: slotsPayload.session_slots,
     };
 
     if (effectiveServiceType === 'training_course') {
@@ -532,10 +540,13 @@ export function InstanceDetailPanel({
     return payload;
   };
 
-  const buildUpdatePayload = (): ApiSchemas['UpdateInstanceRequest'] => ({
-    ...buildCreatePayload(),
-    status: instanceForm.status,
-  });
+  const buildUpdatePayload = (): ApiSchemas['UpdateInstanceRequest'] | null => {
+    const base = buildCreatePayload();
+    if (!base) {
+      return null;
+    }
+    return { ...base, status: instanceForm.status };
+  };
 
   const externalUrlInvalid =
     effectiveServiceType === 'event' &&
@@ -573,7 +584,11 @@ export function InstanceDetailPanel({
                     if (!instance || !selectedServiceId) {
                       return;
                     }
-                    void onUpdate(selectedServiceId, instance.id, buildUpdatePayload());
+                    const payload = buildUpdatePayload();
+                    if (!payload) {
+                      return;
+                    }
+                    void onUpdate(selectedServiceId, instance.id, payload);
                   }}
                 >
                   {isLoading ? 'Updating...' : 'Update instance'}
@@ -593,7 +608,11 @@ export function InstanceDetailPanel({
                   if (!selectedServiceId) {
                     return;
                   }
-                  void onCreate(selectedServiceId, buildCreatePayload());
+                  const payload = buildCreatePayload();
+                  if (!payload) {
+                    return;
+                  }
+                  void onCreate(selectedServiceId, payload);
                 }}
               >
                 {isLoading ? 'Adding...' : 'Add instance'}
@@ -743,8 +762,12 @@ export function InstanceDetailPanel({
         locationOptions={locationOptions}
         isLoadingLocations={isLoadingLocations}
         defaultLocationId={effectiveSessionSlotDefaultLocationId}
-        onChange={(sessionSlots) => setInstanceForm((prev) => ({ ...prev, sessionSlots }))}
+        onChange={(sessionSlots) => {
+          setSessionSlotsError('');
+          setInstanceForm((prev) => ({ ...prev, sessionSlots }));
+        }}
       />
+      {sessionSlotsError ? <AdminInlineError>{sessionSlotsError}</AdminInlineError> : null}
 
       {effectiveServiceType === 'event' && eventPriceMissing ? (
         <AdminInlineError>Enter a price for this event instance.</AdminInlineError>

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -56,6 +56,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
+import { mapSessionSlotsFromApiToForm, sessionSlotsToUtcApiPayload } from '@/lib/format';
 import type { EntityTagRef } from '@/lib/entity-api';
 
 type ApiSchemas = components['schemas'];
@@ -191,7 +192,7 @@ function mapPartnerRefsFromInstance(instance: ServiceInstance): PartnerOrgRef[] 
 }
 
 function cloneSessionSlotsForCreate(slots: SessionSlot[]): SessionSlot[] {
-  return slots.map((slot) => ({
+  return mapSessionSlotsFromApiToForm(slots).map((slot) => ({
     id: null,
     instanceId: null,
     locationId: slot.locationId,
@@ -259,7 +260,7 @@ export function InstanceDetailPanel({
           cohort: instance.cohort ?? '',
           externalUrl: instance.externalUrl ?? '',
           partnerOrganizations: mapPartnerRefsFromInstance(instance),
-          sessionSlots: instance.sessionSlots,
+          sessionSlots: mapSessionSlotsFromApiToForm(instance.sessionSlots),
         }
       : DEFAULT_INSTANCE_FORM
   );
@@ -409,7 +410,7 @@ export function InstanceDetailPanel({
         cohort: instance.cohort ?? '',
         externalUrl: instance.externalUrl ?? '',
         partnerOrganizations: mapPartnerRefsFromInstance(instance),
-        sessionSlots: instance.sessionSlots,
+        sessionSlots: mapSessionSlotsFromApiToForm(instance.sessionSlots),
       });
       setTrainingForm({
         pricingUnit: instance.resolvedTrainingDetails?.pricingUnit ?? 'per_person',
@@ -460,12 +461,7 @@ export function InstanceDetailPanel({
       external_url: instanceForm.externalUrl.trim() || null,
       partner_organization_ids: instanceForm.partnerOrganizations.map((row) => row.id),
       tag_ids: tagIds,
-      session_slots: instanceForm.sessionSlots.map((slot, index) => ({
-        location_id: slot.locationId,
-        starts_at: slot.startsAt,
-        ends_at: slot.endsAt,
-        sort_order: slot.sortOrder ?? index,
-      })),
+      session_slots: sessionSlotsToUtcApiPayload(instanceForm.sessionSlots),
     };
 
     if (effectiveServiceType === 'training_course') {

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -16,7 +16,7 @@ import type {
   ServiceSummary,
 } from '@/types/services';
 
-import type { SessionSlot } from '@/types/services';
+import type { SessionSlotFormRow } from '@/types/services';
 
 /** Same pattern as service instance cohorts; matches backend `SERVICE_INSTANCE_SLUG_RE`. */
 export const INSTANCE_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
@@ -41,7 +41,7 @@ export interface InstanceFormState {
   notes: string;
   externalUrl: string;
   partnerOrganizations: PartnerOrgRef[];
-  sessionSlots: SessionSlot[];
+  sessionSlots: SessionSlotFormRow[];
 }
 
 export interface InstanceFormFieldsProps {

--- a/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
+++ b/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
@@ -9,26 +9,26 @@ import { Select } from '@/components/ui/select';
 import { formatLocationLabel } from '@/lib/format';
 import { addHoursToDatetimeLocal } from '@/lib/session-slot-datetime';
 
-import type { LocationSummary, SessionSlot } from '@/types/services';
+import type { LocationSummary, SessionSlotFormRow } from '@/types/services';
 
 export interface SessionSlotEditorProps {
-  slots: SessionSlot[];
+  slots: SessionSlotFormRow[];
   disabled?: boolean;
   locationOptions?: LocationSummary[];
   isLoadingLocations?: boolean;
   /** Instance (or inherited service) venue id used to prefill slot locations. */
   defaultLocationId?: string | null;
-  onChange: (slots: SessionSlot[]) => void;
+  onChange: (slots: SessionSlotFormRow[]) => void;
 }
 
-function emptySlot(sortOrder: number, defaultLocationId?: string | null): SessionSlot {
+function emptySlot(sortOrder: number, defaultLocationId?: string | null): SessionSlotFormRow {
   const locationId = defaultLocationId?.trim() || null;
   return {
     id: null,
     instanceId: null,
     locationId,
-    startsAt: null,
-    endsAt: null,
+    startsAtLocal: null,
+    endsAtLocal: null,
     sortOrder,
   };
 }
@@ -67,23 +67,23 @@ export function SessionSlotEditor({
                   type='datetime-local'
                   disabled={disabled}
                   aria-label='Start time'
-                  value={(slot.startsAt ?? '').slice(0, 16)}
+                  value={(slot.startsAtLocal ?? '').slice(0, 16)}
                   onChange={(event) => {
                     const next = [...slots];
-                    const startsAt = event.target.value || null;
-                    const startComplete = Boolean(startsAt && startsAt.length === 16);
-                    let { endsAt } = slot;
-                    if (!startsAt) {
-                      endsAt = null;
+                    const startsAtLocal = event.target.value || null;
+                    const startComplete = Boolean(startsAtLocal && startsAtLocal.length === 16);
+                    let { endsAtLocal } = slot;
+                    if (!startsAtLocal) {
+                      endsAtLocal = null;
                     } else if (startComplete) {
-                      const computedEnd = addHoursToDatetimeLocal(startsAt, 2);
-                      endsAt = computedEnd ?? endsAt;
+                      const computedEnd = addHoursToDatetimeLocal(startsAtLocal, 2);
+                      endsAtLocal = computedEnd ?? endsAtLocal;
                     }
                     let { locationId } = slot;
                     if (startComplete && trimmedDefaultLocation && !locationId?.trim()) {
                       locationId = trimmedDefaultLocation;
                     }
-                    next[index] = { ...slot, startsAt, endsAt, locationId };
+                    next[index] = { ...slot, startsAtLocal, endsAtLocal, locationId };
                     onChange(next);
                   }}
                 />
@@ -99,10 +99,10 @@ export function SessionSlotEditor({
                   type='datetime-local'
                   disabled={disabled}
                   aria-label='End time'
-                  value={(slot.endsAt ?? '').slice(0, 16)}
+                  value={(slot.endsAtLocal ?? '').slice(0, 16)}
                   onChange={(event) => {
                     const next = [...slots];
-                    next[index] = { ...slot, endsAt: event.target.value || null };
+                    next[index] = { ...slot, endsAtLocal: event.target.value || null };
                     onChange(next);
                   }}
                 />

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -1,7 +1,13 @@
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { formatAmountInCurrency } from '@/lib/vendor-spend';
 import { CLIENT_DOCUMENT_ASSET_TAG, EXPENSE_ATTACHMENT_ASSET_TAG } from '@/types/assets';
-import type { LocationSummary, ServiceInstance, ServiceSummary, SessionSlot } from '@/types/services';
+import type {
+  LocationSummary,
+  ServiceInstance,
+  ServiceSummary,
+  SessionSlot,
+  SessionSlotFormRow,
+} from '@/types/services';
 
 import adminSelectableCurrency from '@shared-config/admin-selectable-currency-codes.json';
 
@@ -456,11 +462,62 @@ export function formatIsoForDatetimeLocalInput(iso: string | null): string {
   return `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}T${pad(parsed.getHours())}:${pad(parsed.getMinutes())}`;
 }
 
-/** Parse `datetime-local` string as local wall time and return UTC ISO for the API. */
+/** `YYYY-MM-DDTHH:mm` only (no offset, no seconds); used for `datetime-local` and strict parsing. */
+export const DATETIME_LOCAL_WALL_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+
+function parseWallDatetimeLocalToUtcDate(trimmed: string): Date | null {
+  if (!DATETIME_LOCAL_WALL_PATTERN.test(trimmed)) {
+    return null;
+  }
+  const [datePart, timePart] = trimmed.split('T');
+  const dateSegments = datePart.split('-').map(Number);
+  const timeSegments = timePart.split(':').map(Number);
+  if (
+    dateSegments.length !== 3 ||
+    timeSegments.length !== 2 ||
+    dateSegments.some((n) => !Number.isFinite(n)) ||
+    timeSegments.some((n) => !Number.isFinite(n))
+  ) {
+    return null;
+  }
+  const [y, mo, d] = dateSegments;
+  const [hh, mm] = timeSegments;
+  const parsed = new Date(y, mo - 1, d, hh, mm, 0, 0);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Parse `datetime-local` wall time (`YYYY-MM-DDTHH:mm` only) and return UTC ISO for the API.
+ * Uses explicit `Date(year, monthIndex, …)` construction (no `new Date(string)` for this shape).
+ * Strings with offsets, `Z`, or seconds are rejected so callers do not double-shift instants.
+ */
 export function parseDatetimeLocalToIsoUtc(local: string): string | null {
   const trimmed = local.trim();
   if (!trimmed) {
     return null;
+  }
+  const wall = parseWallDatetimeLocalToUtcDate(trimmed);
+  if (!wall) {
+    return null;
+  }
+  return wall.toISOString();
+}
+
+/**
+ * Parse admin date-time input: `YYYY-MM-DDTHH:mm` wall time (explicit local calendar fields),
+ * or any other string accepted by `Date` (for example pasted RFC 3339 with `Z` or offset).
+ */
+export function parseAdminDateTimeInputToIsoUtc(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const wall = parseWallDatetimeLocalToUtcDate(trimmed);
+  if (wall) {
+    return wall.toISOString();
   }
   const parsed = new Date(trimmed);
   if (Number.isNaN(parsed.getTime())) {
@@ -469,16 +526,19 @@ export function parseDatetimeLocalToIsoUtc(local: string): string | null {
   return parsed.toISOString();
 }
 
-const DATETIME_LOCAL_WALL_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+/** True if the string is exactly `YYYY-MM-DDTHH:mm` (not an offset ISO instant). */
+export function isDatetimeLocalWallString(value: string): boolean {
+  return DATETIME_LOCAL_WALL_PATTERN.test(value.trim());
+}
 
 /**
  * Normalize session slot times from the API (UTC ISO) into `datetime-local` wall strings
  * for editors. Values that are already `YYYY-MM-DDTHH:mm` are left unchanged.
  */
-export function sessionSlotTimesToDatetimeLocalForm(
+export function sessionSlotApiTimesToFormLocals(
   startsAt: string | null | undefined,
   endsAt: string | null | undefined
-): { startsAt: string | null; endsAt: string | null } {
+): { startsAtLocal: string | null; endsAtLocal: string | null } {
   const toLocal = (value: string | null | undefined): string | null => {
     if (!value?.trim()) {
       return null;
@@ -490,35 +550,88 @@ export function sessionSlotTimesToDatetimeLocalForm(
     const formatted = formatIsoForDatetimeLocalInput(t);
     return formatted || null;
   };
-  return { startsAt: toLocal(startsAt), endsAt: toLocal(endsAt) };
+  return { startsAtLocal: toLocal(startsAt), endsAtLocal: toLocal(endsAt) };
 }
 
-/** Map loaded session slots to form state so `datetime-local` inputs show correct local times. */
-export function mapSessionSlotsFromApiToForm(slots: SessionSlot[]): SessionSlot[] {
+/** Map API session slots to form rows (`startsAtLocal` / `endsAtLocal` are `datetime-local` wall times). */
+export function mapSessionSlotsFromApiToForm(slots: SessionSlot[]): SessionSlotFormRow[] {
   return slots.map((slot) => {
-    const { startsAt, endsAt } = sessionSlotTimesToDatetimeLocalForm(slot.startsAt, slot.endsAt);
-    return { ...slot, startsAt, endsAt };
+    const { startsAtLocal, endsAtLocal } = sessionSlotApiTimesToFormLocals(slot.startsAt, slot.endsAt);
+    return {
+      id: slot.id,
+      instanceId: slot.instanceId,
+      locationId: slot.locationId,
+      startsAtLocal,
+      endsAtLocal,
+      sortOrder: slot.sortOrder,
+    };
   });
 }
 
+export type SessionSlotApiRow = {
+  location_id: string | null;
+  starts_at: string | null;
+  ends_at: string | null;
+  sort_order: number;
+};
+
+export type SessionSlotsUtcPayload =
+  | { ok: true; session_slots: SessionSlotApiRow[] }
+  | { ok: false; message: string };
+
 /**
- * Build `session_slots` for create/update API payloads: interpret stored values as
- * browser-local `datetime-local` and send UTC ISO instants.
+ * Build `session_slots` for create/update API payloads: only `YYYY-MM-DDTHH:mm` wall values
+ * are accepted (rejects offset/Z ISO in form state to avoid double-shifting).
  */
-export function sessionSlotsToUtcApiPayload(
-  slots: SessionSlot[]
-): { location_id: string | null; starts_at: string | null; ends_at: string | null; sort_order: number }[] {
-  return slots.map((slot, index) => {
-    const startsLocal = (slot.startsAt ?? '').slice(0, 16);
-    const endsLocal = (slot.endsAt ?? '').slice(0, 16);
-    const starts_at =
-      startsLocal.length === 16 ? parseDatetimeLocalToIsoUtc(startsLocal) : null;
-    const ends_at = endsLocal.length === 16 ? parseDatetimeLocalToIsoUtc(endsLocal) : null;
-    return {
+export function buildSessionSlotsUtcPayload(slots: SessionSlotFormRow[]): SessionSlotsUtcPayload {
+  const session_slots: SessionSlotApiRow[] = [];
+  for (let index = 0; index < slots.length; index += 1) {
+    const slot = slots[index];
+    const startsRaw = (slot.startsAtLocal ?? '').trim();
+    const endsRaw = (slot.endsAtLocal ?? '').trim();
+    if (!startsRaw && !endsRaw) {
+      session_slots.push({
+        location_id: slot.locationId,
+        starts_at: null,
+        ends_at: null,
+        sort_order: slot.sortOrder ?? index,
+      });
+      continue;
+    }
+    if (!startsRaw || !endsRaw) {
+      return {
+        ok: false,
+        message: 'Each session slot needs both a start time and an end time.',
+      };
+    }
+    if (!isDatetimeLocalWallString(startsRaw) || !isDatetimeLocalWallString(endsRaw)) {
+      return {
+        ok: false,
+        message:
+          'Session slot times must use the date and time pickers (local wall format). ' +
+          'Remove any pasted offset or Z suffix and pick the slot times again.',
+      };
+    }
+    const starts_at = parseDatetimeLocalToIsoUtc(startsRaw);
+    const ends_at = parseDatetimeLocalToIsoUtc(endsRaw);
+    if (!starts_at || !ends_at) {
+      return {
+        ok: false,
+        message: 'One or more session slot times are invalid. Check start and end times.',
+      };
+    }
+    if (new Date(starts_at).getTime() >= new Date(ends_at).getTime()) {
+      return {
+        ok: false,
+        message: 'Each session slot must end after it starts.',
+      };
+    }
+    session_slots.push({
       location_id: slot.locationId,
       starts_at,
       ends_at,
       sort_order: slot.sortOrder ?? index,
-    };
-  });
+    });
+  }
+  return { ok: true, session_slots };
 }

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -468,3 +468,57 @@ export function parseDatetimeLocalToIsoUtc(local: string): string | null {
   }
   return parsed.toISOString();
 }
+
+const DATETIME_LOCAL_WALL_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+
+/**
+ * Normalize session slot times from the API (UTC ISO) into `datetime-local` wall strings
+ * for editors. Values that are already `YYYY-MM-DDTHH:mm` are left unchanged.
+ */
+export function sessionSlotTimesToDatetimeLocalForm(
+  startsAt: string | null | undefined,
+  endsAt: string | null | undefined
+): { startsAt: string | null; endsAt: string | null } {
+  const toLocal = (value: string | null | undefined): string | null => {
+    if (!value?.trim()) {
+      return null;
+    }
+    const t = value.trim();
+    if (DATETIME_LOCAL_WALL_PATTERN.test(t)) {
+      return t;
+    }
+    const formatted = formatIsoForDatetimeLocalInput(t);
+    return formatted || null;
+  };
+  return { startsAt: toLocal(startsAt), endsAt: toLocal(endsAt) };
+}
+
+/** Map loaded session slots to form state so `datetime-local` inputs show correct local times. */
+export function mapSessionSlotsFromApiToForm(slots: SessionSlot[]): SessionSlot[] {
+  return slots.map((slot) => {
+    const { startsAt, endsAt } = sessionSlotTimesToDatetimeLocalForm(slot.startsAt, slot.endsAt);
+    return { ...slot, startsAt, endsAt };
+  });
+}
+
+/**
+ * Build `session_slots` for create/update API payloads: interpret stored values as
+ * browser-local `datetime-local` and send UTC ISO instants.
+ */
+export function sessionSlotsToUtcApiPayload(
+  slots: SessionSlot[]
+): { location_id: string | null; starts_at: string | null; ends_at: string | null; sort_order: number }[] {
+  return slots.map((slot, index) => {
+    const startsLocal = (slot.startsAt ?? '').slice(0, 16);
+    const endsLocal = (slot.endsAt ?? '').slice(0, 16);
+    const starts_at =
+      startsLocal.length === 16 ? parseDatetimeLocalToIsoUtc(startsLocal) : null;
+    const ends_at = endsLocal.length === 16 ? parseDatetimeLocalToIsoUtc(endsLocal) : null;
+    return {
+      location_id: slot.locationId,
+      starts_at,
+      ends_at,
+      sort_order: slot.sortOrder ?? index,
+    };
+  });
+}

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4427,9 +4427,15 @@ export interface components {
             instance_id?: string | null;
             /** Format: uuid */
             location_id?: string | null;
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description Instant in UTC or with a numeric timezone offset (RFC 3339). On create/update requests, each value must be timezone-aware (Z suffix or ±HH:MM offset); naive date-time strings are rejected.
+             */
             starts_at?: string | null;
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description Same rules as starts_at. On create/update requests, must be timezone-aware and strictly after starts_at.
+             */
             ends_at?: string | null;
             sort_order?: number | null;
         };

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -187,6 +187,16 @@ export interface SessionSlot {
   sortOrder: number | null;
 }
 
+/** Session slot row in instance create/edit forms (`datetime-local` wall times, no offset). */
+export interface SessionSlotFormRow {
+  id: string | null;
+  instanceId: string | null;
+  locationId: string | null;
+  startsAtLocal: string | null;
+  endsAtLocal: string | null;
+  sortOrder: number | null;
+}
+
 export interface LocationSummary {
   id: string;
   name: string | null;

--- a/apps/admin_web/tests/components/admin/services/create-instance-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/create-instance-dialog.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { CreateInstanceDialog } from '@/components/admin/services/create-instance-dialog';
+
+vi.mock('@/components/ui/form-dialog', () => ({
+  FormDialog: ({
+    children,
+    onSubmit,
+  }: {
+    children: ReactNode;
+    onSubmit: () => void | Promise<void>;
+  }) => (
+    <div>
+      {children}
+      <button type='button' onClick={() => void onSubmit()}>
+        Submit dialog
+      </button>
+    </div>
+  ),
+}));
+
+describe('CreateInstanceDialog', () => {
+  beforeAll(() => {
+    process.env.TZ = 'UTC';
+  });
+
+  it('uses service default location for session slot prefill when instance location is empty', async () => {
+    const user = userEvent.setup();
+    const venueId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <CreateInstanceDialog
+        open
+        serviceType='training_course'
+        serviceDefaultLocationId={venueId}
+        isLoading={false}
+        error=''
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />
+    );
+
+    await user.click(screen.getByText('Session slots'));
+    await user.click(screen.getByRole('button', { name: /add slot/i }));
+    const startInput = screen.getByLabelText('Start time');
+    await user.type(startInput, '2026-09-01T10:00');
+
+    const slotLocation = document.getElementById('slot-0-location') as HTMLInputElement;
+    expect(slotLocation).toBeTruthy();
+    expect(slotLocation.value).toBe(venueId);
+
+    await user.click(screen.getByRole('button', { name: 'Submit dialog' }));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_slots: [
+          expect.objectContaining({
+            location_id: venueId,
+            starts_at: '2026-09-01T10:00:00.000Z',
+            ends_at: '2026-09-01T12:00:00.000Z',
+          }),
+        ],
+      })
+    );
+  });
+});

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -6,6 +6,10 @@ import { InstanceDetailPanel } from '@/components/admin/services/instance-detail
 import * as entityApi from '@/lib/entity-api';
 import type { LocationSummary, ServiceInstance, ServiceSummary } from '@/types/services';
 
+vi.mock('@/hooks/use-instructor-users', () => ({
+  useInstructorUsers: () => ({ users: [], isLoading: false, error: '', refetch: vi.fn() }),
+}));
+
 vi.mock('@/lib/entity-api', async () => {
   const actual = await vi.importActual<typeof import('@/lib/entity-api')>('@/lib/entity-api');
   return {
@@ -61,6 +65,10 @@ function buildLocationSummary(overrides: Partial<LocationSummary> = {}): Locatio
 }
 
 describe('InstanceDetailPanel', () => {
+  beforeAll(() => {
+    process.env.TZ = 'UTC';
+  });
+
   beforeEach(() => {
     vi.mocked(entityApi.listEntityPartnerOrganizationPicker).mockResolvedValue([]);
   });
@@ -429,6 +437,167 @@ describe('InstanceDetailPanel', () => {
       expect.objectContaining({
         slug: null,
         cohort: 'spring-2026',
+      })
+    );
+  });
+
+  it('maps UTC session slots to local wall inputs and sends Z-suffixed instants on update', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const instance: ServiceInstance = {
+      id: 'inst-utc',
+      serviceId: 'service-1',
+      parentServiceTitle: null,
+      parentServiceType: 'training_course',
+      title: 'UTC slots',
+      slug: 'utc-slots',
+      description: null,
+      coverImageS3Key: null,
+      status: 'scheduled',
+      deliveryMode: 'online',
+      locationId: 'location-1',
+      maxCapacity: null,
+      waitlistEnabled: false,
+      externalUrl: null,
+      partnerOrganizations: [],
+      instructorId: null,
+      cohort: null,
+      notes: '',
+      tagIds: [],
+      createdBy: 'admin',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      resolvedTitle: null,
+      resolvedSlug: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      resolvedLocationId: 'location-1',
+      sessionSlots: [
+        {
+          id: 'slot-a',
+          instanceId: 'inst-utc',
+          locationId: 'location-1',
+          startsAt: '2026-06-01T10:00:00Z',
+          endsAt: '2026-06-01T11:00:00Z',
+          sortOrder: 0,
+        },
+      ],
+      trainingDetails: {
+        trainingFormat: 'group',
+        price: '50',
+        currency: 'HKD',
+        pricingUnit: 'per_person',
+      },
+      resolvedTrainingDetails: {
+        trainingFormat: 'group',
+        price: '50',
+        currency: 'HKD',
+        pricingUnit: 'per_person',
+      },
+      eventTicketTiers: [],
+      resolvedEventTicketTiers: [],
+      consultationDetails: null,
+      resolvedConsultationDetails: null,
+    };
+
+    render(
+      <InstanceDetailPanel
+        {...defaultEntityTagProps}
+        instance={instance}
+        selectedServiceId='service-1'
+        serviceOptions={[buildServiceSummary({ locationId: 'location-1' })]}
+        locationOptions={[buildLocationSummary()]}
+        isLoadingLocations={false}
+        serviceType='training_course'
+        isLoading={false}
+        error=''
+        onSelectService={vi.fn()}
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={onUpdate}
+      />
+    );
+
+    await user.click(screen.getByText('Session slots'));
+    const startInput = await screen.findByLabelText('Start time');
+    expect(startInput).toHaveValue('2026-06-01T10:00');
+
+    await user.clear(startInput);
+    await user.type(startInput, '2026-06-01T12:00');
+    const endInput = screen.getByLabelText('End time');
+    await user.clear(endInput);
+    await user.type(endInput, '2026-06-01T14:00');
+
+    await user.click(screen.getByRole('button', { name: 'Update instance' }));
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      'service-1',
+      'inst-utc',
+      expect.objectContaining({
+        session_slots: [
+          expect.objectContaining({
+            starts_at: '2026-06-01T12:00:00.000Z',
+            ends_at: '2026-06-01T14:00:00.000Z',
+          }),
+        ],
+      })
+    );
+  });
+
+  it('prefills new session slot location from service default when instance venue is empty', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const venueFromService = '99999999-9999-9999-9999-999999999999';
+
+    render(
+      <InstanceDetailPanel
+        {...defaultEntityTagProps}
+        instance={null}
+        selectedServiceId='service-1'
+        serviceOptions={[
+          buildServiceSummary({
+            locationId: venueFromService,
+          }),
+        ]}
+        locationOptions={[
+          buildLocationSummary({
+            id: venueFromService,
+            name: 'Service default venue',
+          }),
+        ]}
+        isLoadingLocations={false}
+        serviceType='training_course'
+        isLoading={false}
+        error=''
+        onSelectService={vi.fn()}
+        onCancelSelection={vi.fn()}
+        onCreate={onCreate}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByText('Session slots'));
+    await user.click(screen.getByRole('button', { name: /add slot/i }));
+    const startInput = screen.getByLabelText('Start time');
+    await user.type(startInput, '2026-08-20T09:00');
+
+    const locationSelects = screen.getAllByLabelText('Location');
+    const slotLocationSelect = locationSelects.find((el) => el.id === 'slot-0-location');
+    expect(slotLocationSelect).toBeDefined();
+    expect(slotLocationSelect).toHaveValue(venueFromService);
+
+    await user.click(screen.getByRole('button', { name: 'Add instance' }));
+    expect(onCreate).toHaveBeenCalledWith(
+      'service-1',
+      expect.objectContaining({
+        session_slots: [
+          expect.objectContaining({
+            location_id: venueFromService,
+            starts_at: '2026-08-20T09:00:00.000Z',
+            ends_at: '2026-08-20T11:00:00.000Z',
+          }),
+        ],
       })
     );
   });

--- a/apps/admin_web/tests/components/admin/services/session-slot-editor.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/session-slot-editor.test.tsx
@@ -13,16 +13,16 @@ describe('SessionSlotEditor', () => {
             id: null,
             instanceId: null,
             locationId: null,
-            startsAt: null,
-            endsAt: null,
+            startsAtLocal: null,
+            endsAtLocal: null,
             sortOrder: 0,
           },
           {
             id: null,
             instanceId: null,
             locationId: null,
-            startsAt: null,
-            endsAt: null,
+            startsAtLocal: null,
+            endsAtLocal: null,
             sortOrder: 1,
           },
         ]}
@@ -50,8 +50,8 @@ describe('SessionSlotEditor', () => {
             id: null,
             instanceId: null,
             locationId: null,
-            startsAt: null,
-            endsAt: null,
+            startsAtLocal: null,
+            endsAtLocal: null,
             sortOrder: 0,
           },
         ]}
@@ -64,8 +64,8 @@ describe('SessionSlotEditor', () => {
 
     expect(onChange).toHaveBeenCalled();
     const last = onChange.mock.calls.at(-1)?.[0]?.[0];
-    expect(last?.startsAt).toBe('2026-04-24T10:00');
-    expect(last?.endsAt).toBe('2026-04-24T12:00');
+    expect(last?.startsAtLocal).toBe('2026-04-24T10:00');
+    expect(last?.endsAtLocal).toBe('2026-04-24T12:00');
   });
 
   it('prefills slot location from defaultLocationId when start is set and slot has no location', async () => {
@@ -80,8 +80,8 @@ describe('SessionSlotEditor', () => {
             id: null,
             instanceId: null,
             locationId: null,
-            startsAt: null,
-            endsAt: null,
+            startsAtLocal: null,
+            endsAtLocal: null,
             sortOrder: 0,
           },
         ]}
@@ -94,7 +94,7 @@ describe('SessionSlotEditor', () => {
 
     const last = onChange.mock.calls.at(-1)?.[0]?.[0];
     expect(last?.locationId).toBe(venueId);
-    expect(last?.endsAt).toBe('2026-04-24T11:00');
+    expect(last?.endsAtLocal).toBe('2026-04-24T11:00');
   });
 
   it('add slot uses defaultLocationId for new row location', async () => {
@@ -116,8 +116,8 @@ describe('SessionSlotEditor', () => {
         id: null,
         instanceId: null,
         locationId: venueId,
-        startsAt: null,
-        endsAt: null,
+        startsAtLocal: null,
+        endsAtLocal: null,
         sortOrder: 0,
       },
     ]);

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -14,8 +14,11 @@ import {
   getContentLanguageOptions,
   getCurrencyOptions,
   matchAdminSelectableContentLanguage,
+  mapSessionSlotsFromApiToForm,
   orderSessionSlotsForDisplay,
   parseDatetimeLocalToIsoUtc,
+  sessionSlotsToUtcApiPayload,
+  sessionSlotTimesToDatetimeLocalForm,
 } from '@/lib/format';
 import type { ServiceInstance, ServiceSummary, SessionSlot } from '@/types/services';
 
@@ -287,5 +290,50 @@ describe('format helpers', () => {
   it('returns null for empty datetime-local input', () => {
     expect(parseDatetimeLocalToIsoUtc('')).toBeNull();
     expect(parseDatetimeLocalToIsoUtc('   ')).toBeNull();
+  });
+
+  it('sessionSlotTimesToDatetimeLocalForm keeps wall-clock strings and maps UTC ISO to local input', () => {
+    expect(sessionSlotTimesToDatetimeLocalForm('2026-06-15T14:30', '2026-06-15T16:30')).toEqual({
+      startsAt: '2026-06-15T14:30',
+      endsAt: '2026-06-15T16:30',
+    });
+    const iso = '2026-06-01T08:30:00.000Z';
+    const expectedLocal = formatIsoForDatetimeLocalInput(iso);
+    expect(sessionSlotTimesToDatetimeLocalForm(iso, null).startsAt).toBe(expectedLocal);
+  });
+
+  it('mapSessionSlotsFromApiToForm converts API instants to datetime-local wall strings', () => {
+    const iso = '2026-06-01T08:30:00.000Z';
+    const slots: SessionSlot[] = [
+      {
+        id: 'a',
+        instanceId: 'b',
+        locationId: null,
+        startsAt: iso,
+        endsAt: iso,
+        sortOrder: 0,
+      },
+    ];
+    const local = formatIsoForDatetimeLocalInput(iso);
+    const mapped = mapSessionSlotsFromApiToForm(slots)[0];
+    expect(mapped.startsAt).toBe(local);
+    expect(mapped.endsAt).toBe(local);
+  });
+
+  it('sessionSlotsToUtcApiPayload sends UTC ISO derived from datetime-local via parseDatetimeLocalToIsoUtc', () => {
+    const startsLocal = '2026-06-10T09:15';
+    const endsLocal = '2026-06-10T11:15';
+    const payload = sessionSlotsToUtcApiPayload([
+      {
+        id: null,
+        instanceId: null,
+        locationId: null,
+        startsAt: startsLocal,
+        endsAt: endsLocal,
+        sortOrder: 0,
+      },
+    ]);
+    expect(payload[0].starts_at).toBe(parseDatetimeLocalToIsoUtc(startsLocal));
+    expect(payload[0].ends_at).toBe(parseDatetimeLocalToIsoUtc(endsLocal));
   });
 });

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -14,11 +14,12 @@ import {
   getContentLanguageOptions,
   getCurrencyOptions,
   matchAdminSelectableContentLanguage,
+  buildSessionSlotsUtcPayload,
   mapSessionSlotsFromApiToForm,
   orderSessionSlotsForDisplay,
+  parseAdminDateTimeInputToIsoUtc,
   parseDatetimeLocalToIsoUtc,
-  sessionSlotsToUtcApiPayload,
-  sessionSlotTimesToDatetimeLocalForm,
+  sessionSlotApiTimesToFormLocals,
 } from '@/lib/format';
 import type { ServiceInstance, ServiceSummary, SessionSlot } from '@/types/services';
 
@@ -292,14 +293,26 @@ describe('format helpers', () => {
     expect(parseDatetimeLocalToIsoUtc('   ')).toBeNull();
   });
 
-  it('sessionSlotTimesToDatetimeLocalForm keeps wall-clock strings and maps UTC ISO to local input', () => {
-    expect(sessionSlotTimesToDatetimeLocalForm('2026-06-15T14:30', '2026-06-15T16:30')).toEqual({
-      startsAt: '2026-06-15T14:30',
-      endsAt: '2026-06-15T16:30',
+  it('parseDatetimeLocalToIsoUtc accepts only YYYY-MM-DDTHH:mm (rejects Z, offset, seconds)', () => {
+    expect(parseDatetimeLocalToIsoUtc('2026-06-10T09:15:00.000Z')).toBeNull();
+    expect(parseDatetimeLocalToIsoUtc('2026-06-10T09:15:00+08:00')).toBeNull();
+    expect(parseDatetimeLocalToIsoUtc('2026-06-10T09:15:30')).toBeNull();
+  });
+
+  it('parseAdminDateTimeInputToIsoUtc accepts wall format and RFC3339 with Z', () => {
+    const wall = '2026-06-10T09:15';
+    expect(parseAdminDateTimeInputToIsoUtc(wall)).toBe(parseDatetimeLocalToIsoUtc(wall));
+    expect(parseAdminDateTimeInputToIsoUtc('2026-06-10T09:15:00.000Z')).toMatch(/Z$/);
+  });
+
+  it('sessionSlotApiTimesToFormLocals keeps wall-clock strings and maps UTC ISO to local input', () => {
+    expect(sessionSlotApiTimesToFormLocals('2026-06-15T14:30', '2026-06-15T16:30')).toEqual({
+      startsAtLocal: '2026-06-15T14:30',
+      endsAtLocal: '2026-06-15T16:30',
     });
     const iso = '2026-06-01T08:30:00.000Z';
     const expectedLocal = formatIsoForDatetimeLocalInput(iso);
-    expect(sessionSlotTimesToDatetimeLocalForm(iso, null).startsAt).toBe(expectedLocal);
+    expect(sessionSlotApiTimesToFormLocals(iso, null).startsAtLocal).toBe(expectedLocal);
   });
 
   it('mapSessionSlotsFromApiToForm converts API instants to datetime-local wall strings', () => {
@@ -316,24 +329,67 @@ describe('format helpers', () => {
     ];
     const local = formatIsoForDatetimeLocalInput(iso);
     const mapped = mapSessionSlotsFromApiToForm(slots)[0];
-    expect(mapped.startsAt).toBe(local);
-    expect(mapped.endsAt).toBe(local);
+    expect(mapped.startsAtLocal).toBe(local);
+    expect(mapped.endsAtLocal).toBe(local);
   });
 
-  it('sessionSlotsToUtcApiPayload sends UTC ISO derived from datetime-local via parseDatetimeLocalToIsoUtc', () => {
+  it('buildSessionSlotsUtcPayload sends UTC ISO for wall-format rows and rejects offset ISO in form state', () => {
     const startsLocal = '2026-06-10T09:15';
     const endsLocal = '2026-06-10T11:15';
-    const payload = sessionSlotsToUtcApiPayload([
+    const ok = buildSessionSlotsUtcPayload([
       {
         id: null,
         instanceId: null,
         locationId: null,
-        startsAt: startsLocal,
-        endsAt: endsLocal,
+        startsAtLocal: startsLocal,
+        endsAtLocal: endsLocal,
         sortOrder: 0,
       },
     ]);
-    expect(payload[0].starts_at).toBe(parseDatetimeLocalToIsoUtc(startsLocal));
-    expect(payload[0].ends_at).toBe(parseDatetimeLocalToIsoUtc(endsLocal));
+    expect(ok.ok).toBe(true);
+    if (ok.ok) {
+      expect(ok.session_slots[0].starts_at).toBe(parseDatetimeLocalToIsoUtc(startsLocal));
+      expect(ok.session_slots[0].ends_at).toBe(parseDatetimeLocalToIsoUtc(endsLocal));
+    }
+    const bad = buildSessionSlotsUtcPayload([
+      {
+        id: null,
+        instanceId: null,
+        locationId: null,
+        startsAtLocal: '2026-06-10T06:30:00.000Z',
+        endsAtLocal: '2026-06-10T08:30:00.000Z',
+        sortOrder: 0,
+      },
+    ]);
+    expect(bad.ok).toBe(false);
+  });
+
+  it('buildSessionSlotsUtcPayload allows empty slot rows and rejects partial times', () => {
+    const empty = buildSessionSlotsUtcPayload([
+      {
+        id: null,
+        instanceId: null,
+        locationId: null,
+        startsAtLocal: null,
+        endsAtLocal: null,
+        sortOrder: 0,
+      },
+    ]);
+    expect(empty.ok).toBe(true);
+    if (empty.ok) {
+      expect(empty.session_slots[0].starts_at).toBeNull();
+      expect(empty.session_slots[0].ends_at).toBeNull();
+    }
+    const partial = buildSessionSlotsUtcPayload([
+      {
+        id: null,
+        instanceId: null,
+        locationId: null,
+        startsAtLocal: '2026-06-10T09:15',
+        endsAtLocal: null,
+        sortOrder: 0,
+      },
+    ]);
+    expect(partial.ok).toBe(false);
   });
 });

--- a/backend/src/app/api/admin_services_payload_utils.py
+++ b/backend/src/app/api/admin_services_payload_utils.py
@@ -247,6 +247,29 @@ def parse_instance_type_details(
     }
 
 
+def parse_required_aware_datetime(value: Any, field: str) -> datetime:
+    """Parse a required datetime that must be timezone-aware (Z or numeric offset).
+
+    Naive ISO strings are rejected so callers cannot accidentally persist local
+    wall times as UTC.
+    """
+    if value is None or str(value).strip() == "":
+        raise ValidationError(f"{field} is required", field=field)
+    try:
+        parsed = datetime.fromisoformat(str(value).strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(
+            f"{field} must be a valid ISO datetime", field=field
+        ) from exc
+    if parsed.tzinfo is None:
+        raise ValidationError(
+            f"{field} must include a timezone offset or Z (RFC 3339); "
+            "naive datetimes are not allowed",
+            field=field,
+        )
+    return normalize_datetime(parsed)
+
+
 def parse_session_slots(value: Any) -> list[dict[str, Any]]:
     """Parse and validate session-slot payload list."""
     if value is None:
@@ -260,13 +283,10 @@ def parse_session_slots(value: Any) -> list[dict[str, Any]]:
                 f"session_slots[{idx}] must be an object",
                 field="session_slots",
             )
-        starts_at = parse_optional_datetime(entry.get("starts_at"), "starts_at")
-        ends_at = parse_optional_datetime(entry.get("ends_at"), "ends_at")
-        if starts_at is None or ends_at is None:
-            raise ValidationError(
-                "starts_at and ends_at are required for each session slot",
-                field="session_slots",
-            )
+        starts_field = f"session_slots[{idx}].starts_at"
+        ends_field = f"session_slots[{idx}].ends_at"
+        starts_at = parse_required_aware_datetime(entry.get("starts_at"), starts_field)
+        ends_at = parse_required_aware_datetime(entry.get("ends_at"), ends_field)
         if ends_at <= starts_at:
             raise ValidationError(
                 "ends_at must be after starts_at", field="session_slots"

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3865,10 +3865,17 @@ components:
           type: string
           format: date-time
           nullable: true
+          description: >
+            Instant in UTC or with a numeric timezone offset (RFC 3339). On create/update
+            requests, each value must be timezone-aware (Z suffix or ±HH:MM offset); naive
+            date-time strings are rejected.
         ends_at:
           type: string
           format: date-time
           nullable: true
+          description: >
+            Same rules as starts_at. On create/update requests, must be timezone-aware
+            and strictly after starts_at.
         sort_order:
           type: integer
           nullable: true

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -478,7 +478,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   - `eventbrite_last_payload_hash`, `eventbrite_ticket_class_map`,
     `eventbrite_retry_count`
 - Scheduling/detail tables:
-  - `instance_session_slots` (time blocks + optional location). The public calendar feed
+  - `instance_session_slots` (time blocks + optional location; `starts_at` / `ends_at`
+    are `timestamptz` in Aurora). The admin API rejects naive datetimes in
+    `session_slots` payloads so only explicit instants are stored. The public calendar feed
     eager-loads `Service.location` only in `list_public_offerings`; venue resolution is
     slot location, then instance `location_id`, then parent `services.location_id`.
   - `training_instance_details`

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -82,7 +82,9 @@ their primary responsibilities.
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for
   cross-service instance listing with optional `service_id` / `service_type`
   filters; instance create/update accepts optional `cohort`, and
-  `tag_ids` with `tags` / `tag_ids` echoed on instance responses; instance JSON
+  `tag_ids` with `tags` / `tag_ids` echoed on instance responses; `session_slots`
+  `starts_at` / `ends_at` on create/update must be timezone-aware (RFC 3339 with
+  `Z` or a numeric offset; naive strings are rejected); instance JSON
   includes `resolved_*` fields (title, slug, description, delivery mode, location,
   and type-specific pricing/tiers) when the instance omits a value and the parent
   service supplies the effective default; and

--- a/tests/test_admin_services_session_slots_payload.py
+++ b/tests/test_admin_services_session_slots_payload.py
@@ -1,0 +1,64 @@
+"""Tests for session slot datetime parsing on admin instance payloads."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.api.admin_services_payload_utils import parse_session_slots
+from app.exceptions import ValidationError
+
+
+def test_parse_session_slots_accepts_z_suffix() -> None:
+    slots = parse_session_slots(
+        [
+            {
+                "starts_at": "2026-06-10T09:15:00Z",
+                "ends_at": "2026-06-10T11:15:00Z",
+                "sort_order": 0,
+            }
+        ]
+    )
+    assert len(slots) == 1
+    assert slots[0]["starts_at"] == datetime(2026, 6, 10, 9, 15, tzinfo=UTC)
+    assert slots[0]["ends_at"] == datetime(2026, 6, 10, 11, 15, tzinfo=UTC)
+
+
+def test_parse_session_slots_accepts_numeric_offset() -> None:
+    slots = parse_session_slots(
+        [
+            {
+                "starts_at": "2026-06-10T17:15:00+08:00",
+                "ends_at": "2026-06-10T19:15:00+08:00",
+            }
+        ]
+    )
+    assert slots[0]["starts_at"] == datetime(2026, 6, 10, 9, 15, tzinfo=UTC)
+    assert slots[0]["ends_at"] == datetime(2026, 6, 10, 11, 15, tzinfo=UTC)
+
+
+def test_parse_session_slots_rejects_naive_datetime() -> None:
+    with pytest.raises(ValidationError) as exc:
+        parse_session_slots(
+            [
+                {
+                    "starts_at": "2026-06-10T09:15",
+                    "ends_at": "2026-06-10T11:15",
+                }
+            ]
+        )
+    assert exc.value.field == "session_slots[0].starts_at"
+
+
+def test_parse_session_slots_rejects_ends_before_starts() -> None:
+    with pytest.raises(ValidationError) as exc:
+        parse_session_slots(
+            [
+                {
+                    "starts_at": "2026-06-10T12:00:00Z",
+                    "ends_at": "2026-06-10T11:00:00Z",
+                }
+            ]
+        )
+    assert exc.value.field == "session_slots"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cursor / workflow note

This work was executed in a **headless cloud agent** context where explicit per-turn chat approval is not available; the user request and follow-up items are treated as the approval to implement. **Python changes** in this branch are covered by `pre-commit run ruff-format --all-files`.

## Summary

- **Backend:** `parse_session_slots` requires timezone-aware `starts_at` / `ends_at` (reject naive ISO).
- **OpenAPI:** `SessionSlot` datetime fields documented; admin web types regenerated (earlier commit).
- **Admin web:** `SessionSlotFormRow` / strict UTC payload builder; instance panel + discount code parsing split as before.
- **Tests:** Component-level coverage for UTC → local → Z on **update**, service-default venue on **create**, and **CreateInstanceDialog** `serviceDefaultLocationId` + stubbed `FormDialog`.
- **Docs:** `docs/architecture/lambdas.md` and `docs/architecture/database-schema.md` aligned with the session-slot API / DB contract.

## Validation

- `python3 -m pytest tests/test_admin_services_session_slots_payload.py`
- `npm run test` (instance-detail-panel, create-instance-dialog, format, session-slot-editor, discount-codes-panel as touched)
- `npm run lint`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dcffc44-4ae1-4398-99ef-d7f236ab51e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dcffc44-4ae1-4398-99ef-d7f236ab51e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

