### PR TITLE
Format landing page hero category chips with leading capital

### DIFF
--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -239,6 +239,26 @@ function formatEnumLikeLabel(value: string): string {
     .join(' ');
 }
 
+/**
+ * Present enum-like or API-sourced chip text with a leading capital letter.
+ * All-uppercase tokens become sentence case; phrases that already include
+ * lowercase letters keep their casing aside from the first character.
+ */
+function capitalizeFirstForDisplay(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const first = trimmed.charAt(0).toLocaleUpperCase();
+  const rest = trimmed.slice(1);
+  if (/[a-z]/.test(trimmed)) {
+    return `${first}${rest}`;
+  }
+
+  return `${first}${rest.toLocaleLowerCase()}`;
+}
+
 function sanitizeExternalHref(value: string | undefined): string {
   const href = readOptionalText(value);
   if (!href || !isHttpHref(href)) {
@@ -671,7 +691,21 @@ function readLandingPageCategoryChips(
     }
   }
 
-  return dedupeChipLabels(categories);
+  const uniqueRaw = dedupeChipLabels(categories);
+  const displayChips: string[] = [];
+  const seenDisplay = new Set<string>();
+
+  for (const rawLabel of uniqueRaw) {
+    const displayLabel = capitalizeFirstForDisplay(formatEnumLikeLabel(rawLabel));
+    if (!displayLabel || seenDisplay.has(displayLabel)) {
+      continue;
+    }
+
+    seenDisplay.add(displayLabel);
+    displayChips.push(displayLabel);
+  }
+
+  return displayChips;
 }
 
 function resolveDateTimeDetails(

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -520,6 +520,33 @@ describe('events-data', () => {
     });
   });
 
+  it('formats landing page hero category chips with a leading capital letter', () => {
+    const payload = {
+      status: 'success' as const,
+      data: [
+        {
+          title: 'Capitalize chip fixture',
+          slug: 'test-landing-category-chip-capitalize',
+          categories: ['workshop', 'WORKSHOP', 'parent_child'],
+          dates: [
+            {
+              start_datetime: '2026-04-06T02:00:00Z',
+              end_datetime: '2026-04-06T03:00:00Z',
+            },
+          ],
+        },
+      ],
+    };
+
+    const heroEventContent = getLandingPageHeroEventContentFromPayload(
+      payload,
+      'test-landing-category-chip-capitalize',
+    );
+
+    expect(heroEventContent).not.toBeNull();
+    expect(heroEventContent?.categoryChips).toEqual(['Workshop', 'Parent Child']);
+  });
+
   it('resolves landing page booking payload from calendar payload using slug', () => {
     const bookingEventContent = getLandingPageBookingEventContentFromPayload(
       publicCalendarFixture,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Landing page hero quick-fact chips include category tags from the public calendar payload (`readLandingPageCategoryChips`). Those strings were shown as returned by the API (e.g. lowercase or `snake_case`), unlike event cards where tags pass through `formatEnumLikeLabel`.

## Changes

- After collecting unique raw category labels, each chip is normalized with `formatEnumLikeLabel` then `capitalizeFirstForDisplay` (first character uppercased; all-uppercase tokens become sentence case so the rest is lowercased; strings that already contain lowercase keep internal casing).
- Deduplication uses the final display string so `workshop` and `WORKSHOP` collapse to one chip.
- Added a Vitest case in `tests/lib/events-data.test.ts`.

## Testing

- `npm run test -- tests/lib/events-data.test.ts`
- `npm run test -- tests/components/sections/landing-pages/landing-page-hero.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7af3f91e-a319-4461-adfc-2f4b99407b90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7af3f91e-a319-4461-adfc-2f4b99407b90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

