### PR TITLE
fix(admin): do not copy service title/description into instance editor

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -92,8 +92,6 @@ function mergeServiceIntoInstanceForm(
 ): InstanceFormState {
   return {
     ...prev,
-    title: service.title,
-    description: service.description ?? '',
     deliveryMode: service.deliveryMode,
     locationId: service.locationId ?? '',
   };

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -235,7 +235,7 @@ describe('InstanceDetailPanel', () => {
     });
   });
 
-  it('prefills title, description, delivery, and training pricing from the selected service', async () => {
+  it('prefills delivery, location, and training pricing from the selected service but not title or description', async () => {
     const user = userEvent.setup();
     const onSelectService = vi.fn();
 
@@ -271,8 +271,8 @@ describe('InstanceDetailPanel', () => {
     await user.selectOptions(screen.getByLabelText('Service'), 'service-1');
 
     expect(onSelectService).toHaveBeenCalledWith('service-1');
-    expect(screen.getByLabelText('Title')).toHaveValue('Alpha service');
-    expect(screen.getByLabelText('Description')).toHaveValue('Service body');
+    expect(screen.getByLabelText('Title')).toHaveValue('');
+    expect(screen.getByLabelText('Description')).toHaveValue('');
     expect(screen.getByLabelText('Delivery mode')).toHaveValue('hybrid');
     expect(screen.getByLabelText('Pricing unit')).toHaveValue('per_family');
     expect(screen.getByLabelText('Price')).toHaveValue('199.00');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When creating a new service instance in the admin instance editor, selecting a service used to merge the service template's **title** and **description** into the instance form. That is removed so only **delivery mode** and **default location** (and existing type-specific merges) still come from the service.

## Behavior

- **New instance + pick service:** Title and description stay empty unless the user types them.
- **Duplicate instance** (`createPrefillInstance`): Unchanged; still copies the source instance's title and description.

## Tests

- Updated `instance-detail-panel.test.tsx` to assert empty title/description after service selection while delivery, location, and training pricing still prefill.
- `npx vitest run tests/components/admin/services/instance-detail-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a2c5a53-bea0-4e7c-80fc-db6a99a3a6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a2c5a53-bea0-4e7c-80fc-db6a99a3a6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

