### PR TITLE
fix(api): stop leaking Velocity CORS template in API Gateway error bodies

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2550,10 +2550,14 @@ export class ApiStack extends cdk.Stack {
     // authorizer denials, Lambda timeouts, integration errors) won't include
     // CORS headers, causing the browser to block the response.  The frontend
     // then sees a CORS / network error instead of a useful status code.
+    //
+    // Do not set a gateway response *body* mapping template here: API Gateway
+    // gateway responses support only simple variable substitution in the
+    // payload template, not full VTL.  A prior Velocity template leaked raw
+    // `#set` / `#if` text into JSON error bodies (for example Postman).
+    // Response headers below still apply; browsers get CORS on errors even
+    // when Access-Control-Allow-Origin is a fixed first allowlisted origin.
     // -------------------------------------------------------------------------
-    const gatewayResponseTemplates: Record<string, string> = {
-      "application/json": buildCorsOriginOverrideTemplate(corsAllowedOrigins),
-    };
     const gatewayResponseHeaders: Record<string, string> = {
       "Access-Control-Allow-Origin": `'${corsAllowedOrigins[0]}'`,
       "Access-Control-Allow-Headers":
@@ -2564,12 +2568,10 @@ export class ApiStack extends cdk.Stack {
     api.addGatewayResponse("GatewayResponseDefault4XX", {
       type: apigateway.ResponseType.DEFAULT_4XX,
       responseHeaders: gatewayResponseHeaders,
-      templates: gatewayResponseTemplates,
     });
     api.addGatewayResponse("GatewayResponseDefault5XX", {
       type: apigateway.ResponseType.DEFAULT_5XX,
       responseHeaders: gatewayResponseHeaders,
-      templates: gatewayResponseTemplates,
     });
 
     const publicWwwApiKey = new apigateway.ApiKey(this, "PublicWwwApiKey", {
@@ -3662,31 +3664,6 @@ function normalizeCorsOrigins(value: unknown): string[] {
     .split(",")
     .map((origin) => origin.trim())
     .filter((origin) => origin.length > 0);
-}
-
-function buildCorsOriginOverrideTemplate(allowedOrigins: string[]): string {
-  const conditions = allowedOrigins
-    .map((origin) => origin.trim())
-    .filter((origin) => origin.length > 0)
-    .map((origin) =>
-      origin
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
-    )
-    .map((origin) => `$origin == "${origin}"`)
-    .join(" || ");
-
-  const allowlistCondition = conditions || "false";
-
-  return [
-    '#set($origin = $input.params().header.get("Origin"))',
-    '#if($origin == "")',
-    '  #set($origin = $input.params().header.get("origin"))',
-    "#end",
-    `#if(${allowlistCondition})`,
-    "  #set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)",
-    "#end",
-  ].join("\n");
 }
 
 function addCheckovMethodSuppression(

--- a/backend/infrastructure/test/api-stack.test.ts
+++ b/backend/infrastructure/test/api-stack.test.ts
@@ -54,6 +54,25 @@ function assertStageHasNoApiGatewayCacheCluster(template: Template): void {
   }
 }
 
+function assertGatewayResponsesHaveNoBodyTemplates(template: Template): void {
+  const responses = template.findResources("AWS::ApiGateway::GatewayResponse");
+  const entries = Object.entries(responses);
+  if (entries.length === 0) {
+    throw new Error("Expected at least one AWS::ApiGateway::GatewayResponse resource");
+  }
+  for (const [logicalId, resource] of entries) {
+    const props = resource.Properties ?? {};
+    if ("ResponseTemplates" in props && props.ResponseTemplates != null) {
+      const rt = props.ResponseTemplates;
+      if (typeof rt === "object" && rt !== null && Object.keys(rt as object).length > 0) {
+        throw new Error(
+          `GatewayResponse ${logicalId} must not set ResponseTemplates (API Gateway only supports simple substitution in gateway response body templates; VTL leaks into JSON bodies). Found ${JSON.stringify(rt)}`,
+        );
+      }
+    }
+  }
+}
+
 function assertStageHasCheckovCkv120Suppression(template: Template): void {
   const stages = template.findResources("AWS::ApiGateway::Stage");
   const entries = Object.entries(stages);
@@ -90,6 +109,7 @@ function assertStageHasCheckovCkv120Suppression(template: Template): void {
 function main(): void {
   const template = synthApiTemplate();
   assertStageHasNoApiGatewayCacheCluster(template);
+  assertGatewayResponsesHaveNoBodyTemplates(template);
   assertStageHasCheckovCkv120Suppression(template);
   // eslint-disable-next-line no-console
   console.log("api-stack API Gateway stage cache assertions passed.");

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -498,9 +498,13 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 
 CORS headers are added to API Gateway error responses so the browser can
 read error status codes instead of silently blocking them.
-Gateway responses use a static fallback origin plus a response-template
-override that echoes the request `Origin` when it matches the configured
-allowlist (`CORS_ALLOWED_ORIGINS` plus required defaults).
+Gateway responses set CORS headers only via `responseParameters` (static
+values). API Gateway gateway-response body templates do not run full VTL,
+so we do not attach a payload mapping template there (a prior template would
+have leaked Velocity directives into JSON error bodies).
+`Access-Control-Allow-Origin` on these errors uses the first resolved
+allowlisted origin (required defaults plus `CORS_ALLOWED_ORIGINS` / context),
+not per-request `Origin` echoing.
 
 | Response Type | Headers Added |
 |--------------|---------------|


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Postman (and other clients) could see raw Velocity text like `#set(...)` in JSON bodies for API Gateway–generated 4XX/5XX responses.

Per [AWS docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gatewayResponse-definition.html#customize-gateway-responses), gateway response payload templates support **only simple variable substitution**, not full VTL. Our `buildCorsOriginOverrideTemplate` used `#set`, `#if`, and `$input.params()`, which do not run in that context and were returned as literal body content.

## Changes

- Remove gateway response `templates` / `ResponseTemplates` from `DEFAULT_4XX` and `DEFAULT_5XX`; keep CORS headers via `responseParameters` (static `Access-Control-Allow-Origin` using the first resolved allowlisted origin, unchanged from before for headers).
- Delete the unused `buildCorsOriginOverrideTemplate` helper.
- Add a synth test assertion that no `AWS::ApiGateway::GatewayResponse` sets non-empty `ResponseTemplates`.
- Update `docs/architecture/aws-assets-map.md` to match actual behavior.

## Testing

- `npm run test:infra` in `backend/infrastructure`
- `bash scripts/validate-cursorrules.sh`

## Deploy note

Redeploy the API stack (CDK) for the fix to take effect in AWS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c07b0538-92c1-45d0-afe0-a1173a5cb4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c07b0538-92c1-45d0-afe0-a1173a5cb4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

