### PR TITLE
Admin web: discount codes table scope matches editor labels

### DIFF
--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -19,6 +19,7 @@ import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import { useServiceInstanceOptions } from '@/hooks/use-service-instance-options';
 import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
 import { tryCopyTextToClipboard } from '@/lib/clipboard';
+import { listInstances } from '@/lib/services-api';
 import {
   bumpDuplicateDiscountCode,
   DISCOUNT_CODE_ALLOCATION_FAILED_MESSAGE,
@@ -32,6 +33,7 @@ import { formatDiscountRowValue } from '@/lib/discount-row-format';
 import {
   formatDate,
   formatDiscountCodeInstanceOptionLabel,
+  formatDiscountCodeScopeSummary,
   formatEnumLabel,
   formatIsoForDatetimeLocalInput,
   formatServiceTitleWithTier,
@@ -46,33 +48,9 @@ import {
   REFERRAL_DEFAULT_CURRENCY,
   REFERRAL_DEFAULT_DISCOUNT_VALUE,
 } from '@/types/services';
-import type { DiscountCode, DiscountCodeFilters, DiscountType, ServiceSummary } from '@/types/services';
+import type { DiscountCode, DiscountCodeFilters, DiscountType, ServiceInstance, ServiceSummary } from '@/types/services';
 
 type ApiSchemas = components['schemas'];
-
-function formatScopeSummary(row: DiscountCode, serviceById: Map<string, ServiceSummary>): string {
-  if (!row.serviceId && !row.instanceId) {
-    return 'All services';
-  }
-  let title: string;
-  if (!row.serviceId) {
-    title = 'Service';
-  } else {
-    const svc = serviceById.get(row.serviceId);
-    if (!svc) {
-      title = 'Service (unknown)';
-    } else if (svc.status === 'archived') {
-      title = svc.title?.trim() ? `${svc.title.trim()} (archived)` : 'Service (archived)';
-    } else {
-      title = svc.title;
-    }
-  }
-  if (row.instanceId) {
-    const short = row.instanceId.replace(/-/g, '').slice(0, 8);
-    return `${title} · instance ${short}`;
-  }
-  return title;
-}
 
 export interface DiscountCodesPanelProps {
   codes: DiscountCode[];
@@ -161,6 +139,73 @@ export function DiscountCodesPanel({
     }
     return map;
   }, [directoryList]);
+
+  const scopeInstanceFetchKey = useMemo(() => {
+    const keys: string[] = [];
+    for (const row of codes) {
+      const sid = row.serviceId?.trim();
+      const iid = row.instanceId?.trim();
+      if (sid && iid) {
+        keys.push(`${sid}:${iid}`);
+      }
+    }
+    keys.sort();
+    return keys.join('|');
+  }, [codes]);
+
+  const [scopeInstanceById, setScopeInstanceById] = useState<Map<string, ServiceInstance>>(() => new Map());
+
+  useEffect(() => {
+    if (!scopeInstanceFetchKey) {
+      setScopeInstanceById(new Map());
+      return;
+    }
+    let cancelled = false;
+    const byService = new Map<string, Set<string>>();
+    for (const pair of scopeInstanceFetchKey.split('|')) {
+      const colon = pair.indexOf(':');
+      if (colon <= 0) {
+        continue;
+      }
+      const sid = pair.slice(0, colon).trim();
+      const iid = pair.slice(colon + 1).trim();
+      if (!sid || !iid) {
+        continue;
+      }
+      let set = byService.get(sid);
+      if (!set) {
+        set = new Set();
+        byService.set(sid, set);
+      }
+      set.add(iid);
+    }
+    void (async () => {
+      const out = new Map<string, ServiceInstance>();
+      await Promise.all(
+        [...byService.entries()].map(async ([serviceId, instanceIds]) => {
+          try {
+            const { items } = await listInstances(serviceId, { limit: 100 });
+            if (cancelled) {
+              return;
+            }
+            for (const inst of items) {
+              if (instanceIds.has(inst.id)) {
+                out.set(inst.id, inst);
+              }
+            }
+          } catch {
+            /* scope column falls back to id-only label when fetch fails */
+          }
+        })
+      );
+      if (!cancelled) {
+        setScopeInstanceById(out);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [scopeInstanceFetchKey]);
 
   /** “Applies to service” picker: published only, plus current selection if not published (edit legacy rows). */
   const serviceSelectOptions = useMemo(() => {
@@ -611,7 +656,9 @@ export function DiscountCodesPanel({
                 onClick={() => applyCodeSelection(row)}
               >
                 <td className='px-4 py-3'>{row.code}</td>
-                <td className='px-4 py-3 text-sm text-slate-700'>{formatScopeSummary(row, serviceById)}</td>
+                <td className='px-4 py-3 text-sm text-slate-700'>
+                  {formatDiscountCodeScopeSummary(row, serviceById, scopeInstanceById)}
+                </td>
                 <td className='px-4 py-3'>{formatDate(row.validFrom)}</td>
                 <td className='px-4 py-3'>{formatDate(row.validUntil)}</td>
                 <td className='px-4 py-3'>{formatDiscountRowValue(row)}</td>

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -2,6 +2,7 @@ import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { formatAmountInCurrency } from '@/lib/vendor-spend';
 import { CLIENT_DOCUMENT_ASSET_TAG, EXPENSE_ATTACHMENT_ASSET_TAG } from '@/types/assets';
 import type {
+  DiscountCode,
   LocationSummary,
   ServiceInstance,
   ServiceSummary,
@@ -23,12 +24,10 @@ export function formatServiceTitleWithTier(title: string, serviceTier: string | 
   return title;
 }
 
-/**
- * Discount code editor — instance scope select: instance `title` when set,
- * otherwise parent service title, then resolved title, then id; then optional
- * parent tier and cohort, each separated by space + interpunct + space when present.
- */
-export function formatDiscountCodeInstanceOptionLabel(instance: ServiceInstance): string {
+/** Title + optional tier + cohort for discount instance scope (editor select and table). */
+export function formatDiscountCodeInstanceScopeLabel(
+  instance: Pick<ServiceInstance, 'id' | 'title' | 'parentServiceTitle' | 'resolvedTitle' | 'parentServiceTier' | 'cohort'>
+): string {
   const baseTitle =
     instance.title?.trim() ||
     instance.parentServiceTitle?.trim() ||
@@ -44,6 +43,65 @@ export function formatDiscountCodeInstanceOptionLabel(instance: ServiceInstance)
     label = `${label}${DISPLAY_PART_SEP}${cohort}`;
   }
   return label;
+}
+
+/**
+ * Discount code editor — instance scope select: instance `title` when set,
+ * otherwise parent service title, then resolved title, then id; then optional
+ * parent tier and cohort, each separated by space + interpunct + space when present.
+ */
+export function formatDiscountCodeInstanceOptionLabel(instance: ServiceInstance): string {
+  return formatDiscountCodeInstanceScopeLabel(instance);
+}
+
+/** Discount codes table — scope column: same labels as the editor service/instance pickers. */
+export function formatDiscountCodeScopeSummary(
+  row: DiscountCode,
+  serviceById: Map<string, ServiceSummary>,
+  instanceById: ReadonlyMap<string, ServiceInstance>
+): string {
+  if (!row.serviceId && !row.instanceId) {
+    return 'All services';
+  }
+  const serviceId = row.serviceId?.trim() ?? '';
+  const instanceId = row.instanceId?.trim() ?? '';
+
+  if (instanceId) {
+    const resolved = instanceById.get(instanceId);
+    if (resolved) {
+      return formatDiscountCodeInstanceScopeLabel(resolved);
+    }
+    if (serviceId) {
+      const svc = serviceById.get(serviceId);
+      if (svc) {
+        return formatDiscountCodeInstanceScopeLabel({
+          id: instanceId,
+          title: null,
+          parentServiceTitle: svc.title?.trim() ? svc.title : null,
+          resolvedTitle: null,
+          parentServiceTier: svc.serviceTier,
+          cohort: null,
+        });
+      }
+    }
+    return formatDiscountCodeInstanceScopeLabel({
+      id: instanceId,
+      title: null,
+      parentServiceTitle: null,
+      resolvedTitle: null,
+      parentServiceTier: null,
+      cohort: null,
+    });
+  }
+
+  if (!serviceId) {
+    return 'Service';
+  }
+  const svc = serviceById.get(serviceId);
+  if (!svc) {
+    return 'Service (unknown)';
+  }
+  return formatServiceTitleWithTier(svc.title, svc.serviceTier);
 }
 
 /** Short user-visible label for a location (venue name, address, or id). */

--- a/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/discount-codes-panel.test.tsx
@@ -142,7 +142,7 @@ describe('DiscountCodesPanel', () => {
     expect(screen.getByRole('button', { name: 'Link and QR' })).toBeInTheDocument();
   });
 
-  it('shows archived service title in Scope while picker omits archived services', () => {
+  it('shows archived service title in Scope (editor-aligned, no suffix) while picker omits archived services', () => {
     const archived = {
       ...baseService,
       id: 'svc-archived',
@@ -187,7 +187,7 @@ describe('DiscountCodesPanel', () => {
       />,
     );
 
-    expect(screen.getByText('MBA Archived (archived)')).toBeInTheDocument();
+    expect(screen.getByText('MBA Archived')).toBeInTheDocument();
     const serviceSelect = screen.getByLabelText('Applies to service') as HTMLSelectElement;
     expect(
       [...serviceSelect.options].some((opt) => opt.textContent?.includes('MBA Archived')),

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -13,6 +13,8 @@ import {
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
   formatDiscountCodeInstanceOptionLabel,
+  formatDiscountCodeInstanceScopeLabel,
+  formatDiscountCodeScopeSummary,
   formatServiceTitleWithTier,
   formatSessionSlotStartsAtDisplay,
   getFirstSessionSlotForDisplay,
@@ -27,7 +29,7 @@ import {
   parseDatetimeLocalToIsoUtc,
   sessionSlotApiTimesToFormLocals,
 } from '@/lib/format';
-import type { ServiceInstance, ServiceSummary, SessionSlot } from '@/types/services';
+import type { DiscountCode, ServiceInstance, ServiceSummary, SessionSlot } from '@/types/services';
 
 function baseSummary(overrides: Partial<ServiceSummary> = {}): ServiceSummary {
   return {
@@ -195,6 +197,137 @@ describe('format helpers', () => {
         title: null,
       })
     ).toBe('inst-uuid');
+  });
+
+  it('formats discount code instance scope label same as option label helper', () => {
+    const inst: ServiceInstance = {
+      id: 'i1',
+      serviceId: 's1',
+      parentServiceTitle: 'P',
+      parentServiceTier: 't',
+      parentServiceType: 'training_course',
+      title: 'Own',
+      slug: null,
+      description: null,
+      coverImageS3Key: null,
+      status: 'scheduled',
+      deliveryMode: null,
+      locationId: null,
+      maxCapacity: null,
+      waitlistEnabled: false,
+      externalUrl: null,
+      partnerOrganizations: [],
+      instructorId: null,
+      cohort: 'c',
+      notes: null,
+      tagIds: [],
+      createdBy: 'u',
+      createdAt: null,
+      updatedAt: null,
+      resolvedTitle: null,
+      resolvedSlug: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      resolvedLocationId: null,
+      sessionSlots: [],
+      trainingDetails: null,
+      resolvedTrainingDetails: null,
+      eventTicketTiers: [],
+      resolvedEventTicketTiers: [],
+      consultationDetails: null,
+      resolvedConsultationDetails: null,
+    };
+    expect(formatDiscountCodeInstanceScopeLabel(inst)).toBe(formatDiscountCodeInstanceOptionLabel(inst));
+  });
+
+  it('formats discount code scope summary for table (editor-aligned service and instance)', () => {
+    const svc = baseSummary({ id: 'svc-1', title: 'Yoga', serviceTier: 'adults' });
+    const serviceById = new Map<string, ServiceSummary>([[svc.id, svc]]);
+    const emptyInstances = new Map<string, ServiceInstance>();
+
+    const unscoped: DiscountCode = {
+      id: 'd0',
+      code: 'ALL',
+      description: null,
+      discountType: 'percentage',
+      discountValue: '5',
+      currency: 'HKD',
+      validFrom: null,
+      validUntil: null,
+      serviceId: null,
+      instanceId: null,
+      maxUses: null,
+      currentUses: 0,
+      active: true,
+      createdBy: 'u',
+      createdAt: null,
+      updatedAt: null,
+    };
+    expect(formatDiscountCodeScopeSummary(unscoped, serviceById, emptyInstances)).toBe('All services');
+
+    const serviceOnly: DiscountCode = { ...unscoped, id: 'd1', serviceId: 'svc-1' };
+    expect(formatDiscountCodeScopeSummary(serviceOnly, serviceById, emptyInstances)).toBe('Yoga · adults');
+
+    const unknownService: DiscountCode = { ...unscoped, id: 'd2', serviceId: 'missing' };
+    expect(formatDiscountCodeScopeSummary(unknownService, serviceById, emptyInstances)).toBe('Service (unknown)');
+
+    const inst: ServiceInstance = {
+      id: 'inst-1',
+      serviceId: 'svc-1',
+      parentServiceTitle: 'Yoga',
+      parentServiceTier: 'adults',
+      parentServiceType: 'training_course',
+      title: 'Spring',
+      slug: null,
+      description: null,
+      coverImageS3Key: null,
+      status: 'scheduled',
+      deliveryMode: null,
+      locationId: null,
+      maxCapacity: null,
+      waitlistEnabled: false,
+      externalUrl: null,
+      partnerOrganizations: [],
+      instructorId: null,
+      cohort: 'March',
+      notes: null,
+      tagIds: [],
+      createdBy: 'u',
+      createdAt: null,
+      updatedAt: null,
+      resolvedTitle: null,
+      resolvedSlug: null,
+      resolvedDescription: null,
+      resolvedCoverImageS3Key: null,
+      resolvedDeliveryMode: null,
+      resolvedLocationId: null,
+      sessionSlots: [],
+      trainingDetails: null,
+      resolvedTrainingDetails: null,
+      eventTicketTiers: [],
+      resolvedEventTicketTiers: [],
+      consultationDetails: null,
+      resolvedConsultationDetails: null,
+    };
+    const instanceById = new Map<string, ServiceInstance>([[inst.id, inst]]);
+    const instanceScoped: DiscountCode = {
+      ...unscoped,
+      id: 'd3',
+      serviceId: 'svc-1',
+      instanceId: 'inst-1',
+    };
+    expect(formatDiscountCodeScopeSummary(instanceScoped, serviceById, instanceById)).toBe('Spring · adults · March');
+
+    const instanceScopedNoFetch: DiscountCode = {
+      ...unscoped,
+      id: 'd4',
+      serviceId: 'svc-1',
+      instanceId: 'inst-missing',
+    };
+    expect(formatDiscountCodeScopeSummary(instanceScopedNoFetch, serviceById, emptyInstances)).toBe(
+      'Yoga · adults'
+    );
   });
 
   it('formats instance table title from own title or parent service title', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Discount codes **Scope** column now uses the same strings as the editor: `formatServiceTitleWithTier` for service-only rows and the shared instance scope formatter for instance rows (title fallback chain + tier + cohort).
- **No duplicated label logic**: `formatDiscountCodeInstanceOptionLabel` delegates to new `formatDiscountCodeInstanceScopeLabel`; table uses `formatDiscountCodeScopeSummary`.
- Instance-scoped rows **prefetch** instances via `listInstances` per distinct `serviceId` on the current code list (limit 100 per service) so labels match the dropdown when the instance is in the first page. If the instance is not returned or the request fails, scope falls back to **service title · tier** from `ServiceSummary` when `serviceId` is known, otherwise UUID-only (editor rule with synthetic pick).

## Tests

- `npm run lint` (admin_web)
- `npm ci && npm run test` (admin_web, full vitest)
- `bash scripts/validate-cursorrules.sh`

## Notes

- Removed the previous archived-service suffix in the scope column so scope matches the service `<select>` options exactly.
- Follow-up commit adjusts `discount-codes-panel.test.tsx` for the new Scope expectation (CI Test Node).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ad221d-152c-4b0e-a17f-0db38f2824bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ad221d-152c-4b0e-a17f-0db38f2824bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

