### PR TITLE
Unique service slug per tier; admin services table shows tier

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -147,11 +147,11 @@ export function ServiceDetailPanel({
     referencingCodeCount: number;
   } | null>(null);
   const [discountUsageLoadState, setDiscountUsageLoadState] = useState<DiscountUsageLoadState>('idle');
-  /** Last slug+tier 409: messages shown only while inputs still match this pair. */
+  /** Last slug+tier 409 (`field: slug_tier`); messages shown only while inputs match this pair. */
   const [slugTierConflict, setSlugTierConflict] = useState<{
     slug: string;
     tierNormalized: string;
-    conflictField: 'slug' | 'service_tier';
+    variant: 'slug_tier_same' | 'slug_tier_empty';
   } | null>(null);
 
   useEffect(() => {
@@ -305,14 +305,14 @@ export function ServiceDetailPanel({
   }, [slugTierConflict, normalizedSlugInput, tierTrimmedForValidation]);
 
   const slugConflictInline = useMemo(() => {
-    if (!slugTierConflictActive || !slugTierConflict || slugTierConflict.conflictField !== 'slug') {
+    if (!slugTierConflictActive || !slugTierConflict || slugTierConflict.variant !== 'slug_tier_same') {
       return undefined;
     }
     return SLUG_TIER_PAIR_CONFLICT_MSG;
   }, [slugTierConflictActive, slugTierConflict]);
 
   const tierConflictInline = useMemo(() => {
-    if (!slugTierConflictActive || !slugTierConflict || slugTierConflict.conflictField !== 'service_tier') {
+    if (!slugTierConflictActive || !slugTierConflict || slugTierConflict.variant !== 'slug_tier_empty') {
       return undefined;
     }
     return EMPTY_TIER_CONFLICT_MSG;
@@ -335,15 +335,16 @@ export function ServiceDetailPanel({
       return false;
     }
     const field = readAdminApiErrorField(caught);
-    if (field === 'service_tier' || field === 'slug') {
-      setSlugTierConflict({
-        slug: pair.slug ?? '',
-        tierNormalized: pair.tierNormalized ?? '',
-        conflictField: field === 'service_tier' ? 'service_tier' : 'slug',
-      });
-      return true;
+    if (field !== 'slug_tier') {
+      return false;
     }
-    return false;
+    const tierNorm = pair.tierNormalized ?? '';
+    setSlugTierConflict({
+      slug: pair.slug ?? '',
+      tierNormalized: tierNorm,
+      variant: tierNorm.length > 0 ? 'slug_tier_same' : 'slug_tier_empty',
+    });
+    return true;
   }
 
   const deliveryModeSelect = (
@@ -638,12 +639,7 @@ export function ServiceDetailPanel({
           </div>
           <ServiceReferralSlugField
             value={serviceForm.slug}
-            onChange={(next) => {
-              if (next !== serviceForm.slug) {
-                setSlugTierConflict(null);
-              }
-              setServiceForm({ ...serviceForm, slug: next });
-            }}
+            onChange={(next) => setServiceForm({ ...serviceForm, slug: next })}
             slugUsageLoadError={
               discountUsageLoadState === 'error'
                 ? 'Could not load discount code usage. Try again later.'
@@ -698,12 +694,7 @@ export function ServiceDetailPanel({
             {deliveryModeSelect}
             <ServiceTierControl
               value={serviceTier}
-              onChange={(next) => {
-                if (next !== serviceTier) {
-                  setSlugTierConflict(null);
-                }
-                setServiceTier(next);
-              }}
+              onChange={setServiceTier}
               id='service-tier-training'
               invalid={tierInvalid}
               tierConflictError={tierConflictInline}
@@ -730,12 +721,7 @@ export function ServiceDetailPanel({
             {deliveryModeSelect}
             <ServiceTierControl
               value={serviceTier}
-              onChange={(next) => {
-                if (next !== serviceTier) {
-                  setSlugTierConflict(null);
-                }
-                setServiceTier(next);
-              }}
+              onChange={setServiceTier}
               id='service-tier-event'
               invalid={tierInvalid}
               tierConflictError={tierConflictInline}
@@ -758,12 +744,7 @@ export function ServiceDetailPanel({
             {deliveryModeSelect}
             <ServiceTierControl
               value={serviceTier}
-              onChange={(next) => {
-                if (next !== serviceTier) {
-                  setSlugTierConflict(null);
-                }
-                setServiceTier(next);
-              }}
+              onChange={setServiceTier}
               id='service-tier-consultation'
               invalid={tierInvalid}
               tierConflictError={tierConflictInline}

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -57,6 +57,11 @@ type ApiSchemas = components['schemas'];
 
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
+const SLUG_TIER_PAIR_CONFLICT_MSG =
+  'This slug and tier are already used by another service. Change the slug or tier.';
+const EMPTY_TIER_CONFLICT_MSG =
+  'Another service uses this slug with an empty tier. Add a tier or use a different slug.';
+
 export interface ServiceDetailPanelProps {
   service: ServiceDetail | null;
   /** When set with `service` null, seed the create form from this template (UI-only duplicate). */
@@ -142,8 +147,12 @@ export function ServiceDetailPanel({
     referencingCodeCount: number;
   } | null>(null);
   const [discountUsageLoadState, setDiscountUsageLoadState] = useState<DiscountUsageLoadState>('idle');
-  const [slugConflictError, setSlugConflictError] = useState('');
-  const [conflictingSlugNormalized, setConflictingSlugNormalized] = useState<string | null>(null);
+  /** Last slug+tier 409: messages shown only while inputs still match this pair. */
+  const [slugTierConflict, setSlugTierConflict] = useState<{
+    slug: string;
+    tierNormalized: string;
+    conflictField: 'slug' | 'service_tier';
+  } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -224,8 +233,7 @@ export function ServiceDetailPanel({
               }
             : DEFAULT_CONSULTATION_FORM
         );
-        setSlugConflictError('');
-        setConflictingSlugNormalized(null);
+        setSlugTierConflict(null);
         return;
       }
       if (!service) {
@@ -237,8 +245,7 @@ export function ServiceDetailPanel({
         setBookingSystem('');
         setServiceTier('');
         setLocationId('');
-        setSlugConflictError('');
-        setConflictingSlugNormalized(null);
+        setSlugTierConflict(null);
         return;
       }
       setServiceType(service.serviceType);
@@ -272,8 +279,7 @@ export function ServiceDetailPanel({
         defaultPackageSessions: service.consultationDetails?.defaultPackageSessions?.toString() ?? '',
         defaultCurrency: service.consultationDetails?.defaultCurrency ?? 'HKD',
       });
-      setSlugConflictError('');
-      setConflictingSlugNormalized(null);
+      setSlugTierConflict(null);
     });
     return () => {
       cancelled = true;
@@ -285,19 +291,60 @@ export function ServiceDetailPanel({
     return t.length ? t : null;
   }, [serviceForm.slug]);
 
+  const normalizedSlugInput = serviceForm.slug.trim().toLowerCase();
+  const tierTrimmedForValidation = serviceTier.trim().toLowerCase();
+
+  const slugTierConflictActive = useMemo(() => {
+    if (!slugTierConflict) {
+      return false;
+    }
+    return (
+      normalizedSlugInput === slugTierConflict.slug &&
+      tierTrimmedForValidation === slugTierConflict.tierNormalized
+    );
+  }, [slugTierConflict, normalizedSlugInput, tierTrimmedForValidation]);
+
+  const slugConflictInline = useMemo(() => {
+    if (!slugTierConflictActive || !slugTierConflict || slugTierConflict.conflictField !== 'slug') {
+      return undefined;
+    }
+    return SLUG_TIER_PAIR_CONFLICT_MSG;
+  }, [slugTierConflictActive, slugTierConflict]);
+
+  const tierConflictInline = useMemo(() => {
+    if (!slugTierConflictActive || !slugTierConflict || slugTierConflict.conflictField !== 'service_tier') {
+      return undefined;
+    }
+    return EMPTY_TIER_CONFLICT_MSG;
+  }, [slugTierConflictActive, slugTierConflict]);
+
   const hasLocationOptions = locationOptions.length > 0;
   const locationExists = locationOptions.some((entry) => entry.id === locationId);
   const selectedLocationValue = locationExists ? locationId : locationId || '';
   const showDefaultLocationField = serviceForm.deliveryMode !== 'online';
 
-  const normalizedSlugInput = serviceForm.slug.trim().toLowerCase();
-  const saveBlockedBySlugConflict =
-    Boolean(slugConflictError) &&
-    conflictingSlugNormalized !== null &&
-    normalizedSlugInput === conflictingSlugNormalized;
+  const saveBlockedByPairConflict = slugTierConflictActive;
 
-  const tierTrimmedForValidation = serviceTier.trim().toLowerCase();
   const tierInvalid = Boolean(tierTrimmedForValidation) && !SLUG_PATTERN.test(tierTrimmedForValidation);
+
+  function applySlugTierConflictFromApiError(
+    caught: unknown,
+    pair: { slug: string | null; tierNormalized: string | null },
+  ): boolean {
+    if (!(caught instanceof AdminApiError) || caught.statusCode !== 409) {
+      return false;
+    }
+    const field = readAdminApiErrorField(caught);
+    if (field === 'service_tier' || field === 'slug') {
+      setSlugTierConflict({
+        slug: pair.slug ?? '',
+        tierNormalized: pair.tierNormalized ?? '',
+        conflictField: field === 'service_tier' ? 'service_tier' : 'slug',
+      });
+      return true;
+    }
+    return false;
+  }
 
   const deliveryModeSelect = (
     <div>
@@ -457,6 +504,7 @@ export function ServiceDetailPanel({
       return;
     }
     const newSlug = slugTrimmed.toLowerCase() || null;
+    const tierPayloadNormalized = serviceTier.trim().toLowerCase() || null;
     const oldSlug = (service.slug ?? '').trim().toLowerCase() || null;
     const ok = await confirmSlugChangeIfNeeded(newSlug, oldSlug);
     if (!ok) {
@@ -474,16 +522,9 @@ export function ServiceDetailPanel({
         status: serviceForm.status,
         ...buildTypeSpecificPayload(service.serviceType),
       });
-      setSlugConflictError('');
-      setConflictingSlugNormalized(null);
+      setSlugTierConflict(null);
     } catch (caught) {
-      if (
-        caught instanceof AdminApiError &&
-        caught.statusCode === 409 &&
-        readAdminApiErrorField(caught) === 'slug'
-      ) {
-        setSlugConflictError('Referral slug already in use. Choose another.');
-        setConflictingSlugNormalized(newSlug ?? '');
+      if (applySlugTierConflictFromApiError(caught, { slug: newSlug, tierNormalized: tierPayloadNormalized })) {
         return;
       }
       throw caught;
@@ -491,6 +532,7 @@ export function ServiceDetailPanel({
   }
 
   async function submitCreate() {
+    const tierPayloadNormalized = serviceTier.trim().toLowerCase() || null;
     try {
       await onCreate({
         service_type: serviceType,
@@ -504,16 +546,14 @@ export function ServiceDetailPanel({
         status: serviceForm.status,
         ...buildTypeSpecificPayload(serviceType),
       });
-      setSlugConflictError('');
-      setConflictingSlugNormalized(null);
+      setSlugTierConflict(null);
     } catch (caught) {
       if (
-        caught instanceof AdminApiError &&
-        caught.statusCode === 409 &&
-        readAdminApiErrorField(caught) === 'slug'
+        applySlugTierConflictFromApiError(caught, {
+          slug: slugPayloadValue,
+          tierNormalized: tierPayloadNormalized,
+        })
       ) {
-        setSlugConflictError('Referral slug already in use. Choose another.');
-        setConflictingSlugNormalized(slugPayloadValue ?? '');
         return;
       }
       throw caught;
@@ -537,7 +577,7 @@ export function ServiceDetailPanel({
                   disabled={
                     isLoading ||
                     !service ||
-                    saveBlockedBySlugConflict ||
+                    saveBlockedByPairConflict ||
                     tierInvalid ||
                     Boolean(serviceForm.slug.trim() && !SLUG_PATTERN.test(serviceForm.slug.trim().toLowerCase()))
                   }
@@ -559,7 +599,7 @@ export function ServiceDetailPanel({
                 type='button'
                 disabled={
                   isLoading ||
-                  saveBlockedBySlugConflict ||
+                  saveBlockedByPairConflict ||
                   tierInvalid ||
                   !serviceForm.title.trim() ||
                   Boolean(serviceForm.slug.trim() && !SLUG_PATTERN.test(serviceForm.slug.trim().toLowerCase()))
@@ -600,8 +640,7 @@ export function ServiceDetailPanel({
             value={serviceForm.slug}
             onChange={(next) => {
               if (next !== serviceForm.slug) {
-                setSlugConflictError('');
-                setConflictingSlugNormalized(null);
+                setSlugTierConflict(null);
               }
               setServiceForm({ ...serviceForm, slug: next });
             }}
@@ -610,7 +649,7 @@ export function ServiceDetailPanel({
                 ? 'Could not load discount code usage. Try again later.'
                 : undefined
             }
-            slugConflictError={slugConflictError || undefined}
+            slugConflictError={slugConflictInline}
           />
           <div>
             <div className='relative mb-1'>
@@ -659,9 +698,15 @@ export function ServiceDetailPanel({
             {deliveryModeSelect}
             <ServiceTierControl
               value={serviceTier}
-              onChange={setServiceTier}
+              onChange={(next) => {
+                if (next !== serviceTier) {
+                  setSlugTierConflict(null);
+                }
+                setServiceTier(next);
+              }}
               id='service-tier-training'
               invalid={tierInvalid}
+              tierConflictError={tierConflictInline}
             />
             {bookingAndCover}
           </div>
@@ -685,9 +730,15 @@ export function ServiceDetailPanel({
             {deliveryModeSelect}
             <ServiceTierControl
               value={serviceTier}
-              onChange={setServiceTier}
+              onChange={(next) => {
+                if (next !== serviceTier) {
+                  setSlugTierConflict(null);
+                }
+                setServiceTier(next);
+              }}
               id='service-tier-event'
               invalid={tierInvalid}
+              tierConflictError={tierConflictInline}
             />
             {bookingAndCover}
           </div>
@@ -707,9 +758,15 @@ export function ServiceDetailPanel({
             {deliveryModeSelect}
             <ServiceTierControl
               value={serviceTier}
-              onChange={setServiceTier}
+              onChange={(next) => {
+                if (next !== serviceTier) {
+                  setSlugTierConflict(null);
+                }
+                setServiceTier(next);
+              }}
               id='service-tier-consultation'
               invalid={tierInvalid}
+              tierConflictError={tierConflictInline}
             />
             {bookingAndCover}
           </div>

--- a/apps/admin_web/src/components/admin/services/service-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-list-panel.tsx
@@ -149,6 +149,7 @@ export function ServiceListPanel({
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Title</th>
+              <th className='px-4 py-3 font-semibold'>Tier</th>
               <th className='px-4 py-3 font-semibold'>Type</th>
               <th className='px-4 py-3 font-semibold'>Price</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
@@ -170,6 +171,7 @@ export function ServiceListPanel({
                 aria-selected={selectedServiceId === service.id}
               >
                 <td className='px-4 py-3'>{service.title}</td>
+                <td className='px-4 py-3'>{service.serviceTier?.trim() ? service.serviceTier : '—'}</td>
                 <td className='px-4 py-3'>{formatEnumLabel(service.serviceType)}</td>
                 <td className='px-4 py-3'>{formatServiceListPriceLabel(service)}</td>
                 <td className='px-4 py-3'>{formatEnumLabel(service.status)}</td>

--- a/apps/admin_web/src/components/admin/services/service-tier-control.tsx
+++ b/apps/admin_web/src/components/admin/services/service-tier-control.tsx
@@ -9,6 +9,7 @@ export interface ServiceTierControlProps {
   id?: string;
   disabled?: boolean;
   invalid?: boolean;
+  tierConflictError?: string;
 }
 
 export function ServiceTierControl({
@@ -17,6 +18,7 @@ export function ServiceTierControl({
   id = 'service-tier',
   disabled = false,
   invalid = false,
+  tierConflictError,
 }: ServiceTierControlProps) {
   return (
     <div>
@@ -36,6 +38,7 @@ export function ServiceTierControl({
           Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing hyphen).
         </p>
       ) : null}
+      {tierConflictError ? <p className='mt-1 text-xs text-red-600'>{tierConflictError}</p> : null}
     </div>
   );
 }

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -1420,7 +1420,7 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
-                /** @description Referral slug conflict. */
+                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier). Error body may use `field` `slug` or `service_tier` depending on the conflicting pair. */
                 409: {
                     headers: {
                         [name: string]: unknown;
@@ -1602,7 +1602,7 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
-                /** @description Referral slug conflict. */
+                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier). Error body may use `field` `slug` or `service_tier` depending on the conflicting pair. */
                 409: {
                     headers: {
                         [name: string]: unknown;
@@ -1679,7 +1679,7 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
-                /** @description Referral slug conflict. */
+                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier). Error body may use `field` `slug` or `service_tier` depending on the conflicting pair. */
                 409: {
                     headers: {
                         [name: string]: unknown;

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -1379,7 +1379,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Service list response. */
+                /** @description Service list response. Each `ServiceSummary` item includes `service_tier` (nullable) for admin list display and filtering context. */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -1420,7 +1420,7 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
-                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier). Error body may use `field` `slug` or `service_tier` depending on the conflicting pair. */
+                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier, NULL tiers treated as one bucket). Error body uses `field` value `slug_tier` (see `ErrorResponse.field`). */
                 409: {
                     headers: {
                         [name: string]: unknown;
@@ -1602,7 +1602,7 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
-                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier). Error body may use `field` `slug` or `service_tier` depending on the conflicting pair. */
+                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier, NULL tiers treated as one bucket). Error body uses `field` value `slug_tier` (see `ErrorResponse.field`). */
                 409: {
                     headers: {
                         [name: string]: unknown;
@@ -1679,7 +1679,7 @@ export interface paths {
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
                 404: components["responses"]["NotFound"];
-                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier). Error body may use `field` `slug` or `service_tier` depending on the conflicting pair. */
+                /** @description Referral slug and service tier conflict with another service (unique index on case-insensitive slug and tier, NULL tiers treated as one bucket). Error body uses `field` value `slug_tier` (see `ErrorResponse.field`). */
                 409: {
                     headers: {
                         [name: string]: unknown;
@@ -5367,6 +5367,8 @@ export interface components {
         ErrorResponse: {
             error: string;
             detail?: string | null;
+            /** @description Optional input field key for validation-style errors. Duplicate service slug+tier conflicts use the literal `slug_tier` (not `slug` or `service_tier`). */
+            field?: string | null;
         };
         HealthResponse: {
             healthy: boolean;

--- a/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
@@ -157,22 +157,25 @@ describe('ServiceDetailPanel referral slug', () => {
     });
   });
 
-  it('shows inline slug conflict error and blocks save until slug changes after 409', async () => {
+  it('shows inline slug+tier conflict error and blocks save until slug or tier changes after 409', async () => {
     const user = userEvent.setup();
     const onUpdate = vi
       .fn()
       .mockRejectedValueOnce(
         new AdminApiError({
           statusCode: 409,
-          payload: { error: 'Referral slug already in use', field: 'slug' },
-          message: 'Referral slug already in use',
+          payload: {
+            error: 'Another service already uses this referral slug with the same tier.',
+            field: 'slug',
+          },
+          message: 'Conflict',
         }),
       )
       .mockResolvedValueOnce(undefined);
 
     render(
       <ServiceDetailPanel
-        service={buildService({ slug: 'old-slug' })}
+        service={buildService({ slug: 'old-slug', serviceTier: 'cohort-a' })}
         isLoading={false}
         error=''
         onCancelSelection={vi.fn()}
@@ -187,11 +190,12 @@ describe('ServiceDetailPanel referral slug', () => {
     await user.click(screen.getByRole('button', { name: 'Update service' }));
 
     expect(
-      await screen.findByText('Referral slug already in use. Choose another.'),
+      await screen.findByText(/This slug and tier are already used by another service/),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Update service' })).toBeDisabled();
 
-    fireEvent.change(slugInput, { target: { value: 'taken-slug-x' } });
+    const tierInput = screen.getByLabelText('Service tier');
+    fireEvent.change(tierInput, { target: { value: 'cohort-b' } });
     expect(screen.getByRole('button', { name: 'Update service' })).not.toBeDisabled();
 
     await user.click(screen.getByRole('button', { name: 'Update service' }));

--- a/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-editor-slug.test.tsx
@@ -166,7 +166,7 @@ describe('ServiceDetailPanel referral slug', () => {
           statusCode: 409,
           payload: {
             error: 'Another service already uses this referral slug with the same tier.',
-            field: 'slug',
+            field: 'slug_tier',
           },
           message: 'Conflict',
         }),
@@ -202,5 +202,38 @@ describe('ServiceDetailPanel referral slug', () => {
     await vi.waitFor(() => {
       expect(onUpdate).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('shows empty-tier conflict on tier field when API returns slug_tier 409 for blank tier', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn().mockRejectedValueOnce(
+      new AdminApiError({
+        statusCode: 409,
+        payload: {
+          error: 'Another service already uses this referral slug with an empty tier.',
+          field: 'slug_tier',
+        },
+        message: 'Conflict',
+      }),
+    );
+
+    render(
+      <ServiceDetailPanel
+        service={buildService({ slug: 'shared-slug', serviceTier: '' })}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={onUpdate}
+        onUploadCover={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Update service' }));
+
+    expect(
+      await screen.findByText(/Another service uses this slug with an empty tier/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update service' })).toBeDisabled();
   });
 });

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -137,7 +137,7 @@ describe('services tables value formatting', () => {
     expect(within(table).getByText('Training Course')).toBeInTheDocument();
     expect(within(table).getByText('Published')).toBeInTheDocument();
     expect(within(table).getByText('In Person')).toBeInTheDocument();
-    expect(within(table).getByText('—')).toBeInTheDocument();
+    expect(within(table).getAllByText('—').length).toBeGreaterThanOrEqual(1);
   });
 
   it('disables delete when the service has instances', () => {

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -140,6 +140,44 @@ describe('services tables value formatting', () => {
     expect(within(table).getAllByText('—').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('renders Tier column after Title with tier value or em dash', () => {
+    const withTier: ServiceSummary = { ...SERVICE_FIXTURE, serviceTier: 'cohort-a' };
+    render(
+      <ServiceListPanel
+        services={[withTier]}
+        selectedServiceId={null}
+        filters={{ serviceType: '', status: '', search: '' }}
+        isLoading={false}
+        isLoadingMore={false}
+        hasMore={false}
+        error=''
+        isMutating={false}
+        onSelectService={vi.fn()}
+        onFilterChange={vi.fn()}
+        onLoadMore={vi.fn()}
+        onDuplicateService={vi.fn()}
+        onDeleteService={vi.fn()}
+      />
+    );
+
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers.map((el) => el.textContent?.trim())).toEqual([
+      'Title',
+      'Tier',
+      'Type',
+      'Price',
+      'Status',
+      'Delivery',
+      'Operations',
+    ]);
+
+    const table = screen.getByRole('table');
+    const dataRow = screen.getByText('Service title').closest('tr');
+    expect(dataRow).toBeTruthy();
+    expect(within(dataRow as HTMLElement).getByText('cohort-a')).toBeInTheDocument();
+    expect(within(dataRow as HTMLElement).getAllByText('—').length).toBeGreaterThanOrEqual(1);
+  });
+
   it('disables delete when the service has instances', () => {
     const withInstances: ServiceSummary = { ...SERVICE_FIXTURE, instancesCount: 2 };
     render(

--- a/backend/db/alembic/versions/0041_services_slug_tier_unique.py
+++ b/backend/db/alembic/versions/0041_services_slug_tier_unique.py
@@ -1,0 +1,47 @@
+"""Replace services slug-only unique index with slug + service_tier composite.
+
+Seed-data assessment:
+1. Compatibility: seed only UPDATEs slugs on known rows; no duplicate (slug, tier)
+   pairs are introduced by seed.
+2. NOT NULL: none; partial index still requires slug IS NOT NULL.
+3. Dropped index `services_slug_unique_idx` replaced by
+   `services_slug_tier_unique_idx` on (lower(slug), lower(service_tier)).
+4. New tables: N/A.
+5. Enum/values: N/A.
+6. FK: N/A.
+
+If production had duplicate (lower(slug), coalesce(lower(service_tier), '')) rows,
+migration would fail until data is deduplicated (unlikely given prior slug-only
+uniqueness unless tier was NULL for duplicates).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0041_slug_tier_unique"
+down_revision = "0040_service_tier_location"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("DROP INDEX IF EXISTS services_slug_unique_idx"))
+    op.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX services_slug_tier_unique_idx "
+            "ON services (lower(slug), lower(service_tier)) "
+            "WHERE slug IS NOT NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP INDEX IF EXISTS services_slug_tier_unique_idx"))
+    op.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX services_slug_unique_idx "
+            "ON services (lower(slug)) WHERE slug IS NOT NULL"
+        )
+    )

--- a/backend/db/alembic/versions/0041_services_slug_tier_unique.py
+++ b/backend/db/alembic/versions/0041_services_slug_tier_unique.py
@@ -1,8 +1,8 @@
 """Replace services slug-only unique index with slug + service_tier composite.
 
 Seed-data assessment:
-1. Compatibility: seed only UPDATEs slugs on known rows; no duplicate (slug, tier)
-   pairs are introduced by seed.
+1. Compatibility: seed UPDATEs slugs only when exactly one candidate row exists
+   (see `backend/db/seed/seed_data.sql`), avoiding accidental duplicate slugs.
 2. NOT NULL: none; partial index still requires slug IS NOT NULL.
 3. Dropped index `services_slug_unique_idx` replaced by
    `services_slug_tier_unique_idx` on (lower(slug), lower(service_tier)).
@@ -10,9 +10,10 @@ Seed-data assessment:
 5. Enum/values: N/A.
 6. FK: N/A.
 
-If production had duplicate (lower(slug), coalesce(lower(service_tier), '')) rows,
-migration would fail until data is deduplicated (unlikely given prior slug-only
-uniqueness unless tier was NULL for duplicates).
+Note: PostgreSQL treats NULL as distinct in unique indexes by default; revision
+`0042_slug_nulls_nd` replaces this index with NULLS NOT DISTINCT so duplicate
+(slug, NULL tier) rows cannot coexist. Until 0042 is applied, only one NULL-tier
+row per slug is enforced in practice by application behavior, not by this index alone.
 """
 
 from __future__ import annotations
@@ -38,6 +39,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    """Restore slug-only uniqueness. Not safe after multiple tiers share one slug."""
     op.execute(sa.text("DROP INDEX IF EXISTS services_slug_tier_unique_idx"))
     op.execute(
         sa.text(

--- a/backend/db/alembic/versions/0042_services_slug_tier_nulls_nd.py
+++ b/backend/db/alembic/versions/0042_services_slug_tier_nulls_nd.py
@@ -1,0 +1,79 @@
+"""Recreate services_slug_tier_unique_idx with NULLS NOT DISTINCT.
+
+PostgreSQL treats NULL as distinct in unique indexes by default; without
+NULLS NOT DISTINCT, two rows with the same slug and NULL service_tier would
+not violate the index. This revision replaces the index from 0041 with an
+equivalent definition that treats NULL tier like a single value.
+
+Pre-upgrade guard: fails if duplicate (lower(slug), service_tier) pairs exist
+among rows with slug set (including multiple NULL tiers for the same slug).
+
+Seed-data assessment:
+1. Seed `UPDATE services SET slug = ...` is tightened (see seed_data.sql) so
+   slugs are only set when exactly one candidate row exists, avoiding accidental
+   duplicate slugs from broad title matches.
+2. NOT NULL: unchanged.
+3. Index only: replaces `services_slug_tier_unique_idx` DDL.
+4. New tables: N/A.
+5. Enum/values: N/A.
+6. FK: N/A.
+
+Downgrade: restores the 0041 index (without NULLS NOT DISTINCT). This is not
+reversible in production once distinct tiers share a slug: re-applying the
+slug-only unique index would fail. Prefer forward-only migration in deployed
+environments.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0042_slug_nulls_nd"
+down_revision = "0041_slug_tier_unique"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            DECLARE dup_count int;
+            BEGIN
+              SELECT count(*) INTO dup_count FROM (
+                SELECT lower(slug) AS ls, service_tier
+                FROM services
+                WHERE slug IS NOT NULL
+                GROUP BY lower(slug), service_tier
+                HAVING count(*) > 1
+              ) d;
+              IF dup_count > 0 THEN
+                RAISE EXCEPTION
+                  'services: duplicate (slug, service_tier) rows exist; dedupe before upgrade';
+              END IF;
+            END $$;
+            """
+        )
+    )
+    op.execute(sa.text("DROP INDEX IF EXISTS services_slug_tier_unique_idx"))
+    op.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX services_slug_tier_unique_idx "
+            "ON services (lower(slug), lower(service_tier)) NULLS NOT DISTINCT "
+            "WHERE slug IS NOT NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    """Restore 0041 index semantics (not safe if multiple tiers share one slug)."""
+    op.execute(sa.text("DROP INDEX IF EXISTS services_slug_tier_unique_idx"))
+    op.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX services_slug_tier_unique_idx "
+            "ON services (lower(slug), lower(service_tier)) "
+            "WHERE slug IS NOT NULL"
+        )
+    )

--- a/backend/db/seed/seed_data.sql
+++ b/backend/db/seed/seed_data.sql
@@ -10,17 +10,44 @@ INSERT INTO tags (id, name, created_by)
 SELECT gen_random_uuid(), 'client_document', 'system'
 WHERE NOT EXISTS (SELECT 1 FROM tags WHERE lower(name) = lower('client_document'));
 
--- Referral slugs on services (nullable column; safe when no matching row).
-UPDATE services
+-- Referral slugs on services (nullable column). Only set when exactly one row matches,
+-- so seed never assigns the same slug to multiple services.
+UPDATE services s
 SET slug = 'my-best-auntie'
-WHERE slug IS NULL
-  AND service_type = 'training_course'
+FROM (
+  SELECT id
+  FROM services
+  WHERE slug IS NULL
+    AND service_type = 'training_course'
+    AND (
+      lower(title) LIKE '%best auntie%'
+      OR lower(title) LIKE '%my best auntie%'
+    )
+) pick
+WHERE s.id = pick.id
   AND (
-    lower(title) LIKE '%best auntie%'
-    OR lower(title) LIKE '%my best auntie%'
-  );
+    SELECT count(*)::int
+    FROM services
+    WHERE slug IS NULL
+      AND service_type = 'training_course'
+      AND (
+        lower(title) LIKE '%best auntie%'
+        OR lower(title) LIKE '%my best auntie%'
+      )
+  ) = 1;
 
-UPDATE services
+UPDATE services s
 SET slug = 'consultations'
-WHERE slug IS NULL
-  AND service_type = 'consultation';
+FROM (
+  SELECT id
+  FROM services
+  WHERE slug IS NULL
+    AND service_type = 'consultation'
+) pick
+WHERE s.id = pick.id
+  AND (
+    SELECT count(*)::int
+    FROM services
+    WHERE slug IS NULL
+      AND service_type = 'consultation'
+  ) = 1;

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Mapping
-from datetime import UTC, datetime, timedelta
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -24,6 +22,11 @@ from app.api.admin_services_common import (
     request_id,
     serialize_service_detail,
     serialize_service_summary,
+)
+from app.api.admin_services_cover import create_cover_image_upload
+from app.api.admin_services_integrity import (
+    is_services_slug_tier_unique_violation,
+    slug_tier_uniqueness_validation_error,
 )
 from app.api.admin_services_payload_utils import parse_service_type_details
 from app.api.admin_entities_helpers import require_assignable_tag
@@ -47,8 +50,7 @@ from app.db.repositories import (
     ServiceRepository,
 )
 from app.exceptions import NotFoundError, ValidationError
-from app.services.aws_clients import get_s3_client
-from app.utils import json_response, require_env
+from app.utils import json_response
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -111,7 +113,7 @@ def handle_admin_services_request(
     if len(parts) == 4 and parts[3] == "cover-image":
         if method != "POST":
             return json_response(405, {"error": "Method not allowed"}, event=event)
-        return _create_cover_image_upload(
+        return create_cover_image_upload(
             event, service_id=service_id, actor_sub=identity.user_sub
         )
 
@@ -205,8 +207,8 @@ def _create_service(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, An
             session.commit()
         except IntegrityError as exc:
             session.rollback()
-            if _is_services_slug_tier_unique_violation(exc):
-                raise _slug_tier_uniqueness_validation_error(
+            if is_services_slug_tier_unique_violation(exc):
+                raise slug_tier_uniqueness_validation_error(
                     slug=payload["slug"],
                     service_tier=payload["service_tier"],
                 ) from exc
@@ -302,8 +304,8 @@ def _update_service(
             session.commit()
         except IntegrityError as exc:
             session.rollback()
-            if _is_services_slug_tier_unique_violation(exc):
-                raise _slug_tier_uniqueness_validation_error(
+            if is_services_slug_tier_unique_violation(exc):
+                raise slug_tier_uniqueness_validation_error(
                     slug=service.slug,
                     service_tier=service.service_tier,
                 ) from exc
@@ -344,65 +346,6 @@ def _delete_service(
         repository.delete(service)
         session.commit()
         return json_response(204, {}, event=event)
-
-
-def _create_cover_image_upload(
-    event: Mapping[str, Any],
-    *,
-    service_id: UUID,
-    actor_sub: str,
-) -> dict[str, Any]:
-    body = parse_body(event)
-    file_name = str(body.get("file_name") or "").strip()
-    if not file_name:
-        raise ValidationError("file_name is required", field="file_name")
-    content_type = (
-        str(body.get("content_type") or "").strip() or "application/octet-stream"
-    )
-    normalized_file_name = _sanitize_file_name(file_name)
-    s3_key = f"media/services/{service_id}/cover/{uuid4()}-{normalized_file_name}"
-    logger.info(
-        "Creating service cover image upload URL",
-        extra={"service_id": str(service_id), "actor_sub": actor_sub},
-    )
-
-    media_bucket = require_env("ASSETS_BUCKET_NAME")
-    ttl = _presign_ttl_seconds()
-    expires_at = datetime.now(UTC) + timedelta(seconds=ttl)
-    s3_client = get_s3_client()
-    upload_url = s3_client.generate_presigned_url(
-        "put_object",
-        Params={
-            "Bucket": media_bucket,
-            "Key": s3_key,
-            "ContentType": content_type,
-        },
-        ExpiresIn=ttl,
-        HttpMethod="PUT",
-    )
-
-    with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
-        repository = ServiceRepository(session)
-        service = repository.get_by_id(service_id)
-        if service is None:
-            raise NotFoundError("Service", str(service_id))
-        service.cover_image_s3_key = s3_key
-        repository.update_service(service)
-        session.commit()
-
-    return json_response(
-        200,
-        {
-            "upload_url": upload_url,
-            "upload_method": "PUT",
-            "upload_headers": {"Content-Type": content_type},
-            "s3_key": s3_key,
-            "expires_at": expires_at.isoformat(),
-            "service": {"id": str(service_id), "cover_image_s3_key": s3_key},
-        },
-        event=event,
-    )
 
 
 def _build_service_type_details(
@@ -456,45 +399,6 @@ def _get_discount_code_usage_summary(
         )
 
 
-def _slug_tier_uniqueness_validation_error(
-    *, slug: str | None, service_tier: str | None
-) -> ValidationError:
-    """409 for duplicate (referral slug, service tier) pair."""
-    if slug:
-        if service_tier:
-            return ValidationError(
-                "Another service already uses this referral slug with the same tier. "
-                "Change the slug or use a different tier.",
-                field="slug",
-                status_code=409,
-            )
-        return ValidationError(
-            "Another service already uses this referral slug with an empty tier. "
-            "Set a tier or change the slug.",
-            field="service_tier",
-            status_code=409,
-        )
-    return ValidationError(
-        "Service slug and tier combination conflicts with an existing service.",
-        field="slug",
-        status_code=409,
-    )
-
-
-def _is_services_slug_tier_unique_violation(exc: IntegrityError) -> bool:
-    orig = getattr(exc.orig, "__cause__", None) or exc.orig
-    diag = getattr(orig, "diag", None)
-    constraint = getattr(diag, "constraint_name", None) if diag else None
-    if constraint == "services_slug_tier_unique_idx":
-        return True
-    message = str(exc).lower()
-    if "services_slug_tier_unique_idx" not in message:
-        return False
-    if "svc_instances_slug" in message:
-        return False
-    return True
-
-
 def _apply_service_type_details(*, service: Service, details: Any) -> None:
     if isinstance(details, TrainingCourseDetails):
         if service.training_course_details is None:
@@ -531,21 +435,3 @@ def _apply_service_type_details(*, service: Service, details: Any) -> None:
             consultation_row.default_currency = details.default_currency
         service.training_course_details = None
         service.event_details = None
-
-
-def _sanitize_file_name(file_name: str) -> str:
-    safe = "".join(
-        char if char.isalnum() or char in {".", "-", "_"} else "-"
-        for char in file_name.strip()
-    )
-    safe = safe.strip("-")
-    return safe or "cover-image"
-
-
-def _presign_ttl_seconds() -> int:
-    raw = os.getenv("ASSET_PRESIGN_TTL_SECONDS", "900").strip()
-    try:
-        parsed = int(raw)
-    except ValueError as exc:
-        raise ValidationError("ASSET_PRESIGN_TTL_SECONDS must be an integer") from exc
-    return max(60, min(3600, parsed))

--- a/backend/src/app/api/admin_services.py
+++ b/backend/src/app/api/admin_services.py
@@ -205,11 +205,10 @@ def _create_service(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, An
             session.commit()
         except IntegrityError as exc:
             session.rollback()
-            if _is_services_slug_unique_violation(exc):
-                raise ValidationError(
-                    "Referral slug already in use",
-                    field="slug",
-                    status_code=409,
+            if _is_services_slug_tier_unique_violation(exc):
+                raise _slug_tier_uniqueness_validation_error(
+                    slug=payload["slug"],
+                    service_tier=payload["service_tier"],
                 ) from exc
             raise
         with_details = repository.get_by_id_with_details(created.id)
@@ -303,11 +302,10 @@ def _update_service(
             session.commit()
         except IntegrityError as exc:
             session.rollback()
-            if _is_services_slug_unique_violation(exc):
-                raise ValidationError(
-                    "Referral slug already in use",
-                    field="slug",
-                    status_code=409,
+            if _is_services_slug_tier_unique_violation(exc):
+                raise _slug_tier_uniqueness_validation_error(
+                    slug=service.slug,
+                    service_tier=service.service_tier,
                 ) from exc
             raise
         with_details = repository.get_by_id_with_details(updated.id)
@@ -458,17 +456,39 @@ def _get_discount_code_usage_summary(
         )
 
 
-def _is_services_slug_unique_violation(exc: IntegrityError) -> bool:
+def _slug_tier_uniqueness_validation_error(
+    *, slug: str | None, service_tier: str | None
+) -> ValidationError:
+    """409 for duplicate (referral slug, service tier) pair."""
+    if slug:
+        if service_tier:
+            return ValidationError(
+                "Another service already uses this referral slug with the same tier. "
+                "Change the slug or use a different tier.",
+                field="slug",
+                status_code=409,
+            )
+        return ValidationError(
+            "Another service already uses this referral slug with an empty tier. "
+            "Set a tier or change the slug.",
+            field="service_tier",
+            status_code=409,
+        )
+    return ValidationError(
+        "Service slug and tier combination conflicts with an existing service.",
+        field="slug",
+        status_code=409,
+    )
+
+
+def _is_services_slug_tier_unique_violation(exc: IntegrityError) -> bool:
     orig = getattr(exc.orig, "__cause__", None) or exc.orig
     diag = getattr(orig, "diag", None)
     constraint = getattr(diag, "constraint_name", None) if diag else None
-    if constraint == "services_slug_unique_idx":
+    if constraint == "services_slug_tier_unique_idx":
         return True
     message = str(exc).lower()
-    # Prefer diag.constraint_name (above). Some drivers omit it; keep a narrow
-    # substring fallback so unrelated unique violations (e.g. instance slug) do
-    # not map to a services.slug 409.
-    if "services_slug_unique_idx" not in message:
+    if "services_slug_tier_unique_idx" not in message:
         return False
     if "svc_instances_slug" in message:
         return False

--- a/backend/src/app/api/admin_services_cover.py
+++ b/backend/src/app/api/admin_services_cover.py
@@ -1,0 +1,100 @@
+"""Admin service cover image presign helpers."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy.orm import Session
+
+from app.api.admin_request import parse_body
+from app.api.admin_services_common import request_id
+from app.db.audit import set_audit_context
+from app.db.engine import get_engine
+from app.db.repositories import ServiceRepository
+from app.exceptions import NotFoundError, ValidationError
+from app.services.aws_clients import get_s3_client
+from app.utils import json_response, require_env
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def create_cover_image_upload(
+    event: Mapping[str, Any],
+    *,
+    service_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    body = parse_body(event)
+    file_name = str(body.get("file_name") or "").strip()
+    if not file_name:
+        raise ValidationError("file_name is required", field="file_name")
+    content_type = (
+        str(body.get("content_type") or "").strip() or "application/octet-stream"
+    )
+    normalized_file_name = _sanitize_file_name(file_name)
+    s3_key = f"media/services/{service_id}/cover/{uuid4()}-{normalized_file_name}"
+    logger.info(
+        "Creating service cover image upload URL",
+        extra={"service_id": str(service_id), "actor_sub": actor_sub},
+    )
+
+    media_bucket = require_env("ASSETS_BUCKET_NAME")
+    ttl = _presign_ttl_seconds()
+    expires_at = datetime.now(UTC) + timedelta(seconds=ttl)
+    s3_client = get_s3_client()
+    upload_url = s3_client.generate_presigned_url(
+        "put_object",
+        Params={
+            "Bucket": media_bucket,
+            "Key": s3_key,
+            "ContentType": content_type,
+        },
+        ExpiresIn=ttl,
+        HttpMethod="PUT",
+    )
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
+        repository = ServiceRepository(session)
+        service = repository.get_by_id(service_id)
+        if service is None:
+            raise NotFoundError("Service", str(service_id))
+        service.cover_image_s3_key = s3_key
+        repository.update_service(service)
+        session.commit()
+
+    return json_response(
+        200,
+        {
+            "upload_url": upload_url,
+            "upload_method": "PUT",
+            "upload_headers": {"Content-Type": content_type},
+            "s3_key": s3_key,
+            "expires_at": expires_at.isoformat(),
+            "service": {"id": str(service_id), "cover_image_s3_key": s3_key},
+        },
+        event=event,
+    )
+
+
+def _sanitize_file_name(file_name: str) -> str:
+    safe = "".join(
+        char if char.isalnum() or char in {".", "-", "_"} else "-"
+        for char in file_name.strip()
+    )
+    safe = safe.strip("-")
+    return safe or "cover-image"
+
+
+def _presign_ttl_seconds() -> int:
+    raw = os.getenv("ASSET_PRESIGN_TTL_SECONDS", "900").strip()
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise ValidationError("ASSET_PRESIGN_TTL_SECONDS must be an integer") from exc
+    return max(60, min(3600, parsed))

--- a/backend/src/app/api/admin_services_integrity.py
+++ b/backend/src/app/api/admin_services_integrity.py
@@ -1,0 +1,45 @@
+"""Integrity helpers for admin service routes (slug + tier uniqueness)."""
+
+from __future__ import annotations
+
+from sqlalchemy.exc import IntegrityError
+
+from app.exceptions import ValidationError
+
+# Admin API `field` for duplicate (referral slug, service_tier) unique violations (409).
+SERVICE_SLUG_TIER_UNIQUE_FIELD = "slug_tier"
+
+
+def slug_tier_uniqueness_validation_error(
+    *, slug: str | None, service_tier: str | None
+) -> ValidationError:
+    """409 for duplicate (referral slug, service tier) pair, including NULL/empty tier."""
+    if slug and service_tier:
+        message = (
+            "Another service already uses this referral slug with the same tier. "
+            "Change the slug or use a different tier."
+        )
+    elif slug:
+        message = (
+            "Another service already uses this referral slug with an empty tier. "
+            "Set a tier or change the slug."
+        )
+    else:
+        message = (
+            "Service slug and tier combination conflicts with an existing service."
+        )
+    return ValidationError(message, field=SERVICE_SLUG_TIER_UNIQUE_FIELD, status_code=409)
+
+
+def is_services_slug_tier_unique_violation(exc: IntegrityError) -> bool:
+    orig = getattr(exc.orig, "__cause__", None) or exc.orig
+    diag = getattr(orig, "diag", None)
+    constraint = getattr(diag, "constraint_name", None) if diag else None
+    if constraint == "services_slug_tier_unique_idx":
+        return True
+    message = str(exc).lower()
+    if "services_slug_tier_unique_idx" not in message:
+        return False
+    if "svc_instances_slug" in message:
+        return False
+    return True

--- a/backend/src/app/api/admin_services_integrity.py
+++ b/backend/src/app/api/admin_services_integrity.py
@@ -28,7 +28,9 @@ def slug_tier_uniqueness_validation_error(
         message = (
             "Service slug and tier combination conflicts with an existing service."
         )
-    return ValidationError(message, field=SERVICE_SLUG_TIER_UNIQUE_FIELD, status_code=409)
+    return ValidationError(
+        message, field=SERVICE_SLUG_TIER_UNIQUE_FIELD, status_code=409
+    )
 
 
 def is_services_slug_tier_unique_violation(exc: IntegrityError) -> bool:

--- a/backend/src/app/db/models/service.py
+++ b/backend/src/app/db/models/service.py
@@ -55,6 +55,13 @@ class Service(Base):
     __table_args__ = (
         Index("services_type_idx", "service_type"),
         Index("services_status_idx", "status"),
+        Index(
+            "services_slug_tier_unique_idx",
+            text("lower(slug)"),
+            text("lower(service_tier)"),
+            unique=True,
+            postgresql_where=text("slug IS NOT NULL"),
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(

--- a/backend/src/app/db/models/service.py
+++ b/backend/src/app/db/models/service.py
@@ -61,6 +61,7 @@ class Service(Base):
             text("lower(service_tier)"),
             unique=True,
             postgresql_where=text("slug IS NOT NULL"),
+            postgresql_nulls_not_distinct=True,
         ),
     )
 

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1095,7 +1095,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Referral slug conflict.
+          description: >
+            Referral slug and service tier conflict with another service (unique index
+            on case-insensitive slug and tier). Error body may use `field` `slug` or
+            `service_tier` depending on the conflicting pair.
           content:
             application/json:
               schema:
@@ -1224,7 +1227,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Referral slug conflict.
+          description: >
+            Referral slug and service tier conflict with another service (unique index
+            on case-insensitive slug and tier). Error body may use `field` `slug` or
+            `service_tier` depending on the conflicting pair.
           content:
             application/json:
               schema:
@@ -1253,7 +1259,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Referral slug conflict.
+          description: >
+            Referral slug and service tier conflict with another service (unique index
+            on case-insensitive slug and tier). Error body may use `field` `slug` or
+            `service_tier` depending on the conflicting pair.
           content:
             application/json:
               schema:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1060,7 +1060,9 @@ paths:
             type: string
       responses:
         "200":
-          description: Service list response.
+          description: >
+            Service list response. Each `ServiceSummary` item includes `service_tier`
+            (nullable) for admin list display and filtering context.
           content:
             application/json:
               schema:
@@ -1097,8 +1099,8 @@ paths:
         "409":
           description: >
             Referral slug and service tier conflict with another service (unique index
-            on case-insensitive slug and tier). Error body may use `field` `slug` or
-            `service_tier` depending on the conflicting pair.
+            on case-insensitive slug and tier, NULL tiers treated as one bucket).
+            Error body uses `field` value `slug_tier` (see `ErrorResponse.field`).
           content:
             application/json:
               schema:
@@ -1229,8 +1231,8 @@ paths:
         "409":
           description: >
             Referral slug and service tier conflict with another service (unique index
-            on case-insensitive slug and tier). Error body may use `field` `slug` or
-            `service_tier` depending on the conflicting pair.
+            on case-insensitive slug and tier, NULL tiers treated as one bucket).
+            Error body uses `field` value `slug_tier` (see `ErrorResponse.field`).
           content:
             application/json:
               schema:
@@ -1261,8 +1263,8 @@ paths:
         "409":
           description: >
             Referral slug and service tier conflict with another service (unique index
-            on case-insensitive slug and tier). Error body may use `field` `slug` or
-            `service_tier` depending on the conflicting pair.
+            on case-insensitive slug and tier, NULL tiers treated as one bucket).
+            Error body uses `field` value `slug_tier` (see `ErrorResponse.field`).
           content:
             application/json:
               schema:
@@ -6109,6 +6111,12 @@ components:
         detail:
           type: string
           nullable: true
+        field:
+          type: string
+          nullable: true
+          description: >
+            Optional input field key for validation-style errors. Duplicate service
+            slug+tier conflicts use the literal `slug_tier` (not `slug` or `service_tier`).
     HealthResponse:
       type: object
       required:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -64,8 +64,13 @@ null (case-insensitive uniqueness for public referral URLs).
 
 Migration `0041_slug_tier_unique` drops `services_slug_unique_idx` and creates
 `services_slug_tier_unique_idx` on `(lower(slug), lower(service_tier))` where `slug`
-is not null, so the same referral slug may exist on different tiers (and duplicate
-slug with empty tier remains disallowed).
+is not null (composite uniqueness; PostgreSQL still treats NULL tiers as distinct until
+the next revision).
+
+Migration `0042_slug_nulls_nd` recreates `services_slug_tier_unique_idx` with
+`NULLS NOT DISTINCT` so at most one row per slug may have NULL `service_tier`, and
+rejects duplicate real tier values case-insensitively. Upgrade runs a guard that fails
+when duplicate `(lower(slug), service_tier)` groups already exist among slugged rows.
 
 Migration `0032_services_booking` adds nullable `services.booking_system` (varchar(80))
 for an optional admin-visible booking-system label.
@@ -454,7 +459,8 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 - `services` stores reusable templates (title/description/cover image, type,
   delivery mode, status).
 - Optional `slug` for public referral URLs; uniqueness is case-insensitive on the
-  pair `(slug, service_tier)` when `slug` is set (see `services_slug_tier_unique_idx`).
+  pair `(slug, service_tier)` when `slug` is set (`services_slug_tier_unique_idx` with
+  `NULLS NOT DISTINCT` from migration `0042_slug_nulls_nd`, so NULL tier is one bucket).
 - Optional `booking_system` varchar(80) for an admin-visible booking-system label.
 - Optional `service_tier` varchar(128): slug-like tier id shared by all instances.
 - Optional `location_id` UUID FK to `locations.id` ON DELETE SET NULL: default venue for

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -62,6 +62,11 @@ Migration `0023_services_add_slug` adds nullable `services.slug` (varchar(80)) w
 unique partial index `services_slug_unique_idx` on `lower(slug)` where `slug` is not
 null (case-insensitive uniqueness for public referral URLs).
 
+Migration `0041_slug_tier_unique` drops `services_slug_unique_idx` and creates
+`services_slug_tier_unique_idx` on `(lower(slug), lower(service_tier))` where `slug`
+is not null, so the same referral slug may exist on different tiers (and duplicate
+slug with empty tier remains disallowed).
+
 Migration `0032_services_booking` adds nullable `services.booking_system` (varchar(80))
 for an optional admin-visible booking-system label.
 
@@ -448,7 +453,8 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 
 - `services` stores reusable templates (title/description/cover image, type,
   delivery mode, status).
-- Optional `slug` for public referral URLs.
+- Optional `slug` for public referral URLs; uniqueness is case-insensitive on the
+  pair `(slug, service_tier)` when `slug` is set (see `services_slug_tier_unique_idx`).
 - Optional `booking_system` varchar(80) for an admin-visible booking-system label.
 - Optional `service_tier` varchar(128): slug-like tier id shared by all instances.
 - Optional `location_id` UUID FK to `locations.id` ON DELETE SET NULL: default venue for

--- a/tests/test_admin_services_create_slug_duplicate.py
+++ b/tests/test_admin_services_create_slug_duplicate.py
@@ -13,9 +13,9 @@ from app.db.models import Service, TrainingCourseDetails
 from app.exceptions import ValidationError
 
 
-def _make_services_slug_integrity_error() -> IntegrityError:
+def _make_services_slug_tier_integrity_error() -> IntegrityError:
     class _Diag:
-        constraint_name = "services_slug_unique_idx"
+        constraint_name = "services_slug_tier_unique_idx"
 
     class _Orig:
         diag = _Diag()
@@ -53,7 +53,7 @@ def test_create_service_duplicate_slug_maps_to_validation_error(
             pass
 
         def create_service(self, _service: Service, _details: TrainingCourseDetails) -> Service:
-            raise _make_services_slug_integrity_error()
+            raise _make_services_slug_tier_integrity_error()
 
     monkeypatch.setattr(admin_services, "Session", _SessionCtx)
     monkeypatch.setattr(admin_services, "get_engine", lambda: object())
@@ -65,6 +65,7 @@ def test_create_service_duplicate_slug_maps_to_validation_error(
         "service_type": "training_course",
         "title": "Another course",
         "slug": "existing-slug",
+        "service_tier": "shared-tier",
         "delivery_mode": "online",
         "status": "draft",
         "tag_ids": [],

--- a/tests/test_admin_services_create_slug_duplicate.py
+++ b/tests/test_admin_services_create_slug_duplicate.py
@@ -86,5 +86,5 @@ def test_create_service_duplicate_slug_maps_to_validation_error(
     with pytest.raises(ValidationError) as exc_info:
         admin_services._create_service(event, actor_sub="actor")
     assert exc_info.value.status_code == 409
-    assert exc_info.value.field == "slug"
+    assert exc_info.value.field == "slug_tier"
     assert "slug" in exc_info.value.message.lower()

--- a/tests/test_admin_services_slug_violation.py
+++ b/tests/test_admin_services_slug_violation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from sqlalchemy.exc import IntegrityError
 
-from app.api.admin_services import _is_services_slug_unique_violation
+from app.api.admin_services import _is_services_slug_tier_unique_violation
 
 
 def _make_integrity_error(*, constraint_name: str | None, message: str) -> IntegrityError:
@@ -19,31 +19,31 @@ def _make_integrity_error(*, constraint_name: str | None, message: str) -> Integ
     return IntegrityError(message, None, orig)
 
 
-def test_slug_violation_true_when_constraint_name_matches() -> None:
+def test_slug_tier_violation_true_when_constraint_name_matches() -> None:
     exc = _make_integrity_error(
-        constraint_name="services_slug_unique_idx",
+        constraint_name="services_slug_tier_unique_idx",
         message="duplicate key",
     )
-    assert _is_services_slug_unique_violation(exc) is True
+    assert _is_services_slug_tier_unique_violation(exc) is True
 
 
-def test_slug_violation_false_for_other_unique_constraint() -> None:
+def test_slug_tier_violation_false_for_other_unique_constraint() -> None:
     exc = _make_integrity_error(
         constraint_name="svc_instances_slug_uq",
         message="duplicate key value violates unique constraint svc_instances_slug_uq",
     )
-    assert _is_services_slug_unique_violation(exc) is False
+    assert _is_services_slug_tier_unique_violation(exc) is False
 
 
-def test_slug_violation_message_fallback_rejects_instance_slug_constraint() -> None:
+def test_slug_tier_violation_message_fallback_rejects_instance_slug_constraint() -> None:
     exc_instance = _make_integrity_error(
         constraint_name=None,
         message='duplicate key value violates unique constraint "svc_instances_slug_uq"',
     )
-    assert _is_services_slug_unique_violation(exc_instance) is False
+    assert _is_services_slug_tier_unique_violation(exc_instance) is False
 
     exc_ok = _make_integrity_error(
         constraint_name=None,
-        message='duplicate key value violates unique constraint "services_slug_unique_idx"',
+        message='duplicate key value violates unique constraint "services_slug_tier_unique_idx"',
     )
-    assert _is_services_slug_unique_violation(exc_ok) is True
+    assert _is_services_slug_tier_unique_violation(exc_ok) is True

--- a/tests/test_admin_services_slug_violation.py
+++ b/tests/test_admin_services_slug_violation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from sqlalchemy.exc import IntegrityError
 
-from app.api.admin_services import _is_services_slug_tier_unique_violation
+from app.api.admin_services_integrity import is_services_slug_tier_unique_violation
 
 
 def _make_integrity_error(*, constraint_name: str | None, message: str) -> IntegrityError:
@@ -24,7 +24,7 @@ def test_slug_tier_violation_true_when_constraint_name_matches() -> None:
         constraint_name="services_slug_tier_unique_idx",
         message="duplicate key",
     )
-    assert _is_services_slug_tier_unique_violation(exc) is True
+    assert is_services_slug_tier_unique_violation(exc) is True
 
 
 def test_slug_tier_violation_false_for_other_unique_constraint() -> None:
@@ -32,7 +32,7 @@ def test_slug_tier_violation_false_for_other_unique_constraint() -> None:
         constraint_name="svc_instances_slug_uq",
         message="duplicate key value violates unique constraint svc_instances_slug_uq",
     )
-    assert _is_services_slug_tier_unique_violation(exc) is False
+    assert is_services_slug_tier_unique_violation(exc) is False
 
 
 def test_slug_tier_violation_message_fallback_rejects_instance_slug_constraint() -> None:
@@ -40,10 +40,10 @@ def test_slug_tier_violation_message_fallback_rejects_instance_slug_constraint()
         constraint_name=None,
         message='duplicate key value violates unique constraint "svc_instances_slug_uq"',
     )
-    assert _is_services_slug_tier_unique_violation(exc_instance) is False
+    assert is_services_slug_tier_unique_violation(exc_instance) is False
 
     exc_ok = _make_integrity_error(
         constraint_name=None,
         message='duplicate key value violates unique constraint "services_slug_tier_unique_idx"',
     )
-    assert _is_services_slug_tier_unique_violation(exc_ok) is True
+    assert is_services_slug_tier_unique_violation(exc_ok) is True

--- a/tests/test_services_slug_tier_unique_postgres.py
+++ b/tests/test_services_slug_tier_unique_postgres.py
@@ -1,0 +1,61 @@
+"""PostgreSQL semantics for services slug+tier unique index (NULLS NOT DISTINCT).
+
+Skipped unless ``TEST_DATABASE_URL`` is set (e.g. local Postgres for integration).
+Validates the DDL pattern used in migration ``0042_slug_nulls_nd``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg", reason="psycopg required for DB integration test")
+
+
+def _database_url() -> str | None:
+    url = os.getenv("TEST_DATABASE_URL", "").strip()
+    return url or None
+
+
+@pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
+def test_slug_tier_unique_index_treats_null_tier_as_single_bucket() -> None:
+    """Two rows with same slug and NULL tier must violate NULLS NOT DISTINCT unique index."""
+    ddl = (
+        "CREATE TEMP TABLE slug_tier_uq_probe ("
+        "slug varchar(80), service_tier varchar(128)"
+        ") ON COMMIT DROP"
+    )
+    idx = (
+        "CREATE UNIQUE INDEX slug_tier_uq_probe_idx "
+        "ON slug_tier_uq_probe (lower(slug), lower(service_tier)) "
+        "NULLS NOT DISTINCT WHERE slug IS NOT NULL"
+    )
+    url = _database_url()
+    assert url is not None
+
+    with psycopg.connect(url) as conn:
+        conn.execute(ddl)
+        conn.execute(idx)
+        conn.execute(
+            "INSERT INTO slug_tier_uq_probe (slug, service_tier) VALUES ('same-slug', NULL)"
+        )
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            conn.execute(
+                "INSERT INTO slug_tier_uq_probe (slug, service_tier) VALUES ('same-slug', NULL)"
+            )
+        conn.rollback()
+
+    with psycopg.connect(url) as conn:
+        conn.execute(ddl)
+        conn.execute(idx)
+        conn.execute(
+            "INSERT INTO slug_tier_uq_probe (slug, service_tier) VALUES ('x', NULL)"
+        )
+        conn.execute(
+            "INSERT INTO slug_tier_uq_probe (slug, service_tier) VALUES ('x', 'tier-a')"
+        )
+        conn.execute(
+            "INSERT INTO slug_tier_uq_probe (slug, service_tier) VALUES ('x', 'tier-b')"
+        )
+        conn.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **C1 (NULL tier):** New migration `0042_slug_nulls_nd` drops and recreates `services_slug_tier_unique_idx` with **`NULLS NOT DISTINCT`** so duplicate `(slug, NULL service_tier)` rows cannot coexist. Pre-upgrade **DO** block fails if duplicate `(lower(slug), service_tier)` groups exist among slugged rows.
- **C2 (downgrade / seed):** 0041 and 0042 downgrades document that restoring slug-only uniqueness is **not safe** once multiple tiers share a slug. Seed `UPDATE services SET slug = …` is tightened so slugs apply only when **exactly one** candidate row exists (avoids accidental duplicate slugs from broad title matches).
- **API (M1):** Duplicate slug+tier conflicts return **`field: slug_tier`** (single literal) with tier-specific messages; avoids swallowing unrelated `field: slug` 409s.
- **Admin web:** Conflict UI only activates for **`slug_tier`**; empty-tier message path covered by a Vitest case. **Service list:** tests assert column order (Title, Tier, …) and tier display.
- **H3:** `admin_services.py` split: integrity helpers → `admin_services_integrity.py`, cover presign → `admin_services_cover.py` (**437 lines** in main handler file).
- **Regression test:** `tests/test_services_slug_tier_unique_postgres.py` validates NULLS NOT DISTINCT DDL when **`TEST_DATABASE_URL`** is set (skipped in CI without DB).

## Testing

- `pytest tests/test_admin_services_slug_violation.py tests/test_admin_services_create_slug_duplicate.py tests/test_services_slug_tier_unique_postgres.py`
- `npm run lint` and Vitest for `service-editor-slug` + `table-value-formatting`

## Deploy

- Run migrations through **`0042_slug_nulls_nd`**; duplicate data will fail the guard until deduped.
- Downgrade from 0042/0041 is documented as unsafe in multi-tier-per-slug scenarios.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9d18660-e9d5-469a-a9f4-17e201c74495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9d18660-e9d5-469a-a9f4-17e201c74495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

