### PR TITLE
Format landing page hero category chips from CRM categories

### DIFF
--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -257,6 +257,25 @@ function formatEnumLikeLabel(value: string): string {
     .join(' ');
 }
 
+/** Display labels for landing page hero category chips (CRM `categories` list). */
+function formatLandingPageCategoryChipLabel(value: string): string {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return '';
+  }
+
+  if (/^\d+\s*-\s*\d+$/.test(trimmedValue)) {
+    return trimmedValue.replace(/\s*-\s*/g, '-');
+  }
+
+  return trimmedValue
+    .split('-')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
 function sanitizeExternalHref(value: string | undefined): string {
   const href = readOptionalText(value);
   if (!href || !isHttpHref(href)) {
@@ -689,7 +708,9 @@ function readLandingPageCategoryChips(
     }
   }
 
-  return dedupeChipLabels(categories);
+  return dedupeChipLabels(
+    categories.map((entry) => formatLandingPageCategoryChipLabel(entry)),
+  );
 }
 
 function resolveDateTimeDetails(

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -525,6 +525,35 @@ describe('events-data', () => {
     });
   });
 
+  it('title-cases landing page hero category chips and splits hyphenated CRM categories', () => {
+    const heroEventContent = getLandingPageHeroEventContentFromPayload(
+      {
+        status: 'success',
+        data: [
+          {
+            slug: 'test-landing-category-chip-labels',
+            title: 'Test Event',
+            categories: ['workshop', 'training-course', '1-4'],
+            dates: [
+              {
+                start_datetime: '2026-01-01T12:00:00Z',
+                end_datetime: '2026-01-01T13:00:00Z',
+              },
+            ],
+          },
+        ],
+      },
+      'test-landing-category-chip-labels',
+    );
+
+    expect(heroEventContent).not.toBeNull();
+    expect(heroEventContent?.categoryChips).toEqual([
+      'Workshop',
+      'Training Course',
+      '1-4',
+    ]);
+  });
+
   it('resolves landing page booking payload from calendar payload using slug', () => {
     const bookingEventContent = getLandingPageBookingEventContentFromPayload(
       publicCalendarFixture,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Landing page hero chips are built from the calendar event `categories` list (`readLandingPageCategoryChips` in `events-data.ts`). Category strings from the API are often slug-like (`workshop`, `training-course`).

## Changes

- Added `formatLandingPageCategoryChipLabel`: split on `-`, trim each segment, title-case each word (first letter upper, rest lower), join with a space.
- Preserved numeric ranges matching `^\d+\s*-\s*\d+$` (e.g. `1-4`) unchanged, consistent with event tag handling.
- Applied formatting when building `categoryChips` so SSR and client refresh stay aligned.

## Tests

- New unit test in `events-data.test.ts` covering `workshop`, `training-course`, and `1-4`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb547aee-1185-4e53-90b1-a71f3b883588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb547aee-1185-4e53-90b1-a71f3b883588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

