### PR TITLE
fix(admin_web): remove Service column from instances table

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -18,7 +18,6 @@ import {
   formatEnumLabel,
   formatInstanceSlotLocationSummary,
   formatInstanceTableTitle,
-  formatServiceTitleWithTier,
   formatSessionSlotStartsAtDisplay,
   orderSessionSlotsForDisplay,
 } from '@/lib/format';
@@ -59,7 +58,7 @@ export interface InstanceListPanelProps {
     value: string;
     onChange: (value: string) => void;
   };
-  /** When true, add cross-service columns (title, cohort, locations, slots). */
+  /** When true, add cross-service columns (title, cohort, locations, slots) before status. */
   showServiceColumn?: boolean;
   /** Resolve location ids for the locations column (optional; ids shown when unknown). */
   locationOptions?: LocationSummary[];
@@ -200,9 +199,6 @@ export function InstanceListPanel({
                 <th className='px-4 py-3 font-semibold'>Title</th>
               ) : null}
               {showServiceColumn ? (
-                <th className='px-4 py-3 font-semibold'>Service</th>
-              ) : null}
-              {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Cohort</th>
               ) : null}
               {showServiceColumn ? (
@@ -232,16 +228,6 @@ export function InstanceListPanel({
               >
                 {showServiceColumn ? (
                   <td className='px-4 py-3'>{formatInstanceTableTitle(instance)}</td>
-                ) : null}
-                {showServiceColumn ? (
-                  <td className='px-4 py-3'>
-                    {instance.parentServiceTitle
-                      ? formatServiceTitleWithTier(
-                          instance.parentServiceTitle,
-                          instance.parentServiceTier
-                        )
-                      : '-'}
-                  </td>
                 ) : null}
                 {showServiceColumn ? (
                   <td className='px-4 py-3'>

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -210,8 +210,6 @@ describe('services tables value formatting', () => {
             {
               ...INSTANCE_FIXTURE,
               title: 'Custom instance title',
-              parentServiceTitle: 'Yoga',
-              parentServiceTier: 'adults',
             },
           ]}
           selectedInstanceId={null}
@@ -247,7 +245,6 @@ describe('services tables value formatting', () => {
     const tables = screen.getAllByRole('table');
     const instanceTable = tables[0] as HTMLElement;
     expect(within(instanceTable).getByText('Custom instance title')).toBeInTheDocument();
-    expect(within(instanceTable).getByText('Yoga · adults')).toBeInTheDocument();
     expect(within(instanceTable).getByText('In Progress')).toBeInTheDocument();
     expect(within(instanceTable).getByText('spring-2024')).toBeInTheDocument();
     expect(within(instanceTable).getByText('Unlimited')).toBeInTheDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Service** column from the admin Services **Instances** table (the cross-service list that uses `showServiceColumn` on `InstanceListPanel`). Title, cohort, locations, slots, status, capacity, instructor, and operations are unchanged.

## Testing

- `npm run test -- tests/components/admin/services/table-value-formatting.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f1f3a26-ef81-45e0-8820-fba598491c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f1f3a26-ef81-45e0-8820-fba598491c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

