### PR TITLE
Admin: show instance cohort in title column (drop cohort column)

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -58,7 +58,7 @@ export interface InstanceListPanelProps {
     value: string;
     onChange: (value: string) => void;
   };
-  /** When true, add cross-service columns (title, cohort, locations, slots) before status. */
+  /** When true, add cross-service columns (title with cohort, locations, slots) before status. */
   showServiceColumn?: boolean;
   /** Resolve location ids for the locations column (optional; ids shown when unknown). */
   locationOptions?: LocationSummary[];
@@ -199,9 +199,6 @@ export function InstanceListPanel({
                 <th className='px-4 py-3 font-semibold'>Title</th>
               ) : null}
               {showServiceColumn ? (
-                <th className='px-4 py-3 font-semibold'>Cohort</th>
-              ) : null}
-              {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Locations</th>
               ) : null}
               {showServiceColumn ? (
@@ -228,11 +225,6 @@ export function InstanceListPanel({
               >
                 {showServiceColumn ? (
                   <td className='px-4 py-3'>{formatInstanceTableTitle(instance)}</td>
-                ) : null}
-                {showServiceColumn ? (
-                  <td className='px-4 py-3'>
-                    {instance.cohort != null && instance.cohort.trim() !== '' ? instance.cohort : '-'}
-                  </td>
                 ) : null}
                 {showServiceColumn ? (
                   <td className='max-w-[14rem] px-4 py-3 text-sm'>

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -115,7 +115,7 @@ export function InstanceListPanel({
     const deleteLabel = formatInstanceTableTitle(instance);
     const confirmed = await requestConfirm({
       title: 'Delete instance',
-      description: `Delete "${deleteLabel !== '-' ? deleteLabel : 'this instance'}"? This action cannot be undone.`,
+      description: `Delete "${deleteLabel.trim() !== '' ? deleteLabel : 'this instance'}"? This action cannot be undone.`,
       confirmLabel: 'Delete',
       cancelLabel: 'Cancel',
       variant: 'danger',
@@ -211,72 +211,77 @@ export function InstanceListPanel({
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
-            {instances.map((instance) => (
-              <tr
-                key={instance.id}
-                className={`cursor-pointer transition ${
-                  selectedInstanceId === instance.id ? 'bg-slate-100' : 'hover:bg-slate-50'
-                }`}
-                onClick={() => onSelectInstance(instance.id)}
-                onKeyDown={(event) => handleRowKeyDown(event, instance.id)}
-                tabIndex={0}
-                role='row'
-                aria-selected={selectedInstanceId === instance.id}
-              >
-                {showServiceColumn ? (
-                  <td className='px-4 py-3'>{formatInstanceTableTitle(instance)}</td>
-                ) : null}
-                {showServiceColumn ? (
-                  <td className='max-w-[14rem] px-4 py-3 text-sm'>
-                    {formatInstanceSlotLocationSummary(instance, locationById)}
+            {instances.map((instance) => {
+              const instanceTableTitle = formatInstanceTableTitle(instance);
+              return (
+                <tr
+                  key={instance.id}
+                  className={`cursor-pointer transition ${
+                    selectedInstanceId === instance.id ? 'bg-slate-100' : 'hover:bg-slate-50'
+                  }`}
+                  onClick={() => onSelectInstance(instance.id)}
+                  onKeyDown={(event) => handleRowKeyDown(event, instance.id)}
+                  tabIndex={0}
+                  role='row'
+                  aria-selected={selectedInstanceId === instance.id}
+                >
+                  {showServiceColumn ? (
+                    <td className='px-4 py-3'>
+                      {instanceTableTitle.trim() !== '' ? instanceTableTitle : '\u00a0'}
+                    </td>
+                  ) : null}
+                  {showServiceColumn ? (
+                    <td className='max-w-[14rem] px-4 py-3 text-sm'>
+                      {formatInstanceSlotLocationSummary(instance, locationById)}
+                    </td>
+                  ) : null}
+                  {showServiceColumn ? (
+                    <td className='px-4 py-3 align-top'>
+                      {instance.sessionSlots.length === 0 ? (
+                        '-'
+                      ) : (
+                        <ul className='m-0 max-w-[11rem] list-none space-y-0.5 p-0'>
+                          {orderSessionSlotsForDisplay(instance.sessionSlots).map((slot, slotIndex) => (
+                            <li key={slot.id ?? `${instance.id}-slot-${slotIndex}`}>
+                              {formatSessionSlotStartsAtDisplay(slot.startsAt)}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </td>
+                  ) : null}
+                  <td className='px-4 py-3'>{formatEnumLabel(instance.status)}</td>
+                  <td className='px-4 py-3'>{instance.maxCapacity ?? 'Unlimited'}</td>
+                  <td className='px-4 py-3'>{instance.instructorId ?? '-'}</td>
+                  <td className='px-4 py-3 text-right'>
+                    <div className='flex justify-end gap-2'>
+                      <CopyFeedbackIconButton
+                        copied={duplicateDraftFeedbackId === instance.id}
+                        idleVariant='outline'
+                        idleIcon={<DuplicateIcon className='h-4 w-4' />}
+                        disabled={isMutating}
+                        onClick={(event) => void handleDuplicateInstance(instance, event)}
+                        idleLabel='Duplicate instance as new row'
+                        copiedLabel='Draft copy ready'
+                        idleTitle='Duplicate instance as new row'
+                        copiedTitle='Copied'
+                      />
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='danger'
+                        onClick={(event) => void handleDeleteInstance(instance, event)}
+                        disabled={isMutating}
+                        aria-label='Delete instance'
+                        title='Delete instance'
+                      >
+                        <DeleteIcon className='h-4 w-4' />
+                      </Button>
+                    </div>
                   </td>
-                ) : null}
-                {showServiceColumn ? (
-                  <td className='px-4 py-3 align-top'>
-                    {instance.sessionSlots.length === 0 ? (
-                      '-'
-                    ) : (
-                      <ul className='m-0 max-w-[11rem] list-none space-y-0.5 p-0'>
-                        {orderSessionSlotsForDisplay(instance.sessionSlots).map((slot, slotIndex) => (
-                          <li key={slot.id ?? `${instance.id}-slot-${slotIndex}`}>
-                            {formatSessionSlotStartsAtDisplay(slot.startsAt)}
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </td>
-                ) : null}
-                <td className='px-4 py-3'>{formatEnumLabel(instance.status)}</td>
-                <td className='px-4 py-3'>{instance.maxCapacity ?? 'Unlimited'}</td>
-                <td className='px-4 py-3'>{instance.instructorId ?? '-'}</td>
-                <td className='px-4 py-3 text-right'>
-                  <div className='flex justify-end gap-2'>
-                    <CopyFeedbackIconButton
-                      copied={duplicateDraftFeedbackId === instance.id}
-                      idleVariant='outline'
-                      idleIcon={<DuplicateIcon className='h-4 w-4' />}
-                      disabled={isMutating}
-                      onClick={(event) => void handleDuplicateInstance(instance, event)}
-                      idleLabel='Duplicate instance as new row'
-                      copiedLabel='Draft copy ready'
-                      idleTitle='Duplicate instance as new row'
-                      copiedTitle='Copied'
-                    />
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant='danger'
-                      onClick={(event) => void handleDeleteInstance(instance, event)}
-                      disabled={isMutating}
-                      aria-label='Delete instance'
-                      title='Delete instance'
-                    >
-                      <DeleteIcon className='h-4 w-4' />
-                    </Button>
-                  </div>
-                </td>
-              </tr>
-            ))}
+                </tr>
+              );
+            })}
           </AdminDataTableBody>
         </AdminDataTable>
       </PaginatedTableCard>

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -91,7 +91,7 @@ export function ServicesPage() {
     return state.instanceList.instances.filter((instance) => {
       const tableTitle = formatInstanceTableTitle(instance);
       const parts: string[] = [
-        tableTitle !== '-' ? tableTitle : null,
+        tableTitle.trim() !== '' ? tableTitle : null,
         instance.resolvedTitle,
         instance.title,
         instance.parentServiceTitle,

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -35,16 +35,25 @@ export function formatLocationLabel(location: LocationSummary): string {
   return location.id;
 }
 
-/** Instances table: own title when set, otherwise parent service title (with tier). */
+/** Instances table: own title when set, otherwise parent service title (with tier); cohort appended when set. */
 export function formatInstanceTableTitle(instance: ServiceInstance): string {
   const own = instance.title?.trim();
+  let base: string;
   if (own) {
-    return own;
+    base = own;
+  } else if (instance.parentServiceTitle) {
+    base = formatServiceTitleWithTier(instance.parentServiceTitle, instance.parentServiceTier);
+  } else {
+    base = '-';
   }
-  if (instance.parentServiceTitle) {
-    return formatServiceTitleWithTier(instance.parentServiceTitle, instance.parentServiceTier);
+  const cohort = instance.cohort?.trim();
+  if (!cohort) {
+    return base;
   }
-  return '-';
+  if (base === '-') {
+    return cohort;
+  }
+  return `${base} ${SERVICE_TITLE_TIER_SEP} ${cohort}`;
 }
 
 /** Full venue label: address (when present) plus geographic area name. */

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -35,7 +35,7 @@ export function formatLocationLabel(location: LocationSummary): string {
   return location.id;
 }
 
-/** Instances table: own title when set, otherwise parent service title (with tier); cohort appended when set. */
+/** Instances table: own title when set, otherwise parent service title (with tier); cohort appended when set. Empty when nothing to show. */
 export function formatInstanceTableTitle(instance: ServiceInstance): string {
   const own = instance.title?.trim();
   let base: string;
@@ -44,13 +44,13 @@ export function formatInstanceTableTitle(instance: ServiceInstance): string {
   } else if (instance.parentServiceTitle) {
     base = formatServiceTitleWithTier(instance.parentServiceTitle, instance.parentServiceTier);
   } else {
-    base = '-';
+    base = '';
   }
   const cohort = instance.cohort?.trim();
   if (!cohort) {
     return base;
   }
-  if (base === '-') {
+  if (!base) {
     return cohort;
   }
   return `${base} ${SERVICE_TITLE_TIER_SEP} ${cohort}`;

--- a/apps/admin_web/tests/components/admin/services/services-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/services-page.test.tsx
@@ -255,7 +255,7 @@ describe('ServicesPage', () => {
 
     state.instancesSearchQuery = 'spring-2024';
     rerender(<ServicesPage />);
-    expect(screen.getByText('spring-2024')).toBeInTheDocument();
+    expect(screen.getByText('Yoga · spring-2024')).toBeInTheDocument();
 
     unmount();
   });

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -244,9 +244,8 @@ describe('services tables value formatting', () => {
 
     const tables = screen.getAllByRole('table');
     const instanceTable = tables[0] as HTMLElement;
-    expect(within(instanceTable).getByText('Custom instance title')).toBeInTheDocument();
+    expect(within(instanceTable).getByText('Custom instance title · spring-2024')).toBeInTheDocument();
     expect(within(instanceTable).getByText('In Progress')).toBeInTheDocument();
-    expect(within(instanceTable).getByText('spring-2024')).toBeInTheDocument();
     expect(within(instanceTable).getByText('Unlimited')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('SAVE10')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('10%')).toBeInTheDocument();

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -125,7 +125,7 @@ describe('format helpers', () => {
         title: null,
         parentServiceTitle: null,
       })
-    ).toBe('-');
+    ).toBe('');
     expect(formatInstanceTableTitle({ ...base(), title: 'My run', cohort: 'spring-2024' })).toBe(
       'My run · spring-2024'
     );

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -126,6 +126,19 @@ describe('format helpers', () => {
         parentServiceTitle: null,
       })
     ).toBe('-');
+    expect(formatInstanceTableTitle({ ...base(), title: 'My run', cohort: 'spring-2024' })).toBe(
+      'My run · spring-2024'
+    );
+    expect(formatInstanceTableTitle({ ...base(), cohort: 'spring-2024' })).toBe('Parent · tier-a · spring-2024');
+    expect(
+      formatInstanceTableTitle({
+        ...base(),
+        title: null,
+        parentServiceTitle: null,
+        parentServiceTier: null,
+        cohort: 'spring-2024',
+      })
+    ).toBe('spring-2024');
   });
 
   it('summarizes instance locations including partner org venues', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Instances table (Services → Instances):** Removed the separate **Cohort** column when cross-service columns are shown (`showServiceColumn`).
- **Title column** shows the same base title as before, with cohort appended when set: `title · cohort` (space, middle dot U+00B7, space), matching `formatServiceTitleWithTier`.
- When there is **no** instance title, **no** parent service title, and **no** cohort, the formatter returns an **empty string** (no `-`, no interpunct). The table cell renders a non-breaking space so the row layout stays consistent.

## Implementation

- `formatInstanceTableTitle` in `apps/admin_web/src/lib/format.ts`.
- Instance search (`services-page.tsx`) skips empty table titles when building searchable text; delete confirm uses "this instance" when the formatted title is empty.
- `instance-list-panel.tsx`: single `formatInstanceTableTitle` call per row; empty title shows `\u00a0`.

## Tests

- `format.test.ts`, `table-value-formatting.test.tsx`, `services-page.test.tsx` updated for combined title / empty base.

## Docs / API

- No OpenAPI or backend changes (display-only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06890263-94c1-4753-b2b4-7715cca0c3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06890263-94c1-4753-b2b4-7715cca0c3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

