### PR TITLE
Admin web: merge instances table tier and cohort column

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -17,9 +17,11 @@ import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import {
   formatEnumLabel,
   formatInstanceSlotLocationSummary,
+  formatInstanceTableTierCohort,
   formatInstanceTableTitle,
   formatSessionSlotStartsAtDisplay,
   getFirstSessionSlotForDisplay,
+  INSTANCE_TABLE_TIER_COHORT_HEADER,
 } from '@/lib/format';
 
 import type { LocationSummary, ServiceInstance, ServiceType } from '@/types/services';
@@ -58,7 +60,7 @@ export interface InstanceListPanelProps {
     value: string;
     onChange: (value: string) => void;
   };
-  /** When true, add cross-service columns (title, tier, cohort, locations, first slot) before status. */
+  /** When true, add cross-service columns (title, tier · cohort, locations, first slot) before status. */
   showServiceColumn?: boolean;
   /** Resolve location ids for the locations column (optional; ids shown when unknown). */
   locationOptions?: LocationSummary[];
@@ -199,10 +201,7 @@ export function InstanceListPanel({
                 <th className='w-[20%] px-4 py-3 font-semibold'>Title</th>
               ) : null}
               {showServiceColumn ? (
-                <th className='px-4 py-3 font-semibold'>Tier</th>
-              ) : null}
-              {showServiceColumn ? (
-                <th className='px-4 py-3 font-semibold'>Cohort</th>
+                <th className='max-w-[14rem] px-4 py-3 font-semibold'>{INSTANCE_TABLE_TIER_COHORT_HEADER}</th>
               ) : null}
               {showServiceColumn ? (
                 <th className='px-4 py-3 font-semibold'>Locations</th>
@@ -218,8 +217,7 @@ export function InstanceListPanel({
           <AdminDataTableBody>
             {instances.map((instance) => {
               const instanceTableTitle = formatInstanceTableTitle(instance);
-              const tierDisplay = instance.parentServiceTier?.trim() ?? '';
-              const cohortDisplay = instance.cohort?.trim() ?? '';
+              const tierCohortDisplay = formatInstanceTableTierCohort(instance);
               const firstSlot = getFirstSessionSlotForDisplay(instance.sessionSlots);
               return (
                 <tr
@@ -239,13 +237,8 @@ export function InstanceListPanel({
                     </td>
                   ) : null}
                   {showServiceColumn ? (
-                    <td className='max-w-[10rem] min-w-0 break-words px-4 py-3 text-sm'>
-                      {tierDisplay !== '' ? tierDisplay : '-'}
-                    </td>
-                  ) : null}
-                  {showServiceColumn ? (
-                    <td className='max-w-[12rem] min-w-0 break-words px-4 py-3 text-sm'>
-                      {cohortDisplay !== '' ? cohortDisplay : '-'}
+                    <td className='max-w-[14rem] min-w-0 break-words px-4 py-3 text-sm'>
+                      {tierCohortDisplay !== '' ? tierCohortDisplay : '-'}
                     </td>
                   ) : null}
                   {showServiceColumn ? (

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -80,8 +80,10 @@ export function formatInstanceTableTitle(instance: ServiceInstance): string {
 export const INSTANCE_TABLE_TIER_COHORT_HEADER = `Tier${DISPLAY_PART_SEP}Cohort`;
 
 /**
- * Instances table: parent service tier and cohort joined by space + interpunct + space when both are set;
- * otherwise the single non-empty part; empty when neither is set (show placeholder in UI).
+ * Instances table: parent service tier and cohort.
+ * Uses space + interpunct + space only when both tier and cohort are non-empty after trim.
+ * If only one is present, returns that value alone (no interpunct).
+ * Returns empty string when neither is present (UI should show a single placeholder dash).
  */
 export function formatInstanceTableTierCohort(instance: ServiceInstance): string {
   const tier = instance.parentServiceTier?.trim() ?? '';

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -67,13 +67,35 @@ export function formatInstanceLocationOptionLabel(location: LocationSummary): st
   return formatLocationLabel(location);
 }
 
-/** Instances table: instance title when set, otherwise parent service title only (no tier; tier has its own column). */
+/** Instances table: instance title when set, otherwise parent service title only (tier/cohort use {@link formatInstanceTableTierCohort}). */
 export function formatInstanceTableTitle(instance: ServiceInstance): string {
   const own = instance.title?.trim();
   if (own) {
     return own;
   }
   return instance.parentServiceTitle?.trim() ?? '';
+}
+
+/** Column header for the instances table tier + cohort column (space, interpunct, space between words). */
+export const INSTANCE_TABLE_TIER_COHORT_HEADER = `Tier${DISPLAY_PART_SEP}Cohort`;
+
+/**
+ * Instances table: parent service tier and cohort joined by space + interpunct + space when both are set;
+ * otherwise the single non-empty part; empty when neither is set (show placeholder in UI).
+ */
+export function formatInstanceTableTierCohort(instance: ServiceInstance): string {
+  const tier = instance.parentServiceTier?.trim() ?? '';
+  const cohort = instance.cohort?.trim() ?? '';
+  if (tier && cohort) {
+    return `${tier}${DISPLAY_PART_SEP}${cohort}`;
+  }
+  if (tier) {
+    return tier;
+  }
+  if (cohort) {
+    return cohort;
+  }
+  return '';
 }
 
 /** Full venue label: address (when present) plus geographic area name. */

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -256,6 +256,71 @@ describe('services tables value formatting', () => {
     expect(currencySelect).toBeDisabled();
   });
 
+  it('merges tier and cohort in instances table: interpunct only when both set, else single dash when empty', () => {
+    render(
+      <InstanceListPanel
+        instances={[
+          {
+            ...INSTANCE_FIXTURE,
+            title: 'A',
+            parentServiceTier: 'only-tier',
+            cohort: null,
+          },
+          {
+            ...INSTANCE_FIXTURE,
+            id: 'instance-2',
+            title: 'B',
+            parentServiceTier: null,
+            cohort: 'only-cohort',
+          },
+          {
+            ...INSTANCE_FIXTURE,
+            id: 'instance-3',
+            title: 'C',
+            parentServiceTier: 't1',
+            cohort: 'c1',
+          },
+          {
+            ...INSTANCE_FIXTURE,
+            id: 'instance-4',
+            title: 'D',
+            parentServiceTier: null,
+            cohort: null,
+          },
+        ]}
+        selectedInstanceId={null}
+        isLoading={false}
+        isLoadingMore={false}
+        hasMore={false}
+        error=''
+        isMutating={false}
+        onSelectInstance={vi.fn()}
+        onLoadMore={vi.fn()}
+        onDuplicateInstance={vi.fn()}
+        onDeleteInstance={vi.fn()}
+        showServiceColumn
+      />
+    );
+
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('Tier \u00b7 Cohort')).toBeInTheDocument();
+    expect(within(table).getByText('only-tier')).toBeInTheDocument();
+    expect(within(table).getByText('only-cohort')).toBeInTheDocument();
+    expect(within(table).getByText('t1 \u00b7 c1')).toBeInTheDocument();
+
+    const tierCohortColumnIndex = 1;
+    const rowFor = (title: string) => {
+      const titleCell = within(table).getByText(title);
+      const row = titleCell.closest('tr');
+      expect(row).toBeTruthy();
+      return within(row as HTMLElement).getAllByRole('cell');
+    };
+    expect(rowFor('A')[tierCohortColumnIndex].textContent).toBe('only-tier');
+    expect(rowFor('B')[tierCohortColumnIndex].textContent).toBe('only-cohort');
+    expect(rowFor('C')[tierCohortColumnIndex].textContent).toBe('t1 \u00b7 c1');
+    expect(rowFor('D')[tierCohortColumnIndex].textContent).toBe('-');
+  });
+
   it('formats enum and date values in enrollment table rows', () => {
     render(
       <EnrollmentListPanel

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -7,7 +7,9 @@ import {
   formatDateOnly,
   formatEnumLabel,
   formatInstanceSlotLocationSummary,
+  formatInstanceTableTierCohort,
   formatInstanceTableTitle,
+  INSTANCE_TABLE_TIER_COHORT_HEADER,
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
   formatDiscountCodeInstanceOptionLabel,
@@ -252,6 +254,64 @@ describe('format helpers', () => {
         parentServiceTitle: null,
         parentServiceTier: null,
         cohort: 'spring-2024',
+      })
+    ).toBe('');
+  });
+
+  it('formats instance table tier and cohort with interpunct when both are set', () => {
+    const base = (): ServiceInstance => ({
+      id: 'i1',
+      serviceId: 's1',
+      parentServiceTitle: 'Parent',
+      parentServiceTier: 'tier-a',
+      parentServiceType: 'training_course',
+      title: null,
+      slug: null,
+      description: null,
+      coverImageS3Key: null,
+      status: 'scheduled',
+      deliveryMode: null,
+      locationId: null,
+      maxCapacity: null,
+      waitlistEnabled: false,
+      externalUrl: null,
+      partnerOrganizations: [],
+      instructorId: null,
+      cohort: null,
+      notes: null,
+      tagIds: [],
+      createdBy: 'u',
+      createdAt: null,
+      updatedAt: null,
+      resolvedTitle: 'Resolved',
+      resolvedSlug: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      resolvedLocationId: null,
+      sessionSlots: [],
+      trainingDetails: null,
+      resolvedTrainingDetails: null,
+      eventTicketTiers: [],
+      resolvedEventTicketTiers: [],
+      consultationDetails: null,
+      resolvedConsultationDetails: null,
+    });
+    expect(INSTANCE_TABLE_TIER_COHORT_HEADER).toBe('Tier \u00b7 Cohort');
+    expect(formatInstanceTableTierCohort(base())).toBe('tier-a');
+    expect(formatInstanceTableTierCohort({ ...base(), cohort: 'spring-2024' })).toBe('tier-a \u00b7 spring-2024');
+    expect(
+      formatInstanceTableTierCohort({
+        ...base(),
+        parentServiceTier: null,
+        cohort: '  spring-2024  ',
+      })
+    ).toBe('spring-2024');
+    expect(
+      formatInstanceTableTierCohort({
+        ...base(),
+        parentServiceTier: '  ',
+        cohort: null,
       })
     ).toBe('');
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Services **Instances** table (cross-service view with `showServiceColumn`) previously had separate **Tier** and **Cohort** columns. They are merged into a single column whose header is **Tier · Cohort** (space + interpunct + space).

**Cell values:** interpunct appears only when **both** tier and cohort are non-empty after trim. If only one is set, that value alone is shown (no interpunct). If neither is set, a **single** `-` is shown.

## Changes

- `instance-list-panel.tsx`: one column; cell uses `formatInstanceTableTierCohort` and `-` when the formatter returns empty.
- `format.ts`: `formatInstanceTableTierCohort()`, `INSTANCE_TABLE_TIER_COHORT_HEADER`, and docstring describing the rules above.
- `format.test.ts`: unit tests for the formatter.
- `table-value-formatting.test.tsx`: component test for tier-only, cohort-only, both, and empty rows.

## Testing

- `npm run test -- tests/lib/format.test.ts tests/components/admin/services/table-value-formatting.test.tsx`
- `npm run lint` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-866c2dd1-c5bd-4ae1-9b42-3b462d46303d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-866c2dd1-c5bd-4ae1-9b42-3b462d46303d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

