### PR TITLE
Remove Reset to suggestion from instance slug editor

### DIFF
--- a/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
+++ b/apps/admin_web/src/components/admin/services/create-instance-dialog.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
-import { Button } from '@/components/ui/button';
 import { FormDialog } from '@/components/ui/form-dialog';
 
 import { buildSessionSlotsUtcPayload } from '@/lib/format';
@@ -182,21 +181,6 @@ export function CreateInstanceDialog({
   };
 
   const slugFieldMode = serviceType === 'consultation' ? 'optional' : 'required';
-  const slugAccessory =
-    serviceType === 'event' || serviceType === 'training_course' ? (
-      <Button
-        type='button'
-        variant='secondary'
-        className='text-xs'
-        onClick={() => {
-          slugTouchedRef.current = false;
-          setInstanceForm((prev) => ({ ...prev, slug: suggestedSlug.trim().toLowerCase() }));
-          setSlugSubmitError('');
-        }}
-      >
-        Reset to suggestion
-      </Button>
-    ) : null;
 
   return (
     <FormDialog
@@ -219,7 +203,6 @@ export function CreateInstanceDialog({
         }}
         slugFieldMode={slugFieldMode}
         slugFieldError={slugSubmitError}
-        slugFieldAccessory={slugAccessory}
       />
       {serviceType === 'training_course' ? (
         <div className='mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2'>

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -645,25 +645,6 @@ export function InstanceDetailPanel({
   const slugFieldMode =
     effectiveServiceType === 'consultation' ? 'optional' : 'required';
   const slugFieldError = [slugSubmitError, slugConflictError].filter(Boolean).join(' ');
-  const slugFieldAccessory =
-    !instance && (effectiveServiceType === 'event' || effectiveServiceType === 'training_course') ? (
-      <Button
-        type='button'
-        variant='secondary'
-        className='text-xs'
-        onClick={() => {
-          createSlugTouchedRef.current = false;
-          setSlugConflictError('');
-          setSlugSubmitError('');
-          setInstanceForm((prev) => ({
-            ...prev,
-            slug: suggestedCreateSlug.trim().toLowerCase(),
-          }));
-        }}
-      >
-        Reset to suggestion
-      </Button>
-    ) : null;
 
   const runCreate = async () => {
     if (!selectedServiceId) {
@@ -778,7 +759,6 @@ export function InstanceDetailPanel({
         }}
         slugFieldMode={slugFieldMode}
         slugFieldError={slugFieldError}
-        slugFieldAccessory={slugFieldAccessory}
       />
 
       {effectiveServiceType === 'training_course' ? (

--- a/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-form-fields.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import type { ReactNode } from 'react';
-
 import { WarningTriangleIcon } from '@/components/icons/action-icons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -63,8 +61,6 @@ export interface InstanceFormFieldsProps {
   slugFieldMode?: 'required' | 'optional';
   /** Inline message under the slug field (for example submit validation or API field errors). */
   slugFieldError?: string;
-  /** Optional control rendered under the slug input (for example “Reset to suggestion”). */
-  slugFieldAccessory?: ReactNode;
 }
 
 function getInstructorOptionLabel(entry: InstanceInstructorOption): string {
@@ -132,7 +128,6 @@ export function InstanceFormFields({
   onChange,
   slugFieldMode = 'optional',
   slugFieldError = '',
-  slugFieldAccessory = null,
 }: InstanceFormFieldsProps) {
   const canSelectService = Boolean(onSelectService);
   const serviceExists = serviceOptions.some((entry) => entry.id === serviceId);
@@ -264,7 +259,6 @@ export function InstanceFormFields({
           placeholder='e.g. spring-workshop-2026-04-20'
           autoComplete='off'
         />
-        {slugFieldAccessory ? <div className='mt-1'>{slugFieldAccessory}</div> : null}
         {slugPatternInvalid ? (
           <p className='mt-1 text-xs text-red-600'>
             Use lowercase letters, digits, and single hyphens between segments (no leading or trailing hyphen).

--- a/apps/admin_web/tests/components/admin/services/create-instance-dialog.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/create-instance-dialog.test.tsx
@@ -189,11 +189,6 @@ describe('CreateInstanceDialog', () => {
     await user.clear(screen.getByLabelText('Title'));
     await user.type(screen.getByLabelText('Title'), 'Ignored');
     expect(slugInput).toHaveValue('custom-slug');
-
-    await user.click(screen.getByRole('button', { name: /reset to suggestion/i }));
-    await waitFor(() => {
-      expect(slugInput.value).not.toBe('custom-slug');
-    });
   });
 
   it('shows inline error when event slug is empty on submit', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Reset to suggestion** control from the admin Services instance slug field.

## Changes

- **Instance inline editor** (`InstanceDetailPanel`): removed the button that reset the create slug to the computed suggestion and cleared slug errors.
- **Create instance dialog**: removed the same control for consistency (dialog is not the main inline editor but shared the pattern).
- **`InstanceFormFields`**: removed the `slugFieldAccessory` prop and the optional slot under the slug input.
- **Tests**: updated `create-instance-dialog` test to stop clicking the removed button; the test still covers auto-slug behavior and manual slug override.

Slug auto-suggestion from title/session slots (when the user has not manually edited the slug) is unchanged.

## Validation

- `npx vitest run tests/components/admin/services/create-instance-dialog.test.tsx tests/components/admin/services/instance-detail-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acb830cd-1fe0-490b-b958-198f96a077fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acb830cd-1fe0-490b-b958-198f96a077fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

