### PR TITLE
infra(public_www): serialize CloudFront Function updates; self-heal UPDATE_ROLLBACK_FAILED

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -220,6 +220,47 @@ jobs:
 
           # Lambda occasionally returns 500 during UpdateFunctionCode (SDK retries
           # exhaust inside CloudFormation). Brief backoff + redeploy usually succeeds.
+          # Some CloudFormation rollbacks themselves fail (e.g., CloudFront Functions
+          # rate-limit during rollback) and leave the stack wedged in
+          # UPDATE_ROLLBACK_FAILED, which CloudFormation then refuses to update
+          # further. Detect that state and call ``continue-update-rollback`` to
+          # nudge it back to ``UPDATE_ROLLBACK_COMPLETE`` before the next retry.
+          MANAGED_STACKS=(
+            evolvesprouts
+            evolvesprouts-admin-web
+            evolvesprouts-public-www
+          )
+
+          continue_rollback_for_wedged_stacks() {
+            for managed in "${MANAGED_STACKS[@]}"; do
+              if [[ ! " $CDK_STACKS " == *" $managed "* ]]; then
+                continue
+              fi
+              local status
+              status="$(aws cloudformation describe-stacks \
+                --stack-name "$managed" \
+                --region "$AWS_REGION" \
+                --query 'Stacks[0].StackStatus' \
+                --output text 2>/dev/null || echo MISSING)"
+              if [ "$status" != "UPDATE_ROLLBACK_FAILED" ]; then
+                continue
+              fi
+              echo "Stack ${managed} is in UPDATE_ROLLBACK_FAILED; calling continue-update-rollback."
+              if ! aws cloudformation continue-update-rollback \
+                --stack-name "$managed" \
+                --region "$AWS_REGION"; then
+                echo "continue-update-rollback failed for ${managed}; the next deploy attempt will report the wedged state."
+                continue
+              fi
+              echo "Waiting for ${managed} to reach UPDATE_ROLLBACK_COMPLETE (timeout ~15m)."
+              if ! aws cloudformation wait stack-rollback-complete \
+                --stack-name "$managed" \
+                --region "$AWS_REGION"; then
+                echo "Wait for stack-rollback-complete on ${managed} timed out or failed."
+              fi
+            done
+          }
+
           MAX_CDK_DEPLOY_ATTEMPTS=3
           attempt=1
           deploy_exit=1
@@ -240,10 +281,21 @@ jobs:
               exit "$deploy_exit"
             fi
 
+            saw_rollback_failed=0
+            if grep -Eiq 'is in UPDATE_ROLLBACK_FAILED state and can not be updated' "$ATTEMPT_LOG"; then
+              saw_rollback_failed=1
+            fi
+
             rm -f "$ATTEMPT_LOG"
             if [ "$attempt" -eq "$MAX_CDK_DEPLOY_ATTEMPTS" ]; then
               break
             fi
+
+            if [ "$saw_rollback_failed" -eq 1 ]; then
+              echo "Detected UPDATE_ROLLBACK_FAILED; attempting continue-update-rollback before retry."
+              continue_rollback_for_wedged_stacks
+            fi
+
             delay=$((45 * attempt))
             echo "CDK deploy failed (exit ${deploy_exit}); waiting ${delay}s before retry..."
             sleep "$delay"
@@ -251,6 +303,7 @@ jobs:
           done
           exit "$deploy_exit"
         env:
+          AWS_REGION: ${{ steps.region.outputs.region }}
           CDK_STACKS: ${{ github.event.inputs.cdk_stacks || vars.CDK_STACKS || 'all stacks' }}
           RUN_SEED_DATA: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_seed_data || 'false' }}
           CDK_PARAM_FILE: ${{ vars.CDK_PARAM_FILE }}

--- a/backend/infrastructure/lib/public-www-stack.ts
+++ b/backend/infrastructure/lib/public-www-stack.ts
@@ -426,6 +426,17 @@ function handler(event) {
 `),
       },
     );
+    // Serialize CloudFront Function updates inside this environment so
+    // CloudFormation does not exhaust the regional CloudFront Functions API
+    // rate limit. Without this chain, CDK schedules all four updates in
+    // parallel and AWS returns ``Limit exceeded ... Reason: Rate exceeded``
+    // (``ServiceLimitExceeded``), rolling the stack back. Production and
+    // staging environments still run in parallel with each other (2-way
+    // concurrency stays under the throttle); chain order is otherwise
+    // arbitrary because none of these functions reference each other.
+    wwwProxyAllowlistFunction.node.addDependency(pathRewriteFunction);
+    mediaRequestProxyFunction.node.addDependency(wwwProxyAllowlistFunction);
+    wwwApiErrorResponseFunction.node.addDependency(mediaRequestProxyFunction);
 
     const customHeaders: cloudfront.ResponseCustomHeader[] = [
       {

--- a/backend/infrastructure/test/public-www-stack.test.ts
+++ b/backend/infrastructure/test/public-www-stack.test.ts
@@ -136,12 +136,85 @@ function assertEachDistributionWwwBehaviors(template: Template): void {
   }
 }
 
+/**
+ * Verify CloudFront Function updates are serialized within each environment.
+ *
+ * The four functions per environment (``PathRewrite``, ``WwwProxyAllowlist``,
+ * ``MediaRequestProxy``, ``WwwApiErrorResponse``) must form a single chain via
+ * CloudFormation ``DependsOn`` so CloudFormation cannot schedule parallel
+ * updates that exhaust the regional CloudFront Functions API rate limit.
+ */
+function assertCloudFrontFunctionUpdatesAreSerialized(template: Template): void {
+  const fns = template.findResources("AWS::CloudFront::Function");
+  const entries = Object.entries(fns);
+  if (entries.length !== 8) {
+    throw new Error(
+      `Expected exactly 8 AWS::CloudFront::Function resources (4 per environment x 2), found ${entries.length}`,
+    );
+  }
+  const expectedEnvKinds = [
+    "PathRewriteFunction",
+    "WwwProxyAllowlistFunction",
+    "MediaRequestProxyFunction",
+    "WwwApiErrorResponseFunction",
+  ] as const;
+  for (const envPrefix of ["PublicWww", "PublicWwwStaging"] as const) {
+    const ids = expectedEnvKinds.map((kind) => {
+      const id = entries.find(([logicalId]) =>
+        logicalId.startsWith(`${envPrefix}${kind}`),
+      )?.[0];
+      if (!id) {
+        throw new Error(
+          `Missing CloudFront Function ${envPrefix}${kind} in synthesized template`,
+        );
+      }
+      return id;
+    });
+    const [pathRewriteId, allowlistId, mediaProxyId, errorResponseId] = ids;
+    const dependsOn = (logicalId: string): string[] => {
+      const raw = fns[logicalId]?.DependsOn;
+      if (raw === undefined || raw === null) {
+        return [];
+      }
+      return Array.isArray(raw) ? (raw as string[]) : [raw as string];
+    };
+    if (!dependsOn(allowlistId).includes(pathRewriteId)) {
+      throw new Error(
+        `${envPrefix}: WwwProxyAllowlistFunction must DependsOn PathRewriteFunction`,
+      );
+    }
+    if (!dependsOn(mediaProxyId).includes(allowlistId)) {
+      throw new Error(
+        `${envPrefix}: MediaRequestProxyFunction must DependsOn WwwProxyAllowlistFunction`,
+      );
+    }
+    if (!dependsOn(errorResponseId).includes(mediaProxyId)) {
+      throw new Error(
+        `${envPrefix}: WwwApiErrorResponseFunction must DependsOn MediaRequestProxyFunction`,
+      );
+    }
+    // Pathrewrite (chain head) must not depend on any sibling function in this
+    // environment so the chain stays single-threaded but doesn't deadlock the
+    // first item.
+    for (const sibling of [allowlistId, mediaProxyId, errorResponseId]) {
+      if (dependsOn(pathRewriteId).includes(sibling)) {
+        throw new Error(
+          `${envPrefix}: PathRewriteFunction must not DependsOn ${sibling}`,
+        );
+      }
+    }
+  }
+}
+
 function main(): void {
   const template = synthPublicWwwTemplate();
   assertApiProxyCachePolicies(template);
   assertEachDistributionWwwBehaviors(template);
+  assertCloudFrontFunctionUpdatesAreSerialized(template);
   // eslint-disable-next-line no-console
-  console.log("public-www-stack CloudFront cache policy assertions passed.");
+  console.log(
+    "public-www-stack CloudFront cache policy and function-chain assertions passed.",
+  );
 }
 
 try {

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -69,6 +69,18 @@ Public WWW CloudFront includes:
     - `frame-ancestors` is intentionally omitted from the page-level CSP meta
       because browsers ignore it outside the response header.
 - Staging distribution adds `X-Robots-Tag: noindex, nofollow, noarchive`.
+- CloudFront Function updates within each environment are serialized in
+  `public-www-stack.ts` via CDK `node.addDependency`
+  (`PathRewriteFunction → WwwProxyAllowlistFunction → MediaRequestProxyFunction
+  → WwwApiErrorResponseFunction`). Without this chain, CloudFormation issues
+  parallel update calls for all four functions, which trips the regional
+  CloudFront Functions API rate limit (`HandlerErrorCode:
+  ServiceLimitExceeded`, "Reason: Rate exceeded") and rolls the stack back.
+  Production and staging environments still update in parallel with each
+  other; that 2-way concurrency stays under the throttle. The
+  `Deploy Backend` workflow additionally calls
+  `aws cloudformation continue-update-rollback` when it detects a wedged
+  `UPDATE_ROLLBACK_FAILED` state before retrying.
 
 ### Admin Web CloudFront distribution
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `Deploy Backend` workflow has been failing on every run since `2c6bfb20` because the `evolvesprouts-public-www` stack updates 8 CloudFront Functions (4 per environment × 2 environments) in parallel and consistently trips the regional CloudFront Functions API rate limit:

```
Resource handler returned message: "Limit exceeded for resource of type 'AWS::CloudFront::Function'.
Reason: Rate exceeded ... HandlerErrorCode: ServiceLimitExceeded"
```

CloudFormation rolls the stack back, the rollback itself sometimes also throttles (leaving `UPDATE_ROLLBACK_FAILED`), and the existing retry loop's three attempts are guaranteed to fail because each retry hits the same throttle and the wedged stack rejects every changeset until it is manually unblocked with `continue-update-rollback`.

This PR fixes both the cause and the failure mode:

### 1. Serialize CloudFront Function updates (root cause)

`backend/infrastructure/lib/public-www-stack.ts` adds `node.addDependency` chains so each environment's four CloudFront Functions update sequentially:

```
PathRewriteFunction
  → WwwProxyAllowlistFunction
  → MediaRequestProxyFunction
  → WwwApiErrorResponseFunction
```

Production and staging environments still update in parallel with each other (2-way concurrency stays well under the throttle). Verified against the synthesized template.

### 2. Self-heal `UPDATE_ROLLBACK_FAILED` in `deploy-backend.yml`

`.github/workflows/deploy-backend.yml` detects the wedge marker in the `cdk deploy` log and calls `aws cloudformation continue-update-rollback` for each managed stack in `UPDATE_ROLLBACK_FAILED`, then waits for `UPDATE_ROLLBACK_COMPLETE` before retrying. The CDK fix makes the wedge unlikely; this hook ensures any future transient throttle (CloudFront, Lambda, etc.) auto-recovers within a single workflow run.

## Files changed

- `backend/infrastructure/lib/public-www-stack.ts` — addDependency chain inside `createWebsiteEnvironment`.
- `backend/infrastructure/test/public-www-stack.test.ts` — new `assertCloudFrontFunctionUpdatesAreSerialized` walks all 8 functions in the synthesized template and verifies the `DependsOn` arrays. Negative-tested by temporarily removing the chain.
- `.github/workflows/deploy-backend.yml` — `continue_rollback_for_wedged_stacks` helper + `AWS_REGION` env entry.
- `docs/architecture/aws-assets-map.md` — note explaining both mechanisms.

## Validation

- `npm run test:infra` (in `backend/infrastructure/`): passes, including the new function-chain assertion. Negative test (chain removed) correctly fails with `WwwProxyAllowlistFunction must DependsOn PathRewriteFunction`.
- `cdk synth evolvesprouts-public-www` shows the expected `DependsOn` on each function, matching the chain order.
- Workflow YAML parses cleanly; `bash -n` on the extracted `run` script is clean.
- `bash scripts/validate-cursorrules.sh` and `pre-commit run ruff-format --all-files` are green.

## Why three commits

Per `.cursorrules` "separate commits per logical change":

1. `725956a6` — CDK serialization + matching test.
2. `8e43cb97` — workflow self-heal.
3. `dae22686` — docs note.

## Risks

- `addDependency` only changes update ordering, not runtime semantics. Distribution wiring through `functionAssociations` is untouched.
- Worst-case deploy time grows by ≈30s per environment (4 × ~7s sequential vs all-parallel). Acceptable.
- `continue-update-rollback` is idempotent and safe to call when the stack is already in `*_COMPLETE` (returns `ValidationError`, captured and ignored). The script proceeds with the regular retry path either way.
- The current production stack is in `UPDATE_ROLLBACK_COMPLETE` after this morning's manual rollback — no manual intervention needed before re-running the deploy with this PR merged.

## Follow-ups (not in this PR)

- If the same throttle pattern shows up on another stack (admin web has only one CloudFront Function so it's not at risk), apply the same chain pattern there.
- Consider migrating the inline CloudFront Function code to per-file modules (`src/cloudfront-functions/*.js`) to reduce the chance of CDK re-emitting unchanged functions on unrelated template churn.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df58a265-5ea0-4f6f-b12f-7038ced55c0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df58a265-5ea0-4f6f-b12f-7038ced55c0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

