### PR TITLE
Suppress Checkov CKV_AWS_120 on disabled API Gateway stage cache

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2520,6 +2520,27 @@ export class ApiStack extends cdk.Stack {
     api.deploymentStage.node.addDependency(apiAccessLogGroupRetention);
     api.deploymentStage.node.addDependency(apiAccessLogGroupKey);
 
+    const cfnApiStage = api.deploymentStage.node
+      .defaultChild as apigateway.CfnStage | undefined;
+    if (!cfnApiStage) {
+      throw new Error(
+        "ApiStack: expected api.deploymentStage.node.defaultChild to be apigateway.CfnStage so Checkov CKV_AWS_120 suppression can be attached",
+      );
+    }
+    cfnApiStage.addMetadata("checkov", {
+      skip: [
+        {
+          id: "CKV_AWS_120",
+          comment: [
+            "Stage caching is intentionally disabled: no method opts into cachingEnabled: true; any historical cache cluster would have been idle.",
+            "Public-website cacheable GETs are edge-cached on the public_www CloudFront distribution via ApiProxyCachePolicy (see backend/infrastructure/lib/public-www-stack.ts).",
+            'Architectural decision: docs/architecture/decisions.md and docs/architecture/overview.md under "Caching".',
+            "Re-enabling stage cache requires removing this suppression and setting cachingEnabled: true on each cacheable method.",
+          ].join("\n"),
+        },
+      ],
+    });
+
     // -------------------------------------------------------------------------
     // Gateway Responses – add CORS headers to API Gateway error responses
     //

--- a/backend/infrastructure/test/api-stack.test.ts
+++ b/backend/infrastructure/test/api-stack.test.ts
@@ -54,9 +54,43 @@ function assertStageHasNoApiGatewayCacheCluster(template: Template): void {
   }
 }
 
+function assertStageHasCheckovCkv120Suppression(template: Template): void {
+  const stages = template.findResources("AWS::ApiGateway::Stage");
+  const entries = Object.entries(stages);
+  if (entries.length === 0) {
+    throw new Error("Expected at least one AWS::ApiGateway::Stage resource");
+  }
+  for (const [logicalId, resource] of entries) {
+    const skipUnknown = (resource as { Metadata?: { checkov?: { skip?: unknown } } })
+      .Metadata?.checkov?.skip;
+    if (!Array.isArray(skipUnknown)) {
+      throw new Error(
+        `Stage ${logicalId}: expected Metadata.checkov.skip to be an array; got ${JSON.stringify(skipUnknown)}`,
+      );
+    }
+    const ckv120 = skipUnknown.filter(
+      (item): item is { id?: unknown; comment?: unknown } =>
+        Boolean(item) && typeof item === "object",
+    );
+    const matches = ckv120.filter((item) => item.id === "CKV_AWS_120");
+    if (matches.length !== 1) {
+      throw new Error(
+        `Stage ${logicalId}: expected exactly one Checkov skip entry with id CKV_AWS_120; found ${matches.length}. Metadata.checkov.skip=${JSON.stringify(skipUnknown)}`,
+      );
+    }
+    const comment = matches[0].comment;
+    if (typeof comment !== "string" || comment.trim().length === 0) {
+      throw new Error(
+        `Stage ${logicalId}: CKV_AWS_120 suppression must include a non-empty comment string`,
+      );
+    }
+  }
+}
+
 function main(): void {
   const template = synthApiTemplate();
   assertStageHasNoApiGatewayCacheCluster(template);
+  assertStageHasCheckovCkv120Suppression(template);
   // eslint-disable-next-line no-console
   console.log("api-stack API Gateway stage cache assertions passed.");
 }

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -114,6 +114,10 @@ drops the old polymorphic tables, renames `crm_notes` → `notes`, and adds null
 - API Gateway stage caching is disabled; public website cacheability is driven
   by Lambda `Cache-Control` headers and the `public_www` CloudFront `www/*`
   cache policy (see architecture overview).
+  Checkov rule CKV_AWS_120 ("API Gateway caching enabled") is suppressed at the
+  stage level via CDK template metadata with a justified comment; re-enabling a
+  cache cluster would require removing that suppression and opting individual
+  methods into `cachingEnabled: true`.
 - See the OpenAPI specs for per-endpoint authentication requirements:
   [`docs/api/admin.yaml`](../api/admin.yaml).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Attach Checkov inline suppression **CKV_AWS_120** to the API Gateway deployment stage (`CfnStage`) via CDK `addMetadata("checkov", { skip: [...] })`, immediately after the existing `api.deploymentStage.node.addDependency(...)` calls in `ApiStack`.
- Guard with optional chaining on `defaultChild` and throw at synth time if missing (fail-fast).
- Add `assertStageHasCheckovCkv120Suppression` in `api-stack.test.ts` so every synthesized `AWS::ApiGateway::Stage` must carry exactly one justified CKV_AWS_120 skip.
- Extend the existing caching bullet in `docs/architecture/decisions.md` with a short note about the suppression and how to re-enable caching.

## Rationale

Stage-level API Gateway caching remains **off** by design; public cacheability is handled at CloudFront (`ApiProxyCachePolicy` in `public-www-stack.ts`) and via `Cache-Control` from Lambdas. CKV_AWS_120 is suppressed with a multi-line comment so SARIF/Code Scanning records a **skipped** finding with justification rather than an open violation.

## Validation

- `python3 backend/scripts/build_lambda_bundle.py`
- `npm run test:infra` (in `backend/infrastructure`)
- `bash scripts/validate-cursorrules.sh`
- `pre-commit run ruff-format --all-files`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af94c003-8060-4c8c-9e2a-a5f3d7600d7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af94c003-8060-4c8c-9e2a-a5f3d7600d7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

