### PR TITLE
Gate admin web and API on Cognito staff groups

### DIFF
--- a/apps/admin_web/src/components/admin-access-denied-screen.tsx
+++ b/apps/admin_web/src/components/admin-access-denied-screen.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { StatusBanner } from '@/components/status-banner';
+import { Button } from '@/components/ui/button';
+
+export interface AdminAccessDeniedScreenProps {
+  onSignOut: () => void;
+}
+
+export function AdminAccessDeniedScreen({ onSignOut }: AdminAccessDeniedScreenProps) {
+  return (
+    <main className='mx-auto flex min-h-screen max-w-lg flex-col justify-center gap-6 px-6 py-12'>
+      <StatusBanner variant='error' title='Access not granted'>
+        Your account is signed in but is not assigned to an Evolve Sprouts admin role. If you
+        believe this is a mistake, contact your administrator. You can sign out below.
+      </StatusBanner>
+      <div>
+        <Button type='button' variant='primary' onClick={onSignOut}>
+          Sign out
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/apps/admin_web/src/components/admin-authenticated-shell.tsx
+++ b/apps/admin_web/src/components/admin-authenticated-shell.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 
 import { usePathname } from 'next/navigation';
 
+import { AdminAccessDeniedScreen } from '@/components/admin-access-denied-screen';
 import { AppShell } from '@/components/app-shell';
 import { useAuth } from '@/components/auth-provider';
 import { LoginScreen } from '@/components/login-screen';
@@ -23,6 +24,10 @@ export function AdminAuthenticatedShell({ children }: { children: ReactNode }) {
         </StatusBanner>
       </main>
     );
+  }
+
+  if (status === 'authenticated_no_access') {
+    return <AdminAccessDeniedScreen onSignOut={logout} />;
   }
 
   if (status === 'authenticated') {

--- a/apps/admin_web/src/components/auth-provider.tsx
+++ b/apps/admin_web/src/components/auth-provider.tsx
@@ -9,6 +9,7 @@ import {
   completeLogin,
   ensureFreshTokens,
   getUserProfile,
+  hasStaffAdminAccess,
   startLogin,
   startLogout,
   storeTokensFromPasswordless,
@@ -21,7 +22,11 @@ import {
 } from '../lib/cognito-auth';
 import { getConfigErrors } from '../lib/config';
 
-export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+export type AuthStatus =
+  | 'loading'
+  | 'authenticated'
+  | 'authenticated_no_access'
+  | 'unauthenticated';
 
 export type PasswordlessStatus =
   | 'idle'
@@ -95,7 +100,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           const profile = getUserProfile(tokens);
           setError('');
           setUser(profile);
-          setStatus('authenticated');
+          setStatus(
+            hasStaffAdminAccess(profile.groups) ? 'authenticated' : 'authenticated_no_access'
+          );
         } else {
           setStatus('unauthenticated');
         }
@@ -183,7 +190,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         });
 
         setUser(profile);
-        setStatus('authenticated');
+        setStatus(
+          hasStaffAdminAccess(profile.groups) ? 'authenticated' : 'authenticated_no_access'
+        );
         setPasswordlessStatus('idle');
         setCognitoUser(null);
         setPasswordlessEmail('');

--- a/apps/admin_web/src/lib/auth.ts
+++ b/apps/admin_web/src/lib/auth.ts
@@ -1,6 +1,14 @@
 import { appConfig, getCognitoDomain } from './config';
 import { generatePkcePair } from './pkce';
 
+/** Cognito group names that may use the admin web app and admin API (see user pool groups in CDK). */
+export const COGNITO_STAFF_ADMIN_GROUPS = ['admin', 'manager', 'instructor'] as const;
+
+export function hasStaffAdminAccess(groups: string[]): boolean {
+  const allowed = new Set<string>(COGNITO_STAFF_ADMIN_GROUPS);
+  return groups.some((g) => allowed.has(g));
+}
+
 const tokenStorageKey = 'admin_auth_tokens';
 const pkceStorageKey = 'admin_auth_pkce';
 const loginRedirectStorageKey = 'admin_auth_redirect';

--- a/apps/admin_web/tests/components/admin-authenticated-shell.test.tsx
+++ b/apps/admin_web/tests/components/admin-authenticated-shell.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockUsePathname = vi.fn(() => '/finance');
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+const mockUseAuth = vi.fn();
+
+vi.mock('@/components/auth-provider', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+import { AdminAuthenticatedShell } from '@/components/admin-authenticated-shell';
+
+describe('AdminAuthenticatedShell', () => {
+  it('shows access denied with sign out when authenticated without staff groups', async () => {
+    const user = userEvent.setup();
+    const logout = vi.fn();
+    mockUseAuth.mockReturnValue({
+      status: 'authenticated_no_access',
+      user: { email: 'x@example.com', groups: [] },
+      logout,
+    });
+
+    render(
+      <AdminAuthenticatedShell>
+        <p>Secret</p>
+      </AdminAuthenticatedShell>
+    );
+
+    expect(screen.queryByText('Secret')).not.toBeInTheDocument();
+    expect(screen.getByText(/Access not granted/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Sign out' }));
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders app shell when authenticated with staff group', () => {
+    mockUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: { email: 'a@example.com', groups: ['manager'] },
+      logout: vi.fn(),
+    });
+
+    render(
+      <AdminAuthenticatedShell>
+        <p>Dashboard</p>
+      </AdminAuthenticatedShell>
+    );
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+});

--- a/apps/admin_web/tests/lib/auth.test.ts
+++ b/apps/admin_web/tests/lib/auth.test.ts
@@ -67,6 +67,16 @@ describe('auth helpers', () => {
     expect(profile.lastAuthTime).toBe('2023-11-14T22:13:20.000Z');
   });
 
+  it('hasStaffAdminAccess is true for admin, manager, or instructor', async () => {
+    const auth = await loadAuthModule();
+    expect(auth.hasStaffAdminAccess([])).toBe(false);
+    expect(auth.hasStaffAdminAccess(['guest'])).toBe(false);
+    expect(auth.hasStaffAdminAccess(['admin'])).toBe(true);
+    expect(auth.hasStaffAdminAccess(['manager'])).toBe(true);
+    expect(auth.hasStaffAdminAccess(['instructor'])).toBe(true);
+    expect(auth.hasStaffAdminAccess(['manager', 'other'])).toBe(true);
+  });
+
   it('returns current tokens when not near expiry', async () => {
     const auth = await loadAuthModule();
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2253,7 +2253,7 @@ export class ApiStack extends cdk.Stack {
         timeout: cdk.Duration.seconds(5),
         noVpc: true,
         environment: {
-          ALLOWED_GROUPS: adminGroupName,
+          ALLOWED_GROUPS: `${adminGroupName},manager,instructor`,
         },
       }
     );

--- a/backend/lambda/authorizers/cognito_group/handler.py
+++ b/backend/lambda/authorizers/cognito_group/handler.py
@@ -10,7 +10,7 @@ SECURITY NOTES:
 
 Environment Variables:
     ALLOWED_GROUPS: Comma-separated list of groups that can access the endpoint
-                    (e.g., "admin" or "admin,manager")
+                    (e.g., "admin,manager,instructor")
 """
 
 from __future__ import annotations

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -512,7 +512,7 @@ allowlist (`CORS_ALLOWED_ORIGINS` plus required defaults).
 | Resource Type | Logical ID | Type | Handler | Notes |
 |--------------|------------|------|---------|-------|
 | Request Authorizer | `DeviceAttestationRequestAuthorizer` | Lambda | `DeviceAttestationAuthorizer` | Validates `x-device-attestation` header, no caching |
-| Request Authorizer | `AdminGroupAuthorizer` | Lambda | `AdminGroupAuthorizerFunction` | JWT + admin group check, 5-min cache |
+| Request Authorizer | `AdminGroupAuthorizer` | Lambda | `AdminGroupAuthorizerFunction` | JWT + staff group check (`admin` / `manager` / `instructor`), 5-min cache |
 | Request Authorizer | `UserAuthorizer` | Lambda | `UserAuthorizerFunction` | JWT validation (any user), 5-min cache |
 
 ### API Gateway API Key and Usage Plan

--- a/docs/architecture/infrastructure-map.md
+++ b/docs/architecture/infrastructure-map.md
@@ -286,7 +286,7 @@ All functions use Python 3.12, KMS-encrypted environment variables,
 | Function | Handler | Purpose |
 |---|---|---|
 | DeviceAttestationAuthorizer | `lambda/authorizers/device_attestation/handler.py` | Validates `x-device-attestation` JWT |
-| AdminGroupAuthorizerFunction | `lambda/authorizers/cognito_group/handler.py` | Cognito JWT + admin group check |
+| AdminGroupAuthorizerFunction | `lambda/authorizers/cognito_group/handler.py` | Cognito JWT + staff group check (`admin`, `manager`, `instructor`) |
 | UserAuthorizerFunction | `lambda/authorizers/cognito_user/handler.py` | Cognito JWT (any valid user) |
 
 ### AWS API proxy (not in VPC)
@@ -315,7 +315,8 @@ User/Admin
 Cognito User Pool (evolvesprouts-user-pool)
     │
     ├─▶ Group: admin (full admin access)
-    └─▶ Group: manager (limited management access)
+    ├─▶ Group: manager (limited management access)
+    └─▶ Group: instructor (instructor access)
 ```
 
 | Resource | Value |
@@ -324,7 +325,7 @@ Cognito User Pool (evolvesprouts-user-pool)
 | Domain | `auth.evolvesprouts.com` |
 | Identity provider | Google OAuth |
 | Auth flows | Custom auth (passwordless), SRP, refresh token |
-| Groups | `admin`, `manager` |
+| Groups | `admin`, `manager`, `instructor` |
 
 ## Messaging (SNS + SQS)
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -280,9 +280,9 @@ their primary responsibilities.
 - Function: AdminGroupAuthorizerFunction
 - Handler: backend/lambda/authorizers/cognito_group/handler.py
 - Trigger: API Gateway request authorizer
-- Purpose: verify JWT and check user belongs to the `admin` Cognito group
+- Purpose: verify JWT and check the user belongs to at least one staff Cognito group (`admin`, `manager`, or `instructor`)
 - VPC: **No** (runs outside VPC to fetch JWKS from Cognito)
-- Environment: `ALLOWED_GROUPS=admin`
+- Environment: `ALLOWED_GROUPS=admin,manager,instructor`
 
 ### User authorizer (any authenticated user)
 - Function: UserAuthorizerFunction

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -149,8 +149,10 @@ pull requests for dependency updates:
 - IAM auth for RDS Proxy, TLS enforced on DB connections.
 - Secrets stored in GitHub Secrets or AWS Secrets Manager.
 - Public asset routes require an API key plus device attestation (JWKS-validated).
-- Admin routes require membership in the Cognito `admin` group.
-- Manager routes (when exposed) require `admin` or `manager` group membership.
+- Admin API routes protected by the admin group authorizer require membership in
+  at least one of the Cognito groups `admin`, `manager`, or `instructor`.
+- The admin web app shows the dashboard only for the same staff groups; other
+  signed-in pool users see an access-denied screen with sign out.
 - User routes (when exposed) require any valid Cognito JWT (no group requirement).
 - API keys are rotated every 90 days via a scheduled Lambda.
 - Optional CDK parameters can bootstrap an initial admin user.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -98,6 +98,14 @@ logger.info("Processing user", extra={"user_id_masked": mask_pii(user_id)})
 
 ## Authentication Security
 
+### Admin web and admin API (Cognito groups)
+
+Access to the admin Next.js app (beyond sign-in) and to admin API routes that use
+the Cognito group authorizer requires membership in at least one of the user pool
+groups **`admin`**, **`manager`**, or **`instructor`**. Users who complete social
+or passwordless sign-in without any of these groups must not see the admin
+dashboard; the client shows an access-denied state and sign out instead.
+
 ### OTP/Code Generation
 
 **Always use cryptographically secure random for security tokens.**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Admin web:** After a valid Cognito session (OAuth or passwordless), the dashboard shell is shown only if the JWT `cognito:groups` includes at least one of `admin`, `manager`, or `instructor`. Otherwise the user sees a full-page access-denied message and **Sign out** (no nav, no child routes).
- **Admin API:** The group authorizer `ALLOWED_GROUPS` is aligned to `admin,manager,instructor` so managers and instructors are not denied at the gateway while using the same app.

## Files

- `apps/admin_web/src/lib/auth.ts` — `COGNITO_STAFF_ADMIN_GROUPS`, `hasStaffAdminAccess()`
- `apps/admin_web/src/components/auth-provider.tsx` — new status `authenticated_no_access`
- `apps/admin_web/src/components/admin-authenticated-shell.tsx` — branch for denied state
- `apps/admin_web/src/components/admin-access-denied-screen.tsx` — UX + sign out
- `backend/infrastructure/lib/api-stack.ts` — authorizer env
- `backend/lambda/authorizers/cognito_group/handler.py` — docstring example
- Architecture docs: `security.md`, `lambdas.md`, `aws-assets-map.md`, `infrastructure-map.md`, `overview.md`

## Tests

- `npm run test -- --run` on new shell tests and extended `auth.test.ts`
- `npm run lint` (admin web)

## Deploy note

CDK will update the **AdminGroupAuthorizerFunction** environment on deploy; API Gateway authorizer cache (5 minutes) may briefly serve old decisions for unchanged tokens.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9deb1ca-705d-4a10-9731-b513faba4710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9deb1ca-705d-4a10-9731-b513faba4710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

