### PR TITLE
Enrollment discount picker and public reservation enrollment metadata

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -15,9 +15,10 @@ import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useEnrollmentParentPickers } from '@/hooks/use-enrollment-parent-pickers';
 import { formatDate, formatEnumLabel, getCurrencyOptions } from '@/lib/format';
+import { isAbortRequestError, listEnrollmentDiscountOptions } from '@/lib/services-api';
 
 import type { components } from '@/types/generated/admin-api.generated';
-import type { Enrollment } from '@/types/services';
+import type { DiscountCode, Enrollment } from '@/types/services';
 import { ENROLLMENT_STATUSES } from '@/types/services';
 
 type ApiSchemas = components['schemas'];
@@ -40,6 +41,9 @@ function ensureOption(
 
 export interface EnrollmentListPanelProps {
   enrollments: Enrollment[];
+  /** Required to load instance-eligible discount codes for the picker. */
+  serviceId: string | null;
+  instanceId: string | null;
   canCreate: boolean;
   isLoading: boolean;
   isLoadingMore: boolean;
@@ -57,6 +61,8 @@ export interface EnrollmentListPanelProps {
 
 export function EnrollmentListPanel({
   enrollments,
+  serviceId,
+  instanceId,
   canCreate,
   isLoading,
   isLoadingMore,
@@ -87,6 +93,10 @@ export function EnrollmentListPanel({
   const [status, setStatus] = useState<ApiSchemas['EnrollmentStatus']>('registered');
   const [amountPaid, setAmountPaid] = useState('');
   const [currency, setCurrency] = useState('HKD');
+  const [discountCodeId, setDiscountCodeId] = useState('');
+  const [discountOptions, setDiscountOptions] = useState<DiscountCode[]>([]);
+  const [discountOptionsLoading, setDiscountOptionsLoading] = useState(false);
+  const [discountOptionsError, setDiscountOptionsError] = useState('');
   const [notes, setNotes] = useState('');
 
   const selectedEnrollment = useMemo(
@@ -106,6 +116,46 @@ export function EnrollmentListPanel({
   const organizationSelectOptions = useMemo(
     () => ensureOption(organizations, selectedEnrollment?.organizationId ?? null, 'Organization'),
     [organizations, selectedEnrollment?.organizationId]
+  );
+
+  const loadDiscountOptions = useCallback(async () => {
+    if (!serviceId?.trim() || !instanceId?.trim()) {
+      setDiscountOptions([]);
+      setDiscountOptionsError('');
+      setDiscountOptionsLoading(false);
+      return;
+    }
+    setDiscountOptionsLoading(true);
+    setDiscountOptionsError('');
+    try {
+      const rows = await listEnrollmentDiscountOptions(serviceId.trim(), instanceId.trim());
+      setDiscountOptions(rows);
+    } catch (err) {
+      if (isAbortRequestError(err)) {
+        return;
+      }
+      setDiscountOptions([]);
+      setDiscountOptionsError(err instanceof Error ? err.message : 'Failed to load discount codes');
+    } finally {
+      setDiscountOptionsLoading(false);
+    }
+  }, [serviceId, instanceId]);
+
+  useEffect(() => {
+    void loadDiscountOptions();
+  }, [loadDiscountOptions]);
+
+  const discountSelectOptions = useMemo(
+    () =>
+      ensureOption(
+        discountOptions.map((row) => ({
+          id: row.id,
+          label: row.description?.trim() ? `${row.code} — ${row.description.trim()}` : row.code,
+        })),
+        selectedEnrollment?.discountCodeId ?? null,
+        'Discount'
+      ),
+    [discountOptions, selectedEnrollment?.discountCodeId]
   );
 
   const formatEnrollmentParentCell = (enrollment: Enrollment): string => {
@@ -129,6 +179,7 @@ export function EnrollmentListPanel({
     setStatus('registered');
     setAmountPaid('');
     setCurrency('HKD');
+    setDiscountCodeId('');
     setNotes('');
   };
 
@@ -136,18 +187,27 @@ export function EnrollmentListPanel({
     contact_id: contactId.trim() || null,
     family_id: familyId.trim() || null,
     organization_id: organizationId.trim() || null,
+    discount_code_id: discountCodeId.trim() || null,
     status,
     amount_paid: amountPaid.trim() || null,
     currency: currency.trim() || null,
     notes: notes.trim() || null,
   });
 
-  const buildUpdatePayload = (): ApiSchemas['UpdateEnrollmentRequest'] => ({
-    status,
-    amount_paid: amountPaid.trim() || null,
-    currency: currency.trim() || null,
-    notes: notes.trim() || null,
-  });
+  const buildUpdatePayload = (): ApiSchemas['UpdateEnrollmentRequest'] => {
+    const base: ApiSchemas['UpdateEnrollmentRequest'] = {
+      status,
+      amount_paid: amountPaid.trim() || null,
+      currency: currency.trim() || null,
+      notes: notes.trim() || null,
+    };
+    const nextDiscount = discountCodeId.trim() || null;
+    const prev = selectedEnrollment?.discountCodeId?.trim() || null;
+    if (nextDiscount !== prev) {
+      base.discount_code_id = nextDiscount;
+    }
+    return base;
+  };
 
   const handleSave = async () => {
     try {
@@ -173,6 +233,7 @@ export function EnrollmentListPanel({
     setStatus(enrollment.status);
     setAmountPaid(enrollment.amountPaid ?? '');
     setCurrency(enrollment.currency ?? 'HKD');
+    setDiscountCodeId(enrollment.discountCodeId ?? '');
     setNotes(enrollment.notes ?? '');
   };
 
@@ -306,7 +367,12 @@ export function EnrollmentListPanel({
           Contact, family, and organization are chosen when creating an enrollment and cannot be changed
           afterward.
         </p>
-        <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
+        {canCreate && discountOptionsError ? (
+          <p className='text-xs text-red-600' role='alert'>
+            {discountOptionsError}
+          </p>
+        ) : null}
+        <div className='grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4'>
           <div>
             <Label htmlFor='enrollment-status'>Status</Label>
             <Select
@@ -339,6 +405,26 @@ export function EnrollmentListPanel({
               ))}
             </Select>
           </div>
+          <div>
+            <Label htmlFor='enrollment-discount'>Discount code</Label>
+            <Select
+              id='enrollment-discount'
+              value={discountCodeId || EMPTY_PARENT_VALUE}
+              onChange={(event) => {
+                const next = event.target.value;
+                setDiscountCodeId(next === EMPTY_PARENT_VALUE ? '' : next);
+              }}
+              disabled={!canCreate || discountOptionsLoading}
+              aria-busy={discountOptionsLoading}
+            >
+              <option value={EMPTY_PARENT_VALUE}>None</option>
+              {discountSelectOptions.map((row) => (
+                <option key={row.id} value={row.id}>
+                  {row.label}
+                </option>
+              ))}
+            </Select>
+          </div>
         </div>
         <div>
           <Label htmlFor='enrollment-notes'>Notes</Label>
@@ -361,6 +447,7 @@ export function EnrollmentListPanel({
               <th className='px-4 py-3 font-semibold'>Parent</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Amount</th>
+              <th className='px-4 py-3 font-semibold'>Discount</th>
               <th className='px-4 py-3 font-semibold'>Enrolled at</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>
@@ -378,6 +465,12 @@ export function EnrollmentListPanel({
                 <td className='px-4 py-3'>{formatEnumLabel(enrollment.status)}</td>
                 <td className='px-4 py-3'>
                   {enrollment.amountPaid ? `${enrollment.amountPaid} ${enrollment.currency ?? ''}` : '-'}
+                </td>
+                <td className='px-4 py-3'>
+                  {enrollment.discountCodeId
+                    ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
+                        enrollment.discountCodeId)
+                    : '-'}
                 </td>
                 <td className='px-4 py-3'>{formatDate(enrollment.enrolledAt)}</td>
                 <td className='px-4 py-3 text-right'>

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -316,6 +316,8 @@ export function ServicesPage() {
           />
           <EnrollmentListPanel
             enrollments={state.enrollmentList.enrollments}
+            serviceId={instancesContextServiceId}
+            instanceId={state.selectedInstanceId}
             canCreate={Boolean(instancesContextServiceId && state.selectedInstanceId)}
             isLoading={state.enrollmentList.isLoading}
             isLoadingMore={state.enrollmentList.isLoadingMore}

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -895,8 +895,41 @@ export async function deleteEnrollment(
   });
 }
 
+const ENROLLMENT_DISCOUNT_OPTIONS_PAGE_LIMIT = 200;
+
+/**
+ * Discount codes applicable when creating/editing an enrollment for one instance:
+ * global (unscoped), service-scoped for `serviceId`, and instance-scoped for `instanceId`.
+ */
+export async function listEnrollmentDiscountOptions(
+  serviceId: string,
+  instanceId: string,
+  signal?: AbortSignal
+): Promise<DiscountCode[]> {
+  const base = { active: 'true' as const, limit: ENROLLMENT_DISCOUNT_OPTIONS_PAGE_LIMIT };
+  const [unscoped, forService, forInstance] = await Promise.all([
+    listDiscountCodes({ ...base, scope: 'unscoped' }, signal),
+    listDiscountCodes({ ...base, scope: 'service', service_id: serviceId }, signal),
+    listDiscountCodes({ ...base, scope: 'instance', instance_id: instanceId }, signal),
+  ]);
+  const byId = new Map<string, DiscountCode>();
+  for (const row of [...unscoped.items, ...forService.items, ...forInstance.items]) {
+    if (row.id) {
+      byId.set(row.id, row);
+    }
+  }
+  return [...byId.values()].sort((a, b) =>
+    a.code.localeCompare(b.code, undefined, { sensitivity: 'base' })
+  );
+}
+
 export async function listDiscountCodes(
-  params: Partial<DiscountCodeFilters> & { cursor?: string | null; limit?: number },
+  params: Partial<DiscountCodeFilters> & {
+    cursor?: string | null;
+    limit?: number;
+    service_id?: string;
+    instance_id?: string;
+  },
   signal?: AbortSignal
 ): Promise<{ items: DiscountCode[]; nextCursor: string | null; totalCount: number }> {
   const query = new URLSearchParams();
@@ -905,6 +938,8 @@ export async function listDiscountCodes(
   if (params.active) query.set('active', params.active);
   if (params.search?.trim()) query.set('search', params.search.trim());
   if (params.scope) query.set('scope', params.scope);
+  if (params.service_id?.trim()) query.set('service_id', params.service_id.trim());
+  if (params.instance_id?.trim()) query.set('instance_id', params.instance_id.trim());
   const queryString = query.toString();
   const payload = await adminApiRequest<ApiDiscountCodeListResponse>({
     endpointPath: `/v1/admin/discount-codes${queryString ? `?${queryString}` : ''}`,

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4638,7 +4638,10 @@ export interface components {
             organization_id?: string | null;
             /** Format: uuid */
             ticket_tier_id?: string | null;
-            /** Format: uuid */
+            /**
+             * Format: uuid
+             * @description Must be globally scoped, scoped to this instance's service, or scoped to this instance; otherwise the API returns 400.
+             */
             discount_code_id?: string | null;
             status?: components["schemas"]["EnrollmentStatus"];
             amount_paid?: string | null;
@@ -4651,7 +4654,7 @@ export interface components {
             currency?: string | null;
             /**
              * Format: uuid
-             * @description Set to null to clear the enrollment discount; changing the id adjusts discount code usage counts accordingly.
+             * @description Set to null to clear the enrollment discount; changing the id adjusts discount code usage counts accordingly. The new id must be globally scoped, scoped to this instance's service, or scoped to this instance; otherwise the API returns 400.
              */
             discount_code_id?: string | null;
             notes?: string | null;

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4649,6 +4649,11 @@ export interface components {
             status?: components["schemas"]["EnrollmentStatus"];
             amount_paid?: string | null;
             currency?: string | null;
+            /**
+             * Format: uuid
+             * @description Set to null to clear the enrollment discount; changing the id adjusts discount code usage counts accordingly.
+             */
+            discount_code_id?: string | null;
             notes?: string | null;
         };
         DiscountCode: {

--- a/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
@@ -4,6 +4,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { EnrollmentListPanel } from '@/components/admin/services/enrollment-list-panel';
 import type { Enrollment } from '@/types/services';
 
+vi.mock('@/lib/services-api', () => ({
+  isAbortRequestError: () => false,
+  listEnrollmentDiscountOptions: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
   useEnrollmentParentPickers: () => ({
     contactOptions: [{ id: 'contact-1', label: 'Jane Doe' }],
@@ -41,6 +46,8 @@ describe('EnrollmentListPanel', () => {
     render(
       <EnrollmentListPanel
         enrollments={[ENROLLMENT_FIXTURE]}
+        serviceId='service-1'
+        instanceId='instance-1'
         canCreate={true}
         isLoading={false}
         isLoadingMore={false}
@@ -74,6 +81,8 @@ describe('EnrollmentListPanel', () => {
     render(
       <EnrollmentListPanel
         enrollments={[]}
+        serviceId='service-1'
+        instanceId='instance-1'
         canCreate={true}
         isLoading={false}
         isLoadingMore={false}

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -8,6 +8,11 @@ import { ServiceListPanel } from '@/components/admin/services/service-list-panel
 import { formatDate } from '@/lib/format';
 import type { DiscountCode, Enrollment, ServiceInstance, ServiceSummary } from '@/types/services';
 
+vi.mock('@/lib/services-api', () => ({
+  isAbortRequestError: () => false,
+  listEnrollmentDiscountOptions: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
   useEnrollmentParentPickers: () => ({
     contactOptions: [{ id: 'contact-1', label: 'Resolved contact label' }],
@@ -338,6 +343,8 @@ describe('services tables value formatting', () => {
     render(
       <EnrollmentListPanel
         enrollments={[ENROLLMENT_FIXTURE]}
+        serviceId='service-1'
+        instanceId='instance-1'
         canCreate={true}
         isLoading={false}
         isLoadingMore={false}

--- a/backend/db/alembic/versions/0045_enroll_inst_contact_uidx.py
+++ b/backend/db/alembic/versions/0045_enroll_inst_contact_uidx.py
@@ -2,7 +2,7 @@
 
 Seed-data assessment (``backend/db/seed/seed_data.sql``):
 1. Compatibility: seed has no ``enrollments`` inserts.
-2. NOT NULL: index only applies where ``contact_id`` IS NOT NULL; no seed rows.
+2. NOT NULL: index only applies where ``contact_id`` is not null; no seed rows.
 3. Renamed/dropped: none.
 4. New tables: none.
 5. Enum/allowed-value changes: none.
@@ -19,7 +19,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0045_enrollment_inst_contact_uidx"
+revision: str = "0045_enroll_inst_contact_uidx"
 down_revision: Union[str, None] = "0044_drop_landing_page"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/db/alembic/versions/0045_enrollment_inst_contact_uidx.py
+++ b/backend/db/alembic/versions/0045_enrollment_inst_contact_uidx.py
@@ -1,0 +1,41 @@
+"""Partial unique index: one enrollment per contact per instance when contact set.
+
+Seed-data assessment (``backend/db/seed/seed_data.sql``):
+1. Compatibility: seed has no ``enrollments`` inserts.
+2. NOT NULL: index only applies where ``contact_id`` IS NOT NULL; no seed rows.
+3. Renamed/dropped: none.
+4. New tables: none.
+5. Enum/allowed-value changes: none.
+6. FK/cascade changes: none.
+
+Upgrade fails if duplicate (instance_id, contact_id) pairs exist with non-null
+contact_id; resolve data before applying.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0045_enrollment_inst_contact_uidx"
+down_revision: Union[str, None] = "0044_drop_landing_page"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            CREATE UNIQUE INDEX enrollments_instance_contact_uidx
+            ON enrollments (instance_id, contact_id)
+            WHERE contact_id IS NOT NULL
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP INDEX IF EXISTS enrollments_instance_contact_uidx"))

--- a/backend/src/app/api/admin_enrollments.py
+++ b/backend/src/app/api/admin_enrollments.py
@@ -201,6 +201,26 @@ def _update_enrollment(
             enrollment.currency = payload["currency"]
         if "notes" in payload:
             enrollment.notes = payload["notes"]
+        if "discount_code_id" in payload:
+            new_id = payload["discount_code_id"]
+            old_id = enrollment.discount_code_id
+            if new_id != old_id:
+                discount_repo = DiscountCodeRepository(session)
+                if old_id is not None:
+                    if not discount_repo.decrement_uses(old_id):
+                        raise ValidationError(
+                            "Unable to release prior discount code usage",
+                            field="discount_code_id",
+                        )
+                if new_id is not None:
+                    if not discount_repo.validate_and_increment(new_id):
+                        if old_id is not None:
+                            discount_repo.validate_and_increment(old_id)
+                        raise ValidationError(
+                            "Discount code is invalid, inactive, expired, or exhausted",
+                            field="discount_code_id",
+                        )
+                enrollment.discount_code_id = new_id
 
         updated = repository.update(enrollment)
         session.commit()
@@ -232,6 +252,13 @@ def _delete_enrollment(
         enrollment = repository.get_by_id(enrollment_id)
         if enrollment is None or enrollment.instance_id != instance_id:
             raise NotFoundError("Enrollment", str(enrollment_id))
+        discount_repo = DiscountCodeRepository(session)
+        if enrollment.discount_code_id is not None:
+            if not discount_repo.decrement_uses(enrollment.discount_code_id):
+                raise ValidationError(
+                    "Unable to release discount code usage for this enrollment",
+                    field="discount_code_id",
+                )
         repository.delete(enrollment)
         session.commit()
         return json_response(204, {}, event=event)

--- a/backend/src/app/api/admin_enrollments.py
+++ b/backend/src/app/api/admin_enrollments.py
@@ -10,6 +10,10 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.api.admin_request import parse_body, parse_uuid
+from app.api.discount_enrollment_scope import (
+    ensure_discount_code_eligible_for_instance,
+    service_id_for_instance,
+)
 from app.api.admin_services_common import (
     encode_enrollment_cursor,
     parse_create_enrollment_payload,
@@ -138,6 +142,13 @@ def _create_enrollment(
         discount_code_repository = DiscountCodeRepository(session)
         discount_code_id = payload["discount_code_id"]
         if discount_code_id is not None:
+            parent_service_id = service_id_for_instance(session, instance_id)
+            ensure_discount_code_eligible_for_instance(
+                session,
+                discount_code_id=discount_code_id,
+                service_id=parent_service_id,
+                instance_id=instance_id,
+            )
             if not discount_code_repository.validate_and_increment(discount_code_id):
                 raise ValidationError(
                     "Discount code is invalid, inactive, expired, or exhausted",
@@ -206,6 +217,7 @@ def _update_enrollment(
             old_id = enrollment.discount_code_id
             if new_id != old_id:
                 discount_repo = DiscountCodeRepository(session)
+                parent_service_id = service_id_for_instance(session, instance_id)
                 if old_id is not None:
                     if not discount_repo.decrement_uses(old_id):
                         raise ValidationError(
@@ -213,6 +225,12 @@ def _update_enrollment(
                             field="discount_code_id",
                         )
                 if new_id is not None:
+                    ensure_discount_code_eligible_for_instance(
+                        session,
+                        discount_code_id=new_id,
+                        service_id=parent_service_id,
+                        instance_id=instance_id,
+                    )
                     if not discount_repo.validate_and_increment(new_id):
                         if old_id is not None:
                             discount_repo.validate_and_increment(old_id)

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -550,6 +550,14 @@ def parse_update_enrollment_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         payload["notes"] = parse_optional_text(
             body.get("notes"), max_length=MAX_DESCRIPTION_LENGTH
         )
+    if has_field(body, "discount_code_id"):
+        raw_dc = body.get("discount_code_id")
+        if raw_dc is None or (isinstance(raw_dc, str) and not raw_dc.strip()):
+            payload["discount_code_id"] = None
+        else:
+            payload["discount_code_id"] = parse_optional_uuid(
+                raw_dc, "discount_code_id"
+            )
     if not payload:
         raise ValidationError("At least one updatable field is required", field="body")
     return payload

--- a/backend/src/app/api/discount_enrollment_scope.py
+++ b/backend/src/app/api/discount_enrollment_scope.py
@@ -1,0 +1,47 @@
+"""Validate discount code scope for a service instance enrollment."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.db.models import DiscountCode, ServiceInstance
+from app.exceptions import ValidationError
+
+
+def ensure_discount_code_eligible_for_instance(
+    session: Session,
+    *,
+    discount_code_id: UUID,
+    service_id: UUID,
+    instance_id: UUID,
+) -> DiscountCode:
+    """Load the code and ensure it applies to this instance (global, service, or instance)."""
+    row = session.get(DiscountCode, discount_code_id)
+    if row is None:
+        raise ValidationError("Discount code not found", field="discount_code_id")
+
+    if row.instance_id is not None:
+        if row.instance_id != instance_id:
+            raise ValidationError(
+                "Discount code is not valid for this service instance",
+                field="discount_code_id",
+            )
+        return row
+
+    if row.service_id is not None and row.service_id != service_id:
+        raise ValidationError(
+            "Discount code is not valid for this service instance",
+            field="discount_code_id",
+        )
+
+    return row
+
+
+def service_id_for_instance(session: Session, instance_id: UUID) -> UUID:
+    """Return the parent service id for a service instance."""
+    inst = session.get(ServiceInstance, instance_id)
+    if inst is None:
+        raise ValidationError("Service instance not found", field="instance_id")
+    return inst.service_id

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -32,11 +32,17 @@ from app.api.public_form_hooks import (
     send_booking_confirmation_email,
 )
 from app.db.engine import get_engine
-from app.db.repositories import DiscountCodeRepository, ServiceRepository
+from app.db.models import Enrollment
+from app.db.repositories import (
+    DiscountCodeRepository,
+    EnrollmentRepository,
+    ServiceRepository,
+)
 from app.db.repositories.service_instance import ServiceInstanceRepository
 from app.db.models.enums import (
     ContactSource,
     ContactType,
+    EnrollmentStatus,
     FunnelStage,
     LeadEventType,
     LeadType,
@@ -82,6 +88,7 @@ _STRIPE_PAYMENT_INTENTS_URL_PREFIX = "https://api.stripe.com/v1/payment_intents/
 _STRIPE_PAYMENT_INTENT_ID_PATTERN = re.compile(r"^pi_[A-Za-z0-9]+$")
 _ALLOWED_LOCALES = frozenset({"en", "zh-CN", "zh-HK"})
 _ALLOWED_SERVICE_SLUGS = frozenset({"event", "training-course", "consultation"})
+_PUBLIC_RESERVATION_ENROLLMENT_ACTOR = "public-reservation"
 
 
 def _handle_public_reservation(
@@ -148,6 +155,61 @@ def _handle_public_reservation(
                 contact.phone_region = new_region
                 contact.phone_national_number = new_national
             contact_repo.update(contact)
+
+            dc_text = reservation_payload.get("discount_code")
+            dc_row = None
+            if dc_text:
+                dc_lookup = DiscountCodeRepository(session)
+                dc_row = dc_lookup.get_by_code(str(dc_text))
+
+            raw_slug = reservation_payload.get("service_instance_slug")
+            instance_id_resolved: UUID | None = None
+            if raw_slug and str(raw_slug).strip():
+                instance_id_resolved = ServiceInstanceRepository(
+                    session
+                ).get_id_by_slug(str(raw_slug).strip())
+
+            enrollment_repo = EnrollmentRepository(session)
+            discount_repo = DiscountCodeRepository(session)
+            if (
+                instance_id_resolved is not None
+                and not enrollment_repo.contact_has_enrollment_for_instance(
+                    instance_id=instance_id_resolved,
+                    contact_id=contact.id,
+                )
+            ):
+                discount_id_for_enrollment: UUID | None = None
+                incremented_code_id: UUID | None = None
+                if dc_row is not None:
+                    if discount_repo.validate_and_increment(dc_row.id):
+                        incremented_code_id = dc_row.id
+                        discount_id_for_enrollment = dc_row.id
+                    else:
+                        raise ValidationError(
+                            "Discount code is invalid, inactive, expired, or exhausted",
+                            field="discountCode",
+                        )
+                try:
+                    enrollment_repo.create_enrollment(
+                        Enrollment(
+                            instance_id=instance_id_resolved,
+                            contact_id=contact.id,
+                            family_id=None,
+                            organization_id=None,
+                            ticket_tier_id=None,
+                            discount_code_id=discount_id_for_enrollment,
+                            status=EnrollmentStatus.REGISTERED,
+                            amount_paid=reservation_payload["total_amount"],
+                            currency="HKD",
+                            notes=None,
+                            created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
+                        )
+                    )
+                except ValueError:
+                    if incremented_code_id is not None:
+                        discount_repo.decrement_uses(incremented_code_id)
+                    raise
+
             lead_metadata: dict[str, object] = {
                 "payment_method": reservation_payload["payment_method"],
                 "course_label": reservation_payload["course_label"],
@@ -159,6 +221,10 @@ def _handle_public_reservation(
                 lead_metadata["course_slug"] = reservation_payload["course_slug"]
             if reservation_payload.get("service"):
                 lead_metadata["service"] = reservation_payload["service"]
+            if dc_text and str(dc_text).strip():
+                lead_metadata["discount_code"] = str(dc_text).strip()
+                if dc_row is not None:
+                    lead_metadata["discount_code_id"] = str(dc_row.id)
             lead = SalesLead(
                 contact_id=contact.id,
                 lead_type=LeadType.PROGRAM_ENROLLMENT,

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -39,9 +39,14 @@ from app.db.repositories import (
     ServiceRepository,
 )
 from app.db.repositories.service_instance import ServiceInstanceRepository
+from app.api.discount_enrollment_scope import (
+    ensure_discount_code_eligible_for_instance,
+    service_id_for_instance,
+)
 from app.db.models.enums import (
     ContactSource,
     ContactType,
+    DiscountType,
     EnrollmentStatus,
     FunnelStage,
     LeadEventType,
@@ -178,37 +183,53 @@ def _handle_public_reservation(
                     contact_id=contact.id,
                 )
             ):
-                discount_id_for_enrollment: UUID | None = None
-                incremented_code_id: UUID | None = None
+                instance_service_id = service_id_for_instance(
+                    session, instance_id_resolved
+                )
                 if dc_row is not None:
-                    if discount_repo.validate_and_increment(dc_row.id):
-                        incremented_code_id = dc_row.id
-                        discount_id_for_enrollment = dc_row.id
-                    else:
-                        raise ValidationError(
-                            "Discount code is invalid, inactive, expired, or exhausted",
-                            field="discountCode",
-                        )
-                try:
-                    enrollment_repo.create_enrollment(
-                        Enrollment(
-                            instance_id=instance_id_resolved,
-                            contact_id=contact.id,
-                            family_id=None,
-                            organization_id=None,
-                            ticket_tier_id=None,
-                            discount_code_id=discount_id_for_enrollment,
-                            status=EnrollmentStatus.REGISTERED,
-                            amount_paid=reservation_payload["total_amount"],
-                            currency="HKD",
-                            notes=None,
-                            created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
-                        )
+                    ensure_discount_code_eligible_for_instance(
+                        session,
+                        discount_code_id=dc_row.id,
+                        service_id=instance_service_id,
+                        instance_id=instance_id_resolved,
                     )
-                except ValueError:
-                    if incremented_code_id is not None:
-                        discount_repo.decrement_uses(incremented_code_id)
-                    raise
+                enrollment_row = Enrollment(
+                    instance_id=instance_id_resolved,
+                    contact_id=contact.id,
+                    family_id=None,
+                    organization_id=None,
+                    ticket_tier_id=None,
+                    discount_code_id=None,
+                    status=EnrollmentStatus.REGISTERED,
+                    amount_paid=reservation_payload["total_amount"],
+                    currency="HKD",
+                    notes=None,
+                    created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
+                )
+                created_enrollment, create_err = (
+                    enrollment_repo.try_create_enrollment_with_capacity_guard(
+                        enrollment_row
+                    )
+                )
+                if create_err == "capacity_full":
+                    raise ValidationError(
+                        "This cohort is full and is not accepting a waitlist for "
+                        "public bookings. Your payment was processed; contact support "
+                        "if you need a refund.",
+                        field="serviceInstanceSlug",
+                        status_code=409,
+                    )
+                if create_err != "duplicate" and created_enrollment is not None:
+                    if dc_row is not None:
+                        if not discount_repo.validate_and_increment(dc_row.id):
+                            session.delete(created_enrollment)
+                            session.flush()
+                            raise ValidationError(
+                                "Discount code is invalid, inactive, expired, or exhausted",
+                                field="discountCode",
+                            )
+                        created_enrollment.discount_code_id = dc_row.id
+                        session.flush()
 
             lead_metadata: dict[str, object] = {
                 "payment_method": reservation_payload["payment_method"],
@@ -646,6 +667,9 @@ def _validate_discount_code_redemption_scope(
     repository = DiscountCodeRepository(session)
     row = repository.get_by_code(str(code))
     if row is None or not discount_code_is_usable_now(row):
+        raise ValidationError("Invalid discount code", field="discountCode")
+
+    if row.discount_type == DiscountType.REFERRAL:
         raise ValidationError("Invalid discount code", field="discountCode")
 
     if row.instance_id is not None:

--- a/backend/src/app/db/models/enrollment.py
+++ b/backend/src/app/db/models/enrollment.py
@@ -44,6 +44,13 @@ class Enrollment(Base):
         Index("enrollments_family_idx", "family_id"),
         Index("enrollments_org_idx", "organization_id"),
         Index("enrollments_status_idx", "status"),
+        Index(
+            "enrollments_instance_contact_uidx",
+            "instance_id",
+            "contact_id",
+            unique=True,
+            postgresql_where=text("contact_id IS NOT NULL"),
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(

--- a/backend/src/app/db/repositories/discount_code.py
+++ b/backend/src/app/db/repositories/discount_code.py
@@ -162,3 +162,15 @@ class DiscountCodeRepository(BaseRepository[DiscountCode]):
         )
         row = self._session.execute(statement).first()
         return row is not None
+
+    def decrement_uses(self, code_id: UUID) -> bool:
+        """Decrement current_uses when at least one use is recorded (undo redemption)."""
+        statement = (
+            update(DiscountCode)
+            .where(DiscountCode.id == code_id)
+            .where(DiscountCode.current_uses > 0)
+            .values(current_uses=DiscountCode.current_uses - 1)
+            .returning(DiscountCode.id)
+        )
+        row = self._session.execute(statement).first()
+        return row is not None

--- a/backend/src/app/db/repositories/enrollment.py
+++ b/backend/src/app/db/repositories/enrollment.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
 from app.db.models import Enrollment, EnrollmentStatus, ServiceInstance
@@ -115,6 +116,53 @@ class EnrollmentRepository(BaseRepository[Enrollment]):
         self._session.flush()
         self._session.refresh(enrollment)
         return enrollment
+
+    def try_create_enrollment_with_capacity_guard(
+        self, enrollment: Enrollment
+    ) -> tuple[Enrollment | None, str | None]:
+        """Create enrollment when capacity allows; avoid 500 on full instance.
+
+        Returns ``(enrollment, None)`` on success. Returns ``(None, "capacity_full")`` when
+        the instance is at capacity and waitlist is disabled (no row inserted). Returns
+        ``(None, "duplicate")`` when a concurrent insert violates the partial unique index
+        on ``(instance_id, contact_id)`` (no row inserted).
+
+        Callers that pre-incremented a discount code must decrement on ``capacity_full``
+        or ``duplicate``.
+        """
+        instance_statement = (
+            select(ServiceInstance)
+            .where(ServiceInstance.id == enrollment.instance_id)
+            .with_for_update()
+        )
+        instance = self._session.execute(instance_statement).scalar_one_or_none()
+        if instance is None:
+            raise ValueError("Service instance not found")
+
+        if instance.max_capacity is not None:
+            active_count_statement = (
+                select(func.count(Enrollment.id))
+                .where(Enrollment.instance_id == instance.id)
+                .where(Enrollment.status.in_(CAPACITY_ENROLLMENT_STATUSES))
+            )
+            active_count = int(
+                self._session.execute(active_count_statement).scalar_one_or_none() or 0
+            )
+            if active_count >= instance.max_capacity:
+                if instance.waitlist_enabled:
+                    enrollment.status = EnrollmentStatus.WAITLISTED
+                else:
+                    return None, "capacity_full"
+
+        try:
+            with self._session.begin_nested():
+                self._session.add(enrollment)
+                self._session.flush()
+        except IntegrityError:
+            return None, "duplicate"
+
+        self._session.refresh(enrollment)
+        return enrollment, None
 
     def update_status(
         self, enrollment_id: UUID, status: EnrollmentStatus

--- a/backend/src/app/db/repositories/enrollment.py
+++ b/backend/src/app/db/repositories/enrollment.py
@@ -72,6 +72,18 @@ class EnrollmentRepository(BaseRepository[Enrollment]):
         count = self._session.execute(statement).scalar_one_or_none()
         return int(count or 0)
 
+    def contact_has_enrollment_for_instance(
+        self, *, instance_id: UUID, contact_id: UUID
+    ) -> bool:
+        """True if any enrollment row exists for this contact on this instance."""
+        statement = (
+            select(func.count(Enrollment.id))
+            .where(Enrollment.instance_id == instance_id)
+            .where(Enrollment.contact_id == contact_id)
+        )
+        n = int(self._session.execute(statement).scalar_one_or_none() or 0)
+        return n > 0
+
     def create_enrollment(self, enrollment: Enrollment) -> Enrollment:
         """Create enrollment with capacity guard where required."""
         # Lock the instance row so capacity checks and inserts are serialized.

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -4396,6 +4396,13 @@ components:
         currency:
           type: string
           nullable: true
+        discount_code_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: >
+            Set to null to clear the enrollment discount; changing the id adjusts
+            discount code usage counts accordingly.
         notes:
           type: string
           nullable: true

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -4373,6 +4373,9 @@ components:
           type: string
           format: uuid
           nullable: true
+          description: >
+            Must be globally scoped, scoped to this instance's service, or scoped to this
+            instance; otherwise the API returns 400.
         status:
           $ref: "#/components/schemas/EnrollmentStatus"
         amount_paid:
@@ -4402,7 +4405,9 @@ components:
           nullable: true
           description: >
             Set to null to clear the enrollment discount; changing the id adjusts
-            discount code usage counts accordingly.
+            discount code usage counts accordingly. The new id must be globally scoped,
+            scoped to this instance's service, or scoped to this instance; otherwise the
+            API returns 400.
         notes:
           type: string
           nullable: true

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -585,8 +585,13 @@ paths:
       description: >
         Submit a public reservation from `public_www` (execute-api origin).
 
-        Persists the attendee as a CRM contact and creates a program-enrollment
-        sales lead, then returns **202** on success. Best-effort SES booking
+        Persists the attendee as a CRM contact, creates a program-enrollment
+        sales lead (lead event metadata may include `discount_code` and
+        `discount_code_id` when a valid code was supplied), and when
+        `serviceInstanceSlug` resolves to a `service_instances` row and the
+        contact has no existing enrollment for that instance, inserts an
+        `enrollments` row (`created_by`: `public-reservation`) with optional
+        `discount_code_id` and paid amount, then returns **202** on success. Best-effort SES booking
         confirmation to the attendee, optional Mailchimp subscribe, and plain-text
         **sales recap** to `ADMIN_GROUP` verified emails run after commit (hook
         failures are logged; HTTP **202** is still returned). Returns **500** when

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -587,11 +587,14 @@ paths:
 
         Persists the attendee as a CRM contact, creates a program-enrollment
         sales lead (lead event metadata may include `discount_code` and
-        `discount_code_id` when a valid code was supplied), and when
+        `discount_code_id` when a valid non-referral code was supplied), and when
         `serviceInstanceSlug` resolves to a `service_instances` row and the
         contact has no existing enrollment for that instance, inserts an
         `enrollments` row (`created_by`: `public-reservation`) with optional
-        `discount_code_id` and paid amount, then returns **202** on success. Best-effort SES booking
+        `discount_code_id` and paid amount, then returns **202** on success.
+        Referral-type discount codes are rejected like the public validate endpoint.
+        Returns **409** when the instance is full and public bookings may not waitlist.
+        Best-effort SES booking
         confirmation to the attendee, optional Mailchimp subscribe, and plain-text
         **sales recap** to `ADMIN_GROUP` verified emails run after commit (hook
         failures are logged; HTTP **202** is still returned). Returns **500** when
@@ -620,6 +623,15 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "409":
+          description: >
+            Conflict (for example the resolved instance is at capacity with waitlist
+            disabled for public bookings). May occur after payment confirmation; response
+            body uses the standard error shape with `field` when applicable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Persistence failed.
           content:
@@ -653,6 +665,12 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Same conflict cases as `POST /v1/reservations`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Persistence failed.
           content:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -540,7 +540,7 @@ without breaking existing junction references.
 - Registration/booking rows linked to a `service_instances` row.
 - Supports parent linkage to one of contact/family/organization.
 - Optional links to event ticket tiers and discount codes.
-- Migration `0045_enrollment_inst_contact_uidx` adds partial unique index
+- Migration `0045_enroll_inst_contact_uidx` adds partial unique index
   `enrollments_instance_contact_uidx` on `(instance_id, contact_id)` where
   `contact_id` is not null (at most one enrollment per contact per instance when
   the parent is a contact).

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -540,6 +540,10 @@ without breaking existing junction references.
 - Registration/booking rows linked to a `service_instances` row.
 - Supports parent linkage to one of contact/family/organization.
 - Optional links to event ticket tiers and discount codes.
+- Migration `0045_enrollment_inst_contact_uidx` adds partial unique index
+  `enrollments_instance_contact_uidx` on `(instance_id, contact_id)` where
+  `contact_id` is not null (at most one enrollment per contact per instance when
+  the parent is a contact).
 
 ### `service_tags` + `service_assets`
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -206,8 +206,10 @@ their primary responsibilities.
   is used (reservation submission uses the same selection for PaymentIntent retrieval).
   `POST /v1/reservations` (and `/www/v1/reservations`) accepts camelCase booking-modal
   fields, persists contact + program-enrollment lead (including discount metadata when
-  applicable), may insert an `enrollments` row for the resolved instance slug when the
-  contact is not already enrolled on that instance, then sends booking confirmation
+  applicable; referral-type codes are rejected). May insert an `enrollments` row for the
+  resolved instance slug when capacity allows (or returns **409** when the instance is
+  full with waitlist disabled). Admin enrollment APIs validate discount code scope to
+  the instance's service before incrementing usage. Then sends booking confirmation
   (SES), optional Mailchimp subscribe, and a plain-text **sales recap** with extended
   booking context when provided, and signed upload/download URL generation in
   `backend/src/app/api/admin.py`.

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -205,7 +205,9 @@ their primary responsibilities.
   the staging Stripe secret; otherwise the live `EVOLVESPROUTS_STRIPE_SECRET_KEY`
   is used (reservation submission uses the same selection for PaymentIntent retrieval).
   `POST /v1/reservations` (and `/www/v1/reservations`) accepts camelCase booking-modal
-  fields, persists contact + program-enrollment lead, then sends booking confirmation
+  fields, persists contact + program-enrollment lead (including discount metadata when
+  applicable), may insert an `enrollments` row for the resolved instance slug when the
+  contact is not already enrolled on that instance, then sends booking confirmation
   (SES), optional Mailchimp subscribe, and a plain-text **sales recap** with extended
   booking context when provided, and signed upload/download URL generation in
   `backend/src/app/api/admin.py`.

--- a/tests/test_admin_enrollments_api.py
+++ b/tests/test_admin_enrollments_api.py
@@ -11,6 +11,19 @@ from app.db.models.enums import EnrollmentStatus
 from app.exceptions import ValidationError
 
 
+def _patch_enrollment_discount_scope_ok(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        admin_enrollments,
+        "service_id_for_instance",
+        lambda _session, _instance_id: uuid4(),
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
+        "ensure_discount_code_eligible_for_instance",
+        lambda *_a, **_k: None,
+    )
+
+
 def test_create_enrollment_rejects_invalid_or_exhausted_discount_code(
     monkeypatch: Any,
     api_gateway_event: Any,
@@ -75,6 +88,7 @@ def test_create_enrollment_rejects_invalid_or_exhausted_discount_code(
         "EnrollmentRepository",
         _FakeEnrollmentRepository,
     )
+    _patch_enrollment_discount_scope_ok(monkeypatch)
 
     with pytest.raises(ValidationError, match="Discount code is invalid"):
         admin_enrollments._create_enrollment(
@@ -170,6 +184,7 @@ def test_create_enrollment_with_discount_code_calls_validate_and_increment(
         "serialize_enrollment",
         lambda e: {"id": "new-1", "discount_code_id": str(e.discount_code_id)},
     )
+    _patch_enrollment_discount_scope_ok(monkeypatch)
 
     response = admin_enrollments._create_enrollment(
         api_gateway_event(
@@ -185,3 +200,157 @@ def test_create_enrollment_with_discount_code_calls_validate_and_increment(
     assert validate_calls == [discount_code_id]
     assert created_holder["discount_code_id"] == discount_code_id
     assert created_holder["amount_paid"] is None
+
+
+def test_update_enrollment_discount_swaps_usage_counts(monkeypatch: Any, api_gateway_event: Any) -> None:
+    target_instance_id = uuid4()
+    enrollment_id = uuid4()
+    old_dc = uuid4()
+    new_dc = uuid4()
+
+    class _FakeEnrollment:
+        instance_id = target_instance_id
+        discount_code_id = old_dc
+        status = EnrollmentStatus.REGISTERED
+        cancelled_at = None
+        amount_paid = None
+        currency = None
+        notes = None
+
+    decrement_calls: list[Any] = []
+    increment_calls: list[Any] = []
+
+    class _FakeDiscountRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def decrement_uses(self, code_id: Any) -> bool:
+            decrement_calls.append(code_id)
+            return True
+
+        def validate_and_increment(self, code_id: Any) -> bool:
+            increment_calls.append(code_id)
+            return True
+
+    class _FakeEnrollmentRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id(self, eid: Any) -> Any:
+            if eid == enrollment_id:
+                return _FakeEnrollment()
+            return None
+
+        def update(self, enrollment: Any) -> Any:
+            return enrollment
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    monkeypatch.setattr(admin_enrollments, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_enrollments, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_enrollments, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        admin_enrollments,
+        "parse_body",
+        lambda _e: json.loads(_e["body"]),
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
+        "parse_update_enrollment_payload",
+        lambda _body: {"discount_code_id": new_dc},
+    )
+    monkeypatch.setattr(admin_enrollments, "EnrollmentRepository", _FakeEnrollmentRepo)
+    monkeypatch.setattr(admin_enrollments, "DiscountCodeRepository", _FakeDiscountRepo)
+    monkeypatch.setattr(
+        admin_enrollments,
+        "serialize_enrollment",
+        lambda e: {"id": str(enrollment_id), "discount_code_id": str(e.discount_code_id)},
+    )
+    _patch_enrollment_discount_scope_ok(monkeypatch)
+
+    resp = admin_enrollments._update_enrollment(
+        api_gateway_event(
+            method="PATCH",
+            path="/v1/admin/services/x/instances/y/enrollments/z",
+            body=json.dumps({"discount_code_id": str(new_dc)}),
+        ),
+        instance_id=target_instance_id,
+        enrollment_id=enrollment_id,
+        actor_sub="test-admin-sub-12345",
+    )
+    assert resp["statusCode"] == 200
+    assert decrement_calls == [old_dc]
+    assert increment_calls == [new_dc]
+
+
+def test_delete_enrollment_decrements_discount_usage(monkeypatch: Any, api_gateway_event: Any) -> None:
+    target_instance_id = uuid4()
+    enrollment_id = uuid4()
+    dc_id = uuid4()
+
+    class _FakeEnrollment:
+        instance_id = target_instance_id
+        discount_code_id = dc_id
+
+    decrement_calls: list[Any] = []
+
+    class _FakeDiscountRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def decrement_uses(self, code_id: Any) -> bool:
+            decrement_calls.append(code_id)
+            return True
+
+    class _FakeEnrollmentRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id(self, eid: Any) -> Any:
+            if eid == enrollment_id:
+                return _FakeEnrollment()
+            return None
+
+        def delete(self, _enrollment: Any) -> None:
+            return None
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    monkeypatch.setattr(admin_enrollments, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_enrollments, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_enrollments, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(admin_enrollments, "EnrollmentRepository", _FakeEnrollmentRepo)
+    monkeypatch.setattr(admin_enrollments, "DiscountCodeRepository", _FakeDiscountRepo)
+
+    resp = admin_enrollments._delete_enrollment(
+        api_gateway_event(method="DELETE", path="/v1/admin/services/x/instances/y/enrollments/z"),
+        instance_id=target_instance_id,
+        enrollment_id=enrollment_id,
+        actor_sub="test-admin-sub-12345",
+    )
+    assert resp["statusCode"] == 204
+    assert decrement_calls == [dc_id]

--- a/tests/test_discount_enrollment_scope.py
+++ b/tests/test_discount_enrollment_scope.py
@@ -1,0 +1,112 @@
+"""Tests for discount code eligibility against a service instance."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.api.discount_enrollment_scope import (
+    ensure_discount_code_eligible_for_instance,
+    service_id_for_instance,
+)
+from decimal import Decimal
+
+from app.db.models import DiscountCode, ServiceInstance
+from app.db.models.enums import DiscountType
+from app.exceptions import ValidationError
+
+
+class _FakeSession:
+    def __init__(self, *, discount: DiscountCode | None, instance: ServiceInstance | None):
+        self._discount = discount
+        self._instance = instance
+
+    def get(self, model: type, entity_id):  # noqa: ANN001
+        if model is DiscountCode:
+            if self._discount is not None and self._discount.id == entity_id:
+                return self._discount
+            return None
+        if model is ServiceInstance:
+            if self._instance is not None and self._instance.id == entity_id:
+                return self._instance
+            return None
+        return None
+
+
+def test_ensure_discount_accepts_global_code() -> None:
+    sid = uuid4()
+    iid = uuid4()
+    dc_id = uuid4()
+    dc = DiscountCode(
+        id=dc_id,
+        code="G",
+        discount_type=DiscountType.PERCENTAGE,
+        discount_value=Decimal("10"),
+        service_id=None,
+        instance_id=None,
+        created_by="test",
+    )
+    inst = ServiceInstance(id=iid, service_id=sid)
+    session = _FakeSession(discount=dc, instance=inst)
+    assert ensure_discount_code_eligible_for_instance(
+        session, discount_code_id=dc_id, service_id=sid, instance_id=iid
+    ) is dc
+
+
+def test_ensure_discount_rejects_wrong_service() -> None:
+    sid = uuid4()
+    other = uuid4()
+    iid = uuid4()
+    dc_id = uuid4()
+    dc = DiscountCode(
+        id=dc_id,
+        code="S",
+        discount_type=DiscountType.PERCENTAGE,
+        discount_value=Decimal("10"),
+        service_id=other,
+        instance_id=None,
+        created_by="test",
+    )
+    inst = ServiceInstance(id=iid, service_id=sid)
+    session = _FakeSession(discount=dc, instance=inst)
+    with pytest.raises(ValidationError, match="not valid"):
+        ensure_discount_code_eligible_for_instance(
+            session, discount_code_id=dc_id, service_id=sid, instance_id=iid
+        )
+
+
+def test_ensure_discount_rejects_wrong_instance() -> None:
+    sid = uuid4()
+    iid = uuid4()
+    other_i = uuid4()
+    dc_id = uuid4()
+    dc = DiscountCode(
+        id=dc_id,
+        code="I",
+        discount_type=DiscountType.PERCENTAGE,
+        discount_value=Decimal("10"),
+        service_id=sid,
+        instance_id=other_i,
+        created_by="test",
+    )
+    inst = ServiceInstance(id=iid, service_id=sid)
+    session = _FakeSession(discount=dc, instance=inst)
+    with pytest.raises(ValidationError, match="not valid"):
+        ensure_discount_code_eligible_for_instance(
+            session, discount_code_id=dc_id, service_id=sid, instance_id=iid
+        )
+
+
+def test_service_id_for_instance() -> None:
+    sid = uuid4()
+    iid = uuid4()
+    inst = ServiceInstance(id=iid, service_id=sid)
+    session = _FakeSession(discount=None, instance=inst)
+    assert service_id_for_instance(session, iid) == sid
+
+
+def test_service_id_for_missing_instance() -> None:
+    session = _FakeSession(discount=None, instance=None)
+    with pytest.raises(ValidationError, match="not found"):
+        service_id_for_instance(session, uuid4())

--- a/tests/test_public_reservations_extended.py
+++ b/tests/test_public_reservations_extended.py
@@ -14,6 +14,7 @@ from app.api.public_reservations import (
     _validate_discount_code_redemption_scope,
     _validate_reservation_payload,
 )
+from app.db.models.enums import DiscountType
 
 
 def _reservation_body(**overrides: object) -> dict[str, Any]:
@@ -99,6 +100,125 @@ def _patch_public_reservation_db_helpers(monkeypatch: pytest.MonkeyPatch) -> Non
         "app.api.public_reservations.EnrollmentRepository",
         _FakeEnrollmentRepo,
     )
+
+
+def test_handle_public_reservation_returns_409_when_instance_capacity_full(
+    api_gateway_event: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.api.public_reservations.verify_turnstile_token",
+        lambda *_a, **_k: True,
+    )
+    _patch_public_reservation_db_helpers(monkeypatch)
+
+    contact_id = uuid4()
+    instance_uuid = uuid4()
+
+    class _FakeDiscountRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_by_code(self, _code: str) -> None:
+            return None
+
+    class _FakeInstanceRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_id_by_slug(self, slug: str) -> object | None:
+            return instance_uuid if slug == "full-cohort" else None
+
+    class _FakeEnrollmentRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def contact_has_enrollment_for_instance(self, **_kwargs: object) -> bool:
+            return False
+
+        def try_create_enrollment_with_capacity_guard(
+            self, _enrollment: object
+        ) -> tuple[None, str]:
+            return None, "capacity_full"
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.DiscountCodeRepository",
+        _FakeDiscountRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.ServiceInstanceRepository",
+        _FakeInstanceRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.EnrollmentRepository",
+        _FakeEnrollmentRepo,
+    )
+
+    class _FakeContactRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def upsert_by_email(self, _email: str, **kwargs: object) -> tuple[object, bool]:
+            c = MagicMock()
+            c.id = contact_id
+            c.phone_region = None
+            c.phone_national_number = None
+            return c, True
+
+        def update(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _FakeLeadRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def create_with_event(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _FakeSalesLead:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    monkeypatch.setattr("app.api.public_reservations.SalesLead", _FakeSalesLead)
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+    class _FakeSessionCM:
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_a: object) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.ContactRepository",
+        _FakeContactRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLeadRepository",
+        _FakeLeadRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.Session",
+        lambda _e: _FakeSessionCM(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.get_engine",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.service_id_for_instance",
+        lambda _session, _iid: uuid4(),
+    )
+
+    body = _reservation_body(serviceInstanceSlug="full-cohort")
+    event = _post_event(api_gateway_event, body)
+    resp = _handle_public_reservation(event, "POST")
+    assert resp["statusCode"] == 409
+    body_json = json.loads(resp["body"])
+    assert body_json.get("field") == "serviceInstanceSlug"
 
 
 def test_handle_public_reservation_accepts_free_payment_zero_total(
@@ -508,6 +628,7 @@ def test_discount_redemption_rejects_service_scope_mismatch(
     class _FakeRow:
         service_id = svc
         instance_id = None
+        discount_type = DiscountType.PERCENTAGE
         active = True
         valid_from = None
         valid_until = None
@@ -570,6 +691,7 @@ def test_discount_redemption_requires_instance_slug_for_instance_scoped_code(
     class _FakeRow:
         service_id = uuid4()
         instance_id = inst
+        discount_type = DiscountType.PERCENTAGE
         active = True
         valid_from = None
         valid_until = None
@@ -616,6 +738,36 @@ def test_discount_redemption_requires_instance_slug_for_instance_scoped_code(
     assert getattr(excinfo.value, "field", None) == "serviceInstanceSlug"
 
 
+def test_discount_redemption_rejects_referral_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.exceptions import ValidationError
+
+    class _FakeRow:
+        service_id = None
+        instance_id = None
+        discount_type = DiscountType.REFERRAL
+        active = True
+        valid_from = None
+        valid_until = None
+        max_uses = None
+        current_uses = 0
+
+    class _FakeDiscountRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_by_code(self, _code: str) -> object:
+            return _FakeRow()
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.DiscountCodeRepository",
+        _FakeDiscountRepo,
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        _validate_discount_code_redemption_scope(object(), {"discount_code": "REF"})
+    assert getattr(excinfo.value, "field", None) == "discountCode"
+
+
 def test_handle_public_reservation_writes_discount_metadata_and_creates_enrollment(
     api_gateway_event: Any,
     monkeypatch: pytest.MonkeyPatch,
@@ -642,6 +794,7 @@ def test_handle_public_reservation_writes_discount_metadata_and_creates_enrollme
         id = discount_uuid
         service_id = None
         instance_id = None
+        discount_type = DiscountType.PERCENTAGE
         active = True
         valid_from = None
         valid_until = None
@@ -682,9 +835,11 @@ def test_handle_public_reservation_writes_discount_metadata_and_creates_enrollme
         def contact_has_enrollment_for_instance(self, **_kwargs: object) -> bool:
             return False
 
-        def create_enrollment(self, enrollment: object) -> object:
+        def try_create_enrollment_with_capacity_guard(
+            self, enrollment: object
+        ) -> tuple[object | None, str | None]:
             created_enrollments.append(enrollment)
-            return enrollment
+            return enrollment, None
 
     monkeypatch.setattr(
         "app.api.public_reservations.DiscountCodeRepository",
@@ -735,6 +890,12 @@ def test_handle_public_reservation_writes_discount_metadata_and_creates_enrollme
         def commit(self) -> None:
             return None
 
+        def flush(self) -> None:
+            return None
+
+        def delete(self, *_a: object, **_k: object) -> None:
+            return None
+
     class _FakeSessionCM:
         def __enter__(self) -> _FakeSession:
             return _FakeSession()
@@ -757,6 +918,14 @@ def test_handle_public_reservation_writes_discount_metadata_and_creates_enrollme
     monkeypatch.setattr(
         "app.api.public_reservations.get_engine",
         lambda: object(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.service_id_for_instance",
+        lambda _session, _iid: uuid4(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.ensure_discount_code_eligible_for_instance",
+        lambda *_a, **_k: None,
     )
 
     body = _reservation_body(

--- a/tests/test_public_reservations_extended.py
+++ b/tests/test_public_reservations_extended.py
@@ -50,6 +50,57 @@ def _post_event(api_gateway_event: Any, body: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _patch_public_reservation_db_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Minimal fakes so reservation persistence does not require real DB helpers."""
+    monkeypatch.setattr(
+        "app.api.public_reservations._validate_payment_confirmation",
+        lambda *_a, **_k: None,
+    )
+
+    class _FakeDiscountRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_by_code(self, _code: str) -> None:
+            return None
+
+        def validate_and_increment(self, _code_id: object) -> bool:
+            return True
+
+        def decrement_uses(self, _code_id: object) -> bool:
+            return True
+
+    class _FakeInstanceRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_id_by_slug(self, _slug: str) -> None:
+            return None
+
+    class _FakeEnrollmentRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def contact_has_enrollment_for_instance(self, **_kwargs: object) -> bool:
+            return False
+
+        def create_enrollment(self, _enrollment: object) -> object:
+            return _enrollment
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.DiscountCodeRepository",
+        _FakeDiscountRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.ServiceInstanceRepository",
+        _FakeInstanceRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.EnrollmentRepository",
+        _FakeEnrollmentRepo,
+    )
+
+
 def test_handle_public_reservation_accepts_free_payment_zero_total(
     api_gateway_event: Any,
     monkeypatch: pytest.MonkeyPatch,
@@ -58,6 +109,7 @@ def test_handle_public_reservation_accepts_free_payment_zero_total(
         "app.api.public_reservations.verify_turnstile_token",
         lambda *_a, **_k: True,
     )
+    _patch_public_reservation_db_helpers(monkeypatch)
     hooks = MagicMock()
     monkeypatch.setattr(
         "app.api.public_reservations._run_reservation_post_success_hooks",
@@ -181,6 +233,7 @@ def test_handle_public_reservation_forces_pending_false_for_free_even_if_client_
         "app.api.public_reservations.verify_turnstile_token",
         lambda *_a, **_k: True,
     )
+    _patch_public_reservation_db_helpers(monkeypatch)
     hooks = MagicMock()
     monkeypatch.setattr(
         "app.api.public_reservations._run_reservation_post_success_hooks",
@@ -267,6 +320,7 @@ def test_handle_public_reservation_runs_hooks_after_persist(
         "app.api.public_reservations.verify_turnstile_token",
         lambda *_a, **_k: True,
     )
+    _patch_public_reservation_db_helpers(monkeypatch)
     hooks = MagicMock()
     monkeypatch.setattr(
         "app.api.public_reservations._run_reservation_post_success_hooks",
@@ -351,6 +405,7 @@ def test_handle_public_reservation_accepts_missing_service_tier(
         "app.api.public_reservations.verify_turnstile_token",
         lambda *_a, **_k: True,
     )
+    _patch_public_reservation_db_helpers(monkeypatch)
     hooks = MagicMock()
     monkeypatch.setattr(
         "app.api.public_reservations._run_reservation_post_success_hooks",
@@ -559,3 +614,165 @@ def test_discount_redemption_requires_instance_slug_for_instance_scoped_code(
     with pytest.raises(ValidationError) as excinfo:
         _validate_discount_code_redemption_scope(object(), payload)
     assert getattr(excinfo.value, "field", None) == "serviceInstanceSlug"
+
+
+def test_handle_public_reservation_writes_discount_metadata_and_creates_enrollment(
+    api_gateway_event: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.api.public_reservations.verify_turnstile_token",
+        lambda *_a, **_k: True,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations._validate_payment_confirmation",
+        lambda *_a, **_k: None,
+    )
+    hooks = MagicMock()
+    monkeypatch.setattr(
+        "app.api.public_reservations._run_reservation_post_success_hooks",
+        hooks,
+    )
+
+    contact_id = uuid4()
+    instance_uuid = uuid4()
+    discount_uuid = uuid4()
+
+    class _FakeDcRow:
+        id = discount_uuid
+        service_id = None
+        instance_id = None
+        active = True
+        valid_from = None
+        valid_until = None
+        max_uses = None
+        current_uses = 0
+
+    class _FakeDiscountRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_by_code(self, code: str) -> object | None:
+            if code.strip().lower() == "spring10":
+                return _FakeDcRow()
+            return None
+
+        def validate_and_increment(self, code_id: object) -> bool:
+            assert code_id == discount_uuid
+            return True
+
+        def decrement_uses(self, _code_id: object) -> bool:
+            return True
+
+    class _FakeInstanceRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_id_by_slug(self, slug: str) -> object | None:
+            if slug == "cohort-a":
+                return instance_uuid
+            return None
+
+    created_enrollments: list[object] = []
+
+    class _FakeEnrollmentRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def contact_has_enrollment_for_instance(self, **_kwargs: object) -> bool:
+            return False
+
+        def create_enrollment(self, enrollment: object) -> object:
+            created_enrollments.append(enrollment)
+            return enrollment
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.DiscountCodeRepository",
+        _FakeDiscountRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.ServiceInstanceRepository",
+        _FakeInstanceRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.EnrollmentRepository",
+        _FakeEnrollmentRepo,
+    )
+
+    class _FakeContactRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def upsert_by_email(self, _email: str, **kwargs: object) -> tuple[object, bool]:
+            c = MagicMock()
+            c.id = contact_id
+            c.phone_region = None
+            c.phone_national_number = None
+            return c, True
+
+        def update(self, *_a: object, **_k: object) -> None:
+            return None
+
+    lead_calls: list[dict[str, object]] = []
+
+    class _FakeLeadRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def create_with_event(self, *_a: object, **kwargs: object) -> None:
+            lead_calls.append(kwargs)
+
+    class _FakeSalesLead:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLead",
+        _FakeSalesLead,
+    )
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+    class _FakeSessionCM:
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_a: object) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.ContactRepository",
+        _FakeContactRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLeadRepository",
+        _FakeLeadRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.Session",
+        lambda _e: _FakeSessionCM(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.get_engine",
+        lambda: object(),
+    )
+
+    body = _reservation_body(
+        discountCode="SPRING10",
+        serviceInstanceSlug="cohort-a",
+    )
+    event = _post_event(api_gateway_event, body)
+    resp = _handle_public_reservation(event, "POST")
+    assert resp["statusCode"] == 202
+    assert len(created_enrollments) == 1
+    en = created_enrollments[0]
+    assert en.instance_id == instance_uuid
+    assert en.contact_id == contact_id
+    assert en.discount_code_id == discount_uuid
+    assert lead_calls and lead_calls[0].get("metadata")
+    meta = lead_calls[0]["metadata"]
+    assert isinstance(meta, dict)
+    assert meta.get("discount_code") == "SPRING10"
+    assert meta.get("discount_code_id") == str(discount_uuid)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Admin web (Services → Instances → Enrollments):** Loads active discount codes that are global, scoped to the current service, or scoped to the current instance (merged client-side via three list calls). Adds a **Discount code** select on the same row as status, amount paid, and currency (4-column grid on large screens). Sends `discount_code_id` on create; on update, includes `discount_code_id` only when it changed (including clearing to `null`). Table adds a **Discount** column (code when found in loaded options).
- **Public `POST /v1/reservations`:** Lead event metadata adds `discount_code` and `discount_code_id` when a valid non-referral code was supplied. When `serviceInstanceSlug` resolves and the contact has no existing enrollment for that instance, inserts an `enrollments` row when capacity allows (`created_by`: `public-reservation`), then increments discount usage only after a successful insert. Returns **409** when the instance is full with waitlist disabled (after payment confirmation). Referral-type codes are rejected in scope validation. Partial unique index `(instance_id, contact_id)` where `contact_id` is not null reduces duplicate enrollment races.
- **Admin enrollments API:** Validates discount code scope to the instance's service before `validate_and_increment`; `PATCH` / `DELETE` adjust usage counts as before.
- **Docs:** OpenAPI (`admin.yaml`, `public.yaml`) and architecture docs updated; admin generated types refreshed.

## Follow-up commit (review findings)

- **409** instead of 500 when instance is full (no waitlist) for public reservations.
- Admin create/update: enforce global / service / instance scope for `discount_code_id`.
- Public reservations: reject `DiscountType.REFERRAL` in `_validate_discount_code_redemption_scope`.
- Alembic `0045_enrollment_inst_contact_uidx` + `try_create_enrollment_with_capacity_guard` for duplicate-safe insert under savepoint.
- Tests: `test_discount_enrollment_scope.py`, admin PATCH/delete discount usage, public 409 capacity, referral rejection; extended reservation test fakes.

## Tests

- `python3 -m pytest tests/test_discount_enrollment_scope.py tests/test_admin_enrollments_api.py tests/test_public_reservations_extended.py`
- `npm run lint` (admin_web)

## Notes

- Public enrollment `currency` remains **HKD** to match the booking modal.
- **409** body includes `field: serviceInstanceSlug` for the capacity-full case; operators should handle refunds manually per message copy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa4b6209-d70f-488b-9d42-87993be7fa87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa4b6209-d70f-488b-9d42-87993be7fa87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

