### PR TITLE
Landing pages: match public calendar by instance slug

### DIFF
--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -19,6 +19,7 @@ import {
   formatSiteTimeZoneShortName,
 } from '@/lib/site-datetime';
 import {
+  getAllLandingPageSlugs,
   getLandingPageContent,
   isValidLandingPageSlug,
 } from '@/lib/landing-pages';
@@ -76,7 +77,7 @@ export interface EventCalendarBookingModalPayload {
   dateParts: EventBookingDatePart[];
   selectedDateLabel: string;
   selectedDateStartTime: string;
-  /** From landing page JSON `cta.bookingTopicsField` when `landing_page` matches a registered page. */
+  /** From landing page JSON `cta.bookingTopicsField` when the event maps to a registered landing page (via `slug` or legacy `landing_page`). */
   topicsFieldConfig?: BookingTopicsFieldConfig;
   /** Optional notes/topics prefill when opening via `EventBookingModal` (e.g. landing CTA). */
   topicsPrefill?: string;
@@ -207,6 +208,34 @@ export interface LandingPageStructuredDataContent {
   offerPrice?: string;
   offerCurrency?: string;
   offerAvailability: 'InStock' | 'SoldOut';
+}
+
+/**
+ * Maps a calendar event record to a registered landing page slug when the public
+ * API `slug` (`service_instances.slug`) equals that slug or uses it as a hyphenated
+ * prefix (e.g. `easter-workshop-2026-04-06`). Falls back to legacy `landing_page` when
+ * it is itself a registered slug.
+ */
+function resolveLandingPageKeyFromCalendarRecord(
+  record: Record<string, unknown>,
+): string | null {
+  const instanceSlug = readCandidateText(record, ['slug', 'Slug'])?.trim().toLowerCase() ?? '';
+  if (instanceSlug) {
+    const sortedRegistered = [...getAllLandingPageSlugs()].sort((a, b) => b.length - a.length);
+    for (const reg of sortedRegistered) {
+      const r = reg.toLowerCase();
+      if (instanceSlug === r || instanceSlug.startsWith(`${r}-`)) {
+        return reg;
+      }
+    }
+  }
+
+  const legacy = readCandidateText(record, ['landing_page', 'landingPage'])?.trim() ?? '';
+  if (legacy && isValidLandingPageSlug(legacy)) {
+    return legacy;
+  }
+
+  return null;
 }
 
 function resolveEventsLocale(locale?: string): Locale {
@@ -365,9 +394,8 @@ function resolveBookingTopicsFieldFromLandingPage(
   record: Record<string, unknown>,
   locale: Locale,
 ): BookingTopicsFieldConfig | undefined {
-  const landingPageSlug =
-    readCandidateText(record, ['landing_page', 'landingPage'])?.trim() ?? '';
-  if (!landingPageSlug || !isValidLandingPageSlug(landingPageSlug)) {
+  const landingPageSlug = resolveLandingPageKeyFromCalendarRecord(record);
+  if (!landingPageSlug) {
     return undefined;
   }
 
@@ -1023,12 +1051,8 @@ export function findLandingPageEventInPayload(
       continue;
     }
 
-    const landingPageSlug = readCandidateText(record, ['landing_page', 'landingPage']);
-    if (!landingPageSlug) {
-      continue;
-    }
-
-    if (landingPageSlug.trim().toLowerCase() === normalizedSlug) {
+    const landingPageKey = resolveLandingPageKeyFromCalendarRecord(record);
+    if (landingPageKey !== null && landingPageKey.toLowerCase() === normalizedSlug) {
       return record;
     }
   }

--- a/apps/public_www/tests/fixtures/public-calendar.ts
+++ b/apps/public_www/tests/fixtures/public-calendar.ts
@@ -105,7 +105,6 @@ export const publicCalendarFixture = {
       title: 'Easter 2026 Montessori Play Coaching Workshop',
       description:
         'A practical Montessori-inspired play coaching workshop for children ages 1-4, with parent and child participation (helpers warmly welcome).',
-      landing_page: 'easter-2026-montessori-play-coaching-workshop',
       tags: ['1-4', 'Parent + Child', 'Helpers Welcome'],
       categories: ['Workshop'],
       partners: ['happy-baton', 'baumhaus'],
@@ -135,6 +134,7 @@ export const publicCalendarFixture = {
       title: 'The Missing Piece',
       description:
         'A hands-on workshop for families with children aged 0–2: the right toys, simple play-space tweaks, and practical tools your helper can use right away. Hosted with Little HK at Acorn Playhouse.',
+      /** Marketing slug differs from `service_instances.slug` (`the-missing-piece-…`). */
       landing_page: 'may-2026-the-missing-piece',
       tags: ['0-2', 'Parent + Child', 'Helpers Welcome'],
       categories: ['Workshop'],

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -372,7 +372,39 @@ describe('events-data', () => {
     });
   });
 
-  it('merges landing page bookingTopicsField onto event-booking modal payload when landing_page matches', () => {
+  it('still merges bookingTopicsField when only legacy landing_page matches a registered slug (no slug prefix)', () => {
+    const payload = {
+      data: [
+        {
+          id: 'legacy-lp',
+          title: 'Legacy landing_page only',
+          description: 'Workshop description',
+          booking_system: 'event-booking',
+          landing_page: 'easter-2026-montessori-play-coaching-workshop',
+          location_name: 'Venue',
+          location_address: '123 Road',
+          location_url: 'https://maps.google.com/?q=test',
+          dates: [
+            {
+              id: 'session-1',
+              start_datetime: '2026-04-06T02:00:00Z',
+              end_datetime: '2026-04-06T03:00:00Z',
+            },
+          ],
+          price: 350,
+          currency: 'HKD',
+          is_fully_booked: false,
+        },
+      ],
+    };
+
+    const eventsEn = normalizeEvents(payload, enContent.events, 'en');
+    expect(eventsEn[0]?.bookingModalPayload).toMatchObject({
+      topicsFieldConfig: easterWorkshopLandingContent.en.cta.bookingTopicsField,
+    });
+  });
+
+  it('merges landing page bookingTopicsField onto event-booking modal payload when instance slug maps to a registered landing page', () => {
     const payload = {
       data: [
         {
@@ -380,7 +412,7 @@ describe('events-data', () => {
           title: 'Easter Workshop',
           description: 'Workshop description',
           booking_system: 'event-booking',
-          landing_page: 'easter-2026-montessori-play-coaching-workshop',
+          slug: 'easter-2026-montessori-play-coaching-workshop-2026-04-06',
           location_name: 'Venue',
           location_address: '123 Road',
           location_url: 'https://maps.google.com/?q=test',
@@ -503,7 +535,7 @@ describe('events-data', () => {
     expect(events[0]?.tags).toEqual(['1-4', 'Parent + Child', 'Workshop']);
   });
 
-  it('resolves landing page hero content from calendar payload using landing_page slug', () => {
+  it('resolves landing page hero content from calendar payload using public instance slug', () => {
     const heroEventContent = getLandingPageHeroEventContentFromPayload(
       publicCalendarFixture,
       'easter-2026-montessori-play-coaching-workshop',
@@ -520,7 +552,7 @@ describe('events-data', () => {
     });
   });
 
-  it('resolves landing page booking payload from calendar payload using landing_page slug', () => {
+  it('resolves landing page booking payload from calendar payload using public instance slug', () => {
     const bookingEventContent = getLandingPageBookingEventContentFromPayload(
       publicCalendarFixture,
       'easter-2026-montessori-play-coaching-workshop',
@@ -546,7 +578,7 @@ describe('events-data', () => {
     });
   });
 
-  it('resolves landing page structured data content from calendar payload using landing_page slug', () => {
+  it('resolves landing page structured data content from calendar payload using public instance slug', () => {
     const structuredDataContent = getLandingPageStructuredDataContentFromPayload(
       publicCalendarFixture,
       'easter-2026-montessori-play-coaching-workshop',

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -267,7 +267,14 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             .limit(limit)
         )
         if landing_page:
-            statement = statement.where(ServiceInstance.landing_page == landing_page)
+            lp = landing_page
+            statement = statement.where(
+                or_(
+                    ServiceInstance.landing_page == lp,
+                    func.lower(ServiceInstance.slug) == func.lower(lp),
+                    func.lower(ServiceInstance.slug).like(f"{lp.lower()}-%"),
+                )
+            )
         if service_key:
             statement = statement.where(func.lower(Service.slug) == service_key.lower())
         statement = statement.where(ServiceInstance.slug.is_not(None)).where(

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -295,9 +295,12 @@ paths:
             maxLength: 255
             pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
           description: >
-            Filter results to at most one instance whose
-            `service_instances.landing_page` matches the provided slug.
-            Invalid or empty values are silently ignored.
+            Filter results to at most one instance when any of the following holds
+            (case-insensitive on `service_instances.slug`): `service_instances.landing_page`
+            equals the provided value, `service_instances.slug` equals the provided value,
+            or `service_instances.slug` starts with the provided value followed by a hyphen
+            (so a public website landing route slug can match dated instance slugs such as
+            `easter-workshop-2026-04-06`). Invalid or empty values are silently ignored.
         - name: service_key
           in: query
           required: false
@@ -371,9 +374,12 @@ paths:
             maxLength: 255
             pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
           description: >
-            Filter results to at most one instance whose
-            `service_instances.landing_page` matches the provided slug.
-            Invalid or empty values are silently ignored.
+            Filter results to at most one instance when any of the following holds
+            (case-insensitive on `service_instances.slug`): `service_instances.landing_page`
+            equals the provided value, `service_instances.slug` equals the provided value,
+            or `service_instances.slug` starts with the provided value followed by a hyphen
+            (so a public website landing route slug can match dated instance slugs such as
+            `easter-workshop-2026-04-06`). Invalid or empty values are silently ignored.
         - name: service_key
           in: query
           required: false
@@ -1122,6 +1128,11 @@ components:
         landing_page:
           type: string
           nullable: true
+          description: >
+            Optional marketing key from `service_instances.landing_page` when set.
+            The public website prefers matching landing pages to the `slug` field
+            (instance slug); this property may differ from the route slug when operators
+            keep a separate marketing key.
         service_tier:
           type: string
           nullable: true

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -482,7 +482,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   in practice for public calendar visibility; legacy NULL slugs were backfilled by migration
   `0043_backfill_inst_slug`. **Consultation** instances may keep `slug` NULL (consultations are
   not exposed on the public calendar feed). `landing_page`
-  (marketing route key for the public website).
+  (optional marketing key for the public website; may differ from `slug` when the instance
+  slug encodes a date suffix). The public calendar `landing_page` query parameter matches
+  `landing_page`, exact `slug`, or `slug` with that value as a hyphenated prefix.
 - Optional `cohort` varchar(128): admin label stored with the same normalization rules as
   instance referral slugs (lowercase letters, digits, single hyphens between segments).
 - Optional `external_url` varchar(500): operator-provided external registration/info URL

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -131,9 +131,12 @@ their primary responsibilities.
   cohorts default to `my-best-auntie-booking` when `services.slug` is
   `my-best-auntie`). Results order by earliest upcoming session slot ascending
   with `service_instances.id` as tie-break. Optional query filters:
-  `landing_page`, `service_type`, `service_key` (matched case-insensitively against
-  `services.slug`; invalid values ignored). Optional `slug` and `landing_page` echo from
-  `service_instances`; `spaces_total` / `spaces_left` when `max_capacity` is set,
+  `landing_page`, `service_type`, `service_key` (`service_key` matched case-insensitively against
+  `services.slug`; invalid values ignored). The `landing_page` query filter matches when
+  `service_instances.landing_page` equals the parameter, or `service_instances.slug` equals it
+  (case-insensitive), or `service_instances.slug` has the parameter as a hyphenated prefix
+  (so a website landing route slug can select a dated instance slug). Optional `slug` and
+  `landing_page` echo from `service_instances`; `spaces_total` / `spaces_left` when `max_capacity` is set,
   using the same enrollment statuses as capacity checks: registered, confirmed,
   completed),
   `/www/v1/assets/free` (lists public assets tagged `client_document`;

--- a/tests/test_public_events_repository.py
+++ b/tests/test_public_events_repository.py
@@ -130,6 +130,8 @@ def test_list_public_offerings_landing_page_filter() -> None:
     stmt = mock_session.execute.call_args[0][0]
     sql = _compiled_sql(stmt)
     assert f"service_instances.landing_page = '{slug}'" in sql
+    assert f"lower(service_instances.slug) = lower('{slug}')" in sql
+    assert f"lower(service_instances.slug) LIKE '{slug.lower()}-%%'" in sql
 
 
 def test_list_event_instances_for_public_feed_wraps_list_public_offerings() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Landing pages were correlating calendar rows using the API `landing_page` field. Public events already expose a canonical **`slug`** (`service_instances.slug`), which often includes a date suffix (for example `easter-…-2026-04-06`) while the site route stays shorter (for example `easter-…-montessori-play-coaching-workshop`).

## Changes

- **`apps/public_www/src/lib/events-data.ts`**: Resolve the registered landing page from each calendar item by matching **`slug`** against registered slugs (longest-prefix wins: exact match or `{registeredSlug}-…`). **`landing_page`** is still accepted when it is itself a registered slug (legacy / marketing-only rows where instance slug does not share the route prefix).
- **`backend/src/app/db/repositories/service_instance.py`**: When the `landing_page` query param is set, the DB filter now matches **`landing_page` column OR exact `slug` OR `slug` LIKE `{param}-%`** (case-insensitive on slug), so the existing `fetchEventsPayload({ landingPage: routeSlug })` still returns the instance even if `landing_page` is null.
- **Tests**: Vitest updates + repository SQL assertion; fixture Easter row uses slug-only; Missing Piece keeps `landing_page` where slug differs from the marketing route.
- **Docs**: `docs/api/public.yaml`, `docs/architecture/lambdas.md`, `docs/architecture/database-schema.md`.

## Validation

- `npm run test -- --run tests/lib/events-data.test.ts` (public_www)
- `pytest tests/test_public_events_repository.py tests/test_public_events_api.py`
- `pre-commit run ruff-format` on touched Python files
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf0ffe25-67aa-4ff4-b487-228b0cddaefe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf0ffe25-67aa-4ff4-b487-228b0cddaefe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

