### PR TITLE
fix(public-events): partner venue location_name uses org display name

### DIFF
--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -257,6 +257,26 @@ def _resolve_partners(instance: ServiceInstance) -> list[str]:
     ]
 
 
+def _partner_display_name_for_location(
+    instance: ServiceInstance,
+    location: Location,
+) -> str | None:
+    """Partner org display name when ``location`` is that partner's CRM location."""
+    loc_id = getattr(location, "id", None)
+    if loc_id is None:
+        return None
+    for link in instance.partner_organization_links:
+        org = link.organization
+        if org is None or org.location_id is None:
+            continue
+        if org.location_id != loc_id:
+            continue
+        label = _clean_text(org.name)
+        if label is not None:
+            return label
+    return None
+
+
 def _resolve_external_url(instance: ServiceInstance) -> str | None:
     return instance.external_url or instance.eventbrite_event_url or None
 
@@ -346,6 +366,10 @@ def _serialize_public_event(
         if is_virtual
         else _clean_text(primary_location.name if primary_location else None)
     )
+    if not is_virtual and primary_location is not None and location_name is None:
+        partner_label = _partner_display_name_for_location(instance, primary_location)
+        if partner_label is not None:
+            location_name = partner_label
     location_address = (
         None
         if is_virtual

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1054,7 +1054,11 @@ components:
         location_name:
           type: string
           nullable: true
-          description: Venue display name; derivation matches `location_url`.
+          description: >
+            Venue display name; derivation matches `location_url`. When the resolved
+            location row has no display name but matches a linked partner organization's
+            CRM location (`organizations.location_id`), the API uses that partner's
+            `organizations.name` instead of `null`.
         location_address:
           type: string
           nullable: true

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -124,7 +124,9 @@ their primary responsibilities.
   and `title` augmented with the tier, a spaced hyphen, and a title-cased cohort label
   when both `service_tier` and `cohort` are present (cohort hyphen segments capitalized,
   e.g. `may-26` → `May 26`),
-  `is_fully_booked`, and a server-derived `location_url`. `booking_system` comes
+  `is_fully_booked`, and a server-derived `location_url`. `location_name` falls back
+  to the linked partner organization's display name when the venue location row has
+  no name but is that partner's `organizations.location`. `booking_system` comes
   from `services.booking_system` or defaults from service type (MBA training
   cohorts default to `my-best-auntie-booking` when `services.slug` is
   `my-best-auntie`). Results order by earliest upcoming session slot ascending

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -447,6 +447,57 @@ def test_primary_location_all_null() -> None:
     assert out["location_address"] is None
 
 
+def test_partner_venue_location_name_falls_back_to_organization_name() -> None:
+    """Partner CRM locations often omit ``locations.name``; use the org display name."""
+    loc_id = uuid4()
+    venue = SimpleNamespace(
+        id=loc_id,
+        name=None,
+        address="99 Partner Rd",
+        lat=None,
+        lng=None,
+    )
+    org = SimpleNamespace(
+        name="Springfield Community Center",
+        slug="springfield-cc",
+        location_id=loc_id,
+    )
+    link = SimpleNamespace(sort_order=0, organization=org)
+    service = _event_service()
+    service.location = None
+    inst = _minimal_instance(service, partner_organization_links=[link])
+    inst.session_slots[0].location = venue
+    inst.location = venue
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["location_name"] == "Springfield Community Center"
+    assert out["partners"] == ["springfield-cc"]
+
+
+def test_location_without_partner_match_does_not_use_partner_name() -> None:
+    """Only substitute when the resolved location is a linked partner's org location."""
+    loc_id = uuid4()
+    other_id = uuid4()
+    venue = SimpleNamespace(
+        id=loc_id,
+        name=None,
+        address="Somewhere",
+        lat=None,
+        lng=None,
+    )
+    org = SimpleNamespace(
+        name="Partner Org",
+        slug="partner",
+        location_id=other_id,
+    )
+    link = SimpleNamespace(sort_order=0, organization=org)
+    service = _event_service()
+    inst = _minimal_instance(service, partner_organization_links=[link])
+    inst.session_slots[0].location = venue
+    inst.location = venue
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert out["location_name"] is None
+
+
 def test_max_capacity_none_omits_spaces() -> None:
     service = _event_service()
     inst = _minimal_instance(service, max_capacity=None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public calendar serialization set `location_name` from `locations.name`. Partner-hosted venues often reuse the partner organization's CRM location row, where `name` is null while `organizations.name` carries the human-readable label.

## Changes

- After resolving the primary physical location, when `location_name` would be null, look up a linked partner whose `organization.location_id` matches the resolved location's id and use `_clean_text(organization.name)` as `location_name`.
- Only apply this substitution when the location id matches a partner link (avoids using a partner name for unrelated unnamed venues).
- Tests: partner match yields display name; mismatched `location_id` leaves `location_name` null.
- Documented behavior in `docs/api/public.yaml` and `docs/architecture/lambdas.md`.

## Validation

- `pre-commit run ruff-format --all-files`
- `python3 -m pytest tests/test_public_events_serializer.py -q`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cb229bc-9e79-4802-94e9-e19a68b54d26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cb229bc-9e79-4802-94e9-e19a68b54d26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

