### PR TITLE
feat(admin_web): enrollment parent dropdowns sorted by name

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -13,6 +13,7 @@ import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { useEnrollmentParentPickers } from '@/hooks/use-enrollment-parent-pickers';
 import { formatDate, formatEnumLabel, getCurrencyOptions } from '@/lib/format';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -20,6 +21,22 @@ import type { Enrollment } from '@/types/services';
 import { ENROLLMENT_STATUSES } from '@/types/services';
 
 type ApiSchemas = components['schemas'];
+
+const EMPTY_PARENT_VALUE = '';
+
+function ensureOption(
+  options: { id: string; label: string }[],
+  id: string | null | undefined,
+  fallbackPrefix: string
+): { id: string; label: string }[] {
+  if (!id?.trim()) {
+    return options;
+  }
+  if (options.some((o) => o.id === id)) {
+    return options;
+  }
+  return [...options, { id, label: `${fallbackPrefix} (${id})` }];
+}
 
 export interface EnrollmentListPanelProps {
   enrollments: Enrollment[];
@@ -52,6 +69,16 @@ export function EnrollmentListPanel({
   onDelete,
 }: EnrollmentListPanelProps) {
   const currencyOptions = getCurrencyOptions();
+  const {
+    contactOptions,
+    families,
+    organizations,
+    loading: parentPickersLoading,
+    error: parentPickersError,
+    labelByContactId,
+    labelByFamilyId,
+    labelByOrganizationId,
+  } = useEnrollmentParentPickers(canCreate);
   const [confirmDialogProps, requestConfirm] = useConfirmDialog();
   const [selectedEnrollmentId, setSelectedEnrollmentId] = useState<string | null>(null);
   const [contactId, setContactId] = useState('');
@@ -67,6 +94,32 @@ export function EnrollmentListPanel({
     [enrollments, selectedEnrollmentId]
   );
   const isEditMode = Boolean(selectedEnrollment);
+
+  const contactSelectOptions = useMemo(
+    () => ensureOption(contactOptions, selectedEnrollment?.contactId ?? null, 'Contact'),
+    [contactOptions, selectedEnrollment?.contactId]
+  );
+  const familySelectOptions = useMemo(
+    () => ensureOption(families, selectedEnrollment?.familyId ?? null, 'Family'),
+    [families, selectedEnrollment?.familyId]
+  );
+  const organizationSelectOptions = useMemo(
+    () => ensureOption(organizations, selectedEnrollment?.organizationId ?? null, 'Organization'),
+    [organizations, selectedEnrollment?.organizationId]
+  );
+
+  const formatEnrollmentParentCell = (enrollment: Enrollment): string => {
+    if (enrollment.contactId) {
+      return labelByContactId.get(enrollment.contactId) ?? enrollment.contactId;
+    }
+    if (enrollment.familyId) {
+      return labelByFamilyId.get(enrollment.familyId) ?? enrollment.familyId;
+    }
+    if (enrollment.organizationId) {
+      return labelByOrganizationId.get(enrollment.organizationId) ?? enrollment.organizationId;
+    }
+    return '-';
+  };
 
   const resetCreateForm = () => {
     setSelectedEnrollmentId(null);
@@ -166,6 +219,7 @@ export function EnrollmentListPanel({
                 disabled={
                   !canCreate ||
                   isMutating ||
+                  parentPickersLoading ||
                   (!contactId.trim() && !familyId.trim() && !organizationId.trim())
                 }
                 onClick={() => void handleSave()}
@@ -181,37 +235,76 @@ export function EnrollmentListPanel({
             Select a service and instance before creating or editing enrollments.
           </p>
         ) : null}
+        {canCreate && parentPickersError ? (
+          <p className='text-xs text-red-600' role='alert'>
+            {parentPickersError}
+          </p>
+        ) : null}
         <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
           <div>
-            <Label htmlFor='enrollment-contact-id'>Contact ID</Label>
-            <Input
-              id='enrollment-contact-id'
-              value={contactId}
-              onChange={(event) => setContactId(event.target.value)}
-              disabled={isEditMode}
-            />
+            <Label htmlFor='enrollment-contact'>Contact</Label>
+            <Select
+              id='enrollment-contact'
+              value={contactId || EMPTY_PARENT_VALUE}
+              onChange={(event) => {
+                const next = event.target.value;
+                setContactId(next === EMPTY_PARENT_VALUE ? '' : next);
+              }}
+              disabled={isEditMode || parentPickersLoading}
+              aria-busy={parentPickersLoading}
+            >
+              <option value={EMPTY_PARENT_VALUE}>None</option>
+              {contactSelectOptions.map((row) => (
+                <option key={row.id} value={row.id}>
+                  {row.label}
+                </option>
+              ))}
+            </Select>
           </div>
           <div>
-            <Label htmlFor='enrollment-family-id'>Family ID</Label>
-            <Input
-              id='enrollment-family-id'
-              value={familyId}
-              onChange={(event) => setFamilyId(event.target.value)}
-              disabled={isEditMode}
-            />
+            <Label htmlFor='enrollment-family'>Family</Label>
+            <Select
+              id='enrollment-family'
+              value={familyId || EMPTY_PARENT_VALUE}
+              onChange={(event) => {
+                const next = event.target.value;
+                setFamilyId(next === EMPTY_PARENT_VALUE ? '' : next);
+              }}
+              disabled={isEditMode || parentPickersLoading}
+              aria-busy={parentPickersLoading}
+            >
+              <option value={EMPTY_PARENT_VALUE}>None</option>
+              {familySelectOptions.map((row) => (
+                <option key={row.id} value={row.id}>
+                  {row.label}
+                </option>
+              ))}
+            </Select>
           </div>
           <div>
-            <Label htmlFor='enrollment-organization-id'>Organization ID</Label>
-            <Input
-              id='enrollment-organization-id'
-              value={organizationId}
-              onChange={(event) => setOrganizationId(event.target.value)}
-              disabled={isEditMode}
-            />
+            <Label htmlFor='enrollment-organization'>Organization</Label>
+            <Select
+              id='enrollment-organization'
+              value={organizationId || EMPTY_PARENT_VALUE}
+              onChange={(event) => {
+                const next = event.target.value;
+                setOrganizationId(next === EMPTY_PARENT_VALUE ? '' : next);
+              }}
+              disabled={isEditMode || parentPickersLoading}
+              aria-busy={parentPickersLoading}
+            >
+              <option value={EMPTY_PARENT_VALUE}>None</option>
+              {organizationSelectOptions.map((row) => (
+                <option key={row.id} value={row.id}>
+                  {row.label}
+                </option>
+              ))}
+            </Select>
           </div>
         </div>
         <p className='text-xs text-slate-500'>
-          Contact, family, and organization IDs are set during creation and are read-only when editing.
+          Contact, family, and organization are chosen when creating an enrollment and cannot be changed
+          afterward.
         </p>
         <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
           <div>
@@ -281,9 +374,7 @@ export function EnrollmentListPanel({
                 }`}
                 onClick={() => applyEnrollmentSelection(enrollment)}
               >
-                <td className='px-4 py-3'>
-                  {enrollment.contactId ?? enrollment.familyId ?? enrollment.organizationId ?? '-'}
-                </td>
+                <td className='px-4 py-3'>{formatEnrollmentParentCell(enrollment)}</td>
                 <td className='px-4 py-3'>{formatEnumLabel(enrollment.status)}</td>
                 <td className='px-4 py-3'>
                   {enrollment.amountPaid ? `${enrollment.amountPaid} ${enrollment.currency ?? ''}` : '-'}

--- a/apps/admin_web/src/hooks/use-enrollment-parent-pickers.ts
+++ b/apps/admin_web/src/hooks/use-enrollment-parent-pickers.ts
@@ -1,0 +1,149 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  listAdminContacts,
+  listEntityFamilyPicker,
+  listEntityOrganizationPicker,
+} from '@/lib/entity-api';
+import { DEFAULT_CONTACT_LIST_FILTERS } from '@/types/entity-list';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type AdminContact = components['schemas']['AdminContact'];
+
+export interface EnrollmentParentPickerOption {
+  id: string;
+  label: string;
+}
+
+function formatContactSortKey(contact: AdminContact): string {
+  const name = [contact.first_name, contact.last_name].filter(Boolean).join(' ').trim();
+  return (name || contact.email || contact.id).toLowerCase();
+}
+
+function formatContactOptionLabel(contact: AdminContact): string {
+  const name = [contact.first_name, contact.last_name].filter(Boolean).join(' ').trim();
+  return name ? `${name}${contact.email ? ` · ${contact.email}` : ''}` : contact.email || contact.id;
+}
+
+export function useEnrollmentParentPickers(canCreate: boolean) {
+  const [contacts, setContacts] = useState<AdminContact[]>([]);
+  const [families, setFamilies] = useState<EnrollmentParentPickerOption[]>([]);
+  const [organizations, setOrganizations] = useState<EnrollmentParentPickerOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!canCreate) {
+      setContacts([]);
+      setFamilies([]);
+      setOrganizations([]);
+      setLoading(false);
+      setError('');
+      return;
+    }
+
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    async function load() {
+      setLoading(true);
+      setError('');
+      try {
+        const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
+
+        const [familyItems, orgItems] = await Promise.all([
+          listEntityFamilyPicker(signal),
+          listEntityOrganizationPicker(undefined, signal),
+        ]);
+
+        const sortedFamilies = [...familyItems].sort((a, b) =>
+          collator.compare(a.label.toLowerCase(), b.label.toLowerCase())
+        );
+        const sortedOrgs = [...orgItems].sort((a, b) =>
+          collator.compare(a.label.toLowerCase(), b.label.toLowerCase())
+        );
+
+        setFamilies(sortedFamilies.map((row) => ({ id: row.id, label: row.label })));
+        setOrganizations(sortedOrgs.map((row) => ({ id: row.id, label: row.label })));
+
+        const contactRows: AdminContact[] = [];
+        let cursor: string | null = null;
+        do {
+          const page = await listAdminContacts(
+            {
+              ...DEFAULT_CONTACT_LIST_FILTERS,
+              cursor,
+              limit: 100,
+            },
+            signal
+          );
+          contactRows.push(...page.items);
+          cursor = page.nextCursor;
+        } while (cursor);
+
+        contactRows.sort((a, b) => collator.compare(formatContactSortKey(a), formatContactSortKey(b)));
+        setContacts(contactRows);
+      } catch (err) {
+        if (signal.aborted) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : 'Failed to load parent options.';
+        setError(message);
+        setContacts([]);
+        setFamilies([]);
+        setOrganizations([]);
+      } finally {
+        if (!signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => controller.abort();
+  }, [canCreate]);
+
+  const contactOptions = useMemo<EnrollmentParentPickerOption[]>(
+    () => contacts.map((c) => ({ id: c.id, label: formatContactOptionLabel(c) })),
+    [contacts]
+  );
+
+  const labelByContactId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const row of contactOptions) {
+      map.set(row.id, row.label);
+    }
+    return map;
+  }, [contactOptions]);
+
+  const labelByFamilyId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const row of families) {
+      map.set(row.id, row.label);
+    }
+    return map;
+  }, [families]);
+
+  const labelByOrganizationId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const row of organizations) {
+      map.set(row.id, row.label);
+    }
+    return map;
+  }, [organizations]);
+
+  return {
+    contactOptions,
+    families,
+    organizations,
+    loading,
+    error,
+    labelByContactId,
+    labelByFamilyId,
+    labelByOrganizationId,
+  };
+}

--- a/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
@@ -1,8 +1,21 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { EnrollmentListPanel } from '@/components/admin/services/enrollment-list-panel';
 import type { Enrollment } from '@/types/services';
+
+vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
+  useEnrollmentParentPickers: () => ({
+    contactOptions: [{ id: 'contact-1', label: 'Jane Doe' }],
+    families: [{ id: 'family-1', label: 'Smith family' }],
+    organizations: [{ id: 'org-1', label: 'Acme Org' }],
+    loading: false,
+    error: '',
+    labelByContactId: new Map([['contact-1', 'Jane Doe']]),
+    labelByFamilyId: new Map([['family-1', 'Smith family']]),
+    labelByOrganizationId: new Map([['org-1', 'Acme Org']]),
+  }),
+}));
 
 const ENROLLMENT_FIXTURE: Enrollment = {
   id: 'enrollment-1',
@@ -24,7 +37,7 @@ const ENROLLMENT_FIXTURE: Enrollment = {
 };
 
 describe('EnrollmentListPanel', () => {
-  it('uses the same copy for create/edit and locks parent IDs in edit mode', () => {
+  it('uses the same copy for create/edit and locks parent pickers in edit mode', () => {
     render(
       <EnrollmentListPanel
         enrollments={[ENROLLMENT_FIXTURE]}
@@ -42,18 +55,19 @@ describe('EnrollmentListPanel', () => {
     );
 
     expect(screen.getByText('Add or update an enrollment using the same fields below.')).toBeInTheDocument();
-    expect(screen.getByLabelText('Contact ID')).toBeEnabled();
-    expect(screen.getByLabelText('Family ID')).toBeEnabled();
-    expect(screen.getByLabelText('Organization ID')).toBeEnabled();
+    expect(screen.getByLabelText('Contact')).toBeEnabled();
+    expect(screen.getByLabelText('Family')).toBeEnabled();
+    expect(screen.getByLabelText('Organization')).toBeEnabled();
 
-    const selectedRow = screen.getByText('contact-1').closest('tr');
+    const table = screen.getByRole('table');
+    const selectedRow = within(table).getByText('Jane Doe').closest('tr');
     expect(selectedRow).not.toBeNull();
     fireEvent.click(selectedRow as HTMLTableRowElement);
 
     expect(screen.getByText('Add or update an enrollment using the same fields below.')).toBeInTheDocument();
-    expect(screen.getByLabelText('Contact ID')).toBeDisabled();
-    expect(screen.getByLabelText('Family ID')).toBeDisabled();
-    expect(screen.getByLabelText('Organization ID')).toBeDisabled();
+    expect(screen.getByLabelText('Contact')).toBeDisabled();
+    expect(screen.getByLabelText('Family')).toBeDisabled();
+    expect(screen.getByLabelText('Organization')).toBeDisabled();
   });
 
   it('uses selectable currency options in the enrollment editor', () => {

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -8,6 +8,19 @@ import { ServiceListPanel } from '@/components/admin/services/service-list-panel
 import { formatDate } from '@/lib/format';
 import type { DiscountCode, Enrollment, ServiceInstance, ServiceSummary } from '@/types/services';
 
+vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
+  useEnrollmentParentPickers: () => ({
+    contactOptions: [{ id: 'contact-1', label: 'Resolved contact label' }],
+    families: [],
+    organizations: [],
+    loading: false,
+    error: '',
+    labelByContactId: new Map([['contact-1', 'Resolved contact label']]),
+    labelByFamilyId: new Map(),
+    labelByOrganizationId: new Map(),
+  }),
+}));
+
 const SERVICE_FIXTURE: ServiceSummary = {
   id: 'service-1',
   instancesCount: 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the Services enrollment inline editor’s free-text **Contact ID**, **Family ID**, and **Organization ID** fields with **dropdowns** backed by the admin CRM APIs.

## Behavior

- **Create**: Three `<select>` fields (Contact, Family, Organization) with a **None** option each. Exactly one parent must still be chosen before **Add enrollment** (unchanged rule: at least one of the three).
- **Edit**: Parent fields remain **read-only** (disabled selects), matching the API (create payload only for those IDs).
- **Data loading** (`useEnrollmentParentPickers`):
  - **Families** and **organizations**: `GET /v1/admin/families/picker` and `GET /v1/admin/organizations/picker` (already documented as name-ordered); client applies `Intl.Collator` for consistent sorting.
  - **Contacts**: Paginated `listAdminContacts` with default active filters, merged and sorted by display name (name + optional email, same pattern as contacts panel).
- **Enrollments table** “Parent” column shows the **resolved label** when the ID is in the loaded maps; otherwise falls back to the raw ID (and edit mode injects a synthetic option `Type (uuid)` when the enrolled parent is missing from the list, e.g. archived or beyond pagination).
- **Errors**: Load failures show a small alert above the grid; **Add enrollment** stays disabled while pickers are loading.

## Tests

- Vitest mocks for `useEnrollmentParentPickers` in enrollment list and table formatting tests.

## Risks / limits

- Contact dropdown is built from **all active contacts** via repeated 100-row pages; very large directories add initial load time. Organizations/families are capped at API **limit 100** (existing picker contract).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dea163a-09ee-476d-bac2-0d87dc59204c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dea163a-09ee-476d-bac2-0d87dc59204c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

