### PR TITLE
fix(admin_web): show raw cohort in instances table

### DIFF
--- a/apps/admin_web/src/components/admin/services/event-instance-partners-field.tsx
+++ b/apps/admin_web/src/components/admin/services/event-instance-partners-field.tsx
@@ -112,7 +112,7 @@ export function EventInstancePartnersField({
             }
             const fromPicker = pickerItems.find((row) => row.id === id);
             if (fromPicker) {
-              next.push({ id: fromPicker.id, name: fromPicker.label, active: true });
+              next.push({ id: fromPicker.id, name: fromPicker.label, active: true, locationId: null });
             }
           }
           onChange(next);

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -189,6 +189,7 @@ function mapPartnerRefsFromInstance(instance: ServiceInstance): PartnerOrgRef[] 
     id: row.id,
     name: row.name,
     active: row.active,
+    locationId: row.locationId ?? null,
   }));
 }
 

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { KeyboardEvent, MouseEvent } from 'react';
+import { useMemo } from 'react';
 
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
@@ -15,12 +16,14 @@ import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import {
   formatEnumLabel,
+  formatInstanceSlotLocationSummary,
+  formatInstanceTableTitle,
   formatServiceTitleWithTier,
   formatSessionSlotStartsAtDisplay,
   orderSessionSlotsForDisplay,
 } from '@/lib/format';
 
-import type { ServiceInstance, ServiceType } from '@/types/services';
+import type { LocationSummary, ServiceInstance, ServiceType } from '@/types/services';
 import { SERVICE_TYPES } from '@/types/services';
 
 export interface InstanceServiceFilterOption {
@@ -56,8 +59,10 @@ export interface InstanceListPanelProps {
     value: string;
     onChange: (value: string) => void;
   };
-  /** When true, add a Service column (e.g. cross-service instance list). */
+  /** When true, add cross-service columns (title, cohort, locations, slots). */
   showServiceColumn?: boolean;
+  /** Resolve location ids for the locations column (optional; ids shown when unknown). */
+  locationOptions?: LocationSummary[];
 }
 
 export function InstanceListPanel({
@@ -76,9 +81,14 @@ export function InstanceListPanel({
   serviceTypeFilter,
   searchFilter,
   showServiceColumn = false,
+  locationOptions = [],
 }: InstanceListPanelProps) {
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
   const { copiedKey: duplicateDraftFeedbackId, markCopied: markDuplicateDraftFeedback } = useCopyFeedback(1000);
+  const locationById = useMemo(
+    () => new Map(locationOptions.map((loc) => [loc.id, loc])),
+    [locationOptions]
+  );
 
   const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, instanceId: string) => {
     if (event.target !== event.currentTarget) {
@@ -103,9 +113,10 @@ export function InstanceListPanel({
     event: MouseEvent<HTMLButtonElement>
   ) => {
     event.stopPropagation();
+    const deleteLabel = formatInstanceTableTitle(instance);
     const confirmed = await requestConfirm({
       title: 'Delete instance',
-      description: `Delete "${instance.resolvedTitle ?? instance.title ?? 'this instance'}"? This action cannot be undone.`,
+      description: `Delete "${deleteLabel !== '-' ? deleteLabel : 'this instance'}"? This action cannot be undone.`,
       confirmLabel: 'Delete',
       cancelLabel: 'Cancel',
       variant: 'danger',
@@ -186,10 +197,16 @@ export function InstanceListPanel({
           <AdminDataTableHead>
             <tr>
               {showServiceColumn ? (
+                <th className='px-4 py-3 font-semibold'>Title</th>
+              ) : null}
+              {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Service</th>
               ) : null}
               {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Cohort</th>
+              ) : null}
+              {showServiceColumn ? (
+                <th className='px-4 py-3 font-semibold'>Locations</th>
               ) : null}
               {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Slots</th>
@@ -214,6 +231,9 @@ export function InstanceListPanel({
                 aria-selected={selectedInstanceId === instance.id}
               >
                 {showServiceColumn ? (
+                  <td className='px-4 py-3'>{formatInstanceTableTitle(instance)}</td>
+                ) : null}
+                {showServiceColumn ? (
                   <td className='px-4 py-3'>
                     {instance.parentServiceTitle
                       ? formatServiceTitleWithTier(
@@ -226,6 +246,11 @@ export function InstanceListPanel({
                 {showServiceColumn ? (
                   <td className='px-4 py-3'>
                     {instance.cohort != null && instance.cohort.trim() !== '' ? instance.cohort : '-'}
+                  </td>
+                ) : null}
+                {showServiceColumn ? (
+                  <td className='max-w-[14rem] px-4 py-3 text-sm'>
+                    {formatInstanceSlotLocationSummary(instance, locationById)}
                   </td>
                 ) : null}
                 {showServiceColumn ? (

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -15,7 +15,6 @@ import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import {
   formatEnumLabel,
-  formatInstanceCohortDisplay,
   formatServiceTitleWithTier,
   formatSessionSlotStartsAtDisplay,
   orderSessionSlotsForDisplay,
@@ -225,7 +224,9 @@ export function InstanceListPanel({
                   </td>
                 ) : null}
                 {showServiceColumn ? (
-                  <td className='px-4 py-3'>{formatInstanceCohortDisplay(instance.cohort)}</td>
+                  <td className='px-4 py-3'>
+                    {instance.cohort != null && instance.cohort.trim() !== '' ? instance.cohort : '-'}
+                  </td>
                 ) : null}
                 {showServiceColumn ? (
                   <td className='px-4 py-3 align-top'>

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -5,7 +5,12 @@ import { useCallback, useMemo, useState } from 'react';
 import { StatusBanner } from '@/components/status-banner';
 
 import { useServicesPage, type ServicesView } from '@/hooks/use-services-page';
-import { compareInstancesByFirstSlotStartsDesc, formatServiceTitleWithTier } from '@/lib/format';
+import {
+  compareInstancesByFirstSlotStartsDesc,
+  formatInstanceSlotLocationSummary,
+  formatInstanceTableTitle,
+  formatServiceTitleWithTier,
+} from '@/lib/format';
 import { getInstance, getService } from '@/lib/services-api';
 import type { ServiceDetail, ServiceInstance } from '@/types/services';
 
@@ -75,12 +80,18 @@ export function ServicesPage() {
     return allServiceOptionsIncludingArchived.filter((svc) => svc.status !== 'archived');
   }, [showArchivedDiscountServices, allServiceOptionsIncludingArchived]);
   const normalizedInstanceSearch = state.instancesSearchQuery.trim().toLowerCase();
+  const instanceSearchLocationById = useMemo(
+    () => new Map(state.locationList.locations.map((loc) => [loc.id, loc])),
+    [state.locationList.locations]
+  );
   const filteredInstances = useMemo(() => {
     if (state.activeView !== 'instances' || !normalizedInstanceSearch) {
       return state.instanceList.instances;
     }
     return state.instanceList.instances.filter((instance) => {
+      const tableTitle = formatInstanceTableTitle(instance);
       const parts: string[] = [
+        tableTitle !== '-' ? tableTitle : null,
         instance.resolvedTitle,
         instance.title,
         instance.parentServiceTitle,
@@ -90,15 +101,38 @@ export function ServicesPage() {
           : null,
         instance.instructorId,
         instance.status,
+        formatInstanceSlotLocationSummary(instance, instanceSearchLocationById),
       ].filter((value): value is string => Boolean(value));
       const cohortTrimmed = instance.cohort?.trim();
       if (cohortTrimmed) {
         parts.push(cohortTrimmed);
       }
+      const locResolved = instance.locationId ?? instance.resolvedLocationId;
+      if (locResolved?.trim()) {
+        parts.push(locResolved);
+      }
+      for (const slot of instance.sessionSlots) {
+        if (slot.locationId?.trim()) {
+          parts.push(slot.locationId);
+        }
+      }
+      for (const partner of instance.partnerOrganizations) {
+        if (partner.name?.trim()) {
+          parts.push(partner.name);
+        }
+        if (partner.locationId?.trim()) {
+          parts.push(partner.locationId);
+        }
+      }
       const searchable = parts.join(' ').toLowerCase();
       return searchable.includes(normalizedInstanceSearch);
     });
-  }, [normalizedInstanceSearch, state.activeView, state.instanceList.instances]);
+  }, [
+    normalizedInstanceSearch,
+    state.activeView,
+    state.instanceList.instances,
+    instanceSearchLocationById,
+  ]);
   const instancesTableRows = useMemo(() => {
     if (state.activeView !== 'instances') {
       return filteredInstances;
@@ -260,6 +294,7 @@ export function ServicesPage() {
             }}
             onLoadMore={state.instanceList.loadMore}
             showServiceColumn
+            locationOptions={state.locationList.locations}
             searchFilter={{
               value: state.instancesSearchQuery,
               onChange: state.setInstancesSearchQuery,

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -5,11 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { StatusBanner } from '@/components/status-banner';
 
 import { useServicesPage, type ServicesView } from '@/hooks/use-services-page';
-import {
-  compareInstancesByFirstSlotStartsDesc,
-  formatInstanceCohortDisplay,
-  formatServiceTitleWithTier,
-} from '@/lib/format';
+import { compareInstancesByFirstSlotStartsDesc, formatServiceTitleWithTier } from '@/lib/format';
 import { getInstance, getService } from '@/lib/services-api';
 import type { ServiceDetail, ServiceInstance } from '@/types/services';
 
@@ -97,7 +93,7 @@ export function ServicesPage() {
       ].filter((value): value is string => Boolean(value));
       const cohortTrimmed = instance.cohort?.trim();
       if (cohortTrimmed) {
-        parts.push(cohortTrimmed, formatInstanceCohortDisplay(instance.cohort));
+        parts.push(cohortTrimmed);
       }
       const searchable = parts.join(' ').toLowerCase();
       return searchable.includes(normalizedInstanceSearch);

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -35,6 +35,18 @@ export function formatLocationLabel(location: LocationSummary): string {
   return location.id;
 }
 
+/** Instances table: own title when set, otherwise parent service title (with tier). */
+export function formatInstanceTableTitle(instance: ServiceInstance): string {
+  const own = instance.title?.trim();
+  if (own) {
+    return own;
+  }
+  if (instance.parentServiceTitle) {
+    return formatServiceTitleWithTier(instance.parentServiceTitle, instance.parentServiceTier);
+  }
+  return '-';
+}
+
 /** Full venue label: address (when present) plus geographic area name. */
 export function formatEntityVenueLocationLabel(location: {
   name?: string | null;
@@ -211,6 +223,51 @@ export function orderSessionSlotsForDisplay(slots: SessionSlot[]): SessionSlot[]
       return a.index - b.index;
     })
     .map(({ slot }) => slot);
+}
+
+function collectDistinctLocationLabels(
+  locationById: Map<string, LocationSummary>,
+  ids: Iterable<string | null | undefined>
+): string[] {
+  const labels = new Map<string, string>();
+  for (const raw of ids) {
+    const id = raw?.trim();
+    if (!id || labels.has(id)) {
+      continue;
+    }
+    const loc = locationById.get(id);
+    labels.set(id, loc ? formatLocationLabel(loc) : id);
+  }
+  return [...labels.values()];
+}
+
+/**
+ * Distinct venue labels for instance default, session slots, and partner org venues.
+ */
+export function formatInstanceSlotLocationSummary(
+  instance: ServiceInstance,
+  locationById: Map<string, LocationSummary>
+): string {
+  const idSequence: string[] = [];
+  const resolved = instance.locationId ?? instance.resolvedLocationId;
+  if (resolved?.trim()) {
+    idSequence.push(resolved);
+  }
+  for (const slot of orderSessionSlotsForDisplay(instance.sessionSlots)) {
+    if (slot.locationId?.trim()) {
+      idSequence.push(slot.locationId);
+    }
+  }
+  for (const partner of instance.partnerOrganizations) {
+    if (partner.locationId?.trim()) {
+      idSequence.push(partner.locationId);
+    }
+  }
+  const labels = collectDistinctLocationLabels(locationById, idSequence);
+  if (labels.length === 0) {
+    return '-';
+  }
+  return labels.join(' · ');
 }
 
 /** Timestamp of the earliest slot with a valid `startsAt`, or `null` if none. */

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -144,30 +144,6 @@ export function formatEnumLabel(value: string): string {
   return toTitleCase(value.toLowerCase());
 }
 
-/**
- * Service instance cohort slugs use hyphens (e.g. `spring-2024`); show each segment
- * as a word with a capitalized first letter.
- */
-export function formatInstanceCohortDisplay(cohort: string | null | undefined): string {
-  if (cohort == null) {
-    return '-';
-  }
-  const trimmed = cohort.trim();
-  if (!trimmed) {
-    return '-';
-  }
-  const words = trimmed
-    .split('-')
-    .map((part) => part.trim())
-    .filter((part) => part.length > 0);
-  if (words.length === 0) {
-    return '-';
-  }
-  return words
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(' ');
-}
-
 const SESSION_SLOT_TABLE_DATETIME_FORMATTER = new Intl.DateTimeFormat('en-GB', {
   day: '2-digit',
   month: 'short',

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -130,6 +130,7 @@ function parsePartnerOrganization(value: unknown): PartnerOrgRef | null {
     id,
     name: asNullableString(item.name) ?? '',
     active: !asBoolean(item.archived, false),
+    locationId: asNullableString(item.location_id),
   };
 }
 

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4457,6 +4457,11 @@ export interface components {
             name: string;
             /** @description True when the organization is archived (omitted from active pickers). */
             archived: boolean;
+            /**
+             * Format: uuid
+             * @description Partner organization venue id when set (FK locations).
+             */
+            location_id?: string | null;
         };
         ServiceInstance: {
             /** Format: uuid */

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -251,6 +251,8 @@ export interface PartnerOrgRef {
   id: string;
   name: string;
   active: boolean;
+  /** Partner organization venue id when set (FK locations). */
+  locationId: string | null;
 }
 
 export interface ServiceInstance {

--- a/apps/admin_web/tests/components/admin/services/event-instance-partners-field.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/event-instance-partners-field.test.tsx
@@ -26,7 +26,7 @@ describe('EventInstancePartnersField', () => {
 
     render(
       <EventInstancePartnersField
-        value={[{ id: 'arch-1', name: 'Archived Co', active: false }]}
+        value={[{ id: 'arch-1', name: 'Archived Co', active: false, locationId: null }]}
         onChange={onChange}
       />
     );

--- a/apps/admin_web/tests/components/admin/services/services-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/services-page.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ServicesView } from '@/hooks/use-services-page';
+import type { ServiceInstance } from '@/types/services';
 
 const { mockUseServicesPage, state } = vi.hoisted(() => {
   const state = {
@@ -146,9 +147,50 @@ vi.mock('@/components/admin/services/partners-tab', () => ({
 
 import { ServicesPage } from '@/components/admin/services/services-page';
 
+const INSTANCE_FOR_SEARCH: ServiceInstance = {
+  id: 'instance-search-1',
+  serviceId: 'service-1',
+  parentServiceTitle: 'Yoga',
+  parentServiceTier: null,
+  parentServiceType: 'training_course',
+  title: null,
+  slug: null,
+  description: null,
+  coverImageS3Key: null,
+  status: 'in_progress',
+  deliveryMode: null,
+  locationId: null,
+  maxCapacity: null,
+  waitlistEnabled: false,
+  externalUrl: null,
+  partnerOrganizations: [],
+  instructorId: null,
+  notes: null,
+  tagIds: [],
+  createdBy: 'admin-sub',
+  createdAt: '2026-03-01T10:00:00Z',
+  updatedAt: '2026-03-01T10:00:00Z',
+  resolvedTitle: 'Yoga cohort run',
+  cohort: 'spring-2024',
+  resolvedSlug: null,
+  resolvedDescription: null,
+  resolvedCoverImageS3Key: null,
+  resolvedDeliveryMode: null,
+  resolvedLocationId: null,
+  sessionSlots: [],
+  trainingDetails: null,
+  resolvedTrainingDetails: null,
+  eventTicketTiers: [],
+  resolvedEventTicketTiers: [],
+  consultationDetails: null,
+  resolvedConsultationDetails: null,
+};
+
 describe('ServicesPage', () => {
   beforeEach(() => {
     state.activeView = 'catalog';
+    state.instanceList.instances = [];
+    state.instancesSearchQuery = '';
   });
 
   it('renders tabs-only header and switches views', async () => {
@@ -201,5 +243,20 @@ describe('ServicesPage', () => {
     await user.type(screen.getByLabelText('Search instances'), 'yoga');
 
     expect(state.setInstancesSearchQuery).toHaveBeenCalled();
+  });
+
+  it('filters instances by cohort using the raw stored value only', () => {
+    state.activeView = 'instances';
+    state.instanceList.instances = [INSTANCE_FOR_SEARCH];
+
+    state.instancesSearchQuery = 'spring 2024';
+    const { rerender, unmount } = render(<ServicesPage />);
+    expect(screen.queryByText('spring-2024')).not.toBeInTheDocument();
+
+    state.instancesSearchQuery = 'spring-2024';
+    rerender(<ServicesPage />);
+    expect(screen.getByText('spring-2024')).toBeInTheDocument();
+
+    unmount();
   });
 });

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -207,7 +207,12 @@ describe('services tables value formatting', () => {
       <>
         <InstanceListPanel
           instances={[
-            { ...INSTANCE_FIXTURE, parentServiceTitle: 'Yoga', parentServiceTier: 'adults' },
+            {
+              ...INSTANCE_FIXTURE,
+              title: 'Custom instance title',
+              parentServiceTitle: 'Yoga',
+              parentServiceTier: 'adults',
+            },
           ]}
           selectedInstanceId={null}
           isLoading={false}
@@ -241,6 +246,7 @@ describe('services tables value formatting', () => {
 
     const tables = screen.getAllByRole('table');
     const instanceTable = tables[0] as HTMLElement;
+    expect(within(instanceTable).getByText('Custom instance title')).toBeInTheDocument();
     expect(within(instanceTable).getByText('Yoga · adults')).toBeInTheDocument();
     expect(within(instanceTable).getByText('In Progress')).toBeInTheDocument();
     expect(within(instanceTable).getByText('spring-2024')).toBeInTheDocument();

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -243,7 +243,7 @@ describe('services tables value formatting', () => {
     const instanceTable = tables[0] as HTMLElement;
     expect(within(instanceTable).getByText('Yoga · adults')).toBeInTheDocument();
     expect(within(instanceTable).getByText('In Progress')).toBeInTheDocument();
-    expect(within(instanceTable).getByText('Spring 2024')).toBeInTheDocument();
+    expect(within(instanceTable).getByText('spring-2024')).toBeInTheDocument();
     expect(within(instanceTable).getByText('Unlimited')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('SAVE10')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('10%')).toBeInTheDocument();

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -6,7 +6,6 @@ import {
   formatDate,
   formatDateOnly,
   formatEnumLabel,
-  formatInstanceCohortDisplay,
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
   formatServiceTitleWithTier,
@@ -52,13 +51,6 @@ describe('format helpers', () => {
   it('formats snake_case values into title case labels', () => {
     expect(formatEnumLabel('training_course')).toBe('Training Course');
     expect(formatEnumLabel('in_person')).toBe('In Person');
-  });
-
-  it('formats instance cohort slugs for table display', () => {
-    expect(formatInstanceCohortDisplay(null)).toBe('-');
-    expect(formatInstanceCohortDisplay('')).toBe('-');
-    expect(formatInstanceCohortDisplay('spring-2024')).toBe('Spring 2024');
-    expect(formatInstanceCohortDisplay('MY-BEST-AUNTIE')).toBe('My Best Auntie');
   });
 
   it('formats session slot starts for instances table', () => {

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -6,6 +6,8 @@ import {
   formatDate,
   formatDateOnly,
   formatEnumLabel,
+  formatInstanceSlotLocationSummary,
+  formatInstanceTableTitle,
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
   formatServiceTitleWithTier,
@@ -74,6 +76,141 @@ describe('format helpers', () => {
     expect(formatServiceTitleWithTier('Yoga', 'adults')).toBe('Yoga · adults');
     expect(formatServiceTitleWithTier('Yoga', null)).toBe('Yoga');
     expect(formatServiceTitleWithTier('Yoga', '  ')).toBe('Yoga');
+  });
+
+  it('formats instance table title from own title or parent service title', () => {
+    const base = (): ServiceInstance => ({
+      id: 'i1',
+      serviceId: 's1',
+      parentServiceTitle: 'Parent',
+      parentServiceTier: 'tier-a',
+      parentServiceType: 'training_course',
+      title: null,
+      slug: null,
+      description: null,
+      coverImageS3Key: null,
+      status: 'scheduled',
+      deliveryMode: null,
+      locationId: null,
+      maxCapacity: null,
+      waitlistEnabled: false,
+      externalUrl: null,
+      partnerOrganizations: [],
+      instructorId: null,
+      cohort: null,
+      notes: null,
+      tagIds: [],
+      createdBy: 'u',
+      createdAt: null,
+      updatedAt: null,
+      resolvedTitle: 'Resolved',
+      resolvedSlug: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      resolvedLocationId: null,
+      sessionSlots: [],
+      trainingDetails: null,
+      resolvedTrainingDetails: null,
+      eventTicketTiers: [],
+      resolvedEventTicketTiers: [],
+      consultationDetails: null,
+      resolvedConsultationDetails: null,
+    });
+    expect(formatInstanceTableTitle({ ...base(), title: '  My run  ' })).toBe('My run');
+    expect(formatInstanceTableTitle(base())).toBe('Parent · tier-a');
+    expect(
+      formatInstanceTableTitle({
+        ...base(),
+        title: null,
+        parentServiceTitle: null,
+      })
+    ).toBe('-');
+  });
+
+  it('summarizes instance locations including partner org venues', () => {
+    const locById = new Map([
+      [
+        'loc-a',
+        {
+          id: 'loc-a',
+          name: 'Hall A',
+          areaId: 'area-1',
+          address: null,
+          lat: null,
+          lng: null,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: false,
+          partnerOrganizationLabels: [],
+        },
+      ],
+      [
+        'loc-b',
+        {
+          id: 'loc-b',
+          name: 'Partner venue',
+          areaId: 'area-1',
+          address: null,
+          lat: null,
+          lng: null,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: false,
+          partnerOrganizationLabels: [],
+        },
+      ],
+    ]);
+    const instance: ServiceInstance = {
+      id: 'i1',
+      serviceId: 's1',
+      parentServiceTitle: null,
+      parentServiceTier: null,
+      parentServiceType: null,
+      title: null,
+      slug: null,
+      description: null,
+      coverImageS3Key: null,
+      status: 'scheduled',
+      deliveryMode: null,
+      locationId: 'loc-a',
+      maxCapacity: null,
+      waitlistEnabled: false,
+      externalUrl: null,
+      partnerOrganizations: [
+        { id: 'org-1', name: 'Co', active: true, locationId: 'loc-b' },
+      ],
+      instructorId: null,
+      cohort: null,
+      notes: null,
+      tagIds: [],
+      createdBy: 'u',
+      createdAt: null,
+      updatedAt: null,
+      resolvedTitle: null,
+      resolvedSlug: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      resolvedLocationId: null,
+      sessionSlots: [
+        {
+          id: 'slot-1',
+          instanceId: 'i1',
+          locationId: 'loc-a',
+          startsAt: '2026-01-01T10:00:00Z',
+          endsAt: null,
+          sortOrder: 0,
+        },
+      ],
+      trainingDetails: null,
+      resolvedTrainingDetails: null,
+      eventTicketTiers: [],
+      resolvedEventTicketTiers: [],
+      consultationDetails: null,
+      resolvedConsultationDetails: null,
+    };
+    expect(formatInstanceSlotLocationSummary(instance, locById)).toBe('Hall A · Partner venue');
   });
 
   it('uses earliest ordered slot time for instance sort key', () => {

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -269,6 +269,9 @@ def serialize_instance(instance: ServiceInstance) -> dict[str, Any]:
                 "id": str(link.organization_id),
                 "name": link.organization.name,
                 "archived": link.organization.archived_at is not None,
+                "location_id": str(link.organization.location_id)
+                if link.organization.location_id
+                else None,
             }
             for link in sorted(
                 instance.partner_organization_links,

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3935,6 +3935,11 @@ components:
         archived:
           type: boolean
           description: True when the organization is archived (omitted from active pickers).
+        location_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Partner organization venue id when set (FK locations).
     ServiceInstance:
       type: object
       required: [id, service_id, status]

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -89,7 +89,8 @@ their primary responsibilities.
   and type-specific pricing/tiers) when the instance omits a value and the parent
   service supplies the effective default; instance payloads also include
   `parent_service_title` / `parent_service_tier` / `parent_service_type` for
-  cross-service lists; and
+  cross-service lists; `partner_organizations` entries include optional
+  `location_id` (partner venue); and
   `GET /v1/admin/services/{id}/discount-code-usage-summary` for
   aggregate discount usage before service slug changes; `DELETE /v1/admin/services/{id}`
   returns `409` when the service still has instances), `/v1/admin/discount-codes/*`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Instances table (cross-service view):** Added **Title** (instance `title` when non-empty, otherwise parent service title with tier) and **Locations** (distinct labels for instance default / resolved venue, each session slot venue, and each linked partner organization venue). Service column unchanged.
- **Search:** Instance search includes the table title string, formatted location summary, raw location UUIDs, partner org names, and existing fields.
- **API:** `partner_organizations` entries now include optional `location_id` (partner CRM venue FK). Admin serializer, OpenAPI, generated TS types, and `PartnerOrgRef.locationId` parsing updated; `lambdas.md` note extended.

## Testing

- `npm run lint` and `npm run generate:admin-api-types` (admin_web)
- Vitest: `format.test`, `table-value-formatting`, `services-page`, `event-instance-partners-field`
- `pre-commit run ruff-format` on touched Python
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fb33910-9b81-427a-9bfd-4bf1d98be254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fb33910-9b81-427a-9bfd-4bf1d98be254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

