### PR TITLE
fix(public_www): title-case lowercase workshop category chip

### DIFF
--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -229,6 +229,13 @@ function formatEnumLikeLabel(value: string): string {
   }
 
   if (/\s/.test(trimmedValue) || !/[_-]/.test(trimmedValue)) {
+    // Calendar payloads often send single-token enum slugs in all lowercase (for
+    // example, "workshop"). Title-case those for display while leaving mixed
+    // case (proper nouns) and non-ASCII labels unchanged.
+    if (/^[a-z]+$/.test(trimmedValue)) {
+      return trimmedValue.charAt(0).toUpperCase() + trimmedValue.slice(1).toLowerCase();
+    }
+
     return trimmedValue;
   }
 
@@ -671,7 +678,9 @@ function readLandingPageCategoryChips(
     }
   }
 
-  return dedupeChipLabels(categories);
+  return dedupeChipLabels(
+    categories.map((label) => formatEnumLikeLabel(label)),
+  );
 }
 
 function resolveDateTimeDetails(

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -503,6 +503,26 @@ describe('events-data', () => {
     expect(events[0]?.tags).toEqual(['1-4', 'Parent + Child', 'Workshop']);
   });
 
+  it('title-cases all-lowercase single-token category labels for landing page chips', () => {
+    const heroEventContent = getLandingPageHeroEventContentFromPayload(
+      {
+        data: [
+          {
+            slug: 'test-workshop-event',
+            title: 'Test Workshop Event',
+            categories: ['workshop'],
+            dates: [{ start_datetime: '2026-05-16T01:00:00Z' }],
+          },
+        ],
+      },
+      'test-workshop-event',
+    );
+
+    expect(heroEventContent).toMatchObject({
+      categoryChips: ['Workshop'],
+    });
+  });
+
   it('resolves landing page hero content from calendar payload using slug', () => {
     const heroEventContent = getLandingPageHeroEventContentFromPayload(
       publicCalendarFixture,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The landing page hero shows quick-fact chips (date, time, location, category) built from the public calendar payload. Category text came from `categories` on the event record **without** the same display normalization used for tags.

`formatEnumLikeLabel` only rewrote values that contained hyphens or underscores (for example `in_person` → `In Person`). A single API token like `workshop` was returned unchanged, so the chip showed **workshop**.

## Changes

- Extend `formatEnumLikeLabel` to title-case **all-lowercase ASCII** single tokens (e.g. `workshop` → `Workshop`) while preserving mixed-case proper nouns and non-ASCII strings.
- Run landing page category chip strings through `formatEnumLikeLabel` in `readLandingPageCategoryChips`.
- Add a focused unit test for the lowercase category case.

## Testing

- `npm run test -- --run tests/lib/events-data.test.ts`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42864683-df1b-4936-9826-1d21fc40cb55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42864683-df1b-4936-9826-1d21fc40cb55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

