### PR TITLE
backend: backfill service_instances.slug; require it at admin create for event/training_course

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      TEST_DATABASE_URL: postgresql://test:test@localhost:5432/evolvesprouts_test
+      TEST_DATABASE_URL: postgresql+psycopg://test:test@localhost:5432/evolvesprouts_test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -179,6 +179,12 @@ jobs:
             echo "Missing backend dependency manifest"
             exit 1
           fi
+
+      - name: Apply Alembic migrations to test database
+        env:
+          DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
+        run: |
+          python -m alembic -c backend/db/alembic.ini upgrade head
 
       - name: Run Python tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,22 @@ jobs:
   test-python:
     name: Test Python
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: evolvesprouts_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test -d evolvesprouts_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      TEST_DATABASE_URL: postgresql://test:test@localhost:5432/evolvesprouts_test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
+import { Button } from '@/components/ui/button';
 import { FormDialog } from '@/components/ui/form-dialog';
 
+import { buildSessionSlotsUtcPayload } from '@/lib/format';
+import { computeSuggestedInstanceSlug, INSTANCE_SLUG_PATTERN } from '@/lib/slug-utils';
+
 import type { components } from '@/types/generated/admin-api.generated';
-import type { ServiceType } from '@/types/services';
+import type { ServiceSummary, ServiceType } from '@/types/services';
 
 import { ConsultationFormFields, type ConsultationFormState } from './consultation-form-fields';
 import {
@@ -23,7 +27,6 @@ import {
 } from './form-defaults';
 import { EventInstancePartnersField } from './event-instance-partners-field';
 import {
-  INSTANCE_SLUG_PATTERN,
   InstanceFormFields,
   InstanceInstructorField,
   type InstanceFormState,
@@ -31,13 +34,13 @@ import {
 import { SessionSlotEditor } from './session-slot-editor';
 import { TrainingFormFields, type TrainingFormState } from './training-form-fields';
 
-import { buildSessionSlotsUtcPayload } from '@/lib/format';
-
 type ApiSchemas = components['schemas'];
 
 export interface CreateInstanceDialogProps {
   open: boolean;
   serviceType: ServiceType;
+  /** When set, used to suggest training_course slugs (MBA vs other). */
+  serviceSummary?: ServiceSummary | null;
   /** Parent service default venue when the instance row has no location yet (matches instance panel). */
   serviceDefaultLocationId?: string | null;
   isLoading: boolean;
@@ -49,6 +52,7 @@ export interface CreateInstanceDialogProps {
 export function CreateInstanceDialog({
   open,
   serviceType,
+  serviceSummary = null,
   serviceDefaultLocationId = null,
   isLoading,
   error,
@@ -62,24 +66,70 @@ export function CreateInstanceDialog({
     DEFAULT_CONSULTATION_FORM
   );
   const [sessionSlotsError, setSessionSlotsError] = useState('');
+  const [slugSubmitError, setSlugSubmitError] = useState('');
+  const slugTouchedRef = useRef(false);
 
   const effectiveSessionSlotDefaultLocationId = useMemo(
     () => instanceForm.locationId.trim() || serviceDefaultLocationId?.trim() || null,
     [instanceForm.locationId, serviceDefaultLocationId]
   );
 
+  const suggestedSlug = useMemo(
+    () => computeSuggestedInstanceSlug(serviceType, serviceSummary ?? null, instanceForm),
+    [serviceType, serviceSummary, instanceForm]
+  );
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    slugTouchedRef.current = false;
+    queueMicrotask(() => {
+      setInstanceForm(DEFAULT_INSTANCE_FORM);
+      setTrainingForm(DEFAULT_TRAINING_FORM);
+      setEventForm(DEFAULT_EVENT_FORM);
+      setConsultationForm(DEFAULT_CONSULTATION_FORM);
+      setSessionSlotsError('');
+      setSlugSubmitError('');
+    });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || slugTouchedRef.current) {
+      return;
+    }
+    if (serviceType !== 'event' && serviceType !== 'training_course') {
+      return;
+    }
+    const next = suggestedSlug.trim().toLowerCase();
+    queueMicrotask(() => {
+      setInstanceForm((prev) => ({ ...prev, slug: next }));
+    });
+  }, [open, serviceType, suggestedSlug]);
+
   const eventPriceMissing = serviceType === 'event' && !eventForm.defaultPrice.trim();
   const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
   const cohortInvalid = Boolean(cohortTrimmed) && !INSTANCE_SLUG_PATTERN.test(cohortTrimmed);
-
+  const slugTrimmed = instanceForm.slug.trim().toLowerCase();
+  const slugPatternInvalid = Boolean(slugTrimmed) && !INSTANCE_SLUG_PATTERN.test(slugTrimmed);
   const handleSubmit = async () => {
+    setSlugSubmitError('');
+    if (serviceType === 'event' || serviceType === 'training_course') {
+      if (!slugTrimmed) {
+        setSlugSubmitError('slug is required for event and training_course instances');
+        return;
+      }
+      if (!INSTANCE_SLUG_PATTERN.test(slugTrimmed)) {
+        setSlugSubmitError('Use lowercase letters, digits, and single hyphens between segments.');
+        return;
+      }
+    }
     const slotsPayload = buildSessionSlotsUtcPayload(instanceForm.sessionSlots);
     if (!slotsPayload.ok) {
       setSessionSlotsError(slotsPayload.message);
       return;
     }
     setSessionSlotsError('');
-    const slugTrimmed = instanceForm.slug.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
       title: instanceForm.title.trim() || null,
       slug: slugTrimmed || null,
@@ -131,6 +181,23 @@ export function CreateInstanceDialog({
     await onCreate(payload);
   };
 
+  const slugFieldMode = serviceType === 'consultation' ? 'optional' : 'required';
+  const slugAccessory =
+    serviceType === 'event' || serviceType === 'training_course' ? (
+      <Button
+        type='button'
+        variant='secondary'
+        className='text-xs'
+        onClick={() => {
+          slugTouchedRef.current = false;
+          setInstanceForm((prev) => ({ ...prev, slug: suggestedSlug.trim().toLowerCase() }));
+          setSlugSubmitError('');
+        }}
+      >
+        Reset to suggestion
+      </Button>
+    ) : null;
+
   return (
     <FormDialog
       open={open}
@@ -138,11 +205,22 @@ export function CreateInstanceDialog({
       isLoading={isLoading}
       error={error}
       submitLabel='Create instance'
-      submitDisabled={eventPriceMissing || cohortInvalid}
+      submitDisabled={eventPriceMissing || cohortInvalid || slugPatternInvalid}
       onClose={onClose}
       onSubmit={handleSubmit}
     >
-      <InstanceFormFields value={instanceForm} onChange={setInstanceForm} />
+      <InstanceFormFields
+        value={instanceForm}
+        onChange={(next) => {
+          if (next.slug !== instanceForm.slug) {
+            slugTouchedRef.current = true;
+          }
+          setInstanceForm(next);
+        }}
+        slugFieldMode={slugFieldMode}
+        slugFieldError={slugSubmitError}
+        slugFieldAccessory={slugAccessory}
+      />
       {serviceType === 'training_course' ? (
         <div className='mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2'>
           <InstanceInstructorField

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -20,12 +20,7 @@ import {
   DEFAULT_TRAINING_FORM,
 } from './form-defaults';
 import { EventInstancePartnersField } from './event-instance-partners-field';
-import {
-  INSTANCE_SLUG_PATTERN,
-  InstanceFormFields,
-  InstanceInstructorField,
-  type InstanceFormState,
-} from './instance-form-fields';
+import { InstanceFormFields, InstanceInstructorField, type InstanceFormState } from './instance-form-fields';
 import { SessionSlotEditor } from './session-slot-editor';
 import {
   TrainingCurrencyControl,
@@ -56,10 +51,12 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
+import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { buildSessionSlotsUtcPayload, mapSessionSlotsFromApiToForm } from '@/lib/format';
 import { filterLocationsForInstance } from '@/lib/instance-location-options';
 import type { EntityTagRef } from '@/lib/entity-api';
+import { computeSuggestedInstanceSlug, INSTANCE_SLUG_PATTERN } from '@/lib/slug-utils';
 
 type ApiSchemas = components['schemas'];
 const defaultCurrencyCode = getAdminDefaultCurrencyCode();
@@ -241,12 +238,15 @@ export function InstanceDetailPanel({
   const lastMergedServiceIdForCreateRef = useRef<string | null>(null);
   const duplicateCreateHydratedRef = useRef(false);
   const duplicateEventTiersTemplateRef = useRef<EventTicketTier[] | null>(null);
+  const createSlugTouchedRef = useRef(false);
   const { users: instructorUsers, isLoading: isLoadingInstructors } = useInstructorUsers(
     Boolean(selectedServiceId)
   );
 
   const [tagIds, setTagIds] = useState<string[]>(() => instance?.tagIds ?? []);
   const [sessionSlotsError, setSessionSlotsError] = useState('');
+  const [slugSubmitError, setSlugSubmitError] = useState('');
+  const [slugConflictError, setSlugConflictError] = useState('');
 
   const [instanceForm, setInstanceForm] = useState<InstanceFormState>(
     instance
@@ -291,6 +291,10 @@ export function InstanceDetailPanel({
   );
 
   useEffect(() => {
+    createSlugTouchedRef.current = false;
+  }, [selectedServiceId]);
+
+  useEffect(() => {
     if (!createPrefillInstance) {
       duplicateCreateHydratedRef.current = false;
       duplicateEventTiersTemplateRef.current = null;
@@ -312,6 +316,9 @@ export function InstanceDetailPanel({
     duplicateEventTiersTemplateRef.current = cloneEventTiersForCreate(createPrefillInstance.eventTicketTiers);
     const source = createPrefillInstance;
     queueMicrotask(() => {
+      setSlugSubmitError('');
+      setSlugConflictError('');
+      createSlugTouchedRef.current = false;
       setTagIds([...source.tagIds]);
       setInstanceForm({
         title: source.title ?? '',
@@ -348,6 +355,8 @@ export function InstanceDetailPanel({
 
   const handleSelectService = useCallback(
     (serviceId: string | null) => {
+      setSlugSubmitError('');
+      setSlugConflictError('');
       onSelectService(serviceId);
       if (!serviceId) {
         lastMergedServiceIdForCreateRef.current = null;
@@ -399,6 +408,8 @@ export function InstanceDetailPanel({
       return;
     }
     queueMicrotask(() => {
+      setSlugSubmitError('');
+      setSlugConflictError('');
       setTagIds(instance.tagIds);
       setInstanceForm({
         title: instance.title ?? '',
@@ -439,6 +450,32 @@ export function InstanceDetailPanel({
   const canSubmit = Boolean(selectedServiceId);
   const typeFieldsLocked = !selectedServiceId;
 
+  const suggestedCreateSlug = useMemo(
+    () =>
+      computeSuggestedInstanceSlug(
+        effectiveServiceType,
+        selectedService,
+        instanceForm
+      ),
+    [effectiveServiceType, selectedService, instanceForm]
+  );
+
+  useEffect(() => {
+    if (instance || !selectedServiceId) {
+      return;
+    }
+    if (effectiveServiceType !== 'event' && effectiveServiceType !== 'training_course') {
+      return;
+    }
+    if (createSlugTouchedRef.current) {
+      return;
+    }
+    const next = suggestedCreateSlug.trim().toLowerCase();
+    queueMicrotask(() => {
+      setInstanceForm((prev) => ({ ...prev, slug: next }));
+    });
+  }, [instance, selectedServiceId, effectiveServiceType, suggestedCreateSlug]);
+
   const effectiveSessionSlotDefaultLocationId =
     instanceForm.locationId.trim() || selectedService?.locationId?.trim() || null;
 
@@ -477,6 +514,8 @@ export function InstanceDetailPanel({
   );
 
   const buildCreatePayload = (): ApiSchemas['CreateInstanceRequest'] | null => {
+    setSlugSubmitError('');
+    setSlugConflictError('');
     const slotsPayload = buildSessionSlotsUtcPayload(instanceForm.sessionSlots);
     if (!slotsPayload.ok) {
       setSessionSlotsError(slotsPayload.message);
@@ -484,10 +523,25 @@ export function InstanceDetailPanel({
     }
     setSessionSlotsError('');
     const slugTrimmed = instanceForm.slug.trim().toLowerCase();
+    if (effectiveServiceType === 'event' || effectiveServiceType === 'training_course') {
+      if (!slugTrimmed) {
+        setSlugSubmitError('slug is required for event and training_course instances');
+        return null;
+      }
+      if (!INSTANCE_SLUG_PATTERN.test(slugTrimmed)) {
+        setSlugSubmitError(
+          'Use lowercase letters, digits, and single hyphens between segments.'
+        );
+        return null;
+      }
+    }
     const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
     const payload: ApiSchemas['CreateInstanceRequest'] = {
       title: instanceForm.title.trim() || null,
-      slug: slugTrimmed || null,
+      slug:
+        effectiveServiceType === 'consultation'
+          ? slugTrimmed || null
+          : slugTrimmed,
       description: instanceForm.description.trim() || null,
       status: instanceForm.status,
       delivery_mode: instanceForm.deliveryMode || undefined,
@@ -590,6 +644,69 @@ export function InstanceDetailPanel({
   const cohortTrimmed = instanceForm.cohort.trim().toLowerCase();
   const cohortInvalid = Boolean(cohortTrimmed) && !INSTANCE_SLUG_PATTERN.test(cohortTrimmed);
 
+  const slugFieldMode =
+    effectiveServiceType === 'consultation' ? 'optional' : 'required';
+  const slugFieldError = [slugSubmitError, slugConflictError].filter(Boolean).join(' ');
+  const slugFieldAccessory =
+    !instance && (effectiveServiceType === 'event' || effectiveServiceType === 'training_course') ? (
+      <Button
+        type='button'
+        variant='secondary'
+        className='text-xs'
+        onClick={() => {
+          createSlugTouchedRef.current = false;
+          setSlugConflictError('');
+          setSlugSubmitError('');
+          setInstanceForm((prev) => ({
+            ...prev,
+            slug: suggestedCreateSlug.trim().toLowerCase(),
+          }));
+        }}
+      >
+        Reset to suggestion
+      </Button>
+    ) : null;
+
+  const runCreate = async () => {
+    if (!selectedServiceId) {
+      return;
+    }
+    const payload = buildCreatePayload();
+    if (!payload) {
+      return;
+    }
+    try {
+      await onCreate(selectedServiceId, payload);
+      setSlugConflictError('');
+    } catch (err) {
+      if (err instanceof AdminApiError && err.statusCode === 409 && readAdminApiErrorField(err) === 'slug') {
+        setSlugConflictError(err.message || 'This slug is already in use.');
+        return;
+      }
+      throw err;
+    }
+  };
+
+  const runUpdate = async () => {
+    if (!instance || !selectedServiceId) {
+      return;
+    }
+    const payload = buildUpdatePayload();
+    if (!payload) {
+      return;
+    }
+    try {
+      await onUpdate(selectedServiceId, instance.id, payload);
+      setSlugConflictError('');
+    } catch (err) {
+      if (err instanceof AdminApiError && err.statusCode === 409 && readAdminApiErrorField(err) === 'slug') {
+        setSlugConflictError(err.message || 'This slug is already in use.');
+        return;
+      }
+      throw err;
+    }
+  };
+
   return (
     <AdminEditorCard
       title='Instance'
@@ -612,14 +729,7 @@ export function InstanceDetailPanel({
                     cohortInvalid
                   }
                   onClick={() => {
-                    if (!instance || !selectedServiceId) {
-                      return;
-                    }
-                    const payload = buildUpdatePayload();
-                    if (!payload) {
-                      return;
-                    }
-                    void onUpdate(selectedServiceId, instance.id, payload);
+                    void runUpdate();
                   }}
                 >
                   {isLoading ? 'Updating...' : 'Update instance'}
@@ -636,14 +746,7 @@ export function InstanceDetailPanel({
                   cohortInvalid
                 }
                 onClick={() => {
-                  if (!selectedServiceId) {
-                    return;
-                  }
-                  const payload = buildCreatePayload();
-                  if (!payload) {
-                    return;
-                  }
-                  void onCreate(selectedServiceId, payload);
+                  void runCreate();
                 }}
               >
                 {isLoading ? 'Adding...' : 'Add instance'}
@@ -666,7 +769,18 @@ export function InstanceDetailPanel({
         instructorOptions={instructorUsers}
         isLoadingInstructors={isLoadingInstructors}
         onSelectService={handleSelectService}
-        onChange={setInstanceForm}
+        onChange={(next) => {
+          if (next.slug !== instanceForm.slug) {
+            setSlugConflictError('');
+            if (!instance) {
+              createSlugTouchedRef.current = true;
+            }
+          }
+          setInstanceForm(next);
+        }}
+        slugFieldMode={slugFieldMode}
+        slugFieldError={slugFieldError}
+        slugFieldAccessory={slugFieldAccessory}
       />
 
       {effectiveServiceType === 'training_course' ? (

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import { WarningTriangleIcon } from '@/components/icons/action-icons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -7,6 +9,7 @@ import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { formatEnumLabel, formatServiceTitleWithTier } from '@/lib/format';
 import { formatInstanceLocationOptionLabel } from '@/lib/instance-location-options';
+import { INSTANCE_SLUG_PATTERN } from '@/lib/slug-utils';
 
 import { INSTANCE_STATUSES, SERVICE_DELIVERY_MODES } from '@/types/services';
 import type {
@@ -19,8 +22,7 @@ import type {
 
 import type { SessionSlotFormRow } from '@/types/services';
 
-/** Same pattern as service instance cohorts; matches backend `SERVICE_INSTANCE_SLUG_RE`. */
-export const INSTANCE_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+export { INSTANCE_SLUG_PATTERN } from '@/lib/slug-utils';
 
 export interface InstanceInstructorOption {
   sub: string;
@@ -57,6 +59,12 @@ export interface InstanceFormFieldsProps {
   isLoadingInstructors?: boolean;
   onSelectService?: (serviceId: string | null) => void;
   onChange: (value: InstanceFormState) => void;
+  /** When `required`, show a required marker; consultations stay `optional`. */
+  slugFieldMode?: 'required' | 'optional';
+  /** Inline message under the slug field (for example submit validation or API field errors). */
+  slugFieldError?: string;
+  /** Optional control rendered under the slug input (for example “Reset to suggestion”). */
+  slugFieldAccessory?: ReactNode;
 }
 
 function getInstructorOptionLabel(entry: InstanceInstructorOption): string {
@@ -122,6 +130,9 @@ export function InstanceFormFields({
   isLoadingInstructors = false,
   onSelectService,
   onChange,
+  slugFieldMode = 'optional',
+  slugFieldError = '',
+  slugFieldAccessory = null,
 }: InstanceFormFieldsProps) {
   const canSelectService = Boolean(onSelectService);
   const serviceExists = serviceOptions.some((entry) => entry.id === serviceId);
@@ -132,6 +143,8 @@ export function InstanceFormFields({
   const instanceFieldsLocked = canSelectService && !serviceId;
   const cohortTrimmed = value.cohort.trim().toLowerCase();
   const cohortInvalid = Boolean(cohortTrimmed) && !INSTANCE_SLUG_PATTERN.test(cohortTrimmed);
+  const slugTrimmed = value.slug.trim().toLowerCase();
+  const slugPatternInvalid = Boolean(slugTrimmed) && !INSTANCE_SLUG_PATTERN.test(slugTrimmed);
 
   const topRowClass =
     canSelectService && !instanceFieldsLocked
@@ -231,6 +244,33 @@ export function InstanceFormFields({
           rows={2}
           placeholder='Leave empty to inherit from service'
         />
+      </div>
+      <div>
+        <Label htmlFor='instance-slug'>
+          Slug
+          {slugFieldMode === 'required' ? (
+            <span className='text-red-600' aria-hidden>
+              {' '}
+              *
+            </span>
+          ) : null}
+        </Label>
+        <Input
+          id='instance-slug'
+          value={value.slug}
+          disabled={instanceFieldsLocked}
+          onChange={(event) => onChange({ ...value, slug: event.target.value })}
+          onBlur={() => onChange({ ...value, slug: value.slug.trim().toLowerCase() })}
+          placeholder='e.g. spring-workshop-2026-04-20'
+          autoComplete='off'
+        />
+        {slugFieldAccessory ? <div className='mt-1'>{slugFieldAccessory}</div> : null}
+        {slugPatternInvalid ? (
+          <p className='mt-1 text-xs text-red-600'>
+            Use lowercase letters, digits, and single hyphens between segments (no leading or trailing hyphen).
+          </p>
+        ) : null}
+        {slugFieldError ? <p className='mt-1 text-xs text-red-600'>{slugFieldError}</p> : null}
       </div>
       <div className='grid grid-cols-1 gap-3 sm:grid-cols-4'>
         <div>

--- a/apps/admin_web/src/components/admin/services/service-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/service-form-fields.tsx
@@ -7,10 +7,9 @@ import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { formatEnumLabel } from '@/lib/format';
 
+import { INSTANCE_SLUG_PATTERN } from '@/lib/slug-utils';
 import { SERVICE_DELIVERY_MODES, SERVICE_STATUSES } from '@/types/services';
 import type { ServiceDeliveryMode, ServiceStatus } from '@/types/services';
-
-const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 export interface ServiceReferralSlugFieldProps {
   value: string;
@@ -36,7 +35,7 @@ export function ServiceReferralSlugField({
         placeholder='e.g. my-best-auntie'
         autoComplete='off'
       />
-      {value.trim() && !SLUG_PATTERN.test(value.trim()) ? (
+      {value.trim() && !INSTANCE_SLUG_PATTERN.test(value.trim()) ? (
         <p className='mt-1 text-xs text-red-600'>
           Use lowercase letters and numbers, with single hyphens between segments (no leading or trailing
           hyphen).

--- a/apps/admin_web/src/lib/slug-utils.ts
+++ b/apps/admin_web/src/lib/slug-utils.ts
@@ -1,0 +1,87 @@
+/** URL-safe instance slug: lowercase segments of alphanumerics separated by single hyphens. */
+export const INSTANCE_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const _MAX_INSTANCE_SLUG_LEN = 128;
+
+/**
+ * Normalize free text to the same rules as the DB backfill slugify (migration 0043):
+ * lowercase, non-alphanumeric runs to a single hyphen, trim hyphens, cap length.
+ */
+export function slugifyForInstance(raw: string): string {
+  const lower = raw.trim().toLowerCase();
+  const withHyphens = lower.replace(/[^a-z0-9]+/g, '-');
+  const trimmed = withHyphens.replace(/^-+|-+$/g, '');
+  if (trimmed.length <= _MAX_INSTANCE_SLUG_LEN) {
+    return trimmed.replace(/-+$/, '');
+  }
+  return trimmed.slice(0, _MAX_INSTANCE_SLUG_LEN).replace(/-+$/, '');
+}
+
+export interface SuggestedInstanceSlugSlot {
+  sortOrder: number | null;
+  startsAtLocal: string | null;
+}
+
+function _todayYmdUtc(): string {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function _firstSessionSlotYmd(slots: SuggestedInstanceSlugSlot[]): string | null {
+  if (!slots.length) {
+    return null;
+  }
+  const sorted = [...slots].sort((a, b) => {
+    const so = (a.sortOrder ?? 0) - (b.sortOrder ?? 0);
+    if (so !== 0) {
+      return so;
+    }
+    return String(a.startsAtLocal ?? '').localeCompare(String(b.startsAtLocal ?? ''));
+  });
+  const first = sorted[0]?.startsAtLocal?.trim();
+  if (!first) {
+    return null;
+  }
+  const ymd = first.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(ymd) ? ymd : null;
+}
+
+/** Suggested public instance slug for create flows (event / training_course). */
+export function computeSuggestedInstanceSlug(
+  serviceType: 'event' | 'training_course' | 'consultation',
+  service: { title: string; slug: string | null | undefined; serviceTier: string | null | undefined } | null,
+  instanceForm: { title: string; cohort: string; sessionSlots: SuggestedInstanceSlugSlot[] }
+): string {
+  if (serviceType === 'event') {
+    const titlePart = slugifyForInstance(instanceForm.title || '');
+    const datePart = _firstSessionSlotYmd(instanceForm.sessionSlots) ?? _todayYmdUtc();
+    if (!titlePart) {
+      return datePart;
+    }
+    return `${titlePart}-${datePart}`;
+  }
+  if (serviceType === 'training_course') {
+    if (!service) {
+      return slugifyForInstance(instanceForm.cohort.trim() || instanceForm.title);
+    }
+    const slugLower = (service.slug ?? '').trim().toLowerCase();
+    const tier = (service.serviceTier ?? '').trim();
+    const cohortRaw = instanceForm.cohort.trim() || instanceForm.title;
+    const cohortPart = slugifyForInstance(cohortRaw);
+    if (slugLower === 'my-best-auntie' && tier && cohortPart) {
+      return slugifyForInstance(`my-best-auntie-${tier}-${cohortRaw}`);
+    }
+    const base = slugifyForInstance((service.slug ?? '').trim() || service.title || '');
+    if (!cohortPart) {
+      return base;
+    }
+    if (!base) {
+      return cohortPart;
+    }
+    return `${base}-${cohortPart}`;
+  }
+  return '';
+}

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4469,7 +4469,7 @@ export interface components {
             /** Format: uuid */
             service_id: string;
             title?: string | null;
-            /** @description Optional URL-safe slug: lowercase letters, digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized to lowercase. */
+            /** @description Required for event and training_course instances; optional for consultations. Public-calendar visibility depends on this field. URL-safe: lowercase letters, digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized to lowercase. */
             slug?: string | null;
             landing_page?: string | null;
             description?: string | null;
@@ -4553,9 +4553,10 @@ export interface components {
         InstanceResponse: {
             instance: components["schemas"]["ServiceInstance"];
         };
+        /** @description Instance create body for `POST /v1/admin/services/{id}/instances`. The parent service `service_type` determines slug rules: `slug` is required for `event` and `training_course` (400 with `field: slug` when missing or invalid); optional for `consultation`. Duplicate instance slugs return 409 with `field: slug`. */
         CreateInstanceRequest: {
             title?: string | null;
-            /** @description Optional URL-safe slug: lowercase letters, digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized to lowercase. Must be unique among instances when set. */
+            /** @description Required for event and training_course instances; optional for consultations. Public-calendar visibility depends on this field. URL-safe: lowercase letters, digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized to lowercase. Must be unique among instances when set. */
             slug?: string | null;
             description?: string | null;
             cover_image_s3_key?: string | null;
@@ -4589,6 +4590,7 @@ export interface components {
                 package_sessions?: number | null;
             } | null;
         };
+        /** @description Clearing `slug` to null on event or training_course instances returns 400 with `field: slug`. */
         UpdateInstanceRequest: WithRequired<components["schemas"]["CreateInstanceRequest"], "status">;
         Enrollment: {
             /** Format: uuid */

--- a/apps/admin_web/tests/components/admin/services/create-instance-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/create-instance-dialog.test.tsx
@@ -1,9 +1,31 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 
 import { CreateInstanceDialog } from '@/components/admin/services/create-instance-dialog';
+import type { ServiceSummary } from '@/types/services';
+
+const trainingServiceSummary: ServiceSummary = {
+  id: 'svc-1',
+  instancesCount: 0,
+  serviceType: 'training_course',
+  title: 'Training',
+  slug: 'training-template',
+  bookingSystem: null,
+  description: null,
+  coverImageS3Key: null,
+  deliveryMode: 'online',
+  status: 'published',
+  createdBy: 'admin',
+  createdAt: null,
+  updatedAt: null,
+  serviceTier: null,
+  locationId: null,
+  trainingDetails: null,
+  eventDetails: null,
+  consultationDetails: null,
+};
 
 vi.mock('@/components/ui/form-dialog', () => ({
   FormDialog: ({
@@ -36,6 +58,7 @@ describe('CreateInstanceDialog', () => {
       <CreateInstanceDialog
         open
         serviceType='training_course'
+        serviceSummary={trainingServiceSummary}
         serviceDefaultLocationId={venueId}
         isLoading={false}
         error=''
@@ -43,6 +66,10 @@ describe('CreateInstanceDialog', () => {
         onCreate={onCreate}
       />
     );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^slug/i)).toHaveValue('training-template');
+    });
 
     await user.click(screen.getByText('Session slots'));
     await user.click(screen.getByRole('button', { name: /add slot/i }));
@@ -57,6 +84,7 @@ describe('CreateInstanceDialog', () => {
 
     expect(onCreate).toHaveBeenCalledWith(
       expect.objectContaining({
+        slug: 'training-template',
         session_slots: [
           expect.objectContaining({
             location_id: venueId,
@@ -66,5 +94,128 @@ describe('CreateInstanceDialog', () => {
         ],
       })
     );
+  });
+
+  it('auto-populates event slug from title and first session slot date until slug is edited', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const eventService: ServiceSummary = {
+      ...trainingServiceSummary,
+      id: 'evt-svc',
+      serviceType: 'event',
+      title: 'Events',
+      slug: 'events',
+    };
+
+    const { rerender } = render(
+      <CreateInstanceDialog
+        open={false}
+        serviceType='event'
+        serviceSummary={eventService}
+        isLoading={false}
+        error=''
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />
+    );
+
+    rerender(
+      <CreateInstanceDialog
+        open
+        serviceType='event'
+        serviceSummary={eventService}
+        isLoading={false}
+        error=''
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />
+    );
+
+    const slugInput = screen.getByLabelText(/^slug/i) as HTMLInputElement;
+    await waitFor(() => {
+      expect(slugInput.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    await user.click(screen.getByText('Session slots'));
+    await user.click(screen.getByRole('button', { name: /add slot/i }));
+    const startInput = screen.getByLabelText('Start time');
+    await user.clear(startInput);
+    await user.type(startInput, '2026-04-20T14:00');
+
+    await waitFor(() => {
+      expect(slugInput.value.endsWith('2026-04-20')).toBe(true);
+    });
+
+    await user.type(screen.getByLabelText('Title'), 'Spring Gala');
+    await waitFor(() => {
+      expect(slugInput.value).toBe('spring-gala-2026-04-20');
+    });
+
+    await user.clear(slugInput);
+    await user.type(slugInput, 'custom-slug');
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Ignored');
+    expect(slugInput).toHaveValue('custom-slug');
+
+    await user.click(screen.getByRole('button', { name: /reset to suggestion/i }));
+    await waitFor(() => {
+      expect(slugInput.value).not.toBe('custom-slug');
+    });
+  });
+
+  it('shows inline error when event slug is empty on submit', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const eventService: ServiceSummary = {
+      ...trainingServiceSummary,
+      id: 'evt-svc-2',
+      serviceType: 'event',
+      title: 'Events',
+      slug: 'events',
+    };
+
+    render(
+      <CreateInstanceDialog
+        open
+        serviceType='event'
+        serviceSummary={eventService}
+        isLoading={false}
+        error=''
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/default price/i), '25');
+
+    const slugInput = screen.getByLabelText(/^slug/i);
+    await user.clear(slugInput);
+    await user.click(screen.getByRole('button', { name: 'Submit dialog' }));
+    expect(
+      screen.getByText(/slug is required for event and training_course instances/i)
+    ).toBeInTheDocument();
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('does not require slug for consultation create', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <CreateInstanceDialog
+        open
+        serviceType='consultation'
+        isLoading={false}
+        error=''
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />
+    );
+
+    const slugLabel = screen.getByText('Slug');
+    expect(slugLabel.parentElement?.textContent).not.toMatch(/\*/);
+
+    await user.click(screen.getByRole('button', { name: 'Submit dialog' }));
+    expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ slug: null }));
   });
 });

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -408,7 +408,7 @@ describe('InstanceDetailPanel', () => {
     expect(optionTexts.some((t) => t.includes('Secret'))).toBe(false);
   });
 
-  it('prefills duplicate create from createPrefillInstance and sends null slug with cohort', async () => {
+  it('prefills duplicate create from createPrefillInstance and sends suggested slug with cohort', async () => {
     const user = userEvent.setup();
     const onCreate = vi.fn().mockResolvedValue(undefined);
     const prefill: ServiceInstance = {
@@ -491,7 +491,9 @@ describe('InstanceDetailPanel', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Title')).toHaveValue('Workshop A');
     });
-    expect(screen.queryByLabelText('Slug')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^slug/i)).toHaveValue('alpha-service-spring-2026');
+    });
     expect(screen.getByLabelText('Description')).toHaveValue('Body');
     expect(screen.getByLabelText('Delivery mode')).toHaveValue('hybrid');
     expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
@@ -503,7 +505,7 @@ describe('InstanceDetailPanel', () => {
     expect(onCreate).toHaveBeenCalledWith(
       'service-1',
       expect.objectContaining({
-        slug: null,
+        slug: 'alpha-service-spring-2026',
         cohort: 'spring-2026',
       })
     );

--- a/apps/admin_web/tests/lib/slug-utils.test.ts
+++ b/apps/admin_web/tests/lib/slug-utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeSuggestedInstanceSlug, slugifyForInstance } from '@/lib/slug-utils';
+import type { ServiceSummary } from '@/types/services';
+
+describe('slugifyForInstance', () => {
+  it('lowercases, collapses non-alphanumeric, trims hyphens, caps length', () => {
+    expect(slugifyForInstance('  Hello   World!!  ')).toBe('hello-world');
+    const long = 'a'.repeat(200);
+    expect(slugifyForInstance(long).length).toBeLessThanOrEqual(128);
+  });
+});
+
+describe('computeSuggestedInstanceSlug', () => {
+  const baseService: ServiceSummary = {
+    id: 's1',
+    instancesCount: 0,
+    serviceType: 'training_course',
+    title: 'My Course',
+    slug: 'my-course',
+    bookingSystem: null,
+    description: null,
+    coverImageS3Key: null,
+    deliveryMode: 'online',
+    status: 'published',
+    createdBy: 'x',
+    createdAt: null,
+    updatedAt: null,
+    serviceTier: '1-3',
+    locationId: null,
+    trainingDetails: null,
+    eventDetails: null,
+    consultationDetails: null,
+  };
+
+  it('builds MBA slug from service tier and cohort', () => {
+    const svc: ServiceSummary = {
+      ...baseService,
+      slug: 'my-best-auntie',
+      serviceTier: '1-3',
+    };
+    expect(
+      computeSuggestedInstanceSlug('training_course', svc, {
+        title: '',
+        cohort: 'apr-26',
+        sessionSlots: [],
+      })
+    ).toBe('my-best-auntie-1-3-apr-26');
+  });
+
+  it('builds event slug from title and first slot date', () => {
+    expect(
+      computeSuggestedInstanceSlug('event', null, {
+        title: 'Easter 2026 Workshop',
+        cohort: '',
+        sessionSlots: [
+          { sortOrder: 1, startsAtLocal: '2026-04-13T10:00' },
+          { sortOrder: 0, startsAtLocal: '2026-04-06T10:00' },
+        ],
+      })
+    ).toBe('easter-2026-workshop-2026-04-06');
+  });
+});

--- a/apps/public_www/src/app/[locale]/[slug]/page.tsx
+++ b/apps/public_www/src/app/[locale]/[slug]/page.tsx
@@ -110,7 +110,7 @@ export default async function LandingPageRoute({ params }: LandingPageRouteProps
     }
   } else {
     reportInternalError({
-      context: 'landing-page-calendar-fetch',
+      context: 'landing-page-no-crm-client',
       error: new Error('CRM API client is not configured'),
       metadata: { locale, slug: resolvedParams.slug, reason: 'missing_public_crm_client' },
     });

--- a/apps/public_www/src/app/[locale]/services/my-best-auntie-training-course/page.tsx
+++ b/apps/public_www/src/app/[locale]/services/my-best-auntie-training-course/page.tsx
@@ -84,7 +84,7 @@ export default async function MyBestAuntieRoutePage({
     }
   } else {
     reportInternalError({
-      context: 'my-best-auntie-training-course-calendar-fetch',
+      context: 'my-best-auntie-training-course-no-crm-client',
       error: new Error('CRM API client is not configured'),
       metadata: { locale, reason: 'missing_public_crm_client' },
     });

--- a/backend/db/alembic/env.py
+++ b/backend/db/alembic/env.py
@@ -44,6 +44,20 @@ from app.db import models  # noqa: F401,E402
 target_metadata = Base.metadata
 
 
+def _normalize_sqlalchemy_postgres_url(url: str) -> str:
+    """Prefer psycopg v3 (``psycopg``); plain ``postgresql://`` defaults to psycopg2."""
+    trimmed = url.strip()
+    if not trimmed:
+        return trimmed
+    if trimmed.startswith("postgresql+") or trimmed.startswith("postgres+"):
+        return trimmed
+    if trimmed.startswith("postgresql://"):
+        return "postgresql+psycopg://" + trimmed.removeprefix("postgresql://")
+    if trimmed.startswith("postgres://"):
+        return "postgresql+psycopg://" + trimmed.removeprefix("postgres://")
+    return trimmed
+
+
 def get_database_url() -> str:
     """Return the database URL from environment variables."""
     url = config.get_main_option("sqlalchemy.url")
@@ -51,7 +65,7 @@ def get_database_url() -> str:
         url = os.getenv("DATABASE_URL")
     if not url:
         raise RuntimeError("DATABASE_URL is required for Alembic migrations.")
-    return url
+    return _normalize_sqlalchemy_postgres_url(url)
 
 
 def _escape_for_config(value: str) -> str:

--- a/backend/db/alembic/versions/0043_backfill_inst_slug.py
+++ b/backend/db/alembic/versions/0043_backfill_inst_slug.py
@@ -7,8 +7,8 @@ collisions with numeric suffixes ``-2``, ``-3``, … (case-insensitive uniquenes
 Seed-data assessment:
 1. Compatible: seed only sets ``services.slug``; ``service_instances.slug`` is
    untouched by seed.
-2. NOT NULL: column stays nullable; backfill only targets rows where
-   ``slug IS NULL`` for ``event`` and ``training_course`` services.
+2. NOT NULL: column stays nullable; backfill targets rows where ``slug`` is
+   NULL or blank (``trim`` empty) for ``event`` and ``training_course`` services.
 3. Renamed/dropped columns: none.
 4. New tables: none (uses session-local temp table inside DO block).
 5. Enum/allowed-value changes: none.
@@ -84,7 +84,7 @@ base_rows AS (
   INNER JOIN services AS s ON s.id = si.service_id
   LEFT JOIN first_slot AS fs ON fs.instance_id = si.id
   WHERE s.service_type IN ('event', 'training_course')
-    AND si.slug IS NULL
+    AND (si.slug IS NULL OR trim(si.slug) = '')
 ),
 computed AS (
   SELECT
@@ -101,7 +101,7 @@ computed AS (
               regexp_replace(
                 substring(lower(coalesce(b.si_title, '')) FROM '([a-z]{3}\s*\d{2,4})$'),
                 '\s+',
-                '',
+                '-',
                 'g'
               ),
               substring(b.si_title FROM '(\d{2}-\d{2})$'),
@@ -121,7 +121,7 @@ computed AS (
               regexp_replace(
                 substring(lower(coalesce(b.si_title, '')) FROM '([a-z]{3}\s*\d{2,4})$'),
                 '\s+',
-                '',
+                '-',
                 'g'
               ),
               substring(b.si_title FROM '(\d{2}-\d{2})$'),
@@ -132,7 +132,7 @@ computed AS (
       WHEN b.stype = 'training_course'
       THEN
         CASE
-          WHEN migration_0043_slugify(trim(coalesce(b.si_cohort, b.si_title, '')))) = ''
+          WHEN migration_0043_slugify(trim(coalesce(b.si_cohort, b.si_title, ''))) = ''
           THEN migration_0043_slugify(b.s_title)
           ELSE
             trim(
@@ -180,7 +180,7 @@ BEGIN
       SELECT 1
       FROM service_instances AS si
       INNER JOIN tmp_0043_slug_candidates AS t ON t.id = si.id
-      WHERE si.slug IS NULL
+      WHERE si.slug IS NULL OR trim(si.slug) = ''
     ) THEN
       EXIT;
     END IF;
@@ -209,7 +209,7 @@ BEGIN
         ) AS final_slug
       FROM service_instances AS si
       INNER JOIN tmp_0043_slug_candidates AS t ON t.id = si.id
-      WHERE si.slug IS NULL
+      WHERE si.slug IS NULL OR trim(si.slug) = ''
     ),
     ranked AS (
       SELECT
@@ -242,7 +242,7 @@ BEGIN
 END
 $collision$;
 
-DROP FUNCTION migration_0043_slugify(text);
+DROP FUNCTION IF EXISTS migration_0043_slugify(text);
 
 DO $assert1$
 BEGIN
@@ -251,7 +251,7 @@ BEGIN
     FROM service_instances AS si
     INNER JOIN services AS s ON s.id = si.service_id
     WHERE s.service_type IN ('event', 'training_course')
-      AND (si.slug IS NULL OR si.slug = '')
+      AND (si.slug IS NULL OR trim(coalesce(si.slug, '')) = '')
   ) THEN
     RAISE EXCEPTION 'Backfill incomplete: event/training_course instances with NULL/empty slug remain';
   END IF;

--- a/backend/db/alembic/versions/0043_backfill_inst_slug.py
+++ b/backend/db/alembic/versions/0043_backfill_inst_slug.py
@@ -29,7 +29,12 @@ down_revision = "0042_slug_nulls_nd"
 branch_labels = None
 depends_on = None
 
-_UPGRADE_SQL = r"""
+# Multi-statement migration split into separate ``op.execute`` calls below.
+# psycopg3's extended-query protocol only runs the first top-level statement when
+# multiple semicolon-separated statements are passed to a single ``execute()``;
+# matching the per-statement pattern used in 0042 keeps each step actually run.
+
+_CREATE_SLUGIFY_FN_SQL = r"""
 CREATE OR REPLACE FUNCTION migration_0043_slugify(input text)
 RETURNS text
 LANGUAGE sql
@@ -54,13 +59,17 @@ AS $slugfn$
       ''
     )
   );
-$slugfn$;
+$slugfn$
+"""
 
+_CREATE_TMP_TABLE_SQL = r"""
 CREATE TEMP TABLE tmp_0043_slug_candidates (
   id uuid PRIMARY KEY,
   base_candidate text NOT NULL
-) ON COMMIT DROP;
+) ON COMMIT DROP
+"""
 
+_INSERT_CANDIDATES_SQL = r"""
 INSERT INTO tmp_0043_slug_candidates (id, base_candidate)
 WITH first_slot AS (
   SELECT DISTINCT ON (iss.instance_id)
@@ -169,8 +178,10 @@ SELECT
     THEN 'instance-' || substring(replace(c.id::text, '-', ''), 1, 8)
     ELSE migration_0043_slugify(c.raw_candidate)
   END
-FROM computed AS c;
+FROM computed AS c
+"""
 
+_RESOLVE_COLLISIONS_SQL = r"""
 DO $collision$
 DECLARE
   iter int := 0;
@@ -241,10 +252,12 @@ BEGIN
     END IF;
   END LOOP;
 END
-$collision$;
+$collision$
+"""
 
-DROP FUNCTION IF EXISTS migration_0043_slugify(text);
+_DROP_SLUGIFY_FN_SQL = "DROP FUNCTION IF EXISTS migration_0043_slugify(text)"
 
+_ASSERT_NO_NULL_SLUGS_SQL = r"""
 DO $assert1$
 BEGIN
   IF EXISTS (
@@ -257,8 +270,10 @@ BEGIN
     RAISE EXCEPTION 'Backfill incomplete: event/training_course instances with NULL/empty slug remain';
   END IF;
 END
-$assert1$;
+$assert1$
+"""
 
+_ASSERT_VALID_SLUG_SHAPE_SQL = r"""
 DO $assert2$
 BEGIN
   IF EXISTS (
@@ -270,12 +285,35 @@ BEGIN
     RAISE EXCEPTION 'Migration produced invalid slug shape; aborting';
   END IF;
 END
-$assert2$;
+$assert2$
 """
+
+# Concatenated form preserved for the migration test's raw idempotency check
+# (executes everything in one go via psycopg, which the test wraps in its own
+# loop). Trailing semicolons separate statements; psycopg accepts them as long
+# as the test passes them via ``cursor.execute`` without parameter binding.
+_UPGRADE_SQL = ";\n".join(
+    s.strip()
+    for s in (
+        _CREATE_SLUGIFY_FN_SQL,
+        _CREATE_TMP_TABLE_SQL,
+        _INSERT_CANDIDATES_SQL,
+        _RESOLVE_COLLISIONS_SQL,
+        _DROP_SLUGIFY_FN_SQL,
+        _ASSERT_NO_NULL_SLUGS_SQL,
+        _ASSERT_VALID_SLUG_SHAPE_SQL,
+    )
+)
 
 
 def upgrade() -> None:
-    op.execute(sa.text(_UPGRADE_SQL))
+    op.execute(sa.text(_CREATE_SLUGIFY_FN_SQL))
+    op.execute(sa.text(_CREATE_TMP_TABLE_SQL))
+    op.execute(sa.text(_INSERT_CANDIDATES_SQL))
+    op.execute(sa.text(_RESOLVE_COLLISIONS_SQL))
+    op.execute(sa.text(_DROP_SLUGIFY_FN_SQL))
+    op.execute(sa.text(_ASSERT_NO_NULL_SLUGS_SQL))
+    op.execute(sa.text(_ASSERT_VALID_SLUG_SHAPE_SQL))
 
 
 def downgrade() -> None:

--- a/backend/db/alembic/versions/0043_backfill_inst_slug.py
+++ b/backend/db/alembic/versions/0043_backfill_inst_slug.py
@@ -2,7 +2,8 @@
 
 Fills NULL slugs using deterministic rules (MBA cohorts, event title + first
 slot date, other training course service slug + cohort/title). Resolves
-collisions with numeric suffixes ``-2``, ``-3``, … (case-insensitive uniqueness).
+collisions with numeric suffixes ``-2``, ``-3``, … (case-insensitive uniqueness)
+in a single statement using window functions and a count of pre-existing slugs.
 
 Seed-data assessment:
 1. Compatible: seed only sets ``services.slug``; ``service_instances.slug`` is
@@ -10,7 +11,11 @@ Seed-data assessment:
 2. NOT NULL: column stays nullable; backfill targets rows where ``slug`` is
    NULL or blank (``trim`` empty) for ``event`` and ``training_course`` services.
 3. Renamed/dropped columns: none.
-4. New tables: none (uses session-local temp table inside DO block).
+4. New tables: none. Earlier draft used a temp table; replaced with a single
+   ``UPDATE … FROM (CTE)`` because temp tables with ``ON COMMIT DROP`` did not
+   survive across separate ``op.execute(sa.text(...))`` calls reliably under
+   SQLAlchemy 2.x + psycopg3 (each ``op.execute`` may flush state in a way that
+   triggers the drop), leaving the backfill silently a no-op.
 5. Enum/allowed-value changes: none.
 6. FK/cascade changes: none.
 
@@ -29,10 +34,9 @@ down_revision = "0042_slug_nulls_nd"
 branch_labels = None
 depends_on = None
 
-# Multi-statement migration split into separate ``op.execute`` calls below.
-# psycopg3's extended-query protocol only runs the first top-level statement when
-# multiple semicolon-separated statements are passed to a single ``execute()``;
-# matching the per-statement pattern used in 0042 keeps each step actually run.
+# Each module-level constant is exactly one top-level SQL statement so each
+# ``op.execute(sa.text(...))`` call sends a single statement under psycopg3's
+# extended-query protocol. Order matches the production ``upgrade()`` body.
 
 _CREATE_SLUGIFY_FN_SQL = r"""
 CREATE OR REPLACE FUNCTION migration_0043_slugify(input text)
@@ -62,15 +66,18 @@ AS $slugfn$
 $slugfn$
 """
 
-_CREATE_TMP_TABLE_SQL = r"""
-CREATE TEMP TABLE tmp_0043_slug_candidates (
-  id uuid PRIMARY KEY,
-  base_candidate text NOT NULL
-) ON COMMIT DROP
-"""
-
-_INSERT_CANDIDATES_SQL = r"""
-INSERT INTO tmp_0043_slug_candidates (id, base_candidate)
+# Single-statement backfill. Computes a base candidate per target row, dedupes
+# via window function within the backfill batch, and adds an offset for any
+# pre-existing populated slugs that collide on lowercase. Final slug shape:
+#   base                              when first occurrence in batch + no DB collision
+#   base-<rn>                         when 2nd+ occurrence in batch + no DB collision
+#   base-<rn + existing_count>        when at least one DB row already uses ``base``
+#
+# ``existing_count`` is the number of populated rows whose lowercased slug equals
+# the base candidate; the unique partial index ``svc_instances_slug_uq`` would
+# fail an UPDATE that produced a duplicate, so a residual ``base-N`` collision
+# against an existing ``base-N`` (extremely rare) surfaces as a deploy error.
+_BACKFILL_UPDATE_SQL = r"""
 WITH first_slot AS (
   SELECT DISTINCT ON (iss.instance_id)
     iss.instance_id,
@@ -81,7 +88,6 @@ WITH first_slot AS (
 base_rows AS (
   SELECT
     si.id,
-    si.service_id,
     si.title AS si_title,
     si.cohort AS si_cohort,
     si.created_at,
@@ -170,89 +176,48 @@ computed AS (
       ELSE migration_0043_slugify('')
     END AS raw_candidate
   FROM base_rows AS b
-)
-SELECT
-  c.id,
-  CASE
-    WHEN migration_0043_slugify(c.raw_candidate) = ''
-    THEN 'instance-' || substring(replace(c.id::text, '-', ''), 1, 8)
-    ELSE migration_0043_slugify(c.raw_candidate)
-  END
-FROM computed AS c
-"""
-
-_RESOLVE_COLLISIONS_SQL = r"""
-DO $collision$
-DECLARE
-  iter int := 0;
-  assigned int;
-BEGIN
-  LOOP
-    IF NOT EXISTS (
-      SELECT 1
-      FROM service_instances AS si
-      INNER JOIN tmp_0043_slug_candidates AS t ON t.id = si.id
-      WHERE si.slug IS NULL OR trim(si.slug) = ''
-    ) THEN
-      EXIT;
-    END IF;
-
-    iter := iter + 1;
-    IF iter > 100 THEN
-      RAISE EXCEPTION 'Backfill slug collision resolution exceeded 100 levels';
-    END IF;
-
-    WITH proposed AS (
-      SELECT
-        si.id,
-        trim(
-          both '-'
-          FROM regexp_replace(
-            substring(
-              trim(
-                both '-'
-                FROM (t.base_candidate || CASE WHEN iter = 1 THEN '' ELSE '-' || iter::text END)
-              )
-              FROM 1 FOR 128
-            ),
-            '-+$',
-            ''
-          )
-        ) AS final_slug
-      FROM service_instances AS si
-      INNER JOIN tmp_0043_slug_candidates AS t ON t.id = si.id
-      WHERE si.slug IS NULL OR trim(si.slug) = ''
-    ),
-    ranked AS (
-      SELECT
-        id,
-        final_slug,
-        row_number() OVER (PARTITION BY lower(final_slug) ORDER BY id) AS rn
-      FROM proposed
-    ),
-    winners AS (
-      SELECT r.id, r.final_slug
-      FROM ranked AS r
-      WHERE r.rn = 1
-        AND NOT EXISTS (
-          SELECT 1
-          FROM service_instances AS x
-          WHERE x.slug IS NOT NULL
-            AND lower(x.slug) = lower(r.final_slug)
+),
+candidates AS (
+  SELECT
+    c.id,
+    CASE
+      WHEN migration_0043_slugify(c.raw_candidate) = ''
+      THEN 'instance-' || substring(replace(c.id::text, '-', ''), 1, 8)
+      ELSE migration_0043_slugify(c.raw_candidate)
+    END AS base
+  FROM computed AS c
+),
+ranked AS (
+  SELECT
+    cand.id,
+    cand.base,
+    row_number() OVER (PARTITION BY lower(cand.base) ORDER BY cand.id) AS within_batch_rn,
+    (
+      SELECT count(*)::int
+      FROM service_instances AS x
+      WHERE x.slug IS NOT NULL
+        AND lower(x.slug) = lower(cand.base)
+    ) AS existing_count
+  FROM candidates AS cand
+),
+final_slugs AS (
+  SELECT
+    r.id,
+    CASE
+      WHEN r.within_batch_rn = 1 AND r.existing_count = 0
+      THEN r.base
+      ELSE
+        substring(
+          r.base || '-' || (r.within_batch_rn + r.existing_count)::text
+          FROM 1 FOR 128
         )
-    )
-    UPDATE service_instances AS si
-    SET slug = w.final_slug
-    FROM winners AS w
-    WHERE si.id = w.id;
-
-    GET DIAGNOSTICS assigned = ROW_COUNT;
-    IF assigned = 0 THEN
-      RAISE EXCEPTION 'Backfill deadlock: no progress assigning slugs at iteration %', iter;
-    END IF;
-  END LOOP;
-END
-$collision$
+    END AS final_slug
+  FROM ranked AS r
+)
+UPDATE service_instances AS si
+SET slug = fs.final_slug
+FROM final_slugs AS fs
+WHERE si.id = fs.id
 """
 
 _DROP_SLUGIFY_FN_SQL = "DROP FUNCTION IF EXISTS migration_0043_slugify(text)"
@@ -288,29 +253,10 @@ END
 $assert2$
 """
 
-# Concatenated form preserved for the migration test's raw idempotency check
-# (executes everything in one go via psycopg, which the test wraps in its own
-# loop). Trailing semicolons separate statements; psycopg accepts them as long
-# as the test passes them via ``cursor.execute`` without parameter binding.
-_UPGRADE_SQL = ";\n".join(
-    s.strip()
-    for s in (
-        _CREATE_SLUGIFY_FN_SQL,
-        _CREATE_TMP_TABLE_SQL,
-        _INSERT_CANDIDATES_SQL,
-        _RESOLVE_COLLISIONS_SQL,
-        _DROP_SLUGIFY_FN_SQL,
-        _ASSERT_NO_NULL_SLUGS_SQL,
-        _ASSERT_VALID_SLUG_SHAPE_SQL,
-    )
-)
-
 
 def upgrade() -> None:
     op.execute(sa.text(_CREATE_SLUGIFY_FN_SQL))
-    op.execute(sa.text(_CREATE_TMP_TABLE_SQL))
-    op.execute(sa.text(_INSERT_CANDIDATES_SQL))
-    op.execute(sa.text(_RESOLVE_COLLISIONS_SQL))
+    op.execute(sa.text(_BACKFILL_UPDATE_SQL))
     op.execute(sa.text(_DROP_SLUGIFY_FN_SQL))
     op.execute(sa.text(_ASSERT_NO_NULL_SLUGS_SQL))
     op.execute(sa.text(_ASSERT_VALID_SLUG_SHAPE_SQL))

--- a/backend/db/alembic/versions/0043_backfill_inst_slug.py
+++ b/backend/db/alembic/versions/0043_backfill_inst_slug.py
@@ -1,0 +1,287 @@
+"""Backfill ``service_instances.slug`` for event and training_course rows.
+
+Fills NULL slugs using deterministic rules (MBA cohorts, event title + first
+slot date, other training course service slug + cohort/title). Resolves
+collisions with numeric suffixes ``-2``, ``-3``, … (case-insensitive uniqueness).
+
+Seed-data assessment:
+1. Compatible: seed only sets ``services.slug``; ``service_instances.slug`` is
+   untouched by seed.
+2. NOT NULL: column stays nullable; backfill only targets rows where
+   ``slug IS NULL`` for ``event`` and ``training_course`` services.
+3. Renamed/dropped columns: none.
+4. New tables: none (uses session-local temp table inside DO block).
+5. Enum/allowed-value changes: none.
+6. FK/cascade changes: none.
+
+Downgrade is intentionally non-destructive: backfilled values are not safely
+reversible without losing public URLs.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0043_backfill_inst_slug"
+down_revision = "0042_slug_nulls_nd"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_SQL = r"""
+CREATE OR REPLACE FUNCTION migration_0043_slugify(input text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $slugfn$
+  SELECT trim(
+    both '-'
+    FROM regexp_replace(
+      substring(
+        trim(
+          both '-'
+          FROM regexp_replace(
+            lower(coalesce(input, '')),
+            '[^a-z0-9]+',
+            '-',
+            'g'
+          )
+        )
+        FROM 1 FOR 128
+      ),
+      '-+$',
+      ''
+    )
+  );
+$slugfn$;
+
+CREATE TEMP TABLE tmp_0043_slug_candidates (
+  id uuid PRIMARY KEY,
+  base_candidate text NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO tmp_0043_slug_candidates (id, base_candidate)
+WITH first_slot AS (
+  SELECT DISTINCT ON (iss.instance_id)
+    iss.instance_id,
+    iss.starts_at
+  FROM instance_session_slots AS iss
+  ORDER BY iss.instance_id, iss.sort_order ASC, iss.starts_at ASC
+),
+base_rows AS (
+  SELECT
+    si.id,
+    si.service_id,
+    si.title AS si_title,
+    si.cohort AS si_cohort,
+    si.created_at,
+    s.service_type::text AS stype,
+    lower(trim(coalesce(s.slug, ''))) AS s_slug,
+    s.title AS s_title,
+    s.service_tier,
+    fs.starts_at AS first_starts_at
+  FROM service_instances AS si
+  INNER JOIN services AS s ON s.id = si.service_id
+  LEFT JOIN first_slot AS fs ON fs.instance_id = si.id
+  WHERE s.service_type IN ('event', 'training_course')
+    AND si.slug IS NULL
+),
+computed AS (
+  SELECT
+    b.id,
+    CASE
+      WHEN b.stype = 'training_course'
+        AND b.s_slug = 'my-best-auntie'
+        AND nullif(trim(coalesce(b.service_tier, substring(b.si_title FROM '(\d+-\d+)'), '')), '')
+          IS NOT NULL
+        AND nullif(
+          trim(
+            coalesce(
+              b.si_cohort,
+              regexp_replace(
+                substring(lower(coalesce(b.si_title, '')) FROM '([a-z]{3}\s*\d{2,4})$'),
+                '\s+',
+                '',
+                'g'
+              ),
+              substring(b.si_title FROM '(\d{2}-\d{2})$'),
+              ''
+            )
+          ),
+          ''
+        ) IS NOT NULL
+      THEN
+        migration_0043_slugify(
+          'my-best-auntie-'
+          || trim(coalesce(b.service_tier, substring(b.si_title FROM '(\d+-\d+)'), ''))
+          || '-'
+          || trim(
+            coalesce(
+              b.si_cohort,
+              regexp_replace(
+                substring(lower(coalesce(b.si_title, '')) FROM '([a-z]{3}\s*\d{2,4})$'),
+                '\s+',
+                '',
+                'g'
+              ),
+              substring(b.si_title FROM '(\d{2}-\d{2})$'),
+              ''
+            )
+          )
+        )
+      WHEN b.stype = 'training_course'
+      THEN
+        CASE
+          WHEN migration_0043_slugify(trim(coalesce(b.si_cohort, b.si_title, '')))) = ''
+          THEN migration_0043_slugify(b.s_title)
+          ELSE
+            trim(
+              both '-'
+              FROM concat_ws(
+                '-',
+                nullif(
+                  migration_0043_slugify(
+                    coalesce(nullif(b.s_slug, ''), b.s_title)
+                  ),
+                  ''
+                ),
+                migration_0043_slugify(trim(coalesce(b.si_cohort, b.si_title, '')))
+              )
+            )
+        END
+      WHEN b.stype = 'event'
+      THEN
+        migration_0043_slugify(trim(coalesce(b.si_title, b.s_title)))
+        || '-'
+        || coalesce(
+          to_char(b.first_starts_at AT TIME ZONE 'UTC', 'YYYY-MM-DD'),
+          to_char(b.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD')
+        )
+      ELSE migration_0043_slugify('')
+    END AS raw_candidate
+  FROM base_rows AS b
+)
+SELECT
+  c.id,
+  CASE
+    WHEN migration_0043_slugify(c.raw_candidate) = ''
+    THEN 'instance-' || substring(replace(c.id::text, '-', ''), 1, 8)
+    ELSE migration_0043_slugify(c.raw_candidate)
+  END
+FROM computed AS c;
+
+DO $collision$
+DECLARE
+  iter int := 0;
+  assigned int;
+BEGIN
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1
+      FROM service_instances AS si
+      INNER JOIN tmp_0043_slug_candidates AS t ON t.id = si.id
+      WHERE si.slug IS NULL
+    ) THEN
+      EXIT;
+    END IF;
+
+    iter := iter + 1;
+    IF iter > 100 THEN
+      RAISE EXCEPTION 'Backfill slug collision resolution exceeded 100 levels';
+    END IF;
+
+    WITH proposed AS (
+      SELECT
+        si.id,
+        trim(
+          both '-'
+          FROM regexp_replace(
+            substring(
+              trim(
+                both '-'
+                FROM (t.base_candidate || CASE WHEN iter = 1 THEN '' ELSE '-' || iter::text END)
+              )
+              FROM 1 FOR 128
+            ),
+            '-+$',
+            ''
+          )
+        ) AS final_slug
+      FROM service_instances AS si
+      INNER JOIN tmp_0043_slug_candidates AS t ON t.id = si.id
+      WHERE si.slug IS NULL
+    ),
+    ranked AS (
+      SELECT
+        id,
+        final_slug,
+        row_number() OVER (PARTITION BY lower(final_slug) ORDER BY id) AS rn
+      FROM proposed
+    ),
+    winners AS (
+      SELECT r.id, r.final_slug
+      FROM ranked AS r
+      WHERE r.rn = 1
+        AND NOT EXISTS (
+          SELECT 1
+          FROM service_instances AS x
+          WHERE x.slug IS NOT NULL
+            AND lower(x.slug) = lower(r.final_slug)
+        )
+    )
+    UPDATE service_instances AS si
+    SET slug = w.final_slug
+    FROM winners AS w
+    WHERE si.id = w.id;
+
+    GET DIAGNOSTICS assigned = ROW_COUNT;
+    IF assigned = 0 THEN
+      RAISE EXCEPTION 'Backfill deadlock: no progress assigning slugs at iteration %', iter;
+    END IF;
+  END LOOP;
+END
+$collision$;
+
+DROP FUNCTION migration_0043_slugify(text);
+
+DO $assert1$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM service_instances AS si
+    INNER JOIN services AS s ON s.id = si.service_id
+    WHERE s.service_type IN ('event', 'training_course')
+      AND (si.slug IS NULL OR si.slug = '')
+  ) THEN
+    RAISE EXCEPTION 'Backfill incomplete: event/training_course instances with NULL/empty slug remain';
+  END IF;
+END
+$assert1$;
+
+DO $assert2$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM service_instances
+    WHERE slug IS NOT NULL
+      AND slug !~ '^[a-z0-9]+(-[a-z0-9]+)*$'
+  ) THEN
+    RAISE EXCEPTION 'Migration produced invalid slug shape; aborting';
+  END IF;
+END
+$assert2$;
+"""
+
+
+def upgrade() -> None:
+    op.execute(sa.text(_UPGRADE_SQL))
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "DO $dn$ BEGIN "
+            "RAISE NOTICE 'Downgrade is a no-op: backfilled slugs are not safely reversible'; "
+            "END $dn$;"
+        )
+    )

--- a/backend/db/alembic/versions/0043_backfill_inst_slug.py
+++ b/backend/db/alembic/versions/0043_backfill_inst_slug.py
@@ -15,7 +15,8 @@ Seed-data assessment:
 6. FK/cascade changes: none.
 
 Downgrade is intentionally non-destructive: backfilled values are not safely
-reversible without losing public URLs.
+reversible without losing public URLs. ``downgrade()`` prints a one-line message
+to stdout (for tests and deploy logs); it does not alter data.
 """
 
 from __future__ import annotations
@@ -278,10 +279,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        sa.text(
-            "DO $dn$ BEGIN "
-            "RAISE NOTICE 'Downgrade is a no-op: backfilled slugs are not safely reversible'; "
-            "END $dn$;"
-        )
+    print(
+        "0043_backfill_inst_slug: downgrade is a no-op; backfilled slugs are not safely reversible"
     )

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.admin_enrollments import handle_admin_enrollments_request
@@ -45,6 +46,15 @@ from app.utils import json_response
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def _is_service_instance_slug_unique_violation(exc: IntegrityError) -> bool:
+    orig = getattr(exc.orig, "__cause__", None) or exc.orig
+    diag = getattr(orig, "diag", None)
+    constraint = getattr(diag, "constraint_name", None) if diag else None
+    if constraint == "svc_instances_slug_uq":
+        return True
+    return "svc_instances_slug_uq" in str(exc).lower()
 
 
 def _event_category_name(service: Service) -> str:
@@ -426,18 +436,28 @@ def _create_instance(
             )
             for item in payload["session_slots"]
         ]
-        created = instance_repository.create_instance(instance, type_details, slots)
-        reconcile_instance_partner_organizations(
-            session,
-            instance_id=created.id,
-            ordered_org_ids=payload["partner_organization_ids"],
-        )
-        replace_service_instance_tags(
-            session,
-            instance_id=created.id,
-            tag_ids=payload["tag_ids"],
-        )
-        session.commit()
+        try:
+            created = instance_repository.create_instance(instance, type_details, slots)
+            reconcile_instance_partner_organizations(
+                session,
+                instance_id=created.id,
+                ordered_org_ids=payload["partner_organization_ids"],
+            )
+            replace_service_instance_tags(
+                session,
+                instance_id=created.id,
+                tag_ids=payload["tag_ids"],
+            )
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            if _is_service_instance_slug_unique_violation(exc):
+                raise ValidationError(
+                    "Another instance already uses this slug. Choose a different slug.",
+                    field="slug",
+                    status_code=409,
+                ) from exc
+            raise
         if service.service_type == ServiceType.EVENT:
             enqueue_eventbrite_instance_sync_by_id(created.id)
         with_details = instance_repository.get_by_id_with_details(created.id)
@@ -574,7 +594,17 @@ def _update_instance(
                 tag_ids=payload["tag_ids"],
             )
 
-        session.commit()
+        try:
+            session.commit()
+        except IntegrityError as exc:
+            session.rollback()
+            if _is_service_instance_slug_unique_violation(exc):
+                raise ValidationError(
+                    "Another instance already uses this slug. Choose a different slug.",
+                    field="slug",
+                    status_code=409,
+                ) from exc
+            raise
         if service.service_type == ServiceType.EVENT:
             enqueue_eventbrite_instance_sync_by_id(instance.id)
         with_details = instance_repository.get_by_id_with_details(instance.id)

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -13,6 +13,7 @@ from app.api.admin_validators import (
     MAX_DESCRIPTION_LENGTH,
     parse_optional_service_instance_slug,
     parse_optional_service_instance_slug_like_text,
+    parse_required_service_instance_slug,
 )
 from app.api.admin_services_cursor import (
     parse_created_cursor,
@@ -353,9 +354,13 @@ def parse_create_instance_payload(
 ) -> dict[str, Any]:
     """Parse and validate service-instance creation payload."""
     _reject_deprecated_instance_age_group(body)
+    if service.service_type in (ServiceType.EVENT, ServiceType.TRAINING_COURSE):
+        slug_value = parse_required_service_instance_slug(body.get("slug"))
+    else:
+        slug_value = parse_optional_service_instance_slug(body.get("slug"))
     return {
         "title": parse_optional_text(body.get("title"), max_length=255),
-        "slug": parse_optional_service_instance_slug(body.get("slug")),
+        "slug": slug_value,
         "landing_page": parse_optional_text(body.get("landing_page"), max_length=255),
         "description": parse_optional_text(
             body.get("description"), max_length=MAX_DESCRIPTION_LENGTH
@@ -407,7 +412,16 @@ def parse_update_instance_payload(
     if has_field(body, "title"):
         payload["title"] = parse_optional_text(body.get("title"), max_length=255)
     if has_field(body, "slug"):
-        payload["slug"] = parse_optional_service_instance_slug(body.get("slug"))
+        parsed_slug = parse_optional_service_instance_slug(body.get("slug"))
+        if parsed_slug is None and service.service_type in (
+            ServiceType.EVENT,
+            ServiceType.TRAINING_COURSE,
+        ):
+            raise ValidationError(
+                "slug cannot be cleared for event or training_course instances",
+                field="slug",
+            )
+        payload["slug"] = parsed_slug
     if has_field(body, "landing_page"):
         payload["landing_page"] = parse_optional_text(
             body.get("landing_page"), max_length=255

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -354,6 +354,7 @@ def parse_create_instance_payload(
 ) -> dict[str, Any]:
     """Parse and validate service-instance creation payload."""
     _reject_deprecated_instance_age_group(body)
+    slug_value: str | None
     if service.service_type in (ServiceType.EVENT, ServiceType.TRAINING_COURSE):
         slug_value = parse_required_service_instance_slug(body.get("slug"))
     else:

--- a/backend/src/app/api/admin_validators.py
+++ b/backend/src/app/api/admin_validators.py
@@ -84,6 +84,14 @@ def _valid_currencies() -> frozenset[str]:
     return frozenset(codes)
 
 
+def parse_required_service_instance_slug(value: Any, *, field: str = "slug") -> str:
+    """Return a normalized lowercase slug; raises ValidationError if missing or invalid."""
+    parsed = parse_optional_service_instance_slug(value, field=field)
+    if parsed is None:
+        raise ValidationError("slug is required", field=field)
+    return parsed
+
+
 def parse_optional_service_instance_slug(
     value: Any, *, field: str = "slug"
 ) -> str | None:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3957,8 +3957,10 @@ components:
           type: string
           nullable: true
           description: >
-            Optional URL-safe slug: lowercase letters, digits, and single hyphens between segments
-            (e.g. spring-workshop). Stored normalized to lowercase.
+            Required for event and training_course instances; optional for consultations.
+            Public-calendar visibility depends on this field. URL-safe: lowercase letters,
+            digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized
+            to lowercase.
         landing_page:
           type: string
           nullable: true
@@ -4161,6 +4163,11 @@ components:
           $ref: "#/components/schemas/ServiceInstance"
     CreateInstanceRequest:
       type: object
+      description: >
+        Instance create body for `POST /v1/admin/services/{id}/instances`. The parent service
+        `service_type` determines slug rules: `slug` is required for `event` and
+        `training_course` (400 with `field: slug` when missing or invalid); optional for
+        `consultation`. Duplicate instance slugs return 409 with `field: slug`.
       properties:
         title:
           type: string
@@ -4169,8 +4176,10 @@ components:
           type: string
           nullable: true
           description: >
-            Optional URL-safe slug: lowercase letters, digits, and single hyphens between segments
-            (e.g. spring-workshop). Stored normalized to lowercase. Must be unique among instances when set.
+            Required for event and training_course instances; optional for consultations.
+            Public-calendar visibility depends on this field. URL-safe: lowercase letters,
+            digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized
+            to lowercase. Must be unique among instances when set.
         description:
           type: string
           nullable: true
@@ -4262,6 +4271,9 @@ components:
         - $ref: "#/components/schemas/CreateInstanceRequest"
       required:
         - status
+      description: >
+        Clearing `slug` to null on event or training_course instances returns 400 with
+        `field: slug`.
     Enrollment:
       type: object
       required: [id, instance_id, status]

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1104,7 +1104,10 @@ components:
           type: string
           pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
           maxLength: 128
-          description: Stable public identifier for the offering. Maps to `service_instances.slug`.
+          description: >
+            Stable public identifier for the offering. Maps to `service_instances.slug`.
+            The calendar feed omits rows where the instance slug is missing or does not match
+            this public pattern (invalid values are filtered server-side).
         landing_page:
           type: string
           nullable: true

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -476,9 +476,12 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 - `service_instances` stores dated offerings linked to a `services` template.
 - Template fields can be overridden per instance (`title`, `description`,
   `cover_image_s3_key`, `delivery_mode`).
-- Optional public-site fields: `slug` (unique when set; **canonical public identifier**
-  for calendar/discount/reservation instance scope—must be set for rows included in the
-  public calendar feed), `landing_page`
+- Optional public-site fields: `slug` (unique when set via partial unique index
+  `svc_instances_slug_uq`; **canonical public identifier** for calendar/discount/reservation
+  instance scope). For **event** and **training_course** rows, a non-empty slug is required
+  in practice for public calendar visibility; legacy NULL slugs were backfilled by migration
+  `0043_backfill_inst_slug`. **Consultation** instances may keep `slug` NULL (consultations are
+  not exposed on the public calendar feed). `landing_page`
   (marketing route key for the public website).
 - Optional `cohort` varchar(128): admin label stored with the same normalization rules as
   instance referral slugs (lowercase letters, digits, single hyphens between segments).

--- a/tests/db/migrations/test_0043_backfill_inst_slug.py
+++ b/tests/db/migrations/test_0043_backfill_inst_slug.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import re
 import subprocess
@@ -27,7 +28,7 @@ def _alembic_ini() -> Path:
     return _repo_root() / "backend" / "db" / "alembic.ini"
 
 
-def _run_alembic(*args: str) -> None:
+def _run_alembic(*args: str) -> subprocess.CompletedProcess[str]:
     env = {**os.environ, "DATABASE_URL": _database_url() or ""}
     cmd = [sys.executable, "-m", "alembic", "-c", str(_alembic_ini()), *args]
     proc = subprocess.run(
@@ -42,6 +43,24 @@ def _run_alembic(*args: str) -> None:
         raise AssertionError(
             f"alembic {' '.join(args)} failed:\n{proc.stdout}\n{proc.stderr}"
         )
+    return proc
+
+
+def _load_migration_upgrade_sql() -> str:
+    """Load ``_UPGRADE_SQL`` from the revision file (for idempotency checks without Alembic)."""
+    path = (
+        _repo_root()
+        / "backend"
+        / "db"
+        / "alembic"
+        / "versions"
+        / "0043_backfill_inst_slug.py"
+    )
+    spec = importlib.util.spec_from_file_location("revision_0043_inst_slug", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return str(getattr(mod, "_UPGRADE_SQL"))
 
 
 @pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
@@ -51,9 +70,8 @@ def test_0043_backfill_service_instance_slugs() -> None:
     assert url is not None
     _run_alembic("upgrade", "0042_slug_nulls_nd")
 
-    mba_svc_01 = UUID("21111111-1111-1111-1111-111111111101")
-    mba_svc_13 = UUID("21111111-1111-1111-1111-111111111102")
-    mba_svc_36 = UUID("21111111-1111-1111-1111-111111111103")
+    # One MBA template (same slug+tier as unique index); instances vary tier/cohort via title/cohort.
+    mba_svc = UUID("21111111-1111-1111-1111-111111111101")
     mba_i01 = UUID("31111111-1111-1111-1111-111111111101")
     mba_i13 = UUID("31111111-1111-1111-1111-111111111102")
     mba_i36 = UUID("31111111-1111-1111-1111-111111111103")
@@ -100,27 +118,22 @@ def test_0043_backfill_service_instance_slugs() -> None:
             ) VALUES
             (%s, 'training_course', 'MBA', 'my-best-auntie', NULL, NULL, NULL,
              'online', 'published', 'test', NULL, NULL),
-            (%s, 'training_course', 'MBA', 'my-best-auntie', NULL, NULL, NULL,
-             'online', 'published', 'test', NULL, NULL),
-            (%s, 'training_course', 'MBA', 'my-best-auntie', NULL, NULL, NULL,
-             'online', 'published', 'test', '3-6', NULL),
             (%s, 'event', 'Event Svc', 'evt-svc-0043', NULL, NULL, NULL,
              'in_person', 'published', 'test', NULL, NULL),
             (%s, 'consultation', 'Cons', NULL, NULL, NULL, NULL,
              'online', 'published', 'test', NULL, NULL)
             """,
-            (mba_svc_01, mba_svc_13, mba_svc_36, evt_svc, cons_svc),
+            (mba_svc, evt_svc, cons_svc),
         )
 
-        for sid in (mba_svc_01, mba_svc_13, mba_svc_36):
-            conn.execute(
-                """
-                INSERT INTO training_course_details (
-                  service_id, pricing_unit, default_price, default_currency
-                ) VALUES (%s, 'per_person', 1.00, 'HKD')
-                """,
-                (sid,),
-            )
+        conn.execute(
+            """
+            INSERT INTO training_course_details (
+              service_id, pricing_unit, default_price, default_currency
+            ) VALUES (%s, 'per_person', 1.00, 'HKD')
+            """,
+            (mba_svc,),
+        )
 
         conn.execute(
             """
@@ -155,7 +168,7 @@ def test_0043_backfill_service_instance_slugs() -> None:
             (%s, %s, 'MBA 1-3 cohort 04-26', NULL, NULL, NULL, NULL, 'scheduled', NULL, NULL,
              NULL, false, NULL, '04-26', NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
              NULL, NULL, 'pending'),
-            (%s, %s, 'MBA May 26', NULL, NULL, NULL, NULL, 'scheduled', NULL, NULL,
+            (%s, %s, 'MBA 3-6 May 26', NULL, NULL, NULL, NULL, 'scheduled', NULL, NULL,
              NULL, false, NULL, 'may-26', NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
              NULL, NULL, 'pending'),
             (%s, %s, 'Easter 2026 Workshop', NULL, NULL, NULL, NULL, 'scheduled', 'in_person', NULL,
@@ -179,11 +192,11 @@ def test_0043_backfill_service_instance_slugs() -> None:
             """,
             (
                 mba_i01,
-                mba_svc_01,
+                mba_svc,
                 mba_i13,
-                mba_svc_13,
+                mba_svc,
                 mba_i36,
-                mba_svc_36,
+                mba_svc,
                 evt1,
                 evt_svc,
                 evt2,
@@ -272,26 +285,38 @@ def test_0043_backfill_service_instance_slugs() -> None:
         assert slug is not None and slug_pat.match(slug), (sid, slug)
 
     snapshots = dict(by_id)
+
+    # Re-applying the raw SQL block is a no-op when all target rows already have slugs.
+    upgrade_sql = _load_migration_upgrade_sql()
+    with psycopg.connect(url) as conn:
+        conn.execute(upgrade_sql)
+        conn.commit()
+    with psycopg.connect(url) as conn:
+        cur = conn.execute(
+            "SELECT id, slug FROM service_instances WHERE id = ANY(%s)",
+            (ids,),
+        )
+        after_raw = {row[0]: row[1] for row in cur.fetchall()}
+    assert after_raw == snapshots
+
+    # Alembic does not re-run an already-applied revision; prove idempotency by
+    # clearing slugs, downgrading one step, and upgrading again.
+    with psycopg.connect(url) as conn:
+        conn.execute(
+            "UPDATE service_instances SET slug = NULL WHERE id = ANY(%s)",
+            (ids,),
+        )
+        conn.commit()
+    _run_alembic("downgrade", "0042_slug_nulls_nd")
     _run_alembic("upgrade", "0043_backfill_inst_slug")
     with psycopg.connect(url) as conn:
         cur = conn.execute(
             "SELECT id, slug FROM service_instances WHERE id = ANY(%s)",
             (ids,),
         )
-        after = {row[0]: row[1] for row in cur.fetchall()}
-    assert after == snapshots
+        after_cycle = {row[0]: row[1] for row in cur.fetchall()}
+    assert after_cycle == snapshots
 
-    notices: list[str] = []
-    conn = psycopg.connect(url)
-    try:
-        conn.add_notice_handler(lambda diag: notices.append(diag.message_primary))
-        with conn.cursor() as cur:
-            cur.execute(
-                "DO $dn$ BEGIN "
-                "RAISE NOTICE 'Downgrade is a no-op: backfilled slugs are not safely reversible'; "
-                "END $dn$;"
-            )
-        conn.commit()
-    finally:
-        conn.close()
-    assert any("no-op" in n.lower() for n in notices)
+    proc_down = _run_alembic("downgrade", "0042_slug_nulls_nd")
+    combined = f"{proc_down.stdout}\n{proc_down.stderr}".lower()
+    assert "no-op" in combined

--- a/tests/db/migrations/test_0043_backfill_inst_slug.py
+++ b/tests/db/migrations/test_0043_backfill_inst_slug.py
@@ -89,7 +89,18 @@ def test_0043_backfill_service_instance_slugs() -> None:
     url = _database_url()
     assert url is not None
     conn_url = _libpq_conn_url(url)
-    _run_alembic("upgrade", "0042_slug_nulls_nd")
+    # Park the schema at 0042 regardless of current head. CI pre-applies
+    # ``alembic upgrade head`` before pytest, so a plain ``upgrade 0042`` is a
+    # no-op and a follow-up ``upgrade 0043`` also no-ops (already applied),
+    # leaving the inserted fixtures un-backfilled. Reach 0042 via:
+    # 1) ``upgrade 0043`` (no-op when at head; ensures we're past 0042 for the
+    #    downgrade to do something) and
+    # 2) ``downgrade 0042`` (data-safe: 0043 downgrade prints a notice without
+    #    modifying rows; only ``alembic_version`` moves back).
+    # The subsequent explicit upgrade to 0043 then re-runs the migration SQL
+    # against the freshly inserted fixtures.
+    _run_alembic("upgrade", "0043_backfill_inst_slug")
+    _run_alembic("downgrade", "0042_slug_nulls_nd")
 
     # One MBA template (same slug+tier as unique index); instances vary tier/cohort via title/cohort.
     mba_svc = UUID("21111111-1111-1111-1111-111111111101")

--- a/tests/db/migrations/test_0043_backfill_inst_slug.py
+++ b/tests/db/migrations/test_0043_backfill_inst_slug.py
@@ -1,0 +1,297 @@
+"""PostgreSQL integration: migration ``0043_backfill_inst_slug`` slug rules."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg", reason="psycopg required for DB integration test")
+
+
+def _database_url() -> str | None:
+    url = os.getenv("TEST_DATABASE_URL", "").strip()
+    return url or None
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _alembic_ini() -> Path:
+    return _repo_root() / "backend" / "db" / "alembic.ini"
+
+
+def _run_alembic(*args: str) -> None:
+    env = {**os.environ, "DATABASE_URL": _database_url() or ""}
+    cmd = [sys.executable, "-m", "alembic", "-c", str(_alembic_ini()), *args]
+    proc = subprocess.run(
+        cmd,
+        cwd=str(_repo_root() / "backend"),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"alembic {' '.join(args)} failed:\n{proc.stdout}\n{proc.stderr}"
+        )
+
+
+@pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
+def test_0043_backfill_service_instance_slugs() -> None:
+    """Backfill MBA, events, collision suffix, empty title fallback, no-slot date; skip consultation."""
+    url = _database_url()
+    assert url is not None
+    _run_alembic("upgrade", "0042_slug_nulls_nd")
+
+    mba_svc_01 = UUID("21111111-1111-1111-1111-111111111101")
+    mba_svc_13 = UUID("21111111-1111-1111-1111-111111111102")
+    mba_svc_36 = UUID("21111111-1111-1111-1111-111111111103")
+    mba_i01 = UUID("31111111-1111-1111-1111-111111111101")
+    mba_i13 = UUID("31111111-1111-1111-1111-111111111102")
+    mba_i36 = UUID("31111111-1111-1111-1111-111111111103")
+
+    evt_svc = UUID("21111111-1111-1111-1111-111111111201")
+    evt1 = UUID("31111111-1111-1111-1111-111111111201")
+    evt2 = UUID("31111111-1111-1111-1111-111111111202")
+    evt3 = UUID("31111111-1111-1111-1111-111111111203")
+    evt_empty = UUID("31111111-1111-1111-1111-111111111204")
+    evt_noslot = UUID("31111111-1111-1111-1111-111111111205")
+
+    cons_svc = UUID("21111111-1111-1111-1111-111111111301")
+    cons_inst = UUID("31111111-1111-1111-1111-111111111301")
+
+    slug_pat = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+    inst_re = re.compile(r"^instance-[a-f0-9]{8}$")
+
+    with psycopg.connect(url) as conn:
+        conn.execute(
+            "DELETE FROM instance_session_slots WHERE instance_id::text LIKE '31111111%'"
+        )
+        conn.execute(
+            "DELETE FROM event_ticket_tiers WHERE instance_id::text LIKE '31111111%'"
+        )
+        conn.execute(
+            "DELETE FROM training_instance_details WHERE instance_id::text LIKE '31111111%'"
+        )
+        conn.execute("DELETE FROM service_instances WHERE id::text LIKE '31111111%'")
+        conn.execute("DELETE FROM event_details WHERE service_id::text LIKE '21111111%'")
+        conn.execute(
+            "DELETE FROM training_course_details WHERE service_id::text LIKE '21111111%'"
+        )
+        conn.execute(
+            "DELETE FROM consultation_details WHERE service_id::text LIKE '21111111%'"
+        )
+        conn.execute("DELETE FROM services WHERE id::text LIKE '21111111%'")
+
+        conn.execute(
+            """
+            INSERT INTO services (
+              id, service_type, title, slug, booking_system, description,
+              cover_image_s3_key, delivery_mode, status, created_by,
+              service_tier, location_id
+            ) VALUES
+            (%s, 'training_course', 'MBA', 'my-best-auntie', NULL, NULL, NULL,
+             'online', 'published', 'test', NULL, NULL),
+            (%s, 'training_course', 'MBA', 'my-best-auntie', NULL, NULL, NULL,
+             'online', 'published', 'test', NULL, NULL),
+            (%s, 'training_course', 'MBA', 'my-best-auntie', NULL, NULL, NULL,
+             'online', 'published', 'test', '3-6', NULL),
+            (%s, 'event', 'Event Svc', 'evt-svc-0043', NULL, NULL, NULL,
+             'in_person', 'published', 'test', NULL, NULL),
+            (%s, 'consultation', 'Cons', NULL, NULL, NULL, NULL,
+             'online', 'published', 'test', NULL, NULL)
+            """,
+            (mba_svc_01, mba_svc_13, mba_svc_36, evt_svc, cons_svc),
+        )
+
+        for sid in (mba_svc_01, mba_svc_13, mba_svc_36):
+            conn.execute(
+                """
+                INSERT INTO training_course_details (
+                  service_id, pricing_unit, default_price, default_currency
+                ) VALUES (%s, 'per_person', 1.00, 'HKD')
+                """,
+                (sid,),
+            )
+
+        conn.execute(
+            """
+            INSERT INTO event_details (service_id, event_category, default_price, default_currency)
+            VALUES (%s, 'workshop', 10.00, 'HKD')
+            """,
+            (evt_svc,),
+        )
+
+        conn.execute(
+            """
+            INSERT INTO consultation_details (
+              service_id, consultation_format, max_group_size, duration_minutes,
+              pricing_model, default_hourly_rate, default_package_price,
+              default_package_sessions, default_currency, calendly_url
+            ) VALUES (%s, 'one_on_one', NULL, 60, 'free', NULL, NULL, NULL, 'HKD', NULL)
+            """,
+            (cons_svc,),
+        )
+
+        conn.execute(
+            """
+            INSERT INTO service_instances (
+              id, service_id, title, slug, landing_page, description, cover_image_s3_key,
+              status, delivery_mode, location_id, max_capacity, waitlist_enabled,
+              instructor_id, cohort, notes, created_by, created_at,
+              eventbrite_event_id, eventbrite_event_url, eventbrite_sync_status
+            ) VALUES
+            (%s, %s, 'MBA 0-1 Apr 26', NULL, NULL, NULL, NULL, 'scheduled', NULL, NULL,
+             NULL, false, NULL, NULL, NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
+             NULL, NULL, 'pending'),
+            (%s, %s, 'MBA 1-3 cohort 04-26', NULL, NULL, NULL, NULL, 'scheduled', NULL, NULL,
+             NULL, false, NULL, '04-26', NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
+             NULL, NULL, 'pending'),
+            (%s, %s, 'MBA May 26', NULL, NULL, NULL, NULL, 'scheduled', NULL, NULL,
+             NULL, false, NULL, 'may-26', NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
+             NULL, NULL, 'pending'),
+            (%s, %s, 'Easter 2026 Workshop', NULL, NULL, NULL, NULL, 'scheduled', 'in_person', NULL,
+             10, false, NULL, NULL, NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
+             NULL, NULL, 'pending'),
+            (%s, %s, 'Easter 2026 Workshop', NULL, NULL, NULL, NULL, 'scheduled', 'in_person', NULL,
+             10, false, NULL, NULL, NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
+             NULL, NULL, 'pending'),
+            (%s, %s, 'Easter 2026 Workshop', NULL, NULL, NULL, NULL, 'scheduled', 'in_person', NULL,
+             10, false, NULL, NULL, NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
+             NULL, NULL, 'pending'),
+            (%s, %s, NULL, NULL, NULL, NULL, NULL, 'scheduled', 'in_person', NULL,
+             10, false, NULL, NULL, NULL, 'test', TIMESTAMPTZ '2026-05-10 00:00:00Z',
+             NULL, NULL, 'pending'),
+            (%s, %s, 'No Slot Title', NULL, NULL, NULL, NULL, 'scheduled', 'in_person', NULL,
+             10, false, NULL, NULL, NULL, 'test', TIMESTAMPTZ '2026-03-15 12:00:00Z',
+             NULL, NULL, 'pending'),
+            (%s, %s, 'Consult', NULL, NULL, NULL, NULL, 'scheduled', NULL, NULL,
+             NULL, false, NULL, NULL, NULL, 'test', TIMESTAMPTZ '2026-01-01 00:00:00Z',
+             NULL, NULL, 'pending')
+            """,
+            (
+                mba_i01,
+                mba_svc_01,
+                mba_i13,
+                mba_svc_13,
+                mba_i36,
+                mba_svc_36,
+                evt1,
+                evt_svc,
+                evt2,
+                evt_svc,
+                evt3,
+                evt_svc,
+                evt_empty,
+                evt_svc,
+                evt_noslot,
+                evt_svc,
+                cons_inst,
+                cons_svc,
+            ),
+        )
+
+        conn.execute(
+            """
+            INSERT INTO training_instance_details (
+              instance_id, training_format, price, currency, pricing_unit
+            ) VALUES
+            (%s, 'group', 1.00, 'HKD', 'per_person'),
+            (%s, 'group', 1.00, 'HKD', 'per_person'),
+            (%s, 'group', 1.00, 'HKD', 'per_person')
+            """,
+            (mba_i01, mba_i13, mba_i36),
+        )
+
+        conn.execute(
+            """
+            INSERT INTO instance_session_slots (
+              instance_id, location_id, starts_at, ends_at, sort_order
+            ) VALUES
+            (%s, NULL, TIMESTAMPTZ '2026-04-06 10:00:00Z', TIMESTAMPTZ '2026-04-06 12:00:00Z', 0),
+            (%s, NULL, TIMESTAMPTZ '2026-04-13 10:00:00Z', TIMESTAMPTZ '2026-04-13 12:00:00Z', 0),
+            (%s, NULL, TIMESTAMPTZ '2026-04-06 10:00:00Z', TIMESTAMPTZ '2026-04-06 12:00:00Z', 0)
+            """,
+            (evt1, evt2, evt3),
+        )
+
+        for eid in (evt1, evt2, evt3, evt_empty, evt_noslot):
+            conn.execute(
+                """
+                INSERT INTO event_ticket_tiers (
+                  instance_id, name, description, price, currency, max_quantity, sort_order
+                ) VALUES (%s, 'workshop', NULL, 10.00, 'HKD', NULL, 0)
+                """,
+                (eid,),
+            )
+
+        conn.commit()
+
+    _run_alembic("upgrade", "0043_backfill_inst_slug")
+
+    ids = [
+        mba_i01,
+        mba_i13,
+        mba_i36,
+        evt1,
+        evt2,
+        evt3,
+        evt_empty,
+        evt_noslot,
+        cons_inst,
+    ]
+
+    with psycopg.connect(url) as conn:
+        cur = conn.execute(
+            "SELECT id, slug FROM service_instances WHERE id = ANY(%s)",
+            (ids,),
+        )
+        by_id = {row[0]: row[1] for row in cur.fetchall()}
+
+    assert by_id[mba_i01] == "my-best-auntie-0-1-apr-26"
+    assert by_id[mba_i13] == "my-best-auntie-1-3-04-26"
+    assert by_id[mba_i36] == "my-best-auntie-3-6-may-26"
+    assert by_id[evt1] == "easter-2026-workshop-2026-04-06"
+    assert by_id[evt2] == "easter-2026-workshop-2026-04-13"
+    assert by_id[evt3] == "easter-2026-workshop-2026-04-06-2"
+    assert inst_re.match(by_id[evt_empty] or "")
+    assert by_id[evt_noslot] == "no-slot-title-2026-03-15"
+    assert by_id[cons_inst] is None
+
+    for sid, slug in by_id.items():
+        if sid == cons_inst:
+            continue
+        assert slug is not None and slug_pat.match(slug), (sid, slug)
+
+    snapshots = dict(by_id)
+    _run_alembic("upgrade", "0043_backfill_inst_slug")
+    with psycopg.connect(url) as conn:
+        cur = conn.execute(
+            "SELECT id, slug FROM service_instances WHERE id = ANY(%s)",
+            (ids,),
+        )
+        after = {row[0]: row[1] for row in cur.fetchall()}
+    assert after == snapshots
+
+    notices: list[str] = []
+    conn = psycopg.connect(url)
+    try:
+        conn.add_notice_handler(lambda diag: notices.append(diag.message_primary))
+        with conn.cursor() as cur:
+            cur.execute(
+                "DO $dn$ BEGIN "
+                "RAISE NOTICE 'Downgrade is a no-op: backfilled slugs are not safely reversible'; "
+                "END $dn$;"
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    assert any("no-op" in n.lower() for n in notices)

--- a/tests/db/migrations/test_0043_backfill_inst_slug.py
+++ b/tests/db/migrations/test_0043_backfill_inst_slug.py
@@ -75,9 +75,7 @@ def _load_migration_upgrade_statements() -> list[str]:
         str(getattr(mod, name))
         for name in (
             "_CREATE_SLUGIFY_FN_SQL",
-            "_CREATE_TMP_TABLE_SQL",
-            "_INSERT_CANDIDATES_SQL",
-            "_RESOLVE_COLLISIONS_SQL",
+            "_BACKFILL_UPDATE_SQL",
             "_DROP_SLUGIFY_FN_SQL",
             "_ASSERT_NO_NULL_SLUGS_SQL",
             "_ASSERT_VALID_SLUG_SHAPE_SQL",
@@ -110,7 +108,6 @@ def test_0043_backfill_service_instance_slugs() -> None:
     cons_inst = UUID("31111111-1111-1111-1111-111111111301")
 
     slug_pat = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
-    inst_re = re.compile(r"^instance-[a-f0-9]{8}$")
 
     with psycopg.connect(conn_url) as conn:
         conn.execute(
@@ -299,7 +296,9 @@ def test_0043_backfill_service_instance_slugs() -> None:
     assert by_id[evt1] == "easter-2026-workshop-2026-04-06"
     assert by_id[evt2] == "easter-2026-workshop-2026-04-13"
     assert by_id[evt3] == "easter-2026-workshop-2026-04-06-2"
-    assert inst_re.match(by_id[evt_empty] or "")
+    # evt_empty has no instance.title; falls back to service.title ('Event Svc')
+    # plus the instance.created_at date (no session slots).
+    assert by_id[evt_empty] == "event-svc-2026-05-10"
     assert by_id[evt_noslot] == "no-slot-title-2026-03-15"
     assert by_id[cons_inst] is None
 
@@ -310,10 +309,9 @@ def test_0043_backfill_service_instance_slugs() -> None:
 
     snapshots = dict(by_id)
 
-    # Re-applying the per-statement upgrade SQL is a no-op when all target rows
-    # already have slugs. Note that the temp table from upgrade() is bound to
-    # the alembic process's connection and dropped on commit; this test's
-    # connection re-creates it via the CREATE TEMP TABLE statement below.
+    # Re-applying the upgrade SQL is a no-op because the backfill UPDATE only
+    # targets rows where ``slug IS NULL OR trim(slug) = ''``. The migration is
+    # now temp-table-free, so each statement is independent.
     upgrade_statements = _load_migration_upgrade_statements()
     with psycopg.connect(conn_url) as conn:
         for stmt in upgrade_statements:

--- a/tests/db/migrations/test_0043_backfill_inst_slug.py
+++ b/tests/db/migrations/test_0043_backfill_inst_slug.py
@@ -52,8 +52,13 @@ def _run_alembic(*args: str) -> subprocess.CompletedProcess[str]:
     return proc
 
 
-def _load_migration_upgrade_sql() -> str:
-    """Load ``_UPGRADE_SQL`` from the revision file (for idempotency checks without Alembic)."""
+def _load_migration_upgrade_statements() -> list[str]:
+    """Load per-statement upgrade SQL from the revision (for SQL-level idempotency checks).
+
+    The revision exposes one constant per top-level statement because psycopg3's
+    extended-query protocol only runs the first statement of a multi-statement
+    script via ``cursor.execute``. We replay those statements in order.
+    """
     path = (
         _repo_root()
         / "backend"
@@ -66,7 +71,18 @@ def _load_migration_upgrade_sql() -> str:
     assert spec and spec.loader
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    return str(getattr(mod, "_UPGRADE_SQL"))
+    return [
+        str(getattr(mod, name))
+        for name in (
+            "_CREATE_SLUGIFY_FN_SQL",
+            "_CREATE_TMP_TABLE_SQL",
+            "_INSERT_CANDIDATES_SQL",
+            "_RESOLVE_COLLISIONS_SQL",
+            "_DROP_SLUGIFY_FN_SQL",
+            "_ASSERT_NO_NULL_SLUGS_SQL",
+            "_ASSERT_VALID_SLUG_SHAPE_SQL",
+        )
+    ]
 
 
 @pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
@@ -294,10 +310,14 @@ def test_0043_backfill_service_instance_slugs() -> None:
 
     snapshots = dict(by_id)
 
-    # Re-applying the raw SQL block is a no-op when all target rows already have slugs.
-    upgrade_sql = _load_migration_upgrade_sql()
+    # Re-applying the per-statement upgrade SQL is a no-op when all target rows
+    # already have slugs. Note that the temp table from upgrade() is bound to
+    # the alembic process's connection and dropped on commit; this test's
+    # connection re-creates it via the CREATE TEMP TABLE statement below.
+    upgrade_statements = _load_migration_upgrade_statements()
     with psycopg.connect(conn_url) as conn:
-        conn.execute(upgrade_sql)
+        for stmt in upgrade_statements:
+            conn.execute(stmt)
         conn.commit()
     with psycopg.connect(conn_url) as conn:
         cur = conn.execute(

--- a/tests/db/migrations/test_0043_backfill_inst_slug.py
+++ b/tests/db/migrations/test_0043_backfill_inst_slug.py
@@ -150,13 +150,14 @@ def test_0043_backfill_service_instance_slugs() -> None:
             (evt_svc,),
         )
 
+        # `calendly_url` was dropped by migration 0034_drop_calendly_fields; do not include it.
         conn.execute(
             """
             INSERT INTO consultation_details (
               service_id, consultation_format, max_group_size, duration_minutes,
               pricing_model, default_hourly_rate, default_package_price,
-              default_package_sessions, default_currency, calendly_url
-            ) VALUES (%s, 'one_on_one', NULL, 60, 'free', NULL, NULL, NULL, 'HKD', NULL)
+              default_package_sessions, default_currency
+            ) VALUES (%s, 'one_on_one', NULL, 60, 'free', NULL, NULL, NULL, 'HKD')
             """,
             (cons_svc,),
         )

--- a/tests/db/migrations/test_0043_backfill_inst_slug.py
+++ b/tests/db/migrations/test_0043_backfill_inst_slug.py
@@ -20,6 +20,11 @@ def _database_url() -> str | None:
     return url or None
 
 
+def _libpq_conn_url(url: str) -> str:
+    """Strip SQLAlchemy driver so ``psycopg.connect`` uses a libpq-style URI."""
+    return url.replace("postgresql+psycopg://", "postgresql://", 1)
+
+
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
@@ -29,11 +34,12 @@ def _alembic_ini() -> Path:
 
 
 def _run_alembic(*args: str) -> subprocess.CompletedProcess[str]:
+    """CWD must be repo root: ``alembic.ini`` has ``script_location = backend/db/alembic``."""
     env = {**os.environ, "DATABASE_URL": _database_url() or ""}
     cmd = [sys.executable, "-m", "alembic", "-c", str(_alembic_ini()), *args]
     proc = subprocess.run(
         cmd,
-        cwd=str(_repo_root() / "backend"),
+        cwd=str(_repo_root()),
         env=env,
         capture_output=True,
         text=True,
@@ -68,6 +74,7 @@ def test_0043_backfill_service_instance_slugs() -> None:
     """Backfill MBA, events, collision suffix, empty title fallback, no-slot date; skip consultation."""
     url = _database_url()
     assert url is not None
+    conn_url = _libpq_conn_url(url)
     _run_alembic("upgrade", "0042_slug_nulls_nd")
 
     # One MBA template (same slug+tier as unique index); instances vary tier/cohort via title/cohort.
@@ -89,7 +96,7 @@ def test_0043_backfill_service_instance_slugs() -> None:
     slug_pat = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
     inst_re = re.compile(r"^instance-[a-f0-9]{8}$")
 
-    with psycopg.connect(url) as conn:
+    with psycopg.connect(conn_url) as conn:
         conn.execute(
             "DELETE FROM instance_session_slots WHERE instance_id::text LIKE '31111111%'"
         )
@@ -262,7 +269,7 @@ def test_0043_backfill_service_instance_slugs() -> None:
         cons_inst,
     ]
 
-    with psycopg.connect(url) as conn:
+    with psycopg.connect(conn_url) as conn:
         cur = conn.execute(
             "SELECT id, slug FROM service_instances WHERE id = ANY(%s)",
             (ids,),
@@ -288,10 +295,10 @@ def test_0043_backfill_service_instance_slugs() -> None:
 
     # Re-applying the raw SQL block is a no-op when all target rows already have slugs.
     upgrade_sql = _load_migration_upgrade_sql()
-    with psycopg.connect(url) as conn:
+    with psycopg.connect(conn_url) as conn:
         conn.execute(upgrade_sql)
         conn.commit()
-    with psycopg.connect(url) as conn:
+    with psycopg.connect(conn_url) as conn:
         cur = conn.execute(
             "SELECT id, slug FROM service_instances WHERE id = ANY(%s)",
             (ids,),
@@ -301,7 +308,7 @@ def test_0043_backfill_service_instance_slugs() -> None:
 
     # Alembic does not re-run an already-applied revision; prove idempotency by
     # clearing slugs, downgrading one step, and upgrading again.
-    with psycopg.connect(url) as conn:
+    with psycopg.connect(conn_url) as conn:
         conn.execute(
             "UPDATE service_instances SET slug = NULL WHERE id = ANY(%s)",
             (ids,),
@@ -309,7 +316,7 @@ def test_0043_backfill_service_instance_slugs() -> None:
         conn.commit()
     _run_alembic("downgrade", "0042_slug_nulls_nd")
     _run_alembic("upgrade", "0043_backfill_inst_slug")
-    with psycopg.connect(url) as conn:
+    with psycopg.connect(conn_url) as conn:
         cur = conn.execute(
             "SELECT id, slug FROM service_instances WHERE id = ANY(%s)",
             (ids,),
@@ -319,4 +326,5 @@ def test_0043_backfill_service_instance_slugs() -> None:
 
     proc_down = _run_alembic("downgrade", "0042_slug_nulls_nd")
     combined = f"{proc_down.stdout}\n{proc_down.stderr}".lower()
-    assert "no-op" in combined
+    assert proc_down.returncode == 0
+    assert "0043_backfill_inst_slug: downgrade is a no-op" in combined

--- a/tests/db/repositories/test_service_instance_public_offerings.py
+++ b/tests/db/repositories/test_service_instance_public_offerings.py
@@ -1,0 +1,172 @@
+"""PostgreSQL integration: ``list_public_offerings`` filters on instance slug."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db.models import (
+    EventDetails,
+    EventTicketTier,
+    GeographicArea,
+    Location,
+    Service,
+    ServiceInstance,
+)
+from app.db.models.enums import (
+    EventCategory,
+    InstanceStatus,
+    ServiceDeliveryMode,
+    ServiceStatus,
+    ServiceType,
+)
+from app.db.models.service_instance import InstanceSessionSlot
+from app.db.repositories.service_instance import ServiceInstanceRepository
+
+
+def _database_url() -> str | None:
+    url = os.getenv("TEST_DATABASE_URL", "").strip()
+    return url or None
+
+
+@pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
+def test_list_public_offerings_omits_null_slug_instances() -> None:
+    url = _database_url()
+    assert url is not None
+    engine = create_engine(url)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    now = datetime.now(UTC)
+    starts = now + timedelta(days=7)
+    ends = starts + timedelta(hours=2)
+
+    area_id = uuid4()
+    loc_id = uuid4()
+    service_id = uuid4()
+    inst_null = uuid4()
+    inst_slug = uuid4()
+
+    with SessionLocal() as session:
+        session.add(
+            GeographicArea(
+                id=area_id,
+                parent_id=None,
+                name="Area PO",
+                name_translations={},
+                level="country",
+                code="HK",
+                active=True,
+                display_order=0,
+                sovereign_country_id=None,
+            )
+        )
+        session.add(
+            Location(
+                id=loc_id,
+                area_id=area_id,
+                name="Venue",
+                address="1 St",
+                lat=None,
+                lng=None,
+            )
+        )
+        session.add(
+            Service(
+                id=service_id,
+                service_type=ServiceType.EVENT,
+                title="Public Feed Svc",
+                slug=f"pub-feed-{service_id.hex[:8]}",
+                booking_system=None,
+                description=None,
+                cover_image_s3_key=None,
+                delivery_mode=ServiceDeliveryMode.IN_PERSON,
+                status=ServiceStatus.PUBLISHED,
+                created_by="pytest",
+                location_id=loc_id,
+            )
+        )
+        session.add(
+            EventDetails(
+                service_id=service_id,
+                event_category=EventCategory.WORKSHOP,
+                default_price=Decimal("10.00"),
+                default_currency="HKD",
+            )
+        )
+        session.add(
+            ServiceInstance(
+                id=inst_null,
+                service_id=service_id,
+                title="No slug",
+                slug=None,
+                landing_page=None,
+                description=None,
+                cover_image_s3_key=None,
+                status=InstanceStatus.SCHEDULED,
+                delivery_mode=ServiceDeliveryMode.IN_PERSON,
+                location_id=loc_id,
+                max_capacity=10,
+                waitlist_enabled=False,
+                instructor_id=None,
+                cohort=None,
+                notes=None,
+                external_url=None,
+                created_by="pytest",
+            )
+        )
+        session.add(
+            ServiceInstance(
+                id=inst_slug,
+                service_id=service_id,
+                title="Has slug",
+                slug=f"pub-inst-{inst_slug.hex[:8]}",
+                landing_page=None,
+                description=None,
+                cover_image_s3_key=None,
+                status=InstanceStatus.SCHEDULED,
+                delivery_mode=ServiceDeliveryMode.IN_PERSON,
+                location_id=loc_id,
+                max_capacity=10,
+                waitlist_enabled=False,
+                instructor_id=None,
+                cohort=None,
+                notes=None,
+                external_url=None,
+                created_by="pytest",
+            )
+        )
+        for iid in (inst_null, inst_slug):
+            session.add(
+                InstanceSessionSlot(
+                    instance_id=iid,
+                    location_id=loc_id,
+                    starts_at=starts,
+                    ends_at=ends,
+                    sort_order=0,
+                )
+            )
+            session.add(
+                EventTicketTier(
+                    instance_id=iid,
+                    name="workshop",
+                    description=None,
+                    price=Decimal("10.00"),
+                    currency="HKD",
+                    max_quantity=None,
+                    sort_order=0,
+                )
+            )
+        session.commit()
+
+    with SessionLocal() as session:
+        repo = ServiceInstanceRepository(session)
+        rows = repo.list_public_offerings(limit=50, now=now)
+        ids = [r.id for r in rows if r.id in (inst_null, inst_slug)]
+        assert inst_null not in ids
+        assert inst_slug in ids

--- a/tests/db/repositories/test_service_instance_public_offerings.py
+++ b/tests/db/repositories/test_service_instance_public_offerings.py
@@ -35,11 +35,22 @@ def _database_url() -> str | None:
     return url or None
 
 
+def _sqlalchemy_engine_url(url: str) -> str:
+    """Use psycopg v3; bare ``postgresql://`` defaults to psycopg2 in SQLAlchemy."""
+    if url.startswith("postgresql+") or url.startswith("postgres+"):
+        return url
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgresql://")
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgres://")
+    return url
+
+
 @pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
 def test_list_public_offerings_omits_null_slug_instances() -> None:
     url = _database_url()
     assert url is not None
-    engine = create_engine(url)
+    engine = create_engine(_sqlalchemy_engine_url(url))
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
 
     now = datetime.now(UTC)

--- a/tests/test_admin_service_instances_partner_update_postgres.py
+++ b/tests/test_admin_service_instances_partner_update_postgres.py
@@ -41,12 +41,23 @@ def _database_url() -> str | None:
     return url or None
 
 
+def _sqlalchemy_engine_url(url: str) -> str:
+    """Use psycopg v3; bare ``postgresql://`` defaults to psycopg2 in SQLAlchemy."""
+    if url.startswith("postgresql+") or url.startswith("postgres+"):
+        return url
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgresql://")
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgres://")
+    return url
+
+
 @pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
 def test_reconcile_partner_links_after_selectinload_commit_succeeds() -> None:
     """Mirrors admin PUT path: loaded instance + bulk reconcile + commit (no session.add)."""
     url = _database_url()
     assert url is not None
-    engine = create_engine(url)
+    engine = create_engine(_sqlalchemy_engine_url(url))
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
 
     service_id = uuid4()
@@ -193,7 +204,7 @@ def test_reconcile_partner_links_after_selectinload_commit_succeeds() -> None:
 def test_location_repository_two_partners_same_venue_distinct_ids() -> None:
     url = _database_url()
     assert url is not None
-    engine = create_engine(url)
+    engine = create_engine(_sqlalchemy_engine_url(url))
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
 
     area_id = uuid4()

--- a/tests/test_admin_service_instances_slug_requirements.py
+++ b/tests/test_admin_service_instances_slug_requirements.py
@@ -1,0 +1,182 @@
+"""Slug requirements for event and training_course instance create/update."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.api.admin_services_payloads import (
+    parse_create_instance_payload,
+    parse_update_instance_payload,
+)
+from app.db.models import EventDetails, Service
+from app.db.models.enums import (
+    EventCategory,
+    InstanceStatus,
+    ServiceDeliveryMode,
+    ServiceStatus,
+    ServiceType,
+)
+from app.exceptions import ValidationError
+
+
+def _event_service() -> Service:
+    sid = uuid4()
+    s = Service(
+        id=sid,
+        service_type=ServiceType.EVENT,
+        title="Workshop",
+        slug="ws-svc",
+        booking_system=None,
+        description=None,
+        cover_image_s3_key=None,
+        delivery_mode=ServiceDeliveryMode.IN_PERSON,
+        status=ServiceStatus.PUBLISHED,
+        created_by="t",
+    )
+    s.event_details = EventDetails(
+        service_id=sid,
+        event_category=EventCategory.WORKSHOP,
+        default_price=Decimal("10.00"),
+        default_currency="HKD",
+    )
+    return s
+
+
+def _training_service() -> Service:
+    sid = uuid4()
+    return Service(
+        id=sid,
+        service_type=ServiceType.TRAINING_COURSE,
+        title="Course",
+        slug="course-slug",
+        booking_system=None,
+        description=None,
+        cover_image_s3_key=None,
+        delivery_mode=ServiceDeliveryMode.ONLINE,
+        status=ServiceStatus.PUBLISHED,
+        created_by="t",
+    )
+
+
+def _consultation_service() -> Service:
+    sid = uuid4()
+    return Service(
+        id=sid,
+        service_type=ServiceType.CONSULTATION,
+        title="Cons",
+        slug=None,
+        booking_system=None,
+        description=None,
+        cover_image_s3_key=None,
+        delivery_mode=ServiceDeliveryMode.ONLINE,
+        status=ServiceStatus.PUBLISHED,
+        created_by="t",
+    )
+
+
+def test_parse_create_instance_requires_slug_for_event() -> None:
+    service = _event_service()
+    body = {
+        "status": "scheduled",
+        "session_slots": [],
+        "event_ticket_tiers": [{"price": "10.00", "currency": "HKD"}],
+    }
+    with pytest.raises(ValidationError) as exc:
+        parse_create_instance_payload(body, service)
+    assert exc.value.field == "slug"
+
+
+def test_parse_create_instance_requires_slug_for_training_course() -> None:
+    service = _training_service()
+    body = {
+        "training_details": {
+            "training_format": "group",
+            "price": "10.00",
+            "currency": "HKD",
+            "pricing_unit": "per_person",
+        },
+    }
+    with pytest.raises(ValidationError) as exc:
+        parse_create_instance_payload(body, service)
+    assert exc.value.field == "slug"
+
+
+def test_parse_create_instance_allows_missing_slug_for_consultation() -> None:
+    service = _consultation_service()
+    body = {
+        "consultation_details": {
+            "pricing_model": "free",
+            "currency": "HKD",
+        },
+    }
+    parsed = parse_create_instance_payload(body, service)
+    assert parsed["slug"] is None
+
+
+def test_parse_update_instance_rejects_clearing_slug_for_event() -> None:
+    service = _event_service()
+    body = {
+        "status": "scheduled",
+        "slug": None,
+        "event_ticket_tiers": [{"price": "10.00", "currency": "HKD"}],
+    }
+    with pytest.raises(ValidationError) as exc:
+        parse_update_instance_payload(body, service)
+    assert exc.value.field == "slug"
+
+
+def test_parse_update_instance_accepts_slug_for_event() -> None:
+    service = _event_service()
+    body = {
+        "status": "scheduled",
+        "slug": "my-event-2026-04-01",
+        "event_ticket_tiers": [{"price": "10.00", "currency": "HKD"}],
+    }
+    parsed = parse_update_instance_payload(body, service)
+    assert parsed["slug"] == "my-event-2026-04-01"
+
+
+def test_parse_create_instance_accepts_slug_for_event() -> None:
+    service = _event_service()
+    body = {
+        "slug": "spring-workshop-2026-04-20",
+        "status": "scheduled",
+        "session_slots": [],
+        "event_ticket_tiers": [{"price": "10.00", "currency": "HKD"}],
+    }
+    parsed = parse_create_instance_payload(body, service)
+    assert parsed["slug"] == "spring-workshop-2026-04-20"
+
+
+def test_parse_create_instance_accepts_slug_for_training() -> None:
+    service = _training_service()
+    body = {
+        "slug": "run-a",
+        "training_details": {
+            "training_format": "group",
+            "price": "10.00",
+            "currency": "HKD",
+            "pricing_unit": "per_person",
+        },
+    }
+    parsed = parse_create_instance_payload(body, service)
+    assert parsed["slug"] == "run-a"
+
+
+def test_parse_update_instance_allows_clearing_slug_for_consultation() -> None:
+    service = _consultation_service()
+    body = {
+        "status": InstanceStatus.SCHEDULED.value,
+        "slug": None,
+        "consultation_details": {
+            "pricing_model": "free",
+            "currency": "HKD",
+        },
+    }
+    parsed = parse_update_instance_payload(body, service)
+    assert parsed.get("slug") is None

--- a/tests/test_admin_service_instances_slug_requirements.py
+++ b/tests/test_admin_service_instances_slug_requirements.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
 from decimal import Decimal
-from typing import Any
 from uuid import uuid4
 
 import pytest

--- a/tests/test_admin_services_instance_metadata.py
+++ b/tests/test_admin_services_instance_metadata.py
@@ -57,6 +57,7 @@ def _minimal_training_service() -> Service:
 def test_parse_create_instance_payload_persists_cohort() -> None:
     service = _minimal_training_service()
     body = {
+        "slug": "spring-2026-run",
         "cohort": "Spring-2026",
         "training_details": {
             "training_format": "group",
@@ -72,6 +73,7 @@ def test_parse_create_instance_payload_persists_cohort() -> None:
 def test_parse_create_instance_payload_rejects_invalid_cohort_field() -> None:
     service = _minimal_training_service()
     body = {
+        "slug": "valid-slug",
         "cohort": "Bad_Slug",
         "training_details": {
             "training_format": "group",
@@ -88,6 +90,7 @@ def test_parse_create_instance_payload_rejects_invalid_cohort_field() -> None:
 def test_parse_create_instance_payload_rejects_deprecated_age_group() -> None:
     service = _minimal_training_service()
     body = {
+        "slug": "x",
         "age_group": "0-1",
         "training_details": {
             "training_format": "group",
@@ -113,6 +116,7 @@ def test_parse_create_instance_payload_accepts_tag_ids() -> None:
     service = _minimal_training_service()
     t1, t2 = uuid4(), uuid4()
     body = {
+        "slug": "tagged-run",
         "tag_ids": [str(t2), str(t1)],
         "training_details": {
             "training_format": "group",

--- a/tests/test_public_events_api.py
+++ b/tests/test_public_events_api.py
@@ -159,6 +159,111 @@ def test_handle_public_events_returns_items(monkeypatch: Any, api_gateway_event:
     assert body["items"][0]["slug"] == "spring-workshop"
 
 
+def test_handle_public_events_skips_instances_without_valid_slug(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    """Repository may return rows; handler drops items with missing or invalid slug."""
+
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    class _FakeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_public_offerings(
+            self,
+            *,
+            limit: int,
+            now: datetime,
+            service_types: Any,
+            landing_page: str | None,
+            service_key: str | None,
+        ) -> list[Any]:
+            return [
+                _instance_row(
+                    status=public_events.InstanceStatus.OPEN,
+                    slug=None,
+                    landing_page=None,
+                )
+            ]
+
+        def get_enrollment_counts_for_instances(self, _instance_ids: list[Any]) -> dict[Any, int]:
+            return {}
+
+    monkeypatch.setattr(public_events, "Session", _SessionCtx)
+    monkeypatch.setattr(public_events, "get_engine", lambda: object())
+    monkeypatch.setattr(public_events, "ServiceInstanceRepository", _FakeRepository)
+
+    response = public_events.handle_public_events(
+        api_gateway_event(method="GET", path="/v1/calendar/public"),
+        "GET",
+    )
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["events"] == []
+    assert body["items"] == []
+
+
+def test_handle_public_events_includes_instance_when_slug_is_set(
+    monkeypatch: Any, api_gateway_event: Any
+) -> None:
+    class _FakeSession:
+        pass
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    row = _instance_row(status=public_events.InstanceStatus.OPEN, slug="spring-workshop-2026-04-20")
+
+    class _FakeRepository:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_public_offerings(
+            self,
+            *,
+            limit: int,
+            now: datetime,
+            service_types: Any,
+            landing_page: str | None,
+            service_key: str | None,
+        ) -> list[Any]:
+            return [row]
+
+        def get_enrollment_counts_for_instances(self, instance_ids: list[Any]) -> dict[Any, int]:
+            return {instance_ids[0]: 0}
+
+    monkeypatch.setattr(public_events, "Session", _SessionCtx)
+    monkeypatch.setattr(public_events, "get_engine", lambda: object())
+    monkeypatch.setattr(public_events, "ServiceInstanceRepository", _FakeRepository)
+
+    response = public_events.handle_public_events(
+        api_gateway_event(method="GET", path="/v1/calendar/public"),
+        "GET",
+    )
+    body = json.loads(response["body"])
+    assert len(body["items"]) == 1
+    assert body["items"][0]["slug"] == "spring-workshop-2026-04-20"
+
+
 def test_handle_public_events_landing_page_filter(
     monkeypatch: Any, api_gateway_event: Any
 ) -> None:

--- a/tests/test_services_slug_tier_unique_postgres.py
+++ b/tests/test_services_slug_tier_unique_postgres.py
@@ -18,6 +18,11 @@ def _database_url() -> str | None:
     return url or None
 
 
+def _libpq_conn_url(url: str) -> str:
+    """Strip SQLAlchemy driver so ``psycopg.connect`` uses a libpq-style URI."""
+    return url.replace("postgresql+psycopg://", "postgresql://", 1)
+
+
 @pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
 def test_slug_tier_unique_index_treats_null_tier_as_single_bucket() -> None:
     """Two rows with same slug and NULL tier must violate NULLS NOT DISTINCT unique index."""
@@ -33,8 +38,9 @@ def test_slug_tier_unique_index_treats_null_tier_as_single_bucket() -> None:
     )
     url = _database_url()
     assert url is not None
+    conn_url = _libpq_conn_url(url)
 
-    with psycopg.connect(url) as conn:
+    with psycopg.connect(conn_url) as conn:
         conn.execute(ddl)
         conn.execute(idx)
         conn.execute(
@@ -46,7 +52,7 @@ def test_slug_tier_unique_index_treats_null_tier_as_single_bucket() -> None:
             )
         conn.rollback()
 
-    with psycopg.connect(url) as conn:
+    with psycopg.connect(conn_url) as conn:
         conn.execute(ddl)
         conn.execute(idx)
         conn.execute(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds Alembic `0043_backfill_inst_slug` to populate NULL `service_instances.slug` for `event` and `training_course` rows (MBA cohort rules, event title + first slot date, collision suffixes, assertions). Downgrade is a documented no-op.
- Admin API: `slug` required on create for event/training_course; clearing `slug` on update is rejected for those types; optional for consultations. Duplicate instance slugs map to HTTP 409 with `field: slug`.
- Tests: migration integration (when `TEST_DATABASE_URL` is set), `list_public_offerings` filter, public calendar handler behavior, payload/parser coverage.
- OpenAPI (`admin.yaml`, `public.yaml`) and regenerated `admin-api.generated.ts`.
- Admin web: slug field, auto-suggestion on create, reset control, inline validation, 409 handling; shared `slug-utils`.
- Public www: distinct `reportInternalError` contexts when the CRM client is missing on landing and MBA training routes.
- Architecture: `database-schema.md` paragraph on slug + migration 0043.

## Validation

- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
- `python3 -m pytest` on touched backend/unit paths
- `cd apps/admin_web && npm run lint && npm run test && npm run build`
- `cd apps/public_www && npm run lint && npm run test` (build requires env: `NEXT_PUBLIC_EMAIL`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, `NEXT_PUBLIC_SITE_ORIGIN`)

## Notes

- Full migration + seed round-trip (`alembic upgrade head` then `psql -f backend/db/seed/seed_data.sql`) was not executed in this environment (no long-lived Postgres); CI or a local DB should run that checklist before deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b29489e2-e5a5-444d-a9bd-c89260c7f4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b29489e2-e5a5-444d-a9bd-c89260c7f4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

