### PR TITLE
fix(public_www): extend CSP for GTM Google Ads script and connect hosts

### DIFF
--- a/apps/public_www/README.md
+++ b/apps/public_www/README.md
@@ -266,6 +266,10 @@ and the free guides resource library list (`GET /v1/assets/free`, same-origin as
 The injected CSP also allows Cloudflare Web Analytics (`static.cloudflareinsights.com`
 for `script-src` and `cloudflareinsights.com` for `connect-src`) when Cloudflare
 injects the beacon at the edge.
+When the build detects Google Tag Manager (`init-gtm.js`), CSP also allows Google
+Ads–related script and connect endpoints used by tags in the container (for example
+`googleads.g.doubleclick.net`, `www.googleadservices.com`, and `www.google.com` for
+CCM/rmkt beacons), in addition to the existing Google Analytics `connect-src` hosts.
 Public website discount validation uses `/v1/discounts/validate`. Contact-us and
 reservation submission use:
 

--- a/apps/public_www/scripts/inject-csp-meta.mjs
+++ b/apps/public_www/scripts/inject-csp-meta.mjs
@@ -11,12 +11,19 @@ const CLOUDFLARE_INSIGHTS_SCRIPT_ORIGIN = 'https://static.cloudflareinsights.com
 const CLOUDFLARE_INSIGHTS_CONNECT_ORIGIN = 'https://cloudflareinsights.com';
 const API_BASE_URL_ENV_NAME = 'NEXT_PUBLIC_API_BASE_URL';
 
-const GTM_SCRIPT_ORIGINS = ['https://www.googletagmanager.com'];
+// GTM may load Google Ads / conversion tags; hosts align with Google Tag Platform CSP guidance.
+const GTM_SCRIPT_ORIGINS = [
+  'https://www.googletagmanager.com',
+  'https://googleads.g.doubleclick.net',
+  'https://www.googleadservices.com',
+];
 const GTM_CONNECT_ORIGINS = [
   'https://www.google-analytics.com',
   'https://analytics.google.com',
   'https://region1.google-analytics.com',
   'https://stats.g.doubleclick.net',
+  'https://www.google.com',
+  'https://googleads.g.doubleclick.net',
 ];
 const GTM_DETECT_MARKER = 'init-gtm.js';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the public website CSP injector so that when the build detects Google Tag Manager (`init-gtm.js`), `script-src` and `connect-src` also allow hosts used by Google Ads tags loaded through GTM (Doubleclick conversion scripts, `www.googleadservices.com`, and `www.google.com` / `googleads.g.doubleclick.net` for CCM and rmkt collection endpoints).

## Changes

- `apps/public_www/scripts/inject-csp-meta.mjs`: add origins to `GTM_SCRIPT_ORIGINS` and `GTM_CONNECT_ORIGINS`.
- `apps/public_www/README.md`: document the additional GTM-related CSP entries.

## Testing

- `npm run lint` in `apps/public_www` (passed).
- Full `npm run build` with CI-like `NEXT_PUBLIC_*` env vars (passed, including `csp:inject` and `csp:validate`).

## Notes

This does not address GTM dynamic inline script CSP violations; those remain a separate follow-up if tags still fail in the console after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8a732d5-6dbe-4b76-843b-8a170e0f1a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8a732d5-6dbe-4b76-843b-8a170e0f1a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

