### PR TITLE
Refactor backend request and SQS helpers

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -1077,6 +1077,7 @@ export interface paths {
             parameters: {
                 query?: {
                     limit?: number;
+                    /** @description Opaque continuation token from `next_cursor`; only valid when `sort` is `created_at`. */
                     cursor?: string;
                     stage?: string;
                     source?: string;

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -162,6 +162,7 @@ class EventbriteSyncNestedStack extends cdk.NestedStack {
     this.processorFunction.addEventSource(
       new lambdaEventSources.SqsEventSource(this.queue, {
         batchSize: 1,
+        reportBatchItemFailures: true,
       })
     );
 
@@ -1892,6 +1893,7 @@ export class ApiStack extends cdk.Stack {
     inboundInvoiceProcessor.addEventSource(
       new lambdaEventSources.SqsEventSource(inboundInvoiceQueue, {
         batchSize: 1,
+        reportBatchItemFailures: true,
       })
     );
 
@@ -2716,29 +2718,25 @@ export class ApiStack extends cdk.Stack {
       publicWwwBusinessPhoneNumber.valueAsString
     );
 
+    const addAdminMethod = (resource: apigateway.IResource, method: string) =>
+      resource.addMethod(method, adminIntegration, {
+        authorizationType: apigateway.AuthorizationType.CUSTOM,
+        authorizer: adminAuthorizer,
+      });
+    const addPublicApiKeyMethod = (resource: apigateway.IResource, method: string) =>
+      resource.addMethod(method, adminIntegration, {
+        authorizationType: apigateway.AuthorizationType.NONE,
+        apiKeyRequired: true,
+      });
+
     const calendar = v1.addResource("calendar");
-    calendar.addResource("public").addMethod("GET", adminIntegration, {
-      authorizationType: apigateway.AuthorizationType.NONE,
-      apiKeyRequired: true,
-    });
+    addPublicApiKeyMethod(calendar.addResource("public"), "GET");
     const reservations = v1.addResource("reservations");
-    reservations.addMethod("POST", adminIntegration, {
-      authorizationType: apigateway.AuthorizationType.NONE,
-      apiKeyRequired: true,
-    });
-    reservations.addResource("payment-intent").addMethod("POST", adminIntegration, {
-      authorizationType: apigateway.AuthorizationType.NONE,
-      apiKeyRequired: true,
-    });
-    v1.addResource("contact-us").addMethod("POST", adminIntegration, {
-      authorizationType: apigateway.AuthorizationType.NONE,
-      apiKeyRequired: true,
-    });
+    addPublicApiKeyMethod(reservations, "POST");
+    addPublicApiKeyMethod(reservations.addResource("payment-intent"), "POST");
+    addPublicApiKeyMethod(v1.addResource("contact-us"), "POST");
     const publicDiscounts = v1.addResource("discounts");
-    publicDiscounts.addResource("validate").addMethod("POST", adminIntegration, {
-      authorizationType: apigateway.AuthorizationType.NONE,
-      apiKeyRequired: true,
-    });
+    addPublicApiKeyMethod(publicDiscounts.addResource("validate"), "POST");
     const mailchimpWebhook = v1.addResource("mailchimp").addResource("webhook");
     const mailchimpWebhookPostMethod = mailchimpWebhook.addMethod("POST", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.NONE,

--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -276,6 +276,7 @@ export class MessagingNestedStack extends cdk.NestedStack {
     this.mediaRequestProcessor.addEventSource(
       new lambdaEventSources.SqsEventSource(this.mediaQueue, {
         batchSize: 1,
+        reportBatchItemFailures: true,
       })
     );
 
@@ -390,6 +391,7 @@ export class MessagingNestedStack extends cdk.NestedStack {
     this.expenseParserFunction.addEventSource(
       new lambdaEventSources.SqsEventSource(this.expenseParserQueue, {
         batchSize: 1,
+        reportBatchItemFailures: true,
       })
     );
 

--- a/backend/lambda/auth/define_auth_challenge/handler.py
+++ b/backend/lambda/auth/define_auth_challenge/handler.py
@@ -6,7 +6,7 @@ or continue with a custom challenge based on the session history.
 
 import os
 
-from app.utils.logging import configure_logging, get_logger
+from app.utils.logging import configure_logging, get_logger, mask_email
 
 configure_logging()
 logger = get_logger(__name__)
@@ -21,9 +21,10 @@ def lambda_handler(event, _context):
     username = (
         event.get("request", {}).get("userAttributes", {}).get("email", "unknown")
     )
+    masked_username = mask_email(username)
 
     logger.debug(
-        f"Define auth challenge for {username}",
+        f"Define auth challenge for {masked_username}",
         extra={"session_length": len(session), "max_attempts": max_attempts},
     )
 
@@ -32,18 +33,18 @@ def lambda_handler(event, _context):
         if last.get("challengeName") == "CUSTOM_CHALLENGE" and last.get(
             "challengeResult"
         ):
-            logger.info(f"Auth successful for {username}")
+            logger.info(f"Auth successful for {masked_username}")
             response["issueTokens"] = True
             response["failAuthentication"] = False
             return event
 
         if len(session) >= max_attempts:
-            logger.warning(f"Max auth attempts reached for {username}")
+            logger.warning(f"Max auth attempts reached for {masked_username}")
             response["issueTokens"] = False
             response["failAuthentication"] = True
             return event
 
-    logger.debug(f"Issuing custom challenge for {username}")
+    logger.debug(f"Issuing custom challenge for {masked_username}")
     response["issueTokens"] = False
     response["failAuthentication"] = False
     response["challengeName"] = "CUSTOM_CHALLENGE"

--- a/backend/lambda/authorizers/cognito_group/handler.py
+++ b/backend/lambda/authorizers/cognito_group/handler.py
@@ -20,12 +20,8 @@ from typing import Any
 
 from app.auth.authorizer_utils import (
     build_iam_policy,
-    extract_bearer_token,
     extract_organization_ids,
-)
-from app.auth.jwt_validator import (
-    JWTValidationError,
-    decode_and_verify_token,
+    verify_cognito_authorizer_claims,
 )
 from app.utils.logging import configure_logging, get_logger
 
@@ -49,7 +45,6 @@ def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
     Returns:
         IAM policy document allowing or denying the request
     """
-    headers = event.get("headers") or {}
     method_arn = event.get("methodArn", "")
 
     # Get configuration
@@ -65,67 +60,51 @@ def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
 
     allowed_groups = {g.strip() for g in allowed_groups_str.split(",") if g.strip()}
 
-    # Extract token from Authorization header
-    token = extract_bearer_token(headers)
-    if not token:
-        logger.warning("Missing or invalid Authorization header")
-        return build_iam_policy(
-            "Deny",
-            method_arn,
-            "anonymous",
-            {"reason": "missing_token"},
-        )
-
-    try:
-        # Verify and decode the JWT token with signature validation
-        claims = decode_and_verify_token(token)
-
-        user_sub = claims.sub
-        email = claims.email
-        user_groups = set(claims.groups)
-        organization_ids = extract_organization_ids(claims.raw_claims)
-
-        # Check if user is in any of the allowed groups
-        matching_groups = user_groups & allowed_groups
-
-        if matching_groups:
-            logger.info(
-                f"Access granted for user {user_sub[:8]}*** "
-                f"(groups: {', '.join(matching_groups)})"
-            )
-            return build_iam_policy(
-                "Allow",
-                method_arn,
-                user_sub,
-                {
-                    "userSub": user_sub,
-                    "email": email,
-                    "groups": ",".join(user_groups),
-                    "matchedGroups": ",".join(matching_groups),
-                    "organizationIds": ",".join(sorted(organization_ids)),
-                },
-            )
-        else:
-            logger.warning(
-                f"Access denied for user {user_sub[:8]}*** "
-                f"(user groups: {user_groups}, required: {allowed_groups})"
-            )
-            return build_iam_policy(
-                "Deny",
-                method_arn,
-                user_sub,
-                {"reason": "insufficient_permissions", "userSub": user_sub},
-            )
-
-    except JWTValidationError as exc:
-        logger.warning(f"JWT validation failed: {exc.message} (reason: {exc.reason})")
-        return build_iam_policy("Deny", method_arn, "invalid", {"reason": exc.reason})
-    except Exception as exc:
-        # SECURITY: Don't expose internal error details
-        logger.warning(f"Token validation failed: {type(exc).__name__}")
+    claims_result = verify_cognito_authorizer_claims(event, method_arn, logger=logger)
+    if claims_result.policy is not None:
+        return claims_result.policy
+    claims = claims_result.claims
+    if claims is None:  # pragma: no cover - defensive invariant
         return build_iam_policy(
             "Deny",
             method_arn,
             "invalid",
             {"reason": "invalid_token"},
         )
+
+    user_sub = claims.sub
+    email = claims.email
+    user_groups = set(claims.groups)
+    organization_ids = extract_organization_ids(claims.raw_claims)
+
+    # Check if user is in any of the allowed groups
+    matching_groups = user_groups & allowed_groups
+
+    if matching_groups:
+        logger.info(
+            f"Access granted for user {user_sub[:8]}*** "
+            f"(groups: {', '.join(matching_groups)})"
+        )
+        return build_iam_policy(
+            "Allow",
+            method_arn,
+            user_sub,
+            {
+                "userSub": user_sub,
+                "email": email,
+                "groups": ",".join(user_groups),
+                "matchedGroups": ",".join(matching_groups),
+                "organizationIds": ",".join(sorted(organization_ids)),
+            },
+        )
+
+    logger.warning(
+        f"Access denied for user {user_sub[:8]}*** "
+        f"(user groups: {user_groups}, required: {allowed_groups})"
+    )
+    return build_iam_policy(
+        "Deny",
+        method_arn,
+        user_sub,
+        {"reason": "insufficient_permissions", "userSub": user_sub},
+    )

--- a/backend/lambda/authorizers/cognito_user/handler.py
+++ b/backend/lambda/authorizers/cognito_user/handler.py
@@ -18,12 +18,7 @@ from typing import Any
 
 from app.auth.authorizer_utils import (
     build_iam_policy,
-    extract_bearer_token,
-    extract_organization_ids,
-)
-from app.auth.jwt_validator import (
-    JWTValidationError,
-    decode_and_verify_token,
+    verified_cognito_context_from_event,
 )
 from app.utils.logging import configure_logging, get_logger
 
@@ -47,55 +42,22 @@ def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
     Returns:
         IAM policy document allowing or denying the request
     """
-    headers = event.get("headers") or {}
     method_arn = event.get("methodArn", "")
+    verified = verified_cognito_context_from_event(
+        event,
+        method_arn=method_arn,
+        logger=logger,
+    )
+    if verified.policy is not None:
+        return verified.policy
 
-    # Extract token from Authorization header
-    token = extract_bearer_token(headers)
-    if not token:
-        logger.warning("Missing or invalid Authorization header")
-        return build_iam_policy(
-            "Deny",
-            method_arn,
-            "anonymous",
-            {"reason": "missing_token"},
-        )
-
-    try:
-        # Verify and decode the JWT token with signature validation
-        claims = decode_and_verify_token(token)
-
-        user_sub = claims.sub
-        email = claims.email
-        user_groups = claims.groups
-        organization_ids = extract_organization_ids(claims.raw_claims)
-
-        logger.info(
-            f"Access granted for authenticated user {user_sub[:8]}*** "
-            f"(groups: {', '.join(user_groups) if user_groups else 'none'})"
-        )
-
-        return build_iam_policy(
-            "Allow",
-            method_arn,
-            user_sub,
-            {
-                "userSub": user_sub,
-                "email": email,
-                "groups": ",".join(user_groups),
-                "organizationIds": ",".join(sorted(organization_ids)),
-            },
-        )
-
-    except JWTValidationError as exc:
-        logger.warning(f"JWT validation failed: {exc.message} (reason: {exc.reason})")
-        return build_iam_policy("Deny", method_arn, "invalid", {"reason": exc.reason})
-    except Exception as exc:
-        # SECURITY: Don't expose internal error details
-        logger.warning(f"Token validation failed: {type(exc).__name__}")
-        return build_iam_policy(
-            "Deny",
-            method_arn,
-            "invalid",
-            {"reason": "invalid_token"},
-        )
+    logger.info(
+        f"Access granted for authenticated user {verified.user_sub[:8]}*** "
+        f"(groups: {', '.join(verified.groups) if verified.groups else 'none'})"
+    )
+    return build_iam_policy(
+        "Allow",
+        method_arn,
+        verified.user_sub,
+        verified.policy_context(),
+    )

--- a/backend/lambda/eventbrite_sync_processor/handler.py
+++ b/backend/lambda/eventbrite_sync_processor/handler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 from uuid import UUID
 
@@ -11,6 +10,8 @@ from sqlalchemy.orm import Session
 from app.db.engine import get_engine
 from app.db.models import ServiceType
 from app.db.repositories import ServiceInstanceRepository
+from app.events.sqs_batch import SqsBatchProcessor
+from app.events.sqs_sns import parse_sqs_sns_message
 from app.services.eventbrite_events import EVENT_TYPE_INSTANCE_SYNC_REQUESTED
 from app.services.eventbrite_sync import sync_instance_to_eventbrite
 from app.utils.logging import configure_logging, get_logger
@@ -21,29 +22,26 @@ logger = get_logger(__name__)
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Process Eventbrite sync requests delivered through SQS."""
-    processed = 0
-    skipped = 0
+    batch = SqsBatchProcessor(logger=logger)
 
     for record in event.get("Records", []):
-        message = _parse_record_message(record)
-        if message.get("event_type") != EVENT_TYPE_INSTANCE_SYNC_REQUESTED:
-            skipped += 1
-            continue
+        with batch.record(record):
+            message = parse_sqs_sns_message(record)
+            if message.get("event_type") != EVENT_TYPE_INSTANCE_SYNC_REQUESTED:
+                batch.skip()
+                continue
 
-        instance_id_raw = str(message.get("instance_id") or "").strip()
-        if not instance_id_raw:
-            skipped += 1
-            continue
-        instance_id = UUID(instance_id_raw)
-        if _sync_if_event_instance(instance_id):
-            processed += 1
-        else:
-            skipped += 1
+            instance_id_raw = str(message.get("instance_id") or "").strip()
+            if not instance_id_raw:
+                batch.skip()
+                continue
+            instance_id = UUID(instance_id_raw)
+            if _sync_if_event_instance(instance_id):
+                batch.process()
+            else:
+                batch.skip()
 
-    return {
-        "statusCode": 200,
-        "body": json.dumps({"processed": processed, "skipped": skipped}),
-    }
+    return batch.response()
 
 
 def _sync_if_event_instance(instance_id: UUID) -> bool:
@@ -61,12 +59,3 @@ def _sync_if_event_instance(instance_id: UUID) -> bool:
             return False
         sync_instance_to_eventbrite(session=session, instance_id=instance_id)
         return True
-
-
-def _parse_record_message(record: dict[str, Any]) -> dict[str, Any]:
-    sqs_body = json.loads(record["body"])
-    sns_message = sqs_body.get("Message", "{}")
-    parsed = json.loads(sns_message)
-    if not isinstance(parsed, dict):
-        raise ValueError("SNS message payload must be an object")
-    return parsed

--- a/backend/lambda/expense_parser/handler.py
+++ b/backend/lambda/expense_parser/handler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-import json
 from decimal import Decimal
 from typing import Any
 
@@ -12,6 +11,8 @@ from sqlalchemy.orm import Session
 from app.db.engine import get_engine
 from app.db.models import ExpenseParseStatus
 from app.db.repositories import ExpenseRepository, OrganizationRepository
+from app.events.sqs_batch import SqsBatchProcessor
+from app.events.sqs_sns import parse_sqs_sns_message
 from app.services.openrouter_expense_parser import parse_invoice_from_assets
 from app.utils.logging import configure_logging, get_logger
 
@@ -24,34 +25,25 @@ _SYSTEM_ACTOR = "system"
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Process expense parser messages from SQS."""
-    processed = 0
-    skipped = 0
+    batch = SqsBatchProcessor(logger=logger)
 
     for record in event.get("Records", []):
-        message = _parse_record_message(record)
-        if message.get("event_type") != _EVENT_TYPE_PARSE_REQUESTED:
-            skipped += 1
-            continue
-        expense_id = str(message.get("expense_id") or "").strip()
-        if not expense_id:
-            skipped += 1
-            continue
-        _process_expense(expense_id)
-        processed += 1
+        with batch.record(
+            record,
+            failure_message="Failed to process expense parser message",
+        ):
+            message = parse_sqs_sns_message(record)
+            if message.get("event_type") != _EVENT_TYPE_PARSE_REQUESTED:
+                batch.skip()
+                continue
+            expense_id = str(message.get("expense_id") or "").strip()
+            if not expense_id:
+                batch.skip()
+                continue
+            _process_expense(expense_id)
+            batch.process()
 
-    return {
-        "statusCode": 200,
-        "body": json.dumps({"processed": processed, "skipped": skipped}),
-    }
-
-
-def _parse_record_message(record: dict[str, Any]) -> dict[str, Any]:
-    sqs_body = json.loads(record["body"])
-    sns_message = sqs_body.get("Message", "{}")
-    parsed = json.loads(sns_message)
-    if not isinstance(parsed, dict):
-        raise ValueError("SNS message payload must be an object")
-    return parsed
+    return batch.response()
 
 
 def _process_expense(expense_id: str) -> None:

--- a/backend/lambda/inbound_invoice_email/handler.py
+++ b/backend/lambda/inbound_invoice_email/handler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-import json
 from typing import Any
 from collections.abc import Mapping
 
@@ -11,6 +10,8 @@ from app.services.inbound_invoice_ingest import (
     InboundInvoiceEmailEvent,
     process_inbound_invoice_email,
 )
+from app.events.sqs_batch import SqsBatchProcessor
+from app.events.sqs_sns import parse_sqs_sns_message
 from app.utils.logging import configure_logging, get_logger
 
 configure_logging()
@@ -19,36 +20,27 @@ logger = get_logger(__name__)
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Process SES inbound-email notifications delivered through SQS + SNS."""
-    processed = 0
-    skipped = 0
+    batch = SqsBatchProcessor(logger=logger)
 
     for record in event.get("Records", []):
-        message = _parse_sqs_sns_record(record)
-        notification = _parse_inbound_notification(message)
-        result = process_inbound_invoice_email(notification)
-        if result.expense_id is None:
-            skipped += 1
-        else:
-            processed += 1
+        with batch.record(
+            record,
+            failure_message="Failed to process inbound invoice email message",
+        ):
+            message = parse_sqs_sns_message(record)
+            notification = _parse_inbound_notification(message)
+            result = process_inbound_invoice_email(notification)
+            if result.expense_id is None:
+                batch.skip()
+            else:
+                batch.process()
 
     logger.info(
         "Inbound invoice email batch processed",
-        extra={"processed": processed, "skipped": skipped},
+        extra=batch.summary(),
     )
 
-    return {
-        "statusCode": 200,
-        "body": json.dumps({"processed": processed, "skipped": skipped}),
-    }
-
-
-def _parse_sqs_sns_record(record: Mapping[str, Any]) -> dict[str, Any]:
-    sqs_body = json.loads(str(record.get("body") or "{}"))
-    sns_message = sqs_body.get("Message", "{}")
-    parsed = json.loads(str(sns_message))
-    if not isinstance(parsed, dict):
-        raise ValueError("SNS message payload must be an object")
-    return parsed
+    return batch.response()
 
 
 def _parse_inbound_notification(message: Mapping[str, Any]) -> InboundInvoiceEmailEvent:

--- a/backend/lambda/media_processor/handler.py
+++ b/backend/lambda/media_processor/handler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from datetime import datetime, timezone
 from typing import Any
@@ -47,6 +46,8 @@ from app.services.public_form_internal_notifications import (
     build_media_lead_recap_lines,
     send_sales_form_recap_email,
 )
+from app.events.sqs_batch import SqsBatchProcessor
+from app.events.sqs_sns import parse_sqs_sns_record
 from app.utils.logging import configure_logging, get_logger, mask_email
 from app.utils.public_slug import normalize_public_slug
 from app.utils.retry import run_with_retry
@@ -62,50 +63,35 @@ _MAX_RESOURCE_KEY_LENGTH = 64
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Process media request messages delivered through SQS."""
-    processed = 0
-    skipped = 0
+    batch = SqsBatchProcessor(logger=logger)
 
     for record in event.get("Records", []):
-        try:
-            message = _parse_record_message(record)
+        with batch.record(record, failure_message="Failed to process media message"):
+            message = parse_sqs_sns_record(record)
             if message.get("event_type") != _EVENT_TYPE:
                 logger.info(
                     "Skipping unsupported event type",
                     extra={"event_type": message.get("event_type")},
                 )
-                skipped += 1
+                batch.skipped += 1
                 continue
 
             was_processed = _process_message(message)
             if was_processed:
-                processed += 1
+                batch.processed += 1
             else:
-                skipped += 1
-        except json.JSONDecodeError as exc:
-            logger.error(f"Failed to parse SQS/SNS payload: {exc}")
-            raise
-        except Exception:
-            logger.exception("Failed to process media message")
-            raise
+                batch.skipped += 1
 
-    result = {
-        "statusCode": 200,
-        "body": json.dumps({"processed": processed, "skipped": skipped}),
-    }
+    result = batch.response()
     logger.info(
         "Media processing complete",
-        extra={"processed": processed, "skipped": skipped},
+        extra={
+            "processed": batch.processed,
+            "skipped": batch.skipped,
+            "failed": len(batch.failures),
+        },
     )
     return result
-
-
-def _parse_record_message(record: dict[str, Any]) -> dict[str, Any]:
-    sqs_body = json.loads(record["body"])
-    sns_message = sqs_body.get("Message", "{}")
-    parsed = json.loads(sns_message)
-    if not isinstance(parsed, dict):
-        raise ValueError("SNS message payload must be a JSON object")
-    return parsed
 
 
 def _process_message(message: dict[str, Any]) -> bool:

--- a/backend/src/app/api/admin_entities_helpers.py
+++ b/backend/src/app/api/admin_entities_helpers.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
-from app.api.admin_request import query_param
+from app.api.admin_request import parse_limit, request_id
 from app.exceptions import ValidationError
 from app.db.models import (
     ContactTag,
@@ -26,20 +26,6 @@ from app.db.models.enums import ContactType
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
-
-
-def parse_limit(event: Mapping[str, Any], *, default: int = 25) -> int:
-    raw = query_param(event, "limit")
-    if raw is None or raw == "":
-        return default
-    try:
-        parsed = int(raw)
-    except (TypeError, ValueError) as exc:
-        logger.warning("Invalid list limit value", extra={"field": "limit"})
-        raise ValidationError("limit must be an integer", field="limit") from exc
-    if parsed < 1 or parsed > 100:
-        raise ValidationError("limit must be between 1 and 100", field="limit")
-    return parsed
 
 
 def parse_active_filter(raw: str | None) -> bool | None:
@@ -218,16 +204,6 @@ def list_all_tags_for_picker(session: Session) -> list[Tag]:
         select(Tag).where(Tag.archived_at.is_(None)).order_by(func.lower(Tag.name))
     )
     return list(session.execute(statement).scalars().all())
-
-
-def request_id(event: Mapping[str, Any]) -> str:
-    """API Gateway request id for audit context (shared by admin CRM handlers)."""
-    request_context = event.get("requestContext")
-    if isinstance(request_context, Mapping):
-        request_id = request_context.get("requestId")
-        if isinstance(request_id, str):
-            return request_id.strip()
-    return ""
 
 
 def parse_relationship_type(

--- a/backend/src/app/api/admin_entities_helpers.py
+++ b/backend/src/app/api/admin_entities_helpers.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from typing import Any
-from collections.abc import Mapping
 from uuid import UUID
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
-from app.api.admin_request import parse_limit, request_id
+from app.api.admin_request import parse_limit as parse_limit
+from app.api.admin_request import request_id as request_id
 from app.exceptions import ValidationError
 from app.db.models import (
     ContactTag,

--- a/backend/src/app/api/admin_expenses.py
+++ b/backend/src/app/api/admin_expenses.py
@@ -297,11 +297,11 @@ def _mark_expense_paid(
         "Marking expense paid",
         extra={"expense_id": str(expense_id), "actor": actor_sub},
     )
-    request_id = _request_id(event)
+    req_id = request_id(event)
     now = datetime.now(UTC)
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
         repository = ExpenseRepository(session)
         expense = repository.get_with_attachments(expense_id)
         if expense is None:
@@ -329,10 +329,10 @@ def _reparse_expense(
         "Requeueing expense parse",
         extra={"expense_id": str(expense_id), "actor": actor_sub},
     )
-    request_id = _request_id(event)
+    req_id = request_id(event)
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
         repository = ExpenseRepository(session)
         expense = repository.get_with_attachments(expense_id)
         if expense is None:
@@ -362,11 +362,11 @@ def _amend_expense(
         extra={"source_expense_id": str(expense_id), "actor": actor_sub},
     )
     payload = parse_update_payload(parse_body(event))
-    request_id = _request_id(event)
+    req_id = request_id(event)
     now = datetime.now(UTC)
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
         expense_repo = ExpenseRepository(session)
         source = expense_repo.get_with_attachments(expense_id)
         if source is None:

--- a/backend/src/app/api/admin_expenses.py
+++ b/backend/src/app/api/admin_expenses.py
@@ -27,8 +27,10 @@ from app.api.admin_request import (
     encode_cursor,
     parse_body,
     parse_cursor,
+    parse_limit,
     parse_uuid,
     query_param,
+    request_id,
 )
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
@@ -107,7 +109,7 @@ def handle_admin_expenses_request(
 
 
 def _list_expenses(event: Mapping[str, Any]) -> dict[str, Any]:
-    limit = _parse_limit(event)
+    limit = parse_limit(event, default=_DEFAULT_LIMIT, max_limit=_MAX_LIMIT)
     cursor = parse_cursor(query_param(event, "cursor"))
     query = parse_optional_string(query_param(event, "query"), max_length=255)
     status = parse_optional_status(query_param(event, "status"))
@@ -147,7 +149,7 @@ def _list_expenses(event: Mapping[str, Any]) -> dict[str, Any]:
 def _create_expense(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]:
     logger.info("Creating expense", extra={"actor": actor_sub})
     payload = parse_create_payload(parse_body(event))
-    request_id = _request_id(event)
+    req_id = request_id(event)
     now = datetime.now(UTC)
     parse_status = (
         ExpenseParseStatus.QUEUED
@@ -156,7 +158,7 @@ def _create_expense(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, An
     )
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
         expense_repo = ExpenseRepository(session)
         vendor = resolve_vendor(session, payload["vendor_id"])
         expense = expense_repo.create_expense(
@@ -212,10 +214,10 @@ def _update_expense(
         extra={"expense_id": str(expense_id), "actor": actor_sub},
     )
     payload = parse_update_payload(parse_body(event))
-    request_id = _request_id(event)
+    req_id = request_id(event)
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
         expense_repo = ExpenseRepository(session)
         expense = expense_repo.get_with_attachments(expense_id)
         if expense is None:
@@ -266,11 +268,11 @@ def _cancel_expense(
     )
     body = parse_body(event)
     reason = required_string(body, "reason", max_length=2000)
-    request_id = _request_id(event)
+    req_id = request_id(event)
     now = datetime.now(UTC)
 
     with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
         repository = ExpenseRepository(session)
         expense = repository.get_with_attachments(expense_id)
         if expense is None:
@@ -426,25 +428,3 @@ def _amend_expense(
         return json_response(
             201, {"expense": serialize_expense(refreshed)}, event=event
         )
-
-
-def _parse_limit(event: Mapping[str, Any]) -> int:
-    raw = query_param(event, "limit")
-    if raw is None or raw == "":
-        return _DEFAULT_LIMIT
-    try:
-        parsed = int(raw)
-    except (TypeError, ValueError) as exc:
-        raise ValidationError("limit must be an integer", field="limit") from exc
-    if parsed < 1 or parsed > _MAX_LIMIT:
-        raise ValidationError("limit must be between 1 and 100", field="limit")
-    return parsed
-
-
-def _request_id(event: Mapping[str, Any]) -> str:
-    request_context = event.get("requestContext")
-    if isinstance(request_context, Mapping):
-        request_id = request_context.get("requestId")
-        if isinstance(request_id, str):
-            return request_id.strip()
-    return ""

--- a/backend/src/app/api/admin_leads_common.py
+++ b/backend/src/app/api/admin_leads_common.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from app.api.admin_request import (
     parse_limit as parse_admin_limit,
     query_param,
-    request_id,
+    request_id as request_id,
 )
 from app.api.admin_validators import (
     MAX_DESCRIPTION_LENGTH,

--- a/backend/src/app/api/admin_leads_common.py
+++ b/backend/src/app/api/admin_leads_common.py
@@ -9,7 +9,11 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
-from app.api.admin_request import query_param
+from app.api.admin_request import (
+    parse_limit as parse_admin_limit,
+    query_param,
+    request_id,
+)
 from app.api.admin_validators import (
     MAX_DESCRIPTION_LENGTH,
     MAX_NAME_LENGTH,
@@ -28,30 +32,27 @@ from app.db.models.enums import (
 )
 from app.exceptions import ValidationError
 
-_LIST_LEADS_DEFAULT_LIMIT = 50
+_LIST_LEADS_DEFAULT_LIMIT = 25
 _LIST_LEADS_MAX_LIMIT = 100
 
 
 def parse_lead_filters(event: Mapping[str, Any]) -> dict[str, Any]:
     """Parse list/query filters for lead list and export endpoints."""
-    raw_limit = query_param(event, "limit")
-    if not raw_limit:
-        limit = _LIST_LEADS_DEFAULT_LIMIT
-    else:
-        try:
-            limit = int(raw_limit)
-        except (TypeError, ValueError) as exc:
-            raise ValidationError("limit must be an integer", field="limit") from exc
-        if limit < 1 or limit > _LIST_LEADS_MAX_LIMIT:
-            raise ValidationError(
-                f"limit must be between 1 and {_LIST_LEADS_MAX_LIMIT}",
-                field="limit",
-            )
-
-    cursor_created_at, cursor_id = parse_lead_cursor(query_param(event, "cursor"))
+    limit = parse_admin_limit(
+        event,
+        default=_LIST_LEADS_DEFAULT_LIMIT,
+        max_limit=_LIST_LEADS_MAX_LIMIT,
+    )
+    raw_cursor = query_param(event, "cursor")
     sort = (query_param(event, "sort") or "created_at").strip().lower()
     if sort not in {"created_at", "updated_at", "funnel_stage", "contact_name"}:
         raise ValidationError("Invalid sort field", field="sort")
+    if raw_cursor and sort != "created_at":
+        raise ValidationError(
+            "cursor is only supported when sort is created_at",
+            field="cursor",
+        )
+    cursor_created_at, cursor_id = parse_lead_cursor(raw_cursor)
     sort_dir = (query_param(event, "sort_dir") or "desc").strip().lower()
     if sort_dir not in {"asc", "desc"}:
         raise ValidationError("sort_dir must be asc or desc", field="sort_dir")
@@ -298,16 +299,6 @@ def parse_lead_cursor(cursor: str | None) -> tuple[datetime | None, UUID | None]
         return created_at, lead_id
     except (ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
         raise ValidationError("Invalid cursor", field="cursor") from exc
-
-
-def request_id(event: Mapping[str, Any]) -> str:
-    """Return API Gateway request ID if present."""
-    request_context = event.get("requestContext")
-    if isinstance(request_context, Mapping):
-        request_id_value = request_context.get("requestId")
-        if isinstance(request_id_value, str):
-            return request_id_value
-    return ""
 
 
 def _serialize_contact(contact: Contact | None) -> dict[str, Any]:

--- a/backend/src/app/api/admin_locations.py
+++ b/backend/src/app/api/admin_locations.py
@@ -257,13 +257,13 @@ def _update_location(
 ) -> dict[str, Any]:
     body = parse_body(event)
     identity = extract_identity(event)
-    request_id = _request_id(event)
+    location_request_id = request_id(event)
 
     with Session(get_engine()) as session:
         set_audit_context(
             session,
             user_id=identity.user_sub or "",
-            request_id=request_id,
+            request_id=location_request_id,
         )
         geo_repo = GeographicAreaRepository(session)
         location_repo = LocationRepository(session)
@@ -330,13 +330,13 @@ def _update_location(
 
 def _delete_location(event: Mapping[str, Any], location_id: UUID) -> dict[str, Any]:
     identity = extract_identity(event)
-    request_id = _request_id(event)
+    location_request_id = request_id(event)
 
     with Session(get_engine()) as session:
         set_audit_context(
             session,
             user_id=identity.user_sub or "",
-            request_id=request_id,
+            request_id=location_request_id,
         )
         location_repo = LocationRepository(session)
         location = location_repo.get_by_id(location_id)

--- a/backend/src/app/api/admin_locations.py
+++ b/backend/src/app/api/admin_locations.py
@@ -13,6 +13,8 @@ from app.api.admin_request import (
     encode_cursor,
     parse_body,
     parse_cursor,
+    parse_limit,
+    request_id,
     parse_uuid,
     query_param,
 )
@@ -173,7 +175,7 @@ def _list_locations(event: Mapping[str, Any]) -> dict[str, Any]:
 def _create_location(event: Mapping[str, Any]) -> dict[str, Any]:
     body = parse_body(event)
     identity = extract_identity(event)
-    request_id = _request_id(event)
+    location_request_id = request_id(event)
 
     area_id_raw = body.get("area_id")
     if area_id_raw is None:
@@ -189,7 +191,7 @@ def _create_location(event: Mapping[str, Any]) -> dict[str, Any]:
         set_audit_context(
             session,
             user_id=identity.user_sub or "",
-            request_id=request_id,
+            request_id=location_request_id,
         )
         geo_repo = GeographicAreaRepository(session)
         if geo_repo.get_by_id(area_id) is None:
@@ -409,16 +411,7 @@ def _parse_query_bool(
 
 
 def _parse_limit(event: Mapping[str, Any]) -> int:
-    raw_value = query_param(event, "limit")
-    if not raw_value:
-        return 50
-    try:
-        limit = int(raw_value)
-    except (TypeError, ValueError) as exc:
-        raise ValidationError("limit must be an integer", field="limit") from exc
-    if limit < 1 or limit > 100:
-        raise ValidationError("limit must be between 1 and 100", field="limit")
-    return limit
+    return parse_limit(event)
 
 
 def _parse_optional_uuid(value: str | None, *, field: str) -> UUID | None:
@@ -463,12 +456,3 @@ def _validate_coordinates(*, lat: Any, lng: Any) -> None:
         raise ValidationError("lat must be between -90 and 90", field="lat")
     if lng is not None and (lng < -180 or lng > 180):
         raise ValidationError("lng must be between -180 and 180", field="lng")
-
-
-def _request_id(event: Mapping[str, Any]) -> str:
-    request_context = event.get("requestContext")
-    if isinstance(request_context, Mapping):
-        request_id = request_context.get("requestId")
-        if isinstance(request_id, str):
-            return request_id
-    return ""

--- a/backend/src/app/api/admin_request.py
+++ b/backend/src/app/api/admin_request.py
@@ -5,12 +5,36 @@ from __future__ import annotations
 import base64
 import json
 import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 from uuid import UUID
 
 from app.exceptions import ValidationError
+from app.utils import json_response
 from app.utils.parsers import collect_query_params, first_param
+
+DEFAULT_LIST_LIMIT = 25
+MAX_LIST_LIMIT = 100
+
+
+@dataclass(frozen=True)
+class RequestIdentity:
+    """Caller identity extracted from API Gateway authorizer context."""
+
+    user_sub: str | None
+    groups: set[str]
+    organization_ids: set[str]
+
+    @property
+    def is_authenticated(self) -> bool:
+        return bool(self.user_sub)
+
+    @property
+    def is_admin_or_manager(self) -> bool:
+        normalized = {group.lower() for group in self.groups}
+        return "admin" in normalized or "manager" in normalized
 
 
 def parse_body(event: Mapping[str, Any]) -> dict[str, Any]:
@@ -33,6 +57,138 @@ def query_param(event: Mapping[str, Any], name: str) -> str | None:
     """Return a query parameter value."""
     params = collect_query_params(event)
     return first_param(params, name)
+
+
+def normalize_path(path: str) -> str:
+    """Normalize route path for deterministic matching."""
+    if not path:
+        return ""
+    normalized = path.strip()
+    if not normalized.startswith("/"):
+        normalized = "/" + normalized
+    if normalized != "/" and normalized.endswith("/"):
+        normalized = normalized[:-1]
+    return normalized
+
+
+def split_route_parts(path: str) -> list[str]:
+    """Split normalized API route into segments without version prefix."""
+    parts = [segment for segment in normalize_path(path).split("/") if segment]
+    if parts and parts[0].startswith("v") and parts[0][1:].isdigit():
+        return parts[1:]
+    return parts
+
+
+def request_id(event: Mapping[str, Any]) -> str:
+    """Return API Gateway request id if present."""
+    request_context = event.get("requestContext")
+    if isinstance(request_context, Mapping):
+        request_id_value = request_context.get("requestId")
+        if isinstance(request_id_value, str):
+            return request_id_value.strip()
+    return ""
+
+
+def extract_identity(event: Mapping[str, Any]) -> RequestIdentity:
+    """Extract request identity from API Gateway custom authorizer context."""
+    request_context = event.get("requestContext")
+    if not isinstance(request_context, Mapping):
+        return RequestIdentity(user_sub=None, groups=set(), organization_ids=set())
+    authorizer = request_context.get("authorizer")
+    if not isinstance(authorizer, Mapping):
+        return RequestIdentity(user_sub=None, groups=set(), organization_ids=set())
+
+    user_sub = _to_optional_string(
+        authorizer.get("userSub")
+        or authorizer.get("principalId")
+        or _extract_claim(authorizer.get("claims"), "sub")
+    )
+    groups = _parse_csv_set(
+        _to_optional_string(authorizer.get("groups"))
+        or _extract_claim(authorizer.get("claims"), "cognito:groups")
+    )
+    organization_ids = _parse_csv_set(
+        _to_optional_string(authorizer.get("organizationIds"))
+        or _to_optional_string(authorizer.get("organizationId"))
+        or _extract_claim(authorizer.get("claims"), "custom:organization_ids")
+        or _extract_claim(authorizer.get("claims"), "custom:organization_id")
+        or _extract_claim(authorizer.get("claims"), "organization_ids")
+        or _extract_claim(authorizer.get("claims"), "organization_id")
+    )
+    return RequestIdentity(
+        user_sub=user_sub,
+        groups=groups,
+        organization_ids=organization_ids,
+    )
+
+
+def parse_limit(
+    event_or_raw: Mapping[str, Any] | str | None,
+    *,
+    default: int = DEFAULT_LIST_LIMIT,
+    max_limit: int = MAX_LIST_LIMIT,
+) -> int:
+    """Parse and validate a list page size from an event or raw query value."""
+    raw_value = (
+        query_param(event_or_raw, "limit")
+        if isinstance(event_or_raw, Mapping)
+        else event_or_raw
+    )
+    if raw_value is None or str(raw_value).strip() == "":
+        return default
+    try:
+        parsed = int(str(raw_value).strip())
+    except (TypeError, ValueError) as exc:
+        raise ValidationError("limit must be an integer", field="limit") from exc
+    if parsed < 1 or parsed > max_limit:
+        raise ValidationError(
+            f"limit must be between 1 and {max_limit}",
+            field="limit",
+        )
+    return parsed
+
+
+def paginate_items(
+    items: Sequence[Any],
+    *,
+    limit: int,
+    cursor_encoder: Callable[[Any], str | None],
+) -> tuple[list[Any], str | None]:
+    """Slice one over-fetched page and derive the next cursor."""
+    page_items = list(items[:limit])
+    has_more = len(items) > limit
+    next_cursor = cursor_encoder(page_items[-1]) if has_more and page_items else None
+    return page_items, next_cursor
+
+
+def paginated_json_response(
+    *,
+    items: Sequence[Any],
+    limit: int,
+    event: Mapping[str, Any],
+    serializer: Callable[[Any], dict[str, Any]],
+    cursor_encoder: Callable[[Any], str | None],
+    extra_fields: Mapping[str, Any] | None = None,
+    headers: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build a standard paginated API response payload."""
+    page_items, next_cursor = paginate_items(
+        items,
+        limit=limit,
+        cursor_encoder=cursor_encoder,
+    )
+    body: dict[str, Any] = {
+        "items": [serializer(item) for item in page_items],
+        "next_cursor": next_cursor,
+    }
+    if extra_fields:
+        body.update(dict(extra_fields))
+    return json_response(
+        200,
+        body,
+        event=event,
+        headers=dict(headers) if headers is not None else None,
+    )
 
 
 def parse_uuid(value: str) -> UUID:
@@ -83,8 +239,62 @@ def encode_cursor(value: Any) -> str:
     return encoded.rstrip("=")
 
 
+def encode_created_cursor(created_at: Any, row_id: UUID) -> str | None:
+    """Encode generic created_at/id cursor."""
+    if created_at is None:
+        return None
+    payload = json.dumps(
+        {"created_at": _normalize_datetime(created_at).isoformat(), "id": str(row_id)}
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
+
+
+def parse_created_cursor(cursor: str | None) -> tuple[datetime | None, UUID | None]:
+    """Parse a generic created_at/id cursor payload."""
+    if not cursor:
+        return None, None
+
+    try:
+        payload = _decode_cursor(cursor)
+        created_at_raw = payload["created_at"]
+        row_id_raw = payload["id"]
+        if not isinstance(created_at_raw, str):
+            raise ValueError("created_at must be a string")
+        parsed_created_at = datetime.fromisoformat(
+            created_at_raw.replace("Z", "+00:00")
+        )
+        return _normalize_datetime(parsed_created_at), UUID(str(row_id_raw))
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise ValidationError("Invalid cursor", field="cursor") from exc
+
+
 def _decode_cursor(cursor: str) -> dict[str, Any]:
     """Decode admin cursor."""
     padding = "=" * (-len(cursor) % 4)
     raw = base64.urlsafe_b64decode(cursor + padding)
     return json.loads(raw)
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _to_optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _parse_csv_set(value: str | None) -> set[str]:
+    if not value:
+        return set()
+    return {part.strip() for part in value.split(",") if part.strip()}
+
+
+def _extract_claim(claims: Any, name: str) -> str | None:
+    if isinstance(claims, Mapping):
+        return _to_optional_string(claims.get(name))
+    return None

--- a/backend/src/app/api/admin_services_cursor.py
+++ b/backend/src/app/api/admin_services_cursor.py
@@ -6,16 +6,16 @@ import base64
 import json
 from uuid import UUID
 
-from app.api.admin_request import (
-    encode_created_cursor,
-    parse_created_cursor,
-    request_id,
-)
+from app import api as _api_package
+from app.api.admin_request import encode_created_cursor
 from app.db.models import DiscountCode, Enrollment, Service, ServiceInstance
 from app.exceptions import ValidationError
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+parse_created_cursor = _api_package.admin_request.parse_created_cursor
+request_id = _api_package.admin_request.request_id
 
 
 def encode_service_cursor(service: Service) -> str | None:

--- a/backend/src/app/api/admin_services_cursor.py
+++ b/backend/src/app/api/admin_services_cursor.py
@@ -4,26 +4,18 @@ from __future__ import annotations
 
 import base64
 import json
-from collections.abc import Mapping
-from datetime import UTC, datetime
-from typing import Any
 from uuid import UUID
 
+from app.api.admin_request import (
+    encode_created_cursor,
+    parse_created_cursor,
+    request_id,
+)
 from app.db.models import DiscountCode, Enrollment, Service, ServiceInstance
 from app.exceptions import ValidationError
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
-
-
-def request_id(event: Mapping[str, Any]) -> str:
-    """Return API Gateway request ID if present."""
-    request_context = event.get("requestContext")
-    if isinstance(request_context, Mapping):
-        request_id_value = request_context.get("requestId")
-        if isinstance(request_id_value, str):
-            return request_id_value
-    return ""
 
 
 def encode_service_cursor(service: Service) -> str | None:
@@ -69,42 +61,3 @@ def encode_enrollment_cursor(enrollment: Enrollment) -> str | None:
 def encode_discount_code_cursor(code: DiscountCode) -> str | None:
     """Encode discount-code cursor for pagination."""
     return encode_created_cursor(code.created_at, code.id)
-
-
-def encode_created_cursor(created_at: datetime | None, row_id: UUID) -> str | None:
-    """Encode generic created_at/id cursor."""
-    if created_at is None:
-        return None
-    normalized_created = _normalize_datetime(created_at)
-    payload = json.dumps(
-        {"created_at": normalized_created.isoformat(), "id": str(row_id)}
-    ).encode("utf-8")
-    return base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
-
-
-def parse_created_cursor(cursor: str | None) -> tuple[datetime | None, UUID | None]:
-    """Parse created_at/id cursor payload."""
-    if not cursor:
-        return None, None
-    try:
-        padded = cursor + ("=" * (-len(cursor) % 4))
-        payload = json.loads(base64.urlsafe_b64decode(padded))
-        created_at_raw = payload["created_at"]
-        row_id_raw = payload["id"]
-        if not isinstance(created_at_raw, str):
-            raise ValueError("created_at must be a string")
-        parsed_created_at = datetime.fromisoformat(
-            created_at_raw.replace("Z", "+00:00")
-        )
-        return _normalize_datetime(parsed_created_at), UUID(str(row_id_raw))
-    except (ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
-        logger.warning(
-            "Invalid pagination cursor", extra={"cursor_length": len(cursor)}
-        )
-        raise ValidationError("Invalid cursor", field="cursor") from exc
-
-
-def _normalize_datetime(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
-from app.api.admin_request import query_param
+from app.api.admin_request import parse_limit, query_param
 from app.api.admin_validators import (
     MAX_DESCRIPTION_LENGTH,
     parse_optional_service_instance_slug,
@@ -54,8 +54,6 @@ from app.db.models import (
 from app.exceptions import ValidationError
 from app.utils.logging import get_logger
 
-_LIST_DEFAULT_LIMIT = 50
-_LIST_MAX_LIMIT = 100
 _MAX_CODE_LENGTH = 50
 _SERVICE_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _MAX_SERVICE_SLUG_LENGTH = 80
@@ -125,7 +123,7 @@ def parse_optional_booking_system(value: Any, field: str) -> str | None:
 def parse_service_filters(event: Mapping[str, Any]) -> dict[str, Any]:
     """Parse query filters for service list endpoint."""
     logger.debug("Parsing service list filters")
-    limit = _parse_limit(query_param(event, "limit"))
+    limit = parse_limit(event)
     cursor_title, cursor_id = parse_service_list_cursor(query_param(event, "cursor"))
     return {
         "limit": limit,
@@ -148,7 +146,7 @@ def parse_service_filters(event: Mapping[str, Any]) -> dict[str, Any]:
 def parse_instance_filters(event: Mapping[str, Any]) -> dict[str, Any]:
     """Parse query filters for service instance list endpoint."""
     logger.debug("Parsing service instance list filters")
-    limit = _parse_limit(query_param(event, "limit"))
+    limit = parse_limit(event)
     cursor_created_at, cursor_id = parse_created_cursor(query_param(event, "cursor"))
     return {
         "limit": limit,
@@ -165,7 +163,7 @@ def parse_instance_filters(event: Mapping[str, Any]) -> dict[str, Any]:
 def parse_global_instance_list_filters(event: Mapping[str, Any]) -> dict[str, Any]:
     """Parse query filters for cross-service instance list endpoint."""
     logger.debug("Parsing global service instance list filters")
-    limit = _parse_limit(query_param(event, "limit"))
+    limit = parse_limit(event)
     cursor_created_at, cursor_id = parse_created_cursor(query_param(event, "cursor"))
     return {
         "limit": limit,
@@ -190,7 +188,7 @@ def parse_global_instance_list_filters(event: Mapping[str, Any]) -> dict[str, An
 def parse_enrollment_filters(event: Mapping[str, Any]) -> dict[str, Any]:
     """Parse query filters for enrollment list endpoint."""
     logger.debug("Parsing enrollment list filters")
-    limit = _parse_limit(query_param(event, "limit"))
+    limit = parse_limit(event)
     cursor_created_at, cursor_id = parse_created_cursor(query_param(event, "cursor"))
     return {
         "limit": limit,
@@ -207,7 +205,7 @@ def parse_enrollment_filters(event: Mapping[str, Any]) -> dict[str, Any]:
 def parse_discount_code_filters(event: Mapping[str, Any]) -> dict[str, Any]:
     """Parse query filters for discount-code list endpoint."""
     logger.debug("Parsing discount code list filters")
-    limit = _parse_limit(query_param(event, "limit"))
+    limit = parse_limit(event)
     cursor_created_at, cursor_id = parse_created_cursor(query_param(event, "cursor"))
     scope_raw = parse_optional_text(query_param(event, "scope"), max_length=20)
     scope = (scope_raw or "").strip().lower()
@@ -659,18 +657,3 @@ def parse_update_discount_code_payload(body: Mapping[str, Any]) -> dict[str, Any
         payload["discount_value"] = REFERRAL_DEFAULT_DISCOUNT_VALUE
         payload["currency"] = REFERRAL_DEFAULT_CURRENCY
     return payload
-
-
-def _parse_limit(raw_limit: str | None) -> int:
-    if not raw_limit:
-        return _LIST_DEFAULT_LIMIT
-    try:
-        limit = int(raw_limit)
-    except (TypeError, ValueError) as exc:
-        raise ValidationError("limit must be an integer", field="limit") from exc
-    if limit < 1 or limit > _LIST_MAX_LIMIT:
-        raise ValidationError(
-            f"limit must be between 1 and {_LIST_MAX_LIMIT}",
-            field="limit",
-        )
-    return limit

--- a/backend/src/app/api/assets/assets_common.py
+++ b/backend/src/app/api/assets/assets_common.py
@@ -36,8 +36,15 @@ from app.services.asset_expense_tagging import (
 )
 from app.services.aws_clients import get_s3_client
 from app.services.cloudfront_signing import generate_signed_download_url
-from app.utils import json_response, require_env
+from app.utils import require_env
 from sqlalchemy import inspect
+
+__all__ = [
+    "RequestIdentity",
+    "extract_identity",
+    "normalize_path",
+    "split_route_parts",
+]
 
 _MAX_FILE_NAME_LENGTH = 255
 # Admin presigned PUT uploads (create + replace): reject completes larger than this (bytes).

--- a/backend/src/app/api/assets/assets_common.py
+++ b/backend/src/app/api/assets/assets_common.py
@@ -5,16 +5,21 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID, uuid4
 
 from app.api.admin_request import (
     encode_cursor,
+    extract_identity,
+    normalize_path,
+    paginated_json_response,
     parse_body,
     parse_cursor as parse_admin_cursor,
+    parse_limit as parse_admin_limit,
     query_param,
+    RequestIdentity,
+    split_route_parts,
 )
 from app.api.admin_validators import validate_string_length
 from app.db.models import (
@@ -63,94 +68,14 @@ _FILENAME_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
 _RESOURCE_KEY_SANITIZE_RE = re.compile(r"[^a-z0-9]+")
 
 
-@dataclass(frozen=True)
-class RequestIdentity:
-    """Caller identity extracted from API Gateway authorizer context."""
-
-    user_sub: str | None
-    groups: set[str]
-    organization_ids: set[str]
-
-    @property
-    def is_authenticated(self) -> bool:
-        return bool(self.user_sub)
-
-    @property
-    def is_admin_or_manager(self) -> bool:
-        normalized = {group.lower() for group in self.groups}
-        return "admin" in normalized or "manager" in normalized
-
-
-def normalize_path(path: str) -> str:
-    """Normalize route path for deterministic matching."""
-    if not path:
-        return ""
-    normalized = path.strip()
-    if not normalized.startswith("/"):
-        normalized = "/" + normalized
-    if normalized != "/" and normalized.endswith("/"):
-        normalized = normalized[:-1]
-    return normalized
-
-
-def split_route_parts(path: str) -> list[str]:
-    """Split normalized API route into segments without version prefix."""
-    parts = [segment for segment in normalize_path(path).split("/") if segment]
-    if parts and parts[0].startswith("v") and parts[0][1:].isdigit():
-        return parts[1:]
-    return parts
-
-
 def parse_limit(event: Mapping[str, Any], default: int = 25) -> int:
     """Parse and validate list page size."""
-    raw_value = query_param(event, "limit")
-    if not raw_value:
-        return default
-    try:
-        parsed = int(raw_value)
-    except (TypeError, ValueError) as exc:
-        raise ValidationError("limit must be an integer", field="limit") from exc
-    if parsed <= 0 or parsed > 100:
-        raise ValidationError("limit must be between 1 and 100", field="limit")
-    return parsed
+    return parse_admin_limit(event, default=default)
 
 
 def parse_cursor(event: Mapping[str, Any]) -> UUID | None:
     """Parse cursor query parameter."""
     return parse_admin_cursor(query_param(event, "cursor"))
-
-
-def extract_identity(event: Mapping[str, Any]) -> RequestIdentity:
-    """Extract request identity from API Gateway custom authorizer context."""
-    request_context = event.get("requestContext")
-    if not isinstance(request_context, Mapping):
-        return RequestIdentity(user_sub=None, groups=set(), organization_ids=set())
-    authorizer = request_context.get("authorizer")
-    if not isinstance(authorizer, Mapping):
-        return RequestIdentity(user_sub=None, groups=set(), organization_ids=set())
-
-    user_sub = _to_optional_string(
-        authorizer.get("userSub")
-        or authorizer.get("principalId")
-        or _extract_claim(authorizer.get("claims"), "sub")
-    )
-    groups = _parse_csv_set(
-        _to_optional_string(authorizer.get("groups"))
-        or _extract_claim(authorizer.get("claims"), "cognito:groups")
-    )
-    organization_ids = _parse_csv_set(
-        _to_optional_string(authorizer.get("organizationIds"))
-        or _to_optional_string(authorizer.get("organizationId"))
-        or _extract_claim(authorizer.get("claims"), "custom:organization_ids")
-        or _extract_claim(authorizer.get("claims"), "custom:organization_id")
-        or _extract_claim(authorizer.get("claims"), "organization_ids")
-        or _extract_claim(authorizer.get("claims"), "organization_id")
-    )
-    return RequestIdentity(
-        user_sub=user_sub,
-        groups=groups,
-        organization_ids=organization_ids,
-    )
 
 
 def parse_admin_asset_list_filters(
@@ -447,21 +372,14 @@ def paginate_response(
     headers: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Build a standard paginated API response payload."""
-    page_items = list(items[:limit])
-    next_cursor = (
-        encode_cursor(page_items[-1].id) if len(items) > limit and page_items else None
-    )
-    body: dict[str, Any] = {
-        "items": [serializer(item) for item in page_items],
-        "next_cursor": next_cursor,
-    }
-    if extra_fields:
-        body.update(dict(extra_fields))
-    return json_response(
-        200,
-        body,
+    return paginated_json_response(
+        items=items,
+        limit=limit,
         event=event,
-        headers=dict(headers) if headers is not None else None,
+        serializer=serializer,
+        cursor_encoder=lambda item: encode_cursor(item.id),
+        extra_fields=extra_fields,
+        headers=headers,
     )
 
 

--- a/backend/src/app/api/public_contact.py
+++ b/backend/src/app/api/public_contact.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from sqlalchemy.orm import Session
 
 from app.api.admin_request import parse_body
-from app.api.admin_validators import (
+from app.api.validators import (
     validate_email,
     validate_phone_fields,
     validate_phone_region,

--- a/backend/src/app/api/public_discount_validate.py
+++ b/backend/src/app/api/public_discount_validate.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.api.admin_request import parse_body
-from app.api.admin_validators import validate_string_length
+from app.api.validators import validate_string_length
 from app.currency_config import currency_symbol_for_iso_code
 from app.db.engine import get_engine
 from app.db.models import DiscountCode

--- a/backend/src/app/api/public_media.py
+++ b/backend/src/app/api/public_media.py
@@ -10,7 +10,7 @@ from typing import Any
 from collections.abc import Mapping
 
 from app.api.admin_request import parse_body
-from app.api.admin_validators import validate_email, validate_string_length
+from app.api.validators import validate_email, validate_string_length
 from app.exceptions import ValidationError
 from app.services.aws_clients import get_sns_client
 from app.services.turnstile import (

--- a/backend/src/app/api/public_reservation_payments.py
+++ b/backend/src/app/api/public_reservation_payments.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping
 from urllib.parse import urlencode
 
 from app.api.admin_request import parse_body
-from app.api.admin_validators import validate_string_length
+from app.api.validators import validate_string_length
 from app.exceptions import ValidationError
 from app.services.aws_proxy import AwsProxyError, http_invoke
 from app.services.stripe_payment_context import resolve_public_www_stripe_secret_key

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -14,7 +14,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.api.admin_request import parse_body
-from app.api.admin_validators import (
+from app.api.validators import (
     validate_email,
     validate_phone_fields,
     validate_phone_region,

--- a/backend/src/app/api/validators.py
+++ b/backend/src/app/api/validators.py
@@ -1,0 +1,142 @@
+"""Shared HTTP payload validation helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.exceptions import ValidationError
+
+MAX_NAME_LENGTH = 200
+MAX_DESCRIPTION_LENGTH = 5000
+MAX_ADDRESS_LENGTH = 500
+MAX_EMAIL_LENGTH = 320
+MAX_PHONE_REGION_LENGTH = 2
+MAX_PHONE_NUMBER_LENGTH = 20
+MAX_SOCIAL_HANDLE_LENGTH = 64
+
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def validate_string_length(
+    value: Any,
+    field_name: str,
+    max_length: int,
+    required: bool = False,
+) -> str | None:
+    """Validate and sanitize a string input."""
+    if value is None:
+        if required:
+            raise ValidationError(f"{field_name} is required", field=field_name)
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    if not value:
+        if required:
+            raise ValidationError(f"{field_name} is required", field=field_name)
+        return None
+    if len(value) > max_length:
+        raise ValidationError(
+            f"{field_name} must be at most {max_length} characters",
+            field=field_name,
+        )
+    return value
+
+
+def validate_email(value: Any) -> str | None:
+    """Validate email address."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValidationError("email must be a string", field="email")
+    value = value.strip().lower()
+    if not value:
+        return None
+    if len(value) > MAX_EMAIL_LENGTH:
+        raise ValidationError(
+            f"email must be at most {MAX_EMAIL_LENGTH} characters",
+            field="email",
+        )
+    if not EMAIL_RE.match(value):
+        raise ValidationError("email must be a valid email address", field="email")
+    return value
+
+
+def validate_phone_region(value: Any) -> str | None:
+    """Validate ISO 3166-1 alpha-2 region code for phone parsing (upper-case)."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValidationError("phone_region must be a string", field="phone_region")
+    value = value.strip().upper()
+    if not value:
+        return None
+    if len(value) != MAX_PHONE_REGION_LENGTH:
+        raise ValidationError(
+            "phone_region must be 2 characters",
+            field="phone_region",
+        )
+
+    import phonenumbers
+
+    if value not in phonenumbers.SUPPORTED_REGIONS:
+        raise ValidationError(
+            "phone_region must be a valid ISO 3166-1 alpha-2 region code",
+            field="phone_region",
+        )
+    return value
+
+
+def validate_phone_fields(
+    phone_region: Any, phone_number: Any
+) -> tuple[str | None, str | None]:
+    """Validate phone_region + phone_number; return (region upper, national digits only)."""
+    if phone_region is None and phone_number is None:
+        return None, None
+
+    if phone_region is None:
+        raise ValidationError("phone_region is required", field="phone_region")
+    if phone_number is None:
+        raise ValidationError("phone_number is required", field="phone_number")
+
+    region = validate_phone_region(phone_region)
+    if region is None:
+        raise ValidationError("phone_region is required", field="phone_region")
+
+    if not isinstance(phone_number, str):
+        raise ValidationError("phone_number must be a string", field="phone_number")
+    number = phone_number.strip()
+    normalized_number = re.sub(r"\D", "", number)
+    if not number:
+        raise ValidationError("phone_number is required", field="phone_number")
+    if number != normalized_number:
+        raise ValidationError(
+            "phone_number must contain digits only (no spaces or punctuation)",
+            field="phone_number",
+        )
+    if len(normalized_number) > MAX_PHONE_NUMBER_LENGTH:
+        raise ValidationError(
+            f"phone_number must be at most {MAX_PHONE_NUMBER_LENGTH} digits",
+            field="phone_number",
+        )
+
+    import phonenumbers
+    from phonenumbers.phonenumberutil import NumberParseException
+
+    try:
+        parsed = phonenumbers.parse(normalized_number, region)
+    except NumberParseException as exc:
+        raise ValidationError(
+            "phone_number must be a valid number",
+            field="phone_number",
+        ) from exc
+
+    if not phonenumbers.is_valid_number(parsed):
+        raise ValidationError(
+            "phone_number is not valid for phone_region",
+            field="phone_number",
+        )
+
+    national_number = phonenumbers.national_significant_number(parsed)
+    return region, national_number

--- a/backend/src/app/auth/authorizer_utils.py
+++ b/backend/src/app/auth/authorizer_utils.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 from collections.abc import Mapping
+
+from app.auth.jwt_validator import (
+    JWTValidationError,
+    TokenClaims,
+    decode_and_verify_token,
+)
 
 
 def get_header_case_insensitive(headers: Mapping[str, Any], name: str) -> str:
@@ -77,3 +84,118 @@ def build_iam_policy(
         },
         "context": dict(context),
     }
+
+
+def deny_missing_token(method_arn: str) -> dict[str, Any]:
+    """Build a Deny policy for requests without a bearer token."""
+    return build_iam_policy(
+        "Deny",
+        method_arn,
+        "anonymous",
+        {"reason": "missing_token"},
+    )
+
+
+def deny_invalid_token(
+    method_arn: str, reason: str = "invalid_token"
+) -> dict[str, Any]:
+    """Build a Deny policy for invalid bearer token requests."""
+    return build_iam_policy("Deny", method_arn, "invalid", {"reason": reason})
+
+
+def decode_authorizer_claims(event: Mapping[str, Any]) -> TokenClaims:
+    """Extract and validate Cognito JWT claims from an authorizer event."""
+    headers = event.get("headers") or {}
+    if not isinstance(headers, Mapping):
+        headers = {}
+    token = extract_bearer_token(headers)
+    if not token:
+        raise JWTValidationError("Missing bearer token", reason="missing_token")
+    return decode_and_verify_token(token)
+
+
+def build_allow_context(claims: TokenClaims) -> dict[str, str]:
+    """Build the common IAM authorizer context from verified claims."""
+    organization_ids = extract_organization_ids(claims.raw_claims)
+    return {
+        "userSub": claims.sub,
+        "email": claims.email,
+        "groups": ",".join(claims.groups),
+        "organizationIds": ",".join(sorted(organization_ids)),
+    }
+
+
+@dataclass(frozen=True)
+class VerifiedCognitoContext:
+    """Verified Cognito identity data or a Deny policy when verification failed."""
+
+    claims: TokenClaims | None
+    policy: dict[str, Any] | None = None
+
+    @property
+    def user_sub(self) -> str:
+        return self.claims.sub if self.claims is not None else ""
+
+    @property
+    def email(self) -> str:
+        return self.claims.email if self.claims is not None else ""
+
+    @property
+    def groups(self) -> list[str]:
+        return list(self.claims.groups) if self.claims is not None else []
+
+    @property
+    def organization_ids(self) -> set[str]:
+        if self.claims is None:
+            return set()
+        return extract_organization_ids(self.claims.raw_claims)
+
+    def policy_context(self) -> dict[str, str]:
+        if self.claims is None:
+            return {}
+        return build_allow_context(self.claims)
+
+
+def verified_cognito_context_from_event(
+    event: Mapping[str, Any],
+    *,
+    method_arn: str,
+    logger: Any,
+) -> VerifiedCognitoContext:
+    """Return verified Cognito context, or a Deny policy for auth failures."""
+    try:
+        claims = decode_authorizer_claims(event)
+        return VerifiedCognitoContext(claims=claims)
+    except JWTValidationError as exc:
+        if exc.reason == "missing_token":
+            logger.warning("Missing or invalid Authorization header")
+            return VerifiedCognitoContext(
+                claims=None,
+                policy=deny_missing_token(method_arn),
+            )
+        logger.warning(f"JWT validation failed: {exc.message} (reason: {exc.reason})")
+        return VerifiedCognitoContext(
+            claims=None,
+            policy=deny_invalid_token(method_arn, exc.reason),
+        )
+    except Exception as exc:
+        # SECURITY: Do not expose internal error details in the authorizer context.
+        logger.warning(f"Token validation failed: {type(exc).__name__}")
+        return VerifiedCognitoContext(
+            claims=None,
+            policy=deny_invalid_token(method_arn),
+        )
+
+
+def verify_cognito_authorizer_claims(
+    event: Mapping[str, Any],
+    method_arn: str,
+    *,
+    logger: Any,
+) -> VerifiedCognitoContext:
+    """Compatibility wrapper for handlers that need raw verified claims."""
+    return verified_cognito_context_from_event(
+        event,
+        method_arn=method_arn,
+        logger=logger,
+    )

--- a/backend/src/app/events/sqs_batch.py
+++ b/backend/src/app/events/sqs_batch.py
@@ -1,0 +1,106 @@
+"""SQS batch processing helpers for Lambda handlers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+from collections.abc import Iterator, Mapping
+
+from app.events.sqs_sns import record_message_id
+
+
+@dataclass
+class SqsBatchResult:
+    """Track per-record SQS processing outcomes."""
+
+    processed: int = 0
+    skipped: int = 0
+    failed_item_ids: list[str] = field(default_factory=list)
+
+    def mark_processed(self) -> None:
+        self.processed += 1
+
+    def mark_skipped(self) -> None:
+        self.skipped += 1
+
+    def mark_failed(self, record: Mapping[str, Any]) -> None:
+        message_id = record.get("messageId")
+        if isinstance(message_id, str) and message_id.strip():
+            self.failed_item_ids.append(message_id.strip())
+            return
+        # Without itemIdentifier Lambda cannot retry only this record. Count it
+        # as skipped so callers still get accurate observability.
+        self.skipped += 1
+
+    def to_lambda_response(self) -> dict[str, Any]:
+        return {
+            "batchItemFailures": [
+                {"itemIdentifier": item_id} for item_id in self.failed_item_ids
+            ],
+            "processed": self.processed,
+            "skipped": self.skipped,
+        }
+
+
+class SqsBatchProcessor:
+    """Track SQS partial batch outcomes with consistent logging."""
+
+    def __init__(self, *, logger: Any) -> None:
+        self._logger = logger
+        self._result = SqsBatchResult()
+
+    @property
+    def processed(self) -> int:
+        return self._result.processed
+
+    @processed.setter
+    def processed(self, value: int) -> None:
+        self._result.processed = value
+
+    @property
+    def skipped(self) -> int:
+        return self._result.skipped
+
+    @skipped.setter
+    def skipped(self, value: int) -> None:
+        self._result.skipped = value
+
+    @property
+    def failures(self) -> list[str]:
+        return self._result.failed_item_ids
+
+    def process(self) -> None:
+        self._result.mark_processed()
+
+    def skip(self) -> None:
+        self._result.mark_skipped()
+
+    def fail_record(self, record: Mapping[str, Any], message: str) -> None:
+        self._logger.exception(
+            message,
+            extra={"message_id": record_message_id(record) or None},
+        )
+        self._result.mark_failed(record)
+
+    @contextmanager
+    def record(
+        self,
+        record: Mapping[str, Any],
+        *,
+        failure_message: str = "Failed to process SQS message",
+    ) -> Iterator[None]:
+        try:
+            yield
+        except Exception:
+            self.fail_record(record, failure_message)
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "processed": self.processed,
+            "skipped": self.skipped,
+            "failed": len(self.failures),
+        }
+
+    def response(self) -> dict[str, Any]:
+        return self._result.to_lambda_response()

--- a/backend/src/app/events/sqs_sns.py
+++ b/backend/src/app/events/sqs_sns.py
@@ -1,0 +1,62 @@
+"""Helpers for Lambda handlers that consume SNS notifications through SQS."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+def parse_sqs_sns_message(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Parse the JSON SNS ``Message`` payload from an SQS event record."""
+    sqs_body_raw = record.get("body")
+    if sqs_body_raw is None:
+        raise ValueError("SQS record body is required")
+    sqs_body = json.loads(str(sqs_body_raw))
+    if not isinstance(sqs_body, Mapping):
+        raise ValueError("SQS record body must be a JSON object")
+
+    sns_message = sqs_body.get("Message")
+    if sns_message is None:
+        raise ValueError("SNS message is required")
+    parsed = json.loads(str(sns_message))
+    if not isinstance(parsed, dict):
+        raise ValueError("SNS message payload must be an object")
+    return parsed
+
+
+def parse_sqs_sns_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Backward-compatible alias for SNS-over-SQS record parsing."""
+    return parse_sqs_sns_message(record)
+
+
+def record_message_id(record: Mapping[str, Any]) -> str:
+    """Return the SQS record identifier used by partial batch failure responses."""
+    raw_message_id = record.get("messageId") or record.get("messageID")
+    if raw_message_id is None:
+        return ""
+    return str(raw_message_id)
+
+
+def sqs_batch_response(*, processed: int, skipped: int) -> dict[str, Any]:
+    """Return the legacy summary body used by existing SQS handlers."""
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"processed": processed, "skipped": skipped}),
+    }
+
+
+def partial_batch_response(
+    *,
+    processed: int,
+    skipped: int,
+    failed_record_ids: list[str],
+) -> dict[str, Any]:
+    """Return a summary plus SQS partial batch failure entries."""
+    response = sqs_batch_response(processed=processed, skipped=skipped)
+    response["batchItemFailures"] = [
+        {"itemIdentifier": record_id}
+        for record_id in failed_record_ids
+        if record_id
+    ]
+    return response

--- a/backend/src/app/events/sqs_sns.py
+++ b/backend/src/app/events/sqs_sns.py
@@ -55,8 +55,6 @@ def partial_batch_response(
     """Return a summary plus SQS partial batch failure entries."""
     response = sqs_batch_response(processed=processed, skipped=skipped)
     response["batchItemFailures"] = [
-        {"itemIdentifier": record_id}
-        for record_id in failed_record_ids
-        if record_id
+        {"itemIdentifier": record_id} for record_id in failed_record_ids if record_id
     ]
     return response

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -542,7 +542,7 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
-            default: 50
+            default: 25
         - name: cursor
           in: query
           required: false
@@ -794,10 +794,11 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
-            default: 50
+            default: 25
         - name: cursor
           in: query
           required: false
+          description: Opaque continuation token from `next_cursor`; only valid when `sort` is `created_at`.
           schema:
             type: string
         - name: stage
@@ -1033,7 +1034,7 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
-            default: 50
+            default: 25
         - name: cursor
           in: query
           required: false
@@ -1122,7 +1123,7 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
-            default: 50
+            default: 25
         - name: cursor
           in: query
           required: false

--- a/tests/test_admin_leads_api.py
+++ b/tests/test_admin_leads_api.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from typing import Any
 from uuid import uuid4
 
+import pytest
+
 from app.api import admin_leads
+from app.api.admin_leads_common import parse_lead_filters
 from app.api.assets.assets_common import RequestIdentity
+from app.exceptions import ValidationError
 
 
 def _build_admin_identity(admin_identity: dict[str, str]) -> RequestIdentity:
@@ -112,3 +116,22 @@ def test_handle_admin_leads_dispatches_note_creation(
     )
 
     assert response is marker
+
+
+def test_parse_lead_filters_defaults_to_standard_admin_limit(api_gateway_event: Any) -> None:
+    filters = parse_lead_filters(api_gateway_event(method="GET", path="/v1/admin/leads"))
+
+    assert filters["limit"] == 25
+
+
+def test_parse_lead_filters_rejects_cursor_for_non_created_sort(
+    api_gateway_event: Any,
+) -> None:
+    event = api_gateway_event(
+        method="GET",
+        path="/v1/admin/leads",
+        query_params={"cursor": "abc", "sort": "updated_at"},
+    )
+
+    with pytest.raises(ValidationError, match="cursor is only supported"):
+        parse_lead_filters(event)

--- a/tests/test_admin_request.py
+++ b/tests/test_admin_request.py
@@ -4,7 +4,7 @@ import base64
 
 import pytest
 
-from app.api.admin_request import parse_body
+from app.api.admin_request import parse_body, parse_limit
 from app.exceptions import ValidationError
 
 
@@ -36,3 +36,12 @@ def test_parse_body_decodes_base64_json_payload() -> None:
     }
 
     assert parse_body(event) == {"title": "Guide"}
+
+
+def test_parse_limit_defaults_to_standard_admin_page_size() -> None:
+    assert parse_limit({"queryStringParameters": {}}) == 25
+
+
+def test_parse_limit_rejects_values_above_standard_max() -> None:
+    with pytest.raises(ValidationError, match="limit must be between 1 and 100"):
+        parse_limit({"queryStringParameters": {"limit": "101"}})

--- a/tests/test_eventbrite_sync_processor_handler.py
+++ b/tests/test_eventbrite_sync_processor_handler.py
@@ -27,7 +27,10 @@ def _load_handler_module() -> Any:
 
 
 def _sqs_record(message: dict[str, Any]) -> dict[str, Any]:
-    return {"body": json.dumps({"Message": json.dumps(message)})}
+    return {
+        "messageId": "message-1",
+        "body": json.dumps({"Message": json.dumps(message)}),
+    }
 
 
 def test_lambda_handler_skips_unknown_event_type() -> None:
@@ -44,10 +47,9 @@ def test_lambda_handler_skips_unknown_event_type() -> None:
     }
 
     response = handler.lambda_handler(event, None)
-    body = json.loads(response["body"])
-
-    assert body["processed"] == 0
-    assert body["skipped"] == 1
+    assert response["processed"] == 0
+    assert response["skipped"] == 1
+    assert response["batchItemFailures"] == []
 
 
 def test_lambda_handler_processes_event_instance(monkeypatch: Any) -> None:
@@ -100,8 +102,20 @@ def test_lambda_handler_processes_event_instance(monkeypatch: Any) -> None:
         ]
     }
     response = handler.lambda_handler(event, None)
-    body = json.loads(response["body"])
-
-    assert body["processed"] == 1
-    assert body["skipped"] == 0
+    assert response["processed"] == 1
+    assert response["skipped"] == 0
+    assert response["batchItemFailures"] == []
     assert seen_sync_ids == [instance_id]
+
+
+def test_lambda_handler_reports_partial_batch_failure() -> None:
+    handler = _load_handler_module()
+
+    response = handler.lambda_handler(
+        {"Records": [{"messageId": "bad-message", "body": "{not-json"}]},
+        None,
+    )
+
+    assert response["processed"] == 0
+    assert response["skipped"] == 0
+    assert response["batchItemFailures"] == [{"itemIdentifier": "bad-message"}]

--- a/tests/test_inbound_invoice_email_handler.py
+++ b/tests/test_inbound_invoice_email_handler.py
@@ -127,7 +127,24 @@ def test_lambda_handler_counts_processed_and_skipped(monkeypatch: Any) -> None:
     }
 
     response = handler.lambda_handler(event, None)
-    body = json.loads(response["body"])
 
-    assert response["statusCode"] == 200
-    assert body == {"processed": 1, "skipped": 1}
+    assert response == {
+        "batchItemFailures": [],
+        "processed": 1,
+        "skipped": 1,
+    }
+
+
+def test_lambda_handler_reports_partial_batch_failure() -> None:
+    handler = _load_handler_module()
+
+    response = handler.lambda_handler(
+        {"Records": [{"messageId": "bad-inbound", "body": "{not-json"}]},
+        None,
+    )
+
+    assert response == {
+        "batchItemFailures": [{"itemIdentifier": "bad-inbound"}],
+        "processed": 0,
+        "skipped": 0,
+    }

--- a/tests/test_lambda_authorizer_handlers.py
+++ b/tests/test_lambda_authorizer_handlers.py
@@ -4,6 +4,8 @@ import importlib.util
 from pathlib import Path
 from typing import Any
 
+from app.auth import authorizer_utils
+
 
 def _load_lambda_module(relative_path: str, module_name: str) -> Any:
     module_path = Path(__file__).resolve().parents[1] / "backend" / "lambda" / relative_path
@@ -28,7 +30,11 @@ def test_cognito_group_authorizer_allows_matching_group(monkeypatch: Any) -> Non
         groups = ["admin"]
         raw_claims = {"custom:organization_ids": "org-1"}
 
-    monkeypatch.setattr(handler, "decode_and_verify_token", lambda _token: _Claims())
+    monkeypatch.setattr(
+        authorizer_utils,
+        "decode_and_verify_token",
+        lambda _token: _Claims(),
+    )
 
     event = {
         "headers": {"Authorization": "Bearer valid.jwt"},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Centralize backend request helpers for identity extraction, route parsing, request IDs, limits, pagination, and created-at cursors.
- Standardize admin list defaults to 25 and reject sales lead cursors when sorting by fields other than `created_at`.
- Add shared SQS/SNS parsing and partial batch failure handling for worker Lambdas, with event source configuration updates.
- Deduplicate Cognito authorizer verification flow and mask custom auth challenge identifiers in logs.
- Move public endpoint validation imports to a neutral shared validator module while leaving passwordless SES templating for a later task.
- Regenerate admin web OpenAPI types and preserve compatibility re-exports required by Python lint/mypy.

## Tests
- `pre-commit run --all-files`
- `python3 -m pytest tests/test_admin_request.py tests/test_admin_leads_api.py tests/test_eventbrite_sync_processor_handler.py tests/test_inbound_invoice_email_handler.py tests/test_lambda_authorizer_handlers.py tests/test_public_media_api.py tests/test_public_contact_api.py tests/test_public_reservations_extended.py tests/test_public_reservation_payments_api.py tests/test_public_discount_validate_api.py tests/test_admin_service_instances_api.py tests/test_admin_discount_codes_api.py tests/test_admin_locations_api.py tests/test_admin_router.py`
- `npm run check:admin-api-types && npm run lint` (in `apps/admin_web`)

Earlier full validation also passed:
- `python3 -m pytest`
- `npm run build` (in `backend/infrastructure`)
- `python3 backend/scripts/build_lambda_bundle.py`
- `npm run test:infra` (in `backend/infrastructure`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07e32e49-f551-416e-af07-159bf4788430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07e32e49-f551-416e-af07-159bf4788430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

