### PR TITLE
Public calendar API: include service tier in tags when set

### DIFF
--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -236,9 +236,16 @@ def _resolve_categories(service: Service) -> list[str]:
     return []
 
 
-def _resolve_tags(instance: ServiceInstance) -> list[str]:
+def _resolve_tags(
+    instance: ServiceInstance,
+    *,
+    service_tier: str | None = None,
+) -> list[str]:
     links = instance.instance_tags
     names = {link.tag.name for link in links if link.tag and link.tag.name}
+    tier = (service_tier or "").strip()
+    if tier:
+        names.add(tier)
     return sorted(names, key=str.casefold)
 
 
@@ -380,7 +387,7 @@ def _serialize_public_event(
         "location_address": location_address,
         "location_url": location_url,
         "dates": dates,
-        "tags": _resolve_tags(instance),
+        "tags": _resolve_tags(instance, service_tier=service_tier),
         "categories": _resolve_categories(service),
         "partners": _resolve_partners(instance),
     }

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1089,7 +1089,9 @@ components:
             type: string
           description: >
             Alphabetically ordered display tag names from
-            `service_instance_tags`. Does not include service-level CRM tags.
+            `service_instance_tags`, plus the `service_tier` value when it is
+            non-null and non-empty (same string as the `service_tier` field).
+            Does not include service-level CRM tags.
         categories:
           type: array
           items:

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -174,6 +174,41 @@ def test_instance_tags_sorted_case_insensitive() -> None:
     assert out["tags"] == ["Alpha", "beta", "zebra"]
 
 
+def test_tags_include_service_tier_when_set() -> None:
+    """Non-empty service_tier is merged into tags (sorted with instance tags)."""
+    service = _event_service()
+    service.service_tier = "premium"
+    inst = _minimal_instance(
+        service,
+        instance_tags=[_tag_link("zebra"), _tag_link("Alpha")],
+    )
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["service_tier"] == "premium"
+    assert out["tags"] == ["Alpha", "premium", "zebra"]
+
+
+def test_service_tier_tag_dedupes_instance_tag_same_name() -> None:
+    service = SimpleNamespace(
+        title="MBA",
+        description="Course",
+        service_type=ServiceType.TRAINING_COURSE,
+        slug="my-best-auntie",
+        booking_system=None,
+        event_details=None,
+        delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier="0-1",
+        location=None,
+    )
+    inst = _minimal_instance(
+        service,
+        cohort="May 2026",
+        training_details=SimpleNamespace(price=Decimal("350"), currency="HKD"),
+        instance_tags=[_tag_link("0-1"), _tag_link("other")],
+    )
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["tags"] == ["0-1", "other"]
+
+
 def test_partners_follow_link_order() -> None:
     service = _event_service()
     inst = _minimal_instance(
@@ -213,6 +248,7 @@ def test_training_mba_booking_and_category() -> None:
     assert out["service_tier"] == "0-1"
     assert out["cohort"] == "May 2026"
     assert out["title"] == "MBA 0-1 - May 2026"
+    assert out["tags"] == ["0-1"]
 
 
 def test_public_calendar_title_appends_tier_and_formatted_cohort() -> None:
@@ -232,6 +268,7 @@ def test_public_calendar_title_appends_tier_and_formatted_cohort() -> None:
     out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["title"] == "bla bla bla 1-3 - May 26"
     assert out["cohort"] == "may-26"
+    assert out["tags"] == ["1-3"]
 
 
 def test_public_calendar_title_unchanged_without_tier_or_cohort() -> None:
@@ -298,6 +335,7 @@ def test_training_mba_infers_service_tier_from_instance_slug() -> None:
     out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["service_tier"] == "1-3"
     assert out["title"] == "MBA 1-3 - Apr 26"
+    assert out["tags"] == ["1-3"]
     assert "id" not in out
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `service_tier` is non-null and non-empty on a public calendar event, that same string is now included in the `tags` array (merged with `service_instance_tags` names, sorted case-insensitively, deduplicated if an instance tag already matches the tier).

## Changes

- `backend/src/app/api/public_events.py`: `_resolve_tags` accepts optional `service_tier` and merges it into tag names.
- `docs/api/public.yaml`: `PublicCalendarEvent.tags` description updated to match.
- `tests/test_public_events_serializer.py`: new coverage for tier-in-tags, dedupe, and existing training-tier cases assert expected `tags`.

## Validation

- `python3 -m pytest tests/test_public_events_serializer.py tests/test_public_events_api.py -q`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d912cf51-e993-44a9-8313-38cb6f239d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d912cf51-e993-44a9-8313-38cb6f239d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

