### PR TITLE
Admin web: discount codes toolbar, status labels, remove archived toggle

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-discount-code-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-discount-code-dialog.tsx
@@ -116,9 +116,9 @@ export function CreateDiscountCodeDialog({
         />
       </div>
       <div>
-        <Label htmlFor='discount-active'>Active</Label>
+        <Label htmlFor='discount-status'>Status</Label>
         <Select
-          id='discount-active'
+          id='discount-status'
           value={active ? 'true' : 'false'}
           onChange={(event) => setActive(event.target.value === 'true')}
         >

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -86,8 +86,6 @@ export interface DiscountCodesPanelProps {
   serviceDirectoryForDisplay?: ServiceSummary[];
   /** Bumps to clear cached instance options after mutations. */
   instanceOptionsRefreshKey?: unknown;
-  showArchivedServices?: boolean;
-  onShowArchivedChange?: (value: boolean) => void;
   onFilterChange: <TKey extends keyof DiscountCodeFilters>(
     key: TKey,
     value: DiscountCodeFilters[TKey]
@@ -117,8 +115,6 @@ export function DiscountCodesPanel({
   serviceOptions = [],
   serviceDirectoryForDisplay,
   instanceOptionsRefreshKey,
-  showArchivedServices = false,
-  onShowArchivedChange,
   onFilterChange,
   onLoadMore,
   onCreate,
@@ -519,9 +515,9 @@ export function DiscountCodesPanel({
             <Input id='discount-max-uses' value={maxUses} onChange={(event) => setMaxUses(event.target.value)} />
           </div>
           <div>
-            <Label htmlFor='discount-active'>Active</Label>
+            <Label htmlFor='discount-status'>Status</Label>
             <Select
-              id='discount-active'
+              id='discount-status'
               value={active ? 'true' : 'false'}
               onChange={(event) => setActive(event.target.value === 'true')}
             >
@@ -551,6 +547,15 @@ export function DiscountCodesPanel({
         onLoadMore={onLoadMore}
         toolbar={
           <div className='mb-3 flex flex-wrap items-end gap-3'>
+            <div className='min-w-[200px] flex-1'>
+              <Label htmlFor='discount-filter-search'>Search</Label>
+              <Input
+                id='discount-filter-search'
+                value={filters.search}
+                onChange={(event) => onFilterChange('search', event.target.value)}
+                placeholder='Code'
+              />
+            </div>
             <div className='min-w-[140px]'>
               <Label htmlFor='discount-filter-active'>Status</Label>
               <Select
@@ -559,8 +564,8 @@ export function DiscountCodesPanel({
                 onChange={(event) => onFilterChange('active', event.target.value as DiscountCodeFilters['active'])}
               >
                 <option value=''>All</option>
-                <option value='true'>Active</option>
-                <option value='false'>Inactive</option>
+                <option value='true'>Enabled</option>
+                <option value='false'>Disabled</option>
               </Select>
             </div>
             <div className='min-w-[180px]'>
@@ -578,29 +583,6 @@ export function DiscountCodesPanel({
                 <option value='instance'>Instance-scoped</option>
               </Select>
             </div>
-            <div className='min-w-[200px] flex-1'>
-              <Label htmlFor='discount-filter-search'>Search</Label>
-              <Input
-                id='discount-filter-search'
-                value={filters.search}
-                onChange={(event) => onFilterChange('search', event.target.value)}
-                placeholder='Code'
-              />
-            </div>
-            {onShowArchivedChange ? (
-              <div className='flex min-w-[140px] items-center gap-2 pt-6'>
-                <input
-                  id='discount-filter-archived'
-                  type='checkbox'
-                  className='h-4 w-4 rounded border-slate-300 text-slate-900'
-                  checked={showArchivedServices}
-                  onChange={(event) => onShowArchivedChange(event.target.checked)}
-                />
-                <Label htmlFor='discount-filter-archived' className='cursor-pointer font-normal'>
-                  Show archived
-                </Label>
-              </div>
-            ) : null}
           </div>
         }
       >

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -26,7 +26,6 @@ import { ServicesHeader } from './services-header';
 
 export function ServicesPage() {
   const state = useServicesPage();
-  const [showArchivedDiscountServices, setShowArchivedDiscountServices] = useState(false);
   const [duplicateServiceTemplate, setDuplicateServiceTemplate] = useState<ServiceDetail | null>(null);
   const [duplicateInstanceTemplate, setDuplicateInstanceTemplate] = useState<ServiceInstance | null>(null);
   const [servicesEditorRemountKey, setServicesEditorRemountKey] = useState(0);
@@ -73,12 +72,7 @@ export function ServicesPage() {
     [state]
   );
   const allServiceOptionsIncludingArchived = state.serviceList.services;
-  const pickerServiceOptions = useMemo(() => {
-    if (showArchivedDiscountServices) {
-      return allServiceOptionsIncludingArchived;
-    }
-    return allServiceOptionsIncludingArchived.filter((svc) => svc.status !== 'archived');
-  }, [showArchivedDiscountServices, allServiceOptionsIncludingArchived]);
+  const pickerServiceOptions = allServiceOptionsIncludingArchived;
   const normalizedInstanceSearch = state.instancesSearchQuery.trim().toLowerCase();
   const instanceSearchLocationById = useMemo(
     () => new Map(state.locationList.locations.map((loc) => [loc.id, loc])),
@@ -374,8 +368,6 @@ export function ServicesPage() {
           serviceOptions={pickerServiceOptions}
           serviceDirectoryForDisplay={allServiceOptionsIncludingArchived}
           instanceOptionsRefreshKey={state.instanceOptionsCacheVersion}
-          showArchivedServices={showArchivedDiscountServices}
-          onShowArchivedChange={setShowArchivedDiscountServices}
           onFilterChange={state.discountCodes.setFilter}
           onLoadMore={state.discountCodes.loadMore}
           onCreate={(payload, options) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Discount codes table toolbar:** Order is now Search → Status → Scope. Status filter keeps **All**; option labels are **Enabled** / **Disabled** (query params unchanged).
- **Inline editor (and create dialog):** Field label is **Status** with `id="discount-status"` / matching `htmlFor` (replacing `discount-active`).
- **Show archived:** Removed. Archived services are always included in the service picker and scope labels (`pickerServiceOptions` now uses the full service list), so codes tied to archived services stay visible and editable without a separate toggle.

## Testing

- `npm run lint` (admin_web)
- `npx vitest run tests/components/admin/services/discount-codes-panel.test.tsx tests/components/admin/services/services-page.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc45b150-2c36-4c23-917c-7dfe61f28849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc45b150-2c36-4c23-917c-7dfe61f28849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

