### PR TITLE
Public calendar API: append tier and formatted cohort to title

### DIFF
--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -281,13 +281,44 @@ def _resolve_public_calendar_service_tier(instance: ServiceInstance) -> str | No
     )
 
 
+def _format_cohort_code_for_public_title(cohort: str) -> str:
+    """Turn a hyphenated cohort code into title words (e.g. ``may-26`` -> ``May 26``)."""
+    parts = [p.strip() for p in cohort.split("-") if p.strip()]
+    if not parts:
+        return cohort.strip()
+    return " ".join(p.capitalize() for p in parts)
+
+
+def _build_public_calendar_display_title(
+    base_title: str | None,
+    *,
+    service_tier: str | None,
+    cohort: str | None,
+) -> str:
+    """Append ``{tier} - {cohort}`` to the base title when both tier and cohort are set."""
+    base = (base_title or "").strip()
+    tier = (service_tier or "").strip()
+    raw_cohort = (cohort or "").strip()
+    if not tier or not raw_cohort:
+        return base
+    cohort_display = _format_cohort_code_for_public_title(raw_cohort)
+    suffix = f"{tier} - {cohort_display}"
+    return f"{base} {suffix}".strip() if base else suffix
+
+
 def _serialize_public_event(
     instance: ServiceInstance,
     *,
     enrollment_counts: dict[UUID, int],
 ) -> dict[str, Any]:
     service = instance.service
-    title = instance.title or service.title
+    base_title = instance.title or service.title
+    service_tier = _resolve_public_calendar_service_tier(instance)
+    title = _build_public_calendar_display_title(
+        base_title,
+        service_tier=service_tier,
+        cohort=instance.cohort,
+    )
     summary = instance.description or service.description
 
     slots = sorted(instance.session_slots, key=lambda s: (s.sort_order, s.starts_at))
@@ -369,7 +400,7 @@ def _serialize_public_event(
 
     if instance.landing_page is not None:
         payload["landing_page"] = instance.landing_page
-    payload["service_tier"] = _resolve_public_calendar_service_tier(instance)
+    payload["service_tier"] = service_tier
     if instance.cohort is not None:
         payload["cohort"] = instance.cohort
 

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1021,6 +1021,11 @@ components:
           enum: [event, training_course]
         title:
           type: string
+          description: >
+            Base instance or service title. When both `service_tier` and `cohort` are
+            non-null, the API appends a space, the tier, a space-hyphen-space, and a
+            humanized cohort label (hyphen-separated cohort segments, each segment
+            capitalized; e.g. cohort `may-26` yields `May 26`).
         summary:
           type: string
           nullable: true

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -121,6 +121,9 @@ their primary responsibilities.
   Each item includes `service_type`,
   `slug` (public instance slug from `service_instances.slug`), `partners`, `service_tier`
   (from parent service, or inferred from instance slug for My Best Auntie) / `cohort`,
+  and `title` augmented with the tier, a spaced hyphen, and a title-cased cohort label
+  when both `service_tier` and `cohort` are present (cohort hyphen segments capitalized,
+  e.g. `may-26` → `May 26`),
   `is_fully_booked`, and a server-derived `location_url`. `booking_system` comes
   from `services.booking_system` or defaults from service type (MBA training
   cohorts default to `my-best-auntie-booking` when `services.slug` is

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -212,6 +212,48 @@ def test_training_mba_booking_and_category() -> None:
     assert out["currency"] == "HKD"
     assert out["service_tier"] == "0-1"
     assert out["cohort"] == "May 2026"
+    assert out["title"] == "MBA 0-1 - May 2026"
+
+
+def test_public_calendar_title_appends_tier_and_formatted_cohort() -> None:
+    """Title suffix uses tier, a spaced dash, and cohort segments capitalized."""
+    service = SimpleNamespace(
+        title="bla bla bla",
+        description="Course",
+        service_type=ServiceType.TRAINING_COURSE,
+        slug="my-best-auntie",
+        booking_system=None,
+        event_details=None,
+        delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier="1-3",
+        location=None,
+    )
+    inst = _minimal_instance(service, cohort="may-26")
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["title"] == "bla bla bla 1-3 - May 26"
+    assert out["cohort"] == "may-26"
+
+
+def test_public_calendar_title_unchanged_without_tier_or_cohort() -> None:
+    service = SimpleNamespace(
+        title="Only Base",
+        description="Course",
+        service_type=ServiceType.TRAINING_COURSE,
+        slug="my-best-auntie",
+        booking_system=None,
+        event_details=None,
+        delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier=None,
+        location=None,
+    )
+    inst = _minimal_instance(
+        service,
+        slug="my-best-auntie-1-3-04-26",
+        cohort=None,
+        training_details=SimpleNamespace(price=Decimal("1"), currency="HKD"),
+    )
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["title"] == "Only Base"
 
 
 def test_training_non_mba_omits_booking_system() -> None:
@@ -255,6 +297,7 @@ def test_training_mba_infers_service_tier_from_instance_slug() -> None:
     )
     out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["service_tier"] == "1-3"
+    assert out["title"] == "MBA 1-3 - Apr 26"
     assert "id" not in out
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public calendar feed items (`GET /v1/calendar/public`) now build `title` as the base instance/service title plus a suffix when **both** `service_tier` and `cohort` are non-null: a space, the tier, ` - `, and a humanized cohort label (cohort split on `-`, empty segments dropped, each segment `.capitalize()`, joined with spaces). Example: base `bla bla bla`, tier `1-3`, cohort `may-26` → `bla bla bla 1-3 - May 26`.

## Changes

- `backend/src/app/api/public_events.py`: `_format_cohort_code_for_public_title`, `_build_public_calendar_display_title`, wired in `_serialize_public_event`.
- `tests/test_public_events_serializer.py`: assertions for MBA training rows and dedicated title tests.
- `docs/api/public.yaml`: `PublicCalendarEvent.title` description.
- `docs/architecture/lambdas.md`: public calendar bullet notes title augmentation.

## Notes

- If either tier or cohort is missing, `title` stays the base title only (no partial suffix).
- Raw `cohort` in JSON is unchanged; only `title` is augmented.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2af418c5-a1aa-46b9-9047-b354c831959c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2af418c5-a1aa-46b9-9047-b354c831959c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

