### PR TITLE
Admin web: instances table — cohort column, next slot, drop instructor

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -19,7 +19,7 @@ import {
   formatInstanceSlotLocationSummary,
   formatInstanceTableTitle,
   formatSessionSlotStartsAtDisplay,
-  orderSessionSlotsForDisplay,
+  getSessionSlotClosestToNow,
 } from '@/lib/format';
 
 import type { LocationSummary, ServiceInstance, ServiceType } from '@/types/services';
@@ -58,7 +58,7 @@ export interface InstanceListPanelProps {
     value: string;
     onChange: (value: string) => void;
   };
-  /** When true, add cross-service columns (title with cohort, locations, slots) before status. */
+  /** When true, add cross-service columns (title, cohort, locations, next slot) before status. */
   showServiceColumn?: boolean;
   /** Resolve location ids for the locations column (optional; ids shown when unknown). */
   locationOptions?: LocationSummary[];
@@ -150,7 +150,7 @@ export function InstanceListPanel({
                     id='instances-filter-search'
                     value={searchFilter.value}
                     onChange={(event) => searchFilter.onChange(event.target.value)}
-                    placeholder='Cohort, service, instructor, status'
+                    placeholder='Cohort, service, status'
                   />
                 </div>
               ) : null}
@@ -196,23 +196,27 @@ export function InstanceListPanel({
           <AdminDataTableHead>
             <tr>
               {showServiceColumn ? (
-                <th className='max-w-[15%] px-4 py-3 font-semibold'>Title</th>
+                <th className='max-w-[20%] px-4 py-3 font-semibold'>Title</th>
+              ) : null}
+              {showServiceColumn ? (
+                <th className='px-4 py-3 font-semibold'>Cohort</th>
               ) : null}
               {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Locations</th>
               ) : null}
               {showServiceColumn ? (
-                <th className='px-4 py-3 font-semibold'>Slots</th>
+                <th className='px-4 py-3 font-semibold'>Next slot</th>
               ) : null}
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Capacity</th>
-              <th className='px-4 py-3 font-semibold'>Instructor</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
             {instances.map((instance) => {
               const instanceTableTitle = formatInstanceTableTitle(instance);
+              const cohortDisplay = instance.cohort?.trim() ?? '';
+              const nextSlot = getSessionSlotClosestToNow(instance.sessionSlots);
               return (
                 <tr
                   key={instance.id}
@@ -226,8 +230,13 @@ export function InstanceListPanel({
                   aria-selected={selectedInstanceId === instance.id}
                 >
                   {showServiceColumn ? (
-                    <td className='max-w-[15%] min-w-0 break-words px-4 py-3'>
+                    <td className='max-w-[20%] min-w-0 break-words px-4 py-3'>
                       {instanceTableTitle.trim() !== '' ? instanceTableTitle : '\u00a0'}
+                    </td>
+                  ) : null}
+                  {showServiceColumn ? (
+                    <td className='max-w-[12rem] min-w-0 break-words px-4 py-3 text-sm'>
+                      {cohortDisplay !== '' ? cohortDisplay : '-'}
                     </td>
                   ) : null}
                   {showServiceColumn ? (
@@ -236,23 +245,12 @@ export function InstanceListPanel({
                     </td>
                   ) : null}
                   {showServiceColumn ? (
-                    <td className='px-4 py-3 align-top'>
-                      {instance.sessionSlots.length === 0 ? (
-                        '-'
-                      ) : (
-                        <ul className='m-0 max-w-[11rem] list-none space-y-0.5 p-0'>
-                          {orderSessionSlotsForDisplay(instance.sessionSlots).map((slot, slotIndex) => (
-                            <li key={slot.id ?? `${instance.id}-slot-${slotIndex}`}>
-                              {formatSessionSlotStartsAtDisplay(slot.startsAt)}
-                            </li>
-                          ))}
-                        </ul>
-                      )}
+                    <td className='px-4 py-3 align-top text-sm'>
+                      {nextSlot ? formatSessionSlotStartsAtDisplay(nextSlot.startsAt) : '-'}
                     </td>
                   ) : null}
                   <td className='px-4 py-3'>{formatEnumLabel(instance.status)}</td>
                   <td className='px-4 py-3'>{instance.maxCapacity ?? 'Unlimited'}</td>
-                  <td className='px-4 py-3'>{instance.instructorId ?? '-'}</td>
                   <td className='px-4 py-3 text-right'>
                     <div className='flex justify-end gap-2'>
                       <CopyFeedbackIconButton

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -43,25 +43,16 @@ export function formatInstanceLocationOptionLabel(location: LocationSummary): st
   return formatLocationLabel(location);
 }
 
-/** Instances table: own title when set, otherwise parent service title (with tier); cohort appended when set. Empty when nothing to show. */
+/** Instances table: own title when set, otherwise parent service title (with tier). Cohort is shown in its own column. Empty when nothing to show. */
 export function formatInstanceTableTitle(instance: ServiceInstance): string {
   const own = instance.title?.trim();
-  let base: string;
   if (own) {
-    base = own;
-  } else if (instance.parentServiceTitle) {
-    base = formatServiceTitleWithTier(instance.parentServiceTitle, instance.parentServiceTier);
-  } else {
-    base = '';
+    return own;
   }
-  const cohort = instance.cohort?.trim();
-  if (!cohort) {
-    return base;
+  if (instance.parentServiceTitle) {
+    return formatServiceTitleWithTier(instance.parentServiceTitle, instance.parentServiceTier);
   }
-  if (!base) {
-    return cohort;
-  }
-  return `${base} ${SERVICE_TITLE_TIER_SEP} ${cohort}`;
+  return '';
 }
 
 /** Full venue label: address (when present) plus geographic area name. */
@@ -216,7 +207,7 @@ function sessionSlotSortKey(slot: SessionSlot, index: number): number {
   return index;
 }
 
-/** Same ordering as the instances table slot column: `sort_order`, then start time, then index. */
+/** Same ordering as legacy multi-slot display: `sort_order`, then start time, then index. */
 export function orderSessionSlotsForDisplay(slots: SessionSlot[]): SessionSlot[] {
   return slots
     .map((slot, index) => ({ slot, index }))
@@ -240,6 +231,31 @@ export function orderSessionSlotsForDisplay(slots: SessionSlot[]): SessionSlot[]
       return a.index - b.index;
     })
     .map(({ slot }) => slot);
+}
+
+/**
+ * Session slot whose start time is closest to now (by absolute difference).
+ * Ties break by {@link orderSessionSlotsForDisplay} order (earlier in that list wins).
+ */
+export function getSessionSlotClosestToNow(slots: SessionSlot[]): SessionSlot | null {
+  const now = Date.now();
+  const ordered = orderSessionSlotsForDisplay(slots);
+  let best: { slot: SessionSlot; dist: number; orderIndex: number } | null = null;
+  ordered.forEach((slot, orderIndex) => {
+    const raw = slot.startsAt?.trim() ?? '';
+    if (!raw) {
+      return;
+    }
+    const ms = new Date(raw).getTime();
+    if (!Number.isFinite(ms)) {
+      return;
+    }
+    const dist = Math.abs(ms - now);
+    if (best === null || dist < best.dist || (dist === best.dist && orderIndex < best.orderIndex)) {
+      best = { slot, dist, orderIndex };
+    }
+  });
+  return best?.slot ?? null;
 }
 
 function collectDistinctLocationLabels(

--- a/apps/admin_web/tests/components/admin/services/services-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/services-page.test.tsx
@@ -255,7 +255,8 @@ describe('ServicesPage', () => {
 
     state.instancesSearchQuery = 'spring-2024';
     rerender(<ServicesPage />);
-    expect(screen.getByText('Yoga · spring-2024')).toBeInTheDocument();
+    expect(screen.getByText('Yoga')).toBeInTheDocument();
+    expect(screen.getAllByText('spring-2024').length).toBeGreaterThanOrEqual(1);
 
     unmount();
   });

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -244,7 +244,8 @@ describe('services tables value formatting', () => {
 
     const tables = screen.getAllByRole('table');
     const instanceTable = tables[0] as HTMLElement;
-    expect(within(instanceTable).getByText('Custom instance title · spring-2024')).toBeInTheDocument();
+    expect(within(instanceTable).getByText('Custom instance title')).toBeInTheDocument();
+    expect(within(instanceTable).getByText('spring-2024')).toBeInTheDocument();
     expect(within(instanceTable).getByText('In Progress')).toBeInTheDocument();
     expect(within(instanceTable).getByText('Unlimited')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('SAVE10')).toBeInTheDocument();

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   compareInstancesByFirstSlotStartsDesc,
@@ -13,6 +13,7 @@ import {
   formatServiceTitleWithTier,
   formatSessionSlotStartsAtDisplay,
   getFirstSessionSlotStartTimeMs,
+  getSessionSlotClosestToNow,
   getContentLanguageOptions,
   getCurrencyOptions,
   matchAdminSelectableContentLanguage,
@@ -72,6 +73,56 @@ describe('format helpers', () => {
     expect(ordered.map((s) => s.id)).toEqual(['b', 'a']);
   });
 
+  describe('getSessionSlotClosestToNow', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-01T12:00:00.000Z'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('returns null when no valid slot times', () => {
+      expect(getSessionSlotClosestToNow([])).toBeNull();
+      expect(
+        getSessionSlotClosestToNow([
+          { id: 'x', instanceId: null, locationId: null, startsAt: null, endsAt: null, sortOrder: 0 },
+        ])
+      ).toBeNull();
+    });
+
+    it('picks the slot with smallest absolute distance to now', () => {
+      const slots: SessionSlot[] = [
+        { id: 'far-past', instanceId: null, locationId: null, startsAt: '2026-01-01T10:00:00Z', endsAt: null, sortOrder: 0 },
+        { id: 'soon', instanceId: null, locationId: null, startsAt: '2026-06-01T18:00:00Z', endsAt: null, sortOrder: 1 },
+        { id: 'far-future', instanceId: null, locationId: null, startsAt: '2026-12-01T10:00:00Z', endsAt: null, sortOrder: 2 },
+      ];
+      expect(getSessionSlotClosestToNow(slots)?.id).toBe('soon');
+    });
+
+    it('breaks distance ties using orderSessionSlotsForDisplay order', () => {
+      const slots: SessionSlot[] = [
+        {
+          id: 'first',
+          instanceId: null,
+          locationId: null,
+          startsAt: '2026-06-01T00:00:00Z',
+          endsAt: null,
+          sortOrder: 0,
+        },
+        {
+          id: 'second',
+          instanceId: null,
+          locationId: null,
+          startsAt: '2026-06-02T00:00:00Z',
+          endsAt: null,
+          sortOrder: 1,
+        },
+      ];
+      expect(getSessionSlotClosestToNow(slots)?.id).toBe('first');
+    });
+  });
+
   it('formats service title with tier using spaced interpunct when tier is set', () => {
     expect(formatServiceTitleWithTier('Yoga', 'adults')).toBe('Yoga · adults');
     expect(formatServiceTitleWithTier('Yoga', null)).toBe('Yoga');
@@ -126,10 +177,8 @@ describe('format helpers', () => {
         parentServiceTitle: null,
       })
     ).toBe('');
-    expect(formatInstanceTableTitle({ ...base(), title: 'My run', cohort: 'spring-2024' })).toBe(
-      'My run · spring-2024'
-    );
-    expect(formatInstanceTableTitle({ ...base(), cohort: 'spring-2024' })).toBe('Parent · tier-a · spring-2024');
+    expect(formatInstanceTableTitle({ ...base(), title: 'My run', cohort: 'spring-2024' })).toBe('My run');
+    expect(formatInstanceTableTitle({ ...base(), cohort: 'spring-2024' })).toBe('Parent · tier-a');
     expect(
       formatInstanceTableTitle({
         ...base(),
@@ -138,7 +187,7 @@ describe('format helpers', () => {
         parentServiceTier: null,
         cohort: 'spring-2024',
       })
-    ).toBe('spring-2024');
+    ).toBe('');
   });
 
   it('summarizes instance locations including partner org venues', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the admin Services **Instances** table (cross-service view with `showServiceColumn`):

- **Title**: `max-w` increased from 15% to **20%**; title no longer appends cohort (cohort-only instances show an empty title cell; cohort still appears in the Cohort column).
- **Cohort**: new column immediately after Title (`-` when unset).
- **Instructor** column removed (search placeholder no longer mentions instructor).
- **Slots** renamed to **Next slot**; shows a single value — the session slot whose `startsAt` is **closest to now** by absolute time difference (ties broken by existing `orderSessionSlotsForDisplay` order).

## Implementation notes

- `formatInstanceTableTitle` no longer includes cohort (instance search still indexes cohort separately in `services-page.tsx`).
- New `getSessionSlotClosestToNow` in `format.ts` with unit tests (fake timers at a fixed instant).

## Testing

- `npm run test -- --run` on touched test files
- `npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1374cef8-45f8-481e-8b99-bacc1429ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1374cef8-45f8-481e-8b99-bacc1429ccd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

