### PR TITLE
fix(public_www): landing page NEXT_PUBLIC_* client env regression

### DIFF
--- a/apps/public_www/src/components/pages/landing-pages/landing-page.tsx
+++ b/apps/public_www/src/components/pages/landing-pages/landing-page.tsx
@@ -14,6 +14,7 @@ import { LandingPageDetails } from '@/components/sections/landing-pages/landing-
 import { LandingPageFaq } from '@/components/sections/landing-pages/landing-page-faq';
 import { LandingPageOutline } from '@/components/sections/landing-pages/landing-page-outline';
 import { LandingPageRehydrateRoot } from '@/lib/landing-page-calendar-context';
+import { resolvePublicSiteConfig } from '@/lib/site-config';
 import type {
   LandingPageBookingEventContent,
   LandingPageHeroEventContent,
@@ -41,6 +42,8 @@ export function LandingPage({
   bookingEventContent,
   structuredDataContent,
 }: LandingPageProps) {
+  const publicSiteConfig = resolvePublicSiteConfig();
+
   return (
     <LandingPageRehydrateRoot
       key={`${slug}-${locale}`}
@@ -51,6 +54,7 @@ export function LandingPage({
       initialHero={heroEventContent}
       initialBooking={bookingEventContent}
       initialStructuredData={structuredDataContent}
+      thankYouWhatsappHref={publicSiteConfig.whatsappUrl}
     >
       <PageLayout
         navbarContent={siteContent.navbar}

--- a/apps/public_www/src/lib/landing-page-calendar-context.tsx
+++ b/apps/public_www/src/lib/landing-page-calendar-context.tsx
@@ -36,6 +36,7 @@ export interface LandingPageRehydrateRootProps {
   initialHero: LandingPageHeroEventContent | null;
   initialBooking: LandingPageBookingEventContent | null;
   initialStructuredData: LandingPageStructuredDataContent | null;
+  thankYouWhatsappHref?: string;
   children: ReactNode;
 }
 
@@ -47,6 +48,7 @@ export function LandingPageRehydrateRoot({
   initialHero,
   initialBooking,
   initialStructuredData,
+  thankYouWhatsappHref,
   children,
 }: LandingPageRehydrateRootProps) {
   const {
@@ -73,6 +75,7 @@ export function LandingPageRehydrateRoot({
         pageContent.meta.title,
         heroEventContent,
         bookingEventContent,
+        thankYouWhatsappHref,
       ),
     [
       locale,
@@ -82,6 +85,7 @@ export function LandingPageRehydrateRoot({
       siteContent,
       heroEventContent,
       bookingEventContent,
+      thankYouWhatsappHref,
     ],
   );
 

--- a/apps/public_www/src/lib/landing-page-cta-resolve.ts
+++ b/apps/public_www/src/lib/landing-page-cta-resolve.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/lib/events-data';
 import type { LandingPageLocaleContent, Locale, SiteContent } from '@/content';
 import { formatContentTemplate } from '@/content/content-field-utils';
-import { buildWhatsappPrefilledHref, resolvePublicSiteConfig } from '@/lib/site-config';
+import { buildWhatsappPrefilledHref } from '@/lib/site-config';
 
 export function resolveLandingPageCtaEyebrow(
   eyebrowTemplate: string | undefined,
@@ -71,6 +71,7 @@ export function buildLandingPageSharedCtaPropsFromCalendar(
   heroTitleFallback: string,
   heroEventContent: LandingPageHeroEventContent | null,
   bookingEventContent: LandingPageBookingEventContent | null,
+  thankYouWhatsappHref: string | undefined,
 ): LandingPageSharedCtaProps {
   const isFullyBooked = bookingEventContent?.status === 'fully_booked';
   const waitlistEventTitle = heroEventContent?.title ?? heroTitleFallback;
@@ -81,8 +82,6 @@ export function buildLandingPageSharedCtaPropsFromCalendar(
     pageContentCta.fullyBookedWaitlistMessageTemplate,
     waitlistEventTitle,
   );
-  const publicSiteConfig = resolvePublicSiteConfig();
-
   return {
     locale,
     slug,
@@ -94,7 +93,7 @@ export function buildLandingPageSharedCtaPropsFromCalendar(
     fullyBookedCtaLabel: pageContentCta.fullyBookedButtonLabel,
     fullyBookedWaitlistHref,
     bookingModalContent: siteContent.bookingModal,
-    thankYouWhatsappHref: publicSiteConfig.whatsappUrl,
+    thankYouWhatsappHref,
     thankYouWhatsappCtaLabel: siteContent.contactUs.form.contactMethodLinks.whatsapp,
   };
 }

--- a/apps/public_www/src/lib/site-config.ts
+++ b/apps/public_www/src/lib/site-config.ts
@@ -1,10 +1,8 @@
-const INSTAGRAM_URL_ENV_NAME = 'NEXT_PUBLIC_INSTAGRAM_URL';
-const LINKEDIN_URL_ENV_NAME = 'NEXT_PUBLIC_LINKEDIN_URL';
-const WHATSAPP_URL_ENV_NAME = 'NEXT_PUBLIC_WHATSAPP_URL';
-const CONTACT_EMAIL_ENV_NAME = 'NEXT_PUBLIC_EMAIL';
-const BUSINESS_ADDRESS_ENV_NAME = 'NEXT_PUBLIC_BUSINESS_ADDRESS';
-const BUSINESS_PHONE_ENV_NAME = 'NEXT_PUBLIC_BUSINESS_PHONE_NUMBER';
-
+/**
+ * Public site config reads `process.env.NEXT_PUBLIC_*` with literal property
+ * access only. Next.js inlines those at build time; dynamic keys like
+ * `process.env[name]` are undefined in client bundles.
+ */
 export interface PublicSiteConfig {
   instagramUrl?: string;
   linkedinUrl?: string;
@@ -14,14 +12,12 @@ export interface PublicSiteConfig {
   businessPhoneNumber?: string;
 }
 
-function readOptionalEnv(name: string): string | undefined {
-  const value = process.env[name];
-  if (typeof value !== 'string') {
+function normalizeOptionalEnvValue(raw: string | undefined): string | undefined {
+  if (typeof raw !== 'string') {
     return undefined;
   }
-
-  const normalized = value.trim();
-  return normalized === '' ? undefined : normalized;
+  const trimmed = raw.trim();
+  return trimmed === '' ? undefined : trimmed;
 }
 
 function parseConfiguredUrl(value: string): URL | null {
@@ -99,10 +95,12 @@ function normalizeConfiguredEmail(value: string | undefined): string | undefined
 }
 
 function resolveRequiredContactEmail(): string {
-  const normalizedEmail = normalizeConfiguredEmail(readOptionalEnv(CONTACT_EMAIL_ENV_NAME));
+  const normalizedEmail = normalizeConfiguredEmail(
+    normalizeOptionalEnvValue(process.env.NEXT_PUBLIC_EMAIL),
+  );
   if (!normalizedEmail) {
     throw new Error(
-      `${CONTACT_EMAIL_ENV_NAME} must be configured with a valid email address.`,
+      'NEXT_PUBLIC_EMAIL must be configured with a valid email address.',
     );
   }
 
@@ -182,11 +180,17 @@ export function buildUtmHref(
 
 export function resolvePublicSiteConfig(): PublicSiteConfig {
   return {
-    instagramUrl: normalizeConfiguredUrl(readOptionalEnv(INSTAGRAM_URL_ENV_NAME)),
-    linkedinUrl: normalizeConfiguredUrl(readOptionalEnv(LINKEDIN_URL_ENV_NAME)),
-    whatsappUrl: normalizeConfiguredUrl(readOptionalEnv(WHATSAPP_URL_ENV_NAME)),
+    instagramUrl: normalizeConfiguredUrl(
+      normalizeOptionalEnvValue(process.env.NEXT_PUBLIC_INSTAGRAM_URL),
+    ),
+    linkedinUrl: normalizeConfiguredUrl(
+      normalizeOptionalEnvValue(process.env.NEXT_PUBLIC_LINKEDIN_URL),
+    ),
+    whatsappUrl: normalizeConfiguredUrl(
+      normalizeOptionalEnvValue(process.env.NEXT_PUBLIC_WHATSAPP_URL),
+    ),
     contactEmail: resolveRequiredContactEmail(),
-    businessAddress: readOptionalEnv(BUSINESS_ADDRESS_ENV_NAME),
-    businessPhoneNumber: readOptionalEnv(BUSINESS_PHONE_ENV_NAME),
+    businessAddress: normalizeOptionalEnvValue(process.env.NEXT_PUBLIC_BUSINESS_ADDRESS),
+    businessPhoneNumber: normalizeOptionalEnvValue(process.env.NEXT_PUBLIC_BUSINESS_PHONE_NUMBER),
   };
 }

--- a/apps/public_www/tests/components/pages/landing-pages/landing-page-rehydrate-integration.test.tsx
+++ b/apps/public_www/tests/components/pages/landing-pages/landing-page-rehydrate-integration.test.tsx
@@ -8,6 +8,27 @@ import easterWorkshopContent from '@/content/landing-pages/easter-2026-montessor
 import { clearCrmApiGetCacheForTests } from '@/lib/crm-api-client';
 import { publicCalendarFixture } from '../../../fixtures/public-calendar';
 
+const mockedReportInternalError = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/internal-error-reporting', () => ({
+  reportInternalError: mockedReportInternalError,
+}));
+
+vi.mock('@/lib/site-config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/site-config')>();
+  return {
+    ...actual,
+    resolvePublicSiteConfig: vi.fn(() => ({
+      instagramUrl: undefined,
+      linkedinUrl: undefined,
+      whatsappUrl: undefined,
+      contactEmail: 'hello@example.com',
+      businessAddress: undefined,
+      businessPhoneNumber: undefined,
+    })),
+  };
+});
+
 vi.mock('@/components/shared/page-layout', () => ({
   PageLayout: ({ children }: { children: ReactNode }) => (
     <div data-testid='page-layout'>{children}</div>
@@ -40,6 +61,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
+  mockedReportInternalError.mockReset();
 });
 
 beforeEach(() => {
@@ -49,6 +71,56 @@ beforeEach(() => {
 });
 
 describe('LandingPage calendar rehydrate', () => {
+  it('does not mount locale error boundary when client NEXT_PUBLIC_* env is empty (thank-you href from server)', async () => {
+    vi.stubEnv('NEXT_PUBLIC_EMAIL', '');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(publicCalendarFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <LandingPage
+        locale='en'
+        slug='easter-2026-montessori-play-coaching-workshop'
+        pagePath='/easter-2026-montessori-play-coaching-workshop'
+        siteContent={enContent}
+        pageContent={easterWorkshopContent.en}
+        heroEventContent={null}
+        bookingEventContent={null}
+        structuredDataContent={null}
+      />,
+    );
+
+    await waitFor(() => {
+      const ctaButton = screen.getByRole('button', {
+        name: new RegExp(
+          easterWorkshopContent.en.cta.buttonLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+        ),
+      });
+      expect(ctaButton).not.toBeDisabled();
+    });
+
+    expect(screen.queryByRole('heading', { name: 'Page not found' })).not.toBeInTheDocument();
+    const heroSection = document.querySelector('#landing-page-hero');
+    expect(heroSection).not.toBeNull();
+    expect(heroSection).toHaveTextContent('Wan Chai');
+    expect(mockedReportInternalError).not.toHaveBeenCalled();
+    const emailConfigErrors = consoleErrorSpy.mock.calls.filter((call) =>
+      call.some(
+        (arg) => typeof arg === 'string' && arg.includes('NEXT_PUBLIC_EMAIL'),
+      ),
+    );
+    expect(emailConfigErrors).toHaveLength(0);
+    consoleErrorSpy.mockRestore();
+  });
+
   it('enables booking CTA and updates hero chips after client fetch', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/public_www/tests/components/pages/landing-pages/landing-page.test.tsx
+++ b/apps/public_www/tests/components/pages/landing-pages/landing-page.test.tsx
@@ -4,6 +4,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { LandingPage } from '@/components/pages/landing-pages/landing-page';
 import enContent from '@/content/en.json';
+import {
+  LandingPageCalendarContext,
+  type LandingPageCalendarContextValue,
+  type LandingPageRehydrateRootProps,
+} from '@/lib/landing-page-calendar-context';
+import { buildLandingPageSharedCtaPropsFromCalendar } from '@/lib/landing-page-cta-resolve';
 import * as siteConfig from '@/lib/site-config';
 import easterWorkshopContent from '@/content/landing-pages/easter-2026-montessori-play-coaching-workshop.json';
 
@@ -13,11 +19,8 @@ const { landingPageRehydrateRootSpy } = vi.hoisted(() => ({
 
 vi.mock('@/lib/landing-page-calendar-context', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/landing-page-calendar-context')>();
-  const { buildLandingPageSharedCtaPropsFromCalendar } = await import('@/lib/landing-page-cta-resolve');
 
-  function MockLandingPageRehydrateRoot(
-    props: import('@/lib/landing-page-calendar-context').LandingPageRehydrateRootProps,
-  ) {
+  function MockLandingPageRehydrateRoot(props: LandingPageRehydrateRootProps) {
     const {
       locale,
       slug,
@@ -41,7 +44,7 @@ vi.mock('@/lib/landing-page-calendar-context', async (importOriginal) => {
       thankYouWhatsappHref,
     );
 
-    const value: import('@/lib/landing-page-calendar-context').LandingPageCalendarContextValue = {
+    const value: LandingPageCalendarContextValue = {
       heroEventContent: initialHero,
       bookingEventContent: initialBooking,
       structuredDataContent: initialStructuredData,

--- a/apps/public_www/tests/components/pages/landing-pages/landing-page.test.tsx
+++ b/apps/public_www/tests/components/pages/landing-pages/landing-page.test.tsx
@@ -4,56 +4,74 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { LandingPage } from '@/components/pages/landing-pages/landing-page';
 import enContent from '@/content/en.json';
+import * as siteConfig from '@/lib/site-config';
 import easterWorkshopContent from '@/content/landing-pages/easter-2026-montessori-play-coaching-workshop.json';
-import {
-  LandingPageCalendarContext,
-  type LandingPageCalendarContextValue,
-  type LandingPageRehydrateRootProps,
-} from '@/lib/landing-page-calendar-context';
-import { buildLandingPageSharedCtaPropsFromCalendar } from '@/lib/landing-page-cta-resolve';
 
-function MockLandingPageRehydrateRoot({
-  locale,
-  slug,
-  siteContent,
-  pageContent,
-  initialHero,
-  initialBooking,
-  initialStructuredData,
-  children,
-}: LandingPageRehydrateRootProps) {
-  const sharedCtaProps = buildLandingPageSharedCtaPropsFromCalendar(
-    locale,
-    slug,
-    pageContent.cta,
-    siteContent,
-    pageContent.meta.title,
-    initialHero,
-    initialBooking,
-  );
-
-  const value: LandingPageCalendarContextValue = {
-    heroEventContent: initialHero,
-    bookingEventContent: initialBooking,
-    structuredDataContent: initialStructuredData,
-    sharedCtaProps,
-    isRefreshing: false,
-    hasRefreshError: false,
-  };
-
-  return (
-    <LandingPageCalendarContext.Provider value={value}>
-      {children}
-    </LandingPageCalendarContext.Provider>
-  );
-}
+const { landingPageRehydrateRootSpy } = vi.hoisted(() => ({
+  landingPageRehydrateRootSpy: vi.fn(),
+}));
 
 vi.mock('@/lib/landing-page-calendar-context', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/landing-page-calendar-context')>();
+  const { buildLandingPageSharedCtaPropsFromCalendar } = await import('@/lib/landing-page-cta-resolve');
+
+  function MockLandingPageRehydrateRoot(
+    props: import('@/lib/landing-page-calendar-context').LandingPageRehydrateRootProps,
+  ) {
+    const {
+      locale,
+      slug,
+      siteContent,
+      pageContent,
+      initialHero,
+      initialBooking,
+      initialStructuredData,
+      thankYouWhatsappHref,
+      children,
+    } = props;
+
+    const sharedCtaProps = buildLandingPageSharedCtaPropsFromCalendar(
+      locale,
+      slug,
+      pageContent.cta,
+      siteContent,
+      pageContent.meta.title,
+      initialHero,
+      initialBooking,
+      thankYouWhatsappHref,
+    );
+
+    const value: import('@/lib/landing-page-calendar-context').LandingPageCalendarContextValue = {
+      heroEventContent: initialHero,
+      bookingEventContent: initialBooking,
+      structuredDataContent: initialStructuredData,
+      sharedCtaProps,
+      isRefreshing: false,
+      hasRefreshError: false,
+    };
+
+    return (
+      <actual.LandingPageCalendarContext.Provider value={value}>
+        {children}
+      </actual.LandingPageCalendarContext.Provider>
+    );
+  }
+
+  landingPageRehydrateRootSpy.mockImplementation(MockLandingPageRehydrateRoot);
+
   return {
     ...actual,
-    LandingPageRehydrateRoot: MockLandingPageRehydrateRoot,
+    LandingPageRehydrateRoot: landingPageRehydrateRootSpy,
   };
+});
+
+vi.spyOn(siteConfig, 'resolvePublicSiteConfig').mockReturnValue({
+  instagramUrl: undefined,
+  linkedinUrl: undefined,
+  whatsappUrl: 'https://wa.me/85212345678',
+  contactEmail: 'hello@example.com',
+  businessAddress: undefined,
+  businessPhoneNumber: undefined,
 });
 
 const mockHeroEventContent = {
@@ -192,6 +210,27 @@ vi.mock('@/components/sections/about-us-ida-coach', () => ({
 }));
 
 describe('LandingPage composition', () => {
+  it('resolves public site config on the server and passes thankYouWhatsappHref to LandingPageRehydrateRoot', () => {
+    render(
+      <LandingPage
+        locale='zh-HK'
+        slug='easter-2026-montessori-play-coaching-workshop'
+        pagePath='/easter-2026-montessori-play-coaching-workshop'
+        siteContent={enContent}
+        pageContent={easterWorkshopContent.en}
+        heroEventContent={mockHeroEventContent}
+        bookingEventContent={mockBookingEventContent}
+        structuredDataContent={null}
+      />,
+    );
+
+    expect(siteConfig.resolvePublicSiteConfig).toHaveBeenCalled();
+    const firstCallProps = landingPageRehydrateRootSpy.mock.calls[0]?.[0];
+    expect(firstCallProps).toMatchObject({
+      thankYouWhatsappHref: 'https://wa.me/85212345678',
+    });
+  });
+
   it('assembles all landing page sections in order', () => {
     render(
       <LandingPage

--- a/apps/public_www/tests/components/sections/landing-pages/landing-page-description.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/landing-page-description.test.tsx
@@ -56,6 +56,7 @@ describe('LandingPageDescription section', () => {
       easterWorkshopContent.en.meta.title,
       null,
       null,
+      undefined,
     );
     render(
       <LandingPageCalendarContext.Provider

--- a/apps/public_www/tests/components/sections/landing-pages/landing-page-details.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/landing-page-details.test.tsx
@@ -65,6 +65,7 @@ describe('LandingPageDetails section', () => {
       easterWorkshopContent.en.meta.title,
       null,
       null,
+      undefined,
     );
     render(
       <LandingPageCalendarContext.Provider

--- a/apps/public_www/tests/components/sections/landing-pages/landing-page-outline.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/landing-page-outline.test.tsx
@@ -39,6 +39,7 @@ describe('LandingPageOutline section', () => {
       easterWorkshopContent.en.meta.title,
       null,
       null,
+      undefined,
     );
     render(
       <LandingPageCalendarContext.Provider

--- a/apps/public_www/tests/components/sections/landing-pages/landing-page-outline.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/landing-page-outline.test.tsx
@@ -4,7 +4,10 @@ import { describe, expect, it } from 'vitest';
 import { LandingPageOutline } from '@/components/sections/landing-pages/landing-page-outline';
 import enContent from '@/content/en.json';
 import easterWorkshopContent from '@/content/landing-pages/easter-2026-montessori-play-coaching-workshop.json';
-import { LandingPageCalendarContext } from '@/lib/landing-page-calendar-context';
+import {
+  LandingPageCalendarContext,
+  useLandingPageCalendarContext,
+} from '@/lib/landing-page-calendar-context';
 import { buildLandingPageSharedCtaPropsFromCalendar } from '@/lib/landing-page-cta-resolve';
 
 describe('LandingPageOutline section', () => {
@@ -59,5 +62,49 @@ describe('LandingPageOutline section', () => {
     expect(
       screen.getByRole('button', { name: easterWorkshopContent.en.cta.buttonLabel }),
     ).toBeInTheDocument();
+  });
+
+  it('passes thankYouWhatsappHref through calendar context for shared CTA props', () => {
+    const thankYouWhatsappHref = 'https://wa.me/85298765432';
+    const sharedCtaProps = buildLandingPageSharedCtaPropsFromCalendar(
+      'en',
+      'easter-2026-montessori-play-coaching-workshop',
+      easterWorkshopContent.en.cta,
+      enContent,
+      easterWorkshopContent.en.meta.title,
+      null,
+      null,
+      thankYouWhatsappHref,
+    );
+    expect(sharedCtaProps.thankYouWhatsappHref).toBe(thankYouWhatsappHref);
+
+    function SharedCtaThankYouHrefProbe() {
+      const calendar = useLandingPageCalendarContext();
+      return (
+        <span data-testid='shared-cta-thank-you-whatsapp-href'>
+          {calendar?.sharedCtaProps.thankYouWhatsappHref ?? ''}
+        </span>
+      );
+    }
+
+    render(
+      <LandingPageCalendarContext.Provider
+        value={{
+          heroEventContent: null,
+          bookingEventContent: null,
+          structuredDataContent: null,
+          sharedCtaProps,
+          isRefreshing: false,
+          hasRefreshError: false,
+        }}
+      >
+        <SharedCtaThankYouHrefProbe />
+        <LandingPageOutline content={easterWorkshopContent.en.outline} />
+      </LandingPageCalendarContext.Provider>,
+    );
+
+    expect(screen.getByTestId('shared-cta-thank-you-whatsapp-href')).toHaveTextContent(
+      thankYouWhatsappHref,
+    );
   });
 });

--- a/apps/public_www/tests/lib/site-config.test.ts
+++ b/apps/public_www/tests/lib/site-config.test.ts
@@ -84,6 +84,12 @@ describe('site-config', () => {
     );
   });
 
+  it('throws when NEXT_PUBLIC_EMAIL is unset', () => {
+    delete process.env.NEXT_PUBLIC_EMAIL;
+
+    expect(() => resolvePublicSiteConfig()).toThrow(/NEXT_PUBLIC_EMAIL/);
+  });
+
   it('normalizes schemeless social URLs by prepending https', () => {
     process.env.NEXT_PUBLIC_WHATSAPP_URL = 'wa.me/message/ZQHVW4DEORD5A1?src=qr';
     process.env.NEXT_PUBLIC_INSTAGRAM_URL = 'instagram.com/evolvesprouts';

--- a/apps/public_www/tests/lib/site-config.test.ts
+++ b/apps/public_www/tests/lib/site-config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildUtmHref,
@@ -17,6 +17,7 @@ const originalEnvValues = Object.fromEntries(
 ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   for (const key of ENV_KEYS) {
     const originalValue = originalEnvValues[key];
     if (typeof originalValue === 'string') {
@@ -85,7 +86,7 @@ describe('site-config', () => {
   });
 
   it('throws when NEXT_PUBLIC_EMAIL is unset', () => {
-    delete process.env.NEXT_PUBLIC_EMAIL;
+    vi.stubEnv('NEXT_PUBLIC_EMAIL', '');
 
     expect(() => resolvePublicSiteConfig()).toThrow(/NEXT_PUBLIC_EMAIL/);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a production regression where `resolvePublicSiteConfig()` ran inside the landing rehydrate client tree. Next.js only inlines `NEXT_PUBLIC_*` when accessed as literal properties (`process.env.NEXT_PUBLIC_FOO`), not via dynamic keys, so the client saw empty env values and `NEXT_PUBLIC_EMAIL` validation threw—surfacing the locale error boundary as a misleading "Page not found".

## Changes

1. **`site-config.ts`**: Replace `readOptionalEnv(name)` with `normalizeOptionalEnvValue()` plus literal `process.env.NEXT_PUBLIC_*` reads. Document the literal-access rule in a file comment.

2. **Landing pages**: Resolve `publicSiteConfig` in the server `LandingPage` component and pass `thankYouWhatsappHref={publicSiteConfig.whatsappUrl}` into `LandingPageRehydrateRoot`. Extend `buildLandingPageSharedCtaPropsFromCalendar` with a `thankYouWhatsappHref` parameter so the client memo no longer imports or calls `resolvePublicSiteConfig`.

3. **Tests**: Assert missing `NEXT_PUBLIC_EMAIL` throws with `NEXT_PUBLIC_EMAIL` in the message; integration test stubs empty client email while server config supplies contact email and asserts no error page / no `reportInternalError`; composition test asserts `resolvePublicSiteConfig` and `thankYouWhatsappHref` wiring. Follow-up: `vi.stubEnv` for unset-email case, `thankYouWhatsappHref` propagation test in outline section, hoisted imports in `landing-page.test.tsx` mock factory.

## Verification

- `cd apps/public_www && npm run lint`
- `cd apps/public_www && npm run test`
- `bash scripts/validate-cursorrules.sh`

**Note:** Branch name follows the cloud agent convention (`cursor/...-cbed`) rather than the issue text branch name without the suffix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2153e2f5-3b7e-46f5-b2ce-9d6db448cbed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2153e2f5-3b7e-46f5-b2ce-9d6db448cbed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

