### PR TITLE
Restore public calendar service_key and prevent booking regressions

### DIFF
--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -323,6 +323,16 @@ export function ServiceDetailPanel({
   const selectedLocationValue = locationExists ? locationId : locationId || '';
   const showDefaultLocationField = serviceForm.deliveryMode !== 'online';
 
+  const saveBlockedByPublishedBookableMissingKey = useMemo(() => {
+    if (serviceForm.status !== 'published') {
+      return false;
+    }
+    if (serviceType !== 'event' && serviceType !== 'training_course') {
+      return false;
+    }
+    return serviceForm.serviceKey.trim() === '';
+  }, [serviceForm.status, serviceForm.serviceKey, serviceType]);
+
   const saveBlockedByPairConflict = serviceKeyTierConflictActive;
 
   const tierInvalid =
@@ -585,6 +595,7 @@ export function ServiceDetailPanel({
                     isLoading ||
                     !service ||
                     saveBlockedByPairConflict ||
+                    saveBlockedByPublishedBookableMissingKey ||
                     tierInvalid ||
                     Boolean(
                       serviceForm.serviceKey.trim() &&
@@ -610,6 +621,7 @@ export function ServiceDetailPanel({
                 disabled={
                   isLoading ||
                   saveBlockedByPairConflict ||
+                  saveBlockedByPublishedBookableMissingKey ||
                   tierInvalid ||
                   !serviceForm.title.trim() ||
                   Boolean(
@@ -658,6 +670,13 @@ export function ServiceDetailPanel({
                 : undefined
             }
             serviceKeyConflictError={serviceKeyConflictInline}
+            publishedBookableKeyWarning={
+              (serviceType === 'event' || serviceType === 'training_course') &&
+              serviceForm.status === 'published' &&
+              !serviceForm.serviceKey.trim()
+                ? 'A service key is required to take public bookings (discount validation and reservation submission). Set one before publishing.'
+                : undefined
+            }
           />
           <div>
             <div className='relative mb-1'>

--- a/apps/admin_web/src/components/admin/services/service-form-fields.tsx
+++ b/apps/admin_web/src/components/admin/services/service-form-fields.tsx
@@ -16,6 +16,8 @@ export interface ServiceKeyFieldProps {
   onChange: (next: string) => void;
   serviceKeyUsageLoadError?: string;
   serviceKeyConflictError?: string;
+  /** When set with empty value, show amber warning (e.g. published bookable types). */
+  publishedBookableKeyWarning?: string;
 }
 
 export function ServiceKeyField({
@@ -23,6 +25,7 @@ export function ServiceKeyField({
   onChange,
   serviceKeyUsageLoadError,
   serviceKeyConflictError,
+  publishedBookableKeyWarning,
 }: ServiceKeyFieldProps) {
   return (
     <div>
@@ -42,6 +45,9 @@ export function ServiceKeyField({
         </p>
       ) : null}
       {serviceKeyUsageLoadError ? <p className='mt-1 text-xs text-amber-700'>{serviceKeyUsageLoadError}</p> : null}
+      {publishedBookableKeyWarning ? (
+        <p className='mt-1 text-xs text-amber-700'>{publishedBookableKeyWarning}</p>
+      ) : null}
       {serviceKeyConflictError ? <p className='mt-1 text-xs text-red-600'>{serviceKeyConflictError}</p> : null}
     </div>
   );
@@ -61,6 +67,7 @@ export interface ServiceFormFieldsProps {
   hideTitle?: boolean;
   serviceKeyUsageLoadError?: string;
   serviceKeyConflictError?: string;
+  publishedBookableKeyWarning?: string;
 }
 
 export function ServiceFormFields({
@@ -69,6 +76,7 @@ export function ServiceFormFields({
   hideTitle = false,
   serviceKeyUsageLoadError,
   serviceKeyConflictError,
+  publishedBookableKeyWarning,
 }: ServiceFormFieldsProps) {
   return (
     <div className='space-y-3'>
@@ -98,6 +106,7 @@ export function ServiceFormFields({
         onChange={(next) => onChange({ ...value, serviceKey: next })}
         serviceKeyUsageLoadError={serviceKeyUsageLoadError}
         serviceKeyConflictError={serviceKeyConflictError}
+        publishedBookableKeyWarning={publishedBookableKeyWarning}
       />
       <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
         <div>

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -374,6 +374,73 @@ describe('ServiceDetailPanel', () => {
     expect(defaultPrice.compareDocumentPosition(defaultLocation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it('warns and disables save when publishing an event without a service key', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    render(
+      <ServiceDetailPanel
+        service={buildService({
+          serviceType: 'event',
+          status: 'draft',
+          serviceKey: null,
+          eventDetails: {
+            eventCategory: 'workshop',
+            defaultPrice: '10',
+            defaultCurrency: 'HKD',
+          },
+        })}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={onUpdate}
+        onUploadCover={vi.fn()}
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText('Status'), 'Published');
+    expect(
+      screen.getByText(
+        'A service key is required to take public bookings (discount validation and reservation submission). Set one before publishing.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Update service/i })).toBeDisabled();
+  });
+
+  it('enables update when published event has a valid service key', async () => {
+    const user = userEvent.setup();
+    render(
+      <ServiceDetailPanel
+        service={buildService({
+          serviceType: 'event',
+          status: 'published',
+          serviceKey: 'spring-workshop',
+          eventDetails: {
+            eventCategory: 'workshop',
+            defaultPrice: '10',
+            defaultCurrency: 'HKD',
+          },
+        })}
+        isLoading={false}
+        error=''
+        onCancelSelection={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onUploadCover={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByText(
+        'A service key is required to take public bookings (discount validation and reservation submission). Set one before publishing.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Update service/i })).toBeEnabled();
+    await user.clear(screen.getByLabelText('Service key'));
+    await user.type(screen.getByLabelText('Service key'), 'new-event-key');
+    expect(screen.getByRole('button', { name: /Update service/i })).toBeEnabled();
+  });
+
   it('consultation shows currency when hourly and a service tier field in Row1', async () => {
     const user = userEvent.setup();
     render(

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -828,9 +828,29 @@ export function BookingReservationForm({
       try {
         if (!scopeKey || !instanceSlugForValidate) {
           setDiscountRule(null);
-          if (!options.autoApply) {
-            setDiscountError(content.invalidDiscountLabel);
+          if (options.autoApply) {
+            trackAnalyticsEvent('booking_discount_autoapply_error', {
+              sectionId: analyticsSectionId,
+              ctaLocation: options.ctaLocation,
+              params: {
+                error_type: 'service_key_missing',
+              },
+            });
+          } else {
+            trackAnalyticsEvent('booking_discount_apply_error', {
+              sectionId: analyticsSectionId,
+              ctaLocation: options.ctaLocation,
+              params: {
+                error_type: 'service_key_missing',
+              },
+            });
           }
+          if (!options.autoApply) {
+            setDiscountError(content.discountUnavailableLabel);
+          }
+          console.warn(
+            '[reservation-form] discount validate skipped: missing serviceKey or serviceInstanceSlug (calendar feed identity)',
+          );
           return;
         }
         const validatedRule = await validateDiscountCode(crmApiClient, {
@@ -924,6 +944,7 @@ export function BookingReservationForm({
     },
     [
       analyticsSectionId,
+      content.discountUnavailableLabel,
       content.invalidDiscountLabel,
       discountRule,
       serviceKey,
@@ -1011,6 +1032,26 @@ export function BookingReservationForm({
           error_type: 'validation_error',
         },
       });
+      return;
+    }
+
+    const sanitizedSubmitServiceKey = sanitizeSingleLineValue(serviceKey);
+    const sanitizedSubmitInstanceSlug = sanitizeSingleLineValue(serviceInstanceSlug);
+    if (!sanitizedSubmitServiceKey || !sanitizedSubmitInstanceSlug) {
+      trackPublicFormOutcome('booking_submit_error', {
+        formKind: 'reservation',
+        formId: BOOKING_RESERVATION_FORM_ANALYTICS_ID,
+        sectionId: analyticsSectionId,
+        ctaLocation: 'reservation_form',
+        params: {
+          payment_method: paymentMethodForAnalytics,
+          service_tier: selectedServiceTierLabel,
+          cohort_date: normalizedCohortDate,
+          total_amount: totalAmount,
+          error_type: 'service_key_missing',
+        },
+      });
+      setSubmissionError(content.bookingUnavailableLabel);
       return;
     }
 

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1573,6 +1573,8 @@
       "applyDiscountLabel": "Apply",
       "applyDiscountLoadingLabel": "Applying discount code",
       "invalidDiscountLabel": "Invalid discount code",
+      "discountUnavailableLabel": "Discount codes aren't available for this booking right now. Please try again later or contact us.",
+      "bookingUnavailableLabel": "This booking isn't available right now. Please try again later or contact us.",
       "referralAppliedNote": "Applied from your referral link.",
       "discountAppliedLabel": "Discount applied",
       "priceBreakdownPriceLabel": "Price",

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1573,6 +1573,8 @@
       "applyDiscountLabel": "应用",
       "applyDiscountLoadingLabel": "正在应用优惠码",
       "invalidDiscountLabel": "优惠码无效",
+      "discountUnavailableLabel": "目前无法为此预约使用优惠码。请稍后再试或联系我们。",
+      "bookingUnavailableLabel": "目前无法完成此预约。请稍后再试或联系我们。",
       "referralAppliedNote": "已通过你的推荐链接应用。",
       "discountAppliedLabel": "优惠已应用",
       "priceBreakdownPriceLabel": "原价",

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1573,6 +1573,8 @@
       "applyDiscountLabel": "套用",
       "applyDiscountLoadingLabel": "正在套用優惠碼",
       "invalidDiscountLabel": "優惠碼無效",
+      "discountUnavailableLabel": "目前無法為此預約使用優惠碼。請稍後再試或聯絡我們。",
+      "bookingUnavailableLabel": "目前無法完成此預約。請稍後再試或聯絡我們。",
       "referralAppliedNote": "已透過你的推薦連結套用。",
       "discountAppliedLabel": "優惠已套用",
       "priceBreakdownPriceLabel": "原價",

--- a/apps/public_www/tests/components/sections/event-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/event-booking-modal.test.tsx
@@ -8,6 +8,7 @@ import { buildThankYouRecapLabels } from '@/components/sections/booking-modal/th
 import enContent from '@/content/en.json';
 import type { EventCalendarBookingModalPayload } from '@/lib/events-data';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
+import { validateDiscountCode } from '@/lib/discounts-data';
 import { generateFpsQrImageDataUrl } from '@/lib/fps-qr-code';
 import { submitReservation } from '@/lib/reservations-data';
 
@@ -163,6 +164,7 @@ const eventPayload: EventCalendarBookingModalPayload = {
 
 describe('EventBookingModal', () => {
   const mockedCreateCrmApiClient = vi.mocked(createPublicCrmApiClient);
+  const mockedValidateDiscountCode = vi.mocked(validateDiscountCode);
   const mockedGenerateFpsQr = vi.mocked(generateFpsQrImageDataUrl);
   const mockedSubmitReservationFn = vi.mocked(submitReservation);
 
@@ -328,5 +330,33 @@ describe('EventBookingModal', () => {
         }),
       }),
     );
+  });
+
+  it('shows discount unavailable copy and skips validate when serviceKey is empty', async () => {
+    const requestSpy = vi.fn().mockResolvedValue({ message: 'ok' });
+    mockedCreateCrmApiClient.mockReturnValue({ request: requestSpy });
+    mockedValidateDiscountCode.mockClear();
+
+    render(
+      <EventBookingModal
+        paymentModalContent={paymentModal}
+        bookingPayload={{ ...eventPayload, serviceKey: '' }}
+        thankYouRecapLabels={buildThankYouRecapLabels(thankYouModalContent)}
+        onClose={() => {}}
+        onSubmitReservation={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(paymentModal.discountCodePlaceholder), {
+      target: { value: 'SAVE10' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: paymentModal.applyDiscountLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(paymentModal.discountUnavailableLabel);
+    });
+
+    expect(mockedValidateDiscountCode).not.toHaveBeenCalled();
+    expect(requestSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/public_www/tests/lib/events-data.test.ts
+++ b/apps/public_www/tests/lib/events-data.test.ts
@@ -510,6 +510,66 @@ describe('events-data', () => {
     expect(events[0]?.tags).toEqual(['1-4', 'Parent + Child', 'Workshop']);
   });
 
+  it('public calendar fixture rows include service_key (API wire contract)', () => {
+    for (const row of publicCalendarFixture.data) {
+      expect(row).toHaveProperty('service_key');
+    }
+  });
+
+  it('resolves event booking modal serviceKey from calendar service_key and empty when omitted', () => {
+    const withKey = getLandingPageBookingEventContentFromPayload(
+      {
+        status: 'success',
+        data: [
+          {
+            title: 'Keyed event',
+            service_type: 'event',
+            service_key: 'my-key',
+            slug: 'keyed-event-slug',
+            booking_system: 'event-booking',
+            dates: [
+              {
+                start_datetime: '2026-08-01T10:00:00Z',
+                end_datetime: '2026-08-01T11:00:00Z',
+                part: 1,
+              },
+            ],
+            location: 'virtual',
+          },
+        ],
+      },
+      'keyed-event-slug',
+      'en',
+    );
+    expect(withKey?.bookingPayload?.variant).toBe('event');
+    expect(withKey?.bookingPayload?.serviceKey).toBe('my-key');
+
+    const withoutKey = getLandingPageBookingEventContentFromPayload(
+      {
+        status: 'success',
+        data: [
+          {
+            title: 'No key event',
+            service_type: 'event',
+            slug: 'no-key-event-slug',
+            booking_system: 'event-booking',
+            dates: [
+              {
+                start_datetime: '2026-08-02T10:00:00Z',
+                end_datetime: '2026-08-02T11:00:00Z',
+                part: 1,
+              },
+            ],
+            location: 'virtual',
+          },
+        ],
+      },
+      'no-key-event-slug',
+      'en',
+    );
+    expect(withoutKey?.bookingPayload?.serviceKey).toBe('');
+  });
+
   it('resolves landing page hero content from calendar payload using slug', () => {
     const heroEventContent = getLandingPageHeroEventContentFromPayload(
       publicCalendarFixture,

--- a/backend/db/alembic/versions/0051_backfill_event_service_key.py
+++ b/backend/db/alembic/versions/0051_backfill_event_service_key.py
@@ -1,0 +1,140 @@
+"""Backfill ``services.service_key`` for event and training_course rows without a key.
+
+Slugifies ``title`` to a kebab-case key (max 80 chars), disambiguates collisions on
+``(lower(service_key), lower(service_tier))`` with numeric suffixes, and uses a
+deterministic fallback when the title slugifies to empty.
+
+Post-upgrade: every **published** ``event`` / ``training_course`` must have a
+non-blank ``service_key`` (raises if not). Draft/archived rows may remain without
+a key.
+
+Seed-data assessment:
+1. Seed compatibility: seed updates that set ``service_key`` remain valid; this
+   migration only fills NULL/blank keys on event and training_course rows.
+2. NOT NULL: unchanged (column stays nullable for non-published types).
+3. N/A.
+4. N/A.
+5. N/A.
+6. Unique index ``services_service_key_tier_unique_idx``: suffix logic avoids
+   collisions within the batch; conflicts with pre-existing keys increment the
+   suffix via ``existing`` count.
+
+Downgrade is intentionally a no-op (forward-only data fix).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0051_backfill_event_service_key"
+down_revision: Union[str, None] = "0050_fix_mba_service_key"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_CREATE_FN = r"""
+CREATE OR REPLACE FUNCTION migration_0051_slugify(input text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $slugfn$
+  SELECT trim(
+    both '-'
+    FROM regexp_replace(
+      substring(
+        trim(
+          both '-'
+          FROM regexp_replace(
+            lower(coalesce(input, '')),
+            '[^a-z0-9]+',
+            '-',
+            'g'
+          )
+        )
+        FROM 1 FOR 80
+      ),
+      '-+$',
+      ''
+    )
+  );
+$slugfn$
+"""
+
+_BACKFILL = r"""
+WITH base AS (
+  SELECT
+    s.id,
+    s.service_tier,
+    CASE
+      WHEN migration_0051_slugify(s.title) = ''
+      THEN
+        substring(
+          'event-' || substring(replace(s.id::text, '-', ''), 1, 8)
+          FROM 1 FOR 80
+        )
+      ELSE migration_0051_slugify(s.title)
+    END AS cand
+  FROM services AS s
+  WHERE s.service_type IN ('event', 'training_course')
+    AND (s.service_key IS NULL OR trim(s.service_key) = '')
+),
+ranked AS (
+  SELECT
+    b.id,
+    b.cand,
+    row_number() OVER (
+      PARTITION BY lower(b.cand), lower(coalesce(b.service_tier, ''))
+      ORDER BY b.id
+    ) AS rn,
+    (
+      SELECT count(*)::int
+      FROM services AS x
+      WHERE x.service_key IS NOT NULL
+        AND trim(x.service_key) <> ''
+        AND lower(trim(x.service_key)) = lower(trim(b.cand))
+        AND coalesce(lower(trim(x.service_tier)), '') = coalesce(lower(trim(b.service_tier)), '')
+    ) AS existing
+  FROM base AS b
+)
+UPDATE services AS s
+SET service_key = CASE
+  WHEN r.rn = 1 AND r.existing = 0 THEN substring(r.cand FROM 1 FOR 80)
+  ELSE substring(r.cand || '-' || (r.rn + r.existing)::text FROM 1 FOR 80)
+END
+FROM ranked AS r
+WHERE s.id = r.id
+"""
+
+_DROP_FN = "DROP FUNCTION IF EXISTS migration_0051_slugify(text)"
+
+_ASSERT = r"""
+DO $assert$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM services
+    WHERE service_type IN ('event', 'training_course')
+      AND status = 'published'
+      AND (service_key IS NULL OR trim(service_key) = '')
+  ) THEN
+    RAISE EXCEPTION 'Backfill incomplete: published event/training_course rows still have no service_key';
+  END IF;
+END
+$assert$
+"""
+
+
+def upgrade() -> None:
+    op.execute(sa.text(_CREATE_FN))
+    op.execute(sa.text(_BACKFILL))
+    op.execute(sa.text(_DROP_FN))
+    op.execute(sa.text(_ASSERT))
+
+
+def downgrade() -> None:
+    print(
+        "0051_backfill_event_service_key: downgrade is a no-op; "
+        "backfilled service_key values are not reverted"
+    )

--- a/backend/src/app/api/public_events.py
+++ b/backend/src/app/api/public_events.py
@@ -414,6 +414,7 @@ def _serialize_public_event(
     payload: dict[str, Any] = {
         "slug": slug,
         "service_type": service.service_type.value,
+        "service_key": service.service_key,
         "title": title,
         "summary": summary,
         "description": summary,

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -275,6 +275,10 @@ paths:
 
         Optional filters: `service_type`, `slug`, `service_key`. Filters
         combine via logical AND; contradictory combinations return `events: []`.
+
+        Each returned event includes `slug` and `service_key` (nullable) from the
+        parent service; together they identify the bookable instance for
+        `POST /v1/discounts/validate` and `POST /v1/reservations`.
       security:
         - ApiKeyAuth: []
       parameters:
@@ -351,6 +355,10 @@ paths:
 
         Optional filters: `service_type`, `slug`, `service_key`. Filters
         combine via logical AND; contradictory combinations return `events: []`.
+
+        Each returned event includes `slug` and `service_key` (nullable) from the
+        parent service; together they identify the bookable instance for
+        `POST /v1/discounts/validate` and `POST /v1/reservations`.
       security:
         - ApiKeyAuth: []
       parameters:
@@ -1162,6 +1170,16 @@ components:
             Stable public identifier for the offering. Maps to `service_instances.slug`.
             The calendar feed omits rows where the instance slug is empty or does not match
             this public pattern (invalid values are filtered server-side).
+        service_key:
+          type: string
+          nullable: true
+          maxLength: 80
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          description: >
+            Parent service public key (`services.service_key`); nullable when the parent
+            service has no key. Required by `POST /v1/discounts/validate` and
+            `POST /v1/reservations` for booking identity, so consumers should treat a
+            null value as "this offering cannot be booked through the public flows yet."
         service_tier:
           type: string
           nullable: true

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -87,8 +87,13 @@ Migration `0049_inst_slug_not_null` sets `service_instances.slug` to `NOT NULL` 
 the backfill succeeds.
 
 Migration `0050_fix_mba_service_key` updates `services.service_key` from the legacy
-legacy MBA key string to `my-best-auntie-training-course` for matching training-course
+MBA key string to `my-best-auntie-training-course` for matching training-course
 titles (idempotent; aligns with the public booking constant).
+
+Migration `0051_backfill_event_service_key` assigns kebab-case `services.service_key`
+values to `event` / `training_course` rows that were missing a key (draft/archived
+rows may remain without a key), then asserts no **published** rows in those types
+remain without a key.
 
 Migration `0032_services_booking` adds nullable `services.booking_system` (varchar(80))
 for an optional admin-visible booking-system label.

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -124,7 +124,9 @@ their primary responsibilities.
   **training_course** `service_instances` for published services; consultation
   is intentionally excluded. Instances with an empty `service_instances.slug` are omitted.
   Each item includes `service_type`,
-  `slug` (public instance slug from `service_instances.slug`), `partners`, `service_tier`
+  `slug` (public instance slug from `service_instances.slug`), parent `service_key`
+  (nullable `services.service_key`; required for public discount validate and reservation
+  submission when non-null), `partners`, `service_tier`
   (from parent service, or inferred from instance slug for My Best Auntie) / `cohort`,
   and `title` augmented with the tier, a spaced hyphen, and a title-cased cohort label
   when both `service_tier` and `cohort` are present (cohort hyphen segments capitalized,

--- a/tests/db/migrations/test_0051_backfill_event_service_key.py
+++ b/tests/db/migrations/test_0051_backfill_event_service_key.py
@@ -1,0 +1,143 @@
+"""PostgreSQL integration: migration ``0051_backfill_event_service_key``."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg", reason="psycopg required for DB integration test")
+
+
+def _database_url() -> str | None:
+    url = os.getenv("TEST_DATABASE_URL", "").strip()
+    return url or None
+
+
+def _libpq_conn_url(url: str) -> str:
+    return url.replace("postgresql+psycopg://", "postgresql://", 1)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _alembic_ini() -> Path:
+    return _repo_root() / "backend" / "db" / "alembic.ini"
+
+
+def _run_alembic(*args: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "DATABASE_URL": _database_url() or ""}
+    cmd = [sys.executable, "-m", "alembic", "-c", str(_alembic_ini()), *args]
+    proc = subprocess.run(
+        cmd,
+        cwd=str(_repo_root()),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"alembic {' '.join(args)} failed:\n{proc.stdout}\n{proc.stderr}"
+        )
+    return proc
+
+
+@pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
+def test_0051_backfills_service_key_for_events_and_training() -> None:
+    url = _database_url()
+    assert url is not None
+    conn_url = _libpq_conn_url(url)
+
+    svc_empty_title = UUID("f1111111-1111-1111-1111-111111115051")
+    svc_event_titled = UUID("f1111111-1111-1111-1111-111111115052")
+    svc_preexisting = UUID("f1111111-1111-1111-1111-211111115053")
+    svc_collision_new = UUID("f1111111-1111-1111-1111-211111115054")
+
+    key_pat = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+    _run_alembic("upgrade", "head")
+    _run_alembic("downgrade", "0050_fix_mba_service_key")
+
+    with psycopg.connect(conn_url) as conn:
+        conn.execute(
+            "DELETE FROM event_details WHERE service_id::text LIKE 'f1111111%'"
+        )
+        conn.execute(
+            "DELETE FROM training_course_details WHERE service_id::text LIKE 'f1111111%'"
+        )
+        conn.execute("DELETE FROM services WHERE id::text LIKE 'f1111111%'")
+
+        conn.execute(
+            """
+            INSERT INTO services (
+              id, service_type, title, service_key, booking_system, description,
+              cover_image_s3_key, delivery_mode, status, created_by,
+              service_tier, location_id
+            ) VALUES
+            (%s, 'event', '', NULL, NULL, NULL, NULL,
+             'in_person', 'published', 'test', NULL, NULL),
+            (%s, 'event', 'Spring Workshop', NULL, NULL, NULL, NULL,
+             'in_person', 'published', 'test', NULL, NULL),
+            (%s, 'training_course', 'Preexisting', 'collision-course', NULL, NULL, NULL,
+             'online', 'published', 'test', NULL, NULL),
+            (%s, 'training_course', 'Collision Course', NULL, NULL, NULL, NULL,
+             'online', 'published', 'test', NULL, NULL)
+            """,
+            (svc_empty_title, svc_event_titled, svc_preexisting, svc_collision_new),
+        )
+
+        conn.execute(
+            """
+            INSERT INTO event_details (service_id, event_category, default_price, default_currency)
+            VALUES (%s, 'workshop', 10.00, 'HKD'),
+                   (%s, 'workshop', 10.00, 'HKD')
+            """,
+            (svc_empty_title, svc_event_titled),
+        )
+
+        conn.execute(
+            """
+            INSERT INTO training_course_details (
+              service_id, pricing_unit, default_price, default_currency
+            ) VALUES (%s, 'per_person', 1.00, 'HKD'),
+                      (%s, 'per_person', 1.00, 'HKD')
+            """,
+            (svc_preexisting, svc_collision_new),
+        )
+
+        conn.commit()
+
+    _run_alembic("upgrade", "0051_backfill_event_service_key")
+
+    with psycopg.connect(conn_url) as conn:
+        rows = conn.execute(
+            "SELECT id, service_key FROM services WHERE id = ANY(%s)",
+            (
+                [
+                    svc_empty_title,
+                    svc_event_titled,
+                    svc_preexisting,
+                    svc_collision_new,
+                ],
+            ),
+        ).fetchall()
+
+    by_id = {r[0]: r[1] for r in rows}
+
+    empty_key = by_id[svc_empty_title]
+    assert empty_key is not None and str(empty_key).strip() != ""
+    assert key_pat.match(str(empty_key)), empty_key
+    assert str(empty_key).startswith("event-")
+
+    assert by_id[svc_event_titled] == "spring-workshop"
+    assert by_id[svc_preexisting] == "collision-course"
+    assert by_id[svc_collision_new] == "collision-course-2"
+
+    _run_alembic("upgrade", "head")

--- a/tests/test_public_events_api.py
+++ b/tests/test_public_events_api.py
@@ -21,6 +21,7 @@ def _instance_row(
     delivery_mode_value: str = "in_person",
     max_capacity: int | None = 10,
     slug: str | None = "spring-workshop",
+    service_key: str | None = None,
 ) -> Any:
     starts = datetime(2026, 4, 20, 18, 0, tzinfo=UTC)
     ends = datetime(2026, 4, 20, 20, 0, tzinfo=UTC)
@@ -31,7 +32,7 @@ def _instance_row(
         title="Parent Service",
         description="Parent description",
         service_type=ServiceType.EVENT,
-        service_key=None,
+        service_key=service_key,
         booking_system=None,
         event_details=SimpleNamespace(event_category=SimpleNamespace(value="workshop")),
         delivery_mode=SimpleNamespace(value=delivery_mode_value),
@@ -118,8 +119,16 @@ def test_handle_public_events_returns_items(monkeypatch: Any, api_gateway_event:
             assert service_types is None
             assert service_key is None
             return [
-                _instance_row(status=public_events.InstanceStatus.OPEN, with_eventbrite_url=True),
-                _instance_row(status=public_events.InstanceStatus.FULL),
+                _instance_row(
+                    status=public_events.InstanceStatus.OPEN,
+                    with_eventbrite_url=True,
+                    service_key="spring-parent-key",
+                ),
+                _instance_row(
+                    status=public_events.InstanceStatus.FULL,
+                    slug="summer-workshop",
+                    service_key="summer-parent-key",
+                ),
             ]
 
         def get_enrollment_counts_for_instances(self, instance_ids: list[Any]) -> dict[Any, int]:
@@ -155,6 +164,8 @@ def test_handle_public_events_returns_items(monkeypatch: Any, api_gateway_event:
     assert body["items"][0]["service_type"] == "event"
     assert "service_instance_id" not in body["items"][0]
     assert body["items"][0]["slug"] == "spring-workshop"
+    assert body["items"][0]["service_key"] == "spring-parent-key"
+    assert body["items"][1]["service_key"] == "summer-parent-key"
 
 
 def test_handle_public_events_skips_instances_without_valid_slug(

--- a/tests/test_public_events_serializer.py
+++ b/tests/test_public_events_serializer.py
@@ -83,6 +83,8 @@ def test_event_ticket_tier_price_and_booking_system_default() -> None:
     assert "service_instance_id" not in out
     assert out["slug"] == "my-event"
     assert out["service_type"] == "event"
+    assert "service_key" in out
+    assert out["service_key"] is None
     assert out["booking_system"] == "event-booking"
     assert out["categories"] == ["workshop"]
     assert out["price"] == 250
@@ -186,7 +188,17 @@ def test_tags_include_service_tier_when_set() -> None:
     assert out["tags"] == ["Alpha", "premium", "zebra"]
 
 
-def test_service_tier_tag_dedupes_instance_tag_same_name() -> None:
+def test_serialized_event_includes_service_key_from_parent() -> None:
+    """Calendar JSON always includes service_key (nullable) from parent service."""
+    service = _event_service()
+    service.service_key = "easter-workshops"
+    inst = _minimal_instance(service)
+    out = public_events._serialize_public_event(inst, enrollment_counts={})
+    assert "service_key" in out
+    assert out["service_key"] == "easter-workshops"
+
+
+def test_training_course_tags_dedupe_tier_with_instance_tags() -> None:
     service = SimpleNamespace(
         title="MBA",
         description="Course",
@@ -240,6 +252,7 @@ def test_training_mba_booking_and_category() -> None:
     )
     out = public_events._serialize_public_event(inst, enrollment_counts={})
     assert out["service_type"] == "training_course"
+    assert out["service_key"] == "my-best-auntie-training-course"
     assert out["booking_system"] == "my-best-auntie-booking"
     assert out["categories"] == ["Training Course"]
     assert out["price"] == 350


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores `service_key` on every `GET /v1/calendar/public` (and `/www/v1/calendar/public`) event object from the parent `services.service_key`, documents the field in OpenAPI, and adds Alembic `0051_backfill_event_service_key` so published `event` / `training_course` rows always get a kebab-case key (with collision suffixing and empty-title fallback). Admin UI warns and blocks saving when an event or training course is **published** without a key. Public booking modal uses clearer copy and a submit guard when identity is missing, plus tests.

## Testing

- `pre-commit run ruff-format --all-files`
- `pytest tests/test_public_events_serializer.py tests/test_public_events_api.py`
- `pytest tests/` (787 passed, 10 skipped)
- `bash scripts/validate-cursorrules.sh`
- `apps/admin_web`: `npm run lint`, `npm test -- --run tests/components/admin/services/service-detail-panel.test.tsx`
- `apps/public_www`: `npm run lint`, `npm test -- --run tests/lib/events-data.test.ts tests/components/sections/event-booking-modal.test.tsx`
- DB migration integration test `tests/db/migrations/test_0051_backfill_event_service_key.py` runs when `TEST_DATABASE_URL` is set.

## Deploy / ops notes

- After release, invalidate CloudFront for `/www/v1/calendar/public*` (or equivalent) so edge caches pick up the new JSON shape quickly.
- Optional seed tweaks for local event keys were not added; migration `0051` covers backfill.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-928bb35a-e55d-4174-8a04-b7d9e903195f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-928bb35a-e55d-4174-8a04-b7d9e903195f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

