### PR TITLE
Fix instance location save and partner location editing

### DIFF
--- a/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
+++ b/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
@@ -187,7 +187,7 @@ function InlineLocationEditorInner({
 
   const areaNameForLocation = location ? areaById.get(location.areaId)?.name ?? '' : '';
 
-  const ownerPartnerId = allowEditWhenOwnerPartnerOrganizationId?.trim() ?? '';
+  const ownerPartnerId = allowEditWhenOwnerPartnerOrganizationId ?? '';
   const ownerCanEditLockedVenue =
     Boolean(ownerPartnerId) &&
     Boolean(location?.partnerOrganizationIds?.includes(ownerPartnerId));

--- a/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
+++ b/apps/admin_web/src/components/admin/locations/inline-location-editor.tsx
@@ -52,6 +52,11 @@ export interface InlineLocationEditorProps {
   /** Extra line under the partner-managed copy when the location is partner-locked (for example orgs screen). */
   lockedSummaryExtra?: string | null;
   /**
+   * When set, a partner org with this id may edit a venue that is otherwise partner-locked
+   * (same row in ``partnerOrganizationIds``).
+   */
+  allowEditWhenOwnerPartnerOrganizationId?: string | null;
+  /**
    * When `canModify` is false and there is no contact-level location to show, render these
    * lines instead of an em dash (for example family/org venue summaries on a linked contact).
    */
@@ -141,6 +146,7 @@ function InlineLocationEditorInner({
   saveError = '',
   allowClearWhenLocked = false,
   lockedSummaryExtra,
+  allowEditWhenOwnerPartnerOrganizationId = null,
   readOnlyLockedLines = null,
 }: InnerProps) {
   const initial = deriveInitialDraft(canModify, location, embeddedSummary);
@@ -181,7 +187,11 @@ function InlineLocationEditorInner({
 
   const areaNameForLocation = location ? areaById.get(location.areaId)?.name ?? '' : '';
 
-  const lockedFromPartner = Boolean(location?.lockedFromPartnerOrg);
+  const ownerPartnerId = allowEditWhenOwnerPartnerOrganizationId?.trim() ?? '';
+  const ownerCanEditLockedVenue =
+    Boolean(ownerPartnerId) &&
+    Boolean(location?.partnerOrganizationIds?.includes(ownerPartnerId));
+  const lockedFromPartner = Boolean(location?.lockedFromPartnerOrg) && !ownerCanEditLockedVenue;
   const effectiveReadOnly = !canModify || lockedFromPartner;
 
   const {
@@ -474,6 +484,9 @@ function InlineLocationEditorInner({
             </div>
             {location || embeddedSummary ? (
               <p className='text-sm text-slate-600'>Editing updates this location wherever it is used.</p>
+            ) : null}
+            {location && location.partnerOrganizationLabels.length > 1 ? (
+              <p className='text-sm text-slate-600'>Editing updates this address everywhere it is shown.</p>
             ) : null}
             {saveError ? <AdminInlineError>{saveError}</AdminInlineError> : null}
             {geocodeError ? <AdminInlineError>{geocodeError}</AdminInlineError> : null}

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -58,6 +58,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { buildSessionSlotsUtcPayload, mapSessionSlotsFromApiToForm } from '@/lib/format';
+import { filterLocationsForInstance } from '@/lib/instance-location-options';
 import type { EntityTagRef } from '@/lib/entity-api';
 
 type ApiSchemas = components['schemas'];
@@ -441,6 +442,32 @@ export function InstanceDetailPanel({
   const effectiveSessionSlotDefaultLocationId =
     instanceForm.locationId.trim() || selectedService?.locationId?.trim() || null;
 
+  const extraSelectedLocationIds = useMemo(() => {
+    const ids = new Set<string>();
+    const add = (v: string | null | undefined) => {
+      const t = v?.trim();
+      if (t) {
+        ids.add(t);
+      }
+    };
+    add(instanceForm.locationId);
+    add(selectedService?.locationId ?? null);
+    for (const slot of instanceForm.sessionSlots) {
+      add(slot.locationId);
+    }
+    return ids;
+  }, [instanceForm.locationId, instanceForm.sessionSlots, selectedService?.locationId]);
+
+  const filteredLocationOptions = useMemo(
+    () =>
+      filterLocationsForInstance(
+        locationOptions,
+        instanceForm.partnerOrganizations,
+        extraSelectedLocationIds
+      ),
+    [locationOptions, instanceForm.partnerOrganizations, extraSelectedLocationIds]
+  );
+
   const resolvedEventCategory = useMemo(
     () => resolveInheritedEventCategory(selectedService, instance),
     [selectedService, instance]
@@ -631,7 +658,7 @@ export function InstanceDetailPanel({
         serviceId={selectedServiceId}
         serviceLocationId={selectedService?.locationId ?? null}
         serviceOptions={serviceOptions}
-        locationOptions={locationOptions}
+        locationOptions={filteredLocationOptions}
         isLoadingLocations={isLoadingLocations}
         instructorOptions={instructorUsers}
         isLoadingInstructors={isLoadingInstructors}
@@ -760,7 +787,7 @@ export function InstanceDetailPanel({
       <SessionSlotEditor
         slots={instanceForm.sessionSlots}
         disabled={typeFieldsLocked}
-        locationOptions={locationOptions}
+        locationOptions={filteredLocationOptions}
         isLoadingLocations={isLoadingLocations}
         defaultLocationId={effectiveSessionSlotDefaultLocationId}
         onChange={(sessionSlots) => {

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -455,8 +455,11 @@ export function InstanceDetailPanel({
     for (const slot of instanceForm.sessionSlots) {
       add(slot.locationId);
     }
+    for (const p of instanceForm.partnerOrganizations) {
+      add(p.locationId);
+    }
     return ids;
-  }, [instanceForm.locationId, instanceForm.sessionSlots, selectedService?.locationId]);
+  }, [instanceForm.locationId, instanceForm.sessionSlots, instanceForm.partnerOrganizations, selectedService?.locationId]);
 
   const filteredLocationOptions = useMemo(
     () =>

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -5,7 +5,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { formatEnumLabel, formatLocationLabel, formatServiceTitleWithTier } from '@/lib/format';
+import { formatEnumLabel, formatServiceTitleWithTier } from '@/lib/format';
+import { formatInstanceLocationOptionLabel } from '@/lib/instance-location-options';
 
 import { INSTANCE_STATUSES, SERVICE_DELIVERY_MODES } from '@/types/services';
 import type {
@@ -265,7 +266,7 @@ export function InstanceFormFields({
               ) : null}
               {locationOptions.map((location) => (
                 <option key={location.id} value={location.id}>
-                  {formatLocationLabel(location)}
+                  {formatInstanceLocationOptionLabel(location)}
                 </option>
               ))}
             </Select>

--- a/apps/admin_web/src/components/admin/services/partners-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/partners-panel.tsx
@@ -99,6 +99,7 @@ export function PartnersPanel({
   );
 
   const inlineLocationStateKey = editorMode === 'create' ? 'partner-new' : `partner:${selectedId ?? 'none'}`;
+  const ownerPartnerOrganizationId = editorMode === 'edit' ? selectedId : null;
 
   const resolvedLocation = useMemo(() => {
     if (!pendingLocationId) {
@@ -152,8 +153,6 @@ export function PartnersPanel({
     clearError: clearLocationSaveError,
   } = useInlineLocationSave(refreshLocations);
   const { geocode: geocodeLocation, isGeocoding: locationGeocoding } = useGeocodeVenueAddress();
-
-  const locationLockedReadOnly = Boolean(resolvedLocation?.lockedFromPartnerOrg);
 
   function resetCreateForm() {
     if (editorMode === 'create' && pendingLocationId && typeof window !== 'undefined') {
@@ -352,12 +351,7 @@ export function PartnersPanel({
                 areas={geographicAreas}
                 areasLoading={areasLoading}
                 canModify
-                allowClearWhenLocked={locationLockedReadOnly}
-                lockedSummaryExtra={
-                  locationLockedReadOnly
-                    ? 'To change the venue name or switch to a different address, use Services → Venues or update the partner organisation record.'
-                    : null
-                }
+                allowEditWhenOwnerPartnerOrganizationId={ownerPartnerOrganizationId}
                 isSaving={isSaving || locationSaveStatus.isSaving}
                 isGeocoding={locationGeocoding}
                 saveError={locationSaveStatus.error}

--- a/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
+++ b/apps/admin_web/src/components/admin/services/session-slot-editor.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
-import { formatLocationLabel } from '@/lib/format';
+import { formatInstanceLocationOptionLabel } from '@/lib/instance-location-options';
 import { addHoursToDatetimeLocal } from '@/lib/session-slot-datetime';
 
 import type { LocationSummary, SessionSlotFormRow } from '@/types/services';
@@ -134,7 +134,7 @@ export function SessionSlotEditor({
                     ) : null}
                     {locationOptions.map((location) => (
                       <option key={location.id} value={location.id}>
-                        {formatLocationLabel(location)}
+                        {formatInstanceLocationOptionLabel(location)}
                       </option>
                     ))}
                   </Select>

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -35,6 +35,14 @@ export function formatLocationLabel(location: LocationSummary): string {
   return location.id;
 }
 
+/** Partner-org name(s) in selects when present; otherwise venue/address label. */
+export function formatInstanceLocationOptionLabel(location: LocationSummary): string {
+  if (location.partnerOrganizationLabels.length > 0) {
+    return location.partnerOrganizationLabels.join(', ');
+  }
+  return formatLocationLabel(location);
+}
+
 /** Instances table: own title when set, otherwise parent service title (with tier); cohort appended when set. Empty when nothing to show. */
 export function formatInstanceTableTitle(instance: ServiceInstance): string {
   const own = instance.title?.trim();
@@ -245,7 +253,7 @@ function collectDistinctLocationLabels(
       continue;
     }
     const loc = locationById.get(id);
-    labels.set(id, loc ? formatLocationLabel(loc) : id);
+    labels.set(id, loc ? formatInstanceLocationOptionLabel(loc) : id);
   }
   return [...labels.values()];
 }

--- a/apps/admin_web/src/lib/instance-location-options.ts
+++ b/apps/admin_web/src/lib/instance-location-options.ts
@@ -1,5 +1,6 @@
-import { formatLocationLabel } from '@/lib/format';
 import type { LocationSummary, PartnerOrgRef } from '@/types/services';
+
+export { formatInstanceLocationOptionLabel } from '@/lib/format';
 
 /**
  * Locations shown on instance create/edit: template venues, assigned partners'
@@ -21,6 +22,8 @@ export function filterLocationsForInstance(
     }
     const partnerIds = location.partnerOrganizationIds ?? [];
     if (partnerIds.length === 0) {
+      // With current API, partner-locked venues always include partner ids; this
+      // branch supports older payloads or admin-web ahead of API deploy.
       if (!location.lockedFromPartnerOrg) {
         return true;
       }
@@ -28,12 +31,4 @@ export function filterLocationsForInstance(
     }
     return partnerIds.some((orgId) => selectedPartnerIds.has(orgId));
   });
-}
-
-/** Dropdown label: partner names when present, else geographic/address label. */
-export function formatInstanceLocationOptionLabel(location: LocationSummary): string {
-  if (location.partnerOrganizationLabels.length > 0) {
-    return location.partnerOrganizationLabels.join(', ');
-  }
-  return formatLocationLabel(location);
 }

--- a/apps/admin_web/src/lib/instance-location-options.ts
+++ b/apps/admin_web/src/lib/instance-location-options.ts
@@ -1,0 +1,39 @@
+import { formatLocationLabel } from '@/lib/format';
+import type { LocationSummary, PartnerOrgRef } from '@/types/services';
+
+/**
+ * Locations shown on instance create/edit: template venues, assigned partners'
+ * venues, and any venue already selected on the form (avoid hiding stale picks).
+ */
+export function filterLocationsForInstance(
+  locations: LocationSummary[],
+  partnerOrgs: PartnerOrgRef[],
+  extraSelectedIds: Set<string>
+): LocationSummary[] {
+  const selectedPartnerIds = new Set(partnerOrgs.map((p) => p.id));
+  const assignedPartnerLocationIds = new Set(
+    partnerOrgs.map((p) => p.locationId).filter((id): id is string => Boolean(id?.trim()))
+  );
+
+  return locations.filter((location) => {
+    if (extraSelectedIds.has(location.id)) {
+      return true;
+    }
+    const partnerIds = location.partnerOrganizationIds ?? [];
+    if (partnerIds.length === 0) {
+      if (!location.lockedFromPartnerOrg) {
+        return true;
+      }
+      return assignedPartnerLocationIds.has(location.id);
+    }
+    return partnerIds.some((orgId) => selectedPartnerIds.has(orgId));
+  });
+}
+
+/** Dropdown label: partner names when present, else geographic/address label. */
+export function formatInstanceLocationOptionLabel(location: LocationSummary): string {
+  if (location.partnerOrganizationLabels.length > 0) {
+    return location.partnerOrganizationLabels.join(', ');
+  }
+  return formatLocationLabel(location);
+}

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -147,6 +147,7 @@ function parseLocationSummary(value: unknown): LocationSummary {
     updatedAt: asNullableString(item.updated_at),
     lockedFromPartnerOrg: asBoolean(item.locked_from_partner_org, false),
     partnerOrganizationLabels: asStringArray(item.partner_organization_labels),
+    partnerOrganizationIds: asStringArray(item.partner_organization_ids),
   };
 }
 

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4769,6 +4769,8 @@ export interface components {
             locked_from_partner_org: boolean;
             /** @description Names of active partner organisations linked to this venue (for display). */
             partner_organization_labels: string[];
+            /** @description UUIDs of active partner organisations linked to this venue, in the same order as ``partner_organization_labels`` (sorted by partner name). */
+            partner_organization_ids: string[];
         };
         LocationResponse: {
             location: components["schemas"]["Location"];

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -210,6 +210,8 @@ export interface LocationSummary {
   lockedFromPartnerOrg: boolean;
   /** Display labels for linked partner organisations (same venue address). */
   partnerOrganizationLabels: string[];
+  /** Partner organisation UUIDs for this venue (same order as labels). */
+  partnerOrganizationIds: string[];
 }
 
 export type GeographicAreaLevel = ApiSchemas['GeographicArea']['level'];

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -421,6 +421,7 @@ describe('ContactsPanel', () => {
       updatedAt: null,
       lockedFromPartnerOrg: false,
       partnerOrganizationLabels: [],
+      partnerOrganizationIds: [],
     });
     geocodeVenueAddress.mockResolvedValue({
       lat: 22.3193,
@@ -517,6 +518,7 @@ describe('ContactsPanel', () => {
             updatedAt: null,
             lockedFromPartnerOrg: false,
             partnerOrganizationLabels: [],
+            partnerOrganizationIds: [],
           },
         ]}
         geographicAreas={[hkArea]}

--- a/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/families-panel.test.tsx
@@ -159,6 +159,7 @@ describe('FamiliesPanel', () => {
             updatedAt: null,
             lockedFromPartnerOrg: false,
             partnerOrganizationLabels: [],
+            partnerOrganizationIds: [],
           },
         ]}
         geographicAreas={[hkArea]}

--- a/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/organizations-panel.test.tsx
@@ -182,6 +182,7 @@ describe('OrganizationsPanel', () => {
             updatedAt: null,
             lockedFromPartnerOrg: true,
             partnerOrganizationLabels: ['Partner Org'],
+            partnerOrganizationIds: [],
           },
         ]}
         geographicAreas={[hkArea]}
@@ -250,6 +251,7 @@ describe('OrganizationsPanel', () => {
             updatedAt: null,
             lockedFromPartnerOrg: false,
             partnerOrganizationLabels: [],
+            partnerOrganizationIds: [],
           },
         ]}
         geographicAreas={[hkArea]}

--- a/apps/admin_web/tests/components/admin/locations/inline-location-editor.test.tsx
+++ b/apps/admin_web/tests/components/admin/locations/inline-location-editor.test.tsx
@@ -33,6 +33,7 @@ describe('InlineLocationEditor', () => {
           updatedAt: null,
           lockedFromPartnerOrg: false,
           partnerOrganizationLabels: [],
+          partnerOrganizationIds: [],
         }}
         areas={[baseArea]}
         areasLoading={false}
@@ -188,6 +189,7 @@ describe('InlineLocationEditor', () => {
           updatedAt: null,
           lockedFromPartnerOrg: false,
           partnerOrganizationLabels: [],
+          partnerOrganizationIds: [],
         }}
         areas={[baseArea]}
         areasLoading={false}
@@ -236,6 +238,7 @@ describe('InlineLocationEditor', () => {
           updatedAt: null,
           lockedFromPartnerOrg: true,
           partnerOrganizationLabels: ['X'],
+          partnerOrganizationIds: ['org-x'],
         }}
         areas={[baseArea]}
         areasLoading={false}
@@ -271,6 +274,7 @@ describe('InlineLocationEditor', () => {
           updatedAt: null,
           lockedFromPartnerOrg: true,
           partnerOrganizationLabels: ['Partner Co'],
+          partnerOrganizationIds: ['org-partner'],
         }}
         areas={[baseArea]}
         areasLoading={false}
@@ -287,6 +291,88 @@ describe('InlineLocationEditor', () => {
 
     expect(screen.queryByRole('button', { name: 'Change' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    expect(screen.getByText(/Managed from the partner organisation \(Partner Co\)/)).toBeInTheDocument();
+  });
+
+  it('owner partner id unlocks Change when venue is partner-locked', async () => {
+    const user = userEvent.setup();
+    const onSaveUpdate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InlineLocationEditor
+        stateKey='own1'
+        location={{
+          id: 'loc-1',
+          name: null,
+          areaId: 'area-1',
+          address: 'Shared addr',
+          lat: null,
+          lng: null,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: true,
+          partnerOrganizationLabels: ['Me', 'Other'],
+          partnerOrganizationIds: ['org-me', 'org-other'],
+        }}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        allowEditWhenOwnerPartnerOrganizationId='org-me'
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={onSaveUpdate}
+        onClear={vi.fn()}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/Managed from the partner organisation/)).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Change' }));
+    expect(
+      screen.getByText('Editing updates this address everywhere it is shown.')
+    ).toBeInTheDocument();
+    await user.clear(screen.getByLabelText('Address'));
+    await user.type(screen.getByLabelText('Address'), 'New addr');
+    await user.click(screen.getByRole('button', { name: 'Update location' }));
+    await waitFor(() => {
+      expect(onSaveUpdate).toHaveBeenCalled();
+    });
+  });
+
+  it('partner-locked stays locked when owner prop does not match partner ids', () => {
+    render(
+      <InlineLocationEditor
+        stateKey='mismatch'
+        location={{
+          id: 'loc-1',
+          name: null,
+          areaId: 'area-1',
+          address: 'A',
+          lat: null,
+          lng: null,
+          createdAt: null,
+          updatedAt: null,
+          lockedFromPartnerOrg: true,
+          partnerOrganizationLabels: ['Partner Co'],
+          partnerOrganizationIds: ['org-partner'],
+        }}
+        areas={[baseArea]}
+        areasLoading={false}
+        canModify
+        allowEditWhenOwnerPartnerOrganizationId='wrong-org'
+        isSaving={false}
+        onRequestEdit={vi.fn()}
+        onCancelEdit={vi.fn()}
+        onSaveCreate={vi.fn()}
+        onSaveUpdate={vi.fn()}
+        onClear={vi.fn()}
+        onGeocode={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Change' })).not.toBeInTheDocument();
     expect(screen.getByText(/Managed from the partner organisation \(Partner Co\)/)).toBeInTheDocument();
   });
 
@@ -309,6 +395,7 @@ describe('InlineLocationEditor', () => {
           updatedAt: null,
           lockedFromPartnerOrg: false,
           partnerOrganizationLabels: [],
+          partnerOrganizationIds: [],
         }}
         areas={[baseArea]}
         areasLoading={false}
@@ -347,6 +434,7 @@ describe('InlineLocationEditor', () => {
           updatedAt: null,
           lockedFromPartnerOrg: false,
           partnerOrganizationLabels: [],
+          partnerOrganizationIds: [],
         }}
         areas={[baseArea]}
         areasLoading={false}

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -60,6 +60,7 @@ function buildLocationSummary(overrides: Partial<LocationSummary> = {}): Locatio
     updatedAt: '2026-01-01T00:00:00Z',
     lockedFromPartnerOrg: false,
     partnerOrganizationLabels: [],
+    partnerOrganizationIds: [],
     ...overrides,
   };
 }
@@ -339,6 +340,72 @@ describe('InstanceDetailPanel', () => {
         tag_ids: [],
       })
     );
+  });
+
+  it('filters instance location dropdown to pure and assigned partner venues for events', async () => {
+    const user = userEvent.setup();
+    vi.mocked(entityApi.listEntityPartnerOrganizationPicker).mockResolvedValue([
+      { id: 'org-p', label: 'Partner P' },
+      { id: 'org-x', label: 'Other partner' },
+    ]);
+
+    const pure = buildLocationSummary({ id: 'loc-pure', address: 'Pure hall' });
+    const partnerVenue = buildLocationSummary({
+      id: 'loc-partner',
+      address: 'Shared street',
+      lockedFromPartnerOrg: true,
+      partnerOrganizationLabels: ['Partner P'],
+      partnerOrganizationIds: ['org-p'],
+    });
+    const foreignVenue = buildLocationSummary({
+      id: 'loc-foreign',
+      address: 'Secret block',
+      lockedFromPartnerOrg: true,
+      partnerOrganizationLabels: ['Other partner'],
+      partnerOrganizationIds: ['org-x'],
+    });
+
+    render(
+      <InstanceDetailPanel
+        {...defaultEntityTagProps}
+        instance={null}
+        selectedServiceId='evt-svc'
+        serviceOptions={[
+          buildServiceSummary({
+            id: 'evt-svc',
+            serviceType: 'event',
+            title: 'Spring open house',
+            trainingDetails: null,
+            eventDetails: {
+              eventCategory: 'open_house',
+              defaultPrice: '50.00',
+              defaultCurrency: 'HKD',
+            },
+          }),
+        ]}
+        locationOptions={[pure, partnerVenue, foreignVenue]}
+        isLoadingLocations={false}
+        serviceType='event'
+        isLoading={false}
+        error=''
+        onSelectService={vi.fn()}
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    const partnerSelect = screen.getByLabelText('Partner organisations');
+    await waitFor(() => {
+      expect(within(partnerSelect).getByRole('option', { name: 'Partner P' })).toBeInTheDocument();
+    });
+    await user.selectOptions(partnerSelect, 'org-p');
+
+    const locationSelect = screen.getByLabelText('Location') as HTMLSelectElement;
+    const optionTexts = Array.from(locationSelect.options).map((o) => o.textContent?.trim() ?? '');
+    expect(optionTexts).toContain('Pure hall');
+    expect(optionTexts).toContain('Partner P');
+    expect(optionTexts.some((t) => t.includes('Secret'))).toBe(false);
   });
 
   it('prefills duplicate create from createPrefillInstance and sends null slug with cohort', async () => {

--- a/apps/admin_web/tests/components/admin/services/partners-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/partners-panel.test.tsx
@@ -73,9 +73,28 @@ vi.mock('@/hooks/use-confirm-dialog', () => ({
   ],
 }));
 
+const { mockUseInlineLocationSave } = vi.hoisted(() => ({
+  mockUseInlineLocationSave: vi.fn(() => ({
+    status: { isSaving: false, error: '' },
+    createSharedLocation: vi.fn(),
+    updateSharedLocation: vi.fn().mockResolvedValue(undefined),
+    clearError: vi.fn(),
+  })),
+}));
+
+vi.mock('@/hooks/use-inline-location-save', () => ({
+  useInlineLocationSave: mockUseInlineLocationSave,
+}));
+
 describe('PartnersPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseInlineLocationSave.mockReturnValue({
+      status: { isSaving: false, error: '' },
+      createSharedLocation: vi.fn(),
+      updateSharedLocation: vi.fn().mockResolvedValue(undefined),
+      clearError: vi.fn(),
+    });
   });
 
   it('always shows slug field and creates with relationship_type partner', async () => {
@@ -184,6 +203,86 @@ describe('PartnersPanel', () => {
         slug: 'row-slug',
       })
     );
+  });
+
+  it('partner owning locked venue can Change and save via updateSharedLocation', async () => {
+    const user = userEvent.setup();
+    const updateSharedLocation = vi.fn().mockResolvedValue(undefined);
+    mockUseInlineLocationSave.mockReturnValue({
+      status: { isSaving: false, error: '' },
+      createSharedLocation: vi.fn(),
+      updateSharedLocation,
+      clearError: vi.fn(),
+    });
+
+    const locId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const partnerId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const row: components['schemas']['AdminOrganization'] = {
+      id: partnerId,
+      name: 'Venue Owner',
+      organization_type: 'company',
+      relationship_type: 'partner',
+      slug: null,
+      website: null,
+      location_id: locId,
+      location_summary: null,
+      tag_ids: [],
+      tags: [],
+      members: [],
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+    };
+    const partners = buildPartnersHook({ partners: [row] });
+    const locations = [
+      {
+        id: locId,
+        name: 'Ignored name',
+        areaId: 'area-1',
+        address: '1 Test St',
+        lat: null,
+        lng: null,
+        createdAt: null,
+        updatedAt: null,
+        lockedFromPartnerOrg: true,
+        partnerOrganizationLabels: ['Venue Owner'],
+        partnerOrganizationIds: [partnerId],
+      },
+    ];
+    const areas = [
+      {
+        id: 'area-1',
+        parentId: null,
+        name: 'Hong Kong',
+        level: 'country' as const,
+        code: 'HK',
+        sovereignCountryId: null,
+        active: true,
+        displayOrder: 0,
+      },
+    ];
+
+    render(
+      <PartnersPanel
+        partners={partners}
+        {...panelShell}
+        locations={locations}
+        geographicAreas={areas}
+      />
+    );
+
+    await user.click(screen.getByText('Venue Owner'));
+    await user.click(screen.getByRole('button', { name: 'Change' }));
+    await user.clear(screen.getByLabelText('Address'));
+    await user.type(screen.getByLabelText('Address'), '2 Test St');
+    await user.click(screen.getByRole('button', { name: 'Update location' }));
+
+    await waitFor(() => {
+      expect(updateSharedLocation).toHaveBeenCalledWith(
+        locId,
+        expect.objectContaining({ address: '2 Test St' })
+      );
+    });
   });
 
   it('deletes partner after confirmation from table', async () => {

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -414,6 +414,7 @@ describe('ServiceDetailPanel', () => {
             updatedAt: null,
             lockedFromPartnerOrg: false,
             partnerOrganizationLabels: [],
+            partnerOrganizationIds: [],
           },
         ]}
         isLoadingLocations={false}
@@ -611,6 +612,7 @@ describe('ServiceDetailPanel', () => {
             updatedAt: null,
             lockedFromPartnerOrg: false,
             partnerOrganizationLabels: [],
+            partnerOrganizationIds: [],
           },
         ]}
         isLoadingLocations={false}
@@ -677,6 +679,7 @@ describe('ServiceDetailPanel', () => {
             updatedAt: null,
             lockedFromPartnerOrg: false,
             partnerOrganizationLabels: [],
+            partnerOrganizationIds: [],
           },
         ]}
         isLoadingLocations={false}

--- a/apps/admin_web/tests/components/admin/services/venues-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/venues-panel.test.tsx
@@ -87,6 +87,7 @@ describe('VenuesPanel', () => {
             updatedAt: '2025-01-01T00:00:00Z',
             lockedFromPartnerOrg: false,
             partnerOrganizationLabels: [],
+            partnerOrganizationIds: [],
           },
         ]}
         geographicAreas={[

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -156,6 +156,7 @@ describe('format helpers', () => {
           updatedAt: null,
           lockedFromPartnerOrg: false,
           partnerOrganizationLabels: [],
+          partnerOrganizationIds: [],
         },
       ],
       [
@@ -171,6 +172,7 @@ describe('format helpers', () => {
           updatedAt: null,
           lockedFromPartnerOrg: false,
           partnerOrganizationLabels: [],
+          partnerOrganizationIds: [],
         },
       ],
     ]);

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -170,9 +170,9 @@ describe('format helpers', () => {
           lng: null,
           createdAt: null,
           updatedAt: null,
-          lockedFromPartnerOrg: false,
-          partnerOrganizationLabels: [],
-          partnerOrganizationIds: [],
+          lockedFromPartnerOrg: true,
+          partnerOrganizationLabels: ['Co'],
+          partnerOrganizationIds: ['org-1'],
         },
       ],
     ]);
@@ -225,7 +225,7 @@ describe('format helpers', () => {
       consultationDetails: null,
       resolvedConsultationDetails: null,
     };
-    expect(formatInstanceSlotLocationSummary(instance, locById)).toBe('Hall A · Partner venue');
+    expect(formatInstanceSlotLocationSummary(instance, locById)).toBe('Hall A · Co');
   });
 
   it('uses earliest ordered slot time for instance sort key', () => {

--- a/apps/admin_web/tests/lib/instance-location-options.test.ts
+++ b/apps/admin_web/tests/lib/instance-location-options.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatInstanceLocationOptionLabel, filterLocationsForInstance } from '@/lib/instance-location-options';
+
+import type { LocationSummary, PartnerOrgRef } from '@/types/services';
+
+function loc(overrides: Partial<LocationSummary>): LocationSummary {
+  return {
+    id: 'loc-1',
+    name: null,
+    areaId: 'area-1',
+    address: 'Addr',
+    lat: null,
+    lng: null,
+    createdAt: null,
+    updatedAt: null,
+    lockedFromPartnerOrg: false,
+    partnerOrganizationLabels: [],
+    partnerOrganizationIds: [],
+    ...overrides,
+  };
+}
+
+describe('filterLocationsForInstance', () => {
+  const pure = loc({ id: 'pure', address: 'Pure venue' });
+  const partnerVenue = loc({
+    id: 'pv',
+    lockedFromPartnerOrg: true,
+    partnerOrganizationLabels: ['P'],
+    partnerOrganizationIds: ['org-p'],
+  });
+  const foreign = loc({
+    id: 'fv',
+    lockedFromPartnerOrg: true,
+    partnerOrganizationLabels: ['Other'],
+    partnerOrganizationIds: ['org-other'],
+  });
+
+  it('keeps pure venues and drops foreign partner venues when unassigned', () => {
+    const partners: PartnerOrgRef[] = [{ id: 'org-p', name: 'P', active: true, locationId: 'pv' }];
+    const out = filterLocationsForInstance([pure, partnerVenue, foreign], partners, new Set());
+    expect(out.map((l) => l.id)).toEqual(['pure', 'pv']);
+  });
+
+  it('keeps unassigned partner venue when id is in extraSelectedIds', () => {
+    const out = filterLocationsForInstance(
+      [pure, foreign],
+      [],
+      new Set(['fv'])
+    );
+    expect(out.map((l) => l.id)).toEqual(['pure', 'fv']);
+  });
+
+  it('with empty partnerOrgs only pure venues remain', () => {
+    const out = filterLocationsForInstance([pure, partnerVenue, foreign], [], new Set());
+    expect(out).toEqual([pure]);
+  });
+});
+
+describe('formatInstanceLocationOptionLabel', () => {
+  it('joins partner labels when present', () => {
+    const label = formatInstanceLocationOptionLabel(
+      loc({
+        partnerOrganizationLabels: ['A', 'B'],
+        partnerOrganizationIds: ['1', '2'],
+      })
+    );
+    expect(label).toBe('A, B');
+  });
+
+  it('falls back to formatLocationLabel when no partner labels', () => {
+    expect(
+      formatInstanceLocationOptionLabel(
+        loc({ name: 'Hall', partnerOrganizationLabels: [], partnerOrganizationIds: [] })
+      )
+    ).toBe('Hall');
+  });
+});

--- a/apps/admin_web/tests/lib/services-api.test.ts
+++ b/apps/admin_web/tests/lib/services-api.test.ts
@@ -320,6 +320,34 @@ describe('services-api', () => {
     expect(result.items[1].lng).toBe(55.5);
   });
 
+  it('maps partner_organization_ids on location list items', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: 'loc-ids',
+            name: null,
+            area_id: '00000000-0000-0000-0000-000000000001',
+            address: '1 Rd',
+            lat: null,
+            lng: null,
+            created_at: null,
+            updated_at: null,
+            locked_from_partner_org: true,
+            partner_organization_labels: ['Alpha'],
+            partner_organization_ids: ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'],
+          },
+        ],
+        next_cursor: null,
+        total_count: 1,
+      },
+    });
+
+    const result = await listLocations({ limit: 50 });
+    expect(result.items[0].partnerOrganizationIds).toEqual(['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa']);
+    expect(result.items[0].partnerOrganizationLabels).toEqual(['Alpha']);
+  });
+
   it('adds exclude_addresses when listLocations requests family/org address exclusion', async () => {
     mockAdminApiRequest.mockResolvedValueOnce({
       data: {
@@ -351,6 +379,7 @@ describe('services-api', () => {
       updated_at: null,
       locked_from_partner_org: false,
       partner_organization_labels: [],
+      partner_organization_ids: [],
     };
     const partnerOnlyRow = {
       id: '00000000-0000-0000-0000-000000000003',
@@ -363,6 +392,7 @@ describe('services-api', () => {
       updated_at: null,
       locked_from_partner_org: true,
       partner_organization_labels: ['Acme Partner'],
+      partner_organization_ids: ['bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'],
     };
 
     mockAdminApiRequest

--- a/backend/src/app/api/admin_locations.py
+++ b/backend/src/app/api/admin_locations.py
@@ -147,7 +147,7 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
         rows = rows[:limit]
         next_cursor = encode_cursor(rows[-1].id) if has_more and rows else None
         partner_by_loc = (
-            location_repo.active_partner_organization_names_by_location_ids(
+            location_repo.active_partner_organization_id_label_pairs_by_location_ids(
                 [cast(UUID, loc.id) for loc in rows]
             )
         )
@@ -157,7 +157,7 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
                 "items": [
                     _serialize_location(
                         location,
-                        partner_organization_names=partner_by_loc.get(
+                        partner_organization_id_label_pairs=partner_by_loc.get(
                             cast(UUID, location.id)
                         ),
                     )
@@ -206,7 +206,7 @@ def _create_location(event: Mapping[str, Any]) -> dict[str, Any]:
         location = location_repo.create(location)
         session.commit()
         partner_by_loc = (
-            location_repo.active_partner_organization_names_by_location_ids(
+            location_repo.active_partner_organization_id_label_pairs_by_location_ids(
                 [cast(UUID, location.id)]
             )
         )
@@ -215,7 +215,7 @@ def _create_location(event: Mapping[str, Any]) -> dict[str, Any]:
             {
                 "location": _serialize_location(
                     location,
-                    partner_organization_names=partner_by_loc.get(
+                    partner_organization_id_label_pairs=partner_by_loc.get(
                         cast(UUID, location.id)
                     ),
                 )
@@ -231,7 +231,7 @@ def _get_location(event: Mapping[str, Any], location_id: UUID) -> dict[str, Any]
         if location is None:
             raise NotFoundError("Location", str(location_id))
         partner_by_loc = (
-            location_repo.active_partner_organization_names_by_location_ids(
+            location_repo.active_partner_organization_id_label_pairs_by_location_ids(
                 [location_id]
             )
         )
@@ -240,7 +240,7 @@ def _get_location(event: Mapping[str, Any], location_id: UUID) -> dict[str, Any]
             {
                 "location": _serialize_location(
                     location,
-                    partner_organization_names=partner_by_loc.get(location_id),
+                    partner_organization_id_label_pairs=partner_by_loc.get(location_id),
                 )
             },
             event=event,
@@ -269,9 +269,12 @@ def _update_location(
         if location is None:
             raise NotFoundError("Location", str(location_id))
 
-        partner_names = location_repo.active_partner_organization_names_by_location_ids(
-            [location_id]
-        ).get(location_id)
+        partner_pairs = (
+            location_repo.active_partner_organization_id_label_pairs_by_location_ids(
+                [location_id]
+            ).get(location_id)
+        )
+        partner_names = [label for _oid, label in (partner_pairs or [])]
         if partner_names and "name" in body:
             parsed_name = _parse_name(body.get("name"), required=False)
             current_norm = (location.name or "").strip()
@@ -307,7 +310,7 @@ def _update_location(
         location = location_repo.update(location)
         session.commit()
         partner_by_loc = (
-            location_repo.active_partner_organization_names_by_location_ids(
+            location_repo.active_partner_organization_id_label_pairs_by_location_ids(
                 [location_id]
             )
         )
@@ -316,7 +319,7 @@ def _update_location(
             {
                 "location": _serialize_location(
                     location,
-                    partner_organization_names=partner_by_loc.get(location_id),
+                    partner_organization_id_label_pairs=partner_by_loc.get(location_id),
                 )
             },
             event=event,
@@ -337,9 +340,12 @@ def _delete_location(event: Mapping[str, Any], location_id: UUID) -> dict[str, A
         location = location_repo.get_by_id(location_id)
         if location is None:
             raise NotFoundError("Location", str(location_id))
-        partner_names = location_repo.active_partner_organization_names_by_location_ids(
-            [location_id]
-        ).get(location_id)
+        partner_pairs = (
+            location_repo.active_partner_organization_id_label_pairs_by_location_ids(
+                [location_id]
+            ).get(location_id)
+        )
+        partner_names = [label for _oid, label in (partner_pairs or [])]
         if partner_names:
             raise ValidationError(
                 "Cannot delete a venue linked to a partner organisation",
@@ -365,9 +371,11 @@ def _optional_coordinate_json(value: Any) -> float | None:
 def _serialize_location(
     location: Location,
     *,
-    partner_organization_names: list[str] | None = None,
+    partner_organization_id_label_pairs: list[tuple[UUID, str]] | None = None,
 ) -> dict[str, Any]:
-    names = partner_organization_names or []
+    pairs = partner_organization_id_label_pairs or []
+    names = [label for _org_id, label in pairs]
+    org_ids = [str(org_id) for org_id, _label in pairs]
     locked = bool(names)
     return {
         "id": str(location.id),
@@ -380,6 +388,7 @@ def _serialize_location(
         "updated_at": location.updated_at,
         "locked_from_partner_org": locked,
         "partner_organization_labels": names,
+        "partner_organization_ids": org_ids,
     }
 
 

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -555,6 +555,13 @@ def _update_instance(
                 parsed_details=type_details_raw,
             )
         if "partner_organization_ids" in payload:
+            # Partner M2M rows are reconciled with bulk DELETE + INSERT (see
+            # reconcile_instance_partner_organizations), not via the ORM collection,
+            # because selectinload-loaded link objects would stay in deleted state in
+            # the session while instance.partner_organization_links still references
+            # them — session.add(instance) would then cascade and raise
+            # InvalidRequestError. Session-tracked instance + commit() persists
+            # scalar changes without re-adding the instance.
             reconcile_instance_partner_organizations(
                 session,
                 instance_id=instance.id,
@@ -567,7 +574,6 @@ def _update_instance(
                 tag_ids=payload["tag_ids"],
             )
 
-        session.flush()
         session.commit()
         if service.service_type == ServiceType.EVENT:
             enqueue_eventbrite_instance_sync_by_id(instance.id)

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -567,13 +567,13 @@ def _update_instance(
                 tag_ids=payload["tag_ids"],
             )
 
-        updated = instance_repository.update_instance(instance)
+        session.flush()
         session.commit()
         if service.service_type == ServiceType.EVENT:
-            enqueue_eventbrite_instance_sync_by_id(updated.id)
-        with_details = instance_repository.get_by_id_with_details(updated.id)
+            enqueue_eventbrite_instance_sync_by_id(instance.id)
+        with_details = instance_repository.get_by_id_with_details(instance.id)
         if with_details is None:
-            raise NotFoundError("ServiceInstance", str(updated.id))
+            raise NotFoundError("ServiceInstance", str(instance.id))
         return json_response(
             200, {"instance": serialize_instance(with_details)}, event=event
         )

--- a/backend/src/app/db/repositories/location.py
+++ b/backend/src/app/db/repositories/location.py
@@ -111,15 +111,19 @@ class LocationRepository(BaseRepository[Location]):
         )
         return self._session.execute(query).scalar_one_or_none()
 
-    def active_partner_organization_names_by_location_ids(
+    def active_partner_organization_id_label_pairs_by_location_ids(
         self,
         location_ids: Sequence[UUID],
-    ) -> dict[UUID, list[str]]:
-        """Map location ids to sorted names of active partner CRM organizations."""
+    ) -> dict[UUID, list[tuple[UUID, str]]]:
+        """Map location ids to (org id, display label) for active partner organisations.
+
+        Labels are sorted by organisation name. Duplicate organisation ids per
+        location are omitted.
+        """
         if not location_ids:
             return {}
         stmt = (
-            select(Organization.location_id, Organization.name)
+            select(Organization.id, Organization.location_id, Organization.name)
             .where(
                 Organization.location_id.in_(location_ids),
                 Organization.relationship_type == RelationshipType.PARTNER,
@@ -128,10 +132,27 @@ class LocationRepository(BaseRepository[Location]):
             .order_by(Organization.name.asc())
         )
         rows = self._session.execute(stmt).all()
-        by_loc: dict[UUID, list[str]] = defaultdict(list)
-        for loc_id, name in rows:
+        by_loc: dict[UUID, list[tuple[UUID, str]]] = defaultdict(list)
+        seen_org_by_loc: dict[UUID, set[UUID]] = defaultdict(set)
+        for org_id, loc_id, name in rows:
             if loc_id is None:
                 continue
+            if org_id in seen_org_by_loc[loc_id]:
+                continue
+            seen_org_by_loc[loc_id].add(org_id)
             label = (name or "").strip() or "Partner organisation"
-            by_loc[loc_id].append(label)
+            by_loc[loc_id].append((org_id, label))
         return dict(by_loc)
+
+    def active_partner_organization_names_by_location_ids(
+        self,
+        location_ids: Sequence[UUID],
+    ) -> dict[UUID, list[str]]:
+        """Map location ids to sorted names of active partner CRM organizations."""
+        pairs_by_loc = self.active_partner_organization_id_label_pairs_by_location_ids(
+            location_ids
+        )
+        return {
+            loc_id: [label for _org_id, label in pairs]
+            for loc_id, pairs in pairs_by_loc.items()
+        }

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -357,10 +357,6 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         self._session.refresh(instance)
         return instance
 
-    def update_instance(self, instance: ServiceInstance) -> ServiceInstance:
-        """Update and refresh an instance."""
-        return self.update(instance)
-
     def get_enrollment_count(self, instance_id: UUID) -> int:
         """Return enrollment count for capacity (same statuses as EnrollmentRepository)."""
         statement = (

--- a/backend/src/app/services/eventbrite_sync.py
+++ b/backend/src/app/services/eventbrite_sync.py
@@ -68,7 +68,6 @@ def sync_instance_to_eventbrite(
     config = _load_config()
     instance.eventbrite_sync_status = EventbriteSyncStatus.SYNCING
     instance.eventbrite_last_error = None
-    repository.update_instance(instance)
     session.commit()
 
     try:
@@ -76,7 +75,6 @@ def sync_instance_to_eventbrite(
             created_event_id, created_event_url = _create_event(instance, config=config)
             instance.eventbrite_event_id = created_event_id
             instance.eventbrite_event_url = created_event_url
-            repository.update_instance(instance)
             session.commit()
 
         if instance.eventbrite_event_id is None:
@@ -92,7 +90,6 @@ def sync_instance_to_eventbrite(
         instance.eventbrite_last_error = None
         instance.eventbrite_retry_count = 0
         instance.eventbrite_sync_status = EventbriteSyncStatus.SYNCED
-        repository.update_instance(instance)
         session.commit()
         logger.info(
             "Eventbrite sync succeeded",
@@ -110,7 +107,6 @@ def sync_instance_to_eventbrite(
         instance.eventbrite_sync_status = EventbriteSyncStatus.FAILED
         instance.eventbrite_last_error = str(exc)
         instance.eventbrite_retry_count = int(instance.eventbrite_retry_count or 0) + 1
-        repository.update_instance(instance)
         session.commit()
         logger.exception(
             "Eventbrite sync failed",

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -4625,6 +4625,7 @@ components:
         - area_id
         - locked_from_partner_org
         - partner_organization_labels
+        - partner_organization_ids
       properties:
         id:
           type: string
@@ -4667,6 +4668,14 @@ components:
             Names of active partner organisations linked to this venue (for display).
           items:
             type: string
+        partner_organization_ids:
+          type: array
+          description: >
+            UUIDs of active partner organisations linked to this venue, in the same
+            order as ``partner_organization_labels`` (sorted by partner name).
+          items:
+            type: string
+            format: uuid
     LocationResponse:
       type: object
       required:

--- a/tests/test_admin_locations_api.py
+++ b/tests/test_admin_locations_api.py
@@ -94,6 +94,7 @@ def test_serialize_location_emits_float_coordinates_for_json() -> None:
     payload = admin_locations._serialize_location(location)  # type: ignore[arg-type]
     assert payload["locked_from_partner_org"] is False
     assert payload["partner_organization_labels"] == []
+    assert payload["partner_organization_ids"] == []
     assert payload["lat"] == 22.3193
     assert payload["lng"] == 114.1694
     assert isinstance(payload["lat"], float)
@@ -131,9 +132,15 @@ def test_serialize_location_partner_metadata() -> None:
         created_at=None,
         updated_at=None,
     )
+    org_a = uuid4()
+    org_b = uuid4()
     payload = admin_locations._serialize_location(
         location,
-        partner_organization_names=["Alpha Partners", "Beta Co"],
+        partner_organization_id_label_pairs=[
+            (org_a, "Alpha Partners"),
+            (org_b, "Beta Co"),
+        ],
     )
     assert payload["locked_from_partner_org"] is True
     assert payload["partner_organization_labels"] == ["Alpha Partners", "Beta Co"]
+    assert payload["partner_organization_ids"] == [str(org_a), str(org_b)]

--- a/tests/test_admin_service_instances_partner_update.py
+++ b/tests/test_admin_service_instances_partner_update.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from typing import Any
 from uuid import uuid4
 
@@ -66,7 +67,7 @@ def test_update_instance_skips_repository_update_instance_after_partner_reconcil
     monkeypatch: Any,
     api_gateway_event: Any,
 ) -> None:
-    """Avoid session.add(instance) after bulk DELETE on partner links (stale ORM)."""
+    """Commit path does not call repository update (no session.add on instance)."""
     service_id = uuid4()
     instance_id = uuid4()
     org_a = uuid4()
@@ -98,9 +99,6 @@ def test_update_instance_skips_repository_update_instance_after_partner_reconcil
     captured: dict[str, Any] = {}
 
     class _FakeSession:
-        def flush(self) -> None:
-            captured["flushed"] = True
-
         def commit(self) -> None:
             captured["committed"] = True
 
@@ -129,10 +127,6 @@ def test_update_instance_skips_repository_update_instance_after_partner_reconcil
         def get_by_id_with_details(self, iid: Any) -> ServiceInstance:
             assert iid == instance_id
             return instance
-
-        def update_instance(self, inst: ServiceInstance) -> ServiceInstance:
-            captured["update_instance_called"] = True
-            return inst
 
         def get_by_id_with_details_after(self, iid: Any) -> ServiceInstance | None:
             assert iid == instance_id
@@ -167,7 +161,18 @@ def test_update_instance_skips_repository_update_instance_after_partner_reconcil
         "parse_update_instance_payload",
         lambda body, svc: {
             "status": InstanceStatus.SCHEDULED,
-            "type_details": {"event_ticket_tiers": [{"price": "10", "currency": "HKD"}]},
+            "type_details": {
+                "event_ticket_tiers": [
+                    {
+                        "name": "workshop",
+                        "description": None,
+                        "price": Decimal("10.00"),
+                        "currency": "HKD",
+                        "max_quantity": None,
+                        "sort_order": 0,
+                    }
+                ]
+            },
             "partner_organization_ids": [org_b, org_a],
         },
     )
@@ -175,11 +180,6 @@ def test_update_instance_skips_repository_update_instance_after_partner_reconcil
         admin_service_instances,
         "validate_partner_organization_ids",
         lambda *_a, **_k: None,
-    )
-    monkeypatch.setattr(
-        admin_service_instances,
-        "_apply_instance_type_details",
-        lambda **_k: None,
     )
     monkeypatch.setattr(
         admin_service_instances,
@@ -221,8 +221,6 @@ def test_update_instance_skips_repository_update_instance_after_partner_reconcil
     )
 
     assert response["statusCode"] == 200
-    assert captured.get("update_instance_called") is None
-    assert captured.get("flushed") is True
     assert captured.get("committed") is True
     assert captured.get("reconcile_ids") == [org_b, org_a]
     assert captured.get("sync_id") == instance_id

--- a/tests/test_admin_service_instances_partner_update.py
+++ b/tests/test_admin_service_instances_partner_update.py
@@ -1,0 +1,241 @@
+"""Regression tests for instance update after bulk partner link reconciliation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.api import admin_service_instances
+from app.api.admin_services_common import parse_update_instance_payload
+from app.api.assets.assets_common import RequestIdentity
+from app.db.models.enums import (
+    InstanceStatus,
+    ServiceDeliveryMode,
+    ServiceStatus,
+    ServiceType,
+)
+from app.db.models.service import Service
+from app.db.models.service_instance import ServiceInstance
+from app.exceptions import ValidationError
+
+pytestmark = pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
+
+
+def _admin_identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_sub="test-admin-sub-12345",
+        groups={"admin"},
+        organization_ids={"org-1"},
+    )
+
+
+def _minimal_event_service() -> Service:
+    sid = uuid4()
+    return Service(
+        id=sid,
+        service_type=ServiceType.EVENT,
+        title="Event",
+        slug="evt",
+        booking_system=None,
+        description=None,
+        cover_image_s3_key=None,
+        delivery_mode=ServiceDeliveryMode.IN_PERSON,
+        status=ServiceStatus.PUBLISHED,
+        created_by="tester",
+    )
+
+
+def test_parse_update_instance_payload_allows_partner_only_with_status_and_tiers() -> (
+    None
+):
+    """PUT body may include only partner_organization_ids when status+tiers present."""
+    service = _minimal_event_service()
+    body = {
+        "status": "scheduled",
+        "event_ticket_tiers": [{"price": "10.00", "currency": "HKD"}],
+        "partner_organization_ids": [str(uuid4())],
+    }
+    parsed = parse_update_instance_payload(body, service)
+    assert "partner_organization_ids" in parsed
+
+
+def test_update_instance_skips_repository_update_instance_after_partner_reconcile(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    """Avoid session.add(instance) after bulk DELETE on partner links (stale ORM)."""
+    service_id = uuid4()
+    instance_id = uuid4()
+    org_a = uuid4()
+    org_b = uuid4()
+
+    service = _minimal_event_service()
+    service.id = service_id
+    instance = ServiceInstance(
+        id=instance_id,
+        service_id=service_id,
+        title="Inst",
+        slug="inst-slug",
+        landing_page=None,
+        description=None,
+        cover_image_s3_key=None,
+        status=InstanceStatus.SCHEDULED,
+        delivery_mode=ServiceDeliveryMode.IN_PERSON,
+        location_id=None,
+        max_capacity=None,
+        waitlist_enabled=False,
+        instructor_id=None,
+        cohort=None,
+        notes=None,
+        external_url=None,
+        created_by="tester",
+    )
+    instance.service = service
+
+    captured: dict[str, Any] = {}
+
+    class _FakeSession:
+        def flush(self) -> None:
+            captured["flushed"] = True
+
+        def commit(self) -> None:
+            captured["committed"] = True
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeServiceRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_with_details(self, sid: Any) -> Service:
+            assert sid == service_id
+            return service
+
+    class _FakeInstanceRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_with_details(self, iid: Any) -> ServiceInstance:
+            assert iid == instance_id
+            return instance
+
+        def update_instance(self, inst: ServiceInstance) -> ServiceInstance:
+            captured["update_instance_called"] = True
+            return inst
+
+        def get_by_id_with_details_after(self, iid: Any) -> ServiceInstance | None:
+            assert iid == instance_id
+            return instance
+
+    def _fake_parse_body(_event: Any) -> dict[str, Any]:
+        return {
+            "status": "scheduled",
+            "event_ticket_tiers": [{"price": "10.00", "currency": "HKD"}],
+            "partner_organization_ids": [str(org_b), str(org_a)],
+        }
+
+    def _fake_reconcile(
+        session: Any,
+        *,
+        instance_id: Any,
+        ordered_org_ids: list[Any],
+    ) -> None:
+        captured["reconcile_ids"] = list(ordered_org_ids)
+
+    monkeypatch.setattr(admin_service_instances, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_service_instances, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        admin_service_instances,
+        "extract_identity",
+        lambda _event: _admin_identity(),
+    )
+    monkeypatch.setattr(admin_service_instances, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(admin_service_instances, "parse_body", _fake_parse_body)
+    monkeypatch.setattr(
+        admin_service_instances,
+        "parse_update_instance_payload",
+        lambda body, svc: {
+            "status": InstanceStatus.SCHEDULED,
+            "type_details": {"event_ticket_tiers": [{"price": "10", "currency": "HKD"}]},
+            "partner_organization_ids": [org_b, org_a],
+        },
+    )
+    monkeypatch.setattr(
+        admin_service_instances,
+        "validate_partner_organization_ids",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        admin_service_instances,
+        "_apply_instance_type_details",
+        lambda **_k: None,
+    )
+    monkeypatch.setattr(
+        admin_service_instances,
+        "reconcile_instance_partner_organizations",
+        _fake_reconcile,
+    )
+    monkeypatch.setattr(
+        admin_service_instances,
+        "replace_service_instance_tags",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        admin_service_instances,
+        "enqueue_eventbrite_instance_sync_by_id",
+        lambda iid: captured.setdefault("sync_id", iid),
+    )
+    monkeypatch.setattr(
+        admin_service_instances,
+        "serialize_instance",
+        lambda inst: {"id": str(inst.id), "partner_ok": True},
+    )
+    monkeypatch.setattr(
+        admin_service_instances,
+        "ServiceRepository",
+        _FakeServiceRepository,
+    )
+    monkeypatch.setattr(
+        admin_service_instances,
+        "ServiceInstanceRepository",
+        _FakeInstanceRepository,
+    )
+
+    path = f"/v1/admin/services/{service_id}/instances/{instance_id}"
+    response = admin_service_instances.handle_admin_service_instances_request(
+        api_gateway_event(method="PUT", path=path, body="{}"),
+        "PUT",
+        path,
+        service_id,
+    )
+
+    assert response["statusCode"] == 200
+    assert captured.get("update_instance_called") is None
+    assert captured.get("flushed") is True
+    assert captured.get("committed") is True
+    assert captured.get("reconcile_ids") == [org_b, org_a]
+    assert captured.get("sync_id") == instance_id
+    body = json.loads(response["body"])
+    assert body["instance"]["partner_ok"] is True
+
+
+def test_parse_update_instance_payload_partner_only_without_tiers_raises() -> None:
+    service = _minimal_event_service()
+    body = {
+        "status": "scheduled",
+        "partner_organization_ids": [str(uuid4())],
+    }
+    with pytest.raises(ValidationError) as exc:
+        parse_update_instance_payload(body, service)
+    assert exc.value.field == "event_ticket_tiers"

--- a/tests/test_admin_service_instances_partner_update_postgres.py
+++ b/tests/test_admin_service_instances_partner_update_postgres.py
@@ -1,0 +1,261 @@
+"""PostgreSQL integration: partner link bulk reconcile + session commit (ORM-safe)."""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.api.admin_service_instance_partners import reconcile_instance_partner_organizations
+from app.db.models import (
+    EventDetails,
+    EventTicketTier,
+    GeographicArea,
+    Location,
+    Organization,
+    Service,
+    ServiceInstance,
+    ServiceInstancePartnerOrganization,
+)
+from app.db.models.enums import (
+    EventCategory,
+    InstanceStatus,
+    OrganizationType,
+    RelationshipType,
+    ServiceDeliveryMode,
+    ServiceStatus,
+    ServiceType,
+)
+from app.db.repositories.location import LocationRepository
+from app.db.repositories.service_instance import ServiceInstanceRepository
+
+psycopg = pytest.importorskip("psycopg", reason="psycopg required for DB integration test")
+
+
+def _database_url() -> str | None:
+    url = os.getenv("TEST_DATABASE_URL", "").strip()
+    return url or None
+
+
+@pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
+def test_reconcile_partner_links_after_selectinload_commit_succeeds() -> None:
+    """Mirrors admin PUT path: loaded instance + bulk reconcile + commit (no session.add)."""
+    url = _database_url()
+    assert url is not None
+    engine = create_engine(url)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    service_id = uuid4()
+    instance_id = uuid4()
+    area_id = uuid4()
+    loc_id = uuid4()
+    org_a = uuid4()
+    org_b = uuid4()
+
+    with SessionLocal() as session:
+        session.add(
+            GeographicArea(
+                id=area_id,
+                parent_id=None,
+                name="Test Area",
+                name_translations={},
+                level="country",
+                code="HK",
+                active=True,
+                display_order=0,
+                sovereign_country_id=None,
+            )
+        )
+        session.add(
+            Location(
+                id=loc_id,
+                area_id=area_id,
+                name=None,
+                address="1 Integration St",
+                lat=None,
+                lng=None,
+            )
+        )
+        session.add(
+            Service(
+                id=service_id,
+                service_type=ServiceType.EVENT,
+                title="Integration Event Service",
+                slug=f"int-evt-{instance_id.hex[:8]}",
+                booking_system=None,
+                description=None,
+                cover_image_s3_key=None,
+                delivery_mode=ServiceDeliveryMode.IN_PERSON,
+                status=ServiceStatus.PUBLISHED,
+                created_by="pytest",
+                location_id=None,
+            )
+        )
+        session.add(
+            EventDetails(
+                service_id=service_id,
+                event_category=EventCategory.WORKSHOP,
+                default_price=Decimal("10.00"),
+                default_currency="HKD",
+            )
+        )
+        session.add(
+            ServiceInstance(
+                id=instance_id,
+                service_id=service_id,
+                title="Instance",
+                slug=f"int-inst-{instance_id.hex[:8]}",
+                landing_page=None,
+                description=None,
+                cover_image_s3_key=None,
+                status=InstanceStatus.SCHEDULED,
+                delivery_mode=ServiceDeliveryMode.IN_PERSON,
+                location_id=loc_id,
+                max_capacity=None,
+                waitlist_enabled=False,
+                instructor_id=None,
+                cohort=None,
+                notes=None,
+                external_url=None,
+                created_by="pytest",
+            )
+        )
+        session.add(
+            EventTicketTier(
+                instance_id=instance_id,
+                name="workshop",
+                description=None,
+                price=Decimal("10.00"),
+                currency="HKD",
+                max_quantity=None,
+                sort_order=0,
+            )
+        )
+        for oid, name in ((org_a, "Partner A"), (org_b, "Partner B")):
+            session.add(
+                Organization(
+                    id=oid,
+                    name=name,
+                    organization_type=OrganizationType.COMPANY,
+                    relationship_type=RelationshipType.PARTNER,
+                    website=None,
+                    slug=None,
+                    location_id=loc_id,
+                    archived_at=None,
+                )
+            )
+        session.add(
+            ServiceInstancePartnerOrganization(
+                service_instance_id=instance_id,
+                organization_id=org_a,
+                sort_order=0,
+            )
+        )
+        session.add(
+            ServiceInstancePartnerOrganization(
+                service_instance_id=instance_id,
+                organization_id=org_b,
+                sort_order=1,
+            )
+        )
+        session.commit()
+
+    with SessionLocal() as session:
+        repo = ServiceInstanceRepository(session)
+        loaded = repo.get_by_id_with_details(instance_id)
+        assert loaded is not None
+        assert len(loaded.partner_organization_links) == 2
+        reconcile_instance_partner_organizations(
+            session,
+            instance_id=instance_id,
+            ordered_org_ids=[org_b, org_a],
+        )
+        session.commit()
+
+    with SessionLocal() as session:
+        rows = session.execute(
+            select(
+                ServiceInstancePartnerOrganization.organization_id,
+                ServiceInstancePartnerOrganization.sort_order,
+            )
+            .where(ServiceInstancePartnerOrganization.service_instance_id == instance_id)
+            .order_by(ServiceInstancePartnerOrganization.sort_order.asc())
+        ).all()
+        assert [r[0] for r in rows] == [org_b, org_a]
+        assert [r[1] for r in rows] == [0, 1]
+
+
+@pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
+def test_location_repository_two_partners_same_venue_distinct_ids() -> None:
+    url = _database_url()
+    assert url is not None
+    engine = create_engine(url)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    area_id = uuid4()
+    loc_id = uuid4()
+    org_a = uuid4()
+    org_b = uuid4()
+
+    with SessionLocal() as session:
+        session.add(
+            GeographicArea(
+                id=area_id,
+                parent_id=None,
+                name="Area 2",
+                name_translations={},
+                level="country",
+                code="HK",
+                active=True,
+                display_order=0,
+                sovereign_country_id=None,
+            )
+        )
+        session.add(
+            Location(
+                id=loc_id,
+                area_id=area_id,
+                name=None,
+                address="Shared venue",
+                lat=None,
+                lng=None,
+            )
+        )
+        session.add(
+            Organization(
+                id=org_a,
+                name="Alpha Shared",
+                organization_type=OrganizationType.NGO,
+                relationship_type=RelationshipType.PARTNER,
+                website=None,
+                slug=None,
+                location_id=loc_id,
+                archived_at=None,
+            )
+        )
+        session.add(
+            Organization(
+                id=org_b,
+                name="Beta Shared",
+                organization_type=OrganizationType.NGO,
+                relationship_type=RelationshipType.PARTNER,
+                website=None,
+                slug=None,
+                location_id=loc_id,
+                archived_at=None,
+            )
+        )
+        session.commit()
+
+    with SessionLocal() as session:
+        repo = LocationRepository(session)
+        pairs = repo.active_partner_organization_id_label_pairs_by_location_ids([loc_id])
+        assert loc_id in pairs
+        ids_and_labels = pairs[loc_id]
+        assert {oid for oid, _ in ids_and_labels} == {org_a, org_b}
+        assert [label for _, label in ids_and_labels] == ["Alpha Shared", "Beta Shared"]

--- a/tests/test_admin_service_instances_partner_update_postgres.py
+++ b/tests/test_admin_service_instances_partner_update_postgres.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import os
 from decimal import Decimal
-from typing import Any
 from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine, select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 from app.api.admin_service_instance_partners import reconcile_instance_partner_organizations
 from app.db.models import (

--- a/tests/test_location_repository_partner_pairs.py
+++ b/tests/test_location_repository_partner_pairs.py
@@ -1,0 +1,53 @@
+"""Unit tests for LocationRepository partner id/label pairs."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from app.db.repositories.location import LocationRepository
+
+
+def test_active_partner_organization_id_label_pairs_dedupes_duplicate_org_rows() -> (
+    None
+):
+    """Same org id must not appear twice for one location (stable name order)."""
+    loc_id = uuid4()
+    org_id = uuid4()
+    other_org = uuid4()
+
+    class _FakeResult:
+        def all(self) -> list[tuple[Any, Any, Any]]:
+            # Mimic SQL ``ORDER BY name ASC`` with duplicate org id collapsed by repo.
+            return [
+                (other_org, loc_id, "Alpha Partners"),
+                (org_id, loc_id, "Zebra Co"),
+                (org_id, loc_id, "Zebra Co"),
+            ]
+
+    class _FakeSession:
+        def execute(self, _stmt: object) -> _FakeResult:
+            return _FakeResult()
+
+    repo = LocationRepository(_FakeSession())  # type: ignore[arg-type]
+    out = repo.active_partner_organization_id_label_pairs_by_location_ids([loc_id])
+    assert out[loc_id] == [(other_org, "Alpha Partners"), (org_id, "Zebra Co")]
+
+
+def test_active_partner_organization_names_delegates_to_pairs() -> None:
+    loc_id = uuid4()
+    org_id = uuid4()
+
+    class _FakeRepo(LocationRepository):
+        def active_partner_organization_id_label_pairs_by_location_ids(
+            self, location_ids: Any
+        ) -> dict[Any, list[tuple[Any, str]]]:
+            assert list(location_ids) == [loc_id]
+            return {loc_id: [(org_id, "Partner A")]}
+
+    class _FakeSession:
+        pass
+
+    repo = _FakeRepo(_FakeSession())  # type: ignore[arg-type]
+    names = repo.active_partner_organization_names_by_location_ids([loc_id])
+    assert names == {loc_id: ["Partner A"]}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change fixes a SQLAlchemy `InvalidRequestError` when updating a service instance with `partner_organization_ids` after bulk reconciliation of partner link rows, surfaces `partner_organization_ids` on admin Location responses for UI matching, and improves admin instance location dropdowns and the partners panel inline venue editor.

## Follow-up fixes (review)

- Removed redundant `session.flush()` before `commit()` in `_update_instance`; added an inline comment on why partner M2M uses bulk SQL vs the ORM collection.
- Removed dead `ServiceInstanceRepository.update_instance`; Eventbrite sync now commits without `session.add(instance)`.
- Mocked handler test runs real `_apply_instance_type_details` with tier data; asserts `commit` only (no `update_instance`).
- **PostgreSQL integration tests** (`TEST_DATABASE_URL`): reconcile after `get_by_id_with_details` + commit; two partners same venue → distinct ids in `LocationRepository`.
- Admin: `formatInstanceSlotLocationSummary` uses partner labels like the editor; `extraSelectedLocationIds` includes archived partners' `locationId`; legacy filter branch documented.

## Backend

- Replace `instance_repository.update_instance(instance)` with `session.commit()` in `_update_instance`, then reload details by `instance.id`.
- Add `active_partner_organization_id_label_pairs_by_location_ids` on `LocationRepository`; delegate names helper; emit `partner_organization_ids` from `_serialize_location` and update OpenAPI `Location` schema.

## Admin web

- Extend `LocationSummary` and `parseLocationSummary` for `partnerOrganizationIds`.
- Add `filterLocationsForInstance` and `formatInstanceLocationOptionLabel`; filter instance + slot location selects.
- `InlineLocationEditor`: `allowEditWhenOwnerPartnerOrganizationId` for owning partner; shared-venue note when multiple partner labels.

## Tests

- Python unit + optional `TEST_DATABASE_URL` integration; Vitest for UI and helpers.

## Validation

- `pre-commit run ruff-format --all-files`, `bash scripts/validate-cursorrules.sh`
- `npm run lint` and `npm test` in `apps/admin_web`
- `pytest` on touched Python tests (integration skipped without `TEST_DATABASE_URL`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2697168-ff85-4ceb-aa9d-04f8e2355846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2697168-ff85-4ceb-aa9d-04f8e2355846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

