### PR TITLE
fix(admin-web): cap instances table title column at 15% width

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -192,11 +192,11 @@ export function InstanceListPanel({
           ) : undefined
         }
       >
-        <AdminDataTable tableClassName='min-w-[960px]'>
+        <AdminDataTable tableClassName='table-fixed min-w-[960px]'>
           <AdminDataTableHead>
             <tr>
               {showServiceColumn ? (
-                <th className='px-4 py-3 font-semibold'>Title</th>
+                <th className='max-w-[15%] px-4 py-3 font-semibold'>Title</th>
               ) : null}
               {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Locations</th>
@@ -226,7 +226,7 @@ export function InstanceListPanel({
                   aria-selected={selectedInstanceId === instance.id}
                 >
                   {showServiceColumn ? (
-                    <td className='px-4 py-3'>
+                    <td className='max-w-[15%] min-w-0 break-words px-4 py-3'>
                       {instanceTableTitle.trim() !== '' ? instanceTableTitle : '\u00a0'}
                     </td>
                   ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the Services **Instances** table (`InstanceListPanel` with `showServiceColumn`), the **Title** column was unconstrained and could dominate horizontal space.

## Changes

- Set the instances table to `table-fixed` so percentage-based column limits apply reliably with `w-full`.
- Applied `max-w-[15%]` to the Title header and body cells.
- Added `min-w-0 break-words` on title cells so long text wraps instead of forcing the column wider.

## Testing

- `npm run test` (focused): `table-value-formatting.test.tsx`, `duplicate-draft-feedback-buttons.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a61c1332-3f2a-4fb1-9e58-513535ef4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a61c1332-3f2a-4fb1-9e58-513535ef4bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

