### PR TITLE
Admin discount codes: service and instance select labels with tier/cohort

### DIFF
--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -31,8 +31,10 @@ import {
 import { formatDiscountRowValue } from '@/lib/discount-row-format';
 import {
   formatDate,
+  formatDiscountCodeInstanceOptionLabel,
   formatEnumLabel,
   formatIsoForDatetimeLocalInput,
+  formatServiceTitleWithTier,
   getCurrencyOptions,
   parseAdminDateTimeInputToIsoUtc,
 } from '@/lib/format';
@@ -465,7 +467,7 @@ export function DiscountCodesPanel({
               <option value=''>All services</option>
               {serviceSelectOptions.map((svc) => (
                 <option key={svc.id} value={svc.id}>
-                  {svc.title}
+                  {formatServiceTitleWithTier(svc.title, svc.serviceTier)}
                 </option>
               ))}
             </Select>
@@ -481,7 +483,7 @@ export function DiscountCodesPanel({
               <option value=''>All instances</option>
               {instances.map((inst) => (
                 <option key={inst.id} value={inst.id}>
-                  {inst.resolvedTitle ?? inst.title ?? inst.id}
+                  {formatDiscountCodeInstanceOptionLabel(inst)}
                 </option>
               ))}
             </Select>

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -12,14 +12,38 @@ import type {
 import adminSelectableCurrency from '@shared-config/admin-selectable-currency-codes.json';
 
 const SERVICE_TITLE_TIER_SEP = '\u00b7';
+const DISPLAY_PART_SEP = ` ${SERVICE_TITLE_TIER_SEP} `;
 
 /** Service list label: title, space, interpunct, space, tier when tier is set. */
 export function formatServiceTitleWithTier(title: string, serviceTier: string | null): string {
   const tier = serviceTier?.trim();
   if (tier) {
-    return `${title} ${SERVICE_TITLE_TIER_SEP} ${tier}`;
+    return `${title}${DISPLAY_PART_SEP}${tier}`;
   }
   return title;
+}
+
+/**
+ * Discount code editor — instance scope select: parent service title (or
+ * resolved/title fallback, then id), then optional parent tier and cohort,
+ * each separated by space + interpunct + space when present.
+ */
+export function formatDiscountCodeInstanceOptionLabel(instance: ServiceInstance): string {
+  const baseTitle =
+    instance.parentServiceTitle?.trim() ||
+    instance.resolvedTitle?.trim() ||
+    instance.title?.trim() ||
+    instance.id;
+  const tier = instance.parentServiceTier?.trim();
+  const cohort = instance.cohort?.trim();
+  let label = baseTitle;
+  if (tier) {
+    label = `${label}${DISPLAY_PART_SEP}${tier}`;
+  }
+  if (cohort) {
+    label = `${label}${DISPLAY_PART_SEP}${cohort}`;
+  }
+  return label;
 }
 
 /** Short user-visible label for a location (venue name, address, or id). */

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -10,6 +10,7 @@ import {
   formatInstanceTableTitle,
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
+  formatDiscountCodeInstanceOptionLabel,
   formatServiceTitleWithTier,
   formatSessionSlotStartsAtDisplay,
   getFirstSessionSlotForDisplay,
@@ -97,6 +98,86 @@ describe('format helpers', () => {
     expect(formatServiceTitleWithTier('Yoga', 'adults')).toBe('Yoga · adults');
     expect(formatServiceTitleWithTier('Yoga', null)).toBe('Yoga');
     expect(formatServiceTitleWithTier('Yoga', '  ')).toBe('Yoga');
+  });
+
+  it('formats discount code instance option label with optional tier and cohort', () => {
+    const base = (): ServiceInstance => ({
+      id: 'inst-uuid',
+      serviceId: 's1',
+      parentServiceTitle: 'Workshop',
+      parentServiceTier: null,
+      parentServiceType: 'training_course',
+      title: null,
+      slug: null,
+      description: null,
+      coverImageS3Key: null,
+      status: 'scheduled',
+      deliveryMode: null,
+      locationId: null,
+      maxCapacity: null,
+      waitlistEnabled: false,
+      externalUrl: null,
+      partnerOrganizations: [],
+      instructorId: null,
+      cohort: null,
+      notes: null,
+      tagIds: [],
+      createdBy: 'u',
+      createdAt: null,
+      updatedAt: null,
+      resolvedTitle: null,
+      resolvedSlug: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      resolvedLocationId: null,
+      sessionSlots: [],
+      trainingDetails: null,
+      resolvedTrainingDetails: null,
+      eventTicketTiers: [],
+      resolvedEventTicketTiers: [],
+      consultationDetails: null,
+      resolvedConsultationDetails: null,
+    });
+    expect(formatDiscountCodeInstanceOptionLabel(base())).toBe('Workshop');
+    expect(formatDiscountCodeInstanceOptionLabel({ ...base(), parentServiceTier: 'standard' })).toBe(
+      'Workshop · standard'
+    );
+    expect(formatDiscountCodeInstanceOptionLabel({ ...base(), cohort: 'March 2026' })).toBe(
+      'Workshop · March 2026'
+    );
+    expect(
+      formatDiscountCodeInstanceOptionLabel({
+        ...base(),
+        parentServiceTier: 'standard',
+        cohort: 'March 2026',
+      })
+    ).toBe('Workshop · standard · March 2026');
+    expect(
+      formatDiscountCodeInstanceOptionLabel({
+        ...base(),
+        parentServiceTitle: null,
+        resolvedTitle: 'Resolved only',
+        parentServiceTier: 't1',
+        cohort: 'c1',
+      })
+    ).toBe('Resolved only · t1 · c1');
+    expect(
+      formatDiscountCodeInstanceOptionLabel({
+        ...base(),
+        parentServiceTitle: null,
+        resolvedTitle: null,
+        title: 'Own title',
+      })
+    ).toBe('Own title');
+    expect(
+      formatDiscountCodeInstanceOptionLabel({
+        ...base(),
+        parentServiceTitle: null,
+        resolvedTitle: null,
+        title: null,
+      })
+    ).toBe('inst-uuid');
   });
 
   it('formats instance table title from own title or parent service title', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Service** scope dropdown on the discount codes editor now shows `formatServiceTitleWithTier` (title · tier when tier is set), matching other admin service labels.
- **Instance** scope dropdown uses new `formatDiscountCodeInstanceOptionLabel`: parent service title (fallback resolved title, own title, then id), then optional parent tier and cohort, each with the same spaced middle dot separator.

## Tests

- Extended `apps/admin_web/tests/lib/format.test.ts` for the new formatter.
- Existing discount panel tests still pass; `npm run lint` in `apps/admin_web` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c09f9a-aa99-4c82-b967-b430380e538c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c09f9a-aa99-4c82-b967-b430380e538c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

