### PR TITLE
Space around title·tier labels; format instance editor service select

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { formatEnumLabel, formatLocationLabel } from '@/lib/format';
+import { formatEnumLabel, formatLocationLabel, formatServiceTitleWithTier } from '@/lib/format';
 
 import { INSTANCE_STATUSES, SERVICE_DELIVERY_MODES } from '@/types/services';
 import type {
@@ -156,7 +156,7 @@ export function InstanceFormFields({
               ) : null}
               {serviceOptions.map((service) => (
                 <option key={service.id} value={service.id}>
-                  {service.title}
+                  {formatServiceTitleWithTier(service.title, service.serviceTier)}
                 </option>
               ))}
             </Select>

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -13,11 +13,11 @@ import adminSelectableCurrency from '@shared-config/admin-selectable-currency-co
 
 const SERVICE_TITLE_TIER_SEP = '\u00b7';
 
-/** Service list label: title, then interpunct, then tier when tier is set. */
+/** Service list label: title, space, interpunct, space, tier when tier is set. */
 export function formatServiceTitleWithTier(title: string, serviceTier: string | null): string {
   const tier = serviceTier?.trim();
   if (tier) {
-    return `${title}${SERVICE_TITLE_TIER_SEP}${tier}`;
+    return `${title} ${SERVICE_TITLE_TIER_SEP} ${tier}`;
   }
   return title;
 }

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -241,7 +241,7 @@ describe('services tables value formatting', () => {
 
     const tables = screen.getAllByRole('table');
     const instanceTable = tables[0] as HTMLElement;
-    expect(within(instanceTable).getByText('Yoga·adults')).toBeInTheDocument();
+    expect(within(instanceTable).getByText('Yoga · adults')).toBeInTheDocument();
     expect(within(instanceTable).getByText('In Progress')).toBeInTheDocument();
     expect(within(instanceTable).getByText('Spring 2024')).toBeInTheDocument();
     expect(within(instanceTable).getByText('Unlimited')).toBeInTheDocument();

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -78,8 +78,8 @@ describe('format helpers', () => {
     expect(ordered.map((s) => s.id)).toEqual(['b', 'a']);
   });
 
-  it('formats service title with tier using interpunct when tier is set', () => {
-    expect(formatServiceTitleWithTier('Yoga', 'adults')).toBe('Yoga·adults');
+  it('formats service title with tier using spaced interpunct when tier is set', () => {
+    expect(formatServiceTitleWithTier('Yoga', 'adults')).toBe('Yoga · adults');
     expect(formatServiceTitleWithTier('Yoga', null)).toBe('Yoga');
     expect(formatServiceTitleWithTier('Yoga', '  ')).toBe('Yoga');
   });


### PR DESCRIPTION
Use spaced interpunct in formatServiceTitleWithTier so list and filter labels match. Apply the same helper to InstanceFormFields service options.