### PR TITLE
Admin: training instance slug suggestion includes tier and cohort

### DIFF
--- a/apps/admin_web/src/lib/slug-utils.ts
+++ b/apps/admin_web/src/lib/slug-utils.ts
@@ -67,21 +67,16 @@ export function computeSuggestedInstanceSlug(
     if (!service) {
       return slugifyForInstance(instanceForm.cohort.trim() || instanceForm.title);
     }
-    const slugLower = (service.slug ?? '').trim().toLowerCase();
-    const tier = (service.serviceTier ?? '').trim();
-    const cohortRaw = instanceForm.cohort.trim() || instanceForm.title;
-    const cohortPart = slugifyForInstance(cohortRaw);
-    if (slugLower === 'my-best-auntie' && tier && cohortPart) {
-      return slugifyForInstance(`my-best-auntie-${tier}-${cohortRaw}`);
-    }
     const base = slugifyForInstance((service.slug ?? '').trim() || service.title || '');
-    if (!cohortPart) {
-      return base;
+    const tierRaw = (service.serviceTier ?? '').trim();
+    const tierPart = tierRaw ? slugifyForInstance(tierRaw) : '';
+    const cohortRaw = instanceForm.cohort.trim();
+    const cohortPart = cohortRaw ? slugifyForInstance(cohortRaw) : '';
+    const segments = [base, tierPart, cohortPart].filter(Boolean);
+    if (!segments.length) {
+      return '';
     }
-    if (!base) {
-      return cohortPart;
-    }
-    return `${base}-${cohortPart}`;
+    return segments.join('-');
   }
   return '';
 }

--- a/apps/admin_web/tests/components/admin/services/create-instance-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/create-instance-dialog.test.tsx
@@ -54,7 +54,7 @@ describe('CreateInstanceDialog', () => {
     const venueId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
     const onCreate = vi.fn().mockResolvedValue(undefined);
 
-    render(
+    const { rerender } = render(
       <CreateInstanceDialog
         open
         serviceType='training_course'
@@ -71,6 +71,39 @@ describe('CreateInstanceDialog', () => {
       expect(screen.getByLabelText(/^slug/i)).toHaveValue('training-template');
     });
 
+    const withTier: ServiceSummary = {
+      ...trainingServiceSummary,
+      slug: 'bla-bla-bla',
+      serviceTier: '1-3',
+    };
+    rerender(
+      <CreateInstanceDialog
+        open
+        serviceType='training_course'
+        serviceSummary={withTier}
+        serviceDefaultLocationId={venueId}
+        isLoading={false}
+        error=''
+        onClose={vi.fn()}
+        onCreate={onCreate}
+      />
+    );
+
+    const slugInput = screen.getByLabelText(/^slug/i) as HTMLInputElement;
+    await waitFor(() => {
+      expect(slugInput).toHaveValue('bla-bla-bla-1-3');
+    });
+
+    await user.type(screen.getByLabelText('Cohort'), 'may-26');
+    await waitFor(() => {
+      expect(slugInput).toHaveValue('bla-bla-bla-1-3-may-26');
+    });
+
+    await user.clear(screen.getByLabelText('Cohort'));
+    await waitFor(() => {
+      expect(slugInput).toHaveValue('bla-bla-bla-1-3');
+    });
+
     await user.click(screen.getByText('Session slots'));
     await user.click(screen.getByRole('button', { name: /add slot/i }));
     const startInput = screen.getByLabelText('Start time');
@@ -84,7 +117,7 @@ describe('CreateInstanceDialog', () => {
 
     expect(onCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        slug: 'training-template',
+        slug: 'bla-bla-bla-1-3',
         session_slots: [
           expect.objectContaining({
             location_id: venueId,

--- a/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/instance-detail-panel.test.tsx
@@ -475,7 +475,7 @@ describe('InstanceDetailPanel', () => {
         instance={null}
         createPrefillInstance={prefill}
         selectedServiceId='service-1'
-        serviceOptions={[buildServiceSummary()]}
+        serviceOptions={[buildServiceSummary({ slug: 'my-course', serviceTier: '1-3' })]}
         locationOptions={[buildLocationSummary()]}
         isLoadingLocations={false}
         serviceType='training_course'
@@ -492,7 +492,7 @@ describe('InstanceDetailPanel', () => {
       expect(screen.getByLabelText('Title')).toHaveValue('Workshop A');
     });
     await waitFor(() => {
-      expect(screen.getByLabelText(/^slug/i)).toHaveValue('alpha-service-spring-2026');
+      expect(screen.getByLabelText(/^slug/i)).toHaveValue('my-course-1-3-spring-2026');
     });
     expect(screen.getByLabelText('Description')).toHaveValue('Body');
     expect(screen.getByLabelText('Delivery mode')).toHaveValue('hybrid');
@@ -505,7 +505,7 @@ describe('InstanceDetailPanel', () => {
     expect(onCreate).toHaveBeenCalledWith(
       'service-1',
       expect.objectContaining({
-        slug: 'alpha-service-spring-2026',
+        slug: 'my-course-1-3-spring-2026',
         cohort: 'spring-2026',
       })
     );

--- a/apps/admin_web/tests/lib/slug-utils.test.ts
+++ b/apps/admin_web/tests/lib/slug-utils.test.ts
@@ -48,6 +48,51 @@ describe('computeSuggestedInstanceSlug', () => {
     ).toBe('my-best-auntie-1-3-apr-26');
   });
 
+  it('appends tier to service slug for training_course when cohort is empty', () => {
+    const svc: ServiceSummary = {
+      ...baseService,
+      slug: 'bla-bla-bla',
+      serviceTier: '1-3',
+    };
+    expect(
+      computeSuggestedInstanceSlug('training_course', svc, {
+        title: 'ignored-title',
+        cohort: '',
+        sessionSlots: [],
+      })
+    ).toBe('bla-bla-bla-1-3');
+  });
+
+  it('appends cohort after tier as cohort is typed for training_course', () => {
+    const svc: ServiceSummary = {
+      ...baseService,
+      slug: 'bla-bla-bla',
+      serviceTier: '1-3',
+    };
+    expect(
+      computeSuggestedInstanceSlug('training_course', svc, {
+        title: '',
+        cohort: 'may-26',
+        sessionSlots: [],
+      })
+    ).toBe('bla-bla-bla-1-3-may-26');
+  });
+
+  it('drops cohort segment from training_course slug when cohort is cleared', () => {
+    const svc: ServiceSummary = {
+      ...baseService,
+      slug: 'bla-bla-bla',
+      serviceTier: '1-3',
+    };
+    expect(
+      computeSuggestedInstanceSlug('training_course', svc, {
+        title: 'fall-title',
+        cohort: '',
+        sessionSlots: [],
+      })
+    ).toBe('bla-bla-bla-1-3');
+  });
+
   it('builds event slug from title and first slot date', () => {
     expect(
       computeSuggestedInstanceSlug('event', null, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `computeSuggestedInstanceSlug` for `training_course` so the autosuggested instance slug is built as `{service-slug}-{tier}-{cohort}` when tier and/or cohort are present.

- **Tier**: appended as soon as the parent service has `serviceTier` (slugified the same way as other segments).
- **Cohort**: appended only from the **Cohort** field (not from title). Typing `may-26` updates the slug to include `-may-26`; clearing cohort removes that segment while keeping `service-slug-tier`.

The create dialog and instance detail panel already sync slug from the suggestion when the slug field has not been manually edited, so no UI wiring changes were required.

## Tests

- `slug-utils` unit tests for tier-only, tier+cohort, and cohort cleared with title set
- `CreateInstanceDialog` integration: rerender with tiered service, type/clear cohort on slug
- `InstanceDetailPanel` duplicate-create prefill expectations updated with explicit service slug + tier
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8874df68-e763-4c4e-8e56-d4a9cc379ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8874df68-e763-4c4e-8e56-d4a9cc379ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

