### PR TITLE
fix(admin_web): Partners tab mount load and alphabetical table sort

### DIFF
--- a/apps/admin_web/src/components/admin/services/partners-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/partners-panel.tsx
@@ -91,6 +91,13 @@ export function PartnersPanel({
     [rows, selectedId]
   );
 
+  // Client-side sort over the loaded page set only (same pattern as other admin panels).
+  // Search/status filters still narrow results via the API; pagination order is not global A–Z.
+  const sortedRows = useMemo(
+    () => [...rows].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+    [rows]
+  );
+
   const inlineLocationStateKey = editorMode === 'create' ? 'partner-new' : `partner:${selectedId ?? 'none'}`;
 
   const resolvedLocation = useMemo(() => {
@@ -443,7 +450,7 @@ export function PartnersPanel({
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
-            {rows.map((row) => (
+            {sortedRows.map((row) => (
               <tr
                 key={row.id}
                 className={`cursor-pointer transition ${

--- a/apps/admin_web/src/components/admin/services/partners-tab.tsx
+++ b/apps/admin_web/src/components/admin/services/partners-tab.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
-
 import { PartnersSection } from '@/components/admin/services/partners-section';
 import { usePartners } from '@/hooks/use-partners';
 import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
@@ -20,10 +18,6 @@ export function PartnersTab({
   refreshLocations,
 }: PartnersTabProps) {
   const partners = usePartners();
-
-  useEffect(() => {
-    void partners.refetch();
-  }, [partners]);
 
   return (
     <PartnersSection

--- a/apps/admin_web/src/hooks/use-partners.ts
+++ b/apps/admin_web/src/hooks/use-partners.ts
@@ -38,7 +38,6 @@ export function usePartners() {
     errorPrefix: 'Failed to load partners',
     debounceKeys: ['query'],
     limit: 50,
-    fetchOnMount: false,
   });
 
   const [isSaving, setIsSaving] = useState(false);

--- a/apps/admin_web/tests/components/admin/services/partners-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/partners-panel.test.tsx
@@ -111,6 +111,40 @@ describe('PartnersPanel', () => {
     expect(setFilter).toHaveBeenCalled();
   });
 
+  it('sorts table rows by name A→Z (case- and accent-insensitive) over the loaded set', () => {
+    const baseRow = {
+      organization_type: 'company' as const,
+      relationship_type: 'partner' as const,
+      slug: null,
+      website: null,
+      location_id: null,
+      location_summary: null,
+      tag_ids: [] as string[],
+      tags: [],
+      members: [],
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+    };
+    const rows: components['schemas']['AdminOrganization'][] = [
+      { id: 'b', name: 'Beta Co', ...baseRow },
+      { id: 'a', name: 'alpha llc', ...baseRow },
+      { id: 'g', name: 'Gamma Org', ...baseRow },
+    ];
+    const partners = buildPartnersHook({ partners: rows });
+
+    render(<PartnersPanel partners={partners} {...panelShell} />);
+
+    const table = screen.getByRole('table');
+    const tableRows = within(table).getAllByRole('row');
+    const dataRows = tableRows.slice(1);
+    expect(dataRows.map((row) => within(row).getAllByRole('cell')[0].textContent)).toEqual([
+      'alpha llc',
+      'Beta Co',
+      'Gamma Org',
+    ]);
+  });
+
   it('edits partner and updates with relationship_type partner', async () => {
     const user = userEvent.setup();
     const updatePartner = vi.fn().mockResolvedValue(null);

--- a/apps/admin_web/tests/components/admin/services/partners-tab.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/partners-tab.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { refetch } = vi.hoisted(() => ({ refetch: vi.fn() }));
+
+vi.mock('@/components/admin/services/partners-section', () => ({
+  PartnersSection: () => <div data-testid='partners-section-mock' />,
+}));
+
+vi.mock('@/hooks/use-partners', () => ({
+  // New object each call simulates hook return identity changing across renders.
+  usePartners: () => ({
+    partners: [],
+    filters: { query: '', active: '' },
+    setFilter: vi.fn(),
+    isLoading: false,
+    isLoadingMore: false,
+    hasMore: false,
+    error: '',
+    loadMore: vi.fn(),
+    totalCount: 0,
+    isSaving: false,
+    createPartner: vi.fn(),
+    updatePartner: vi.fn(),
+    addMember: vi.fn(),
+    removeMember: vi.fn(),
+    updateMember: vi.fn(),
+    deletePartner: vi.fn(),
+    refetch,
+    relationshipOptions: ['partner'] as const,
+  }),
+}));
+
+import { PartnersTab } from '@/components/admin/services/partners-tab';
+
+const tabProps = {
+  locations: [],
+  geographicAreas: [],
+  areasLoading: false,
+  refreshLocations: vi.fn(),
+};
+
+describe('PartnersTab', () => {
+  it('does not refetch on every render when hook returns a new object each time', () => {
+    refetch.mockClear();
+
+    const { rerender } = render(<PartnersTab {...tabProps} />);
+    rerender(<PartnersTab {...tabProps} />);
+    rerender(<PartnersTab {...tabProps} />);
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Loading flicker:** `usePartners` now uses the default `usePaginatedList` mount fetch (removed `fetchOnMount: false`), aligned with other service hooks. `PartnersTab` no longer runs a `useEffect` that depended on the whole `partners` object and repeatedly called `refetch()`, which caused the loading state to flash.
- **Table order:** `PartnersPanel` applies a client-side `sortedRows` memo: `[...rows].sort` with `localeCompare(..., { sensitivity: 'base' })` for case- and accent-insensitive A→Z over the **currently loaded** rows. Selection still uses `rows.find` by id.

## Tests

- `partners-panel.test.tsx`: assert DOM row order for Beta / alpha / Gamma input order.
- `partners-tab.test.tsx`: mock `usePartners` returning a fresh object each render; assert `refetch` is never called (guards against the removed refetch loop).

## Validation

- `npm run lint` in `apps/admin_web`
- `npm run test -- partners`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd9ca101-4bbf-4680-9089-16ce6be61498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd9ca101-4bbf-4680-9089-16ce6be61498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

