### PR TITLE
Remove landing_page from public calendar; clarify service vs instance

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4471,6 +4471,7 @@ export interface components {
             title?: string | null;
             /** @description Required for event and training_course instances; optional for consultations. Public-calendar visibility depends on this field. URL-safe: lowercase letters, digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized to lowercase. */
             slug?: string | null;
+            /** @description Optional instance marketing key (`service_instances.landing_page`). There is no `landing_page` column on `services`; this field applies only to the instance row. */
             landing_page?: string | null;
             description?: string | null;
             cover_image_s3_key?: string | null;

--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -19,8 +19,8 @@ import {
   formatSiteTimeZoneShortName,
 } from '@/lib/site-datetime';
 import {
+  getAllLandingPageSlugs,
   getLandingPageContent,
-  isValidLandingPageSlug,
 } from '@/lib/landing-pages';
 import { isHttpHref } from '@/lib/url-utils';
 
@@ -76,7 +76,7 @@ export interface EventCalendarBookingModalPayload {
   dateParts: EventBookingDatePart[];
   selectedDateLabel: string;
   selectedDateStartTime: string;
-  /** From landing page JSON `cta.bookingTopicsField` when `landing_page` matches a registered page. */
+  /** From landing page JSON `cta.bookingTopicsField` when the instance `slug` maps to a registered landing page. */
   topicsFieldConfig?: BookingTopicsFieldConfig;
   /** Optional notes/topics prefill when opening via `EventBookingModal` (e.g. landing CTA). */
   topicsPrefill?: string;
@@ -207,6 +207,29 @@ export interface LandingPageStructuredDataContent {
   offerPrice?: string;
   offerCurrency?: string;
   offerAvailability: 'InStock' | 'SoldOut';
+}
+
+/**
+ * Maps a calendar event record to a registered landing page slug using public
+ * `slug` only: exact match or `{registeredSlug}-…` prefix (longest registered slug wins).
+ */
+function resolveLandingPageKeyFromCalendarRecord(
+  record: Record<string, unknown>,
+): string | null {
+  const instanceSlug = readCandidateText(record, ['slug', 'Slug'])?.trim().toLowerCase() ?? '';
+  if (!instanceSlug) {
+    return null;
+  }
+
+  const sortedRegistered = [...getAllLandingPageSlugs()].sort((a, b) => b.length - a.length);
+  for (const reg of sortedRegistered) {
+    const r = reg.toLowerCase();
+    if (instanceSlug === r || instanceSlug.startsWith(`${r}-`)) {
+      return reg;
+    }
+  }
+
+  return null;
 }
 
 function resolveEventsLocale(locale?: string): Locale {
@@ -365,9 +388,8 @@ function resolveBookingTopicsFieldFromLandingPage(
   record: Record<string, unknown>,
   locale: Locale,
 ): BookingTopicsFieldConfig | undefined {
-  const landingPageSlug =
-    readCandidateText(record, ['landing_page', 'landingPage'])?.trim() ?? '';
-  if (!landingPageSlug || !isValidLandingPageSlug(landingPageSlug)) {
+  const landingPageSlug = resolveLandingPageKeyFromCalendarRecord(record);
+  if (!landingPageSlug) {
     return undefined;
   }
 
@@ -1023,12 +1045,8 @@ export function findLandingPageEventInPayload(
       continue;
     }
 
-    const landingPageSlug = readCandidateText(record, ['landing_page', 'landingPage']);
-    if (!landingPageSlug) {
-      continue;
-    }
-
-    if (landingPageSlug.trim().toLowerCase() === normalizedSlug) {
+    const landingPageKey = resolveLandingPageKeyFromCalendarRecord(record);
+    if (landingPageKey !== null && landingPageKey.toLowerCase() === normalizedSlug) {
       return record;
     }
   }

--- a/apps/public_www/tests/fixtures/public-calendar.ts
+++ b/apps/public_www/tests/fixtures/public-calendar.ts
@@ -105,7 +105,6 @@ export const publicCalendarFixture = {
       title: 'Easter 2026 Montessori Play Coaching Workshop',
       description:
         'A practical Montessori-inspired play coaching workshop for children ages 1-4, with parent and child participation (helpers warmly welcome).',
-      landing_page: 'easter-2026-montessori-play-coaching-workshop',
       tags: ['1-4', 'Parent + Child', 'Helpers Welcome'],
       categories: ['Workshop'],
       partners: ['happy-baton', 'baumhaus'],
@@ -135,7 +134,6 @@ export const publicCalendarFixture = {
       title: 'The Missing Piece',
       description:
         'A hands-on workshop for families with children aged 0–2: the right toys, simple play-space tweaks, and practical tools your helper can use right away. Hosted with Little HK at Acorn Playhouse.',
-      landing_page: 'may-2026-the-missing-piece',
       tags: ['0-2', 'Parent + Child', 'Helpers Welcome'],
       categories: ['Workshop'],
       partners: ['little-hk'],
@@ -159,7 +157,7 @@ export const publicCalendarFixture = {
       location_address: '3/F, 4 Yip Fat St, Wong Chuk Hang',
       location_url:
         'https://www.google.com/maps/dir/?api=1&destination=3%2FF%2C+4+Yip+Fat+St%2C+Wong+Chuk+Hang',
-      slug: 'the-missing-piece-2026-05-16',
+      slug: 'may-2026-the-missing-piece-2026-05-16',
     },
   ],
 };

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -372,7 +372,7 @@ describe('events-data', () => {
     });
   });
 
-  it('merges landing page bookingTopicsField onto event-booking modal payload when landing_page matches', () => {
+  it('merges landing page bookingTopicsField onto event-booking modal payload when instance slug maps to a registered landing page', () => {
     const payload = {
       data: [
         {
@@ -380,7 +380,7 @@ describe('events-data', () => {
           title: 'Easter Workshop',
           description: 'Workshop description',
           booking_system: 'event-booking',
-          landing_page: 'easter-2026-montessori-play-coaching-workshop',
+          slug: 'easter-2026-montessori-play-coaching-workshop-2026-04-06',
           location_name: 'Venue',
           location_address: '123 Road',
           location_url: 'https://maps.google.com/?q=test',
@@ -503,7 +503,7 @@ describe('events-data', () => {
     expect(events[0]?.tags).toEqual(['1-4', 'Parent + Child', 'Workshop']);
   });
 
-  it('resolves landing page hero content from calendar payload using landing_page slug', () => {
+  it('resolves landing page hero content from calendar payload using public instance slug', () => {
     const heroEventContent = getLandingPageHeroEventContentFromPayload(
       publicCalendarFixture,
       'easter-2026-montessori-play-coaching-workshop',
@@ -520,7 +520,7 @@ describe('events-data', () => {
     });
   });
 
-  it('resolves landing page booking payload from calendar payload using landing_page slug', () => {
+  it('resolves landing page booking payload from calendar payload using public instance slug', () => {
     const bookingEventContent = getLandingPageBookingEventContentFromPayload(
       publicCalendarFixture,
       'easter-2026-montessori-play-coaching-workshop',
@@ -546,7 +546,7 @@ describe('events-data', () => {
     });
   });
 
-  it('resolves landing page structured data content from calendar payload using landing_page slug', () => {
+  it('resolves landing page structured data content from calendar payload using public instance slug', () => {
     const structuredDataContent = getLandingPageStructuredDataContentFromPayload(
       publicCalendarFixture,
       'easter-2026-montessori-play-coaching-workshop',
@@ -598,7 +598,7 @@ describe('events-data', () => {
       bookingPayload: {
         variant: 'event',
         service: 'event',
-        serviceKey: 'the-missing-piece-2026-05-16',
+        serviceKey: 'may-2026-the-missing-piece-2026-05-16',
         title: 'The Missing Piece',
         locationName: 'Acorn Playhouse',
         locationAddress: '3/F, 4 Yip Fat St, Wong Chuk Hang',

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -429,8 +429,6 @@ def _serialize_public_event(
     if external_url:
         payload["external_url"] = external_url
 
-    if instance.landing_page is not None:
-        payload["landing_page"] = instance.landing_page
     payload["service_tier"] = service_tier
     if instance.cohort is not None:
         payload["cohort"] = instance.cohort

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -267,7 +267,14 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             .limit(limit)
         )
         if landing_page:
-            statement = statement.where(ServiceInstance.landing_page == landing_page)
+            lp = landing_page
+            statement = statement.where(
+                or_(
+                    ServiceInstance.landing_page == lp,
+                    func.lower(ServiceInstance.slug) == func.lower(lp),
+                    func.lower(ServiceInstance.slug).like(f"{lp.lower()}-%"),
+                )
+            )
         if service_key:
             statement = statement.where(func.lower(Service.slug) == service_key.lower())
         statement = statement.where(ServiceInstance.slug.is_not(None)).where(

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3964,6 +3964,9 @@ components:
         landing_page:
           type: string
           nullable: true
+          description: >
+            Optional instance marketing key (`service_instances.landing_page`). There is no
+            `landing_page` column on `services`; this field applies only to the instance row.
         description:
           type: string
           nullable: true

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -295,9 +295,12 @@ paths:
             maxLength: 255
             pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
           description: >
-            Filter results to at most one instance whose
-            `service_instances.landing_page` matches the provided slug.
-            Invalid or empty values are silently ignored.
+            Filter results to at most one instance when any of the following holds
+            (case-insensitive on `service_instances.slug`): `service_instances.landing_page`
+            equals the provided value, `service_instances.slug` equals the provided value,
+            or `service_instances.slug` starts with the provided value followed by a hyphen
+            (so a public website landing route slug can match dated instance slugs such as
+            `easter-workshop-2026-04-06`). Invalid or empty values are silently ignored.
         - name: service_key
           in: query
           required: false
@@ -371,9 +374,12 @@ paths:
             maxLength: 255
             pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
           description: >
-            Filter results to at most one instance whose
-            `service_instances.landing_page` matches the provided slug.
-            Invalid or empty values are silently ignored.
+            Filter results to at most one instance when any of the following holds
+            (case-insensitive on `service_instances.slug`): `service_instances.landing_page`
+            equals the provided value, `service_instances.slug` equals the provided value,
+            or `service_instances.slug` starts with the provided value followed by a hyphen
+            (so a public website landing route slug can match dated instance slugs such as
+            `easter-workshop-2026-04-06`). Invalid or empty values are silently ignored.
         - name: service_key
           in: query
           required: false
@@ -1119,9 +1125,6 @@ components:
             Stable public identifier for the offering. Maps to `service_instances.slug`.
             The calendar feed omits rows where the instance slug is missing or does not match
             this public pattern (invalid values are filtered server-side).
-        landing_page:
-          type: string
-          nullable: true
         service_tier:
           type: string
           nullable: true

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -482,7 +482,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   in practice for public calendar visibility; legacy NULL slugs were backfilled by migration
   `0043_backfill_inst_slug`. **Consultation** instances may keep `slug` NULL (consultations are
   not exposed on the public calendar feed). `landing_page`
-  (marketing route key for the public website).
+  (optional instance marketing key; not on `services`). The public calendar JSON exposes
+  `slug` only for instance identity; the `landing_page` query parameter still matches
+  `service_instances.landing_page`, exact `slug`, or `slug` with that value as a hyphenated prefix.
 - Optional `cohort` varchar(128): admin label stored with the same normalization rules as
   instance referral slugs (lowercase letters, digits, single hyphens between segments).
 - Optional `external_url` varchar(500): operator-provided external registration/info URL

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -131,9 +131,13 @@ their primary responsibilities.
   cohorts default to `my-best-auntie-booking` when `services.slug` is
   `my-best-auntie`). Results order by earliest upcoming session slot ascending
   with `service_instances.id` as tie-break. Optional query filters:
-  `landing_page`, `service_type`, `service_key` (matched case-insensitively against
-  `services.slug`; invalid values ignored). Optional `slug` and `landing_page` echo from
-  `service_instances`; `spaces_total` / `spaces_left` when `max_capacity` is set,
+  `landing_page`, `service_type`, `service_key` (`service_key` matched case-insensitively against
+  `services.slug`; invalid values ignored). The `landing_page` query filter matches when
+  `service_instances.landing_page` equals the parameter, or `service_instances.slug` equals it
+  (case-insensitive), or `service_instances.slug` has the parameter as a hyphenated prefix
+  (so a website landing route slug can select a dated instance slug). Each item includes
+  `slug` from `service_instances` (not echoed from `services`, which has no `landing_page` column);
+  `spaces_total` / `spaces_left` when `max_capacity` is set,
   using the same enrollment statuses as capacity checks: registered, confirmed,
   completed),
   `/www/v1/assets/free` (lists public assets tagged `client_document`;

--- a/tests/test_public_events_api.py
+++ b/tests/test_public_events_api.py
@@ -150,7 +150,7 @@ def test_handle_public_events_returns_items(monkeypatch: Any, api_gateway_event:
     assert len(body["items"]) == 2
     assert body["items"][0]["external_url"] == "https://www.eventbrite.com/e/demo"
     assert body["items"][0]["slug"] == "spring-workshop"
-    assert body["items"][0]["landing_page"] == "spring-workshop"
+    assert "landing_page" not in body["items"][0]
     assert body["items"][0]["spaces_total"] == 10
     assert body["items"][0]["spaces_left"] == 9
     assert body["items"][1]["booking_status"] == "fully_booked"

--- a/tests/test_public_events_repository.py
+++ b/tests/test_public_events_repository.py
@@ -130,6 +130,8 @@ def test_list_public_offerings_landing_page_filter() -> None:
     stmt = mock_session.execute.call_args[0][0]
     sql = _compiled_sql(stmt)
     assert f"service_instances.landing_page = '{slug}'" in sql
+    assert f"lower(service_instances.slug) = lower('{slug}')" in sql
+    assert f"lower(service_instances.slug) LIKE '{slug.lower()}-%%'" in sql
 
 
 def test_list_event_instances_for_public_feed_wraps_list_public_offerings() -> None:

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -91,6 +91,28 @@ def test_event_ticket_tier_price_and_booking_system_default() -> None:
     assert out["tags"] == []
     assert out["partners"] == []
     assert out["is_fully_booked"] is False
+    assert "landing_page" not in out
+
+
+def test_public_calendar_payload_omits_instance_landing_page_even_when_set() -> None:
+    service = SimpleNamespace(
+        title="Svc",
+        description="Desc",
+        service_type=ServiceType.EVENT,
+        slug=None,
+        booking_system=None,
+        event_details=SimpleNamespace(
+            event_category=SimpleNamespace(value="workshop"),
+            default_price=Decimal("99"),
+            default_currency="HKD",
+        ),
+        delivery_mode=SimpleNamespace(value="in_person"),
+        service_tier=None,
+        location=None,
+    )
+    inst = _minimal_instance(service, landing_page="marketing-key")
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert "landing_page" not in out
 
 
 def test_event_default_price_when_no_tiers() -> None:
@@ -600,6 +622,7 @@ def _minimal_instance(
     *,
     status: InstanceStatus = InstanceStatus.OPEN,
     slug: str | None = "slug",
+    landing_page: str | None = None,
     ticket_tiers: list[Any] | None = None,
     instance_tags: list[Any] | None = None,
     partner_organization_links: list[Any] | None = None,
@@ -616,7 +639,7 @@ def _minimal_instance(
     return SimpleNamespace(
         id=uuid4(),
         slug=slug,
-        landing_page=None,
+        landing_page=landing_page,
         title=None,
         description=None,
         status=status,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

`landing_page` is not a column on `services`—it exists on `service_instances` only. The public calendar feed was still echoing `landing_page` on each event object, which implied a misleading “service” shape to consumers.

## Changes

- **Public API**: `GET /v1/calendar/public` (and `/www/...`) no longer includes `landing_page` on calendar items. Identity for the public site remains **`slug`** (`service_instances.slug`). OpenAPI `PublicCalendarEvent` updated accordingly.
- **Query filter**: `landing_page` query param again matches `service_instances.landing_page` **or** exact `slug` **or** `slug` with the param as a hyphenated prefix (so `?landing_page=may-2026-the-missing-piece` still works when the instance slug is dated).
- **public_www**: `events-data` resolves landing-page correlation from **`slug` only** (registered slug prefix rules); tests and fixtures updated (Missing Piece fixture slug now uses the marketing prefix).
- **Admin OpenAPI**: `ServiceInstance.landing_page` description explicitly states there is no `services.landing_page`; regenerated `admin-api.generated.ts`.
- **Docs**: `lambdas.md` and `database-schema.md` aligned with the above.

## Tests

- `pytest` on `tests/test_public_events_api.py`, `tests/test_public_events_repository.py`, `tests/test_public_events_serializer.py`
- `npm run test -- --run tests/lib/events-data.test.ts` (public_www)
- `npm run generate:admin-api-types` + `npm run check:admin-api-types`
- `pre-commit run ruff-format` on touched Python; `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf0ffe25-67aa-4ff4-b487-228b0cddaefe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf0ffe25-67aa-4ff4-b487-228b0cddaefe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

