### PR TITLE
fix(public-www): register Acorn Playhouse partner logo for asset audit

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/landing-page-hero.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-hero.tsx
@@ -53,6 +53,7 @@ interface LandingPageHeroProps {
 const PARTNER_LOGO_EXTENSIONS = ['webp', 'svg'] as const;
 const KNOWN_PARTNER_LOGO_SOURCES: Readonly<Record<string, readonly string[]>> = {
   'evolvesprouts': ['/images/evolvesprouts-logo.svg'],
+  'acorn-playhouse': ['/images/partners/acorn-playhouse.webp'],
   'baumhaus': ['/images/partners/baumhaus.webp'],
   'happy-baton': ['/images/partners/happy-baton.webp'],
   'little-hk': ['/images/partners/little-hk.webp'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The asset audit treats files under `public/images` as unused unless a string reference like `'/images/...'` appears in `src`. The new `acorn-playhouse.webp` file was not referenced anywhere.

## Changes

- Add `acorn-playhouse` to `KNOWN_PARTNER_LOGO_SOURCES` in `landing-page-hero.tsx`, matching the pattern used for `baumhaus`, `happy-baton`, and `little-hk`.

## Validation

- `npm run audit:assets` (in `apps/public_www`)
- `npx vitest run tests/components/sections/landing-pages/landing-page-hero.test.tsx`
- `bash scripts/validate-cursorrules.sh`

## Usage

Calendar/API events can include partner slug `acorn-playhouse` in `partners` to show this logo on landing page heroes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d324ed1a-6b09-4ed6-87cc-93c1f0576a03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d324ed1a-6b09-4ed6-87cc-93c1f0576a03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

