### PR TITLE
public-www: MBA hero price uses {currency}{price} aligned with course JSON-LD

### DIFF
--- a/apps/public_www/src/app/[locale]/services/my-best-auntie-training-course/page.tsx
+++ b/apps/public_www/src/app/[locale]/services/my-best-auntie-training-course/page.tsx
@@ -119,6 +119,7 @@ export default async function MyBestAuntieRoutePage({
         data={buildCourseSchema({
           locale,
           content,
+          myBestAuntieCohorts: cohorts,
         })}
       />
       <StructuredDataScript

--- a/apps/public_www/src/components/pages/my-best-auntie.tsx
+++ b/apps/public_www/src/components/pages/my-best-auntie.tsx
@@ -1,9 +1,7 @@
 import type { Locale, SiteContent } from '@/content';
 import type { MyBestAuntieEventCohort } from '@/lib/events-data';
-import {
-  formatTrainingCoursePriceCurrencySymbol,
-  resolveMyBestAuntieHeroCohortSummary,
-} from '@/lib/my-best-auntie-cohort-summary';
+import { formatCurrencyDisplayPrefix } from '@/lib/format';
+import { resolveMyBestAuntieHeroCohortSummary } from '@/lib/my-best-auntie-cohort-summary';
 import { buildWhatsappPrefilledHref, resolvePublicSiteConfig } from '@/lib/site-config';
 import { PageLayout } from '@/components/shared/page-layout';
 import { Faq } from '@/components/sections/faq';
@@ -33,7 +31,7 @@ export function MyBestAuntiePage({ locale, content, cohorts }: MyBestAuntiePageP
     resolveMyBestAuntieHeroCohortSummary(cohorts, locale);
   const priceCurrencySymbol =
     lowestPrice !== undefined && priceCurrency
-      ? formatTrainingCoursePriceCurrencySymbol(priceCurrency)
+      ? formatCurrencyDisplayPrefix(priceCurrency)
       : undefined;
 
   return (

--- a/apps/public_www/src/components/pages/my-best-auntie.tsx
+++ b/apps/public_www/src/components/pages/my-best-auntie.tsx
@@ -1,7 +1,10 @@
 import type { Locale, SiteContent } from '@/content';
 import type { MyBestAuntieEventCohort } from '@/lib/events-data';
+import {
+  formatTrainingCoursePriceCurrencySymbol,
+  resolveMyBestAuntieHeroCohortSummary,
+} from '@/lib/my-best-auntie-cohort-summary';
 import { buildWhatsappPrefilledHref, resolvePublicSiteConfig } from '@/lib/site-config';
-import { formatCohortValue } from '@/lib/format';
 import { PageLayout } from '@/components/shared/page-layout';
 import { Faq } from '@/components/sections/faq';
 import { Testimonials } from '@/components/sections/testimonials';
@@ -18,31 +21,6 @@ interface MyBestAuntiePageProps {
   cohorts: MyBestAuntieEventCohort[];
 }
 
-function resolveHeroCohortSummary(
-  cohorts: MyBestAuntieEventCohort[] | undefined,
-  locale: string,
-): { lowestPrice: number | undefined; nextCohortLabel: string | undefined } {
-  if (!cohorts || cohorts.length === 0) {
-    return { lowestPrice: undefined, nextCohortLabel: undefined };
-  }
-  const available = cohorts.filter((c) => !c.is_fully_booked);
-  if (available.length === 0) {
-    return { lowestPrice: undefined, nextCohortLabel: undefined };
-  }
-
-  const lowestPrice = Math.min(...available.map((c) => c.price));
-
-  const sorted = [...available].sort((a, b) => {
-    const dateA = a.dates[0]?.start_datetime ?? '';
-    const dateB = b.dates[0]?.start_datetime ?? '';
-    return dateA.localeCompare(dateB);
-  });
-  const rawCohort = sorted[0]?.cohort ?? '';
-  const nextCohortLabel = formatCohortValue(rawCohort, locale as Locale) || rawCohort || undefined;
-
-  return { lowestPrice, nextCohortLabel };
-}
-
 export function MyBestAuntiePage({ locale, content, cohorts }: MyBestAuntiePageProps) {
   const publicSiteConfig = resolvePublicSiteConfig();
   const privateProgrammeWhatsappHref = buildWhatsappPrefilledHref(
@@ -51,7 +29,12 @@ export function MyBestAuntiePage({ locale, content, cohorts }: MyBestAuntiePageP
     content.freeIntroSession.phoneNumber,
   ) || content.freeIntroSession.ctaHref;
 
-  const { lowestPrice, nextCohortLabel } = resolveHeroCohortSummary(cohorts, locale);
+  const { lowestPrice, priceCurrency, nextCohortLabel } =
+    resolveMyBestAuntieHeroCohortSummary(cohorts, locale);
+  const priceCurrencySymbol =
+    lowestPrice !== undefined && priceCurrency
+      ? formatTrainingCoursePriceCurrencySymbol(priceCurrency)
+      : undefined;
 
   return (
     <PageLayout
@@ -61,6 +44,7 @@ export function MyBestAuntiePage({ locale, content, cohorts }: MyBestAuntiePageP
       <MyBestAuntieHero
         content={content.myBestAuntie.hero}
         lowestPrice={lowestPrice}
+        priceCurrencySymbol={priceCurrencySymbol}
         nextCohortLabel={nextCohortLabel}
       />
       <MyBestAuntieDescription
@@ -70,6 +54,8 @@ export function MyBestAuntiePage({ locale, content, cohorts }: MyBestAuntiePageP
       <MyBestAuntieOutline
         content={content.myBestAuntie.outline}
         commonAccessibility={content.common.accessibility}
+        lowestPrice={lowestPrice}
+        priceCurrencySymbol={priceCurrencySymbol}
       />
       <Testimonials
         content={content.testimonials}

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-hero.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-hero.tsx
@@ -16,6 +16,8 @@ import type { MyBestAuntieHeroContent } from '@/content';
 interface MyBestAuntieHeroProps {
   content: MyBestAuntieHeroContent;
   lowestPrice?: number;
+  /** Display prefix for lowest price (e.g. HK$); must align with JSON-LD `priceCurrency` cohort data. */
+  priceCurrencySymbol?: string;
   nextCohortLabel?: string;
 }
 
@@ -24,6 +26,7 @@ const MY_BEST_AUNTIE_HERO_CTA_CLASSNAME = 'mt-auto max-w-[360px]';
 function buildMyBestAuntieHeroChips(
   content: MyBestAuntieHeroContent,
   lowestPrice: number | undefined,
+  priceCurrencySymbol: string | undefined,
   nextCohortLabel: string | undefined,
 ): HeroQuickFactChip[] {
   const quickFacts = (content as Record<string, unknown>).quickFacts as
@@ -38,10 +41,11 @@ function buildMyBestAuntieHeroChips(
     { type: 'duration', label: quickFacts.durationLabel.trim() },
   ];
 
-  if (lowestPrice !== undefined) {
+  if (lowestPrice !== undefined && priceCurrencySymbol) {
     chips.push({
       type: 'price',
       label: formatContentTemplate(quickFacts.priceTemplate, {
+        currency: priceCurrencySymbol,
         price: lowestPrice.toLocaleString(),
       }).trim(),
     });
@@ -86,10 +90,16 @@ function MicroTestimonial({ content }: { content: MyBestAuntieHeroContent }) {
 export function MyBestAuntieHero({
   content,
   lowestPrice,
+  priceCurrencySymbol,
   nextCohortLabel,
 }: MyBestAuntieHeroProps) {
   const description = resolveMyBestAuntieHeroDescription(content);
-  const heroChips = buildMyBestAuntieHeroChips(content, lowestPrice, nextCohortLabel);
+  const heroChips = buildMyBestAuntieHeroChips(
+    content,
+    lowestPrice,
+    priceCurrencySymbol,
+    nextCohortLabel,
+  );
 
   return (
     <SectionShell

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-outline.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-outline.tsx
@@ -14,13 +14,15 @@ import type {
   CommonAccessibilityContent,
   MyBestAuntieOutlineContent,
 } from '@/content';
-import { formatContentTemplate } from '@/content/content-field-utils';
+import { formatContentTemplate, readOptionalText } from '@/content/content-field-utils';
 import { useHorizontalCarousel } from '@/lib/hooks/use-horizontal-carousel';
 
 interface MyBestAuntieOutlineProps {
   content: MyBestAuntieOutlineContent;
   ctaHref?: string;
   commonAccessibility?: CommonAccessibilityContent;
+  lowestPrice?: number;
+  priceCurrencySymbol?: string;
 }
 
 type ModuleIconVariant =
@@ -93,6 +95,13 @@ function renderMultilineText(value: string): ReactNode {
 
 function getModuleTone(index: number): ModuleToneVariant {
   return MODULE_TONES[index % MODULE_TONES.length];
+}
+
+function readOptionalOutlineField(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  return readOptionalText(record[key]);
 }
 
 function parseModuleActivity(activity: string | undefined): ParsedModuleActivity | null {
@@ -256,6 +265,8 @@ export function MyBestAuntieOutline({
   content,
   ctaHref,
   commonAccessibility = enContent.common.accessibility,
+  lowestPrice,
+  priceCurrencySymbol,
 }: MyBestAuntieOutlineProps) {
   const firstModuleStep = content.modules[0]?.step ?? null;
 
@@ -281,6 +292,21 @@ export function MyBestAuntieOutline({
   const computedCtaLabel = content.ctaLabel.trim().replace(/\s*>$/, '');
   const computedCtaHref =
     ctaHref?.trim() || content.ctaHref?.trim() || '#my-best-auntie-booking';
+
+  const outlineRecord = content as Record<string, unknown>;
+  const descriptionWithPriceTemplate = readOptionalOutlineField(
+    outlineRecord,
+    'descriptionWithPriceTemplate',
+  );
+  const resolvedOutlineDescription =
+    lowestPrice !== undefined &&
+    priceCurrencySymbol &&
+    descriptionWithPriceTemplate
+      ? formatContentTemplate(descriptionWithPriceTemplate, {
+          currency: priceCurrencySymbol,
+          price: lowestPrice.toLocaleString(),
+        })
+      : content.description;
 
   function handleToggleModule(step: string) {
     setExpandedModuleStep((previousStep) =>
@@ -374,9 +400,9 @@ export function MyBestAuntieOutline({
         </div>
 
         <div className='mx-auto max-w-[760px] text-center'>
-          {content.description && (
+          {resolvedOutlineDescription && (
             <p className='es-type-body-italic text-balance'>
-              {renderQuotedDescriptionText(content.description)}
+              {renderQuotedDescriptionText(resolvedOutlineDescription)}
             </p>
           )}
 

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1173,7 +1173,7 @@
       "quickFacts": {
         "durationLabel": "9 weeks",
         "homeVisitsLabel": "3 home visits",
-        "priceTemplate": "From HK${price}",
+        "priceTemplate": "From {currency}{price}",
         "nextCohortTemplate": "Next: {cohortLabel}"
       },
       "testimonialQuote": "After the programme, our helper sets up independent play every morning without being asked.",
@@ -1183,7 +1183,8 @@
       "eyebrow": "Course Outline",
       "title": "My Best Auntie Course Outline - Designed by Ida",
       "subtitle": "A 9-Week Programme That Changes How Your Child Is Raised.",
-      "description": "Structured helper training with group sessions + private 1:1 coaching. Your child's caregiver learns by doing - in your home, with your routines. Starting from HK$9,000.",
+      "description": "Structured helper training with group sessions + private 1:1 coaching. Your child's caregiver learns by doing - in your home, with your routines.",
+      "descriptionWithPriceTemplate": "Structured helper training with group sessions + private 1:1 coaching. Your child's caregiver learns by doing - in your home, with your routines. Starting from {currency}{price}.",
       "ctaLabel": "Book your spot now!",
       "ctaHref": "#my-best-auntie-booking",
       "modules": [

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1173,7 +1173,7 @@
       "quickFacts": {
         "durationLabel": "9 周",
         "homeVisitsLabel": "3 次上门指导",
-        "priceTemplate": "HK${price} 起",
+        "priceTemplate": "{currency}{price} 起",
         "nextCohortTemplate": "下期：{cohortLabel}"
       },
       "testimonialQuote": "课程之后，我们的助手每天早上都能自主安排独立游戏，无需提醒。",
@@ -1183,7 +1183,8 @@
       "eyebrow": "课程大纲",
       "title": "My Best Auntie 课程大纲 - 由 Ida 设计",
       "subtitle": "一个改变孩子每日成长方式的 9 周课程。",
-      "description": "结构化助手培训，包含小组课程 + 一对一私人辅导。你孩子的照护者在你家中、按你的日常流程学习实践。起步价 HK$9,000。",
+      "description": "结构化助手培训，包含小组课程 + 一对一私人辅导。你孩子的照护者在你家中、按你的日常流程学习实践。",
+      "descriptionWithPriceTemplate": "结构化助手培训，包含小组课程 + 一对一私人辅导。你孩子的照护者在你家中、按你的日常流程学习实践。起步价 {currency}{price}。",
       "ctaLabel": "立即预订名额！",
       "ctaHref": "#my-best-auntie-booking",
       "modules": [

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1173,7 +1173,7 @@
       "quickFacts": {
         "durationLabel": "9 週",
         "homeVisitsLabel": "3 次上門指導",
-        "priceTemplate": "HK${price} 起",
+        "priceTemplate": "{currency}{price} 起",
         "nextCohortTemplate": "下期：{cohortLabel}"
       },
       "testimonialQuote": "課程之後，我哋嘅家傭每朝都自動安排獨立遊戲，唔使再提醒。",
@@ -1183,7 +1183,8 @@
       "eyebrow": "課程大綱",
       "title": "My Best Auntie 課程大綱 - 由 Ida 設計",
       "subtitle": "一個改變孩子每日成長方式的 9 週課程。",
-      "description": "結構化助手培訓，包含小組課程 + 一對一私人輔導。你孩子的照護者在你家中、按你的日常流程學習實踐。起步價 HK$9,000。",
+      "description": "結構化助手培訓，包含小組課程 + 一對一私人輔導。你孩子的照護者在你家中、按你的日常流程學習實踐。",
+      "descriptionWithPriceTemplate": "結構化助手培訓，包含小組課程 + 一對一私人輔導。你孩子的照護者在你家中、按你的日常流程學習實踐。起步價 {currency}{price}。",
       "ctaLabel": "立即預訂名額！",
       "ctaHref": "#my-best-auntie-booking",
       "modules": [

--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -16,7 +16,7 @@ import {
   isAbortRequestError,
 } from '@/lib/crm-api-client';
 import { reportInternalError } from '@/lib/internal-error-reporting';
-import { formatCohortValue } from '@/lib/format';
+import { formatCohortValue, normalizeCurrencyPrefixForDisplay } from '@/lib/format';
 import { ROUTES } from '@/lib/routes';
 import {
   appendTimeZoneLabel,
@@ -862,19 +862,6 @@ function formatNumberWithThousandsSeparators(value: number): string {
   }).format(value);
 }
 
-function normalizeCurrencyPrefix(value: string | undefined): string | undefined {
-  const normalizedValue = readOptionalText(value);
-  if (!normalizedValue) {
-    return undefined;
-  }
-
-  if (normalizedValue.toUpperCase() === 'HKD') {
-    return 'HK$';
-  }
-
-  return normalizedValue;
-}
-
 function resolveEventCost(
   record: Record<string, unknown>,
   content: EventsContent,
@@ -927,7 +914,7 @@ function resolveEventCost(
     'priceCurrency',
     'price_currency',
   ]);
-  const normalizedCurrencyPrefix = normalizeCurrencyPrefix(currencyPrefix);
+  const normalizedCurrencyPrefix = normalizeCurrencyPrefixForDisplay(currencyPrefix);
 
   const amountText =
     typeof rawAmount === 'number' && Number.isFinite(rawAmount)
@@ -970,7 +957,7 @@ function formatLandingPageEventCtaPriceLabel(
   }
 
   const formattedAmount = formatNumberWithThousandsSeparators(amount);
-  const currencyPrefix = normalizeCurrencyPrefix(
+  const currencyPrefix = normalizeCurrencyPrefixForDisplay(
     readCandidateText(record, [
       'currencySymbol',
       'currency_symbol',

--- a/apps/public_www/src/lib/format.ts
+++ b/apps/public_www/src/lib/format.ts
@@ -61,6 +61,44 @@ export function formatCurrencyHkd(value: number, locale?: string): string {
   }
 }
 
+const currencyDisplayPrefixCache = new Map<string, Intl.NumberFormat>();
+
+/**
+ * Prefix/symbol for site copy templates (e.g. `{currency}{price}`), from an ISO 4217 code.
+ * JSON-LD should keep the raw ISO code in `priceCurrency`; use this only for visible strings.
+ */
+export function formatCurrencyDisplayPrefix(iso4217: string): string {
+  const code = iso4217.trim().toUpperCase();
+  if (!code) {
+    return '';
+  }
+  if (code === HKD_CURRENCY) {
+    return 'HK$';
+  }
+  try {
+    let formatter = currencyDisplayPrefixCache.get(code);
+    if (!formatter) {
+      formatter = new Intl.NumberFormat('en', {
+        style: 'currency',
+        currency: code,
+        currencyDisplay: 'narrowSymbol',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      });
+      currencyDisplayPrefixCache.set(code, formatter);
+    }
+    const symbol = formatter
+      .formatToParts(0)
+      .find((part) => part.type === 'currency')?.value;
+    if (symbol && symbol.trim()) {
+      return symbol;
+    }
+  } catch {
+    // fall through
+  }
+  return `${code} `;
+}
+
 /**
  * Broad cohort token shape: three letters or two digits, hyphen, two-digit year suffix.
  * Month validity is enforced in {@link parseCohortValue} (invalid month abbreviations parse to null).

--- a/apps/public_www/src/lib/format.ts
+++ b/apps/public_www/src/lib/format.ts
@@ -1,4 +1,5 @@
 import type { Locale } from '@/content';
+import { readOptionalText } from '@/content/content-field-utils';
 
 import { formatCohortMonthYearLabel } from '@/lib/site-datetime';
 
@@ -64,15 +65,34 @@ export function formatCurrencyHkd(value: number, locale?: string): string {
 const currencyDisplayPrefixCache = new Map<string, Intl.NumberFormat>();
 
 /**
+ * Normalizes API-provided currency hints to a display prefix (calendar/events).
+ * `HKD` maps to `HK$`; any other non-empty string is returned trimmed as-is.
+ */
+export function normalizeCurrencyPrefixForDisplay(
+  value: string | undefined,
+): string | undefined {
+  const normalizedValue = readOptionalText(value);
+  if (!normalizedValue) {
+    return undefined;
+  }
+  if (normalizedValue.toUpperCase() === HKD_CURRENCY) {
+    return 'HK$';
+  }
+  return normalizedValue;
+}
+
+/**
  * Prefix/symbol for site copy templates (e.g. `{currency}{price}`), from an ISO 4217 code.
  * JSON-LD should keep the raw ISO code in `priceCurrency`; use this only for visible strings.
+ * HKD uses the same mapping as {@link normalizeCurrencyPrefixForDisplay}; other codes use Intl.
  */
 export function formatCurrencyDisplayPrefix(iso4217: string): string {
   const code = iso4217.trim().toUpperCase();
   if (!code) {
     return '';
   }
-  if (code === HKD_CURRENCY) {
+  const hkdPrefix = normalizeCurrencyPrefixForDisplay(code);
+  if (hkdPrefix === 'HK$') {
     return 'HK$';
   }
   try {

--- a/apps/public_www/src/lib/my-best-auntie-cohort-summary.ts
+++ b/apps/public_www/src/lib/my-best-auntie-cohort-summary.ts
@@ -58,28 +58,3 @@ export function resolveMyBestAuntieHeroCohortSummary(
     nextCohortLabel,
   };
 }
-
-/** Display symbol for hero/outline copy; JSON-LD keeps ISO codes (e.g. HKD). */
-export function formatTrainingCoursePriceCurrencySymbol(iso: string): string {
-  const code = iso.trim().toUpperCase();
-  if (code === 'HKD') {
-    return 'HK$';
-  }
-  try {
-    const symbol = new Intl.NumberFormat('en', {
-      style: 'currency',
-      currency: code,
-      currencyDisplay: 'narrowSymbol',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    })
-      .formatToParts(0)
-      .find((part) => part.type === 'currency')?.value;
-    if (symbol && symbol.trim()) {
-      return symbol;
-    }
-  } catch {
-    // fall through
-  }
-  return `${code} `;
-}

--- a/apps/public_www/src/lib/my-best-auntie-cohort-summary.ts
+++ b/apps/public_www/src/lib/my-best-auntie-cohort-summary.ts
@@ -1,0 +1,85 @@
+import type { Locale } from '@/content';
+import type { MyBestAuntieEventCohort } from '@/lib/events-data';
+import { formatCohortValue } from '@/lib/format';
+
+export interface MyBestAuntieHeroCohortSummary {
+  lowestPrice: number | undefined;
+  priceCurrency: string | undefined;
+  nextCohortLabel: string | undefined;
+}
+
+/**
+ * Derives hero quick-fact inputs from CRM calendar cohorts (same source as booking).
+ * `nextCohortLabel` is a locale-formatted display string from the cohort token (e.g. apr-26).
+ */
+export function resolveMyBestAuntieHeroCohortSummary(
+  cohorts: MyBestAuntieEventCohort[] | undefined,
+  locale: Locale,
+): MyBestAuntieHeroCohortSummary {
+  if (!cohorts || cohorts.length === 0) {
+    return {
+      lowestPrice: undefined,
+      priceCurrency: undefined,
+      nextCohortLabel: undefined,
+    };
+  }
+  const available = cohorts.filter((c) => !c.is_fully_booked);
+  if (available.length === 0) {
+    return {
+      lowestPrice: undefined,
+      priceCurrency: undefined,
+      nextCohortLabel: undefined,
+    };
+  }
+
+  let lowestPrice = Infinity;
+  let priceCurrency: string | undefined;
+  for (const c of available) {
+    if (c.price < lowestPrice) {
+      lowestPrice = c.price;
+      priceCurrency = c.currency?.trim() || 'HKD';
+    }
+  }
+  const resolvedLowest =
+    lowestPrice === Infinity || lowestPrice <= 0 ? undefined : lowestPrice;
+
+  const sorted = [...available].sort((a, b) => {
+    const dateA = a.dates[0]?.start_datetime ?? '';
+    const dateB = b.dates[0]?.start_datetime ?? '';
+    return dateA.localeCompare(dateB);
+  });
+  const rawCohort = sorted[0]?.cohort ?? '';
+  const nextCohortLabel =
+    formatCohortValue(rawCohort, locale) || rawCohort || undefined;
+
+  return {
+    lowestPrice: resolvedLowest,
+    priceCurrency: resolvedLowest !== undefined ? priceCurrency : undefined,
+    nextCohortLabel,
+  };
+}
+
+/** Display symbol for hero/outline copy; JSON-LD keeps ISO codes (e.g. HKD). */
+export function formatTrainingCoursePriceCurrencySymbol(iso: string): string {
+  const code = iso.trim().toUpperCase();
+  if (code === 'HKD') {
+    return 'HK$';
+  }
+  try {
+    const symbol = new Intl.NumberFormat('en', {
+      style: 'currency',
+      currency: code,
+      currencyDisplay: 'narrowSymbol',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })
+      .formatToParts(0)
+      .find((part) => part.type === 'currency')?.value;
+    if (symbol && symbol.trim()) {
+      return symbol;
+    }
+  } catch {
+    // fall through
+  }
+  return `${code} `;
+}

--- a/apps/public_www/src/lib/structured-data.ts
+++ b/apps/public_www/src/lib/structured-data.ts
@@ -9,7 +9,9 @@ import {
 import {
   type EventCardData,
   type LandingPageStructuredDataContent,
+  type MyBestAuntieEventCohort,
 } from '@/lib/events-data';
+import { resolveMyBestAuntieHeroCohortSummary } from '@/lib/my-best-auntie-cohort-summary';
 import { ROUTES } from '@/lib/routes';
 import { getSiteOrigin, localizePath } from '@/lib/seo';
 import { resolvePublicSiteConfig } from '@/lib/site-config';
@@ -231,11 +233,32 @@ export function buildFaqPageSchema(
   return buildFaqJsonLd(questions);
 }
 
+interface BuildCourseSchemaOptions extends SharedStructuredDataOptions {
+  /** MBA cohort rows from CRM; used for Course.offers (lowest open price) when present. */
+  myBestAuntieCohorts?: MyBestAuntieEventCohort[];
+}
+
 export function buildCourseSchema({
   locale,
   content,
-}: SharedStructuredDataOptions): JsonLdObject {
+  myBestAuntieCohorts,
+}: BuildCourseSchemaOptions): JsonLdObject {
   const organizationSchemaId = getOrganizationSchemaId();
+  const { lowestPrice, priceCurrency } = resolveMyBestAuntieHeroCohortSummary(
+    myBestAuntieCohorts,
+    locale,
+  );
+  const offers =
+    lowestPrice !== undefined && priceCurrency
+      ? compactJsonLdObject({
+          '@type': 'Offer',
+          price: String(lowestPrice),
+          priceCurrency,
+          availability: OFFER_AVAILABILITY_IN_STOCK,
+          url: toLocalizedAbsoluteUrl(ROUTES.servicesMyBestAuntieTrainingCourse, locale),
+        })
+      : undefined;
+
   return compactJsonLdObject({
     '@context': SCHEMA_CONTEXT,
     '@type': 'Course',
@@ -246,6 +269,7 @@ export function buildCourseSchema({
     provider: {
       '@id': organizationSchemaId,
     },
+    offers,
   });
 }
 

--- a/apps/public_www/tests/components/sections/my-best-auntie-hero.test.tsx
+++ b/apps/public_www/tests/components/sections/my-best-auntie-hero.test.tsx
@@ -61,6 +61,7 @@ describe('MyBestAuntieHero', () => {
       <MyBestAuntieHero
         content={content}
         lowestPrice={9000}
+        priceCurrencySymbol='HK$'
         nextCohortLabel='Apr, 2026'
       />,
     );

--- a/apps/public_www/tests/lib/format.test.ts
+++ b/apps/public_www/tests/lib/format.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   COHORT_VALUE_PATTERN,
   formatCohortValue,
+  formatCurrencyDisplayPrefix,
   formatCurrencyHkd,
   formatPartDateTimeLabel,
   parseCohortValue,
@@ -23,6 +24,17 @@ describe('formatCurrencyHkd', () => {
   it('formats HKD values using locale-aware output', () => {
     expect(formatCurrencyHkd(9000, 'zh-CN')).toBe('HK$9,000');
     expect(formatCurrencyHkd(9000, 'zh-HK')).toBe('HK$9,000');
+  });
+});
+
+describe('formatCurrencyDisplayPrefix', () => {
+  it('maps HKD to HK$ for template copy', () => {
+    expect(formatCurrencyDisplayPrefix('HKD')).toBe('HK$');
+    expect(formatCurrencyDisplayPrefix(' hkd ')).toBe('HK$');
+  });
+
+  it('returns a narrow symbol for other ISO codes when Intl supports them', () => {
+    expect(formatCurrencyDisplayPrefix('USD').length).toBeGreaterThan(0);
   });
 });
 

--- a/apps/public_www/tests/lib/format.test.ts
+++ b/apps/public_www/tests/lib/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatCurrencyDisplayPrefix,
   formatCurrencyHkd,
   formatPartDateTimeLabel,
+  normalizeCurrencyPrefixForDisplay,
   parseCohortValue,
 } from '@/lib/format';
 
@@ -24,6 +25,15 @@ describe('formatCurrencyHkd', () => {
   it('formats HKD values using locale-aware output', () => {
     expect(formatCurrencyHkd(9000, 'zh-CN')).toBe('HK$9,000');
     expect(formatCurrencyHkd(9000, 'zh-HK')).toBe('HK$9,000');
+  });
+});
+
+describe('normalizeCurrencyPrefixForDisplay', () => {
+  it('maps HKD to HK$ and passes through other prefixes', () => {
+    expect(normalizeCurrencyPrefixForDisplay('HKD')).toBe('HK$');
+    expect(normalizeCurrencyPrefixForDisplay(' hkd ')).toBe('HK$');
+    expect(normalizeCurrencyPrefixForDisplay('HK$')).toBe('HK$');
+    expect(normalizeCurrencyPrefixForDisplay('  ')).toBeUndefined();
   });
 });
 

--- a/apps/public_www/tests/lib/structured-data.test.ts
+++ b/apps/public_www/tests/lib/structured-data.test.ts
@@ -3,7 +3,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import enContent from '@/content/en.json';
 import { publicCalendarFixture } from '../fixtures/public-calendar';
 import type { EventCardData } from '@/lib/events-data';
-import { getLandingPageStructuredDataContentFromPayload } from '@/lib/events-data';
+import {
+  getLandingPageStructuredDataContentFromPayload,
+  normalizeMyBestAuntieCohortsFromPayload,
+} from '@/lib/events-data';
 import { ROUTES } from '@/lib/routes';
 import {
   buildBreadcrumbSchema,
@@ -121,6 +124,25 @@ describe('structured-data builders', () => {
     } | undefined;
     expect(firstBreadcrumbItem?.item).toContain('/zh-HK');
     expect(secondBreadcrumbItem?.item).toContain('/zh-HK/about-us');
+  });
+
+  it('adds Course.offers from MBA cohorts when lowest open price is available', () => {
+    const mbaCohorts = normalizeMyBestAuntieCohortsFromPayload(publicCalendarFixture);
+    const courseSchema = buildCourseSchema({
+      locale: 'en',
+      content: enContent,
+      myBestAuntieCohorts: mbaCohorts,
+    });
+
+    expect(courseSchema).toMatchObject({
+      '@type': 'Course',
+      offers: {
+        '@type': 'Offer',
+        price: '9000',
+        priceCurrency: 'HKD',
+        availability: 'https://schema.org/InStock',
+      },
+    });
   });
 
   it('builds event schemas only for events with timestamps', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Locale**: `myBestAuntie.hero.quickFacts.priceTemplate` now uses `{currency}{price}` (EN: `From {currency}{price}`; zh-CN/zh-HK: `{currency}{price} 起`) with no hardcoded `HK$`.
- **Single source**: `resolveMyBestAuntieHeroCohortSummary()` reads the same CRM calendar cohorts as booking; it returns `lowestPrice`, ISO `priceCurrency`, and `nextCohortLabel`.
- **JSON-LD**: `buildCourseSchema()` accepts optional `myBestAuntieCohorts` and emits `Course.offers` with `price` and `priceCurrency` when a lowest open price exists (training-course page passes fetched cohorts).
- **Hero**: `formatCurrencyDisplayPrefix()` in `format.ts` maps ISO to display (e.g. `HKD` → `HK$`) for template copy only; JSON-LD keeps ISO codes. Reuses the same `Intl`/HKD patterns as `formatCurrencyHkd`.
- **Outline**: Base `description` drops the fixed HK$ amount; `descriptionWithPriceTemplate` appends `Starting from {currency}{price}.` (and Chinese equivalents) when cohort data is available; otherwise the base description is shown.

## Tests

- Vitest: structured-data (including new offers case), my-best-auntie-hero, my-best-auntie-outline, llms-content, format (including `formatCurrencyDisplayPrefix`).
- `npm run lint` in `apps/public_www`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d040cad2-b575-4813-96f8-aa768299e3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d040cad2-b575-4813-96f8-aa768299e3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

