### PR TITLE
Admin instances table: First slot column, title width 50%

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -19,7 +19,7 @@ import {
   formatInstanceSlotLocationSummary,
   formatInstanceTableTitle,
   formatSessionSlotStartsAtDisplay,
-  getSessionSlotClosestToNow,
+  getFirstSessionSlotForDisplay,
 } from '@/lib/format';
 
 import type { LocationSummary, ServiceInstance, ServiceType } from '@/types/services';
@@ -58,7 +58,7 @@ export interface InstanceListPanelProps {
     value: string;
     onChange: (value: string) => void;
   };
-  /** When true, add cross-service columns (title, cohort, locations, next slot) before status. */
+  /** When true, add cross-service columns (title, cohort, locations, first slot) before status. */
   showServiceColumn?: boolean;
   /** Resolve location ids for the locations column (optional; ids shown when unknown). */
   locationOptions?: LocationSummary[];
@@ -196,7 +196,7 @@ export function InstanceListPanel({
           <AdminDataTableHead>
             <tr>
               {showServiceColumn ? (
-                <th className='max-w-[20%] px-4 py-3 font-semibold'>Title</th>
+                <th className='w-[50%] px-4 py-3 font-semibold'>Title</th>
               ) : null}
               {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Cohort</th>
@@ -205,7 +205,7 @@ export function InstanceListPanel({
                 <th className='px-4 py-3 font-semibold'>Locations</th>
               ) : null}
               {showServiceColumn ? (
-                <th className='px-4 py-3 font-semibold'>Next slot</th>
+                <th className='px-4 py-3 align-middle font-semibold'>First slot</th>
               ) : null}
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Capacity</th>
@@ -216,7 +216,7 @@ export function InstanceListPanel({
             {instances.map((instance) => {
               const instanceTableTitle = formatInstanceTableTitle(instance);
               const cohortDisplay = instance.cohort?.trim() ?? '';
-              const nextSlot = getSessionSlotClosestToNow(instance.sessionSlots);
+              const firstSlot = getFirstSessionSlotForDisplay(instance.sessionSlots);
               return (
                 <tr
                   key={instance.id}
@@ -230,7 +230,7 @@ export function InstanceListPanel({
                   aria-selected={selectedInstanceId === instance.id}
                 >
                   {showServiceColumn ? (
-                    <td className='max-w-[20%] min-w-0 break-words px-4 py-3'>
+                    <td className='w-[50%] min-w-0 break-words px-4 py-3'>
                       {instanceTableTitle.trim() !== '' ? instanceTableTitle : '\u00a0'}
                     </td>
                   ) : null}
@@ -245,8 +245,8 @@ export function InstanceListPanel({
                     </td>
                   ) : null}
                   {showServiceColumn ? (
-                    <td className='px-4 py-3 align-top text-sm'>
-                      {nextSlot ? formatSessionSlotStartsAtDisplay(nextSlot.startsAt) : '-'}
+                    <td className='px-4 py-3 align-middle text-sm'>
+                      {firstSlot ? formatSessionSlotStartsAtDisplay(firstSlot.startsAt) : '-'}
                     </td>
                   ) : null}
                   <td className='px-4 py-3'>{formatEnumLabel(instance.status)}</td>

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -234,37 +234,16 @@ export function orderSessionSlotsForDisplay(slots: SessionSlot[]): SessionSlot[]
 }
 
 /**
- * Session slot whose start time is closest to now (by absolute difference).
- * Ties break by {@link orderSessionSlotsForDisplay} order (earlier in that list wins).
+ * First session slot in {@link orderSessionSlotsForDisplay} order that has a
+ * non-empty `startsAt` (for the instances table "First slot" column).
  */
-export function getSessionSlotClosestToNow(slots: SessionSlot[]): SessionSlot | null {
-  const now = Date.now();
-  const ordered = orderSessionSlotsForDisplay(slots);
-  let bestSlot: SessionSlot | null = null;
-  let bestDist = Number.POSITIVE_INFINITY;
-  let bestOrderIndex = Number.POSITIVE_INFINITY;
-  for (let orderIndex = 0; orderIndex < ordered.length; orderIndex += 1) {
-    const sessionSlot = ordered[orderIndex];
-    const raw = sessionSlot.startsAt?.trim() ?? '';
-    if (!raw) {
-      continue;
-    }
-    const ms = new Date(raw).getTime();
-    if (!Number.isFinite(ms)) {
-      continue;
-    }
-    const dist = Math.abs(ms - now);
-    if (
-      bestSlot === null ||
-      dist < bestDist ||
-      (dist === bestDist && orderIndex < bestOrderIndex)
-    ) {
-      bestSlot = sessionSlot;
-      bestDist = dist;
-      bestOrderIndex = orderIndex;
+export function getFirstSessionSlotForDisplay(slots: SessionSlot[]): SessionSlot | null {
+  for (const slot of orderSessionSlotsForDisplay(slots)) {
+    if (slot.startsAt?.trim()) {
+      return slot;
     }
   }
-  return bestSlot;
+  return null;
 }
 
 function collectDistinctLocationLabels(

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   compareInstancesByFirstSlotStartsDesc,
@@ -12,8 +12,8 @@ import {
   formatServiceListPriceLabel,
   formatServiceTitleWithTier,
   formatSessionSlotStartsAtDisplay,
+  getFirstSessionSlotForDisplay,
   getFirstSessionSlotStartTimeMs,
-  getSessionSlotClosestToNow,
   getContentLanguageOptions,
   getCurrencyOptions,
   matchAdminSelectableContentLanguage,
@@ -73,54 +73,24 @@ describe('format helpers', () => {
     expect(ordered.map((s) => s.id)).toEqual(['b', 'a']);
   });
 
-  describe('getSessionSlotClosestToNow', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date('2026-06-01T12:00:00.000Z'));
-    });
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('returns null when no valid slot times', () => {
-      expect(getSessionSlotClosestToNow([])).toBeNull();
-      expect(
-        getSessionSlotClosestToNow([
-          { id: 'x', instanceId: null, locationId: null, startsAt: null, endsAt: null, sortOrder: 0 },
-        ])
-      ).toBeNull();
-    });
-
-    it('picks the slot with smallest absolute distance to now', () => {
-      const slots: SessionSlot[] = [
-        { id: 'far-past', instanceId: null, locationId: null, startsAt: '2026-01-01T10:00:00Z', endsAt: null, sortOrder: 0 },
-        { id: 'soon', instanceId: null, locationId: null, startsAt: '2026-06-01T18:00:00Z', endsAt: null, sortOrder: 1 },
-        { id: 'far-future', instanceId: null, locationId: null, startsAt: '2026-12-01T10:00:00Z', endsAt: null, sortOrder: 2 },
-      ];
-      expect(getSessionSlotClosestToNow(slots)?.id).toBe('soon');
-    });
-
-    it('breaks distance ties using orderSessionSlotsForDisplay order', () => {
-      const slots: SessionSlot[] = [
-        {
-          id: 'first',
-          instanceId: null,
-          locationId: null,
-          startsAt: '2026-06-01T00:00:00Z',
-          endsAt: null,
-          sortOrder: 0,
-        },
-        {
-          id: 'second',
-          instanceId: null,
-          locationId: null,
-          startsAt: '2026-06-02T00:00:00Z',
-          endsAt: null,
-          sortOrder: 1,
-        },
-      ];
-      expect(getSessionSlotClosestToNow(slots)?.id).toBe('first');
-    });
+  it('getFirstSessionSlotForDisplay returns first ordered slot with non-empty startsAt', () => {
+    expect(getFirstSessionSlotForDisplay([])).toBeNull();
+    expect(
+      getFirstSessionSlotForDisplay([
+        { id: 'x', instanceId: null, locationId: null, startsAt: null, endsAt: null, sortOrder: 0 },
+      ])
+    ).toBeNull();
+    const slots: SessionSlot[] = [
+      { id: 'b', instanceId: null, locationId: null, startsAt: '2026-01-10T10:00:00Z', endsAt: null, sortOrder: 1 },
+      { id: 'a', instanceId: null, locationId: null, startsAt: '2026-01-05T10:00:00Z', endsAt: null, sortOrder: 2 },
+    ];
+    expect(getFirstSessionSlotForDisplay(slots)?.id).toBe('b');
+    expect(
+      getFirstSessionSlotForDisplay([
+        { id: 'empty', instanceId: null, locationId: null, startsAt: '  ', endsAt: null, sortOrder: 0 },
+        { id: 'ok', instanceId: null, locationId: null, startsAt: '2026-01-01T10:00:00Z', endsAt: null, sortOrder: 1 },
+      ])?.id
+    ).toBe('ok');
   });
 
   it('formats service title with tier using spaced interpunct when tier is set', () => {


### PR DESCRIPTION
Rename Next slot to First slot; show first ordered slot with startsAt. Use w-[50%] on title for table-fixed column share; vertically center first-slot cells. Replace getSessionSlotClosestToNow with getFirstSessionSlotForDisplay and update tests.