### PR TITLE
Thank-you modal and booking email: service type + title columns

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/thank-you-modal.tsx
@@ -53,18 +53,28 @@ export interface BookingThankYouModalProps {
 
 const WHATSAPP_ICON_SRC = '/images/contact-whatsapp.svg';
 
-export function resolveThankYouServiceDisplayLabel(
+export function resolveThankYouServiceTypeLabel(
   summary: ReservationSummary | null,
   serviceLabels: BookingThankYouModalContent['serviceLabels'] | undefined,
 ): string {
-  const title = summary?.eventTitle?.trim() ?? '';
   const slug = (summary?.serviceSlug ?? '').trim().toLowerCase();
   if (!slug || !serviceLabels) {
-    return title;
+    return '';
   }
   const mapped = serviceLabels[slug as keyof typeof serviceLabels];
   const label = typeof mapped === 'string' ? mapped.trim() : '';
-  return label || title;
+  return label;
+}
+
+export function resolveThankYouServiceTitle(
+  summary: ReservationSummary | null,
+  courseLabelFallback: string,
+): string {
+  const title = summary?.eventTitle?.trim() ?? '';
+  if (title) {
+    return title;
+  }
+  return courseLabelFallback.trim();
 }
 
 function resolveThankYouLocationDisplay(
@@ -193,7 +203,9 @@ export function BookingThankYouModal({
 
   const attendeeEmail = summary?.attendeeEmail ?? '';
   const eventTitle = summary?.eventTitle ?? content.courseLabel;
-  const serviceDisplayLabel = resolveThankYouServiceDisplayLabel(summary, content.serviceLabels);
+  const serviceTypeLabel = resolveThankYouServiceTypeLabel(summary, content.serviceLabels);
+  const serviceTitleLine = resolveThankYouServiceTitle(summary, content.courseLabel);
+  const serviceRowLeftLabel = serviceTypeLabel || content.serviceLabel;
   const thankYouSessions = useMemo(
     () => resolveThankYouCourseSessions(summary),
     [summary],
@@ -337,10 +349,10 @@ export function BookingThankYouModal({
               <div className='es-booking-thank-you-recap-row-border pb-4'>
                 <div className='grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,140px)_1fr] sm:gap-6'>
                   <dt className='es-booking-thank-you-recap-label'>
-                    {content.serviceLabel}
+                    {serviceRowLeftLabel}
                   </dt>
                   <dd className='es-booking-thank-you-recap-value m-0'>
-                    {serviceDisplayLabel}
+                    {serviceTitleLine}
                   </dd>
                 </div>
               </div>

--- a/apps/public_www/tests/components/sections/booking-thank-you-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-thank-you-modal.test.tsx
@@ -217,7 +217,7 @@ describe('BookingThankYouModal', () => {
     expect(screen.queryByText(thankYouEn.fpsReservationPendingNote)).not.toBeInTheDocument();
   });
 
-  it('shows localized service label from serviceSlug in the recap service row', () => {
+  it('shows service type in the left column and title in the right for the recap row', () => {
     const summary: ReservationSummary = {
       attendeeName: 'Pat',
       attendeeEmail: 'pat@example.com',
@@ -241,6 +241,6 @@ describe('BookingThankYouModal', () => {
     );
 
     expect(screen.getByText(thankYouEn.serviceLabels.consultation)).toBeInTheDocument();
-    expect(screen.queryByText('Family Consultation — long title')).not.toBeInTheDocument();
+    expect(screen.getByText('Family Consultation — long title')).toBeInTheDocument();
   });
 });

--- a/backend/src/app/templates/booking_confirmation_content.py
+++ b/backend/src/app/templates/booking_confirmation_content.py
@@ -234,18 +234,27 @@ _SERVICE_TYPE_LABELS: Final[dict[str, dict[str, str]]] = {
 }
 
 
-def resolve_service_row_label(
-    loc: str, service_slug: str | None, course_label: str
-) -> str:
-    """Localized service row for confirmation templates; falls back to course_label."""
-    label = (course_label or "").strip()
+def resolve_service_type_label(loc: str, service_slug: str | None) -> str:
+    """Localized high-level booking category (event, training-course, consultation)."""
     raw = (service_slug or "").strip().lower()
     if not raw:
-        return label
+        return ""
     locale_key = normalize_booking_locale(loc)
     row = _SERVICE_TYPE_LABELS.get(locale_key, _SERVICE_TYPE_LABELS["en"])
     mapped = row.get(raw)
-    return mapped.strip() if isinstance(mapped, str) and mapped.strip() else label
+    return mapped.strip() if isinstance(mapped, str) and mapped.strip() else ""
+
+
+def resolve_service_row_label(
+    loc: str, service_slug: str | None, course_label: str
+) -> str:
+    """Backward-compatible booking title for SES templates using {{service_row_label}}."""
+    return (course_label or "").strip()
+
+
+def resolve_service_title_label(course_label: str) -> str:
+    """Customer-visible booking title (same as course_label in API payloads)."""
+    return (course_label or "").strip()
 
 
 def normalize_booking_locale(locale: str) -> str:

--- a/backend/src/app/templates/booking_confirmation_render.py
+++ b/backend/src/app/templates/booking_confirmation_render.py
@@ -883,7 +883,6 @@ def render_booking_confirmation_email(
     loc = normalize_booking_locale(locale)
     labels = TABLE_LABELS[loc]
     esc_name = html.escape(full_name.strip())
-    service_row_label = resolve_service_row_label(loc, service_slug, course_label)
     service_type_label = resolve_service_type_label(loc, service_slug)
     service_title_label = resolve_service_title_label(course_label)
     service_table_left_label = service_type_label or labels["service"]

--- a/backend/src/app/templates/booking_confirmation_render.py
+++ b/backend/src/app/templates/booking_confirmation_render.py
@@ -40,6 +40,8 @@ from app.templates.booking_confirmation_content import (
     WHATSAPP_LINK_LABEL,
     normalize_booking_locale,
     resolve_service_row_label,
+    resolve_service_title_label,
+    resolve_service_type_label,
 )
 from app.templates.ses.email_shell import wrap_transactional_html
 
@@ -740,6 +742,8 @@ def booking_confirmation_template_merge_data(
     """Build SES template_data (before shell merge)."""
     loc = normalize_booking_locale(locale)
     service_row_label = resolve_service_row_label(loc, service_slug, course_label)
+    service_type_label = resolve_service_type_label(loc, service_slug)
+    service_title_label = resolve_service_title_label(course_label)
     pm_display = resolve_payment_method_display(payment_method_code)
     use_hkt = location_suggests_hong_kong(
         location_name=location_name,
@@ -793,6 +797,8 @@ def booking_confirmation_template_merge_data(
         "full_name": full_name.strip(),
         "course_label": course_label.strip(),
         "service_row_label": service_row_label,
+        "service_type_label": service_type_label,
+        "service_title_label": service_title_label,
         "total_amount": free_label if is_free else total_amount,
         "is_pending_payment": pending_for_template,
         "is_free": is_free,
@@ -878,7 +884,10 @@ def render_booking_confirmation_email(
     labels = TABLE_LABELS[loc]
     esc_name = html.escape(full_name.strip())
     service_row_label = resolve_service_row_label(loc, service_slug, course_label)
-    esc_service_row = html.escape(service_row_label)
+    service_type_label = resolve_service_type_label(loc, service_slug)
+    service_title_label = resolve_service_title_label(course_label)
+    service_table_left_label = service_type_label or labels["service"]
+    esc_service_title = html.escape(service_title_label)
     pm_display = resolve_payment_method_display(payment_method_code)
     esc_pm = html.escape(pm_display)
     free_label = FREE_TOTAL_LABEL[loc]
@@ -908,7 +917,7 @@ def render_booking_confirmation_email(
     )
 
     rows_html: list[str] = [
-        _html_table_row_bordered(labels["service"], esc_service_row),
+        _html_table_row_bordered(service_table_left_label, esc_service_title),
     ]
     details_cell = format_booking_details_html_cell(
         loc=loc,
@@ -1019,7 +1028,8 @@ def render_booking_confirmation_email(
         loc=loc,
         labels=labels,
         full_name=full_name.strip(),
-        service_row_label=service_row_label,
+        service_type_label=service_type_label,
+        service_title_label=service_title_label,
         schedule_date_label=schedule_date_label,
         schedule_time_label=schedule_time_label,
         location_name=location_name,
@@ -1067,7 +1077,8 @@ def _build_plain_text(
     loc: str,
     labels: dict[str, str],
     full_name: str,
-    service_row_label: str,
+    service_type_label: str,
+    service_title_label: str,
     schedule_date_label: str | None,
     schedule_time_label: str | None,
     location_name: str | None,
@@ -1097,7 +1108,8 @@ def _build_plain_text(
     else:
         lines.append(f"您好 {full_name}，\n")
     lines.append(THANK_YOU_PLAIN[loc])
-    lines.append(f"{labels['service']}{label_sep}{service_row_label}\n")
+    service_plain_left = service_type_label or labels["service"]
+    lines.append(f"{service_plain_left}{label_sep}{service_title_label}\n")
 
     details_plain = format_booking_details_plain(
         loc=loc,

--- a/backend/src/app/templates/ses/booking_confirmation.py
+++ b/backend/src/app/templates/ses/booking_confirmation.py
@@ -38,9 +38,12 @@ def _inner_html_and_text_for_locale(loc: str) -> tuple[str, str]:
     labels = TABLE_LABELS[loc]
     border = "border-bottom:1px solid #eeeeee;"
     row_service = (
-        f'<tr><td style="padding:8px 0;{border}"><strong>{labels["service"]}</strong></td>'
+        f'<tr><td style="padding:8px 0;{border}"><strong>'
+        "{{#if service_type_label}}{{service_type_label}}{{else}}"
+        f"{labels['service']}"
+        "{{/if}}</strong></td>"
         '<td style="padding:8px 0;border-bottom:1px solid #eeeeee;text-align:right;">'
-        "{{service_row_label}}</td></tr>"
+        "{{service_title_label}}</td></tr>"
     )
     row_details = (
         "{{#if details_block_html}}"
@@ -134,8 +137,11 @@ def _inner_html_and_text_for_locale(loc: str) -> tuple[str, str]:
     text_part = (
         greeting_plain
         + THANK_YOU_PLAIN[loc]
-        + f"{labels['service']}{label_sep}"
-        + "{{service_row_label}}\n"
+        + "{{#if service_type_label}}{{service_type_label}}{{else}}"
+        + f"{labels['service']}"
+        + "{{/if}}"
+        + label_sep
+        + "{{service_title_label}}\n"
         + "{{#if details_plain}}"
         + f"{labels['details']}{label_sep}\n"
         + "{{details_plain}}\n"

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1352,7 +1352,10 @@ components:
             - consultation
           description: >
             Optional high-level booking category for localized confirmation email copy.
-            When omitted, the booking confirmation email uses `courseLabel` for the Service row.
+            When present, the confirmation email first table row uses a localized type label
+            (event, training course, consultation) in the left column and `courseLabel` as the
+            title in the right column. When omitted, the left column falls back to a generic
+            "Service" label and the right column shows `courseLabel`.
         locationName:
           type: string
           maxLength: 200

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -227,9 +227,11 @@ their primary responsibilities.
   transactional flows (contact, media download link, booking confirmation).
   Pending FPS bookings may instead send booking confirmation via
   `SendRawEmail` (multipart HTML + inline PNG) when the client supplies a valid
-  PNG data URL. Stored booking-confirmation templates expose `{{service_row_label}}`
-  for the Service table row (localized from optional reservation `service` when present;
-  otherwise the course title).
+  PNG data URL. Stored booking-confirmation templates expose `{{service_type_label}}`
+  and `{{service_title_label}}` for the first details table row (localized service type
+  from optional reservation `service` when present, with generic “Service” fallback
+  in the label column; title is the booking title). `{{service_row_label}}` remains in
+  merge data as the course title for backward compatibility with older template revisions.
 - VPC: **No**
 - Permissions: SES `CreateTemplate`, `UpdateTemplate`, `DeleteTemplate`, `GetTemplate`
 

--- a/tests/test_booking_confirmation_helpers.py
+++ b/tests/test_booking_confirmation_helpers.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from app.templates.booking_confirmation_content import resolve_service_row_label
+from app.templates.booking_confirmation_content import (
+    resolve_service_row_label,
+    resolve_service_type_label,
+)
 from app.templates.booking_confirmation_render import (
     booking_confirmation_template_merge_data,
     format_schedule_datetime_line,
@@ -22,7 +25,7 @@ def test_resolve_payment_method_display() -> None:
     assert resolve_payment_method_display("other") == "other"
 
 
-def test_resolve_service_row_label_falls_back_for_unknown_slug() -> None:
+def test_resolve_service_row_label_matches_course_label() -> None:
     assert resolve_service_row_label("en", "unknown", "My Title") == "My Title"
 
 
@@ -43,6 +46,8 @@ def test_booking_confirmation_template_merge_data_consultation_details() -> None
         consultation_level_label="Essentials",
     )
     assert data["service_row_label"] == "Consultation"
+    assert data["service_type_label"] == ""
+    assert data["service_title_label"] == "Consultation"
     assert data["schedule_datetime_label_html"] == "12 April in the morning"
     assert data["payment_method"] == "FPS"
     assert data["include_fps_instructions"] is True
@@ -134,7 +139,7 @@ def test_booking_confirmation_template_merge_data_free_omits_payment() -> None:
     assert data["include_fps_instructions"] is False
 
 
-def test_booking_confirmation_template_merge_data_service_row_label_from_slug() -> None:
+def test_booking_confirmation_template_merge_data_service_type_and_title() -> None:
     data = booking_confirmation_template_merge_data(
         locale="zh-CN",
         full_name="A",
@@ -148,4 +153,11 @@ def test_booking_confirmation_template_merge_data_service_row_label_from_slug() 
         whatsapp_url="https://wa.me/1",
         is_free=True,
     )
-    assert data["service_row_label"] == "咨询"
+    assert data["service_row_label"] == "家庭咨询预约"
+    assert data["service_type_label"] == "咨询"
+    assert data["service_title_label"] == "家庭咨询预约"
+
+
+def test_resolve_service_type_label_maps_slug() -> None:
+    assert resolve_service_type_label("en", "event") == "Event"
+    assert resolve_service_type_label("en", "unknown") == ""

--- a/tests/test_booking_confirmation_render.py
+++ b/tests/test_booking_confirmation_render.py
@@ -52,6 +52,29 @@ def test_render_booking_confirmation_zh_cn_includes_labels_and_fps_block() -> No
     assert "期待与您见面" in plain
 
 
+def test_render_booking_confirmation_service_row_type_and_title() -> None:
+    _subject, html_doc, plain = render_booking_confirmation_email(
+        locale="en",
+        full_name="Pat",
+        course_label="Spring Playdate",
+        service_slug="event",
+        schedule_date_label=None,
+        schedule_time_label=None,
+        primary_session_iso="2026-04-16T18:00:00+08:00",
+        course_slug="event-booking",
+        payment_method_code="stripe",
+        total_amount="HK$50.00",
+        is_pending_payment=False,
+        whatsapp_url="https://wa.me/x",
+        faq_url="https://site.example/en/contact-us#contact-us-faq",
+        include_fps_qr_image=False,
+    )
+    assert "Event" in html_doc
+    assert "Spring Playdate" in html_doc
+    assert "Service" not in html_doc
+    assert "Event: Spring Playdate" in plain
+
+
 def test_render_booking_confirmation_en_hkt_from_iso() -> None:
     _subject, html_doc, plain = render_booking_confirmation_email(
         locale="en",

--- a/tests/test_ses_booking_confirmation_templates.py
+++ b/tests/test_ses_booking_confirmation_templates.py
@@ -8,8 +8,10 @@ def test_booking_ses_templates_preserve_handlebars_placeholders() -> None:
     assert len(definitions) == 3
     en = next(t for t in definitions if t["TemplateName"].endswith("-en"))
     assert "{{course_label}}" in en["SubjectPart"]
-    assert "{{service_row_label}}" in en["HtmlPart"]
-    assert "{{service_row_label}}" in en["TextPart"]
+    assert "{{service_type_label}}" in en["HtmlPart"]
+    assert "{{service_title_label}}" in en["HtmlPart"]
+    assert "{{service_type_label}}" in en["TextPart"]
+    assert "{{service_title_label}}" in en["TextPart"]
     assert "{{full_name}}" in en["HtmlPart"]
     assert "{{#unless is_free}}" in en["HtmlPart"]
     assert "{{#if is_pending_payment}}" in en["HtmlPart"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The booking thank-you modal recap row now shows the localized **service type** (Event, Training Course, Consultation from `serviceSlug` / locale `serviceLabels`) in the **left** column and the **booking title** (`eventTitle`, or `courseLabel` when the title is empty) in the **right** column, instead of a static "Service" label with the type in the value cell.

Booking confirmation emails (MIME HTML, plain text, and SES template definitions) use the same layout: localized type in the first row’s label column and `courseLabel` as the value. Template merge data adds `service_type_label` and `service_title_label`. `service_row_label` remains set to the course title so older deployed SES templates that still reference only `{{service_row_label}}` continue to show the title.

## Ops note

After merge, **redeploy SES booking confirmation templates** (SesTemplateManager / messaging stack) so production uses the updated Handlebars markup with `{{service_type_label}}` / `{{service_title_label}}`.

## Tests

- `python3 -m pytest tests/test_booking_confirmation_helpers.py tests/test_booking_confirmation_render.py tests/test_ses_booking_confirmation_templates.py`
- `npx vitest run tests/components/sections/booking-thank-you-modal.test.tsx` (from `apps/public_www`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87e1ab05-a833-4f47-a0d8-eeb21a275955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87e1ab05-a833-4f47-a0d8-eeb21a275955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

