### PR TITLE
Public calendar: slug + part ordinals; slug-based discount and reservations

### DIFF
--- a/apps/public_www/scripts/validate-content.mjs
+++ b/apps/public_www/scripts/validate-content.mjs
@@ -25,6 +25,7 @@ const PROTOCOL_RELATIVE_URL_REGEX = /^\/\//;
 const HTTP_PROTOCOL_REGEX = /^https?:\/\//i;
 const UUID_V4_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const INSTANCE_SLUG_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 const MAILTO_PROTOCOL_REGEX = /^mailto:/i;
 const TEL_PROTOCOL_REGEX = /^tel:/i;
 const GENERIC_SOCIAL_PROFILE_ROOT_REGEX =
@@ -462,16 +463,47 @@ function validateMyBestAuntieTrainingCourses(filePath, data, errors) {
       errors.push(`${prefix}: cohort must be an object`);
       continue;
     }
-    if (!('service_instance_id' in cohort)) {
-      errors.push(`${prefix}: missing service_instance_id`);
+    const slug = cohort.slug;
+    if (typeof slug !== 'string' || !slug.trim()) {
+      errors.push(`${prefix}: slug must be a non-empty string`);
       continue;
     }
-    const raw = cohort.service_instance_id;
-    if (raw === null) {
+    if (!INSTANCE_SLUG_REGEX.test(slug.trim())) {
+      errors.push(`${prefix}: slug must match the public instance slug pattern`);
+    }
+    const dates = cohort.dates;
+    if (!Array.isArray(dates) || dates.length === 0) {
+      errors.push(`${prefix}: dates must be a non-empty array`);
       continue;
     }
-    if (typeof raw !== 'string' || !UUID_V4_REGEX.test(raw.trim())) {
-      errors.push(`${prefix}: service_instance_id must be null or a UUID v4 string`);
+    const parts = [];
+    for (let d = 0; d < dates.length; d += 1) {
+      const slot = dates[d];
+      const slotPrefix = `${prefix}.dates[${d}]`;
+      if (!slot || typeof slot !== 'object' || Array.isArray(slot)) {
+        errors.push(`${slotPrefix}: must be an object`);
+        continue;
+      }
+      const part = slot.part;
+      if (typeof part !== 'number' || !Number.isInteger(part) || part < 1) {
+        errors.push(`${slotPrefix}: part must be an integer >= 1`);
+      } else {
+        parts.push(part);
+      }
+      for (const key of ['start_datetime', 'end_datetime']) {
+        if (typeof slot[key] !== 'string' || !slot[key].trim()) {
+          errors.push(`${slotPrefix}: ${key} must be a non-empty string`);
+        }
+      }
+    }
+    const sorted = [...parts].sort((a, b) => a - b);
+    const expected = Array.from({ length: sorted.length }, (_, i) => i + 1);
+    const matches =
+      sorted.length === expected.length && sorted.every((v, i) => v === expected[i]);
+    if (!matches) {
+      errors.push(
+        `${prefix}: dates[].part values must be the dense sequence 1..N with no gaps or duplicates`,
+      );
     }
   }
 }

--- a/apps/public_www/scripts/validate-content.mjs
+++ b/apps/public_www/scripts/validate-content.mjs
@@ -444,6 +444,70 @@ async function loadJson(filePath) {
   return JSON.parse(raw);
 }
 
+function validateEventsJsonFeed(filePath, data, errors) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    errors.push(`${filePath}: root must be an object`);
+    return;
+  }
+  if (data.status !== 'success') {
+    errors.push(`${filePath}: expected status "success"`);
+  }
+  if (!Array.isArray(data.data)) {
+    errors.push(`${filePath}: expected data array`);
+    return;
+  }
+  for (let index = 0; index < data.data.length; index += 1) {
+    const event = data.data[index];
+    const prefix = `${filePath}: data[${index}]`;
+    if (!event || typeof event !== 'object' || Array.isArray(event)) {
+      errors.push(`${prefix}: event must be an object`);
+      continue;
+    }
+    const slug = event.slug;
+    if (typeof slug !== 'string' || !slug.trim()) {
+      errors.push(`${prefix}: slug must be a non-empty string`);
+      continue;
+    }
+    if (!INSTANCE_SLUG_REGEX.test(slug.trim())) {
+      errors.push(`${prefix}: slug must match the public instance slug pattern`);
+    }
+    const dates = event.dates;
+    if (!Array.isArray(dates) || dates.length === 0) {
+      errors.push(`${prefix}: dates must be a non-empty array`);
+      continue;
+    }
+    const parts = [];
+    for (let d = 0; d < dates.length; d += 1) {
+      const slot = dates[d];
+      const slotPrefix = `${prefix}.dates[${d}]`;
+      if (!slot || typeof slot !== 'object' || Array.isArray(slot)) {
+        errors.push(`${slotPrefix}: must be an object`);
+        continue;
+      }
+      const part = slot.part;
+      if (typeof part !== 'number' || !Number.isInteger(part) || part < 1) {
+        errors.push(`${slotPrefix}: part must be an integer >= 1`);
+      } else {
+        parts.push(part);
+      }
+      for (const key of ['start_datetime', 'end_datetime']) {
+        if (typeof slot[key] !== 'string' || !slot[key].trim()) {
+          errors.push(`${slotPrefix}: ${key} must be a non-empty string`);
+        }
+      }
+    }
+    const sorted = [...parts].sort((a, b) => a - b);
+    const expected = Array.from({ length: sorted.length }, (_, i) => i + 1);
+    const matches =
+      sorted.length === expected.length && sorted.every((v, i) => v === expected[i]);
+    if (!matches) {
+      errors.push(
+        `${prefix}: dates[].part values must be the dense sequence 1..N with no gaps or duplicates`,
+      );
+    }
+  }
+}
+
 function validateMyBestAuntieTrainingCourses(filePath, data, errors) {
   if (!data || typeof data !== 'object' || Array.isArray(data)) {
     errors.push(`${filePath}: root must be an object`);
@@ -528,6 +592,10 @@ async function main() {
   const mbaCoursesPath = path.join(CONTENT_DIR, 'my-best-auntie-training-courses.json');
   const mbaCourses = await loadJson(mbaCoursesPath);
   validateMyBestAuntieTrainingCourses('my-best-auntie-training-courses.json', mbaCourses, errors);
+
+  const eventsPath = path.join(CONTENT_DIR, 'events.json');
+  const eventsData = await loadJson(eventsPath);
+  validateEventsJsonFeed('events.json', eventsData, errors);
 
   for (const [locale] of LOCALE_FILES) {
     const localeContent = localeMap[locale];

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -115,8 +115,8 @@ interface BookingReservationFormProps {
   captchaWidgetAction?: string;
   /** When set, included in discount validate API as `service_key` (public slug). */
   discountValidationServiceKey?: string;
-  /** Optional Aurora instance UUID for instance-scoped discount redemption. */
-  serviceInstanceId?: string | null;
+  /** Optional public instance slug for instance-scoped discount redemption. */
+  serviceInstanceSlug?: string | null;
   prefilledDiscountCode?: string;
   referralAppliedNote?: string;
   referralAppliedAnnouncement?: string;
@@ -457,7 +457,7 @@ export function BookingReservationForm({
   metaPixelContentName = PIXEL_CONTENT_NAME.my_best_auntie,
   captchaWidgetAction = 'mba_reservation_submit',
   discountValidationServiceKey,
-  serviceInstanceId,
+  serviceInstanceSlug,
   prefilledDiscountCode = '',
   referralAppliedNote = '',
   referralAppliedAnnouncement = '',
@@ -833,11 +833,11 @@ export function BookingReservationForm({
         setDiscountError('');
       }
       try {
-        const instanceForValidate = sanitizeSingleLineValue(serviceInstanceId ?? '');
+        const instanceSlugForValidate = sanitizeSingleLineValue(serviceInstanceSlug ?? '');
         const validatedRule = await validateDiscountCode(crmApiClient, {
           code: normalizedCode,
           serviceKey: scopeKey || undefined,
-          serviceInstanceId: instanceForValidate || undefined,
+          serviceInstanceSlug: instanceSlugForValidate || undefined,
         });
         if (!validatedRule) {
           if (options.autoApply) {
@@ -929,7 +929,7 @@ export function BookingReservationForm({
       courseSlug,
       discountRule,
       discountValidationServiceKey,
-      serviceInstanceId,
+      serviceInstanceSlug,
       originalPriceAmount,
       referralAppliedAnnouncement,
     ],
@@ -1242,12 +1242,12 @@ export function BookingReservationForm({
       ...(() => {
         const sanitizedServiceKey = sanitizeSingleLineValue(reservationServiceKey ?? '');
         const sanitizedCourseSlug = sanitizeSingleLineValue(courseSlug ?? '');
-        const instanceUuid = sanitizeSingleLineValue(serviceInstanceId ?? '');
+        const instanceSlug = sanitizeSingleLineValue(serviceInstanceSlug ?? '');
         const sanitizedServiceSlug = sanitizeSingleLineValue(serviceSlug ?? '');
         return {
           ...(sanitizedServiceKey ? { serviceKey: sanitizedServiceKey } : {}),
           ...(sanitizedCourseSlug ? { courseSlug: sanitizedCourseSlug } : {}),
-          ...(instanceUuid ? { serviceInstanceId: instanceUuid } : {}),
+          ...(instanceSlug ? { serviceInstanceSlug: instanceSlug } : {}),
           ...(sanitizedServiceSlug ? { service: sanitizedServiceSlug } : {}),
         };
       })(),

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -84,9 +84,12 @@ interface BookingReservationFormProps {
   locale: Locale;
   content: BookingPaymentModalContent;
   eventTitle: string;
-  /** Stable id for reservation payload / Mailchimp booking tag (e.g. cohort or event id). */
+  /**
+   * Aurora `services.slug` for discount scope and lead metadata `service_key`
+   * (e.g. `my-best-auntie` for MBA). Not the instance/cohort slug.
+   */
   reservationServiceKey?: string;
-  /** Optional cohort identifier for Stripe metadata (e.g. MBA cohort id). */
+  /** Instance or event stable id for Stripe PaymentIntent metadata (`cohort_id`). */
   cohortId?: string;
   /** Stable slug when reservationServiceKey is not set (e.g. my-best-auntie, consultation tier). */
   courseSlug?: string;

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking-modal.tsx
@@ -177,7 +177,7 @@ export function MyBestAuntieBookingModal({
               locale={locale}
               content={paymentModalContent}
               eventTitle={modalContent.title}
-              reservationServiceKey={selectedCohort?.slug ?? ''}
+              reservationServiceKey='my-best-auntie'
               cohortId={selectedCohort?.slug ?? ''}
               courseSlug='my-best-auntie'
               serviceSlug={selectedCohort?.service ?? 'training-course'}

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking-modal.tsx
@@ -177,12 +177,12 @@ export function MyBestAuntieBookingModal({
               locale={locale}
               content={paymentModalContent}
               eventTitle={modalContent.title}
-              reservationServiceKey={selectedCohort?.id ?? ''}
-              cohortId={selectedCohort?.id ?? ''}
+              reservationServiceKey={selectedCohort?.slug ?? ''}
+              cohortId={selectedCohort?.slug ?? ''}
               courseSlug='my-best-auntie'
               serviceSlug={selectedCohort?.service ?? 'training-course'}
               discountValidationServiceKey='my-best-auntie'
-              serviceInstanceId={selectedCohort?.service_instance_id ?? null}
+              serviceInstanceSlug={selectedCohort?.slug ?? null}
               prefilledDiscountCode={prefilledDiscountCode}
               referralAppliedNote={referralAppliedNote}
               referralAppliedAnnouncement={referralAppliedAnnouncement}

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking.tsx
@@ -158,7 +158,7 @@ function sortCohortsByPrimarySession(
     return cohortDifference;
   }
 
-  return leftCohort.id.localeCompare(rightCohort.id);
+  return leftCohort.slug.localeCompare(rightCohort.slug);
 }
 
 function findPreferredCohortId(
@@ -169,7 +169,7 @@ function findPreferredCohortId(
     (cohort) => cohort.service_tier === ageGroupId,
   );
   const available = ageGroupCohorts.find((cohort) => !cohort.is_fully_booked);
-  return available?.id ?? ageGroupCohorts[0]?.id ?? '';
+  return available?.slug ?? ageGroupCohorts[0]?.slug ?? '';
 }
 
 function getPrimarySessionDateTimeLabel(
@@ -241,7 +241,7 @@ export function MyBestAuntieBooking({
     return cohort.service_tier === selectedAgeId;
   });
   const dateOptions: BookingDateOption[] = cohortsForSelectedAge.map((cohort) => ({
-    id: cohort.id,
+    id: cohort.slug,
     label: formatCohortValue(cohort.cohort, locale),
     availabilityLabel: formatSpacesLeftLabel(
       cohort.spaces_left,

--- a/apps/public_www/src/content/events.json
+++ b/apps/public_www/src/content/events.json
@@ -2,9 +2,8 @@
   "status": "success",
   "data": [
     {
-      "id": "bimbo-concept-weaning-2026-03-20",
       "title": "Bump does...Weaning",
-      "description": "Join us for a relaxed and informative 2-hour workshop on weaning + play, designed to support parents as they prepare, begin or get new ideas for their baby’s food journey. A 1-hour workshop PLUS 1-hour of access to the wonderful BIMBO playroom!",
+      "description": "Join us for a relaxed and informative 2-hour workshop on weaning + play, designed to support parents as they prepare, begin or get new ideas for their baby\u2019s food journey. A 1-hour workshop PLUS 1-hour of access to the wonderful BIMBO playroom!",
       "tags": [
         "12mo+"
       ],
@@ -19,7 +18,8 @@
       "dates": [
         {
           "start_datetime": "2026-03-20T02:30:00Z",
-          "end_datetime": "2026-03-20T04:30:00Z"
+          "end_datetime": "2026-03-20T04:30:00Z",
+          "part": 1
         }
       ],
       "price": 350,
@@ -28,10 +28,10 @@
       "external_url": "https://www.bump-and-co.com/event-details/bump-does-weaning-with-evolve-sprouts-bimbo-concept",
       "location_address": "9 Bimbo Concept Children's Residency @ Pacific Place Apartments",
       "location_url": "https://maps.google.com/?q=Pacific+Place+Apartments",
-      "location_name": "Bimbo Concept"
+      "location_name": "Bimbo Concept",
+      "slug": "bimbo-concept-weaning-2026-03-20"
     },
     {
-      "id": "easter-2026-montessori-play-coaching-workshop-2026-04-06",
       "title": "Easter 2026 Montessori Play Coaching Workshop",
       "description": "A practical Montessori-inspired play coaching workshop for children ages 1-4, with parent and child participation (helpers warmly welcome).",
       "landing_page": "easter-2026-montessori-play-coaching-workshop",
@@ -53,7 +53,8 @@
       "dates": [
         {
           "start_datetime": "2026-04-06T02:00:00Z",
-          "end_datetime": "2026-04-06T03:00:00Z"
+          "end_datetime": "2026-04-06T03:00:00Z",
+          "part": 1
         }
       ],
       "spaces_total": 6,
@@ -63,12 +64,12 @@
       "is_fully_booked": false,
       "location_name": "Baumhaus",
       "location_address": "1/F Kar Yau Building, 36-44 Queen's Rd E, Wan Chai",
-      "location_url": "https://www.google.com/maps/dir/?api=1&destination=Baumhaus,+1/F+Kar+Yau+Building,+36-44+Queen%27s+Rd+E,+Wan+Chai"
+      "location_url": "https://www.google.com/maps/dir/?api=1&destination=Baumhaus,+1/F+Kar+Yau+Building,+36-44+Queen%27s+Rd+E,+Wan+Chai",
+      "slug": "easter-2026-montessori-play-coaching-workshop-2026-04-06"
     },
     {
-      "id": "the-missing-piece-2026-05-16",
       "title": "The Missing Piece",
-      "description": "A hands-on workshop for families with children aged 0–2: the right toys, simple play-space tweaks, and practical tools your helper can use right away. Hosted with Little HK at Acorn Playhouse.",
+      "description": "A hands-on workshop for families with children aged 0\u20132: the right toys, simple play-space tweaks, and practical tools your helper can use right away. Hosted with Little HK at Acorn Playhouse.",
       "landing_page": "may-2026-the-missing-piece",
       "tags": [
         "0-2",
@@ -87,7 +88,8 @@
       "dates": [
         {
           "start_datetime": "2026-05-16T01:00:00Z",
-          "end_datetime": "2026-05-16T02:00:00Z"
+          "end_datetime": "2026-05-16T02:00:00Z",
+          "part": 1
         }
       ],
       "spaces_total": 8,
@@ -97,7 +99,8 @@
       "is_fully_booked": false,
       "location_name": "Acorn Playhouse",
       "location_address": "3/F, 4 Yip Fat St, Wong Chuk Hang",
-      "location_url": "https://www.google.com/maps/dir/?api=1&destination=3%2FF%2C+4+Yip+Fat+St%2C+Wong+Chuk+Hang"
+      "location_url": "https://www.google.com/maps/dir/?api=1&destination=3%2FF%2C+4+Yip+Fat+St%2C+Wong+Chuk+Hang",
+      "slug": "the-missing-piece-2026-05-16"
     }
   ]
 }

--- a/apps/public_www/src/content/events.json
+++ b/apps/public_www/src/content/events.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "title": "Bump does...Weaning",
-      "description": "Join us for a relaxed and informative 2-hour workshop on weaning + play, designed to support parents as they prepare, begin or get new ideas for their baby\u2019s food journey. A 1-hour workshop PLUS 1-hour of access to the wonderful BIMBO playroom!",
+      "description": "Join us for a relaxed and informative 2-hour workshop on weaning + play, designed to support parents as they prepare, begin or get new ideas for their baby's food journey. A 1-hour workshop PLUS 1-hour of access to the wonderful BIMBO playroom!",
       "tags": [
         "12mo+"
       ],
@@ -69,7 +69,7 @@
     },
     {
       "title": "The Missing Piece",
-      "description": "A hands-on workshop for families with children aged 0\u20132: the right toys, simple play-space tweaks, and practical tools your helper can use right away. Hosted with Little HK at Acorn Playhouse.",
+      "description": "A hands-on workshop for families with children aged 0–2: the right toys, simple play-space tweaks, and practical tools your helper can use right away. Hosted with Little HK at Acorn Playhouse.",
       "landing_page": "may-2026-the-missing-piece",
       "tags": [
         "0-2",

--- a/apps/public_www/src/content/my-best-auntie-training-courses.json
+++ b/apps/public_www/src/content/my-best-auntie-training-courses.json
@@ -2,7 +2,6 @@
   "status": "success",
   "data": [
     {
-      "id": "my-best-auntie-0-1-04-26",
       "service_tier": "0-1",
       "title": "My Best Auntie Training Course 0-1 - Apr 26",
       "description": "Nurturing the Foundations. In the first year, your helper learns to create a calm, responsive environment that supports your baby's natural development. We focus on respectful caregiving routines, safe spaces for exploration, and language-rich interactions that build secure attachment.",
@@ -23,29 +22,28 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-04-19T01:00:00Z",
-          "end_datetime": "2026-04-19T03:00:00Z"
+          "end_datetime": "2026-04-19T03:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-05-10T01:00:00Z",
-          "end_datetime": "2026-05-10T03:00:00Z"
+          "end_datetime": "2026-05-10T03:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-05-31T01:00:00Z",
-          "end_datetime": "2026-05-31T03:00:00Z"
+          "end_datetime": "2026-05-31T03:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-0-1-04-26"
     },
     {
-      "id": "my-best-auntie-0-1-05-26",
       "service_tier": "0-1",
       "title": "My Best Auntie Training Course 0-1 - May 26",
       "description": "Nurturing the Foundations. In the first year, your helper learns to create a calm, responsive environment that supports your baby's natural development. We focus on respectful caregiving routines, safe spaces for exploration, and language-rich interactions that build secure attachment.",
@@ -66,29 +64,28 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-05-17T01:00:00Z",
-          "end_datetime": "2026-05-17T03:00:00Z"
+          "end_datetime": "2026-05-17T03:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-06-07T01:00:00Z",
-          "end_datetime": "2026-06-07T03:00:00Z"
+          "end_datetime": "2026-06-07T03:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-06-28T01:00:00Z",
-          "end_datetime": "2026-06-28T03:00:00Z"
+          "end_datetime": "2026-06-28T03:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-0-1-05-26"
     },
     {
-      "id": "my-best-auntie-0-1-06-26",
       "service_tier": "0-1",
       "title": "My Best Auntie Training Course 0-1 - Jun 26",
       "description": "Nurturing the Foundations. In the first year, your helper learns to create a calm, responsive environment that supports your baby's natural development. We focus on respectful caregiving routines, safe spaces for exploration, and language-rich interactions that build secure attachment.",
@@ -109,29 +106,28 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-06-14T01:00:00Z",
-          "end_datetime": "2026-06-14T03:00:00Z"
+          "end_datetime": "2026-06-14T03:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-07-05T01:00:00Z",
-          "end_datetime": "2026-07-05T03:00:00Z"
+          "end_datetime": "2026-07-05T03:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-07-26T01:00:00Z",
-          "end_datetime": "2026-07-26T03:00:00Z"
+          "end_datetime": "2026-07-26T03:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-0-1-06-26"
     },
     {
-      "id": "my-best-auntie-1-3-04-26",
       "service_tier": "1-3",
       "title": "My Best Auntie Training Course 1-3 - Apr 26",
       "description": "Fostering First Independence. Toddlers are wired to do things themselves - and your helper can nurture this beautifully. This track equips helpers with practical strategies for mealtimes, dressing, and daily routines that build your child's confidence, reduce power struggles, and make \"I do it myself!\" moments a joy, not a battle.",
@@ -152,29 +148,28 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-04-18T01:00:00Z",
-          "end_datetime": "2026-04-18T03:00:00Z"
+          "end_datetime": "2026-04-18T03:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-05-09T01:00:00Z",
-          "end_datetime": "2026-05-09T03:00:00Z"
+          "end_datetime": "2026-05-09T03:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-05-30T01:00:00Z",
-          "end_datetime": "2026-05-30T03:00:00Z"
+          "end_datetime": "2026-05-30T03:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-1-3-04-26"
     },
     {
-      "id": "my-best-auntie-1-3-05-26",
       "service_tier": "1-3",
       "title": "My Best Auntie Training Course 1-3 - May 26",
       "description": "Fostering First Independence. Toddlers are wired to do things themselves - and your helper can nurture this beautifully. This track equips helpers with practical strategies for mealtimes, dressing, and daily routines that build your child's confidence, reduce power struggles, and make \"I do it myself!\" moments a joy, not a battle.",
@@ -195,29 +190,28 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-05-16T01:00:00Z",
-          "end_datetime": "2026-05-16T03:00:00Z"
+          "end_datetime": "2026-05-16T03:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-06-06T01:00:00Z",
-          "end_datetime": "2026-06-06T03:00:00Z"
+          "end_datetime": "2026-06-06T03:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-06-27T01:00:00Z",
-          "end_datetime": "2026-06-27T03:00:00Z"
+          "end_datetime": "2026-06-27T03:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-1-3-05-26"
     },
     {
-      "id": "my-best-auntie-1-3-06-26",
       "service_tier": "1-3",
       "title": "My Best Auntie Training Course 1-3 - Jun 26",
       "description": "Fostering First Independence. Toddlers are wired to do things themselves - and your helper can nurture this beautifully. This track equips helpers with practical strategies for mealtimes, dressing, and daily routines that build your child's confidence, reduce power struggles, and make \"I do it myself!\" moments a joy, not a battle.",
@@ -238,29 +232,28 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-06-13T01:00:00Z",
-          "end_datetime": "2026-06-13T03:00:00Z"
+          "end_datetime": "2026-06-13T03:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-07-04T01:00:00Z",
-          "end_datetime": "2026-07-04T03:00:00Z"
+          "end_datetime": "2026-07-04T03:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-07-25T01:00:00Z",
-          "end_datetime": "2026-07-25T03:00:00Z"
+          "end_datetime": "2026-07-25T03:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-1-3-06-26"
     },
     {
-      "id": "my-best-auntie-3-6-04-26",
       "service_tier": "3-6",
       "title": "My Best Auntie Training Course 3-6 - Apr 26",
       "description": "Building Capable, Confident Kids. At this stage, children are ready to take on real responsibility and thrive with clear boundaries. Your helper will learn how to guide without over-helping, set respectful limits, and create an environment where your child develops focus, independence, and a genuine love of learning.",
@@ -281,29 +274,28 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-04-18T04:00:00Z",
-          "end_datetime": "2026-04-18T06:00:00Z"
+          "end_datetime": "2026-04-18T06:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-05-09T04:00:00Z",
-          "end_datetime": "2026-05-09T06:00:00Z"
+          "end_datetime": "2026-05-09T06:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-05-30T04:00:00Z",
-          "end_datetime": "2026-05-30T06:00:00Z"
+          "end_datetime": "2026-05-30T06:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-3-6-04-26"
     },
     {
-      "id": "my-best-auntie-3-6-05-26",
       "service_tier": "3-6",
       "title": "My Best Auntie Training Course 3-6 - May 26",
       "description": "Building Capable, Confident Kids. At this stage, children are ready to take on real responsibility and thrive with clear boundaries. Your helper will learn how to guide without over-helping, set respectful limits, and create an environment where your child develops focus, independence, and a genuine love of learning.",
@@ -324,29 +316,28 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-05-16T04:00:00Z",
-          "end_datetime": "2026-05-16T06:00:00Z"
+          "end_datetime": "2026-05-16T06:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-06-06T04:00:00Z",
-          "end_datetime": "2026-06-06T06:00:00Z"
+          "end_datetime": "2026-06-06T06:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-06-27T04:00:00Z",
-          "end_datetime": "2026-06-27T06:00:00Z"
+          "end_datetime": "2026-06-27T06:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-3-6-05-26"
     },
     {
-      "id": "my-best-auntie-3-6-06-26",
       "service_tier": "3-6",
       "title": "My Best Auntie Training Course 3-6 - Jun 26",
       "description": "Building Capable, Confident Kids. At this stage, children are ready to take on real responsibility and thrive with clear boundaries. Your helper will learn how to guide without over-helping, set respectful limits, and create an environment where your child develops focus, independence, and a genuine love of learning.",
@@ -367,26 +358,26 @@
       ],
       "dates": [
         {
-          "id": "part-1",
           "start_datetime": "2026-06-13T04:00:00Z",
-          "end_datetime": "2026-06-13T06:00:00Z"
+          "end_datetime": "2026-06-13T06:00:00Z",
+          "part": 1
         },
         {
-          "id": "part-2",
           "start_datetime": "2026-07-04T04:00:00Z",
-          "end_datetime": "2026-07-04T06:00:00Z"
+          "end_datetime": "2026-07-04T06:00:00Z",
+          "part": 2
         },
         {
-          "id": "part-3",
           "start_datetime": "2026-07-25T04:00:00Z",
-          "end_datetime": "2026-07-25T06:00:00Z"
+          "end_datetime": "2026-07-25T06:00:00Z",
+          "part": 3
         }
       ],
       "location_address": "Unit 507, 5/F, Arion Commercial Centre, 2-12 Queen's Road West, Sheung Wan",
       "location_url": "https://www.google.com/maps/dir/?api=1&destination=Arion+Commercial+Centre,+2-12+Queen%27s+Road+West,+Sheung+Wan",
       "location_name": "Evolve Sprouts",
-      "service_instance_id": null,
-      "service": "training-course"
+      "service": "training-course",
+      "slug": "my-best-auntie-3-6-06-26"
     }
   ]
 }

--- a/apps/public_www/src/lib/discounts-data.ts
+++ b/apps/public_www/src/lib/discounts-data.ts
@@ -127,7 +127,7 @@ export function buildDiscountValidationApiUrl(crmApiBaseUrl: string): string {
 export interface ValidateDiscountCodeOptions {
   code: string;
   serviceKey?: string;
-  serviceInstanceId?: string;
+  serviceInstanceSlug?: string;
   signal?: AbortSignal;
 }
 
@@ -147,9 +147,9 @@ export async function validateDiscountCode(
   if (scopedKey) {
     body.service_key = scopedKey;
   }
-  const instanceId = readRequiredText(options.serviceInstanceId ?? '');
-  if (instanceId) {
-    body.service_instance_id = instanceId;
+  const instanceSlug = readRequiredText(options.serviceInstanceSlug ?? '');
+  if (instanceSlug) {
+    body.service_instance_slug = instanceSlug;
   }
 
   const payload = await crmApiClient.request({

--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -42,6 +42,8 @@ const MY_BEST_AUNTIE_BOOKING_HASH = 'my-best-auntie-booking';
 
 interface EventBookingDatePart {
   id: string;
+  /** 1-based session ordinal when known from API/content `part` (for MBA cohort dates). */
+  sessionPart?: number;
   startDateTime: string;
   endDateTime: string;
   description: string;
@@ -103,9 +105,7 @@ interface MyBestAuntieEventCohortDate {
 }
 
 export interface MyBestAuntieEventCohort {
-  /** Stable public cohort key (maps to `service_instances.slug` from API; content `slug`). */
-  id: string;
-  /** Same as `id`; public instance slug for discount/reservation scope. */
+  /** Public instance slug (`service_instances.slug` from API; content `slug`). */
   slug: string;
   /** Tier slug from calendar/API JSON key `service_tier` (formerly `age_group`). */
   service_tier: string;
@@ -421,6 +421,7 @@ function resolveBookingDateParts(
 
       return {
         id,
+        sessionPart: part,
         startDateTime,
         endDateTime,
         description: index === 0 ? defaultDescription : '',
@@ -506,19 +507,17 @@ function buildMyBestAuntieBookingModalPayload(
   const locationUrl = sanitizeGoogleMapsHref(
     readCandidateText(record, ['location_url', 'locationUrl', 'address_url']),
   );
-  const dates = resolveBookingDateParts(record, '')
-    .map((partRow, idx) => {
-      const partMatch = /^part-(\d+)$/.exec(partRow.id);
-      const part =
-        partMatch && partMatch[1]
-          ? Number.parseInt(partMatch[1], 10)
-          : idx + 1;
-      return {
-        part: Number.isFinite(part) && part > 0 ? part : idx + 1,
-        start_datetime: partRow.startDateTime,
-        end_datetime: partRow.endDateTime,
-      };
-    });
+  const dates = resolveBookingDateParts(record, '').map((partRow, idx) => {
+    const part =
+      typeof partRow.sessionPart === 'number' && partRow.sessionPart > 0
+        ? partRow.sessionPart
+        : idx + 1;
+    return {
+      part,
+      start_datetime: partRow.startDateTime,
+      end_datetime: partRow.endDateTime,
+    };
+  });
   if (dates.length === 0) {
     return null;
   }
@@ -526,7 +525,6 @@ function buildMyBestAuntieBookingModalPayload(
   const service = readCandidateText(record, ['service']) ?? 'training-course';
 
   const selectedCohort: MyBestAuntieEventCohort = {
-    id: slug,
     slug,
     service_tier: ageGroup,
     service,

--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -97,13 +97,16 @@ export type EventBookingModalPayload =
   | ConsultationEventBookingModalPayload;
 
 interface MyBestAuntieEventCohortDate {
-  id: string;
+  part: number;
   start_datetime: string;
   end_datetime: string;
 }
 
 export interface MyBestAuntieEventCohort {
+  /** Stable public cohort key (maps to `service_instances.slug` from API; content `slug`). */
   id: string;
+  /** Same as `id`; public instance slug for discount/reservation scope. */
+  slug: string;
   /** Tier slug from calendar/API JSON key `service_tier` (formerly `age_group`). */
   service_tier: string;
   title: string;
@@ -121,8 +124,6 @@ export interface MyBestAuntieEventCohort {
   location_name: string;
   location_address: string;
   location_url: string;
-  /** Aurora `service_instances.id` when present on the source record; otherwise null. */
-  service_instance_id: string | null;
   /** High-level service type for confirmations (from cohort JSON `service`). */
   service?: string;
   dates: MyBestAuntieEventCohortDate[];
@@ -397,7 +398,23 @@ function resolveBookingDateParts(
         'endDateTime',
         'end',
       ]) ?? '';
-      const id = readCandidateText(dateRecord, ['id']) ?? `part-${index + 1}`;
+      const partRaw = readFirstCandidateValue(dateRecord, ['part', 'Part']);
+      let part: number | null = null;
+      if (typeof partRaw === 'number' && Number.isInteger(partRaw) && partRaw > 0) {
+        part = partRaw;
+      } else {
+        const partText = readOptionalText(partRaw);
+        if (partText) {
+          const parsed = Number.parseInt(partText, 10);
+          if (Number.isFinite(parsed) && parsed > 0) {
+            part = parsed;
+          }
+        }
+      }
+      if (part === null) {
+        part = index + 1;
+      }
+      const id = `part-${part}`;
       if (!startDateTime) {
         return null;
       }
@@ -436,7 +453,7 @@ function buildEventBookingModalPayload(
 
   const topicsFieldConfig = resolveBookingTopicsFieldFromLandingPage(record, locale);
 
-  const serviceKey = readCandidateText(record, ['id', 'eventId', 'slug']);
+  const serviceKey = readCandidateText(record, ['slug', 'id', 'eventId']);
   const service = readCandidateText(record, ['service']) ?? 'event';
 
   return {
@@ -461,13 +478,11 @@ function buildMyBestAuntieBookingModalPayload(
   record: Record<string, unknown>,
   locale: Locale,
 ): MyBestAuntieBookingModalPayload | null {
-  const id =
-    readCandidateText(record, ['id', 'eventId', 'slug']) ??
-    readCandidateText(record, ['service_instance_id', 'service_instance_uuid']) ??
-    '';
+  const slug =
+    readCandidateText(record, ['slug', 'id', 'eventId'])?.trim() ?? '';
   const ageGroup = readCandidateText(record, ['service_tier']) ?? '';
   const cohortValue = readCandidateText(record, ['cohort']) ?? '';
-  if (!id || !ageGroup || !cohortValue) {
+  if (!slug || !ageGroup || !cohortValue) {
     return null;
   }
 
@@ -491,14 +506,17 @@ function buildMyBestAuntieBookingModalPayload(
   const locationUrl = sanitizeGoogleMapsHref(
     readCandidateText(record, ['location_url', 'locationUrl', 'address_url']),
   );
-  const serviceInstanceId =
-    readCandidateText(record, ['service_instance_id', 'service_instance_uuid']) ?? null;
   const dates = resolveBookingDateParts(record, '')
-    .map((part) => {
+    .map((partRow, idx) => {
+      const partMatch = /^part-(\d+)$/.exec(partRow.id);
+      const part =
+        partMatch && partMatch[1]
+          ? Number.parseInt(partMatch[1], 10)
+          : idx + 1;
       return {
-        id: part.id,
-        start_datetime: part.startDateTime,
-        end_datetime: part.endDateTime,
+        part: Number.isFinite(part) && part > 0 ? part : idx + 1,
+        start_datetime: partRow.startDateTime,
+        end_datetime: partRow.endDateTime,
       };
     });
   if (dates.length === 0) {
@@ -508,7 +526,8 @@ function buildMyBestAuntieBookingModalPayload(
   const service = readCandidateText(record, ['service']) ?? 'training-course';
 
   const selectedCohort: MyBestAuntieEventCohort = {
-    id,
+    id: slug,
+    slug,
     service_tier: ageGroup,
     service,
     title,
@@ -526,7 +545,6 @@ function buildMyBestAuntieBookingModalPayload(
     location_name: locationName,
     location_address: locationAddress,
     location_url: locationUrl,
-    service_instance_id: serviceInstanceId,
     dates,
   };
 
@@ -1227,7 +1245,7 @@ function normalizeEventCard(
     readCandidateText(record, ['ctaLabel', 'buttonLabel', 'actionLabel']) ??
     content.card.ctaLabel;
 
-  const rawId = readCandidateText(record, ['id', 'eventId', 'slug']) ?? '';
+  const rawId = readCandidateText(record, ['slug', 'id', 'eventId']) ?? '';
   const fallbackId = `${title}-${dateLabel ?? ''}-${index}`;
   const status = resolveEventStatus(record);
   const tags = readTagList(record);

--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -381,53 +381,53 @@ function resolveBookingDateParts(
 ): EventBookingDatePart[] {
   const dateEntries = Array.isArray(record.dates) ? record.dates : [];
 
-  return dateEntries
-    .map((entry, index) => {
-      const dateRecord = toRecord(entry);
-      if (!dateRecord) {
-        return null;
-      }
+  return dateEntries.flatMap((entry, index): EventBookingDatePart[] => {
+    const dateRecord = toRecord(entry);
+    if (!dateRecord) {
+      return [];
+    }
 
-      const startDateTime = readCandidateText(dateRecord, [
-        'start_datetime',
-        'startDateTime',
-        'start',
-      ]) ?? '';
-      const endDateTime = readCandidateText(dateRecord, [
-        'end_datetime',
-        'endDateTime',
-        'end',
-      ]) ?? '';
-      const partRaw = readFirstCandidateValue(dateRecord, ['part', 'Part']);
-      let part: number | null = null;
-      if (typeof partRaw === 'number' && Number.isInteger(partRaw) && partRaw > 0) {
-        part = partRaw;
-      } else {
-        const partText = readOptionalText(partRaw);
-        if (partText) {
-          const parsed = Number.parseInt(partText, 10);
-          if (Number.isFinite(parsed) && parsed > 0) {
-            part = parsed;
-          }
+    const startDateTime = readCandidateText(dateRecord, [
+      'start_datetime',
+      'startDateTime',
+      'start',
+    ]) ?? '';
+    const endDateTime = readCandidateText(dateRecord, [
+      'end_datetime',
+      'endDateTime',
+      'end',
+    ]) ?? '';
+    const partRaw = readFirstCandidateValue(dateRecord, ['part', 'Part']);
+    let part: number | null = null;
+    if (typeof partRaw === 'number' && Number.isInteger(partRaw) && partRaw > 0) {
+      part = partRaw;
+    } else {
+      const partText = readOptionalText(partRaw);
+      if (partText) {
+        const parsed = Number.parseInt(partText, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          part = parsed;
         }
       }
-      if (part === null) {
-        part = index + 1;
-      }
-      const id = `part-${part}`;
-      if (!startDateTime) {
-        return null;
-      }
+    }
+    if (part === null) {
+      part = index + 1;
+    }
+    const id = `part-${part}`;
+    if (!startDateTime) {
+      return [];
+    }
 
-      return {
+    return [
+      {
         id,
         sessionPart: part,
         startDateTime,
         endDateTime,
         description: index === 0 ? defaultDescription : '',
-      };
-    })
-    .filter((entry): entry is EventBookingDatePart => entry !== null);
+      },
+    ];
+  });
 }
 
 function buildEventBookingModalPayload(

--- a/apps/public_www/src/lib/reservations-data.ts
+++ b/apps/public_www/src/lib/reservations-data.ts
@@ -37,8 +37,8 @@ export interface ReservationSubmissionPayload {
   courseSlug?: string;
   /** Optional high-level service type for confirmation email (event, training-course, consultation). */
   service?: string;
-  /** Aurora service_instances.id for instance-scoped discount redemption. */
-  serviceInstanceId?: string;
+  /** Public service_instances.slug for instance-scoped discount redemption. */
+  serviceInstanceSlug?: string;
   scheduleDateLabel?: string;
   scheduleTimeLabel?: string;
   /** Consultation booking: writing focus title for confirmation email Details row. */

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -272,13 +272,17 @@ const expectedMbaMarketingFields = {
   locale: 'en' as const,
   courseLabel: myBestAuntieModalContent.title,
   courseSlug: 'my-best-auntie',
-  serviceKey: selectedCohort.id,
+  service: 'training-course',
+  serviceKey: selectedCohort.slug,
+  serviceInstanceSlug: selectedCohort.slug,
   scheduleDateLabel: 'Apr, 2026',
   scheduleTimeLabel: expectedMbaScheduleTimeLabel,
   locationName: selectedCohort.location_name,
   locationAddress: selectedCohort.location_address,
   locationUrl: selectedCohort.location_url,
   primarySessionStartIso: primarySessionPart?.start_datetime,
+  primarySessionEndIso: primarySessionPart?.end_datetime,
+  commentsFieldLabel: bookingModalContent.topicsInterestLabel,
   courseSessions: selectedCohort.dates.map((part) => {
     return {
       startIso: part.start_datetime,
@@ -763,7 +767,7 @@ describe('my-best-auntie booking modals footer content', () => {
         {
           code: 'SAVE10',
           serviceKey: 'my-best-auntie',
-          serviceInstanceId: selectedCohort.service_instance_id ?? undefined,
+          serviceInstanceSlug: selectedCohort.slug ?? undefined,
         },
       );
       expect(
@@ -1449,7 +1453,7 @@ describe('my-best-auntie booking modals footer content', () => {
       expect.objectContaining({
         payload: expect.objectContaining({
           service_key: 'my-best-auntie',
-          cohort_id: selectedCohort.id,
+          cohort_id: selectedCohort.slug,
         }),
       }),
     );
@@ -2033,7 +2037,7 @@ describe('my-best-auntie booking modals footer content', () => {
     expect(mockedValidateDiscountCode).toHaveBeenCalledWith(expect.anything(), {
       code: 'REFSAVE',
       serviceKey: 'my-best-auntie',
-      serviceInstanceId: selectedCohort.service_instance_id ?? undefined,
+      serviceInstanceSlug: selectedCohort.slug ?? undefined,
     });
 
     await waitFor(() => {
@@ -2049,7 +2053,7 @@ describe('my-best-auntie booking modals footer content', () => {
     ).toHaveLength(1);
   });
 
-  it('forwards service_instance_id to discount validate when cohort provides one', async () => {
+  it('forwards service_instance_slug to discount validate when cohort provides slug', async () => {
     mockedCreateCrmApiClient.mockReturnValue({
       request: vi.fn(),
     });
@@ -2062,13 +2066,13 @@ describe('my-best-auntie booking modals footer content', () => {
       value: 5,
     });
 
-    const cohortWithInstance = {
+    const cohortWithSlug = {
       ...selectedCohort,
-      service_instance_id: '22222222-2222-4222-8222-222222222222',
+      slug: 'mba-test-cohort-slug',
     };
 
     renderBookingModal({
-      selectedCohort: cohortWithInstance,
+      selectedCohort: cohortWithSlug,
       prefilledDiscountCode: 'refsave',
     });
 
@@ -2078,7 +2082,7 @@ describe('my-best-auntie booking modals footer content', () => {
     expect(mockedValidateDiscountCode).toHaveBeenCalledWith(expect.anything(), {
       code: 'REFSAVE',
       serviceKey: 'my-best-auntie',
-      serviceInstanceId: '22222222-2222-4222-8222-222222222222',
+      serviceInstanceSlug: 'mba-test-cohort-slug',
     });
   });
 

--- a/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-booking-modal.test.tsx
@@ -273,7 +273,7 @@ const expectedMbaMarketingFields = {
   courseLabel: myBestAuntieModalContent.title,
   courseSlug: 'my-best-auntie',
   service: 'training-course',
-  serviceKey: selectedCohort.slug,
+  serviceKey: 'my-best-auntie',
   serviceInstanceSlug: selectedCohort.slug,
   scheduleDateLabel: 'Apr, 2026',
   scheduleTimeLabel: expectedMbaScheduleTimeLabel,

--- a/apps/public_www/tests/lib/discounts-data.test.ts
+++ b/apps/public_www/tests/lib/discounts-data.test.ts
@@ -120,7 +120,7 @@ describe('discounts-data', () => {
     });
   });
 
-  it('includes service_key and service_instance_id in the POST body when supplied', async () => {
+  it('includes service_key and service_instance_slug in the POST body when supplied', async () => {
     const fetchSpy = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -152,7 +152,7 @@ describe('discounts-data', () => {
     await validateDiscountCode(crmApiClient, {
       code: 'SAVE',
       serviceKey: 'my-best-auntie',
-      serviceInstanceId: '11111111-1111-4111-8111-111111111111',
+      serviceInstanceSlug: 'my-best-auntie-1-3-04-26',
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -162,10 +162,48 @@ describe('discounts-data', () => {
         body: JSON.stringify({
           code: 'SAVE',
           service_key: 'my-best-auntie',
-          service_instance_id: '11111111-1111-4111-8111-111111111111',
+          service_instance_slug: 'my-best-auntie-1-3-04-26',
         }),
       }),
     );
+  });
+
+  it('does not send service_instance_slug when slug option is absent', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            code: 'SAVE',
+            name: null,
+            amount: 5,
+            is_percentage: true,
+            currency_code: null,
+            currency_symbol: null,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+
+    vi.stubGlobal('fetch', fetchSpy);
+    const crmApiClient = createCrmApiClient({
+      baseUrl: 'https://api.evolvesprouts.com/www',
+      apiKey: 'secret-api-key',
+    });
+    if (!crmApiClient) {
+      throw new Error('Expected CRM API client configuration to be valid');
+    }
+
+    await validateDiscountCode(crmApiClient, {
+      code: 'SAVE',
+      serviceKey: 'my-best-auntie',
+    });
+
+    const body = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body ?? '{}'));
+    expect(body).not.toHaveProperty('service_instance_slug');
   });
 
   it('rejects invalid CRM API client configuration', () => {

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -249,7 +249,7 @@ describe('events-data', () => {
     const payload = {
       data: [
         {
-          id: 'my-best-auntie-booking-event-1',
+          slug: 'my-best-auntie-booking-event-1',
           title: 'My Best Auntie booking event',
           booking_system: 'my-best-auntie-booking',
           service_tier: '1-3',
@@ -264,7 +264,7 @@ describe('events-data', () => {
           external_url: 'https://booking.example.com/events/should-not-be-used',
           dates: [
             {
-              id: 'part-1',
+              part: 1,
               start_datetime: '2026-01-22T09:00:00Z',
               end_datetime: '2026-01-22T11:00:00Z',
             },
@@ -282,15 +282,18 @@ describe('events-data', () => {
     );
     expect(events[0]?.bookingModalPayload?.variant).toBe('my-best-auntie');
     if (events[0]?.bookingModalPayload?.variant === 'my-best-auntie') {
-      expect(events[0].bookingModalPayload.selectedCohort.service_instance_id).toBeNull();
+      expect(events[0].bookingModalPayload.selectedCohort.slug).toBe(
+        'my-best-auntie-booking-event-1',
+      );
+      expect(events[0].bookingModalPayload.selectedCohort.dates[0]?.part).toBe(1);
     }
   });
 
-  it('resolves my-best-auntie cohort id from service_instance_id when id is absent', () => {
+  it('resolves my-best-auntie cohort slug from slug field', () => {
     const payload = {
       data: [
         {
-          service_instance_id: 'e2d0ad6b-70df-4385-873f-bdfc628d59c9',
+          slug: 'mba-cohort-apr-26',
           title: 'My Best Auntie 1-3',
           booking_system: 'my-best-auntie-booking',
           service_tier: '1-3',
@@ -305,7 +308,7 @@ describe('events-data', () => {
           location_url: 'https://www.google.com/maps/dir/?api=1&destination=22.286209%2C114.148303',
           dates: [
             {
-              id: 'da6bcd38-0a63-481b-830f-31de835b9369',
+              part: 1,
               start_datetime: '2026-04-18T09:00:00+00:00',
               end_datetime: '2026-04-18T11:00:00+00:00',
             },
@@ -320,12 +323,8 @@ describe('events-data', () => {
     expect(events).toHaveLength(1);
     expect(events[0]?.bookingModalPayload?.variant).toBe('my-best-auntie');
     if (events[0]?.bookingModalPayload?.variant === 'my-best-auntie') {
-      expect(events[0].bookingModalPayload.selectedCohort.id).toBe(
-        'e2d0ad6b-70df-4385-873f-bdfc628d59c9',
-      );
-      expect(events[0].bookingModalPayload.selectedCohort.service_instance_id).toBe(
-        'e2d0ad6b-70df-4385-873f-bdfc628d59c9',
-      );
+      expect(events[0].bookingModalPayload.selectedCohort.id).toBe('mba-cohort-apr-26');
+      expect(events[0].bookingModalPayload.selectedCohort.slug).toBe('mba-cohort-apr-26');
     }
   });
 

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -323,7 +323,6 @@ describe('events-data', () => {
     expect(events).toHaveLength(1);
     expect(events[0]?.bookingModalPayload?.variant).toBe('my-best-auntie');
     if (events[0]?.bookingModalPayload?.variant === 'my-best-auntie') {
-      expect(events[0].bookingModalPayload.selectedCohort.id).toBe('mba-cohort-apr-26');
       expect(events[0].bookingModalPayload.selectedCohort.slug).toBe('mba-cohort-apr-26');
     }
   });

--- a/backend/src/app/api/public_discount_validate.py
+++ b/backend/src/app/api/public_discount_validate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
@@ -20,6 +19,7 @@ from app.db.repositories import DiscountCodeRepository, ServiceRepository
 from app.db.repositories.service_instance import ServiceInstanceRepository
 from app.utils import json_response
 from app.utils.logging import get_logger, hash_for_correlation, mask_pii
+from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
 
 logger = get_logger(__name__)
 
@@ -35,12 +35,10 @@ _REJECTION_INSTANCE_ID_REQUIRED = "instance_id_required"
 _REJECTION_INSTANCE_SCOPE_MISMATCH = "instance_scope_mismatch"
 _REJECTION_UNKNOWN_INSTANCE_SLUG = "unknown_instance_slug"
 _REJECTION_SERVICE_SCOPE_MISMATCH = "service_scope_mismatch"
-_REJECTION_SERVICE_KEY_REQUIRED = "service_key_required"
 
 _MAX_CODE_LENGTH = 100
 _MAX_SERVICE_KEY_LENGTH = 120
 _MAX_SERVICE_INSTANCE_SLUG_LENGTH = 128
-_SERVICE_INSTANCE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 
 def _log_discount_validate_rejection(
@@ -94,8 +92,13 @@ def handle_public_discount_validate(
         _MAX_SERVICE_INSTANCE_SLUG_LENGTH,
         required=False,
     )
-    if service_instance_slug_raw and not _SERVICE_INSTANCE_SLUG_PATTERN.fullmatch(
-        service_instance_slug_raw
+    service_instance_slug_normalized = (
+        service_instance_slug_raw.strip().lower()
+        if service_instance_slug_raw and service_instance_slug_raw.strip()
+        else ""
+    )
+    if service_instance_slug_normalized and not PUBLIC_INSTANCE_SLUG_PATTERN.fullmatch(
+        service_instance_slug_normalized
     ):
         return json_response(
             400,
@@ -179,9 +182,11 @@ def handle_public_discount_validate(
             resolved_service_id = resolved_from_key
 
         resolved_request_instance_id: UUID | None = None
-        if service_instance_slug_raw:
+        if service_instance_slug_normalized:
             instance_repo = ServiceInstanceRepository(session)
-            resolved_from_slug = instance_repo.get_id_by_slug(service_instance_slug_raw)
+            resolved_from_slug = instance_repo.get_id_by_slug(
+                service_instance_slug_normalized
+            )
             if getattr(row, "instance_id", None) is not None:
                 if resolved_from_slug is None:
                     _log_discount_validate_rejection(
@@ -189,7 +194,7 @@ def handle_public_discount_validate(
                         code=code,
                         extra={
                             "discount_code_id": str(row.id),
-                            "service_instance_slug": service_instance_slug_raw,
+                            "service_instance_slug": service_instance_slug_normalized,
                         },
                     )
                     return json_response(
@@ -286,10 +291,7 @@ def _scope_rejection_reason(
     if service_id is None:
         return None
     if resolved_request_service_id is None:
-        return (
-            _REJECTION_SERVICE_KEY_REQUIRED,
-            {"expected_service_id": str(service_id)},
-        )
+        return None
     if service_id != resolved_request_service_id:
         return (
             _REJECTION_SERVICE_SCOPE_MISMATCH,

--- a/backend/src/app/api/public_discount_validate.py
+++ b/backend/src/app/api/public_discount_validate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
@@ -10,14 +11,13 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.api.admin_request import parse_body
-from app.api.admin_services_payload_utils import parse_optional_uuid
 from app.api.admin_validators import validate_string_length
 from app.currency_config import currency_symbol_for_iso_code
 from app.db.engine import get_engine
 from app.db.models import DiscountCode
 from app.db.models.enums import DiscountType
 from app.db.repositories import DiscountCodeRepository, ServiceRepository
-from app.exceptions import ValidationError
+from app.db.repositories.service_instance import ServiceInstanceRepository
 from app.utils import json_response
 from app.utils.logging import get_logger, hash_for_correlation, mask_pii
 
@@ -33,10 +33,14 @@ _REJECTION_EXPIRED = "expired"
 _REJECTION_MAX_USES = "max_uses_exhausted"
 _REJECTION_INSTANCE_ID_REQUIRED = "instance_id_required"
 _REJECTION_INSTANCE_SCOPE_MISMATCH = "instance_scope_mismatch"
+_REJECTION_UNKNOWN_INSTANCE_SLUG = "unknown_instance_slug"
 _REJECTION_SERVICE_SCOPE_MISMATCH = "service_scope_mismatch"
+_REJECTION_SERVICE_KEY_REQUIRED = "service_key_required"
 
 _MAX_CODE_LENGTH = 100
 _MAX_SERVICE_KEY_LENGTH = 120
+_MAX_SERVICE_INSTANCE_SLUG_LENGTH = 128
+_SERVICE_INSTANCE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 
 def _log_discount_validate_rejection(
@@ -84,16 +88,23 @@ def handle_public_discount_validate(
         _MAX_SERVICE_KEY_LENGTH,
         required=False,
     )
-    try:
-        service_id_body = parse_optional_uuid(body.get("service_id"), "service_id")
-    except ValidationError as exc:
-        return json_response(400, exc.to_dict(), event=event)
-    try:
-        service_instance_id_body = parse_optional_uuid(
-            body.get("service_instance_id"), "service_instance_id"
+    service_instance_slug_raw = validate_string_length(
+        body.get("service_instance_slug"),
+        "service_instance_slug",
+        _MAX_SERVICE_INSTANCE_SLUG_LENGTH,
+        required=False,
+    )
+    if service_instance_slug_raw and not _SERVICE_INSTANCE_SLUG_PATTERN.fullmatch(
+        service_instance_slug_raw
+    ):
+        return json_response(
+            400,
+            {
+                "error": "service_instance_slug must match the public slug pattern",
+                "field": "service_instance_slug",
+            },
+            event=event,
         )
-    except ValidationError as exc:
-        return json_response(400, exc.to_dict(), event=event)
 
     logger.info(
         "Validating discount code",
@@ -103,13 +114,10 @@ def handle_public_discount_validate(
     service_key_normalized = (
         service_key.strip() if service_key and service_key.strip() else ""
     )
-    # When `service_key` is sent it wins over `service_id` in the body (OpenAPI).
     # Slug resolution is deferred until after we load the code row so unscoped
     # ("all services") codes are not rejected when the page sends a stale or
     # placeholder `service_key` that does not match `services.slug`.
-    resolved_service_id: UUID | None = (
-        None if service_key_normalized else service_id_body
-    )
+    resolved_service_id: UUID | None = None
 
     with Session(get_engine()) as session:
         repository = DiscountCodeRepository(session)
@@ -170,10 +178,31 @@ def handle_public_discount_validate(
                 )
             resolved_service_id = resolved_from_key
 
+        resolved_request_instance_id: UUID | None = None
+        if service_instance_slug_raw:
+            instance_repo = ServiceInstanceRepository(session)
+            resolved_from_slug = instance_repo.get_id_by_slug(service_instance_slug_raw)
+            if getattr(row, "instance_id", None) is not None:
+                if resolved_from_slug is None:
+                    _log_discount_validate_rejection(
+                        _REJECTION_UNKNOWN_INSTANCE_SLUG,
+                        code=code,
+                        extra={
+                            "discount_code_id": str(row.id),
+                            "service_instance_slug": service_instance_slug_raw,
+                        },
+                    )
+                    return json_response(
+                        404,
+                        {"error": "Discount code not found or inactive"},
+                        event=event,
+                    )
+                resolved_request_instance_id = resolved_from_slug
+
         scope_reason = _scope_rejection_reason(
             row,
             resolved_request_service_id=resolved_service_id,
-            request_instance_id=service_instance_id_body,
+            request_instance_id=resolved_request_instance_id,
         )
         if scope_reason is not None:
             reason_code, detail = scope_reason
@@ -257,7 +286,10 @@ def _scope_rejection_reason(
     if service_id is None:
         return None
     if resolved_request_service_id is None:
-        return None
+        return (
+            _REJECTION_SERVICE_KEY_REQUIRED,
+            {"expected_service_id": str(service_id)},
+        )
     if service_id != resolved_request_service_id:
         return (
             _REJECTION_SERVICE_SCOPE_MISMATCH,

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -29,6 +29,7 @@ from app.db.repositories.service_instance import ServiceInstanceRepository
 from app.utils import public_cacheable_json_response
 from app.utils.logging import get_logger
 from app.utils.maps import build_google_maps_directions_url
+from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
 
 logger = get_logger(__name__)
 
@@ -156,9 +157,10 @@ def _fetch_public_offerings(
     )
     out: list[dict[str, Any]] = []
     for instance in rows:
-        if not instance.slug:
+        slug = (instance.slug or "").strip()
+        if not slug or not PUBLIC_INSTANCE_SLUG_PATTERN.fullmatch(slug):
             logger.warning(
-                "Public calendar feed skipped instance without slug",
+                "Public calendar feed skipped instance without valid slug",
                 extra={"instance_id": str(instance.id)},
             )
             continue
@@ -326,14 +328,15 @@ def _serialize_public_event(
         "fully_booked" if instance.status == InstanceStatus.FULL else "open"
     )
 
-    if not instance.slug:
-        logger.warning(
-            "Serialized public calendar event without instance slug",
-            extra={"instance_id": str(instance.id)},
+    slug = (instance.slug or "").strip()
+    if not slug or not PUBLIC_INSTANCE_SLUG_PATTERN.fullmatch(slug):
+        raise ValueError(
+            "Public calendar serialization requires a non-empty slug matching "
+            "the public slug pattern (caller must filter slug-less rows)."
         )
 
     payload: dict[str, Any] = {
-        "slug": instance.slug or "",
+        "slug": slug,
         "service_type": service.service_type.value,
         "title": title,
         "summary": summary,

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -154,10 +154,18 @@ def _fetch_public_offerings(
     enrollment_counts = repository.get_enrollment_counts_for_instances(
         capacity_instance_ids
     )
-    return [
-        _serialize_public_event(instance, enrollment_counts=enrollment_counts)
-        for instance in rows
-    ]
+    out: list[dict[str, Any]] = []
+    for instance in rows:
+        if not instance.slug:
+            logger.warning(
+                "Public calendar feed skipped instance without slug",
+                extra={"instance_id": str(instance.id)},
+            )
+            continue
+        out.append(
+            _serialize_public_event(instance, enrollment_counts=enrollment_counts)
+        )
+    return out
 
 
 def _resolve_primary_location(
@@ -283,11 +291,11 @@ def _serialize_public_event(
     slots = sorted(instance.session_slots, key=lambda s: (s.sort_order, s.starts_at))
     dates = [
         {
-            "id": str(s.id),
+            "part": idx + 1,
             "start_datetime": _iso(s.starts_at),
             "end_datetime": _iso(s.ends_at),
         }
-        for s in slots
+        for idx, s in enumerate(slots)
     ]
 
     primary_location = _resolve_primary_location(instance, slots)
@@ -318,8 +326,14 @@ def _serialize_public_event(
         "fully_booked" if instance.status == InstanceStatus.FULL else "open"
     )
 
+    if not instance.slug:
+        logger.warning(
+            "Serialized public calendar event without instance slug",
+            extra={"instance_id": str(instance.id)},
+        )
+
     payload: dict[str, Any] = {
-        "service_instance_id": str(instance.id),
+        "slug": instance.slug or "",
         "service_type": service.service_type.value,
         "title": title,
         "summary": summary,
@@ -350,8 +364,6 @@ def _serialize_public_event(
     if external_url:
         payload["external_url"] = external_url
 
-    if instance.slug is not None:
-        payload["slug"] = instance.slug
     if instance.landing_page is not None:
         payload["landing_page"] = instance.landing_page
     payload["service_tier"] = _resolve_public_calendar_service_tier(instance)

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -59,6 +59,7 @@ from app.services.turnstile import (
 from app.utils import json_response
 from app.utils.fps_qr_png import optional_fps_qr_data_url_from_payload
 from app.utils.logging import get_logger, mask_email, mask_pii
+from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
 
 logger = get_logger(__name__)
 
@@ -75,7 +76,6 @@ _MAX_ISO_FIELD = 50
 _MAX_COHORT_DATE = 100
 _MAX_DISCOUNT_CODE = 100
 _MAX_INSTANCE_SLUG_LENGTH = 128
-_INSTANCE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _MAX_FPS_DATA_URL_BYTES = 120_000
 _MAX_TOTAL_AMOUNT = Decimal("1000000")
 _STRIPE_PAYMENT_INTENTS_URL_PREFIX = "https://api.stripe.com/v1/payment_intents/"
@@ -477,13 +477,14 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         "serviceInstanceSlug",
         _MAX_INSTANCE_SLUG_LENGTH,
     )
-    if service_instance_slug and not _INSTANCE_SLUG_PATTERN.fullmatch(
-        service_instance_slug
-    ):
-        raise ValidationError(
-            "serviceInstanceSlug must match the public slug pattern",
-            field="serviceInstanceSlug",
-        )
+    if service_instance_slug:
+        normalized_instance_slug = service_instance_slug.strip().lower()
+        if not PUBLIC_INSTANCE_SLUG_PATTERN.fullmatch(normalized_instance_slug):
+            raise ValidationError(
+                "serviceInstanceSlug must match the public slug pattern",
+                field="serviceInstanceSlug",
+            )
+        service_instance_slug = normalized_instance_slug
     agreed = body.get("agreedToTermsAndConditions")
     if agreed is not True:
         raise ValidationError(

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -33,6 +33,7 @@ from app.api.public_form_hooks import (
 )
 from app.db.engine import get_engine
 from app.db.repositories import DiscountCodeRepository, ServiceRepository
+from app.db.repositories.service_instance import ServiceInstanceRepository
 from app.db.models.enums import (
     ContactSource,
     ContactType,
@@ -73,7 +74,8 @@ _MAX_LOCATION_URL = 500
 _MAX_ISO_FIELD = 50
 _MAX_COHORT_DATE = 100
 _MAX_DISCOUNT_CODE = 100
-_MAX_INSTANCE_ID_LENGTH = 36
+_MAX_INSTANCE_SLUG_LENGTH = 128
+_INSTANCE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _MAX_FPS_DATA_URL_BYTES = 120_000
 _MAX_TOTAL_AMOUNT = Decimal("1000000")
 _STRIPE_PAYMENT_INTENTS_URL_PREFIX = "https://api.stripe.com/v1/payment_intents/"
@@ -470,11 +472,18 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         "discountCode",
         _MAX_DISCOUNT_CODE,
     )
-    service_instance_id = _optional_text(
-        body.get("serviceInstanceId"),
-        "serviceInstanceId",
-        _MAX_INSTANCE_ID_LENGTH,
+    service_instance_slug = _optional_text(
+        body.get("serviceInstanceSlug"),
+        "serviceInstanceSlug",
+        _MAX_INSTANCE_SLUG_LENGTH,
     )
+    if service_instance_slug and not _INSTANCE_SLUG_PATTERN.fullmatch(
+        service_instance_slug
+    ):
+        raise ValidationError(
+            "serviceInstanceSlug must match the public slug pattern",
+            field="serviceInstanceSlug",
+        )
     agreed = body.get("agreedToTermsAndConditions")
     if agreed is not True:
         raise ValidationError(
@@ -534,7 +543,7 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         "marketing_opt_in": marketing_opt_in,
         "locale": locale,
         "discount_code": discount_code,
-        "service_instance_id": service_instance_id,
+        "service_instance_slug": service_instance_slug,
         "agreed_to_terms_and_conditions": True,
         "reservation_pending_until_payment_confirmed": reservation_pending,
     }
@@ -573,19 +582,20 @@ def _validate_discount_code_redemption_scope(
         raise ValidationError("Invalid discount code", field="discountCode")
 
     if row.instance_id is not None:
-        raw_instance = payload.get("service_instance_id")
-        if not raw_instance:
+        raw_slug = payload.get("service_instance_slug")
+        if not raw_slug or not str(raw_slug).strip():
             raise ValidationError(
-                "serviceInstanceId is required for this discount code",
-                field="serviceInstanceId",
+                "serviceInstanceSlug is required for this discount code",
+                field="serviceInstanceSlug",
             )
-        try:
-            request_instance_id = UUID(str(raw_instance).strip())
-        except ValueError as exc:
+        slug = str(raw_slug).strip()
+        instance_repo = ServiceInstanceRepository(session)
+        request_instance_id = instance_repo.get_id_by_slug(slug)
+        if request_instance_id is None:
             raise ValidationError(
-                "serviceInstanceId must be a UUID",
-                field="serviceInstanceId",
-            ) from exc
+                "Discount code is not valid for this booking",
+                field="discountCode",
+            )
         if request_instance_id != row.instance_id:
             raise ValidationError(
                 "Discount code is not valid for this booking",

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -270,7 +270,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             statement = statement.where(ServiceInstance.landing_page == landing_page)
         if service_key:
             statement = statement.where(func.lower(Service.slug) == service_key.lower())
-        statement = statement.where(ServiceInstance.slug.is_not(None))
+        statement = statement.where(ServiceInstance.slug.is_not(None)).where(
+            ServiceInstance.slug != ""
+        )
         return list(self._session.execute(statement).unique().scalars().all())
 
     def get_id_by_slug(self, slug: str) -> UUID | None:

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -270,7 +270,18 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             statement = statement.where(ServiceInstance.landing_page == landing_page)
         if service_key:
             statement = statement.where(func.lower(Service.slug) == service_key.lower())
+        statement = statement.where(ServiceInstance.slug.is_not(None))
         return list(self._session.execute(statement).unique().scalars().all())
+
+    def get_id_by_slug(self, slug: str) -> UUID | None:
+        """Resolve ``service_instances.id`` from public slug (case-insensitive)."""
+        normalized = slug.strip()
+        if not normalized:
+            return None
+        statement = select(ServiceInstance.id).where(
+            func.lower(ServiceInstance.slug) == normalized.lower()
+        )
+        return self._session.execute(statement).scalar_one_or_none()
 
     def list_event_instances_for_public_feed(
         self,

--- a/backend/src/app/services/public_form_internal_notifications.py
+++ b/backend/src/app/services/public_form_internal_notifications.py
@@ -361,6 +361,8 @@ def build_reservation_recap_lines(*, payload: Mapping[str, Any]) -> list[str]:
         lines.append(f"Service key: {payload['service_key']}")
     if payload.get("course_slug"):
         lines.append(f"Course slug: {payload['course_slug']}")
+    if payload.get("service_instance_slug"):
+        lines.append(f"Service instance slug: {payload['service_instance_slug']}")
     loc_name = str(payload.get("location_name") or "").strip()
     loc_addr = str(payload.get("location_address") or "").strip()
     if loc_name or loc_addr:

--- a/backend/src/app/utils/public_slug.py
+++ b/backend/src/app/utils/public_slug.py
@@ -8,6 +8,9 @@ from typing import Any
 _NON_ALNUM_RUNS = re.compile(r"[^a-z0-9]+")
 DEFAULT_MAX_PUBLIC_SLUG_LENGTH = 64
 
+# Public API / content: kebab-case slug (lowercase letters, digits, single hyphens).
+PUBLIC_INSTANCE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
 
 def normalize_public_slug(
     value: Any,

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -269,7 +269,8 @@ paths:
         Calendar feed for public consumers (direct API).
         Source of truth is the backend `service_instances` projection for
         published `event` and `training_course` services (consultation is never
-        included). Results are ordered by the earliest upcoming session slot,
+        included). Instances without a non-null `service_instances.slug` are
+        omitted from this feed. Results are ordered by the earliest upcoming session slot,
         then `service_instances.id` for a stable tie-break.
 
         Optional filters: `service_type`, `landing_page`, `service_key`. Filters
@@ -344,7 +345,8 @@ paths:
         Same as `GET /v1/calendar/public` for same-origin calls from `public_www`.
         Source of truth is the backend `service_instances` projection for
         published `event` and `training_course` services (consultation is never
-        included). Results are ordered by the earliest upcoming session slot,
+        included). Instances without a non-null `service_instances.slug` are
+        omitted from this feed. Results are ordered by the earliest upcoming session slot,
         then `service_instances.id` for a stable tie-break.
 
         Optional filters: `service_type`, `landing_page`, `service_key`. Filters
@@ -427,11 +429,11 @@ paths:
         Unscoped codes (no `service_id` / `instance_id`) validate regardless of
         `service_key` (unknown slugs are ignored). When the code is scoped to a
         **service only**, the request must include a matching `service_key` (matched
-        case-insensitively against `services.slug`) or a matching `service_id` UUID; if
-        both are supplied, `service_key` wins for resolving the request service. When the
-        code is scoped to an **instance**, the request must include `service_instance_id`
-        equal to the code's instance; `service_key` is optional and not used to reject
-        unknown slugs. Otherwise this endpoint returns **404** (same generic message as
+        case-insensitively against `services.slug`). When the code is scoped to an
+        **instance**, the request must include `service_instance_slug` that resolves to
+        the code's `instance_id` (case-insensitive match on `service_instances.slug`);
+        `service_key` is optional and not used to reject unknown slugs. An unknown
+        instance slug for an instance-scoped code yields **404** (same generic message as
         inactive codes).
       security:
         - ApiKeyAuth: []
@@ -981,12 +983,16 @@ components:
     PublicCalendarEventDate:
       type: object
       required:
-        - id
+        - part
         - start_datetime
         - end_datetime
       properties:
-        id:
-          type: string
+        part:
+          type: integer
+          minimum: 1
+          description: >
+            1-based session-slot ordinal that mirrors the slot's display order. Sequence is
+            dense (1..N) and matches the order returned by the public site.
         start_datetime:
           type: string
           format: date-time
@@ -996,7 +1002,7 @@ components:
     PublicCalendarEvent:
       type: object
       required:
-        - service_instance_id
+        - slug
         - service_type
         - title
         - status
@@ -1010,10 +1016,6 @@ components:
         - partners
         - service_tier
       properties:
-        service_instance_id:
-          type: string
-          format: uuid
-          description: Aurora `service_instances.id`. Stable public identifier for the offering.
         service_type:
           type: string
           enum: [event, training_course]
@@ -1100,7 +1102,9 @@ components:
             `service_instance_organizations`, ordered by `sort_order`.
         slug:
           type: string
-          nullable: true
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          maxLength: 128
+          description: Stable public identifier for the offering. Maps to `service_instances.slug`.
         landing_page:
           type: string
           nullable: true
@@ -1153,20 +1157,15 @@ components:
           maxLength: 120
           description: >
             Public slug for the booked offering (e.g. `my-best-auntie`). Matched
-            case-insensitively against `services.slug` in Aurora. When both `service_key`
-            and `service_id` are provided, `service_key` takes precedence.
-        service_id:
+            case-insensitively against `services.slug` in Aurora for **service-scoped**
+            discount codes.
+        service_instance_slug:
           type: string
-          format: uuid
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          maxLength: 128
           description: >
-            Alternative to `service_key`: explicit Aurora `services.id` for scope checks.
-            Ignored when `service_key` is present and non-empty.
-        service_instance_id:
-          type: string
-          format: uuid
-          description: >
-            Aurora `service_instances.id`. Required for validating instance-scoped discount
-            codes; must match the code's `instance_id`.
+            Public instance slug (`service_instances.slug`). Required for instance-scoped
+            codes; backend resolves it to the underlying instance id.
     DiscountRule:
       type: object
       additionalProperties: false
@@ -1458,12 +1457,14 @@ components:
         discountCode:
           type: string
           maxLength: 100
-        serviceInstanceId:
+        serviceInstanceSlug:
           type: string
-          format: uuid
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          maxLength: 128
           description: >
-            Aurora `service_instances.id` for the booked cohort/instance. Required when
-            redeeming an instance-scoped discount code; used only for redemption checks.
+            Public `service_instances.slug` for the booked cohort/instance. Required when
+            redeeming an instance-scoped discount code; backend resolves to the instance id
+            for scope checks only.
         marketingOptIn:
           type: boolean
           default: false

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -476,7 +476,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 - `service_instances` stores dated offerings linked to a `services` template.
 - Template fields can be overridden per instance (`title`, `description`,
   `cover_image_s3_key`, `delivery_mode`).
-- Optional public-site fields: `slug` (unique when set), `landing_page`
+- Optional public-site fields: `slug` (unique when set; **canonical public identifier**
+  for calendar/discount/reservation instance scope—must be set for rows included in the
+  public calendar feed), `landing_page`
   (marketing route key for the public website).
 - Optional `cohort` varchar(128): admin label stored with the same normalization rules as
   instance referral slugs (lowercase letters, digits, single hyphens between segments).

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -540,6 +540,18 @@ silently. Multi-tier instances accept a single-tier payload only when one tier's
 ``name`` matches the service event category (otherwise the client must send the full
 array, one object per tier).
 
+## Public calendar and booking use instance slugs, not instance UUIDs
+
+**Decision:** The public calendar feed (`GET /v1/calendar/public`) exposes each offering’s
+stable **`slug`** from `service_instances.slug` (required on emitted rows; UUIDs are not
+returned). Session slots use dense 1-based **`part`** ordinals after `(sort_order, starts_at)`
+ordering. Public discount validation accepts **`service_instance_slug`** (not
+`service_instance_id` or `service_id`); public reservations accept **`serviceInstanceSlug`**
+for the same instance scope check (resolved server-side to the instance UUID).
+
+**Why:** Public clients should not handle Aurora primary keys; slugs are human-meaningful
+and align static content fixtures with the API contract.
+
 ## Keeping Documentation Up to Date
 
 **Decision:** Architecture documentation in `docs/architecture/` describes

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -552,6 +552,11 @@ for the same instance scope check (resolved server-side to the instance UUID).
 **Why:** Public clients should not handle Aurora primary keys; slugs are human-meaningful
 and align static content fixtures with the API contract.
 
+**Scope checks:** Dropping `service_id` from `POST /v1/discounts/validate` does **not** narrow
+service-scoped codes: when neither `service_key` nor a resolved service id is present, the
+handler still returns **200** (unchanged from the pre-cutover `service_id`-less request path).
+Mismatching `service_key` for a service-scoped code still returns **404**.
+
 ## Keeping Documentation Up to Date
 
 **Decision:** Architecture documentation in `docs/architecture/` describes

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -104,16 +104,20 @@ their primary responsibilities.
   plus public website proxy routes including
   `/www/v1/discounts/validate` (native Aurora-backed discount validation; optional
   `service_key` is resolved case-insensitively against `services.slug` in Aurora when
-  the code is service-scoped; unscoped and instance-scoped codes do not fail on an
-  unknown slug; codes with `discount_type` `referral` are rejected with the same 404
+  the code is service-scoped;   optional `service_instance_slug` resolves case-insensitively
+  to `service_instances.id` when the code is instance-scoped; unscoped codes do not fail on an
+  unknown `service_key`; service-scoped codes require a matching `service_key` (no `service_id`
+  body field); instance-scoped codes return 404 when the instance slug does not resolve;
+  codes with `discount_type` `referral` are rejected with the same 404
   envelope as unknown/inactive codes; on each 404 the Lambda logs a structured
   `Public discount validate rejected` entry with `rejection_reason`, `code_hash`,
   and `code_prefix`—never the full code),
   `/www/v1/contact-us`, `/www/v1/reservations`,
   `/www/v1/calendar/public` (public calendar feed: returns **event** and
   **training_course** `service_instances` for published services; consultation
-  is intentionally excluded. Each item includes `service_type`,
-  `service_instance_id` (stable id; no separate `id` field), `partners`, `service_tier`
+  is intentionally excluded. Instances without `service_instances.slug` are omitted.
+  Each item includes `service_type`,
+  `slug` (public instance slug from `service_instances.slug`), `partners`, `service_tier`
   (from parent service, or inferred from instance slug for My Best Auntie) / `cohort`,
   `is_fully_booked`, and a server-derived `location_url`. `booking_system` comes
   from `services.booking_system` or defaults from service type (MBA training

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -104,10 +104,11 @@ their primary responsibilities.
   plus public website proxy routes including
   `/www/v1/discounts/validate` (native Aurora-backed discount validation; optional
   `service_key` is resolved case-insensitively against `services.slug` in Aurora when
-  the code is service-scoped;   optional `service_instance_slug` resolves case-insensitively
+  the code is service-scoped; optional `service_instance_slug` resolves case-insensitively
   to `service_instances.id` when the code is instance-scoped; unscoped codes do not fail on an
-  unknown `service_key`; service-scoped codes require a matching `service_key` (no `service_id`
-  body field); instance-scoped codes return 404 when the instance slug does not resolve;
+  unknown `service_key`; service-scoped codes still validate when `service_key` is omitted
+  (same permissive behavior as before `service_id` removal); instance-scoped codes return 404
+  when the instance slug does not resolve;
   codes with `discount_type` `referral` are rejected with the same 404
   envelope as unknown/inactive codes; on each 404 the Lambda logs a structured
   `Public discount validate rejected` entry with `rejection_reason`, `code_hash`,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,12 +45,10 @@ Flutter Mobile / Next.js Admin
 - Referral links for scoped discounts use query parameters (`ref` / `discount`)
   on locale-prefixed course URLs; the backend matches `service_key` to
   `services.slug` in Aurora for validate/redeem scope checks.
-  Instance-scoped discount redemption requires `service_instance_id` to be populated on the
-  corresponding cohort in `my-best-auntie-training-courses.json`; family consultation
-  venue copy for the booking modal lives in `apps/public_www/src/content/family-consultations.json`
-  (per tier). Use the local helper
-  [`backend/scripts/dump_mba_instance_uuids.py`](../../backend/scripts/dump_mba_instance_uuids.py)
-  to list Aurora instance UUIDs keyed for that content (human-edited JSON is not overwritten by the script).
+  Instance-scoped discount redemption uses the public `service_instances.slug` sent as
+  `service_instance_slug` (validate) and `serviceInstanceSlug` (reservations); static
+  MBA cohort fixtures use the same `slug` field. Family consultation venue copy for the
+  booking modal lives in `apps/public_www/src/content/family-consultations.json` (per tier).
 - Hosted on S3 + CloudFront in one stack with separate staging and
   production assets.
 - Deploys to staging first, then promotes immutable release artifacts to

--- a/tests/test_public_discount_validate_api.py
+++ b/tests/test_public_discount_validate_api.py
@@ -995,13 +995,37 @@ def test_public_discount_validate_instance_scoped_unknown_instance_slug_returns_
     assert response["statusCode"] == 404
 
 
-def test_public_discount_validate_service_id_body_ignored(
+def test_public_discount_validate_service_id_body_ignored_when_service_key_matches(
     monkeypatch: Any,
     api_gateway_event: Any,
 ) -> None:
-    """`service_id` is no longer accepted; service-scoped codes need ``service_key``."""
+    """``service_id`` is ignored; ``service_key`` alone must satisfy service scope."""
     svc = uuid4()
     row = _usable_row(code="BYID", service_id=svc, instance_id=None)
+    _patch_discount_validate_repositories(
+        monkeypatch,
+        discount_row=row,
+        slug_to_service_id={"my-svc": svc},
+    )
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/discounts/validate",
+        body=json.dumps(
+            {"code": "BYID", "service_id": str(svc), "service_key": "my-svc"}
+        ),
+    )
+    response = public_discount_validate.handle_public_discount_validate(event, "POST")
+    assert response["statusCode"] == 200
+
+
+def test_public_discount_validate_service_scoped_without_service_context_still_passes(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    """Service-scoped codes remain valid when the client omits service context."""
+    svc = uuid4()
+    row = _usable_row(code="OPEN", service_id=svc, instance_id=None)
     _patch_discount_validate_repositories(
         monkeypatch,
         discount_row=row,
@@ -1011,7 +1035,36 @@ def test_public_discount_validate_service_id_body_ignored(
     event = api_gateway_event(
         method="POST",
         path="/v1/discounts/validate",
-        body=json.dumps({"code": "BYID", "service_id": str(svc)}),
+        body=json.dumps({"code": "OPEN"}),
     )
     response = public_discount_validate.handle_public_discount_validate(event, "POST")
-    assert response["statusCode"] == 404
+    assert response["statusCode"] == 200
+
+
+def test_public_discount_validate_instance_slug_mixed_case_resolves(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    svc = uuid4()
+    inst = uuid4()
+    row = _usable_row(code="INST", service_id=svc, instance_id=inst)
+    _patch_discount_validate_repositories(
+        monkeypatch,
+        discount_row=row,
+        slug_to_service_id={"my-best-auntie": svc},
+        slug_to_instance_id={"mba-apr-26": inst},
+    )
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/discounts/validate",
+        body=json.dumps(
+            {
+                "code": "INST",
+                "service_key": "my-best-auntie",
+                "service_instance_slug": "MBA-Apr-26",
+            }
+        ),
+    )
+    response = public_discount_validate.handle_public_discount_validate(event, "POST")
+    assert response["statusCode"] == 200

--- a/tests/test_public_discount_validate_api.py
+++ b/tests/test_public_discount_validate_api.py
@@ -668,6 +668,7 @@ def _patch_discount_validate_repositories(
     *,
     discount_row: SimpleNamespace,
     slug_to_service_id: dict[str, UUID] | None = None,
+    slug_to_instance_id: dict[str, UUID] | None = None,
 ) -> None:
     """Patch Session + repositories for public_discount_validate unit tests."""
 
@@ -714,6 +715,20 @@ def _patch_discount_validate_repositories(
         public_discount_validate,
         "ServiceRepository",
         _FakeServiceRepository,
+    )
+
+    class _FakeServiceInstanceRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_id_by_slug(self, slug: str) -> UUID | None:
+            mapping = slug_to_instance_id or {}
+            return mapping.get(slug.strip().lower())
+
+    monkeypatch.setattr(
+        public_discount_validate,
+        "ServiceInstanceRepository",
+        _FakeServiceInstanceRepository,
     )
 
 
@@ -873,6 +888,7 @@ def test_public_discount_validate_instance_scoped_match_returns_200(
         monkeypatch,
         discount_row=row,
         slug_to_service_id={"my-best-auntie": svc},
+        slug_to_instance_id={"mba-apr-26": inst},
     )
 
     event = api_gateway_event(
@@ -882,7 +898,7 @@ def test_public_discount_validate_instance_scoped_match_returns_200(
             {
                 "code": "INST",
                 "service_key": "my-best-auntie",
-                "service_instance_id": str(inst),
+                "service_instance_slug": "mba-apr-26",
             }
         ),
     )
@@ -894,7 +910,7 @@ def test_public_discount_validate_instance_scoped_unknown_service_key_ignored(
     monkeypatch: Any,
     api_gateway_event: Any,
 ) -> None:
-    """Instance-scoped validation uses `service_instance_id`; slug is not required."""
+    """Instance-scoped validation uses `service_instance_slug`; service_key may be unknown."""
     svc = uuid4()
     inst = uuid4()
     row = _usable_row(code="INST", service_id=svc, instance_id=inst)
@@ -902,6 +918,7 @@ def test_public_discount_validate_instance_scoped_unknown_service_key_ignored(
         monkeypatch,
         discount_row=row,
         slug_to_service_id={},
+        slug_to_instance_id={"mba-apr-26": inst},
     )
 
     event = api_gateway_event(
@@ -911,7 +928,7 @@ def test_public_discount_validate_instance_scoped_unknown_service_key_ignored(
             {
                 "code": "INST",
                 "service_key": "not-a-real-slug",
-                "service_instance_id": str(inst),
+                "service_instance_slug": "mba-apr-26",
             }
         ),
     )
@@ -925,11 +942,13 @@ def test_public_discount_validate_instance_scoped_mismatch_returns_404(
 ) -> None:
     svc = uuid4()
     inst = uuid4()
+    other_inst = uuid4()
     row = _usable_row(code="INST", service_id=svc, instance_id=inst)
     _patch_discount_validate_repositories(
         monkeypatch,
         discount_row=row,
         slug_to_service_id={"my-best-auntie": svc},
+        slug_to_instance_id={"mba-other": other_inst},
     )
 
     event = api_gateway_event(
@@ -939,7 +958,7 @@ def test_public_discount_validate_instance_scoped_mismatch_returns_404(
             {
                 "code": "INST",
                 "service_key": "my-best-auntie",
-                "service_instance_id": str(uuid4()),
+                "service_instance_slug": "mba-other",
             }
         ),
     )
@@ -947,39 +966,46 @@ def test_public_discount_validate_instance_scoped_mismatch_returns_404(
     assert response["statusCode"] == 404
 
 
-def test_public_discount_validate_service_id_body_path(
+def test_public_discount_validate_instance_scoped_unknown_instance_slug_returns_404(
     monkeypatch: Any,
     api_gateway_event: Any,
 ) -> None:
     svc = uuid4()
+    inst = uuid4()
+    row = _usable_row(code="INST", service_id=svc, instance_id=inst)
+    _patch_discount_validate_repositories(
+        monkeypatch,
+        discount_row=row,
+        slug_to_service_id={"my-best-auntie": svc},
+        slug_to_instance_id={},
+    )
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/discounts/validate",
+        body=json.dumps(
+            {
+                "code": "INST",
+                "service_key": "my-best-auntie",
+                "service_instance_slug": "no-such-cohort",
+            }
+        ),
+    )
+    response = public_discount_validate.handle_public_discount_validate(event, "POST")
+    assert response["statusCode"] == 404
+
+
+def test_public_discount_validate_service_id_body_ignored(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    """`service_id` is no longer accepted; service-scoped codes need ``service_key``."""
+    svc = uuid4()
     row = _usable_row(code="BYID", service_id=svc, instance_id=None)
-
-    class _FakeSession:
-        pass
-
-    class _SessionCtx:
-        def __init__(self, _engine: Any) -> None:
-            self._session = _FakeSession()
-
-        def __enter__(self) -> _FakeSession:
-            return self._session
-
-        def __exit__(self, *_args: Any) -> bool:
-            return False
-
-    class _FakeRepository:
-        def __init__(self, _session: Any) -> None:
-            pass
-
-        def get_by_code(self, _code: str) -> Any:
-            return row
-
-    monkeypatch.setattr(public_discount_validate, "Session", _SessionCtx)
-    monkeypatch.setattr(public_discount_validate, "get_engine", lambda: object())
-    monkeypatch.setattr(
-        public_discount_validate,
-        "DiscountCodeRepository",
-        _FakeRepository,
+    _patch_discount_validate_repositories(
+        monkeypatch,
+        discount_row=row,
+        slug_to_service_id={},
     )
 
     event = api_gateway_event(
@@ -988,4 +1014,4 @@ def test_public_discount_validate_service_id_body_path(
         body=json.dumps({"code": "BYID", "service_id": str(svc)}),
     )
     response = public_discount_validate.handle_public_discount_validate(event, "POST")
-    assert response["statusCode"] == 200
+    assert response["statusCode"] == 404

--- a/tests/test_public_events_api.py
+++ b/tests/test_public_events_api.py
@@ -155,7 +155,8 @@ def test_handle_public_events_returns_items(monkeypatch: Any, api_gateway_event:
     assert body["items"][0]["spaces_left"] == 9
     assert body["items"][1]["booking_status"] == "fully_booked"
     assert body["items"][0]["service_type"] == "event"
-    assert "service_instance_id" in body["items"][0]
+    assert "service_instance_id" not in body["items"][0]
+    assert body["items"][0]["slug"] == "spring-workshop"
 
 
 def test_handle_public_events_landing_page_filter(

--- a/tests/test_public_events_repository.py
+++ b/tests/test_public_events_repository.py
@@ -40,6 +40,7 @@ def test_list_public_offerings_default_types_and_ordering_sql() -> None:
     assert "ORDER BY" in sql.upper()
     assert "service_instances.id ASC" in sql
     assert "service_instances.slug IS NOT NULL" in sql
+    assert "service_instances.slug != ''" in sql
 
 
 def test_list_public_offerings_service_type_event_only() -> None:

--- a/tests/test_public_events_repository.py
+++ b/tests/test_public_events_repository.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
+from uuid import UUID
 
 from sqlalchemy.dialects import postgresql
 
@@ -38,6 +39,7 @@ def test_list_public_offerings_default_types_and_ordering_sql() -> None:
     assert "instance_session_slots.ends_at >=" in sql
     assert "ORDER BY" in sql.upper()
     assert "service_instances.id ASC" in sql
+    assert "service_instances.slug IS NOT NULL" in sql
 
 
 def test_list_public_offerings_service_type_event_only() -> None:
@@ -183,3 +185,19 @@ def test_get_enrollment_counts_for_instances_groups_by_instance() -> None:
     sql = _compiled_sql(stmt)
     assert "GROUP BY" in sql.upper()
     assert "enrollments.instance_id" in sql
+
+
+def test_get_id_by_slug_compiles_lower_match() -> None:
+    mock_session = MagicMock()
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = UUID(int=99)
+    mock_session.execute.return_value = exec_result
+
+    repo = ServiceInstanceRepository(mock_session)
+    resolved = repo.get_id_by_slug("My-Cohort-Slug")
+
+    assert resolved == UUID(int=99)
+    stmt = mock_session.execute.call_args[0][0]
+    sql = _compiled_sql(stmt).lower()
+    assert "lower(service_instances.slug)" in sql
+    assert "my-cohort-slug" in sql

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
 
+import pytest
+
 from app.api import public_events
 from app.db.models.enums import InstanceStatus, ServiceType
 
@@ -382,11 +384,18 @@ def test_max_capacity_with_enrollments() -> None:
     assert out["spaces_left"] == 0
 
 
-def test_slug_empty_string_still_emitted_for_defense_in_depth() -> None:
+def test_serialize_public_event_requires_valid_slug() -> None:
     service = _event_service()
     inst = _minimal_instance(service, slug="")
-    out = public_events._serialize_public_event(inst, enrollment_counts={})
-    assert out["slug"] == ""
+    with pytest.raises(ValueError):
+        public_events._serialize_public_event(inst, enrollment_counts={})
+
+
+def test_serialize_public_event_rejects_slug_not_matching_pattern() -> None:
+    service = _event_service()
+    inst = _minimal_instance(service, slug="Not_Valid")
+    with pytest.raises(ValueError):
+        public_events._serialize_public_event(inst, enrollment_counts={})
 
 
 def test_dates_use_dense_part_after_sort_order() -> None:

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -79,7 +79,8 @@ def test_event_ticket_tier_price_and_booking_system_default() -> None:
     )
     out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert "id" not in out
-    assert out["service_instance_id"] == str(inst.id)
+    assert "service_instance_id" not in out
+    assert out["slug"] == "my-event"
     assert out["service_type"] == "event"
     assert out["booking_system"] == "event-booking"
     assert out["categories"] == ["workshop"]
@@ -381,14 +382,50 @@ def test_max_capacity_with_enrollments() -> None:
     assert out["spaces_left"] == 0
 
 
-def test_omits_id_when_no_slug() -> None:
+def test_slug_empty_string_still_emitted_for_defense_in_depth() -> None:
     service = _event_service()
-    iid = uuid4()
-    inst = _minimal_instance(service, slug=None)
-    inst.id = iid
+    inst = _minimal_instance(service, slug="")
     out = public_events._serialize_public_event(inst, enrollment_counts={})
-    assert "id" not in out
-    assert out["service_instance_id"] == str(iid)
+    assert out["slug"] == ""
+
+
+def test_dates_use_dense_part_after_sort_order() -> None:
+    service = _event_service()
+    s1 = datetime(2026, 5, 2, 10, 0, tzinfo=UTC)
+    e1 = datetime(2026, 5, 2, 11, 0, tzinfo=UTC)
+    s2 = datetime(2026, 5, 1, 10, 0, tzinfo=UTC)
+    e2 = datetime(2026, 5, 1, 11, 0, tzinfo=UTC)
+    loc = SimpleNamespace(name="V", address="1 St", lat=None, lng=None)
+    inst = _minimal_instance(service)
+    inst.session_slots = [
+        SimpleNamespace(
+            id=uuid4(),
+            sort_order=1,
+            starts_at=s1,
+            ends_at=e1,
+            location=loc,
+        ),
+        SimpleNamespace(
+            id=uuid4(),
+            sort_order=0,
+            starts_at=s2,
+            ends_at=e2,
+            location=loc,
+        ),
+    ]
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["dates"] == [
+        {
+            "part": 1,
+            "start_datetime": s2.isoformat(),
+            "end_datetime": e2.isoformat(),
+        },
+        {
+            "part": 2,
+            "start_datetime": s1.isoformat(),
+            "end_datetime": e1.isoformat(),
+        },
+    ]
 
 
 def test_fully_booked_flag() -> None:

--- a/tests/test_public_reservations_extended.py
+++ b/tests/test_public_reservations_extended.py
@@ -475,6 +475,18 @@ def test_discount_redemption_rejects_service_scope_mismatch(
         _FakeServiceRepo,
     )
 
+    class _FakeInstanceRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_id_by_slug(self, _slug: str) -> object | None:
+            return None
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.ServiceInstanceRepository",
+        _FakeInstanceRepo,
+    )
+
     payload = {
         "discount_code": "SAVE",
         "service_key": "my-best-auntie",
@@ -484,7 +496,7 @@ def test_discount_redemption_rejects_service_scope_mismatch(
         _validate_discount_code_redemption_scope(object(), payload)
 
 
-def test_discount_redemption_requires_instance_id_for_instance_scoped_code(
+def test_discount_redemption_requires_instance_slug_for_instance_scoped_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from app.exceptions import ValidationError
@@ -514,6 +526,13 @@ def test_discount_redemption_requires_instance_id_for_instance_scoped_code(
         def get_by_slug(self, slug: str) -> object | None:
             return None
 
+    class _FakeInstanceRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_id_by_slug(self, _slug: str) -> object | None:
+            return None
+
     monkeypatch.setattr(
         "app.api.public_reservations.DiscountCodeRepository",
         _FakeDiscountRepo,
@@ -522,7 +541,12 @@ def test_discount_redemption_requires_instance_id_for_instance_scoped_code(
         "app.api.public_reservations.ServiceRepository",
         _FakeServiceRepo,
     )
+    monkeypatch.setattr(
+        "app.api.public_reservations.ServiceInstanceRepository",
+        _FakeInstanceRepo,
+    )
 
     payload = {"discount_code": "SAVE", "service_key": "cohort-1"}
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as excinfo:
         _validate_discount_code_redemption_scope(object(), payload)
+    assert getattr(excinfo.value, "field", None) == "serviceInstanceSlug"

--- a/tests/test_public_reservations_extended.py
+++ b/tests/test_public_reservations_extended.py
@@ -12,6 +12,7 @@ import pytest
 from app.api.public_reservations import (
     _handle_public_reservation,
     _validate_discount_code_redemption_scope,
+    _validate_reservation_payload,
 )
 
 
@@ -30,6 +31,14 @@ def _reservation_body(**overrides: object) -> dict[str, Any]:
     }
     base.update(overrides)
     return base
+
+
+def test_validate_reservation_payload_normalizes_mixed_case_service_instance_slug() -> None:
+    body = _reservation_body(
+        serviceInstanceSlug="My-Cohort-Slug",
+    )
+    out = _validate_reservation_payload(body)
+    assert out["service_instance_slug"] == "my-cohort-slug"
 
 
 def _post_event(api_gateway_event: Any, body: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Latest: CI Next.js typecheck fix

**`resolveBookingDateParts`** in `apps/public_www/src/lib/events-data.ts` used `.map(... null).filter(type guard)`; TypeScript still inferred `(EventBookingDatePart | null)[]`, which broke **`next build`** (“Running TypeScript …”). Replaced with **`.flatMap(...): EventBookingDatePart[]`** returning `[]` or a one-element array so the return type is correctly **`EventBookingDatePart[]`**.

Commit: `3c320528` on `cursor/public-calendar-slug-cutover-54a3`.

---

(Previous PR description sections for slug cutover + follow-up fixes remain in the thread / earlier commits.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-290679b3-bd1f-4bd7-aa26-e968183f54a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-290679b3-bd1f-4bd7-aa26-e968183f54a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

