### PR TITLE
Deduplicate public events calendar fetch

### DIFF
--- a/apps/public_www/src/components/pages/events.tsx
+++ b/apps/public_www/src/components/pages/events.tsx
@@ -8,6 +8,7 @@ import { Events } from '@/components/sections/events';
 import { EventNotification } from '@/components/sections/event-notification';
 import { PastEvents } from '@/components/sections/past-events';
 import { FreeIntroSession } from '@/components/sections/free-intro-session';
+import { EventsDataProvider } from '@/components/sections/shared/events-shared';
 import { resolvePublicSiteConfig } from '@/lib/site-config';
 
 interface EventsPageProps {
@@ -25,20 +26,22 @@ export function EventsPage({ content }: EventsPageProps) {
       navbarContent={content.navbar}
       footerContent={content.footer}
     >
-      <Events
-        content={content.events}
-        bookingModalContent={content.bookingModal}
-        myBestAuntieModalContent={content.myBestAuntie.modal}
-        locale={resolvedLocale}
-        thankYouWhatsappHref={publicSiteConfig.whatsappUrl}
-        thankYouWhatsappCtaLabel={content.contactUs.form.contactMethodLinks.whatsapp}
-      />
-      <FreeIntroSession
-        content={content.freeIntroSession}
-        titleOverride={content.freeIntroSession.eventPageTitle}
-        sectionClassName="es-free-intro-session-section--standard-spacing"
-      />
-      <PastEvents content={content.events} locale={content.meta.locale} />
+      <EventsDataProvider content={content.events} locale={resolvedLocale}>
+        <Events
+          content={content.events}
+          bookingModalContent={content.bookingModal}
+          myBestAuntieModalContent={content.myBestAuntie.modal}
+          locale={resolvedLocale}
+          thankYouWhatsappHref={publicSiteConfig.whatsappUrl}
+          thankYouWhatsappCtaLabel={content.contactUs.form.contactMethodLinks.whatsapp}
+        />
+        <FreeIntroSession
+          content={content.freeIntroSession}
+          titleOverride={content.freeIntroSession.eventPageTitle}
+          sectionClassName="es-free-intro-session-section--standard-spacing"
+        />
+        <PastEvents content={content.events} locale={resolvedLocale} />
+      </EventsDataProvider>
       <EventNotification
         content={content.events.notification}
         commonCaptchaContent={content.common.captcha}

--- a/apps/public_www/src/components/sections/shared/events-shared.tsx
+++ b/apps/public_www/src/components/sections/shared/events-shared.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
 
 import { SectionCtaAnchor } from '@/components/sections/shared/section-cta-link';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
@@ -42,14 +49,94 @@ interface UseEventCardsOptions {
   sortEventCards: SortEventCardsFn;
 }
 
+interface EventsDataProviderProps {
+  children: ReactNode;
+  content: EventsContent;
+  locale: string;
+}
+
 interface UseEventCardsResult {
   visibleEvents: EventCardData[];
   isLoading: boolean;
   hasRequestError: boolean;
 }
 
+interface EventsDataState {
+  events: EventCardData[];
+  isLoading: boolean;
+  hasRequestError: boolean;
+}
+
+const EventsDataContext = createContext<EventsDataState | null>(null);
+
 function formatPartnerChipLabel(value: string): string {
   return value.replaceAll('-', ' ');
+}
+
+function useFetchEventCards(
+  content: EventsContent,
+  locale: string,
+  enabled = true,
+): EventsDataState {
+  const crmApiClient = useMemo(() => createPublicCrmApiClient(), []);
+  const shouldRequestEvents = enabled && crmApiClient !== null;
+  const [events, setEvents] = useState<EventCardData[]>([]);
+  const [isLoading, setIsLoading] = useState(() => shouldRequestEvents);
+  const [hasRequestError, setHasRequestError] = useState(() => !shouldRequestEvents);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    if (!shouldRequestEvents) {
+      return () => {
+        controller.abort();
+      };
+    }
+
+    fetchEventsPayload(crmApiClient, controller.signal)
+      .then((payload) => {
+        const normalizedEvents = normalizeEvents(payload, content, locale);
+        setHasRequestError(false);
+        setEvents(normalizedEvents);
+      })
+      .catch((error) => {
+        if (isAbortRequestError(error)) {
+          return;
+        }
+
+        setEvents([]);
+        setHasRequestError(true);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [content, crmApiClient, locale, shouldRequestEvents]);
+
+  return {
+    events,
+    isLoading,
+    hasRequestError,
+  };
+}
+
+export function EventsDataProvider({
+  children,
+  content,
+  locale,
+}: EventsDataProviderProps) {
+  const eventsData = useFetchEventCards(content, locale);
+
+  return (
+    <EventsDataContext.Provider value={eventsData}>
+      {children}
+    </EventsDataContext.Provider>
+  );
 }
 
 export function EventsLoadingState({ label, testId }: EventsLoadingStateProps) {
@@ -245,53 +332,17 @@ export function useEventCards({
   locale,
   sortEventCards,
 }: UseEventCardsOptions): UseEventCardsResult {
-  const crmApiClient = useMemo(() => createPublicCrmApiClient(), []);
-  const shouldRequestEvents = crmApiClient !== null;
-  const [events, setEvents] = useState<EventCardData[]>([]);
-  const [isLoading, setIsLoading] = useState(() => shouldRequestEvents);
-  const [hasRequestError, setHasRequestError] = useState(() => !shouldRequestEvents);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    if (!shouldRequestEvents) {
-      return () => {
-        controller.abort();
-      };
-    }
-
-    fetchEventsPayload(crmApiClient, controller.signal)
-      .then((payload) => {
-        const normalizedEvents = normalizeEvents(payload, content, locale);
-        setHasRequestError(false);
-        setEvents(normalizedEvents);
-      })
-      .catch((error) => {
-        if (isAbortRequestError(error)) {
-          return;
-        }
-
-        setEvents([]);
-        setHasRequestError(true);
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) {
-          setIsLoading(false);
-        }
-      });
-
-    return () => {
-      controller.abort();
-    };
-  }, [content, crmApiClient, locale, shouldRequestEvents]);
+  const contextEventsData = useContext(EventsDataContext);
+  const fallbackEventsData = useFetchEventCards(content, locale, contextEventsData === null);
+  const eventsData = contextEventsData ?? fallbackEventsData;
 
   const visibleEvents = useMemo(() => {
-    return sortEventCards(events);
-  }, [events, sortEventCards]);
+    return sortEventCards(eventsData.events);
+  }, [eventsData.events, sortEventCards]);
 
   return {
     visibleEvents,
-    isLoading,
-    hasRequestError,
+    isLoading: eventsData.isLoading,
+    hasRequestError: eventsData.hasRequestError,
   };
 }

--- a/apps/public_www/tests/components/pages/events.test.tsx
+++ b/apps/public_www/tests/components/pages/events.test.tsx
@@ -36,13 +36,20 @@ vi.mock('@/components/sections/free-intro-session', () => ({
     <section data-testid='free-intro-session'>{content.ctaLabel}</section>
   ),
 }));
+vi.mock('@/components/sections/shared/events-shared', () => ({
+  EventsDataProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid='events-data-provider'>{children}</div>
+  ),
+}));
 
 describe('EventsPage', () => {
   it('composes events page sections with locale-aware props', () => {
     render(<EventsPage content={enContent} />);
 
     const pageLayout = screen.getByTestId('page-layout');
+    const eventsDataProvider = screen.getByTestId('events-data-provider');
     expect(pageLayout).toBeInTheDocument();
+    expect(eventsDataProvider).toBeInTheDocument();
     expect(screen.getByTestId('events-section')).toHaveTextContent(
       `${enContent.events.title} (${enContent.meta.locale})`,
     );
@@ -54,14 +61,14 @@ describe('EventsPage', () => {
     );
     expect(screen.getByTestId('free-intro-session')).toBeInTheDocument();
 
-    const renderedSectionOrder = Array.from(pageLayout.querySelectorAll('section')).map(
+    const renderedSectionOrder = Array.from(eventsDataProvider.querySelectorAll('section')).map(
       (section) => section.getAttribute('data-testid'),
     );
     expect(renderedSectionOrder).toEqual([
       'events-section',
       'free-intro-session',
       'past-events-section',
-      'event-notification-section',
     ]);
+    expect(screen.getByTestId('event-notification-section')).toBeInTheDocument();
   });
 });

--- a/apps/public_www/tests/components/sections/events.test.tsx
+++ b/apps/public_www/tests/components/sections/events.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Events } from '@/components/sections/events';
+import { PastEvents } from '@/components/sections/past-events';
+import { EventsDataProvider } from '@/components/sections/shared/events-shared';
 import enContent from '@/content/en.json';
 import {
   createPublicCrmApiClient,
@@ -461,5 +463,55 @@ describe('Events section', () => {
     expect(
       screen.getAllByRole('link', { name: enContent.events.card.ctaLabel }),
     ).toHaveLength(1);
+  });
+
+  it('shares one calendar request across upcoming and past event sections', async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 'success',
+      data: [
+        {
+          title: 'Shared future event card',
+          location: 'physical',
+          address: 'PMQ, Central',
+          address_url: 'https://maps.google.com/?q=PMQ+Central',
+          dates: [
+            {
+              start_datetime: '2099-12-10T10:00:00Z',
+              end_datetime: '2099-12-10T11:00:00Z',
+            },
+          ],
+          is_fully_booked: false,
+        },
+        {
+          title: 'Shared past event card',
+          location: 'physical',
+          address: 'PMQ, Central',
+          address_url: 'https://maps.google.com/?q=PMQ+Central',
+          dates: [
+            {
+              start_datetime: '2024-02-01T09:00:00Z',
+              end_datetime: '2024-02-01T10:00:00Z',
+            },
+          ],
+          is_fully_booked: true,
+        },
+      ],
+    });
+    const mockApiClient: CrmApiClient = { request };
+    mockedCreateCrmApiClient.mockReturnValue(mockApiClient);
+
+    render(
+      <EventsDataProvider content={enContent.events} locale='en'>
+        <Events {...defaultEventsProps} />
+        <PastEvents content={enContent.events} />
+      </EventsDataProvider>,
+    );
+
+    await screen.findByText('Shared future event card');
+    await screen.findByText('Shared past event card');
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared public events data provider for the WWW events page.
- Wrap upcoming and past events sections so they share one `/v1/calendar/public` request.
- Preserve standalone section fetch behavior and add focused coverage for the shared-request path.

## Validation
- `npm run test -- tests/components/sections/events.test.tsx tests/components/sections/past-events.test.tsx tests/components/pages/events.test.tsx`
- `npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2a72170-b104-4c83-aa4d-e8731bd88e80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2a72170-b104-4c83-aa4d-e8731bd88e80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

