### PR TITLE
Generic calendar blockers API, admin Calendar page, consultation picker sync

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -279,7 +279,7 @@ should extend the shared primitives rather than reintroducing one-off layouts.
 
 - **Top-level navigation** (`ADMIN_NAV_ITEMS` in `apps/admin_web/src/lib/admin-nav.ts`, rendered by
   `apps/admin_web/src/components/admin-authenticated-shell.tsx`) must list areas
-  alphabetically: **Assets**, **Contacts**, **Finance**, **Sales**, **Services**, **Tags**, **Website**. The default
+  alphabetically: **Assets**, **Calendar**, **Contacts**, **Finance**, **Sales**, **Services**, **Tags**, **Website**. The default
   section after sign-in is **Finance** unless product requirements change.
 - **In-area view switchers** (for example Finance, Services, Sales pipeline vs analytics)
   must use `AdminTabStrip` from `apps/admin_web/src/components/ui/admin-tab-strip.tsx`

--- a/apps/admin_web/src/app/(dashboard)/calendar/page.tsx
+++ b/apps/admin_web/src/app/(dashboard)/calendar/page.tsx
@@ -1,0 +1,5 @@
+import { CalendarManualBlocksPage } from '@/components/admin/calendar/calendar-manual-blocks-page';
+
+export default function CalendarRoutePage() {
+  return <CalendarManualBlocksPage />;
+}

--- a/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
+++ b/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import type { FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import { AdminEditorCard } from '@/components/ui/admin-editor-card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { Select } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { DeleteIcon } from '@/components/icons/action-icons';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import {
+  CONSULTATION_BOOKING_BLOCK_PURPOSE,
+  createCalendarManualBlock,
+  deleteCalendarManualBlock,
+  listCalendarManualBlocks,
+  updateCalendarManualBlock,
+  type AdminCalendarManualBlockRow,
+} from '@/lib/calendar-manual-blocks-api';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+type BlockPeriod = ApiSchemas['CreateAdminCalendarManualBlockRequest']['period'];
+
+const EDITOR_FORM_ID = 'calendar-manual-blocks-editor-form';
+
+function ymdFromLocalDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function defaultDateRange(): { from: string; to: string } {
+  const now = new Date();
+  const from = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+  const to = new Date(now.getFullYear(), now.getMonth() + 6, now.getDate());
+  return {
+    from: ymdFromLocalDate(from),
+    to: ymdFromLocalDate(to),
+  };
+}
+
+export function CalendarManualBlocksPage() {
+  const [confirmDialogProps, requestConfirm] = useConfirmDialog();
+  const range = useMemo(() => defaultDateRange(), []);
+  const [listFrom, setListFrom] = useState(range.from);
+  const [listTo, setListTo] = useState(range.to);
+  const [rows, setRows] = useState<AdminCalendarManualBlockRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [saveError, setSaveError] = useState('');
+  const [editorMode, setEditorMode] = useState<'create' | 'edit'>('create');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [blockDate, setBlockDate] = useState('');
+  const [period, setPeriod] = useState<BlockPeriod>('am');
+  const [note, setNote] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteBusyId, setDeleteBusyId] = useState<string | null>(null);
+
+  const loadRows = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const items = await listCalendarManualBlocks({
+        purpose: CONSULTATION_BOOKING_BLOCK_PURPOSE,
+        from: listFrom,
+        to: listTo,
+      });
+      setRows(items);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : 'Failed to load blocks.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [listFrom, listTo]);
+
+  useEffect(() => {
+    void loadRows();
+  }, [loadRows]);
+
+  const resetCreateForm = () => {
+    setEditorMode('create');
+    setSelectedId(null);
+    setBlockDate('');
+    setPeriod('am');
+    setNote('');
+    setSaveError('');
+  };
+
+  const applyRowSelection = (row: AdminCalendarManualBlockRow) => {
+    setEditorMode('edit');
+    setSelectedId(row.id);
+    setBlockDate(row.block_date);
+    setPeriod(row.period as BlockPeriod);
+    setNote(row.note?.trim() ?? '');
+    setSaveError('');
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSaveError('');
+    setIsSaving(true);
+    try {
+      if (editorMode === 'create') {
+        const body: ApiSchemas['CreateAdminCalendarManualBlockRequest'] = {
+          purpose: CONSULTATION_BOOKING_BLOCK_PURPOSE,
+          blockDate: blockDate.trim(),
+          period,
+          note: note.trim() === '' ? null : note.trim(),
+        };
+        await createCalendarManualBlock(body);
+        resetCreateForm();
+        await loadRows();
+        return;
+      }
+      if (!selectedId) {
+        return;
+      }
+      const body: ApiSchemas['UpdateAdminCalendarManualBlockRequest'] = {
+        blockDate: blockDate.trim(),
+        period,
+        note: note.trim() === '' ? null : note.trim(),
+      };
+      await updateCalendarManualBlock(selectedId, body);
+      await loadRows();
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : 'Save failed.';
+      setSaveError(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDeleteRow = async (row: AdminCalendarManualBlockRow) => {
+    const confirmed = await requestConfirm({
+      title: 'Remove manual block?',
+      description: `Delete the ${row.period.toUpperCase()} block on ${row.block_date}? Session-derived blocks may still apply.`,
+      confirmLabel: 'Delete',
+      variant: 'danger',
+    });
+    if (!confirmed) {
+      return;
+    }
+    setDeleteBusyId(row.id);
+    setError('');
+    try {
+      await deleteCalendarManualBlock(row.id);
+      if (selectedId === row.id) {
+        resetCreateForm();
+      }
+      await loadRows();
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : 'Delete failed.';
+      setError(message);
+    } finally {
+      setDeleteBusyId(null);
+    }
+  };
+
+  return (
+    <div className='space-y-6'>
+      <AdminEditorCard
+        title='Manual calendar block'
+        description='Adds extra half-day blocks for family consultation booking (merged with event and training session slots on the public site). Session occupancy always wins; removing a manual row does not override an overlapping course or event.'
+        actions={
+          editorMode === 'edit' ? (
+            <>
+              <Button type='button' variant='secondary' disabled={editorIsBusy} onClick={resetCreateForm}>
+                Cancel
+              </Button>
+              <Button
+                type='submit'
+                form={EDITOR_FORM_ID}
+                disabled={editorIsBusy || !blockDate.trim()}
+              >
+                {isSaving ? 'Saving…' : 'Save changes'}
+              </Button>
+            </>
+          ) : (
+            <Button type='submit' form={EDITOR_FORM_ID} disabled={editorIsBusy || !blockDate.trim()}>
+              {isSaving ? 'Creating…' : 'Create block'}
+            </Button>
+          )
+        }
+      >
+        <form id={EDITOR_FORM_ID} className='space-y-4' onSubmit={(event) => void handleSubmit(event)}>
+          <div className='grid gap-4 sm:grid-cols-2'>
+            <div>
+              <Label htmlFor='calendar-block-date'>Date</Label>
+              <Input
+                id='calendar-block-date'
+                type='date'
+                value={blockDate}
+                onChange={(event) => setBlockDate(event.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor='calendar-block-period'>Period</Label>
+              <Select
+                id='calendar-block-period'
+                value={period}
+                onChange={(event) => setPeriod(event.target.value as BlockPeriod)}
+              >
+                <option value='am'>Morning (AM)</option>
+                <option value='pm'>Afternoon (PM)</option>
+                <option value='both'>Full day (both)</option>
+              </Select>
+            </div>
+          </div>
+          <div>
+            <Label htmlFor='calendar-block-note'>Note (optional)</Label>
+            <Textarea
+              id='calendar-block-note'
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              rows={2}
+              maxLength={500}
+            />
+          </div>
+          {saveError ? <p className='text-sm text-red-600'>{saveError}</p> : null}
+        </form>
+      </AdminEditorCard>
+
+      <PaginatedTableCard
+        title='Consultation manual blocks'
+        isLoading={isLoading}
+        isLoadingMore={false}
+        hasMore={false}
+        error={error}
+        loadingLabel='Loading blocks…'
+        onLoadMore={() => {}}
+        toolbar={
+          <div className='mb-3 flex flex-wrap items-end gap-3'>
+            <div>
+              <Label htmlFor='calendar-list-from'>From</Label>
+              <Input
+                id='calendar-list-from'
+                type='date'
+                value={listFrom}
+                onChange={(event) => setListFrom(event.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor='calendar-list-to'>To</Label>
+              <Input
+                id='calendar-list-to'
+                type='date'
+                value={listTo}
+                onChange={(event) => setListTo(event.target.value)}
+              />
+            </div>
+            <Button type='button' variant='secondary' onClick={() => void loadRows()}>
+              Refresh
+            </Button>
+          </div>
+        }
+      >
+        <AdminDataTable tableClassName='min-w-[640px]'>
+          <AdminDataTableHead>
+            <tr>
+              <th className='px-4 py-3 font-semibold'>Date</th>
+              <th className='px-4 py-3 font-semibold'>Period</th>
+              <th className='px-4 py-3 font-semibold'>Note</th>
+              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+            </tr>
+          </AdminDataTableHead>
+          <AdminDataTableBody>
+            {rows.length === 0 && !isLoading ? (
+              <tr>
+                <td className='px-4 py-6 text-slate-600' colSpan={4}>
+                  No manual blocks in this range.
+                </td>
+              </tr>
+            ) : null}
+            {rows.map((row) => (
+              <tr
+                key={row.id}
+                className={`cursor-pointer transition ${
+                  selectedId === row.id ? 'bg-slate-100' : 'hover:bg-slate-50'
+                }`}
+                onClick={() => applyRowSelection(row)}
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    applyRowSelection(row);
+                  }
+                }}
+              >
+                <td className='px-4 py-3 font-medium text-slate-900'>{row.block_date}</td>
+                <td className='px-4 py-3 uppercase'>{row.period}</td>
+                <td className='px-4 py-3 text-slate-700'>{row.note?.trim() || '—'}</td>
+                <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
+                  <Button
+                    type='button'
+                    size='sm'
+                    variant='danger'
+                    className='h-8 min-w-8 px-0'
+                    disabled={editorIsBusy || deleteBusyId === row.id}
+                    onClick={() => void handleDeleteRow(row)}
+                    aria-label='Delete block'
+                    title='Delete block'
+                  >
+                    <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </AdminDataTableBody>
+        </AdminDataTable>
+      </PaginatedTableCard>
+
+      <ConfirmDialog {...confirmDialogProps} />
+    </div>
+  );
+}

--- a/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
+++ b/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
@@ -61,9 +61,16 @@ export function CalendarManualBlocksPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [deleteBusyId, setDeleteBusyId] = useState<string | null>(null);
 
+  const editorIsBusy = isSaving || deleteBusyId !== null;
+
   const loadRows = useCallback(async () => {
     setIsLoading(true);
     setError('');
+    if (listTo < listFrom) {
+      setError('“To” must be on or after “From”.');
+      setIsLoading(false);
+      return;
+    }
     try {
       const items = await listCalendarManualBlocks({
         purpose: CONSULTATION_BOOKING_BLOCK_PURPOSE,
@@ -121,12 +128,29 @@ export function CalendarManualBlocksPage() {
       if (!selectedId) {
         return;
       }
-      const body: ApiSchemas['UpdateAdminCalendarManualBlockRequest'] = {
-        blockDate: blockDate.trim(),
-        period,
-        note: note.trim() === '' ? null : note.trim(),
-      };
-      await updateCalendarManualBlock(selectedId, body);
+      const prev = rows.find((r) => r.id === selectedId);
+      const body: Partial<ApiSchemas['UpdateAdminCalendarManualBlockRequest']> = {};
+      const nextDate = blockDate.trim();
+      const nextPeriod = period;
+      const nextNoteTrim = note.trim();
+      if (nextDate && nextDate !== (prev?.block_date ?? '')) {
+        body.blockDate = nextDate;
+      }
+      if (nextPeriod !== (prev?.period as BlockPeriod | undefined)) {
+        body.period = nextPeriod;
+      }
+      const prevNote = prev?.note?.trim() ?? '';
+      if (nextNoteTrim !== prevNote) {
+        body.note = nextNoteTrim === '' ? null : nextNoteTrim;
+      }
+      if (Object.keys(body).length === 0) {
+        setSaveError('Change at least one field before saving.');
+        return;
+      }
+      await updateCalendarManualBlock(
+        selectedId,
+        body as ApiSchemas['UpdateAdminCalendarManualBlockRequest'],
+      );
       await loadRows();
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : 'Save failed.';

--- a/apps/admin_web/src/lib/admin-nav.ts
+++ b/apps/admin_web/src/lib/admin-nav.ts
@@ -1,5 +1,6 @@
 export const ADMIN_NAV_ITEMS = [
   { key: 'assets', label: 'Assets', href: '/assets' },
+  { key: 'calendar', label: 'Calendar', href: '/calendar' },
   { key: 'contacts', label: 'Contacts', href: '/contacts' },
   { key: 'finance', label: 'Finance', href: '/finance' },
   { key: 'sales', label: 'Sales', href: '/sales' },

--- a/apps/admin_web/src/lib/calendar-manual-blocks-api.ts
+++ b/apps/admin_web/src/lib/calendar-manual-blocks-api.ts
@@ -1,0 +1,67 @@
+import { adminApiRequest } from '@/lib/api-admin-client';
+import { unwrapPayload } from '@/lib/api-payload';
+import { isRecord } from '@/lib/type-guards';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+
+export type AdminCalendarManualBlockRow = ApiSchemas['AdminCalendarManualBlockRef'];
+
+export const CONSULTATION_BOOKING_BLOCK_PURPOSE = 'consultation_booking';
+
+function parseBlock(value: unknown): AdminCalendarManualBlockRow {
+  return (isRecord(value) ? value : {}) as AdminCalendarManualBlockRow;
+}
+
+export async function listCalendarManualBlocks(
+  params: { purpose: string; from: string; to: string },
+  signal?: AbortSignal,
+): Promise<AdminCalendarManualBlockRow[]> {
+  const query = new URLSearchParams();
+  query.set('purpose', params.purpose);
+  query.set('from', params.from);
+  query.set('to', params.to);
+  const payload = await adminApiRequest<ApiSchemas['AdminCalendarManualBlockListResponse']>({
+    endpointPath: `/v1/admin/calendar/manual-blocks?${query.toString()}`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  return Array.isArray(root.items) ? root.items.map((row) => parseBlock(row)) : [];
+}
+
+export async function createCalendarManualBlock(
+  body: ApiSchemas['CreateAdminCalendarManualBlockRequest'],
+): Promise<AdminCalendarManualBlockRow | null> {
+  const payload = await adminApiRequest<ApiSchemas['AdminCalendarManualBlockResponse']>({
+    endpointPath: '/v1/admin/calendar/manual-blocks',
+    method: 'POST',
+    body,
+    expectedSuccessStatuses: [200, 201],
+  });
+  const root = unwrapPayload(payload);
+  return root.block ? parseBlock(root.block) : null;
+}
+
+export async function updateCalendarManualBlock(
+  id: string,
+  body: ApiSchemas['UpdateAdminCalendarManualBlockRequest'],
+): Promise<AdminCalendarManualBlockRow | null> {
+  const payload = await adminApiRequest<ApiSchemas['AdminCalendarManualBlockResponse']>({
+    endpointPath: `/v1/admin/calendar/manual-blocks/${id}`,
+    method: 'PATCH',
+    body,
+  });
+  const root = unwrapPayload(payload);
+  return root.block ? parseBlock(root.block) : null;
+}
+
+export async function deleteCalendarManualBlock(id: string): Promise<boolean> {
+  const payload = await adminApiRequest<ApiSchemas['AdminCalendarManualBlockDeleteResponse']>({
+    endpointPath: `/v1/admin/calendar/manual-blocks/${id}`,
+    method: 'DELETE',
+  });
+  const root = unwrapPayload(payload);
+  return Boolean(isRecord(root) && root.deleted);
+}

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5261,6 +5261,10 @@ export interface components {
             created_at?: string | null;
             /** Format: date-time */
             updated_at?: string | null;
+            /** @description Cognito subject of the admin who created the row (when known). */
+            created_by?: string | null;
+            /** @description Cognito subject of the admin who last updated the row (when known). */
+            updated_by?: string | null;
         };
         AdminCalendarManualBlockListResponse: {
             items: components["schemas"]["AdminCalendarManualBlockRef"][];
@@ -5279,11 +5283,12 @@ export interface components {
             period: "am" | "pm" | "both";
             note?: string | null;
         };
+        /** @description Partial update: include only fields to change. Omitted fields are left unchanged. At least one of `blockDate`, `period`, or `note` must be present. */
         UpdateAdminCalendarManualBlockRequest: {
             /** Format: date */
-            blockDate: string;
+            blockDate?: string;
             /** @enum {string} */
-            period: "am" | "pm" | "both";
+            period?: "am" | "pm" | "both";
             note?: string | null;
         };
         AdminTagDeleteResponse: {

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2217,6 +2217,191 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/calendar/manual-blocks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List manual calendar blocks for a purpose
+         * @description Returns **manual** rows from `calendar_manual_blocks` only (session-derived blockers
+         *     are exposed on `GET /v1/calendar/blockers`). Current release supports `purpose=consultation_booking` only.
+         */
+        get: {
+            parameters: {
+                query: {
+                    purpose: string;
+                    from: string;
+                    to: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Manual block list. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminCalendarManualBlockListResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        /** Create manual calendar block */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateAdminCalendarManualBlockRequest"];
+                };
+            };
+            responses: {
+                /** @description Block created. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminCalendarManualBlockResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                /** @description Duplicate purpose/date/period. */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/calendar/manual-blocks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** Get manual calendar block by id */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Block detail. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminCalendarManualBlockResponse"];
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Delete manual calendar block */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminCalendarManualBlockDeleteResponse"];
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update manual calendar block */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateAdminCalendarManualBlockRequest"];
+                };
+            };
+            responses: {
+                /** @description Updated block. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminCalendarManualBlockResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+                /** @description Duplicate purpose/date/period. */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/v1/admin/tags": {
         parameters: {
             query?: never;
@@ -5062,6 +5247,44 @@ export interface components {
             usage_count: number;
             /** @description True for reserved asset-pipeline tags (`expense_attachment`, `client_document`). These cannot be renamed, archived, or deleted via the admin API. */
             is_system: boolean;
+        };
+        AdminCalendarManualBlockRef: {
+            /** Format: uuid */
+            id: string;
+            purpose: string;
+            /** Format: date */
+            block_date: string;
+            /** @enum {string} */
+            period: "am" | "pm" | "both";
+            note?: string | null;
+            /** Format: date-time */
+            created_at?: string | null;
+            /** Format: date-time */
+            updated_at?: string | null;
+        };
+        AdminCalendarManualBlockListResponse: {
+            items: components["schemas"]["AdminCalendarManualBlockRef"][];
+        };
+        AdminCalendarManualBlockResponse: {
+            block: components["schemas"]["AdminCalendarManualBlockRef"];
+        };
+        AdminCalendarManualBlockDeleteResponse: {
+            deleted: boolean;
+        };
+        CreateAdminCalendarManualBlockRequest: {
+            purpose: string;
+            /** Format: date */
+            blockDate: string;
+            /** @enum {string} */
+            period: "am" | "pm" | "both";
+            note?: string | null;
+        };
+        UpdateAdminCalendarManualBlockRequest: {
+            /** Format: date */
+            blockDate: string;
+            /** @enum {string} */
+            period: "am" | "pm" | "both";
+            note?: string | null;
         };
         AdminTagDeleteResponse: {
             /** @description True when the tag row was removed from the database. */

--- a/apps/admin_web/tests/lib/admin-nav.test.ts
+++ b/apps/admin_web/tests/lib/admin-nav.test.ts
@@ -6,6 +6,7 @@ describe('adminSectionKeyFromPathname', () => {
   it('maps known dashboard paths to section keys', () => {
     expect(adminSectionKeyFromPathname('/sales')).toBe('sales');
     expect(adminSectionKeyFromPathname('/assets')).toBe('assets');
+    expect(adminSectionKeyFromPathname('/calendar')).toBe('calendar');
     expect(adminSectionKeyFromPathname('/contacts')).toBe('contacts');
     expect(adminSectionKeyFromPathname('/finance')).toBe('finance');
     expect(adminSectionKeyFromPathname('/services')).toBe('services');
@@ -16,6 +17,7 @@ describe('adminSectionKeyFromPathname', () => {
   it('matches paths served with a trailing slash (next.config trailingSlash: true)', () => {
     expect(adminSectionKeyFromPathname('/sales/')).toBe('sales');
     expect(adminSectionKeyFromPathname('/assets/')).toBe('assets');
+    expect(adminSectionKeyFromPathname('/calendar/')).toBe('calendar');
     expect(adminSectionKeyFromPathname('/contacts/')).toBe('contacts');
     expect(adminSectionKeyFromPathname('/finance/')).toBe('finance');
     expect(adminSectionKeyFromPathname('/services/')).toBe('services');

--- a/apps/public_www/src/components/pages/consultations.tsx
+++ b/apps/public_www/src/components/pages/consultations.tsx
@@ -1,5 +1,4 @@
 import type { Locale, SiteContent } from '@/content';
-import calendarAvailability from '@/content/calendar-availability.json';
 import { resolvePublicSiteConfig } from '@/lib/site-config';
 import { PageLayout } from '@/components/shared/page-layout';
 import { Faq } from '@/components/sections/faq';
@@ -28,7 +27,6 @@ export function ConsultationsPage({ locale, content }: ConsultationsPageProps) {
         locale={locale}
         content={consultations.booking}
         bookingModalContent={content.bookingModal}
-        calendarAvailability={calendarAvailability}
         thankYouWhatsappHref={publicSiteConfig.whatsappUrl}
         thankYouWhatsappCtaLabel={content.contactUs.form.contactMethodLinks.whatsapp}
         commonAccessibility={content.common.accessibility}

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -35,10 +35,10 @@ import {
   isConsultationPeriodBlocked,
   pickDefaultConsultationSelection,
   rebaseConsultationDateParts,
-  resolveDefaultDateTimeZone,
   type ConsultationDayPeriod,
   type ConsultationUnavailableByYmd,
 } from '@/lib/consultation-booking-slot';
+import { PUBLIC_SITE_IANA_TIMEZONE } from '@/lib/site-datetime';
 import { useModalLockBody } from '@/lib/hooks/use-modal-lock-body';
 import { useModalFocusManagement } from '@/lib/hooks/use-modal-focus-management';
 import { mergeClassNames } from '@/lib/class-name-utils';
@@ -331,7 +331,7 @@ export function ConsultationBookingModal({
   const dialogTitleId = useId();
   const dialogDescriptionId = useId();
 
-  const timeZone = useMemo(() => resolveDefaultDateTimeZone(), []);
+  const timeZone = useMemo(() => PUBLIC_SITE_IANA_TIMEZONE, []);
 
   const unavailableByYmd = useMemo(() => {
     return buildUnavailableSlotMap(calendarAvailability.unavailable_slots);

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -65,8 +65,14 @@ interface ConsultationBookingModalProps {
   bookingPayload: ConsultationEventBookingModalPayload;
   /** Picker labels (AM/PM, weekdays, aria). */
   pickerContent: ConsultationBookingPickerContent;
-  /** Unavailability list (from JSON now; API later). Dates are YYYY-MM-DD. */
+  /** Unavailability list from merged manual + session blockers. Dates are YYYY-MM-DD. */
   calendarAvailability: CalendarAvailabilityPayload;
+  /** Blocker fetch lifecycle from the parent (public API). */
+  calendarBlockersStatus?: 'idle' | 'loading' | 'ready' | 'error';
+  /** Locale string while blockers are loading (`calendarBlockersStatus === 'loading'`). */
+  calendarBlockersLoadingMessage?: string;
+  /** Locale string when the blockers request failed (`calendarBlockersStatus === 'error'`). */
+  calendarBlockersErrorMessage?: string;
   /** Selection context: focus label, level features, upgrade label. */
   selectionInfo?: ConsultationBookingModalSelectionInfo;
   /**
@@ -107,6 +113,7 @@ function ConsultationDatePickerGrid({
   unavailableByYmd,
   selectedYmd,
   dayPeriod,
+  interactionDisabled,
   onSelectYmd,
   onSelectPeriod,
 }: {
@@ -116,6 +123,8 @@ function ConsultationDatePickerGrid({
   unavailableByYmd: ConsultationUnavailableByYmd;
   selectedYmd: string;
   dayPeriod: ConsultationDayPeriod;
+  /** When true, day and period controls are disabled (e.g. while blockers load). */
+  interactionDisabled: boolean;
   onSelectYmd: (ymd: string) => void;
   onSelectPeriod: (period: ConsultationDayPeriod) => void;
 }) {
@@ -186,7 +195,8 @@ function ConsultationDatePickerGrid({
               <tr key={`w-${rowIndex}`}>
                 {row.days.map((cell) => {
                   const isSelected = cell.ymd === selectedYmd;
-                  const ariaDayLabel = cell.isDisabled
+                  const isDayDisabled = cell.isDisabled || interactionDisabled;
+                  const ariaDayLabel = isDayDisabled
                     ? content.datePickerUnavailableDayTemplate.replace(
                         '{day}',
                         String(cell.dayOfMonth),
@@ -199,20 +209,20 @@ function ConsultationDatePickerGrid({
                     <td key={cell.ymd} className='p-1'>
                       <button
                         type='button'
-                        disabled={cell.isDisabled}
+                        disabled={isDayDisabled}
                         aria-pressed={isSelected}
                         aria-label={ariaDayLabel}
                         className={mergeClassNames(
                           'flex h-10 w-full min-w-[2.25rem] items-center justify-center rounded-lg text-base font-semibold transition-colors',
-                          cell.isDisabled
+                          isDayDisabled
                             ? 'cursor-not-allowed opacity-30'
                             : 'es-text-heading hover:es-bg-surface-muted',
-                          isSelected && !cell.isDisabled
+                          isSelected && !isDayDisabled
                             ? 'border-2 es-border-warm-2 es-bg-brand-orange-soft'
                             : 'border border-transparent',
                         )}
                         onClick={() => {
-                          if (!cell.isDisabled) {
+                          if (!isDayDisabled) {
                             onSelectYmd(cell.ymd);
                           }
                         }}
@@ -241,12 +251,15 @@ function ConsultationDatePickerGrid({
           <button
             type='button'
             disabled={
+              interactionDisabled ||
               !selectedYmd ||
               isConsultationPeriodBlocked(selectedYmd, 'am', unavailableByYmd)
             }
             className={mergeClassNames(
               'rounded-full px-4 py-2 text-sm font-semibold transition-colors',
-              !selectedYmd || isConsultationPeriodBlocked(selectedYmd, 'am', unavailableByYmd)
+              interactionDisabled ||
+                !selectedYmd ||
+                isConsultationPeriodBlocked(selectedYmd, 'am', unavailableByYmd)
                 ? 'cursor-not-allowed opacity-40'
                 : dayPeriod === 'am'
                   ? 'es-bg-brand-orange-soft es-text-body opacity-80 shadow-sm'
@@ -262,12 +275,15 @@ function ConsultationDatePickerGrid({
           <button
             type='button'
             disabled={
+              interactionDisabled ||
               !selectedYmd ||
               isConsultationPeriodBlocked(selectedYmd, 'pm', unavailableByYmd)
             }
             className={mergeClassNames(
               'rounded-full px-4 py-2 text-sm font-semibold transition-colors',
-              !selectedYmd || isConsultationPeriodBlocked(selectedYmd, 'pm', unavailableByYmd)
+              interactionDisabled ||
+                !selectedYmd ||
+                isConsultationPeriodBlocked(selectedYmd, 'pm', unavailableByYmd)
                 ? 'cursor-not-allowed opacity-40'
                 : dayPeriod === 'pm'
                   ? 'es-bg-brand-orange-soft es-text-body opacity-80 shadow-sm'
@@ -315,6 +331,9 @@ export function ConsultationBookingModal({
   bookingPayload,
   pickerContent,
   calendarAvailability,
+  calendarBlockersStatus = 'ready',
+  calendarBlockersLoadingMessage = '',
+  calendarBlockersErrorMessage = '',
   selectionInfo,
   levelFeaturesEnterAnimationNonce = 0,
   analyticsSectionId = 'consultations-booking',
@@ -354,6 +373,22 @@ export function ConsultationBookingModal({
 
   const selectedYmd = pickerSelection?.ymd ?? defaultSelection?.ymd ?? '';
   const dayPeriod = pickerSelection?.period ?? defaultSelection?.period ?? 'am';
+
+  const pickerInteractionDisabled = calendarBlockersStatus === 'loading';
+
+  const blockersStatusMessage = useMemo(() => {
+    if (calendarBlockersStatus === 'loading' && calendarBlockersLoadingMessage.trim()) {
+      return calendarBlockersLoadingMessage;
+    }
+    if (calendarBlockersStatus === 'error' && calendarBlockersErrorMessage.trim()) {
+      return calendarBlockersErrorMessage;
+    }
+    return null;
+  }, [
+    calendarBlockersStatus,
+    calendarBlockersLoadingMessage,
+    calendarBlockersErrorMessage,
+  ]);
 
   function handleSelectYmd(ymd: string) {
     setPickerSelection((prev) => {
@@ -397,16 +432,29 @@ export function ConsultationBookingModal({
   const selectedDateStartTime = rebasedParts[0]?.startDateTime ?? '';
 
   const pickerSlot = (
-    <ConsultationDatePickerGrid
-      locale={locale}
-      content={pickerContent}
-      timeZone={timeZone}
-      unavailableByYmd={unavailableByYmd}
-      selectedYmd={selectedYmd}
-      dayPeriod={dayPeriod}
-      onSelectYmd={handleSelectYmd}
-      onSelectPeriod={handleSelectPeriod}
-    />
+    <div className='flex flex-col gap-4'>
+      {blockersStatusMessage ? (
+        <p
+          className='rounded-lg border border-black/15 px-4 py-3 text-sm font-medium leading-snug es-text-body'
+          role='status'
+          aria-live='polite'
+          data-testid='consultation-calendar-blockers-status'
+        >
+          {blockersStatusMessage}
+        </p>
+      ) : null}
+      <ConsultationDatePickerGrid
+        locale={locale}
+        content={pickerContent}
+        timeZone={timeZone}
+        unavailableByYmd={unavailableByYmd}
+        selectedYmd={selectedYmd}
+        dayPeriod={dayPeriod}
+        interactionDisabled={pickerInteractionDisabled}
+        onSelectYmd={handleSelectYmd}
+        onSelectPeriod={handleSelectPeriod}
+      />
+    </div>
   );
 
   const subtitleSlot = selectionInfo ? (

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -102,6 +102,8 @@ export interface ConsultationBookingPickerContent {
   datePickerDayTemplate: string;
   /** Interpolate `{day}`; use when the day is unavailable (past or fully blocked). */
   datePickerUnavailableDayTemplate: string;
+  /** Interpolate `{day}` when the grid is disabled because availability is still loading. */
+  datePickerLoadingDayTemplate: string;
   /** Shown under the selected date summary; same tone as payment modal refund hint. */
   dateConfirmationNote: string;
 }
@@ -196,15 +198,23 @@ function ConsultationDatePickerGrid({
                 {row.days.map((cell) => {
                   const isSelected = cell.ymd === selectedYmd;
                   const isDayDisabled = cell.isDisabled || interactionDisabled;
-                  const ariaDayLabel = isDayDisabled
-                    ? content.datePickerUnavailableDayTemplate.replace(
-                        '{day}',
-                        String(cell.dayOfMonth),
-                      )
-                    : content.datePickerDayTemplate.replace(
-                        '{day}',
-                        String(cell.dayOfMonth),
-                      );
+                  let ariaDayLabel: string;
+                  if (interactionDisabled && !cell.isDisabled) {
+                    ariaDayLabel = content.datePickerLoadingDayTemplate.replace(
+                      '{day}',
+                      String(cell.dayOfMonth),
+                    );
+                  } else if (isDayDisabled) {
+                    ariaDayLabel = content.datePickerUnavailableDayTemplate.replace(
+                      '{day}',
+                      String(cell.dayOfMonth),
+                    );
+                  } else {
+                    ariaDayLabel = content.datePickerDayTemplate.replace(
+                      '{day}',
+                      String(cell.dayOfMonth),
+                    );
+                  }
                   return (
                     <td key={cell.ymd} className='p-1'>
                       <button

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -188,7 +188,7 @@ export function ConsultationsBooking({
 
     let cancelled = false;
     void fetchConsultationCalendarBlockersSlots(controller.signal).then((result) => {
-      if (cancelled) {
+      if (cancelled || controller.signal.aborted) {
         return;
       }
       setCalendarAvailability({ unavailable_slots: result.slots });

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -22,7 +22,6 @@ import type {
 import enContent from '@/content/en.json';
 import { formatContentTemplate } from '@/content/content-field-utils';
 import { trackAnalyticsEvent, trackEcommerceEvent } from '@/lib/analytics';
-import calendarAvailabilityFallback from '@/content/calendar-availability.json';
 import {
   CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS,
   fetchConsultationCalendarBlockersSlots,
@@ -157,7 +156,7 @@ export function ConsultationsBooking({
 }: ConsultationsBookingProps) {
   const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
   const [calendarAvailability, setCalendarAvailability] = useState(() => ({
-    unavailable_slots: [...calendarAvailabilityFallback.unavailable_slots],
+    unavailable_slots: [] as { date: string; period: 'am' | 'pm' | 'both' }[],
   }));
   const [thankYouSummary, setThankYouSummary] = useState<ReservationSummary | null>(
     null,

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -133,6 +133,7 @@ function buildConsultationPickerContent(
     datePickerLegend: p.datePickerLegend,
     datePickerDayTemplate: p.datePickerDayTemplate,
     datePickerUnavailableDayTemplate: p.datePickerUnavailableDayTemplate,
+    datePickerLoadingDayTemplate: p.datePickerLoadingDayTemplate,
     dateConfirmationNote: p.dateConfirmationNote,
   };
 }
@@ -555,8 +556,8 @@ export function ConsultationsBooking({
                     quantity: 1,
                   }],
                 });
-                setCalendarBlockersStatus('loading');
                 setIsBookingModalOpen(true);
+                setCalendarBlockersStatus('loading');
               }}
             >
               {content.reservation.ctaLabel}

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -155,6 +155,9 @@ export function ConsultationsBooking({
   commonAccessibility = enContent.common.accessibility,
 }: ConsultationsBookingProps) {
   const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
+  const [calendarBlockersStatus, setCalendarBlockersStatus] = useState<
+    'idle' | 'loading' | 'ready' | 'error'
+  >('idle');
   const [calendarAvailability, setCalendarAvailability] = useState(() => ({
     unavailable_slots: [] as { date: string; period: 'am' | 'pm' | 'both' }[],
   }));
@@ -183,11 +186,17 @@ export function ConsultationsBooking({
       controller.abort();
     }, CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS);
 
-    void fetchConsultationCalendarBlockersSlots(controller.signal).then((slots) => {
-      setCalendarAvailability({ unavailable_slots: slots });
+    let cancelled = false;
+    void fetchConsultationCalendarBlockersSlots(controller.signal).then((result) => {
+      if (cancelled) {
+        return;
+      }
+      setCalendarAvailability({ unavailable_slots: result.slots });
+      setCalendarBlockersStatus(result.fetchFailed ? 'error' : 'ready');
     });
 
     return () => {
+      cancelled = true;
       window.clearTimeout(timeoutId);
       controller.abort();
     };
@@ -546,6 +555,7 @@ export function ConsultationsBooking({
                     quantity: 1,
                   }],
                 });
+                setCalendarBlockersStatus('loading');
                 setIsBookingModalOpen(true);
               }}
             >
@@ -561,6 +571,9 @@ export function ConsultationsBooking({
           paymentModalContent={bookingModalContent.paymentModal}
           bookingPayload={bookingPayload}
           calendarAvailability={calendarAvailability}
+          calendarBlockersStatus={calendarBlockersStatus}
+          calendarBlockersLoadingMessage={content.calendarBlockersLoadingMessage}
+          calendarBlockersErrorMessage={content.calendarBlockersErrorMessage}
           pickerContent={consultationPickerContent}
           selectionInfo={modalSelectionInfo}
           levelFeaturesEnterAnimationNonce={consultationModalLevelFeaturesAnimNonce}
@@ -570,10 +583,12 @@ export function ConsultationsBooking({
           thankYouRecapLabels={buildThankYouRecapLabels(bookingModalContent.thankYouModal)}
           onClose={() => {
             setIsBookingModalOpen(false);
+            setCalendarBlockersStatus('idle');
             setConsultationModalLevelFeaturesAnimNonce(0);
           }}
           onSubmitReservation={(summary) => {
             setIsBookingModalOpen(false);
+            setCalendarBlockersStatus('idle');
             setThankYouSummary(summary);
             setIsThankYouOpen(true);
           }}

--- a/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultations-booking.tsx
@@ -22,7 +22,11 @@ import type {
 import enContent from '@/content/en.json';
 import { formatContentTemplate } from '@/content/content-field-utils';
 import { trackAnalyticsEvent, trackEcommerceEvent } from '@/lib/analytics';
-import type { CalendarAvailabilityPayload } from '@/lib/calendar-availability';
+import calendarAvailabilityFallback from '@/content/calendar-availability.json';
+import {
+  CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS,
+  fetchConsultationCalendarBlockersSlots,
+} from '@/lib/calendar-blockers-api';
 import {
   buildConsultationsBookingModalPayload,
   type ConsultationsBookingModalTierId,
@@ -138,7 +142,6 @@ interface ConsultationsBookingProps {
   locale: Locale;
   content: ConsultationsBookingContent;
   bookingModalContent: BookingModalContent;
-  calendarAvailability: CalendarAvailabilityPayload;
   thankYouWhatsappHref?: string;
   thankYouWhatsappCtaLabel?: string;
   commonAccessibility?: CommonAccessibilityContent;
@@ -148,12 +151,14 @@ export function ConsultationsBooking({
   locale,
   content,
   bookingModalContent,
-  calendarAvailability,
   thankYouWhatsappHref,
   thankYouWhatsappCtaLabel,
   commonAccessibility = enContent.common.accessibility,
 }: ConsultationsBookingProps) {
   const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
+  const [calendarAvailability, setCalendarAvailability] = useState(() => ({
+    unavailable_slots: [...calendarAvailabilityFallback.unavailable_slots],
+  }));
   const [thankYouSummary, setThankYouSummary] = useState<ReservationSummary | null>(
     null,
   );
@@ -169,6 +174,25 @@ export function ConsultationsBooking({
     useState(false);
   const [consultationModalLevelFeaturesAnimNonce, setConsultationModalLevelFeaturesAnimNonce] =
     useState(0);
+
+  useEffect(() => {
+    if (!isBookingModalOpen) {
+      return;
+    }
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      controller.abort();
+    }, CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS);
+
+    void fetchConsultationCalendarBlockersSlots(controller.signal).then((slots) => {
+      setCalendarAvailability({ unavailable_slots: slots });
+    });
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      controller.abort();
+    };
+  }, [isBookingModalOpen]);
 
   useEffect(() => {
     if (!isThankYouOpen || !thankYouSummary) {

--- a/apps/public_www/src/content/calendar-availability.json
+++ b/apps/public_www/src/content/calendar-availability.json
@@ -1,3 +1,0 @@
-{
-  "unavailable_slots": []
-}

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1614,6 +1614,7 @@
         "datePickerLegend": "Preferred home visit date and time of day",
         "datePickerDayTemplate": "Select day {day}",
         "datePickerUnavailableDayTemplate": "Day {day} unavailable",
+        "datePickerLoadingDayTemplate": "Day {day}, loading availability",
         "dateConfirmationNote": "Date/time confirmed once booking is complete."
       }
     },

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1337,6 +1337,8 @@
     "booking": {
       "eyebrow": "Family Consultations",
       "title": "Book Your Family Consultation",
+      "calendarBlockersLoadingMessage": "Loading available dates…",
+      "calendarBlockersErrorMessage": "We could not load availability. You can still continue; if a time is no longer available, checkout will tell you.",
       "step1Title": "Choose your focus:",
       "focusAreas": [
         {

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1337,6 +1337,8 @@
     "booking": {
       "eyebrow": "家庭咨询",
       "title": "预约你的家庭咨询",
+      "calendarBlockersLoadingMessage": "正在加载可预约日期…",
+      "calendarBlockersErrorMessage": "暂时无法加载可用时段。你仍可继续；若所选时间不可用，结账时会提示。",
       "step1Title": "选择你的方向：",
       "focusAreas": [
         {

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1614,6 +1614,7 @@
         "datePickerLegend": "首选上门评估日期与时段",
         "datePickerDayTemplate": "选择 {day} 日",
         "datePickerUnavailableDayTemplate": "{day} 日不可选",
+        "datePickerLoadingDayTemplate": "{day} 日，正在加载可预约状态",
         "dateConfirmationNote": "完成预约后才会最终确认日期与时间。"
       }
     },

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1614,6 +1614,7 @@
         "datePickerLegend": "首選上門評估日期與時段",
         "datePickerDayTemplate": "選擇 {day} 日",
         "datePickerUnavailableDayTemplate": "{day} 日不可選",
+        "datePickerLoadingDayTemplate": "{day} 日，正在載入可預約狀態",
         "dateConfirmationNote": "完成預約後先會最終確認日期同時間。"
       }
     },

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1337,6 +1337,8 @@
     "booking": {
       "eyebrow": "家庭諮詢",
       "title": "預約你的家庭諮詢",
+      "calendarBlockersLoadingMessage": "正在載入可預約日期…",
+      "calendarBlockersErrorMessage": "暫時無法載入可用時段。你仍可繼續；若所選時間不可用，結帳時會提示。",
       "step1Title": "選擇你的方向：",
       "focusAreas": [
         {

--- a/apps/public_www/src/lib/calendar-availability.ts
+++ b/apps/public_www/src/lib/calendar-availability.ts
@@ -5,7 +5,18 @@ export interface CalendarUnavailableSlot {
   period: CalendarUnavailablePeriod;
 }
 
-/** Shape of `src/content/calendar-availability.json` (and future API payloads). */
+/** Public API `GET /v1/calendar/blockers` success body (and meta). */
+export interface PublicCalendarBlockersApiPayload {
+  blockers: CalendarUnavailableSlot[];
+  meta?: {
+    purpose?: string;
+    from?: string;
+    to?: string;
+    wall_time_zone?: string;
+  };
+}
+
+/** Shape of `src/content/calendar-availability.json` (legacy fallback / tests). */
 export interface CalendarAvailabilityPayload {
   unavailable_slots: CalendarUnavailableSlot[];
 }
@@ -52,4 +63,56 @@ export function buildUnavailableSlotMap(
   }
 
   return map;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parses public calendar blockers API JSON into slot rows for {@link buildUnavailableSlotMap}.
+ */
+export function parsePublicCalendarBlockersPayload(
+  payload: unknown,
+): CalendarUnavailableSlot[] {
+  if (!isRecord(payload)) {
+    return [];
+  }
+  const raw = payload.blockers ?? payload.unavailable_slots;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const out: CalendarUnavailableSlot[] = [];
+  for (const item of raw) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const date = typeof item.date === 'string' ? item.date : '';
+    const period = item.period;
+    if (!date || !isValidPeriod(period)) {
+      continue;
+    }
+    out.push({ date, period });
+  }
+  return out;
+}
+
+export function unavailableSlotMapToSlots(
+  map: Map<string, { am: boolean; pm: boolean }>,
+): CalendarUnavailableSlot[] {
+  const out: CalendarUnavailableSlot[] = [];
+  for (const ymd of [...map.keys()].sort()) {
+    const row = map.get(ymd);
+    if (!row) {
+      continue;
+    }
+    if (row.am && row.pm) {
+      out.push({ date: ymd, period: 'both' });
+    } else if (row.am) {
+      out.push({ date: ymd, period: 'am' });
+    } else if (row.pm) {
+      out.push({ date: ymd, period: 'pm' });
+    }
+  }
+  return out;
 }

--- a/apps/public_www/src/lib/calendar-availability.ts
+++ b/apps/public_www/src/lib/calendar-availability.ts
@@ -16,7 +16,7 @@ export interface PublicCalendarBlockersApiPayload {
   };
 }
 
-/** Shape of `src/content/calendar-availability.json` (legacy fallback / tests). */
+/** Props shape for the consultation booking modal (picker unavailable half-days). */
 export interface CalendarAvailabilityPayload {
   unavailable_slots: CalendarUnavailableSlot[];
 }
@@ -78,7 +78,7 @@ export function parsePublicCalendarBlockersPayload(
   if (!isRecord(payload)) {
     return [];
   }
-  const raw = payload.blockers ?? payload.unavailable_slots;
+  const raw = payload.blockers;
   if (!Array.isArray(raw)) {
     return [];
   }
@@ -93,26 +93,6 @@ export function parsePublicCalendarBlockersPayload(
       continue;
     }
     out.push({ date, period });
-  }
-  return out;
-}
-
-export function unavailableSlotMapToSlots(
-  map: Map<string, { am: boolean; pm: boolean }>,
-): CalendarUnavailableSlot[] {
-  const out: CalendarUnavailableSlot[] = [];
-  for (const ymd of [...map.keys()].sort()) {
-    const row = map.get(ymd);
-    if (!row) {
-      continue;
-    }
-    if (row.am && row.pm) {
-      out.push({ date: ymd, period: 'both' });
-    } else if (row.am) {
-      out.push({ date: ymd, period: 'am' });
-    } else if (row.pm) {
-      out.push({ date: ymd, period: 'pm' });
-    }
   }
   return out;
 }

--- a/apps/public_www/src/lib/calendar-blockers-api.ts
+++ b/apps/public_www/src/lib/calendar-blockers-api.ts
@@ -44,9 +44,29 @@ const _WEEKDAY_TO_OFFSET: Record<string, number> = {
   Sat: 6,
 };
 
-/** Noon on `ymd` in the site zone (HKT has no DST; fixed +08:00). */
+const _SITE_YMD_ONLY = new Intl.DateTimeFormat('en-CA', {
+  timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+/** UTC instant when the calendar date is `ymd` at 00:00 in {@link PUBLIC_SITE_IANA_TIMEZONE}. */
+function utcMillisForSiteWallMidnight(ymd: string): number {
+  const [y, mo, d] = ymd.split('-').map((part) => Number(part));
+  let utc = Date.UTC(y, mo - 1, d, 0, 0, 0);
+  for (let i = 0; i < 48; i += 1) {
+    if (_SITE_YMD_ONLY.format(new Date(utc)) === ymd) {
+      return utc;
+    }
+    utc += 3600000;
+  }
+  return Date.UTC(y, mo - 1, d, 0, 0, 0);
+}
+
+/** Noon on `ymd` in the site IANA zone (works for DST zones; not hardcoded to +08). */
 function noonSiteOnYmd(ymd: string): Date {
-  return new Date(`${ymd}T12:00:00+08:00`);
+  return new Date(utcMillisForSiteWallMidnight(ymd) + 12 * 3600000);
 }
 
 /**

--- a/apps/public_www/src/lib/calendar-blockers-api.ts
+++ b/apps/public_www/src/lib/calendar-blockers-api.ts
@@ -1,0 +1,83 @@
+import calendarAvailabilityFallback from '@/content/calendar-availability.json';
+import {
+  CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS,
+  createPublicCrmApiClient,
+  CrmApiRequestError,
+} from '@/lib/crm-api-client';
+import {
+  type CalendarUnavailableSlot,
+  buildUnavailableSlotMap,
+  parsePublicCalendarBlockersPayload,
+  unavailableSlotMapToSlots,
+} from '@/lib/calendar-availability';
+
+export const CALENDAR_BLOCKERS_API_PATH = '/v1/calendar/blockers';
+
+/** Must match `app.services.calendar_blockers.consultation_booking_purpose()`. */
+export const CONSULTATION_BOOKING_BLOCKERS_PURPOSE = 'consultation_booking';
+
+function ymdFromLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function buildCalendarBlockersApiPath(params: {
+  purpose: string;
+  fromYmd: string;
+  toYmd: string;
+}): string {
+  const search = new URLSearchParams();
+  search.set('purpose', params.purpose);
+  search.set('from', params.fromYmd);
+  search.set('to', params.toYmd);
+  return `${CALENDAR_BLOCKERS_API_PATH}?${search.toString()}`;
+}
+
+/**
+ * Fetches merged manual + session calendar blockers for the public website.
+ * Returns empty slots when the CRM client is missing or the request fails.
+ */
+export async function fetchConsultationCalendarBlockersSlots(
+  signal: AbortSignal,
+): Promise<CalendarUnavailableSlot[]> {
+  const client = createPublicCrmApiClient();
+  if (!client) {
+    return [];
+  }
+
+  const today = new Date();
+  const fromYmd = ymdFromLocalDate(today);
+  const end = new Date(today.getTime() + 120 * 86400000);
+  const toYmd = ymdFromLocalDate(end);
+
+  try {
+    const payload = await client.request({
+      endpointPath: buildCalendarBlockersApiPath({
+        purpose: CONSULTATION_BOOKING_BLOCKERS_PURPOSE,
+        fromYmd,
+        toYmd,
+      }),
+      method: 'GET',
+      signal,
+    });
+    const remote = parsePublicCalendarBlockersPayload(payload);
+    const merged = buildUnavailableSlotMap([
+      ...calendarAvailabilityFallback.unavailable_slots,
+      ...remote,
+    ]);
+    return unavailableSlotMapToSlots(merged);
+  } catch (error) {
+    if (error instanceof CrmApiRequestError && error.statusCode === 404) {
+      return unavailableSlotMapToSlots(
+        buildUnavailableSlotMap(calendarAvailabilityFallback.unavailable_slots),
+      );
+    }
+    return unavailableSlotMapToSlots(
+      buildUnavailableSlotMap(calendarAvailabilityFallback.unavailable_slots),
+    );
+  }
+}
+
+export { CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS };

--- a/apps/public_www/src/lib/calendar-blockers-api.ts
+++ b/apps/public_www/src/lib/calendar-blockers-api.ts
@@ -23,6 +23,25 @@ function ymdFromLocalDate(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+/** Monday 00:00 local of the week containing `d` (local calendar). */
+function startOfWeekMondayLocal(d: Date): Date {
+  const copy = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const dow = copy.getDay(); // 0 Sun .. 6 Sat
+  const offsetFromMonday = (dow + 6) % 7;
+  copy.setDate(copy.getDate() - offsetFromMonday);
+  return copy;
+}
+
+/** Inclusive end date: start Monday + 119 days (17 weeks − 1 day), still ≤120-day API span. */
+export function buildConsultationBlockersQueryRange(now: Date): {
+  fromYmd: string;
+  toYmd: string;
+} {
+  const start = startOfWeekMondayLocal(now);
+  const end = new Date(start.getTime() + 119 * 86400000);
+  return { fromYmd: ymdFromLocalDate(start), toYmd: ymdFromLocalDate(end) };
+}
+
 export function buildCalendarBlockersApiPath(params: {
   purpose: string;
   fromYmd: string;
@@ -47,10 +66,7 @@ export async function fetchConsultationCalendarBlockersSlots(
     return { slots: [], fetchFailed: true };
   }
 
-  const today = new Date();
-  const fromYmd = ymdFromLocalDate(today);
-  const end = new Date(today.getTime() + 120 * 86400000);
-  const toYmd = ymdFromLocalDate(end);
+  const { fromYmd, toYmd } = buildConsultationBlockersQueryRange(new Date());
 
   try {
     const payload = await client.request({

--- a/apps/public_www/src/lib/calendar-blockers-api.ts
+++ b/apps/public_www/src/lib/calendar-blockers-api.ts
@@ -1,11 +1,9 @@
 import {
-  CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS,
-  createPublicCrmApiClient,
-} from '@/lib/crm-api-client';
-import {
   type CalendarUnavailableSlot,
   parsePublicCalendarBlockersPayload,
 } from '@/lib/calendar-availability';
+import { createPublicCrmApiClient } from '@/lib/crm-api-client';
+import { CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS } from '@/lib/events-data';
 
 export const CALENDAR_BLOCKERS_API_PATH = '/v1/calendar/blockers';
 

--- a/apps/public_www/src/lib/calendar-blockers-api.ts
+++ b/apps/public_www/src/lib/calendar-blockers-api.ts
@@ -1,14 +1,10 @@
-import calendarAvailabilityFallback from '@/content/calendar-availability.json';
 import {
   CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS,
   createPublicCrmApiClient,
-  CrmApiRequestError,
 } from '@/lib/crm-api-client';
 import {
   type CalendarUnavailableSlot,
-  buildUnavailableSlotMap,
   parsePublicCalendarBlockersPayload,
-  unavailableSlotMapToSlots,
 } from '@/lib/calendar-availability';
 
 export const CALENDAR_BLOCKERS_API_PATH = '/v1/calendar/blockers';
@@ -37,7 +33,7 @@ export function buildCalendarBlockersApiPath(params: {
 
 /**
  * Fetches merged manual + session calendar blockers for the public website.
- * Returns empty slots when the CRM client is missing or the request fails.
+ * Returns an empty list when the CRM client is missing or the request fails.
  */
 export async function fetchConsultationCalendarBlockersSlots(
   signal: AbortSignal,
@@ -62,21 +58,9 @@ export async function fetchConsultationCalendarBlockersSlots(
       method: 'GET',
       signal,
     });
-    const remote = parsePublicCalendarBlockersPayload(payload);
-    const merged = buildUnavailableSlotMap([
-      ...calendarAvailabilityFallback.unavailable_slots,
-      ...remote,
-    ]);
-    return unavailableSlotMapToSlots(merged);
-  } catch (error) {
-    if (error instanceof CrmApiRequestError && error.statusCode === 404) {
-      return unavailableSlotMapToSlots(
-        buildUnavailableSlotMap(calendarAvailabilityFallback.unavailable_slots),
-      );
-    }
-    return unavailableSlotMapToSlots(
-      buildUnavailableSlotMap(calendarAvailabilityFallback.unavailable_slots),
-    );
+    return parsePublicCalendarBlockersPayload(payload);
+  } catch {
+    return [];
   }
 }
 

--- a/apps/public_www/src/lib/calendar-blockers-api.ts
+++ b/apps/public_www/src/lib/calendar-blockers-api.ts
@@ -4,6 +4,7 @@ import {
 } from '@/lib/calendar-availability';
 import { createPublicCrmApiClient } from '@/lib/crm-api-client';
 import { CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS } from '@/lib/events-data';
+import { PUBLIC_SITE_IANA_TIMEZONE } from '@/lib/site-datetime';
 
 export const CALENDAR_BLOCKERS_API_PATH = '/v1/calendar/blockers';
 
@@ -16,20 +17,49 @@ export interface ConsultationCalendarBlockersFetchResult {
   fetchFailed: boolean;
 }
 
-function ymdFromLocalDate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
+const SITE_YMD_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const SITE_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+  weekday: 'short',
+});
+
+/** YYYY-MM-DD for the calendar date of `instant` in {@link PUBLIC_SITE_IANA_TIMEZONE}. */
+export function ymdFromSiteTimeZone(instant: Date): string {
+  return SITE_YMD_FORMATTER.format(instant);
 }
 
-/** Monday 00:00 local of the week containing `d` (local calendar). */
-function startOfWeekMondayLocal(d: Date): Date {
-  const copy = new Date(d.getFullYear(), d.getMonth(), d.getDate());
-  const dow = copy.getDay(); // 0 Sun .. 6 Sat
+const _WEEKDAY_TO_OFFSET: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+/** Noon on `ymd` in the site zone (HKT has no DST; fixed +08:00). */
+function noonSiteOnYmd(ymd: string): Date {
+  return new Date(`${ymd}T12:00:00+08:00`);
+}
+
+/**
+ * Monday of the ISO week containing `instant`, in the site IANA zone (same “today” as the
+ * consultation picker). Returned as noon that Monday in +08:00 for stable day arithmetic.
+ */
+function startOfWeekMondaySiteTz(instant: Date): Date {
+  const ymd = ymdFromSiteTimeZone(instant);
+  const noon = noonSiteOnYmd(ymd);
+  const wdLabel = SITE_WEEKDAY_FORMATTER.format(noon);
+  const dow = _WEEKDAY_TO_OFFSET[wdLabel] ?? 0;
   const offsetFromMonday = (dow + 6) % 7;
-  copy.setDate(copy.getDate() - offsetFromMonday);
-  return copy;
+  return new Date(noon.getTime() - offsetFromMonday * 86400000);
 }
 
 /** Inclusive end date: start Monday + 119 days (17 weeks − 1 day), still ≤120-day API span. */
@@ -37,9 +67,9 @@ export function buildConsultationBlockersQueryRange(now: Date): {
   fromYmd: string;
   toYmd: string;
 } {
-  const start = startOfWeekMondayLocal(now);
+  const start = startOfWeekMondaySiteTz(now);
   const end = new Date(start.getTime() + 119 * 86400000);
-  return { fromYmd: ymdFromLocalDate(start), toYmd: ymdFromLocalDate(end) };
+  return { fromYmd: ymdFromSiteTimeZone(start), toYmd: ymdFromSiteTimeZone(end) };
 }
 
 export function buildCalendarBlockersApiPath(params: {

--- a/apps/public_www/src/lib/calendar-blockers-api.ts
+++ b/apps/public_www/src/lib/calendar-blockers-api.ts
@@ -10,6 +10,12 @@ export const CALENDAR_BLOCKERS_API_PATH = '/v1/calendar/blockers';
 /** Must match `app.services.calendar_blockers.consultation_booking_purpose()`. */
 export const CONSULTATION_BOOKING_BLOCKERS_PURPOSE = 'consultation_booking';
 
+export interface ConsultationCalendarBlockersFetchResult {
+  slots: CalendarUnavailableSlot[];
+  /** True when the CRM client is missing or the HTTP request failed. */
+  fetchFailed: boolean;
+}
+
 function ymdFromLocalDate(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, '0');
@@ -31,14 +37,14 @@ export function buildCalendarBlockersApiPath(params: {
 
 /**
  * Fetches merged manual + session calendar blockers for the public website.
- * Returns an empty list when the CRM client is missing or the request fails.
+ * Returns empty slots with `fetchFailed` when the CRM client is missing or the request fails.
  */
 export async function fetchConsultationCalendarBlockersSlots(
   signal: AbortSignal,
-): Promise<CalendarUnavailableSlot[]> {
+): Promise<ConsultationCalendarBlockersFetchResult> {
   const client = createPublicCrmApiClient();
   if (!client) {
-    return [];
+    return { slots: [], fetchFailed: true };
   }
 
   const today = new Date();
@@ -55,10 +61,11 @@ export async function fetchConsultationCalendarBlockersSlots(
       }),
       method: 'GET',
       signal,
+      bypassGetCache: true,
     });
-    return parsePublicCalendarBlockersPayload(payload);
+    return { slots: parsePublicCalendarBlockersPayload(payload), fetchFailed: false };
   } catch {
-    return [];
+    return { slots: [], fetchFailed: true };
   }
 }
 

--- a/apps/public_www/src/lib/crm-api-client.ts
+++ b/apps/public_www/src/lib/crm-api-client.ts
@@ -15,6 +15,8 @@ export interface CrmApiRequestOptions {
   headers?: Record<string, string>;
   turnstileToken?: string;
   expectedSuccessStatuses?: readonly number[];
+  /** When true, skip in-memory GET response cache (e.g. frequently invalidated public data). */
+  bypassGetCache?: boolean;
 }
 
 export interface CrmApiClient {
@@ -296,7 +298,10 @@ export function createCrmApiClient(config: CrmApiClientConfig): CrmApiClient | n
       }
 
       const cacheKey = buildGetCacheKey(normalizedApiKey, requestUrl);
-      if (method === 'GET') {
+      if (method === 'GET' && options.bypassGetCache) {
+        getRequestCache.delete(cacheKey);
+      }
+      if (method === 'GET' && !options.bypassGetCache) {
         const now = Date.now();
         const cachedEntry = getRequestCache.get(cacheKey);
         if (cachedEntry && cachedEntry.expiresAt > now) {
@@ -354,7 +359,7 @@ export function createCrmApiClient(config: CrmApiClientConfig): CrmApiClient | n
         });
       }
 
-      if (method === 'GET') {
+      if (method === 'GET' && !options.bypassGetCache) {
         setGetCacheEntry(cacheKey, payload);
       } else {
         getRequestCache.delete(cacheKey);

--- a/apps/public_www/tests/components/sections/consultation-booking-modal-free.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal-free.test.tsx
@@ -152,6 +152,7 @@ function buildPickerContent(
     datePickerLegend: p.datePickerLegend,
     datePickerDayTemplate: p.datePickerDayTemplate,
     datePickerUnavailableDayTemplate: p.datePickerUnavailableDayTemplate,
+    datePickerLoadingDayTemplate: p.datePickerLoadingDayTemplate,
     dateConfirmationNote: p.dateConfirmationNote,
   };
 }

--- a/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
@@ -82,6 +82,62 @@ describe('ConsultationBookingModal', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows loading message and disables date picker while blockers are loading', () => {
+    const bookingPayload = buildConsultationsBookingModalPayload(
+      enContent.consultations.booking.reservation,
+      'en',
+    );
+    const loadingMessage = enContent.consultations.booking.calendarBlockersLoadingMessage;
+
+    render(
+      <ConsultationBookingModal
+        locale='en'
+        paymentModalContent={enContent.bookingModal.paymentModal}
+        bookingPayload={bookingPayload}
+        pickerContent={buildPickerContent(enContent.bookingModal.paymentModal)}
+        calendarAvailability={{ unavailable_slots: [] }}
+        calendarBlockersStatus='loading'
+        calendarBlockersLoadingMessage={loadingMessage}
+        onClose={() => {}}
+        onSubmitReservation={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('consultation-calendar-blockers-status')).toHaveTextContent(
+      loadingMessage,
+    );
+    const day9 = screen.getByRole('button', { name: 'Day 9 unavailable' });
+    expect(day9).toBeDisabled();
+  });
+
+  it('shows error message when blockers failed to load but keeps picker interactive', () => {
+    const bookingPayload = buildConsultationsBookingModalPayload(
+      enContent.consultations.booking.reservation,
+      'en',
+    );
+    const errorMessage = enContent.consultations.booking.calendarBlockersErrorMessage;
+
+    render(
+      <ConsultationBookingModal
+        locale='en'
+        paymentModalContent={enContent.bookingModal.paymentModal}
+        bookingPayload={bookingPayload}
+        pickerContent={buildPickerContent(enContent.bookingModal.paymentModal)}
+        calendarAvailability={{ unavailable_slots: [] }}
+        calendarBlockersStatus='error'
+        calendarBlockersErrorMessage={errorMessage}
+        onClose={() => {}}
+        onSubmitReservation={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('consultation-calendar-blockers-status')).toHaveTextContent(
+      errorMessage,
+    );
+    const day9 = screen.getByRole('button', { name: 'Select day 9' });
+    expect(day9).not.toBeDisabled();
+  });
+
   it('selects PM when only the afternoon slot is available for that day', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,

--- a/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
@@ -36,6 +36,7 @@ function buildPickerContent(
     datePickerLegend: p.datePickerLegend,
     datePickerDayTemplate: p.datePickerDayTemplate,
     datePickerUnavailableDayTemplate: p.datePickerUnavailableDayTemplate,
+    datePickerLoadingDayTemplate: p.datePickerLoadingDayTemplate,
     dateConfirmationNote: p.dateConfirmationNote,
   };
 }
@@ -106,7 +107,7 @@ describe('ConsultationBookingModal', () => {
     expect(screen.getByTestId('consultation-calendar-blockers-status')).toHaveTextContent(
       loadingMessage,
     );
-    const day9 = screen.getByRole('button', { name: 'Day 9 unavailable' });
+    const day9 = screen.getByRole('button', { name: 'Day 9, loading availability' });
     expect(day9).toBeDisabled();
   });
 

--- a/apps/public_www/tests/components/sections/consultations-booking.test.tsx
+++ b/apps/public_www/tests/components/sections/consultations-booking.test.tsx
@@ -27,7 +27,9 @@ vi.mock('@/lib/meta-pixel', () => ({
 
 vi.mock('@/lib/calendar-blockers-api', () => ({
   CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS: 5000,
-  fetchConsultationCalendarBlockersSlots: vi.fn().mockResolvedValue([]),
+  fetchConsultationCalendarBlockersSlots: vi
+    .fn()
+    .mockResolvedValue({ slots: [], fetchFailed: false }),
 }));
 
 const mockedTrackAnalyticsEvent = vi.mocked(trackAnalyticsEvent);

--- a/apps/public_www/tests/components/sections/consultations-booking.test.tsx
+++ b/apps/public_www/tests/components/sections/consultations-booking.test.tsx
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ConsultationsBooking } from '@/components/sections/consultations/consultations-booking';
 import enContent from '@/content/en.json';
-import calendarAvailability from '@/content/calendar-availability.json';
 import { formatContentTemplate } from '@/content/content-field-utils';
 import { trackAnalyticsEvent, trackEcommerceEvent } from '@/lib/analytics';
 import { trackMetaPixelEvent } from '@/lib/meta-pixel';
@@ -24,6 +23,11 @@ vi.mock('@/lib/analytics', () => ({
 
 vi.mock('@/lib/meta-pixel', () => ({
   trackMetaPixelEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/calendar-blockers-api', () => ({
+  CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS: 5000,
+  fetchConsultationCalendarBlockersSlots: vi.fn().mockResolvedValue([]),
 }));
 
 const mockedTrackAnalyticsEvent = vi.mocked(trackAnalyticsEvent);
@@ -77,7 +81,6 @@ describe('ConsultationsBooking', () => {
         locale='en'
         content={booking}
         bookingModalContent={enContent.bookingModal}
-        calendarAvailability={calendarAvailability}
       />,
     );
 
@@ -175,7 +178,6 @@ describe('ConsultationsBooking', () => {
         locale='en'
         content={booking}
         bookingModalContent={enContent.bookingModal}
-        calendarAvailability={calendarAvailability}
       />,
     );
 
@@ -255,7 +257,6 @@ describe('ConsultationsBooking', () => {
         locale='en'
         content={booking}
         bookingModalContent={enContent.bookingModal}
-        calendarAvailability={calendarAvailability}
       />,
     );
 
@@ -300,7 +301,6 @@ describe('ConsultationsBooking', () => {
         locale='en'
         content={booking}
         bookingModalContent={enContent.bookingModal}
-        calendarAvailability={calendarAvailability}
       />,
     );
 

--- a/apps/public_www/tests/components/sections/consultations-booking.test.tsx
+++ b/apps/public_www/tests/components/sections/consultations-booking.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ConsultationsBooking } from '@/components/sections/consultations/consultations-booking';
@@ -7,13 +7,20 @@ import { formatContentTemplate } from '@/content/content-field-utils';
 import { trackAnalyticsEvent, trackEcommerceEvent } from '@/lib/analytics';
 import { trackMetaPixelEvent } from '@/lib/meta-pixel';
 
-vi.mock('next/dynamic', () => ({
-  default: () => {
-    function MockDynamic() {
-      return null;
-    }
-    return MockDynamic;
-  },
+vi.mock('@/components/sections/consultations/consultation-booking-modal', () => ({
+  ConsultationBookingModal: (props: {
+    calendarBlockersStatus?: string;
+    onClose: () => void;
+  }) => (
+    <div
+      data-testid='consultation-booking-modal-stub'
+      data-calendar-blockers-status={props.calendarBlockersStatus ?? ''}
+    >
+      <button type='button' onClick={props.onClose}>
+        Close stub modal
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@/lib/analytics', () => ({
@@ -25,11 +32,13 @@ vi.mock('@/lib/meta-pixel', () => ({
   trackMetaPixelEvent: vi.fn(),
 }));
 
+const { mockFetchConsultationCalendarBlockersSlots } = vi.hoisted(() => ({
+  mockFetchConsultationCalendarBlockersSlots: vi.fn(),
+}));
+
 vi.mock('@/lib/calendar-blockers-api', () => ({
   CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS: 5000,
-  fetchConsultationCalendarBlockersSlots: vi
-    .fn()
-    .mockResolvedValue({ slots: [], fetchFailed: false }),
+  fetchConsultationCalendarBlockersSlots: mockFetchConsultationCalendarBlockersSlots,
 }));
 
 const mockedTrackAnalyticsEvent = vi.mocked(trackAnalyticsEvent);
@@ -60,6 +69,11 @@ afterEach(() => {
   mockedTrackAnalyticsEvent.mockReset();
   mockedTrackEcommerceEvent.mockReset();
   mockedTrackMetaPixelEvent.mockReset();
+  mockFetchConsultationCalendarBlockersSlots.mockReset();
+  mockFetchConsultationCalendarBlockersSlots.mockResolvedValue({
+    slots: [],
+    fetchFailed: false,
+  });
 
   if (originalMatchMedia) {
     Object.defineProperty(window, 'matchMedia', {
@@ -331,6 +345,68 @@ describe('ConsultationsBooking', () => {
         price: deepDiveTier.priceHkd,
         quantity: 1,
       }],
+    });
+
+    expect(mockedTrackMetaPixelEvent).toHaveBeenCalledWith('InitiateCheckout', {
+      content_name: 'consultation_booking',
+    });
+  });
+
+  it('sets calendar blockers status loading then ready when booking CTA opens', async () => {
+    mockViewportMdUp(true);
+    const booking = enContent.consultations.booking;
+    let resolveFetch: (v: { slots: { date: string; period: 'am' }[]; fetchFailed: boolean }) => void;
+    const fetchPromise = new Promise<{ slots: { date: string; period: 'am' }[]; fetchFailed: boolean }>(
+      (resolve) => {
+        resolveFetch = resolve;
+      },
+    );
+    mockFetchConsultationCalendarBlockersSlots.mockReturnValue(fetchPromise as unknown as Promise<{
+      slots: { date: string; period: 'am' }[];
+      fetchFailed: boolean;
+    }>);
+
+    render(
+      <ConsultationsBooking
+        locale='en'
+        content={booking}
+        bookingModalContent={enContent.bookingModal}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: booking.reservation.ctaLabel }));
+
+    const stub = await screen.findByTestId('consultation-booking-modal-stub');
+    expect(stub).toHaveAttribute('data-calendar-blockers-status', 'loading');
+
+    resolveFetch!({ slots: [{ date: '2026-04-09', period: 'am' }], fetchFailed: false });
+
+    await waitFor(() => {
+      expect(stub).toHaveAttribute('data-calendar-blockers-status', 'ready');
+    });
+  });
+
+  it('sets calendar blockers status to error when fetch fails', async () => {
+    mockViewportMdUp(true);
+    const booking = enContent.consultations.booking;
+    mockFetchConsultationCalendarBlockersSlots.mockResolvedValue({
+      slots: [],
+      fetchFailed: true,
+    });
+
+    render(
+      <ConsultationsBooking
+        locale='en'
+        content={booking}
+        bookingModalContent={enContent.bookingModal}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: booking.reservation.ctaLabel }));
+
+    const stub = await screen.findByTestId('consultation-booking-modal-stub');
+    await waitFor(() => {
+      expect(stub).toHaveAttribute('data-calendar-blockers-status', 'error');
     });
   });
 });

--- a/apps/public_www/tests/lib/calendar-availability.test.ts
+++ b/apps/public_www/tests/lib/calendar-availability.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildUnavailableSlotMap, normalizeAvailabilityYmd } from '@/lib/calendar-availability';
+import {
+  buildUnavailableSlotMap,
+  normalizeAvailabilityYmd,
+  parsePublicCalendarBlockersPayload,
+  unavailableSlotMapToSlots,
+} from '@/lib/calendar-availability';
 
 describe('calendar-availability', () => {
   it('normalizeAvailabilityYmd accepts YYYY-MM-DD only', () => {
@@ -19,5 +24,28 @@ describe('calendar-availability', () => {
     ]);
     expect(map.get('2026-04-10')).toEqual({ am: true, pm: true });
     expect(map.get('2026-04-11')).toEqual({ am: true, pm: true });
+  });
+
+  it('parsePublicCalendarBlockersPayload reads blockers or legacy unavailable_slots', () => {
+    expect(
+      parsePublicCalendarBlockersPayload({
+        blockers: [{ date: '2026-05-01', period: 'pm' }],
+      }),
+    ).toEqual([{ date: '2026-05-01', period: 'pm' }]);
+    expect(
+      parsePublicCalendarBlockersPayload({
+        unavailable_slots: [{ date: '2026-05-02', period: 'am' }],
+      }),
+    ).toEqual([{ date: '2026-05-02', period: 'am' }]);
+  });
+
+  it('unavailableSlotMapToSlots emits sorted both/am/pm rows', () => {
+    const map = new Map<string, { am: boolean; pm: boolean }>();
+    map.set('2026-05-03', { am: true, pm: true });
+    map.set('2026-05-02', { am: true, pm: false });
+    expect(unavailableSlotMapToSlots(map)).toEqual([
+      { date: '2026-05-02', period: 'am' },
+      { date: '2026-05-03', period: 'both' },
+    ]);
   });
 });

--- a/apps/public_www/tests/lib/calendar-availability.test.ts
+++ b/apps/public_www/tests/lib/calendar-availability.test.ts
@@ -4,7 +4,6 @@ import {
   buildUnavailableSlotMap,
   normalizeAvailabilityYmd,
   parsePublicCalendarBlockersPayload,
-  unavailableSlotMapToSlots,
 } from '@/lib/calendar-availability';
 
 describe('calendar-availability', () => {
@@ -26,26 +25,21 @@ describe('calendar-availability', () => {
     expect(map.get('2026-04-11')).toEqual({ am: true, pm: true });
   });
 
-  it('parsePublicCalendarBlockersPayload reads blockers or legacy unavailable_slots', () => {
+  it('parsePublicCalendarBlockersPayload reads blockers array', () => {
     expect(
       parsePublicCalendarBlockersPayload({
         blockers: [{ date: '2026-05-01', period: 'pm' }],
       }),
     ).toEqual([{ date: '2026-05-01', period: 'pm' }]);
-    expect(
-      parsePublicCalendarBlockersPayload({
-        unavailable_slots: [{ date: '2026-05-02', period: 'am' }],
-      }),
-    ).toEqual([{ date: '2026-05-02', period: 'am' }]);
+    expect(parsePublicCalendarBlockersPayload({ unavailable_slots: [] })).toEqual([]);
   });
 
-  it('unavailableSlotMapToSlots emits sorted both/am/pm rows', () => {
-    const map = new Map<string, { am: boolean; pm: boolean }>();
-    map.set('2026-05-03', { am: true, pm: true });
-    map.set('2026-05-02', { am: true, pm: false });
-    expect(unavailableSlotMapToSlots(map)).toEqual([
-      { date: '2026-05-02', period: 'am' },
+  it('buildUnavailableSlotMap round-trips sorted slot list semantics', () => {
+    const map = buildUnavailableSlotMap([
       { date: '2026-05-03', period: 'both' },
+      { date: '2026-05-02', period: 'am' },
     ]);
+    expect(map.get('2026-05-02')).toEqual({ am: true, pm: false });
+    expect(map.get('2026-05-03')).toEqual({ am: true, pm: true });
   });
 });

--- a/apps/public_www/tests/lib/calendar-blockers-api.test.ts
+++ b/apps/public_www/tests/lib/calendar-blockers-api.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildConsultationBlockersQueryRange } from '@/lib/calendar-blockers-api';
+import {
+  buildConsultationBlockersQueryRange,
+  ymdFromSiteTimeZone,
+} from '@/lib/calendar-blockers-api';
 
 describe('buildConsultationBlockersQueryRange', () => {
-  it('aligns from to Monday of the local week and spans 120 inclusive days', () => {
-    // Wednesday 2026-04-08 local
-    const wed = new Date(2026, 3, 8, 15, 0, 0);
-    const { fromYmd, toYmd } = buildConsultationBlockersQueryRange(wed);
-    expect(fromYmd).toBe('2026-04-06'); // Monday
-    expect(toYmd).toBe('2026-08-03'); // Monday + 119 days
+  it('uses Asia/Hong_Kong calendar for Monday anchor and 120-day span (not browser local)', () => {
+    // Wednesday 2026-04-08 in HKT (noon), regardless of test runner TZ
+    const wedHkt = new Date('2026-04-08T12:00:00+08:00');
+    const { fromYmd, toYmd } = buildConsultationBlockersQueryRange(wedHkt);
+    expect(fromYmd).toBe('2026-04-06');
+    expect(toYmd).toBe('2026-08-03');
+  });
+
+  it('maps a UTC instant to the site-zone calendar date', () => {
+    const utcMidnightBeforeHktDateRoll = new Date('2026-04-07T16:00:00.000Z');
+    expect(ymdFromSiteTimeZone(utcMidnightBeforeHktDateRoll)).toBe('2026-04-08');
   });
 });

--- a/apps/public_www/tests/lib/calendar-blockers-api.test.ts
+++ b/apps/public_www/tests/lib/calendar-blockers-api.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildConsultationBlockersQueryRange } from '@/lib/calendar-blockers-api';
+
+describe('buildConsultationBlockersQueryRange', () => {
+  it('aligns from to Monday of the local week and spans 120 inclusive days', () => {
+    // Wednesday 2026-04-08 local
+    const wed = new Date(2026, 3, 8, 15, 0, 0);
+    const { fromYmd, toYmd } = buildConsultationBlockersQueryRange(wed);
+    expect(fromYmd).toBe('2026-04-06'); // Monday
+    expect(toYmd).toBe('2026-08-03'); // Monday + 119 days
+  });
+});

--- a/backend/db/alembic/versions/0052_calendar_manual_blocks.py
+++ b/backend/db/alembic/versions/0052_calendar_manual_blocks.py
@@ -1,0 +1,77 @@
+"""Add generic ``calendar_manual_blocks`` for manual calendar blockers.
+
+Manual rows are merged at read time with session-derived blocks (event and
+training_course instance slots intersecting nominal consultation half-day
+windows) for each ``purpose`` value consumed by public clients.
+
+Seed-data assessment:
+1. Seed compatibility: new table; no seed rows required (empty default).
+2. NOT NULL: new columns have defaults or are required; no seed inserts needed.
+3. N/A.
+4. N/A.
+5. N/A.
+6. N/A.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0052_calendar_manual_blocks"
+down_revision: Union[str, None] = "0051_backfill_event_service_key"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "calendar_manual_blocks",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("purpose", sa.String(length=64), nullable=False),
+        sa.Column("block_date", sa.Date(), nullable=False),
+        sa.Column("period", sa.String(length=8), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("note", sa.String(length=500), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="calendar_manual_blocks_pkey"),
+        sa.CheckConstraint(
+            "period IN ('am', 'pm', 'both')",
+            name="calendar_manual_blocks_period_chk",
+        ),
+        sa.UniqueConstraint(
+            "purpose",
+            "block_date",
+            "period",
+            name="calendar_manual_blocks_purpose_date_period_uidx",
+        ),
+    )
+    op.create_index(
+        "calendar_manual_blocks_purpose_date_idx",
+        "calendar_manual_blocks",
+        ["purpose", "block_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("calendar_manual_blocks_purpose_date_idx", table_name="calendar_manual_blocks")
+    op.drop_table("calendar_manual_blocks")

--- a/backend/db/alembic/versions/0052_calendar_manual_blocks.py
+++ b/backend/db/alembic/versions/0052_calendar_manual_blocks.py
@@ -73,5 +73,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("calendar_manual_blocks_purpose_date_idx", table_name="calendar_manual_blocks")
+    op.drop_index(
+        "calendar_manual_blocks_purpose_date_idx", table_name="calendar_manual_blocks"
+    )
     op.drop_table("calendar_manual_blocks")

--- a/backend/db/alembic/versions/0053_calendar_manual_blocks_audit.py
+++ b/backend/db/alembic/versions/0053_calendar_manual_blocks_audit.py
@@ -1,0 +1,38 @@
+"""Add ``created_by`` / ``updated_by`` to ``calendar_manual_blocks``.
+
+Seed-data assessment:
+1. Seed compatibility: new nullable columns; no seed rows reference this table.
+2. NOT NULL: not added; nullable for backfill.
+3. N/A.
+4. N/A.
+5. N/A.
+6. N/A.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0053_calendar_manual_blocks_audit"
+down_revision: Union[str, None] = "0052_calendar_manual_blocks"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "calendar_manual_blocks",
+        sa.Column("created_by", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "calendar_manual_blocks",
+        sa.Column("updated_by", sa.String(length=128), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("calendar_manual_blocks", "updated_by")
+    op.drop_column("calendar_manual_blocks", "created_by")

--- a/backend/db/alembic/versions/0053_manual_block_audit.py
+++ b/backend/db/alembic/versions/0053_manual_block_audit.py
@@ -16,7 +16,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0053_calendar_manual_blocks_audit"
+revision: str = "0053_manual_block_audit"
 down_revision: Union[str, None] = "0052_calendar_manual_blocks"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2733,6 +2733,7 @@ export class ApiStack extends cdk.Stack {
 
     const calendar = v1.addResource("calendar");
     addPublicApiKeyMethod(calendar.addResource("public"), "GET");
+    addPublicApiKeyMethod(calendar.addResource("blockers"), "GET");
     const reservations = v1.addResource("reservations");
     addPublicApiKeyMethod(reservations, "POST");
     addPublicApiKeyMethod(reservations.addResource("payment-intent"), "POST");
@@ -3025,6 +3026,31 @@ export class ApiStack extends cdk.Stack {
       authorizer: adminAuthorizer,
     });
     adminDiscountCodeById.addMethod("DELETE", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+
+    // Admin calendar manual blocks (purpose-scoped; merged with session slots for public reads)
+    const adminCalendar = admin.addResource("calendar");
+    const adminCalendarManualBlocks = adminCalendar.addResource("manual-blocks");
+    adminCalendarManualBlocks.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminCalendarManualBlocks.addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    const adminCalendarManualBlockById = adminCalendarManualBlocks.addResource("{id}");
+    adminCalendarManualBlockById.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminCalendarManualBlockById.addMethod("PATCH", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminCalendarManualBlockById.addMethod("DELETE", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,
     });

--- a/backend/infrastructure/lib/public-www-stack.ts
+++ b/backend/infrastructure/lib/public-www-stack.ts
@@ -339,6 +339,7 @@ function handler(event) {
   var allowlist = {
     'GET': {
       '/www/v1/calendar/public': true,
+      '/www/v1/calendar/blockers': true,
       '/www/v1/assets/free': true
     },
     'POST': {

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -32,6 +32,10 @@ from app.api.public_media import handle_media_request
 from app.api.public_mailchimp_webhook import handle_mailchimp_webhook
 from app.api.public_free_assets import handle_public_free_assets_list_request
 from app.api.public_discount_validate import handle_public_discount_validate
+from app.api.admin_calendar_manual_blocks import (
+    handle_admin_calendar_manual_blocks_request,
+)
+from app.api.public_calendar_blockers import handle_public_calendar_blockers
 from app.api.public_events import handle_public_events
 from app.api.public_contact import handle_public_contact_us
 from app.api.public_reservation_payments import handle_public_reservation_payment_intent
@@ -88,6 +92,16 @@ _ROUTES: tuple[
         "/www/v1/calendar/public",
         True,
         lambda event, method, _path: handle_public_events(event, method),
+    ),
+    (
+        "/v1/calendar/blockers",
+        True,
+        lambda event, method, _path: handle_public_calendar_blockers(event, method),
+    ),
+    (
+        "/www/v1/calendar/blockers",
+        True,
+        lambda event, method, _path: handle_public_calendar_blockers(event, method),
     ),
     (
         "/v1/discounts/validate",
@@ -172,6 +186,11 @@ _ROUTES: tuple[
         "/v1/admin/tags",
         False,
         handle_admin_tags_request,
+    ),
+    (
+        "/v1/admin/calendar/manual-blocks",
+        False,
+        handle_admin_calendar_manual_blocks_request,
     ),
     (
         "/v1/admin/contacts",

--- a/backend/src/app/api/admin_calendar_manual_blocks.py
+++ b/backend/src/app/api/admin_calendar_manual_blocks.py
@@ -132,7 +132,9 @@ def _list_blocks(event: Mapping[str, Any]) -> dict[str, Any]:
 
     with Session(get_engine()) as session:
         repo = CalendarManualBlockRepository(session)
-        rows = repo.list_for_purpose_between(purpose=purpose, start_date=start, end_date=end)
+        rows = repo.list_for_purpose_between(
+            purpose=purpose, start_date=start, end_date=end
+        )
         items = [_serialize_block(r) for r in rows]
         session.commit()
 
@@ -144,7 +146,7 @@ def _get_block(event: Mapping[str, Any], *, block_id: UUID) -> dict[str, Any]:
         repo = CalendarManualBlockRepository(session)
         row = repo.get_by_id(block_id)
         if row is None:
-            raise NotFoundError("Block not found")
+            raise NotFoundError("Calendar manual block", str(block_id))
         payload = _serialize_block(row)
         session.commit()
     return json_response(200, {"block": payload}, event=event)
@@ -166,7 +168,9 @@ def _create_block(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]
     with Session(get_engine()) as session:
         repo = CalendarManualBlockRepository(session)
         try:
-            row = repo.create(purpose=purpose, block_date=block_date, period=period, note=note)
+            row = repo.create_block(
+                purpose=purpose, block_date=block_date, period=period, note=note
+            )
         except IntegrityError as exc:
             session.rollback()
             raise ValidationError(
@@ -196,7 +200,7 @@ def _update_block(
         row = repo.get_by_id(block_id)
         if row is None:
             session.rollback()
-            raise NotFoundError("Block not found")
+            raise NotFoundError("Calendar manual block", str(block_id))
         if row.purpose != consultation_booking_purpose():
             session.rollback()
             raise ValidationError("Block purpose cannot be changed", field="purpose")
@@ -224,6 +228,6 @@ def _delete_block(event: Mapping[str, Any], *, block_id: UUID) -> dict[str, Any]
         deleted = repo.delete_by_id(block_id)
         if not deleted:
             session.rollback()
-            raise NotFoundError("Block not found")
+            raise NotFoundError("Calendar manual block", str(block_id))
         session.commit()
     return json_response(200, {"deleted": True}, event=event)

--- a/backend/src/app/api/admin_calendar_manual_blocks.py
+++ b/backend/src/app/api/admin_calendar_manual_blocks.py
@@ -11,9 +11,11 @@ from uuid import UUID
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.admin_request import parse_body, parse_uuid, query_param
-from app.api.assets.assets_common import extract_identity, split_route_parts
+from app.api.admin_request import parse_body, parse_uuid, query_param, request_id
+from app.api.shared_request import extract_identity, split_route_parts
+from app.db.audit import AuditService
 from app.db.engine import get_engine
+from app.db.models.calendar_manual_block import CalendarManualBlock
 from app.db.repositories.calendar_manual_block import CalendarManualBlockRepository
 from app.exceptions import NotFoundError, ValidationError
 from app.services.calendar_blockers import consultation_booking_purpose
@@ -172,14 +174,21 @@ def _create_block(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]
 
     with Session(get_engine()) as session:
         repo = CalendarManualBlockRepository(session)
+        audit = AuditService(
+            session,
+            user_id=actor_sub,
+            request_id=request_id(event),
+        )
         try:
-            row = repo.create_block(
+            row = CalendarManualBlock(
                 purpose=purpose,
                 block_date=block_date,
                 period=period,
                 note=note,
                 created_by=actor_sub,
+                updated_by=None,
             )
+            row = repo.create(row)
         except IntegrityError as exc:
             session.rollback()
             raise ValidationError(
@@ -187,6 +196,16 @@ def _create_block(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]
                 "Choose a different period or delete the existing row first.",
                 field="period",
             ) from exc
+        audit.log_create(
+            "calendar_manual_blocks",
+            row.id,
+            new_values={
+                "purpose": row.purpose,
+                "block_date": row.block_date.isoformat(),
+                "period": row.period,
+                "note": row.note,
+            },
+        )
         payload = _serialize_block(row)
         session.commit()
 
@@ -223,6 +242,12 @@ def _update_block(
         if row.purpose != consultation_booking_purpose():
             raise ValidationError("Block purpose cannot be changed", field="purpose")
 
+        old_values = {
+            "block_date": row.block_date.isoformat(),
+            "period": row.period,
+            "note": row.note,
+        }
+
         if "blockDate" in body or "block_date" in body:
             row.block_date = _parse_block_date(
                 body.get("blockDate") or body.get("block_date")
@@ -245,6 +270,22 @@ def _update_block(
                 field="period",
             ) from exc
         session.refresh(row)
+        new_values = {
+            "block_date": row.block_date.isoformat(),
+            "period": row.period,
+            "note": row.note,
+        }
+        audit = AuditService(
+            session,
+            user_id=actor_sub,
+            request_id=request_id(event),
+        )
+        audit.log_update(
+            "calendar_manual_blocks",
+            row.id,
+            old_values=old_values,
+            new_values=new_values,
+        )
         payload = _serialize_block(row)
         session.commit()
 
@@ -267,8 +308,23 @@ def _delete_block(
     )
     with Session(get_engine()) as session:
         repo = CalendarManualBlockRepository(session)
+        row = repo.get_by_id(block_id)
+        if row is None:
+            raise NotFoundError("Calendar manual block", str(block_id))
+        old_values = {
+            "purpose": row.purpose,
+            "block_date": row.block_date.isoformat(),
+            "period": row.period,
+            "note": row.note,
+        }
         deleted = repo.delete_by_id(block_id)
         if not deleted:
             raise NotFoundError("Calendar manual block", str(block_id))
+        audit = AuditService(
+            session,
+            user_id=actor_sub,
+            request_id=request_id(event),
+        )
+        audit.log_delete("calendar_manual_blocks", block_id, old_values=old_values)
         session.commit()
     return json_response(200, {"deleted": True}, event=event)

--- a/backend/src/app/api/admin_calendar_manual_blocks.py
+++ b/backend/src/app/api/admin_calendar_manual_blocks.py
@@ -1,0 +1,229 @@
+"""Admin API for purpose-scoped manual calendar blocks."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import date
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.api.admin_request import parse_body, parse_uuid, query_param
+from app.api.assets.assets_common import extract_identity, split_route_parts
+from app.db.engine import get_engine
+from app.db.repositories.calendar_manual_block import CalendarManualBlockRepository
+from app.exceptions import NotFoundError, ValidationError
+from app.services.calendar_blockers import consultation_booking_purpose
+from app.utils import json_response
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_PURPOSE_PATTERN = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
+_MAX_PURPOSE_LEN = 64
+_MAX_NOTE = 500
+
+
+def handle_admin_calendar_manual_blocks_request(
+    event: Mapping[str, Any],
+    method: str,
+    path: str,
+) -> dict[str, Any]:
+    """Handle /v1/admin/calendar/manual-blocks routes."""
+    logger.info(
+        "Handling admin calendar manual blocks",
+        extra={"method": method, "path": path},
+    )
+    parts = split_route_parts(path)
+    if len(parts) < 3 or parts[0] != "admin" or parts[1] != "calendar":
+        return json_response(404, {"error": "Not found"}, event=event)
+    if parts[2] != "manual-blocks":
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    identity = extract_identity(event)
+    if not identity.user_sub:
+        raise ValidationError("Authenticated user is required", field="authorization")
+
+    if len(parts) == 3:
+        if method == "GET":
+            return _list_blocks(event)
+        if method == "POST":
+            return _create_block(event, actor_sub=identity.user_sub)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    block_id = parse_uuid(parts[3])
+    if len(parts) == 4:
+        if method == "GET":
+            return _get_block(event, block_id=block_id)
+        if method == "PATCH":
+            return _update_block(event, block_id=block_id, actor_sub=identity.user_sub)
+        if method == "DELETE":
+            return _delete_block(event, block_id=block_id)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    return json_response(404, {"error": "Not found"}, event=event)
+
+
+def _parse_purpose(raw: Any) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValidationError("purpose is required", field="purpose")
+    s = raw.strip().lower()
+    if len(s) > _MAX_PURPOSE_LEN or not _PURPOSE_PATTERN.fullmatch(s):
+        raise ValidationError("purpose must be a valid identifier", field="purpose")
+    return s
+
+
+def _parse_block_date(raw: Any) -> date:
+    if not isinstance(raw, str) or len(raw.strip()) != 10:
+        raise ValidationError("blockDate must be YYYY-MM-DD", field="blockDate")
+    s = raw.strip()
+    try:
+        y, m, d = int(s[0:4]), int(s[5:7]), int(s[8:10])
+        return date(y, m, d)
+    except ValueError as exc:
+        raise ValidationError("blockDate is invalid", field="blockDate") from exc
+
+
+def _parse_period(raw: Any) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValidationError("period is required", field="period")
+    p = raw.strip().lower()
+    if p not in ("am", "pm", "both"):
+        raise ValidationError("period must be am, pm, or both", field="period")
+    return p
+
+
+def _optional_note(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise ValidationError("note must be a string", field="note")
+    s = raw.strip()
+    if len(s) > _MAX_NOTE:
+        raise ValidationError("note is too long", field="note")
+    return s or None
+
+
+def _serialize_block(row: Any) -> dict[str, Any]:
+    return {
+        "id": str(row.id),
+        "purpose": row.purpose,
+        "block_date": row.block_date.isoformat(),
+        "period": row.period,
+        "note": row.note,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+def _list_blocks(event: Mapping[str, Any]) -> dict[str, Any]:
+    purpose = _parse_purpose(query_param(event, "purpose"))
+    from_s = query_param(event, "from")
+    to_s = query_param(event, "to")
+    if not from_s or not to_s:
+        raise ValidationError("from and to query parameters are required", field="from")
+    start = _parse_block_date(from_s)
+    end = _parse_block_date(to_s)
+    if end < start:
+        raise ValidationError("to must be on or after from", field="to")
+
+    with Session(get_engine()) as session:
+        repo = CalendarManualBlockRepository(session)
+        rows = repo.list_for_purpose_between(purpose=purpose, start_date=start, end_date=end)
+        items = [_serialize_block(r) for r in rows]
+        session.commit()
+
+    return json_response(200, {"items": items}, event=event)
+
+
+def _get_block(event: Mapping[str, Any], *, block_id: UUID) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        repo = CalendarManualBlockRepository(session)
+        row = repo.get_by_id(block_id)
+        if row is None:
+            raise NotFoundError("Block not found")
+        payload = _serialize_block(row)
+        session.commit()
+    return json_response(200, {"block": payload}, event=event)
+
+
+def _create_block(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]:
+    _ = actor_sub
+    body = parse_body(event)
+    purpose = _parse_purpose(body.get("purpose"))
+    if purpose != consultation_booking_purpose():
+        raise ValidationError(
+            "Only consultation_booking purpose is supported in this release",
+            field="purpose",
+        )
+    block_date = _parse_block_date(body.get("blockDate") or body.get("block_date"))
+    period = _parse_period(body.get("period"))
+    note = _optional_note(body.get("note"))
+
+    with Session(get_engine()) as session:
+        repo = CalendarManualBlockRepository(session)
+        try:
+            row = repo.create(purpose=purpose, block_date=block_date, period=period, note=note)
+        except IntegrityError as exc:
+            session.rollback()
+            raise ValidationError(
+                "A block for this purpose, date, and period already exists",
+                field="period",
+            ) from exc
+        payload = _serialize_block(row)
+        session.commit()
+
+    return json_response(201, {"block": payload}, event=event)
+
+
+def _update_block(
+    event: Mapping[str, Any],
+    *,
+    block_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    _ = actor_sub
+    body = parse_body(event)
+    block_date = _parse_block_date(body.get("blockDate") or body.get("block_date"))
+    period = _parse_period(body.get("period"))
+    note = _optional_note(body.get("note"))
+
+    with Session(get_engine()) as session:
+        repo = CalendarManualBlockRepository(session)
+        row = repo.get_by_id(block_id)
+        if row is None:
+            session.rollback()
+            raise NotFoundError("Block not found")
+        if row.purpose != consultation_booking_purpose():
+            session.rollback()
+            raise ValidationError("Block purpose cannot be changed", field="purpose")
+        row.block_date = block_date
+        row.period = period
+        row.note = note
+        try:
+            session.flush()
+        except IntegrityError as exc:
+            session.rollback()
+            raise ValidationError(
+                "A block for this purpose, date, and period already exists",
+                field="period",
+            ) from exc
+        session.refresh(row)
+        payload = _serialize_block(row)
+        session.commit()
+
+    return json_response(200, {"block": payload}, event=event)
+
+
+def _delete_block(event: Mapping[str, Any], *, block_id: UUID) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        repo = CalendarManualBlockRepository(session)
+        deleted = repo.delete_by_id(block_id)
+        if not deleted:
+            session.rollback()
+            raise NotFoundError("Block not found")
+        session.commit()
+    return json_response(200, {"deleted": True}, event=event)

--- a/backend/src/app/api/admin_calendar_manual_blocks.py
+++ b/backend/src/app/api/admin_calendar_manual_blocks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
-from datetime import date
+from datetime import UTC, date, datetime
 from typing import Any
 from uuid import UUID
 
@@ -18,7 +18,7 @@ from app.db.repositories.calendar_manual_block import CalendarManualBlockReposit
 from app.exceptions import NotFoundError, ValidationError
 from app.services.calendar_blockers import consultation_booking_purpose
 from app.utils import json_response
-from app.utils.logging import get_logger
+from app.utils.logging import get_logger, mask_pii
 
 logger = get_logger(__name__)
 
@@ -61,7 +61,7 @@ def handle_admin_calendar_manual_blocks_request(
         if method == "PATCH":
             return _update_block(event, block_id=block_id, actor_sub=identity.user_sub)
         if method == "DELETE":
-            return _delete_block(event, block_id=block_id)
+            return _delete_block(event, block_id=block_id, actor_sub=identity.user_sub)
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     return json_response(404, {"error": "Not found"}, event=event)
@@ -116,6 +116,8 @@ def _serialize_block(row: Any) -> dict[str, Any]:
         "note": row.note,
         "created_at": row.created_at.isoformat() if row.created_at else None,
         "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+        "created_by": row.created_by,
+        "updated_by": row.updated_by,
     }
 
 
@@ -136,7 +138,6 @@ def _list_blocks(event: Mapping[str, Any]) -> dict[str, Any]:
             purpose=purpose, start_date=start, end_date=end
         )
         items = [_serialize_block(r) for r in rows]
-        session.commit()
 
     return json_response(200, {"items": items}, event=event)
 
@@ -148,12 +149,11 @@ def _get_block(event: Mapping[str, Any], *, block_id: UUID) -> dict[str, Any]:
         if row is None:
             raise NotFoundError("Calendar manual block", str(block_id))
         payload = _serialize_block(row)
-        session.commit()
+
     return json_response(200, {"block": payload}, event=event)
 
 
 def _create_block(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]:
-    _ = actor_sub
     body = parse_body(event)
     purpose = _parse_purpose(body.get("purpose"))
     if purpose != consultation_booking_purpose():
@@ -165,16 +165,26 @@ def _create_block(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]
     period = _parse_period(body.get("period"))
     note = _optional_note(body.get("note"))
 
+    logger.info(
+        "calendar_manual_block_create",
+        extra={"actor_sub": mask_pii(actor_sub, visible_chars=6)},
+    )
+
     with Session(get_engine()) as session:
         repo = CalendarManualBlockRepository(session)
         try:
             row = repo.create_block(
-                purpose=purpose, block_date=block_date, period=period, note=note
+                purpose=purpose,
+                block_date=block_date,
+                period=period,
+                note=note,
+                created_by=actor_sub,
             )
         except IntegrityError as exc:
             session.rollback()
             raise ValidationError(
-                "A block for this purpose, date, and period already exists",
+                "That date and period already has a manual block. "
+                "Choose a different period or delete the existing row first.",
                 field="period",
             ) from exc
         payload = _serialize_block(row)
@@ -189,30 +199,49 @@ def _update_block(
     block_id: UUID,
     actor_sub: str,
 ) -> dict[str, Any]:
-    _ = actor_sub
     body = parse_body(event)
-    block_date = _parse_block_date(body.get("blockDate") or body.get("block_date"))
-    period = _parse_period(body.get("period"))
-    note = _optional_note(body.get("note"))
+
+    if not any(k in body for k in ("blockDate", "block_date", "period", "note")):
+        raise ValidationError(
+            "At least one of blockDate, period, or note must be provided",
+            field="blockDate",
+        )
+
+    logger.info(
+        "calendar_manual_block_update",
+        extra={
+            "actor_sub": mask_pii(actor_sub, visible_chars=6),
+            "block_id": str(block_id),
+        },
+    )
 
     with Session(get_engine()) as session:
         repo = CalendarManualBlockRepository(session)
         row = repo.get_by_id(block_id)
         if row is None:
-            session.rollback()
             raise NotFoundError("Calendar manual block", str(block_id))
         if row.purpose != consultation_booking_purpose():
-            session.rollback()
             raise ValidationError("Block purpose cannot be changed", field="purpose")
-        row.block_date = block_date
-        row.period = period
-        row.note = note
+
+        if "blockDate" in body or "block_date" in body:
+            row.block_date = _parse_block_date(
+                body.get("blockDate") or body.get("block_date")
+            )
+        if "period" in body:
+            row.period = _parse_period(body.get("period"))
+        if "note" in body:
+            row.note = _optional_note(body.get("note"))
+
+        row.updated_by = actor_sub
+        row.updated_at = datetime.now(tz=UTC)
+
         try:
             session.flush()
         except IntegrityError as exc:
             session.rollback()
             raise ValidationError(
-                "A block for this purpose, date, and period already exists",
+                "That date and period already has a manual block. "
+                "Choose a different combination or delete the conflicting row.",
                 field="period",
             ) from exc
         session.refresh(row)
@@ -222,12 +251,24 @@ def _update_block(
     return json_response(200, {"block": payload}, event=event)
 
 
-def _delete_block(event: Mapping[str, Any], *, block_id: UUID) -> dict[str, Any]:
+def _delete_block(
+    event: Mapping[str, Any],
+    *,
+    block_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    _ = event
+    logger.info(
+        "calendar_manual_block_delete",
+        extra={
+            "actor_sub": mask_pii(actor_sub, visible_chars=6),
+            "block_id": str(block_id),
+        },
+    )
     with Session(get_engine()) as session:
         repo = CalendarManualBlockRepository(session)
         deleted = repo.delete_by_id(block_id)
         if not deleted:
-            session.rollback()
             raise NotFoundError("Calendar manual block", str(block_id))
         session.commit()
     return json_response(200, {"deleted": True}, event=event)

--- a/backend/src/app/api/admin_calendar_manual_blocks.py
+++ b/backend/src/app/api/admin_calendar_manual_blocks.py
@@ -18,7 +18,10 @@ from app.db.engine import get_engine
 from app.db.models.calendar_manual_block import CalendarManualBlock
 from app.db.repositories.calendar_manual_block import CalendarManualBlockRepository
 from app.exceptions import NotFoundError, ValidationError
-from app.services.calendar_blockers import consultation_booking_purpose
+from app.services.calendar_blockers import (
+    allowed_manual_block_creation_purposes,
+    consultation_booking_purpose,
+)
 from app.utils import json_response
 from app.utils.logging import get_logger, mask_pii
 
@@ -158,7 +161,7 @@ def _get_block(event: Mapping[str, Any], *, block_id: UUID) -> dict[str, Any]:
 def _create_block(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]:
     body = parse_body(event)
     purpose = _parse_purpose(body.get("purpose"))
-    if purpose != consultation_booking_purpose():
+    if purpose not in allowed_manual_block_creation_purposes():
         raise ValidationError(
             "Only consultation_booking purpose is supported in this release",
             field="purpose",
@@ -195,6 +198,7 @@ def _create_block(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]
                 "That date and period already has a manual block. "
                 "Choose a different period or delete the existing row first.",
                 field="period",
+                status_code=409,
             ) from exc
         audit.log_create(
             "calendar_manual_blocks",
@@ -268,6 +272,7 @@ def _update_block(
                 "That date and period already has a manual block. "
                 "Choose a different combination or delete the conflicting row.",
                 field="period",
+                status_code=409,
             ) from exc
         session.refresh(row)
         new_values = {
@@ -298,7 +303,6 @@ def _delete_block(
     block_id: UUID,
     actor_sub: str,
 ) -> dict[str, Any]:
-    _ = event
     logger.info(
         "calendar_manual_block_delete",
         extra={

--- a/backend/src/app/api/public_calendar_blockers.py
+++ b/backend/src/app/api/public_calendar_blockers.py
@@ -121,6 +121,9 @@ def handle_public_calendar_blockers(
             event=event,
         )
     return public_cacheable_json_response(200, body, event=event)
+
+
+def _parse_iso_date(raw: Any, *, default: date) -> date:
     if raw is None or raw == "":
         return default
     if not isinstance(raw, str):

--- a/backend/src/app/api/public_calendar_blockers.py
+++ b/backend/src/app/api/public_calendar_blockers.py
@@ -12,11 +12,14 @@ from sqlalchemy.orm import Session
 from app.db.engine import get_engine
 from app.services.calendar_blockers import (
     consultation_booking_purpose,
+    is_public_blockers_purpose_allowed,
     merge_calendar_blockers_for_purpose,
     resolve_calendar_blockers_wall_timezone,
 )
+from app.utils import json_response
 from app.utils import public_cacheable_json_response
 from app.utils.logging import get_logger
+from app.utils.public_http_cache import CACHE_CONTROL_NO_STORE
 
 logger = get_logger(__name__)
 
@@ -50,6 +53,12 @@ def handle_public_calendar_blockers(
         return public_cacheable_json_response(
             400, {"error": "purpose must be a kebab-case identifier"}, event=event
         )
+    if not is_public_blockers_purpose_allowed(purpose):
+        return public_cacheable_json_response(
+            400,
+            {"error": "Unsupported purpose for public calendar blockers"},
+            event=event,
+        )
 
     from_raw = query.get("from") if isinstance(query, Mapping) else None
     to_raw = query.get("to") if isinstance(query, Mapping) else None
@@ -64,6 +73,17 @@ def handle_public_calendar_blockers(
         )
     max_end = start_date + timedelta(days=_DEFAULT_RANGE_DAYS)
     if end_date > max_end:
+        if isinstance(to_raw, str) and to_raw.strip():
+            return public_cacheable_json_response(
+                400,
+                {
+                    "error": (
+                        f"Date range exceeds maximum of {_DEFAULT_RANGE_DAYS} days "
+                        "from from; narrow to or to omit to for the default window."
+                    ),
+                },
+                event=event,
+            )
         end_date = max_end
 
     logger.info(
@@ -91,14 +111,16 @@ def handle_public_calendar_blockers(
     if purpose == consultation_booking_purpose():
         meta["wall_time_zone"] = resolve_calendar_blockers_wall_timezone()
 
-    return public_cacheable_json_response(
-        200,
-        {"blockers": blockers, "meta": meta},
-        event=event,
-    )
+    body: dict[str, Any] = {"blockers": blockers, "meta": meta}
 
-
-def _parse_iso_date(raw: Any, *, default: date) -> date:
+    if purpose == consultation_booking_purpose():
+        return json_response(
+            200,
+            body,
+            headers={"Cache-Control": CACHE_CONTROL_NO_STORE},
+            event=event,
+        )
+    return public_cacheable_json_response(200, body, event=event)
     if raw is None or raw == "":
         return default
     if not isinstance(raw, str):

--- a/backend/src/app/api/public_calendar_blockers.py
+++ b/backend/src/app/api/public_calendar_blockers.py
@@ -55,7 +55,9 @@ def handle_public_calendar_blockers(
     to_raw = query.get("to") if isinstance(query, Mapping) else None
     today = datetime.now(tz=UTC).date()
     start_date = _parse_iso_date(from_raw, default=today)
-    end_date = _parse_iso_date(to_raw, default=start_date + timedelta(days=_DEFAULT_RANGE_DAYS))
+    end_date = _parse_iso_date(
+        to_raw, default=start_date + timedelta(days=_DEFAULT_RANGE_DAYS)
+    )
     if end_date < start_date:
         return public_cacheable_json_response(
             400, {"error": "to must be on or after from"}, event=event

--- a/backend/src/app/api/public_calendar_blockers.py
+++ b/backend/src/app/api/public_calendar_blockers.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.orm import Session
 
@@ -62,7 +63,8 @@ def handle_public_calendar_blockers(
 
     from_raw = query.get("from") if isinstance(query, Mapping) else None
     to_raw = query.get("to") if isinstance(query, Mapping) else None
-    today = datetime.now(tz=UTC).date()
+    wall_zone = ZoneInfo(resolve_calendar_blockers_wall_timezone())
+    today = datetime.now(tz=wall_zone).date()
     start_date = _parse_iso_date(from_raw, default=today)
     end_date = _parse_iso_date(
         to_raw, default=start_date + timedelta(days=_DEFAULT_RANGE_DAYS)
@@ -86,7 +88,7 @@ def handle_public_calendar_blockers(
             )
         end_date = max_end
 
-    logger.info(
+    logger.debug(
         "Handling public calendar blockers",
         extra={
             "purpose": purpose,

--- a/backend/src/app/api/public_calendar_blockers.py
+++ b/backend/src/app/api/public_calendar_blockers.py
@@ -1,0 +1,111 @@
+"""Public calendar blockers (manual + session-derived half-day blocks)."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.db.engine import get_engine
+from app.services.calendar_blockers import (
+    consultation_booking_purpose,
+    merge_calendar_blockers_for_purpose,
+    resolve_calendar_blockers_wall_timezone,
+)
+from app.utils import public_cacheable_json_response
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_PURPOSE_PATTERN = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
+_MAX_PURPOSE_LEN = 64
+_DEFAULT_RANGE_DAYS = 120
+
+
+def handle_public_calendar_blockers(
+    event: Mapping[str, Any],
+    method: str,
+) -> dict[str, Any]:
+    """Handle GET /v1/calendar/blockers and /www/v1/calendar/blockers."""
+    if method != "GET":
+        logger.info(
+            "Calendar blockers method not allowed",
+            extra={"method": method},
+        )
+        return public_cacheable_json_response(
+            405, {"error": "Method not allowed"}, event=event
+        )
+
+    query = event.get("queryStringParameters") or {}
+    purpose_raw = query.get("purpose") if isinstance(query, Mapping) else None
+    purpose = str(purpose_raw or "").strip().lower()
+    if not purpose:
+        return public_cacheable_json_response(
+            400, {"error": "purpose query parameter is required"}, event=event
+        )
+    if len(purpose) > _MAX_PURPOSE_LEN or not _PURPOSE_PATTERN.fullmatch(purpose):
+        return public_cacheable_json_response(
+            400, {"error": "purpose must be a kebab-case identifier"}, event=event
+        )
+
+    from_raw = query.get("from") if isinstance(query, Mapping) else None
+    to_raw = query.get("to") if isinstance(query, Mapping) else None
+    today = datetime.now(tz=UTC).date()
+    start_date = _parse_iso_date(from_raw, default=today)
+    end_date = _parse_iso_date(to_raw, default=start_date + timedelta(days=_DEFAULT_RANGE_DAYS))
+    if end_date < start_date:
+        return public_cacheable_json_response(
+            400, {"error": "to must be on or after from"}, event=event
+        )
+    max_end = start_date + timedelta(days=_DEFAULT_RANGE_DAYS)
+    if end_date > max_end:
+        end_date = max_end
+
+    logger.info(
+        "Handling public calendar blockers",
+        extra={
+            "purpose": purpose,
+            "from": start_date.isoformat(),
+            "to": end_date.isoformat(),
+        },
+    )
+
+    with Session(get_engine()) as session:
+        blockers = merge_calendar_blockers_for_purpose(
+            session,
+            purpose=purpose,
+            from_date=start_date,
+            to_date=end_date,
+        )
+
+    meta: dict[str, Any] = {
+        "purpose": purpose,
+        "from": start_date.isoformat(),
+        "to": end_date.isoformat(),
+    }
+    if purpose == consultation_booking_purpose():
+        meta["wall_time_zone"] = resolve_calendar_blockers_wall_timezone()
+
+    return public_cacheable_json_response(
+        200,
+        {"blockers": blockers, "meta": meta},
+        event=event,
+    )
+
+
+def _parse_iso_date(raw: Any, *, default: date) -> date:
+    if raw is None or raw == "":
+        return default
+    if not isinstance(raw, str):
+        return default
+    s = raw.strip()
+    if len(s) != 10 or s[4] != "-" or s[7] != "-":
+        return default
+    try:
+        y, m, d = int(s[0:4]), int(s[5:7]), int(s[8:10])
+        return date(y, m, d)
+    except ValueError:
+        return default

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -56,7 +56,8 @@ from app.exceptions import ValidationError
 from app.services.aws_proxy import AwsProxyError, http_invoke
 from app.services.calendar_blockers import (
     consultation_booking_purpose,
-    consultation_slot_blocked,
+    consultation_reservation_has_blocked_slot,
+    validate_session_slot_chronology,
 )
 from app.services.public_form_internal_notifications import (
     build_reservation_recap_lines,
@@ -213,10 +214,24 @@ def _handle_public_reservation(
                         "primarySessionStartIso is required for consultation bookings",
                         field="primarySessionStartIso",
                     )
-                if consultation_slot_blocked(
-                    primary_start_iso=str(start_iso),
-                    purpose=consultation_booking_purpose(),
+                slot_err = validate_session_slot_chronology(
+                    reservation_payload.get("session_slots")
+                )
+                if slot_err == "session_slot_end_before_start":
+                    raise ValidationError(
+                        "Each session slot must end after its start time",
+                        field="sessionSlots",
+                    )
+                if slot_err == "invalid_session_slot_iso":
+                    raise ValidationError(
+                        "Invalid session slot date format",
+                        field="sessionSlots",
+                    )
+                if consultation_reservation_has_blocked_slot(
                     session=session,
+                    purpose=consultation_booking_purpose(),
+                    primary_start_iso=str(start_iso),
+                    session_slots=reservation_payload.get("session_slots"),
                 ):
                     raise ValidationError(
                         "The selected consultation time is no longer available. "

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -56,7 +56,7 @@ from app.exceptions import ValidationError
 from app.services.aws_proxy import AwsProxyError, http_invoke
 from app.services.calendar_blockers import (
     consultation_booking_purpose,
-    consultation_reservation_has_blocked_slot,
+    raise_if_consultation_reservation_blocked,
     validate_session_slot_chronology,
 )
 from app.services.public_form_internal_notifications import (
@@ -227,17 +227,12 @@ def _handle_public_reservation(
                         "Invalid session slot date format",
                         field="sessionSlots",
                     )
-                if consultation_reservation_has_blocked_slot(
+                raise_if_consultation_reservation_blocked(
                     session=session,
                     purpose=consultation_booking_purpose(),
                     primary_start_iso=str(start_iso),
                     session_slots=reservation_payload.get("session_slots"),
-                ):
-                    raise ValidationError(
-                        "The selected consultation time is no longer available. "
-                        "Please pick another slot.",
-                        field="primarySessionStartIso",
-                    )
+                )
             _validate_discount_code_redemption_scope(
                 session, reservation_payload, resolved_instance=resolved_instance
             )

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -54,6 +54,10 @@ from app.db.repositories.contact import ContactRepository
 from app.db.repositories.sales_lead import SalesLeadRepository
 from app.exceptions import ValidationError
 from app.services.aws_proxy import AwsProxyError, http_invoke
+from app.services.calendar_blockers import (
+    consultation_booking_purpose,
+    consultation_slot_blocked,
+)
 from app.services.public_form_internal_notifications import (
     build_reservation_recap_lines,
     send_sales_form_recap_email,
@@ -202,6 +206,23 @@ def _handle_public_reservation(
                 **reservation_payload,
                 "service_type": resolved_instance.service.service_type.value,
             }
+            if reservation_payload.get("booking_system") == "consultation-booking":
+                start_iso = reservation_payload.get("primary_session_start_iso")
+                if not start_iso:
+                    raise ValidationError(
+                        "primarySessionStartIso is required for consultation bookings",
+                        field="primarySessionStartIso",
+                    )
+                if consultation_slot_blocked(
+                    primary_start_iso=str(start_iso),
+                    purpose=consultation_booking_purpose(),
+                    session=session,
+                ):
+                    raise ValidationError(
+                        "The selected consultation time is no longer available. "
+                        "Please pick another slot.",
+                        field="primarySessionStartIso",
+                    )
             _validate_discount_code_redemption_scope(
                 session, reservation_payload, resolved_instance=resolved_instance
             )

--- a/backend/src/app/api/shared_request.py
+++ b/backend/src/app/api/shared_request.py
@@ -1,0 +1,12 @@
+"""Shared API Gateway request helpers for non-admin route modules.
+
+Route handlers outside ``admin_request`` consumers should import from here
+instead of ``app.api.assets.assets_common`` to avoid a misleading dependency
+direction.
+"""
+
+from __future__ import annotations
+
+from app.api.admin_request import extract_identity, split_route_parts
+
+__all__ = ["extract_identity", "split_route_parts"]

--- a/backend/src/app/db/models/__init__.py
+++ b/backend/src/app/db/models/__init__.py
@@ -1,6 +1,7 @@
 """SQLAlchemy models."""
 
 from app.db.models.asset import Asset, AssetAccessGrant, AssetShareLink
+from app.db.models.calendar_manual_block import CalendarManualBlock
 from app.db.models.audit_log import AuditLog
 from app.db.models.contact import Contact
 from app.db.models.discount_code import DiscountCode
@@ -72,6 +73,7 @@ __all__ = [
     "AssetType",
     "AssetVisibility",
     "AuditLog",
+    "CalendarManualBlock",
     "ConsultationDetails",
     "ConsultationFormat",
     "ConsultationInstanceDetails",

--- a/backend/src/app/db/models/calendar_manual_block.py
+++ b/backend/src/app/db/models/calendar_manual_block.py
@@ -1,0 +1,53 @@
+"""Generic manual calendar block rows (purpose-scoped)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from uuid import UUID
+
+from sqlalchemy import CheckConstraint, Date, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import text
+from sqlalchemy.types import TIMESTAMP
+
+from app.db.base import Base
+
+
+class CalendarManualBlock(Base):
+    """Admin-managed half-day blocks merged with session-derived calendar blockers."""
+
+    __tablename__ = "calendar_manual_blocks"
+    __table_args__ = (
+        UniqueConstraint(
+            "purpose",
+            "block_date",
+            "period",
+            name="calendar_manual_blocks_purpose_date_period_uidx",
+        ),
+        CheckConstraint(
+            "period IN ('am', 'pm', 'both')",
+            name="calendar_manual_blocks_period_chk",
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    purpose: Mapped[str] = mapped_column(String(64), nullable=False)
+    block_date: Mapped[date] = mapped_column(Date(), nullable=False)
+    period: Mapped[str] = mapped_column(String(8), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+        onupdate=func.now(),
+    )
+    note: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/backend/src/app/db/models/calendar_manual_block.py
+++ b/backend/src/app/db/models/calendar_manual_block.py
@@ -51,3 +51,5 @@ class CalendarManualBlock(Base):
         onupdate=func.now(),
     )
     note: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String(128), nullable=True)

--- a/backend/src/app/db/repositories/calendar_manual_block.py
+++ b/backend/src/app/db/repositories/calendar_manual_block.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import date
 from uuid import UUID
 
 from sqlalchemy import select

--- a/backend/src/app/db/repositories/calendar_manual_block.py
+++ b/backend/src/app/db/repositories/calendar_manual_block.py
@@ -1,0 +1,82 @@
+"""Repository for purpose-scoped manual calendar blocks."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.db.models.calendar_manual_block import CalendarManualBlock
+from app.db.repositories.base import BaseRepository
+
+
+class CalendarManualBlockRepository(BaseRepository[CalendarManualBlock]):
+    """CRUD for ``calendar_manual_blocks``."""
+
+    def __init__(self, session: Session):
+        super().__init__(session, CalendarManualBlock)
+
+    def list_for_purpose_between(
+        self,
+        *,
+        purpose: str,
+        start_date: date,
+        end_date: date,
+    ) -> list[CalendarManualBlock]:
+        statement = (
+            select(CalendarManualBlock)
+            .where(CalendarManualBlock.purpose == purpose)
+            .where(CalendarManualBlock.block_date >= start_date)
+            .where(CalendarManualBlock.block_date <= end_date)
+            .order_by(CalendarManualBlock.block_date.asc(), CalendarManualBlock.period.asc())
+        )
+        return list(self._session.execute(statement).scalars().all())
+
+    def get_by_id(self, row_id: UUID) -> CalendarManualBlock | None:
+        return self._session.get(CalendarManualBlock, row_id)
+
+    def create(
+        self,
+        *,
+        purpose: str,
+        block_date: date,
+        period: str,
+        note: str | None,
+    ) -> CalendarManualBlock:
+        row = CalendarManualBlock(
+            purpose=purpose,
+            block_date=block_date,
+            period=period,
+            note=note,
+        )
+        self._session.add(row)
+        self._session.flush()
+        self._session.refresh(row)
+        return row
+
+    def update_row(
+        self,
+        row_id: UUID,
+        *,
+        block_date: date,
+        period: str,
+        note: str | None,
+    ) -> CalendarManualBlock | None:
+        row = self.get_by_id(row_id)
+        if row is None:
+            return None
+        row.block_date = block_date
+        row.period = period
+        row.note = note
+        row.updated_at = datetime.now(tz=UTC)
+        self._session.flush()
+        self._session.refresh(row)
+        return row
+
+    def delete_by_id(self, row_id: UUID) -> bool:
+        result = self._session.execute(
+            delete(CalendarManualBlock).where(CalendarManualBlock.id == row_id)
+        )
+        return result.rowcount > 0

--- a/backend/src/app/db/repositories/calendar_manual_block.py
+++ b/backend/src/app/db/repositories/calendar_manual_block.py
@@ -38,25 +38,3 @@ class CalendarManualBlockRepository(BaseRepository[CalendarManualBlock]):
 
     def get_by_id(self, row_id: UUID) -> CalendarManualBlock | None:
         return self._session.get(CalendarManualBlock, row_id)
-
-    def create_block(
-        self,
-        *,
-        purpose: str,
-        block_date: date,
-        period: str,
-        note: str | None,
-        created_by: str | None = None,
-    ) -> CalendarManualBlock:
-        row = CalendarManualBlock(
-            purpose=purpose,
-            block_date=block_date,
-            period=period,
-            note=note,
-            created_by=created_by,
-            updated_by=None,
-        )
-        self._session.add(row)
-        self._session.flush()
-        self._session.refresh(row)
-        return row

--- a/backend/src/app/db/repositories/calendar_manual_block.py
+++ b/backend/src/app/db/repositories/calendar_manual_block.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, date, datetime
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.db.models.calendar_manual_block import CalendarManualBlock
@@ -30,14 +30,16 @@ class CalendarManualBlockRepository(BaseRepository[CalendarManualBlock]):
             .where(CalendarManualBlock.purpose == purpose)
             .where(CalendarManualBlock.block_date >= start_date)
             .where(CalendarManualBlock.block_date <= end_date)
-            .order_by(CalendarManualBlock.block_date.asc(), CalendarManualBlock.period.asc())
+            .order_by(
+                CalendarManualBlock.block_date.asc(), CalendarManualBlock.period.asc()
+            )
         )
         return list(self._session.execute(statement).scalars().all())
 
     def get_by_id(self, row_id: UUID) -> CalendarManualBlock | None:
         return self._session.get(CalendarManualBlock, row_id)
 
-    def create(
+    def create_block(
         self,
         *,
         purpose: str,
@@ -74,9 +76,3 @@ class CalendarManualBlockRepository(BaseRepository[CalendarManualBlock]):
         self._session.flush()
         self._session.refresh(row)
         return row
-
-    def delete_by_id(self, row_id: UUID) -> bool:
-        result = self._session.execute(
-            delete(CalendarManualBlock).where(CalendarManualBlock.id == row_id)
-        )
-        return result.rowcount > 0

--- a/backend/src/app/db/repositories/calendar_manual_block.py
+++ b/backend/src/app/db/repositories/calendar_manual_block.py
@@ -46,33 +46,17 @@ class CalendarManualBlockRepository(BaseRepository[CalendarManualBlock]):
         block_date: date,
         period: str,
         note: str | None,
+        created_by: str | None = None,
     ) -> CalendarManualBlock:
         row = CalendarManualBlock(
             purpose=purpose,
             block_date=block_date,
             period=period,
             note=note,
+            created_by=created_by,
+            updated_by=None,
         )
         self._session.add(row)
-        self._session.flush()
-        self._session.refresh(row)
-        return row
-
-    def update_row(
-        self,
-        row_id: UUID,
-        *,
-        block_date: date,
-        period: str,
-        note: str | None,
-    ) -> CalendarManualBlock | None:
-        row = self.get_by_id(row_id)
-        if row is None:
-            return None
-        row.block_date = block_date
-        row.period = period
-        row.note = note
-        row.updated_at = datetime.now(tz=UTC)
         self._session.flush()
         self._session.refresh(row)
         return row

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -32,6 +32,43 @@ InstanceDetails = (
 )
 
 
+def select_public_calendar_blocker_session_slots(
+    *,
+    range_start_utc: datetime,
+    range_end_utc: datetime,
+):
+    """Session slot rows for public calendar blocker merge (published event/training).
+
+    Must stay aligned with :meth:`ServiceInstanceRepository.list_public_offerings`
+    instance + service eligibility (excluding ``limit``, ``slug``, ``service_key``,
+    ``earliest_upcoming_slot`` ordering, and the ``ends_at >= now`` feed filter).
+    """
+    return (
+        select(InstanceSessionSlot.starts_at, InstanceSessionSlot.ends_at)
+        .join(ServiceInstance, InstanceSessionSlot.instance_id == ServiceInstance.id)
+        .join(Service, ServiceInstance.service_id == Service.id)
+        .where(
+            Service.service_type.in_((ServiceType.EVENT, ServiceType.TRAINING_COURSE))
+        )
+        .where(Service.status == ServiceStatus.PUBLISHED)
+        .where(ServiceInstance.status != InstanceStatus.CANCELLED)
+        .where(
+            ServiceInstance.status.in_(
+                [
+                    InstanceStatus.SCHEDULED,
+                    InstanceStatus.OPEN,
+                    InstanceStatus.FULL,
+                    InstanceStatus.IN_PROGRESS,
+                    InstanceStatus.COMPLETED,
+                ]
+            )
+        )
+        .where(ServiceInstance.slug != "")
+        .where(InstanceSessionSlot.starts_at < range_end_utc)
+        .where(InstanceSessionSlot.ends_at > range_start_utc)
+    )
+
+
 class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
     """Repository for service-instance operations."""
 

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session, joinedload, selectinload
+from sqlalchemy.sql import ColumnElement
 
 from app.db.models import (
     ConsultationInstanceDetails,
@@ -31,6 +32,41 @@ InstanceDetails = (
     TrainingInstanceDetails | ConsultationInstanceDetails | list[EventTicketTier] | None
 )
 
+_PUBLIC_CALENDAR_BLOCKER_DEFAULT_TYPES: tuple[ServiceType, ...] = (
+    ServiceType.EVENT,
+    ServiceType.TRAINING_COURSE,
+)
+
+
+def public_calendar_blocker_instance_predicates(
+    *,
+    service_types: tuple[ServiceType, ...] | None = None,
+) -> tuple[ColumnElement[bool], ...]:
+    """Shared filters for published event/training instances (public calendar + blockers).
+
+    Pass ``service_types`` to mirror :meth:`ServiceInstanceRepository.list_public_offerings`
+    (when ``None``, defaults to event + training_course). Excludes list limit, slug,
+    service_key filters, earliest-slot ordering, and the ``ends_at >= now`` feed filter.
+    """
+    types_tuple = (
+        _PUBLIC_CALENDAR_BLOCKER_DEFAULT_TYPES if not service_types else service_types
+    )
+    return (
+        Service.service_type.in_(types_tuple),
+        Service.status == ServiceStatus.PUBLISHED,
+        ServiceInstance.status != InstanceStatus.CANCELLED,
+        ServiceInstance.status.in_(
+            [
+                InstanceStatus.SCHEDULED,
+                InstanceStatus.OPEN,
+                InstanceStatus.FULL,
+                InstanceStatus.IN_PROGRESS,
+                InstanceStatus.COMPLETED,
+            ]
+        ),
+        ServiceInstance.slug != "",
+    )
+
 
 def select_public_calendar_blocker_session_slots(
     *,
@@ -39,31 +75,14 @@ def select_public_calendar_blocker_session_slots(
 ):
     """Session slot rows for public calendar blocker merge (published event/training).
 
-    Must stay aligned with :meth:`ServiceInstanceRepository.list_public_offerings`
-    instance + service eligibility (excluding ``limit``, ``slug``, ``service_key``,
-    ``earliest_upcoming_slot`` ordering, and the ``ends_at >= now`` feed filter).
+    Uses :func:`public_calendar_blocker_instance_predicates` — same eligibility as
+    :meth:`ServiceInstanceRepository.list_public_offerings` (see that docstring).
     """
     return (
         select(InstanceSessionSlot.starts_at, InstanceSessionSlot.ends_at)
         .join(ServiceInstance, InstanceSessionSlot.instance_id == ServiceInstance.id)
         .join(Service, ServiceInstance.service_id == Service.id)
-        .where(
-            Service.service_type.in_((ServiceType.EVENT, ServiceType.TRAINING_COURSE))
-        )
-        .where(Service.status == ServiceStatus.PUBLISHED)
-        .where(ServiceInstance.status != InstanceStatus.CANCELLED)
-        .where(
-            ServiceInstance.status.in_(
-                [
-                    InstanceStatus.SCHEDULED,
-                    InstanceStatus.OPEN,
-                    InstanceStatus.FULL,
-                    InstanceStatus.IN_PROGRESS,
-                    InstanceStatus.COMPLETED,
-                ]
-            )
-        )
-        .where(ServiceInstance.slug != "")
+        .where(and_(*public_calendar_blocker_instance_predicates()))
         .where(InstanceSessionSlot.starts_at < range_end_utc)
         .where(InstanceSessionSlot.ends_at > range_start_utc)
     )
@@ -268,18 +287,11 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         statement = (
             select(ServiceInstance)
             .join(Service, ServiceInstance.service_id == Service.id)
-            .where(Service.service_type.in_(types_tuple))
-            .where(Service.status == ServiceStatus.PUBLISHED)
-            .where(ServiceInstance.status != InstanceStatus.CANCELLED)
             .where(
-                ServiceInstance.status.in_(
-                    [
-                        InstanceStatus.SCHEDULED,
-                        InstanceStatus.OPEN,
-                        InstanceStatus.FULL,
-                        InstanceStatus.IN_PROGRESS,
-                        InstanceStatus.COMPLETED,
-                    ]
+                and_(
+                    *public_calendar_blocker_instance_predicates(
+                        service_types=types_tuple
+                    )
                 )
             )
             .where(

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -328,7 +328,6 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             statement = statement.where(
                 func.lower(Service.service_key) == service_key.lower()
             )
-        statement = statement.where(ServiceInstance.slug != "")
         return list(self._session.execute(statement).unique().scalars().all())
 
     def get_with_service_by_slug(self, slug: str) -> ServiceInstance | None:

--- a/backend/src/app/services/calendar_blockers.py
+++ b/backend/src/app/services/calendar_blockers.py
@@ -39,6 +39,11 @@ _ALLOWED_PUBLIC_BLOCKER_PURPOSES: frozenset[str] = frozenset(
 )
 
 
+def allowed_manual_block_creation_purposes() -> frozenset[str]:
+    """Purposes allowed for admin-created manual blocks (keep in sync with public read allowlist)."""
+    return _ALLOWED_PUBLIC_BLOCKER_PURPOSES
+
+
 def resolve_calendar_blockers_wall_timezone() -> str:
     raw = os.getenv(_ENV_CALENDAR_BLOCKERS_WALL_TIMEZONE, "").strip()
     return raw or _DEFAULT_WALL_TIMEZONE

--- a/backend/src/app/services/calendar_blockers.py
+++ b/backend/src/app/services/calendar_blockers.py
@@ -10,9 +10,13 @@ from zoneinfo import ZoneInfo
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.db.models import InstanceSessionSlot, Service, ServiceInstance
 from app.db.models.calendar_manual_block import CalendarManualBlock
-from app.db.models.enums import InstanceStatus, ServiceStatus, ServiceType
+from app.db.repositories.service_instance import (
+    select_public_calendar_blocker_session_slots,
+)
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 CalendarBlockPeriod = Literal["am", "pm", "both"]
 
@@ -27,6 +31,10 @@ _PM_END_HOUR = 18
 
 _PURPOSE_CONSULTATION_BOOKING = "consultation_booking"
 
+_ALLOWED_PUBLIC_BLOCKER_PURPOSES: frozenset[str] = frozenset(
+    {_PURPOSE_CONSULTATION_BOOKING}
+)
+
 
 def resolve_calendar_blockers_wall_timezone() -> str:
     raw = os.getenv(_ENV_CALENDAR_BLOCKERS_WALL_TIMEZONE, "").strip()
@@ -35,6 +43,10 @@ def resolve_calendar_blockers_wall_timezone() -> str:
 
 def consultation_booking_purpose() -> str:
     return _PURPOSE_CONSULTATION_BOOKING
+
+
+def is_public_blockers_purpose_allowed(purpose: str) -> bool:
+    return purpose.strip().lower() in _ALLOWED_PUBLIC_BLOCKER_PURPOSES
 
 
 def _ymd_in_zone(instant: datetime, zone: ZoneInfo) -> str:
@@ -131,28 +143,9 @@ def merge_calendar_blockers_for_purpose(
     range_start_utc = range_start_local.astimezone(UTC)
     range_end_utc = range_end_local.astimezone(UTC)
 
-    slot_stmt = (
-        select(InstanceSessionSlot.starts_at, InstanceSessionSlot.ends_at)
-        .join(ServiceInstance, InstanceSessionSlot.instance_id == ServiceInstance.id)
-        .join(Service, ServiceInstance.service_id == Service.id)
-        .where(
-            Service.service_type.in_((ServiceType.EVENT, ServiceType.TRAINING_COURSE))
-        )
-        .where(Service.status == ServiceStatus.PUBLISHED)
-        .where(ServiceInstance.status != InstanceStatus.CANCELLED)
-        .where(
-            ServiceInstance.status.in_(
-                [
-                    InstanceStatus.SCHEDULED,
-                    InstanceStatus.OPEN,
-                    InstanceStatus.FULL,
-                    InstanceStatus.IN_PROGRESS,
-                    InstanceStatus.COMPLETED,
-                ]
-            )
-        )
-        .where(InstanceSessionSlot.starts_at < range_end_utc)
-        .where(InstanceSessionSlot.ends_at > range_start_utc)
+    slot_stmt = select_public_calendar_blocker_session_slots(
+        range_start_utc=range_start_utc,
+        range_end_utc=range_end_utc,
     )
     for starts_at, ends_at in session.execute(slot_stmt).all():
         if starts_at is None or ends_at is None:
@@ -186,52 +179,172 @@ def merge_calendar_blockers_for_purpose(
     return _merge_period_map(by_date)
 
 
-def consultation_slot_blocked(
+def half_day_period_for_consultation_iso(
     *,
-    primary_start_iso: str,
-    purpose: str,
-    session: Session,
-) -> bool:
-    """True when the consultation primary session instant falls on a blocked half-day."""
+    start_iso: str,
+    wall_zone: str | None = None,
+) -> tuple[date, CalendarBlockPeriod] | None:
+    """Map an ISO instant to (local calendar date, am|pm) for consultation windows.
+
+    AM = local hour in [09:00, 12:00); PM = [14:00, 18:00). The gap 12:00–14:00
+    and outside 09–18 are invalid (returns None).
+    """
     try:
-        start = datetime.fromisoformat(primary_start_iso.replace("Z", "+00:00"))
+        start = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
     except ValueError:
-        return True
+        logger.info(
+            "consultation_slot_classification_failed",
+            extra={"reason": "iso_parse_error"},
+        )
+        return None
     if start.tzinfo is None:
         start = start.replace(tzinfo=UTC)
     else:
         start = start.astimezone(UTC)
 
-    zone = ZoneInfo(resolve_calendar_blockers_wall_timezone())
-    ymd = _ymd_in_zone(start, zone)
+    zone_name = (wall_zone or "").strip() or resolve_calendar_blockers_wall_timezone()
+    try:
+        zone = ZoneInfo(zone_name)
+    except Exception:
+        logger.warning(
+            "consultation_slot_classification_failed",
+            extra={"reason": "invalid_wall_zone", "wall_zone": zone_name},
+        )
+        return None
+
+    local = start.astimezone(zone)
+    ymd = local.strftime("%Y-%m-%d")
     try:
         y, m, d_part = (int(ymd[0:4]), int(ymd[5:7]), int(ymd[8:10]))
         day_local = date(y, m, d_part)
     except (ValueError, IndexError):
-        return True
+        return None
 
-    hour = start.astimezone(zone).hour
-    minute = start.astimezone(zone).minute
-    second = start.astimezone(zone).second
-    if hour == _AM_START_HOUR and minute == 0 and second == 0:
-        period: CalendarBlockPeriod = "am"
-    elif hour == _PM_START_HOUR and minute == 0 and second == 0:
-        period = "pm"
-    else:
-        return True
+    hour = local.hour
+    minute = local.minute
+    second = local.second
+    if second != 0 or minute != 0:
+        logger.info(
+            "consultation_slot_classification_failed",
+            extra={"reason": "non_zero_subminute", "ymd": ymd},
+        )
+        return None
 
+    if _AM_START_HOUR <= hour < _AM_END_HOUR:
+        return day_local, "am"
+    if _PM_START_HOUR <= hour < _PM_END_HOUR:
+        return day_local, "pm"
+
+    logger.info(
+        "consultation_slot_classification_failed",
+        extra={
+            "reason": "outside_am_pm_windows",
+            "ymd": ymd,
+            "hour": hour,
+        },
+    )
+    return None
+
+
+def _blocked_ymd_period_set(
+    session: Session,
+    *,
+    purpose: str,
+    from_date: date,
+    to_date: date,
+) -> set[tuple[str, CalendarBlockPeriod]]:
+    """Single merge for a date range; returns {(ymd, am|pm)} blocked half-days."""
     blockers = merge_calendar_blockers_for_purpose(
+        session,
+        purpose=purpose,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    out: set[tuple[str, CalendarBlockPeriod]] = set()
+    for b in blockers:
+        d = str(b.get("date") or "")
+        p = str(b.get("period") or "")
+        if not d:
+            continue
+        if p == "both":
+            out.add((d, "am"))
+            out.add((d, "pm"))
+        elif p in ("am", "pm"):
+            out.add((d, p))
+    return out
+
+
+def consultation_datetime_blocked(
+    *,
+    start_iso: str,
+    purpose: str,
+    session: Session,
+) -> bool:
+    """True when the instant maps to a blocked consultation half-day."""
+    classified = half_day_period_for_consultation_iso(start_iso=start_iso)
+    if classified is None:
+        return True
+    day_local, period = classified
+    blocked = _blocked_ymd_period_set(
         session,
         purpose=purpose,
         from_date=day_local,
         to_date=day_local,
     )
-    for b in blockers:
-        if b.get("date") != ymd:
-            continue
-        p = str(b.get("period") or "")
-        if p == "both":
-            return True
-        if p == period:
+    return (day_local.isoformat(), period) in blocked
+
+
+def consultation_reservation_has_blocked_slot(
+    *,
+    session: Session,
+    purpose: str,
+    primary_start_iso: str | None,
+    session_slots: list[dict[str, str]] | None,
+) -> bool:
+    """True if any primary or session slot start maps to a blocked half-day."""
+    starts: list[str] = []
+    if primary_start_iso and str(primary_start_iso).strip():
+        starts.append(str(primary_start_iso).strip())
+    for row in session_slots or []:
+        s = row.get("start_iso")
+        if isinstance(s, str) and s.strip():
+            starts.append(s.strip())
+    for iso in starts:
+        if consultation_datetime_blocked(
+            start_iso=iso, purpose=purpose, session=session
+        ):
+            logger.info(
+                "consultation_reservation_blocked_slot",
+                extra={"reason": "blocked_half_day"},
+            )
             return True
     return False
+
+
+def validate_session_slot_chronology(
+    session_slots: list[dict[str, str]] | None,
+) -> str | None:
+    """Return error message key if any slot has end before or equal to start."""
+    for row in session_slots or []:
+        start_s = row.get("start_iso")
+        end_s = row.get("end_iso")
+        if not isinstance(start_s, str) or not start_s.strip():
+            continue
+        if not isinstance(end_s, str) or not end_s.strip():
+            continue
+        try:
+            s0 = datetime.fromisoformat(start_s.strip().replace("Z", "+00:00"))
+            s1 = datetime.fromisoformat(end_s.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return "invalid_session_slot_iso"
+        if s0.tzinfo is None:
+            s0 = s0.replace(tzinfo=UTC)
+        else:
+            s0 = s0.astimezone(UTC)
+        if s1.tzinfo is None:
+            s1 = s1.replace(tzinfo=UTC)
+        else:
+            s1 = s1.astimezone(UTC)
+        if s1 <= s0:
+            return "session_slot_end_before_start"
+    return None

--- a/backend/src/app/services/calendar_blockers.py
+++ b/backend/src/app/services/calendar_blockers.py
@@ -1,0 +1,233 @@
+"""Merge manual calendar blocks with session-derived half-day blockers."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Literal
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models import InstanceSessionSlot, Service, ServiceInstance
+from app.db.models.calendar_manual_block import CalendarManualBlock
+from app.db.models.enums import InstanceStatus, ServiceStatus, ServiceType
+
+CalendarBlockPeriod = Literal["am", "pm", "both"]
+
+_ENV_CALENDAR_BLOCKERS_WALL_TIMEZONE = "CALENDAR_BLOCKERS_WALL_TIMEZONE"
+_DEFAULT_WALL_TIMEZONE = "Asia/Hong_Kong"
+
+# Match public consultation picker nominal windows (local wall clock).
+_AM_START_HOUR = 9
+_AM_END_HOUR = 12
+_PM_START_HOUR = 14
+_PM_END_HOUR = 18
+
+_PURPOSE_CONSULTATION_BOOKING = "consultation_booking"
+
+
+def resolve_calendar_blockers_wall_timezone() -> str:
+    raw = os.getenv(_ENV_CALENDAR_BLOCKERS_WALL_TIMEZONE, "").strip()
+    return raw or _DEFAULT_WALL_TIMEZONE
+
+
+def consultation_booking_purpose() -> str:
+    return _PURPOSE_CONSULTATION_BOOKING
+
+
+def _ymd_in_zone(instant: datetime, zone: ZoneInfo) -> str:
+    return instant.astimezone(zone).strftime("%Y-%m-%d")
+
+
+def _window_utc_for_local_hours(
+    ymd: str,
+    *,
+    start_hour: int,
+    end_hour: int,
+    zone: ZoneInfo,
+) -> tuple[datetime, datetime] | None:
+    try:
+        y, m, d_part = (int(ymd[0:4]), int(ymd[5:7]), int(ymd[8:10]))
+    except (TypeError, ValueError, IndexError):
+        return None
+    try:
+        day_local = date(y, m, d_part)
+    except ValueError:
+        return None
+    start_local = datetime.combine(day_local, time(hour=start_hour, minute=0), tzinfo=zone)
+    end_local = datetime.combine(day_local, time(hour=end_hour, minute=0), tzinfo=zone)
+    if end_local <= start_local:
+        return None
+    return start_local.astimezone(UTC), end_local.astimezone(UTC)
+
+
+def _intervals_overlap(a0: datetime, a1: datetime, b0: datetime, b1: datetime) -> bool:
+    return a0 < b1 and b0 < a1
+
+
+def _merge_period_map(
+    by_date: dict[str, dict[str, bool]],
+) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for ymd in sorted(by_date.keys()):
+        row = by_date[ymd]
+        am = bool(row.get("am"))
+        pm = bool(row.get("pm"))
+        if am and pm:
+            out.append({"date": ymd, "period": "both"})
+        elif am:
+            out.append({"date": ymd, "period": "am"})
+        elif pm:
+            out.append({"date": ymd, "period": "pm"})
+    return out
+
+
+def _apply_period(
+    by_date: dict[str, dict[str, bool]],
+    ymd: str,
+    period: str,
+) -> None:
+    row = by_date.setdefault(ymd, {"am": False, "pm": False})
+    if period == "both":
+        row["am"] = True
+        row["pm"] = True
+    elif period == "am":
+        row["am"] = True
+    elif period == "pm":
+        row["pm"] = True
+
+
+def merge_calendar_blockers_for_purpose(
+    session: Session,
+    *,
+    purpose: str,
+    from_date: date,
+    to_date: date,
+) -> list[dict[str, str]]:
+    """Return sorted ``{date, period}`` blockers for API consumers."""
+    zone = ZoneInfo(resolve_calendar_blockers_wall_timezone())
+    by_date: dict[str, dict[str, bool]] = {}
+
+    repo_rows = (
+        session.execute(
+            select(CalendarManualBlock)
+            .where(CalendarManualBlock.purpose == purpose)
+            .where(CalendarManualBlock.block_date >= from_date)
+            .where(CalendarManualBlock.block_date <= to_date)
+        )
+        .scalars()
+        .all()
+    )
+    for row in repo_rows:
+        ymd = row.block_date.isoformat()
+        _apply_period(by_date, ymd, row.period)
+
+    range_start_local = datetime.combine(from_date, time.min, tzinfo=zone)
+    range_end_local = datetime.combine(to_date, time.max, tzinfo=zone)
+    range_start_utc = range_start_local.astimezone(UTC)
+    range_end_utc = range_end_local.astimezone(UTC)
+
+    slot_stmt = (
+        select(InstanceSessionSlot.starts_at, InstanceSessionSlot.ends_at)
+        .join(ServiceInstance, InstanceSessionSlot.instance_id == ServiceInstance.id)
+        .join(Service, ServiceInstance.service_id == Service.id)
+        .where(Service.service_type.in_((ServiceType.EVENT, ServiceType.TRAINING_COURSE)))
+        .where(Service.status == ServiceStatus.PUBLISHED)
+        .where(ServiceInstance.status != InstanceStatus.CANCELLED)
+        .where(
+            ServiceInstance.status.in_(
+                [
+                    InstanceStatus.SCHEDULED,
+                    InstanceStatus.OPEN,
+                    InstanceStatus.FULL,
+                    InstanceStatus.IN_PROGRESS,
+                    InstanceStatus.COMPLETED,
+                ]
+            )
+        )
+        .where(InstanceSessionSlot.starts_at < range_end_utc)
+        .where(InstanceSessionSlot.ends_at > range_start_utc)
+    )
+    for starts_at, ends_at in session.execute(slot_stmt).all():
+        if starts_at is None or ends_at is None:
+            continue
+        start_u = starts_at if starts_at.tzinfo else starts_at.replace(tzinfo=UTC)
+        end_u = ends_at if ends_at.tzinfo else ends_at.replace(tzinfo=UTC)
+        d_start = start_u.astimezone(zone).date()
+        d_end = end_u.astimezone(zone).date()
+        cur = max(d_start, from_date)
+        end_d = min(d_end, to_date)
+        while cur <= end_d:
+            ymd = cur.isoformat()
+            am_win = _window_utc_for_local_hours(
+                ymd,
+                start_hour=_AM_START_HOUR,
+                end_hour=_AM_END_HOUR,
+                zone=zone,
+            )
+            pm_win = _window_utc_for_local_hours(
+                ymd,
+                start_hour=_PM_START_HOUR,
+                end_hour=_PM_END_HOUR,
+                zone=zone,
+            )
+            if am_win and _intervals_overlap(start_u, end_u, am_win[0], am_win[1]):
+                _apply_period(by_date, ymd, "am")
+            if pm_win and _intervals_overlap(start_u, end_u, pm_win[0], pm_win[1]):
+                _apply_period(by_date, ymd, "pm")
+            cur += timedelta(days=1)
+
+    return _merge_period_map(by_date)
+
+
+def consultation_slot_blocked(
+    *,
+    primary_start_iso: str,
+    purpose: str,
+    session: Session,
+) -> bool:
+    """True when the consultation primary session instant falls on a blocked half-day."""
+    try:
+        start = datetime.fromisoformat(primary_start_iso.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=UTC)
+    else:
+        start = start.astimezone(UTC)
+
+    zone = ZoneInfo(resolve_calendar_blockers_wall_timezone())
+    ymd = _ymd_in_zone(start, zone)
+    try:
+        y, m, d_part = (int(ymd[0:4]), int(ymd[5:7]), int(ymd[8:10]))
+        day_local = date(y, m, d_part)
+    except (ValueError, IndexError):
+        return True
+
+    hour = start.astimezone(zone).hour
+    minute = start.astimezone(zone).minute
+    second = start.astimezone(zone).second
+    if hour == _AM_START_HOUR and minute == 0 and second == 0:
+        period: CalendarBlockPeriod = "am"
+    elif hour == _PM_START_HOUR and minute == 0 and second == 0:
+        period = "pm"
+    else:
+        return True
+
+    blockers = merge_calendar_blockers_for_purpose(
+        session,
+        purpose=purpose,
+        from_date=day_local,
+        to_date=day_local,
+    )
+    for b in blockers:
+        if b.get("date") != ymd:
+            continue
+        p = str(b.get("period") or "")
+        if p == "both":
+            return True
+        if p == period:
+            return True
+    return False

--- a/backend/src/app/services/calendar_blockers.py
+++ b/backend/src/app/services/calendar_blockers.py
@@ -269,8 +269,10 @@ def _blocked_ymd_period_set(
         if p == "both":
             out.add((d, "am"))
             out.add((d, "pm"))
-        elif p in ("am", "pm"):
-            out.add((d, p))
+        elif p == "am":
+            out.add((d, "am"))
+        elif p == "pm":
+            out.add((d, "pm"))
     return out
 
 

--- a/backend/src/app/services/calendar_blockers.py
+++ b/backend/src/app/services/calendar_blockers.py
@@ -7,13 +7,16 @@ from datetime import UTC, date, datetime, time, timedelta
 from typing import Literal
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import select
+from sqlalchemy import and_, exists, or_, select
 from sqlalchemy.orm import Session
 
 from app.db.models.calendar_manual_block import CalendarManualBlock
+from app.db.models import InstanceSessionSlot, Service, ServiceInstance
 from app.db.repositories.service_instance import (
+    public_calendar_blocker_instance_predicates,
     select_public_calendar_blocker_session_slots,
 )
+from app.exceptions import ValidationError
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -179,24 +182,29 @@ def merge_calendar_blockers_for_purpose(
     return _merge_period_map(by_date)
 
 
-def half_day_period_for_consultation_iso(
+def classify_consultation_start_local_half_day(
     *,
     start_iso: str,
     wall_zone: str | None = None,
-) -> tuple[date, CalendarBlockPeriod] | None:
-    """Map an ISO instant to (local calendar date, am|pm) for consultation windows.
+    field: str = "primarySessionStartIso",
+) -> tuple[date, CalendarBlockPeriod]:
+    """Map an ISO instant to (local calendar date, am|pm) using wall-clock hour rules.
 
-    AM = local hour in [09:00, 12:00); PM = [14:00, 18:00). The gap 12:00–14:00
-    and outside 09–18 are invalid (returns None).
+    Morning = local hour before 12; afternoon = local hour 14 or later.
+    Local hours 12--13 (noon gap) and invalid timestamps raise ``ValidationError``.
     """
     try:
         start = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
     except ValueError:
         logger.info(
             "consultation_slot_classification_failed",
-            extra={"reason": "iso_parse_error"},
+            extra={"reason": "iso_parse_error", "field": field},
         )
-        return None
+        raise ValidationError(
+            "Invalid consultation session start time format.",
+            field=field,
+        ) from None
+
     if start.tzinfo is None:
         start = start.replace(tzinfo=UTC)
     else:
@@ -208,9 +216,16 @@ def half_day_period_for_consultation_iso(
     except Exception:
         logger.warning(
             "consultation_slot_classification_failed",
-            extra={"reason": "invalid_wall_zone", "wall_zone": zone_name},
+            extra={
+                "reason": "invalid_wall_zone",
+                "wall_zone": zone_name,
+                "field": field,
+            },
         )
-        return None
+        raise ValidationError(
+            "Consultation booking time could not be interpreted (invalid timezone).",
+            field=field,
+        ) from None
 
     local = start.astimezone(zone)
     ymd = local.strftime("%Y-%m-%d")
@@ -218,109 +233,169 @@ def half_day_period_for_consultation_iso(
         y, m, d_part = (int(ymd[0:4]), int(ymd[5:7]), int(ymd[8:10]))
         day_local = date(y, m, d_part)
     except (ValueError, IndexError):
-        return None
-
-    hour = local.hour
-    minute = local.minute
-    second = local.second
-    if second != 0 or minute != 0:
         logger.info(
             "consultation_slot_classification_failed",
-            extra={"reason": "non_zero_subminute", "ymd": ymd},
+            extra={"reason": "invalid_local_date", "field": field},
         )
-        return None
+        raise ValidationError(
+            "Invalid consultation session start time format.",
+            field=field,
+        ) from None
 
-    if _AM_START_HOUR <= hour < _AM_END_HOUR:
-        return day_local, "am"
-    if _PM_START_HOUR <= hour < _PM_END_HOUR:
-        return day_local, "pm"
+    hour = local.hour
+    if hour < 12:
+        period: CalendarBlockPeriod = "am"
+    elif hour >= 14:
+        period = "pm"
+    else:
+        logger.info(
+            "consultation_slot_classification_failed",
+            extra={
+                "reason": "noon_gap_not_bookable",
+                "field": field,
+                "ymd": ymd,
+                "hour": hour,
+            },
+        )
+        raise ValidationError(
+            "Consultation booking times must be in the morning (before noon) or "
+            "afternoon (2pm or later) in the site calendar timezone.",
+            field=field,
+        )
 
-    logger.info(
-        "consultation_slot_classification_failed",
-        extra={
-            "reason": "outside_am_pm_windows",
-            "ymd": ymd,
-            "hour": hour,
-        },
-    )
-    return None
-
-
-def _blocked_ymd_period_set(
-    session: Session,
-    *,
-    purpose: str,
-    from_date: date,
-    to_date: date,
-) -> set[tuple[str, CalendarBlockPeriod]]:
-    """Single merge for a date range; returns {(ymd, am|pm)} blocked half-days."""
-    blockers = merge_calendar_blockers_for_purpose(
-        session,
-        purpose=purpose,
-        from_date=from_date,
-        to_date=to_date,
-    )
-    out: set[tuple[str, CalendarBlockPeriod]] = set()
-    for b in blockers:
-        d = str(b.get("date") or "")
-        p = str(b.get("period") or "")
-        if not d:
-            continue
-        if p == "both":
-            out.add((d, "am"))
-            out.add((d, "pm"))
-        elif p == "am":
-            out.add((d, "am"))
-        elif p == "pm":
-            out.add((d, "pm"))
-    return out
+    return day_local, period
 
 
-def consultation_datetime_blocked(
+def half_day_period_for_consultation_iso(
     *,
     start_iso: str,
-    purpose: str,
+    wall_zone: str | None = None,
+) -> tuple[date, CalendarBlockPeriod] | None:
+    """Best-effort map for read paths; returns ``None`` when classification fails."""
+    try:
+        return classify_consultation_start_local_half_day(
+            start_iso=start_iso, wall_zone=wall_zone
+        )
+    except ValidationError:
+        return None
+
+
+def _manual_block_exists_for_half_day(
     session: Session,
+    *,
+    purpose: str,
+    day_local: date,
+    period: CalendarBlockPeriod,
 ) -> bool:
-    """True when the instant maps to a blocked consultation half-day."""
-    classified = half_day_period_for_consultation_iso(start_iso=start_iso)
-    if classified is None:
-        return True
-    day_local, period = classified
-    blocked = _blocked_ymd_period_set(
-        session,
-        purpose=purpose,
-        from_date=day_local,
-        to_date=day_local,
+    """True when a manual row blocks this calendar half-day."""
+    if period == "am":
+        half_cond = or_(
+            CalendarManualBlock.period == "am",
+            CalendarManualBlock.period == "both",
+        )
+    else:
+        half_cond = or_(
+            CalendarManualBlock.period == "pm",
+            CalendarManualBlock.period == "both",
+        )
+    stmt = select(
+        exists().where(
+            CalendarManualBlock.purpose == purpose,
+            CalendarManualBlock.block_date == day_local,
+            half_cond,
+        )
     )
-    return (day_local.isoformat(), period) in blocked
+    return bool(session.execute(stmt).scalar())
 
 
-def consultation_reservation_has_blocked_slot(
+def _session_blocks_half_day(
+    session: Session,
+    *,
+    day_local: date,
+    period: CalendarBlockPeriod,
+) -> bool:
+    """True when any eligible published session slot intersects the nominal AM/PM window."""
+    zone = ZoneInfo(resolve_calendar_blockers_wall_timezone())
+    ymd = day_local.isoformat()
+    if period == "am":
+        win = _window_utc_for_local_hours(
+            ymd,
+            start_hour=_AM_START_HOUR,
+            end_hour=_AM_END_HOUR,
+            zone=zone,
+        )
+    else:
+        win = _window_utc_for_local_hours(
+            ymd,
+            start_hour=_PM_START_HOUR,
+            end_hour=_PM_END_HOUR,
+            zone=zone,
+        )
+    if win is None:
+        return False
+    w0, w1 = win
+    overlap = and_(
+        InstanceSessionSlot.starts_at < w1,
+        InstanceSessionSlot.ends_at > w0,
+    )
+    stmt = (
+        select(InstanceSessionSlot.id)
+        .join(ServiceInstance, InstanceSessionSlot.instance_id == ServiceInstance.id)
+        .join(Service, ServiceInstance.service_id == Service.id)
+        .where(and_(*public_calendar_blocker_instance_predicates()))
+        .where(overlap)
+        .limit(1)
+    )
+    return session.execute(stmt).first() is not None
+
+
+def is_consultation_half_day_blocked(
+    session: Session,
+    *,
+    purpose: str,
+    day_local: date,
+    period: CalendarBlockPeriod,
+) -> bool:
+    """Whether the given local calendar half-day is blocked (manual ∪ session-derived)."""
+    if _manual_block_exists_for_half_day(
+        session, purpose=purpose, day_local=day_local, period=period
+    ):
+        return True
+    return _session_blocks_half_day(session, day_local=day_local, period=period)
+
+
+def raise_if_consultation_reservation_blocked(
     *,
     session: Session,
     purpose: str,
     primary_start_iso: str | None,
     session_slots: list[dict[str, str]] | None,
-) -> bool:
-    """True if any primary or session slot start maps to a blocked half-day."""
-    starts: list[str] = []
+) -> None:
+    """Raise ``ValidationError`` if any slot maps to a blocked half-day or invalid time."""
+    starts: list[tuple[str, str]] = []
     if primary_start_iso and str(primary_start_iso).strip():
-        starts.append(str(primary_start_iso).strip())
-    for row in session_slots or []:
+        starts.append((str(primary_start_iso).strip(), "primarySessionStartIso"))
+    for idx, row in enumerate(session_slots or []):
         s = row.get("start_iso")
         if isinstance(s, str) and s.strip():
-            starts.append(s.strip())
-    for iso in starts:
-        if consultation_datetime_blocked(
-            start_iso=iso, purpose=purpose, session=session
+            starts.append((s.strip(), f"sessionSlots[{idx}].startIso"))
+
+    for iso, field in starts:
+        day_local, period = classify_consultation_start_local_half_day(
+            start_iso=iso, field=field
+        )
+        if is_consultation_half_day_blocked(
+            session, purpose=purpose, day_local=day_local, period=period
         ):
             logger.info(
                 "consultation_reservation_blocked_slot",
-                extra={"reason": "blocked_half_day"},
+                extra={"reason": "blocked_half_day", "field": field},
             )
-            return True
-    return False
+            raise ValidationError(
+                "The selected consultation time is no longer available. "
+                "Please pick another slot.",
+                field=field,
+            )
 
 
 def validate_session_slot_chronology(

--- a/backend/src/app/services/calendar_blockers.py
+++ b/backend/src/app/services/calendar_blockers.py
@@ -56,7 +56,9 @@ def _window_utc_for_local_hours(
         day_local = date(y, m, d_part)
     except ValueError:
         return None
-    start_local = datetime.combine(day_local, time(hour=start_hour, minute=0), tzinfo=zone)
+    start_local = datetime.combine(
+        day_local, time(hour=start_hour, minute=0), tzinfo=zone
+    )
     end_local = datetime.combine(day_local, time(hour=end_hour, minute=0), tzinfo=zone)
     if end_local <= start_local:
         return None
@@ -133,7 +135,9 @@ def merge_calendar_blockers_for_purpose(
         select(InstanceSessionSlot.starts_at, InstanceSessionSlot.ends_at)
         .join(ServiceInstance, InstanceSessionSlot.instance_id == ServiceInstance.id)
         .join(Service, ServiceInstance.service_id == Service.id)
-        .where(Service.service_type.in_((ServiceType.EVENT, ServiceType.TRAINING_COURSE)))
+        .where(
+            Service.service_type.in_((ServiceType.EVENT, ServiceType.TRAINING_COURSE))
+        )
         .where(Service.status == ServiceStatus.PUBLISHED)
         .where(ServiceInstance.status != InstanceStatus.CANCELLED)
         .where(

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -24,6 +24,8 @@ info:
     - `PATCH|DELETE /v1/admin/services/{id}/instances/{instanceId}/enrollments/{enrollmentId}`
     - `GET|POST /v1/admin/discount-codes`
     - `PUT|DELETE /v1/admin/discount-codes/{id}`
+    - `GET|POST /v1/admin/calendar/manual-blocks` (GET requires `purpose`, `from`, `to`)
+    - `GET|PATCH|DELETE /v1/admin/calendar/manual-blocks/{id}`
     - `GET|POST /v1/admin/tags` (optional `include_archived`, `archived_only`)
     - `GET|PATCH|DELETE /v1/admin/tags/{id}` (DELETE returns JSON with `deleted` and `usage_count`)
     - `GET /v1/admin/contacts/tags`
@@ -1590,6 +1592,141 @@ paths:
                 $ref: "#/components/schemas/DiscountCodeResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/calendar/manual-blocks:
+    get:
+      summary: List manual calendar blocks for a purpose
+      description: |
+        Returns **manual** rows from `calendar_manual_blocks` only (session-derived blockers
+        are exposed on `GET /v1/calendar/blockers`). Current release supports `purpose=consultation_booking` only.
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: purpose
+          in: query
+          required: true
+          schema:
+            type: string
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:[-_][a-z0-9]+)*$
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          description: Manual block list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminCalendarManualBlockListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      summary: Create manual calendar block
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAdminCalendarManualBlockRequest"
+      responses:
+        "201":
+          description: Block created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminCalendarManualBlockResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Duplicate purpose/date/period.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/admin/calendar/manual-blocks/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get manual calendar block by id
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Block detail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminCalendarManualBlockResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      summary: Update manual calendar block
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAdminCalendarManualBlockRequest"
+      responses:
+        "200":
+          description: Updated block.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminCalendarManualBlockResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Duplicate purpose/date/period.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      summary: Delete manual calendar block
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminCalendarManualBlockDeleteResponse"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
@@ -5350,6 +5487,98 @@ components:
               description: >
                 True for reserved asset-pipeline tags (`expense_attachment`, `client_document`).
                 These cannot be renamed, archived, or deleted via the admin API.
+    AdminCalendarManualBlockRef:
+      type: object
+      required:
+        - id
+        - purpose
+        - block_date
+        - period
+      properties:
+        id:
+          type: string
+          format: uuid
+        purpose:
+          type: string
+          maxLength: 64
+        block_date:
+          type: string
+          format: date
+        period:
+          type: string
+          enum: [am, pm, both]
+        note:
+          type: string
+          nullable: true
+          maxLength: 500
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+    AdminCalendarManualBlockListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminCalendarManualBlockRef"
+    AdminCalendarManualBlockResponse:
+      type: object
+      required:
+        - block
+      properties:
+        block:
+          $ref: "#/components/schemas/AdminCalendarManualBlockRef"
+    AdminCalendarManualBlockDeleteResponse:
+      type: object
+      required:
+        - deleted
+      properties:
+        deleted:
+          type: boolean
+    CreateAdminCalendarManualBlockRequest:
+      type: object
+      required:
+        - purpose
+        - blockDate
+        - period
+      properties:
+        purpose:
+          type: string
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:[-_][a-z0-9]+)*$
+        blockDate:
+          type: string
+          format: date
+        period:
+          type: string
+          enum: [am, pm, both]
+        note:
+          type: string
+          nullable: true
+          maxLength: 500
+    UpdateAdminCalendarManualBlockRequest:
+      type: object
+      required:
+        - blockDate
+        - period
+      properties:
+        blockDate:
+          type: string
+          format: date
+        period:
+          type: string
+          enum: [am, pm, both]
+        note:
+          type: string
+          nullable: true
+          maxLength: 500
     AdminTagDeleteResponse:
       type: object
       required:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -5519,6 +5519,16 @@ components:
           type: string
           format: date-time
           nullable: true
+        created_by:
+          type: string
+          nullable: true
+          maxLength: 128
+          description: Cognito subject of the admin who created the row (when known).
+        updated_by:
+          type: string
+          nullable: true
+          maxLength: 128
+          description: Cognito subject of the admin who last updated the row (when known).
     AdminCalendarManualBlockListResponse:
       type: object
       required:
@@ -5565,9 +5575,9 @@ components:
           maxLength: 500
     UpdateAdminCalendarManualBlockRequest:
       type: object
-      required:
-        - blockDate
-        - period
+      description: >
+        Partial update: include only fields to change. Omitted fields are left unchanged.
+        At least one of `blockDate`, `period`, or `note` must be present.
       properties:
         blockDate:
           type: string

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -441,8 +441,9 @@ paths:
         Optional `from` / `to` (`YYYY-MM-DD`) bound the response window (defaults: `from=today`,
         `to=from+120 days`, capped to 120 days). Invalid dates fall back to defaults.
 
-        **Cache keys:** The public website aligns `from` to the Monday of the current local week
-        and sets `to` = `from + 119` days so the query string stays stable for seven days at a time
+        **Cache keys:** The public website aligns `from` to the Monday of the current week in
+        the site IANA zone (`Asia/Hong_Kong`, same as the consultation picker) and sets
+        `to` = `from + 119` days so the query string stays stable for seven days at a time
         (still within the 120-day cap).
       security:
         - ApiKeyAuth: []

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -474,8 +474,10 @@ paths:
               schema:
                 type: string
               description: >
-                `public, max-age=60, s-maxage=300, stale-while-revalidate=600` for
-                CloudFront edge caching on `/www/*` (TTL capped by cache policy).
+                For `purpose=consultation_booking`, `no-store` so manual blockers are not
+                edge-cached. For other supported purposes, the same value as other public
+                cacheable GETs: `public, max-age=60, s-maxage=300, stale-while-revalidate=600`
+                (TTL capped by cache policy on `/www/*`).
           content:
             application/json:
               schema:
@@ -524,8 +526,10 @@ paths:
               schema:
                 type: string
               description: >
-                `public, max-age=60, s-maxage=300, stale-while-revalidate=600` for
-                CloudFront edge caching on `/www/*` (TTL capped by cache policy).
+                For `purpose=consultation_booking`, `no-store` so manual blockers are not
+                edge-cached. For other supported purposes, the same value as other public
+                cacheable GETs: `public, max-age=60, s-maxage=300, stale-while-revalidate=600`
+                (TTL capped by cache policy on `/www/*`).
           content:
             application/json:
               schema:

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -463,7 +463,7 @@ paths:
           schema:
             type: string
             format: date
-          description: Inclusive range start (`YYYY-MM-DD`). Defaults to today (UTC date).
+          description: Inclusive range start (`YYYY-MM-DD`). Defaults to today in the server wall-clock zone (`CALENDAR_BLOCKERS_WALL_TIMEZONE`, default `Asia/Hong_Kong`) when omitted.
         - name: to
           in: query
           required: false

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -440,6 +440,10 @@ paths:
 
         Optional `from` / `to` (`YYYY-MM-DD`) bound the response window (defaults: `from=today`,
         `to=from+120 days`, capped to 120 days). Invalid dates fall back to defaults.
+
+        **Cache keys:** The public website aligns `from` to the Monday of the current local week
+        and sets `to` = `from + 119` days so the query string stays stable for seven days at a time
+        (still within the 120-day cap).
       security:
         - ApiKeyAuth: []
       parameters:
@@ -1603,8 +1607,12 @@ components:
           maxLength: 50
           description: >
             Required when `bookingSystem` is `consultation-booking` (home-visit slot start in
-            ISO-8601). Must fall on a non-blocked half-day for `purpose=consultation_booking`
-            per `GET /v1/calendar/blockers`.
+            ISO-8601). Interpreted in `CALENDAR_BLOCKERS_WALL_TIMEZONE` (default `Asia/Hong_Kong`):
+            local wall-clock hour **before 12** counts as **morning (AM)**; hour **14 or later**
+            counts as **afternoon (PM)**. Local hours **12–13** (inclusive) are invalid and return
+            **400** on `POST /v1/reservations`. Each `sessionSlots[].startIso` (when present) uses
+            the same rule with field `sessionSlots[n].startIso`. Must not fall on a blocked
+            half-day for `purpose=consultation_booking` per `GET /v1/calendar/blockers`.
         primarySessionEndIso:
           type: string
           maxLength: 50
@@ -1621,6 +1629,10 @@ components:
               startIso:
                 type: string
                 maxLength: 50
+                description: >
+                  Same local half-day classification as `primarySessionStartIso` when
+                  `bookingSystem` is `consultation-booking` (morning before noon, afternoon from 2pm;
+                  noon–1pm local invalid).
               endIso:
                 type: string
                 maxLength: 50

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -16,6 +16,7 @@ info:
       `/v1/assets/free`).
     - Public free-asset listing for the website (`/v1/assets/free`, `/www/v1/assets/free`).
     - Public calendar feed (`/v1/calendar/public`, `/www/v1/calendar/public`).
+    - Public calendar blockers (`/v1/calendar/blockers`, `/www/v1/calendar/blockers`).
     - Media lead capture (`/v1/assets/free/request`, `/www/v1/assets/free/request`).
     - Public website endpoints consumed by `apps/public_www`, exposed via the
       CloudFront `/www/*` proxy allowlist in
@@ -413,6 +414,122 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PublicCalendarEventsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/PublicWebsiteCacheableGetNotFound"
+        "405":
+          $ref: "#/components/responses/PublicWebsiteCacheableGetMethodNotAllowed"
+
+  /v1/calendar/blockers:
+    get:
+      summary: List merged calendar blockers
+      description: |
+        Returns half-day **blockers** (`am`, `pm`, or `both` for a calendar date) for a
+        caller-defined `purpose`. Manual admin rows from `calendar_manual_blocks` are merged
+        with **session-derived** blocks from published **event** and **training_course**
+        `instance_session_slots` whose intervals intersect nominal local wall-clock windows
+        (09:00–12:00 blocks `am`, 14:00–18:00 blocks `pm`) in the server wall-clock zone
+        (`CALENDAR_BLOCKERS_WALL_TIMEZONE`, default `Asia/Hong_Kong`).
+
+        For `purpose=consultation_booking`, the merged list matches the public website
+        consultation date picker disable rules; `POST /v1/reservations` rejects
+        `consultation-booking` when `primarySessionStartIso` falls on a blocked half-day.
+
+        Optional `from` / `to` (`YYYY-MM-DD`) bound the response window (defaults: `from=today`,
+        `to=from+120 days`, capped to 120 days). Invalid dates fall back to defaults.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: purpose
+          in: query
+          required: true
+          schema:
+            type: string
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:[-_][a-z0-9]+)*$
+          description: >
+            Blocker namespace. Supported: `consultation_booking` (family consultation home-visit picker).
+        - name: from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Inclusive range start (`YYYY-MM-DD`). Defaults to today (UTC date).
+        - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Inclusive range end (`YYYY-MM-DD`). Defaults to `from` + 120 days (capped).
+      responses:
+        "200":
+          description: Blocker list response.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              description: >
+                `public, max-age=60, s-maxage=300, stale-while-revalidate=600` for
+                CloudFront edge caching on `/www/*` (TTL capped by cache policy).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicCalendarBlockersResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/PublicWebsiteCacheableGetNotFound"
+        "405":
+          $ref: "#/components/responses/PublicWebsiteCacheableGetMethodNotAllowed"
+
+  /www/v1/calendar/blockers:
+    get:
+      summary: List public website calendar blockers
+      description: |
+        Same as `GET /v1/calendar/blockers` for same-origin calls from `public_www`.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: purpose
+          in: query
+          required: true
+          schema:
+            type: string
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:[-_][a-z0-9]+)*$
+        - name: from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          description: Blocker list response.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              description: >
+                `public, max-age=60, s-maxage=300, stale-while-revalidate=600` for
+                CloudFront edge caching on `/www/*` (TTL capped by cache policy).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicCalendarBlockersResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -1218,6 +1335,49 @@ components:
             Deprecated alias of `events` for older clients. Prefer `events`.
           items:
             $ref: "#/components/schemas/PublicCalendarEvent"
+    PublicCalendarBlockerRow:
+      type: object
+      required:
+        - date
+        - period
+      properties:
+        date:
+          type: string
+          format: date
+          description: Calendar date in `YYYY-MM-DD` (wall-clock zone implied by `meta.wall_time_zone` for consultation purposes).
+        period:
+          type: string
+          enum: [am, pm, both]
+    PublicCalendarBlockersMeta:
+      type: object
+      required:
+        - purpose
+        - from
+        - to
+      properties:
+        purpose:
+          type: string
+        from:
+          type: string
+          format: date
+        to:
+          type: string
+          format: date
+        wall_time_zone:
+          type: string
+          description: Present for `purpose=consultation_booking` (IANA zone used for half-day windows).
+    PublicCalendarBlockersResponse:
+      type: object
+      required:
+        - blockers
+        - meta
+      properties:
+        blockers:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublicCalendarBlockerRow"
+        meta:
+          $ref: "#/components/schemas/PublicCalendarBlockersMeta"
     DiscountValidationRequest:
       type: object
       required:
@@ -1437,6 +1597,10 @@ components:
         primarySessionStartIso:
           type: string
           maxLength: 50
+          description: >
+            Required when `bookingSystem` is `consultation-booking` (home-visit slot start in
+            ISO-8601). Must fall on a non-blocked half-day for `purpose=consultation_booking`
+            per `GET /v1/calendar/blockers`.
         primarySessionEndIso:
           type: string
           maxLength: 50

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -463,15 +463,15 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | `/health` | GET | IAM | `HealthCheckFunction` | Health check |
 | `/v1/assets/free/request` | POST | None + API key | `EvolvesproutsAdminFunction` | Publishes `media_request.submitted` to SNS |
 | `/v1/calendar/public` | GET | None + API key | `EvolvesproutsAdminFunction` | Public event feed for `service_type=event` instances |
-| `/v1/calendar/blockers` | GET | None + API key | `EvolvesproutsAdminFunction` | Merged manual + session half-day blockers (`purpose` query); `purpose=consultation_booking` is `Cache-Control: no-store` on 200 |
+| `/v1/calendar/blockers` | GET | None + API key | `EvolvesproutsAdminFunction` | Merged blockers; `purpose` allowlist is `consultation_booking` only (400 otherwise); `purpose=consultation_booking` → `Cache-Control: no-store` on 200 |
 | `/v1/assets/free` | GET | None + API key | `EvolvesproutsAdminFunction` | Lists public `client_document`-tagged assets; optional `language` query |
 | `/v1/admin/geographic-areas` | GET | Admin Group | `EvolvesproutsAdminFunction` | Geographic area lookup for address selection |
 | `/v1/admin/locations` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/locations/{id}` | GET, PUT, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/users` | GET | Admin Group | `EvolvesproutsAdminFunction` | Assignee lookup for sales lead workflows |
 | `/v1/admin/tags` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | CRM tag catalog; GET supports `include_archived` and `archived_only` (mutually exclusive) |
-| `/v1/admin/calendar/manual-blocks` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | Manual calendar blocks; GET requires `purpose`, `from`, `to` |
-| `/v1/admin/calendar/manual-blocks/{id}` | GET, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | Manual block read/update/delete |
+| `/v1/admin/calendar/manual-blocks` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | Manual blocks; GET requires `purpose`, `from`, `to`; writes append `audit_log` rows |
+| `/v1/admin/calendar/manual-blocks/{id}` | GET, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | Manual block read/update/delete; PATCH/DELETE append `audit_log` rows |
 | `/v1/admin/tags/{id}` | GET, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | Tag detail/update; DELETE returns JSON with `deleted` and `usage_count` |
 | `/v1/admin/leads` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | Lead list/create |
 | `/v1/admin/leads/analytics` | GET | Admin Group | `EvolvesproutsAdminFunction` | Funnel analytics and KPI summary |

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -463,12 +463,15 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | `/health` | GET | IAM | `HealthCheckFunction` | Health check |
 | `/v1/assets/free/request` | POST | None + API key | `EvolvesproutsAdminFunction` | Publishes `media_request.submitted` to SNS |
 | `/v1/calendar/public` | GET | None + API key | `EvolvesproutsAdminFunction` | Public event feed for `service_type=event` instances |
+| `/v1/calendar/blockers` | GET | None + API key | `EvolvesproutsAdminFunction` | Merged manual + session half-day blockers (`purpose` query) |
 | `/v1/assets/free` | GET | None + API key | `EvolvesproutsAdminFunction` | Lists public `client_document`-tagged assets; optional `language` query |
 | `/v1/admin/geographic-areas` | GET | Admin Group | `EvolvesproutsAdminFunction` | Geographic area lookup for address selection |
 | `/v1/admin/locations` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/locations/{id}` | GET, PUT, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/users` | GET | Admin Group | `EvolvesproutsAdminFunction` | Assignee lookup for sales lead workflows |
 | `/v1/admin/tags` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | CRM tag catalog; GET supports `include_archived` and `archived_only` (mutually exclusive) |
+| `/v1/admin/calendar/manual-blocks` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | Manual calendar blocks; GET requires `purpose`, `from`, `to` |
+| `/v1/admin/calendar/manual-blocks/{id}` | GET, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | Manual block read/update/delete |
 | `/v1/admin/tags/{id}` | GET, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | Tag detail/update; DELETE returns JSON with `deleted` and `usage_count` |
 | `/v1/admin/leads` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | Lead list/create |
 | `/v1/admin/leads/analytics` | GET | Admin Group | `EvolvesproutsAdminFunction` | Funnel analytics and KPI summary |

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -463,7 +463,7 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | `/health` | GET | IAM | `HealthCheckFunction` | Health check |
 | `/v1/assets/free/request` | POST | None + API key | `EvolvesproutsAdminFunction` | Publishes `media_request.submitted` to SNS |
 | `/v1/calendar/public` | GET | None + API key | `EvolvesproutsAdminFunction` | Public event feed for `service_type=event` instances |
-| `/v1/calendar/blockers` | GET | None + API key | `EvolvesproutsAdminFunction` | Merged manual + session half-day blockers (`purpose` query) |
+| `/v1/calendar/blockers` | GET | None + API key | `EvolvesproutsAdminFunction` | Merged manual + session half-day blockers (`purpose` query); `purpose=consultation_booking` is `Cache-Control: no-store` on 200 |
 | `/v1/assets/free` | GET | None + API key | `EvolvesproutsAdminFunction` | Lists public `client_document`-tagged assets; optional `language` query |
 | `/v1/admin/geographic-areas` | GET | Admin Group | `EvolvesproutsAdminFunction` | Geographic area lookup for address selection |
 | `/v1/admin/locations` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | |

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -573,6 +573,8 @@ without breaking existing junction references.
 
 - Purpose-scoped manual half-day blocks (`purpose` varchar(64), `block_date` date,
   `period` in `am` / `pm` / `both`, optional `note`).
+- Optional `created_by` / `updated_by` (Cognito sub) for admin accountability; admin API
+  writes also append rows to `audit_log` (application source).
 - Unique on `(purpose, block_date, period)`; merged at read time with session slots for
   public `GET /v1/calendar/blockers` (see `app.services.calendar_blockers`).
 

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -569,6 +569,13 @@ without breaking existing junction references.
   `contact_id` is not null (at most one enrollment per contact per instance when
   the parent is a contact).
 
+### `calendar_manual_blocks`
+
+- Purpose-scoped manual half-day blocks (`purpose` varchar(64), `block_date` date,
+  `period` in `am` / `pm` / `both`, optional `note`).
+- Unique on `(purpose, block_date, period)`; merged at read time with session slots for
+  public `GET /v1/calendar/blockers` (see `app.services.calendar_blockers`).
+
 ### `service_tags` + `service_assets`
 
 - Junction tables for many-to-many links between services and existing `tags`

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -572,6 +572,12 @@ reuses the same SQL predicates as `ServiceInstanceRepository.list_public_offerin
 **Public `purpose`:** Only `consultation_booking` is allowed in this release; other
 values return **400**.
 
+**Wall-clock alignment:** The public website picker uses `PUBLIC_SITE_IANA_TIMEZONE`
+(`site-datetime.ts`). The API merge uses `CALENDAR_BLOCKERS_WALL_TIMEZONE` (default
+`Asia/Hong_Kong`). **Operations must keep these identical** (same zone string); if the env
+is set to a different zone than the site build constant, AM/PM boundaries and blocker
+rows can disagree between UI and API.
+
 **Caching:** Responses for `purpose=consultation_booking` use `Cache-Control: no-store`
 so CloudFront does not retain stale blocker lists after admin edits.
 
@@ -582,9 +588,10 @@ return **400** (`primarySessionStartIso` or the corresponding `sessionSlots[n].s
 field). Sub-minute times are allowed within those bands. Blocked half-days reject with
 the same user-facing message; structured logs distinguish classification vs blocked.
 
-**Client / CDN:** The public website requests blockers with `from` aligned to the Monday
-of the current local week and `to` = `from + 119` days so the URL (and CloudFront cache
-key when applicable) stays stable for seven days. The CRM GET client uses
+**Client / CDN:** The public website requests blockers with `from` / `to` derived in
+**the site IANA zone** (same calendar as the consultation modal), aligned to the Monday
+of the current week and `to` = `from + 119` days so the URL (and CloudFront cache key when
+applicable) stays stable for seven days. The CRM GET client uses
 `bypassGetCache` on this request so in-memory GET caching does not hide fresh blockers
 when reopening the booking modal. When `NEXT_PUBLIC_WWW_CRM_API_KEY` is unset at
 runtime, the client cannot call the API and treats the outcome as a fetch failure

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -559,6 +559,44 @@ match the instance’s parent service returns **404** with structured rejection 
 Unscoped codes still validate once the pair resolves; scoped codes compare against the
 resolved `services.id` / `service_instances.id` as before.
 
+## Public calendar blockers and consultation half-day contract
+
+**Decision:** `GET /v1/calendar/blockers` (and `/www/v1/calendar/blockers`) merge
+`calendar_manual_blocks` with published **event** and **training_course** session slots
+that intersect nominal local windows (09:00–12:00 → `am`, 14:00–18:00 → `pm`) in
+`CALENDAR_BLOCKERS_WALL_TIMEZONE` (default `Asia/Hong_Kong`). Session-derived eligibility
+reuses the same SQL predicates as `ServiceInstanceRepository.list_public_offerings`
+(via `public_calendar_blocker_instance_predicates`), excluding feed-only filters
+(``ends_at >= now``, slug/service_key/limit).
+
+**Public `purpose`:** Only `consultation_booking` is allowed in this release; other
+values return **400**.
+
+**Caching:** Responses for `purpose=consultation_booking` use `Cache-Control: no-store`
+so CloudFront does not retain stale blocker lists after admin edits.
+
+**Reservations (`bookingSystem=consultation-booking`):** Each `primarySessionStartIso`
+and every `sessionSlots[].startIso` must classify to **morning** (local hour before 12)
+or **afternoon** (local hour 14 or later) in the wall zone; local hours **12–13**
+return **400** (`primarySessionStartIso` or the corresponding `sessionSlots[n].startIso`
+field). Sub-minute times are allowed within those bands. Blocked half-days reject with
+the same user-facing message; structured logs distinguish classification vs blocked.
+
+**Client / CDN:** The public website requests blockers with `from` aligned to the Monday
+of the current local week and `to` = `from + 119` days so the URL (and CloudFront cache
+key when applicable) stays stable for seven days. The CRM GET client uses
+`bypassGetCache` on this request so in-memory GET caching does not hide fresh blockers
+when reopening the booking modal. When `NEXT_PUBLIC_WWW_CRM_API_KEY` is unset at
+runtime, the client cannot call the API and treats the outcome as a fetch failure
+(empty slots + user-visible warning; server validation remains authoritative).
+
+**TOCTOU:** Between validation and commit another writer may add a conflicting session;
+enrollment is not serialised against the calendar blocker rows. Mitigations are short
+TTL on any cacheable reads and `no-store` for the consultation purpose.
+
+**CloudFront path allowlist:** The viewer function matches the path segment **exactly**
+(e.g. `/www/v1/calendar/blockers`); trailing slash variants are not allowlisted.
+
 ## Keeping Documentation Up to Date
 
 **Decision:** Architecture documentation in `docs/architecture/` describes

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -35,8 +35,9 @@ their primary responsibilities.
   `/v1/reservations/payment-intent`,
   `/v1/calendar/public` (same public calendar feed and contract as
   `/www/v1/calendar/public`; see that entry below for payload, ordering, and query filters),
-  `/v1/calendar/blockers` (merged manual + session half-day blockers for a `purpose` query;
-  same contract as `/www/v1/calendar/blockers`; `purpose=consultation_booking` uses `Cache-Control: no-store`
+  `/v1/calendar/blockers` (merged manual + session half-day blockers; `purpose` allowlist
+  is `consultation_booking` only in this release—other values return 400; same contract as
+  `/www/v1/calendar/blockers`; `purpose=consultation_booking` uses `Cache-Control: no-store`
   on success so admin-driven blockers are not edge-cached; other allowed purposes use the same cache headers
   as `GET /v1/calendar/public`),
   `/v1/discounts/validate`,
@@ -151,8 +152,8 @@ their primary responsibilities.
   when `max_capacity` is set,
   using the same enrollment statuses as capacity checks: registered, confirmed,
   completed),
-  `/www/v1/calendar/blockers` (requires `purpose`; merges `calendar_manual_blocks` with
-  published event/training `instance_session_slots` intersecting nominal AM/PM local windows;
+  `/www/v1/calendar/blockers` (requires `purpose`; allowlist is `consultation_booking` only in this release;
+  merges `calendar_manual_blocks` with published event/training `instance_session_slots` intersecting nominal AM/PM local windows;
   `meta.wall_time_zone` documents the wall-clock zone for consultation purposes;
   `purpose=consultation_booking` responses use `Cache-Control: no-store` on success),
   `/www/v1/assets/free` (lists public assets tagged `client_document`;

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -36,7 +36,9 @@ their primary responsibilities.
   `/v1/calendar/public` (same public calendar feed and contract as
   `/www/v1/calendar/public`; see that entry below for payload, ordering, and query filters),
   `/v1/calendar/blockers` (merged manual + session half-day blockers for a `purpose` query;
-  same contract as `/www/v1/calendar/blockers`),
+  same contract as `/www/v1/calendar/blockers`; `purpose=consultation_booking` uses `Cache-Control: no-store`
+  on success so admin-driven blockers are not edge-cached; other allowed purposes use the same cache headers
+  as `GET /v1/calendar/public`),
   `/v1/discounts/validate`,
   `/v1/contact-us`,
   `/v1/admin/geographic-areas`,
@@ -151,14 +153,15 @@ their primary responsibilities.
   completed),
   `/www/v1/calendar/blockers` (requires `purpose`; merges `calendar_manual_blocks` with
   published event/training `instance_session_slots` intersecting nominal AM/PM local windows;
-  `meta.wall_time_zone` documents the wall-clock zone for consultation purposes),
+  `meta.wall_time_zone` documents the wall-clock zone for consultation purposes;
+  `purpose=consultation_booking` responses use `Cache-Control: no-store` on success),
   `/www/v1/assets/free` (lists public assets tagged `client_document`;
   optional `language` query filters on `assets.content_language` using any valid
   BCP 47-style tag; admin asset writes restrict `content_language` to `en`,
   `zh-CN`, or `zh-HK`; downloads
   remain on `/v1/assets/public/{id}/download` with device attestation),
   Allowlisted public GETs behind `/www/*` (`GET /v1/calendar/public`,
-  `GET /v1/calendar/blockers`,
+  `GET /v1/calendar/blockers` (edge-cacheable on 200 except `purpose=consultation_booking`, which is `no-store`),
   `GET /v1/assets/free`, and `/www/v1/...`) emit `Cache-Control` on success and
   `no-store` on handler error paths; new allowlisted GETs must follow the same
   contract,

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -35,6 +35,8 @@ their primary responsibilities.
   `/v1/reservations/payment-intent`,
   `/v1/calendar/public` (same public calendar feed and contract as
   `/www/v1/calendar/public`; see that entry below for payload, ordering, and query filters),
+  `/v1/calendar/blockers` (merged manual + session half-day blockers for a `purpose` query;
+  same contract as `/www/v1/calendar/blockers`),
   `/v1/discounts/validate`,
   `/v1/contact-us`,
   `/v1/admin/geographic-areas`,
@@ -60,6 +62,9 @@ their primary responsibilities.
   `/v1/admin/tags/*` for CRM tag catalog administration (list with optional `include_archived` or
   `archived_only`, create, update, `PATCH` `archived` to restore, delete returns `deleted` +
   `usage_count`; system tag names are protected),
+  `/v1/admin/calendar/manual-blocks` and `/v1/admin/calendar/manual-blocks/{id}` for purpose-scoped
+  manual calendar blocks (list requires `purpose`, `from`, `to`; create supports `consultation_booking`
+  in the current release; merged public read is `GET /v1/calendar/blockers`),
   `GET /v1/admin/contacts/tags` for tag pickers (active tags only),
   `GET /v1/admin/contacts/search` for contact picker search,
   `GET|POST /v1/admin/contacts/{id}/notes` and `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`
@@ -144,12 +149,16 @@ their primary responsibilities.
   when `max_capacity` is set,
   using the same enrollment statuses as capacity checks: registered, confirmed,
   completed),
+  `/www/v1/calendar/blockers` (requires `purpose`; merges `calendar_manual_blocks` with
+  published event/training `instance_session_slots` intersecting nominal AM/PM local windows;
+  `meta.wall_time_zone` documents the wall-clock zone for consultation purposes),
   `/www/v1/assets/free` (lists public assets tagged `client_document`;
   optional `language` query filters on `assets.content_language` using any valid
   BCP 47-style tag; admin asset writes restrict `content_language` to `en`,
   `zh-CN`, or `zh-HK`; downloads
   remain on `/v1/assets/public/{id}/download` with device attestation),
   Allowlisted public GETs behind `/www/*` (`GET /v1/calendar/public`,
+  `GET /v1/calendar/blockers`,
   `GET /v1/assets/free`, and `/www/v1/...`) emit `Cache-Control` on success and
   `no-store` on handler error paths; new allowlisted GETs must follow the same
   contract,

--- a/tests/test_admin_calendar_manual_blocks.py
+++ b/tests/test_admin_calendar_manual_blocks.py
@@ -1,0 +1,141 @@
+"""Tests for admin calendar manual blocks API."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.api import admin_calendar_manual_blocks as cal_blocks
+from app.exceptions import ValidationError
+
+
+@pytest.fixture
+def _patch_session(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    session = MagicMock()
+
+    class _Ctx:
+        def __enter__(self) -> MagicMock:
+            return session
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(cal_blocks, "Session", lambda _engine: _Ctx())
+    monkeypatch.setattr(cal_blocks, "get_engine", lambda: object())
+    return session
+
+
+def test_create_duplicate_returns_409(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    _patch_session: MagicMock,
+) -> None:
+    repo = MagicMock()
+
+    def _create_raises(_row: Any) -> None:
+        raise IntegrityError("stmt", {}, Exception("dup"))
+
+    repo.create.side_effect = _create_raises
+    repo_cls = MagicMock(return_value=repo)
+    monkeypatch.setattr(cal_blocks, "CalendarManualBlockRepository", repo_cls)
+    monkeypatch.setattr(cal_blocks, "AuditService", MagicMock())
+
+    body = {
+        "purpose": "consultation_booking",
+        "blockDate": "2026-05-01",
+        "period": "am",
+        "note": None,
+    }
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/calendar/manual-blocks",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(ValidationError) as exc:
+        cal_blocks.handle_admin_calendar_manual_blocks_request(
+            event, "POST", "/v1/admin/calendar/manual-blocks"
+        )
+    assert exc.value.status_code == 409
+
+
+def test_update_partial_note_only_calls_flush_with_note_change(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    _patch_session: MagicMock,
+) -> None:
+    block_id = uuid4()
+    row = SimpleNamespace(
+        id=block_id,
+        purpose="consultation_booking",
+        block_date=date(2026, 5, 1),
+        period="am",
+        note="old",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        created_by="creator",
+        updated_by=None,
+        updated_at=None,
+    )
+    repo = MagicMock()
+    repo.get_by_id.return_value = row
+    monkeypatch.setattr(cal_blocks, "CalendarManualBlockRepository", MagicMock(return_value=repo))
+    audit = MagicMock()
+    monkeypatch.setattr(cal_blocks, "AuditService", MagicMock(return_value=audit))
+
+    body = {"note": "new note"}
+    event = api_gateway_event(
+        method="PATCH",
+        path=f"/v1/admin/calendar/manual-blocks/{block_id}",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+    resp = cal_blocks.handle_admin_calendar_manual_blocks_request(
+        event, "PATCH", f"/v1/admin/calendar/manual-blocks/{block_id}"
+    )
+    assert resp["statusCode"] == 200
+    assert row.note == "new note"
+    audit.log_update.assert_called_once()
+
+
+def test_delete_calls_audit_delete(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    _patch_session: MagicMock,
+) -> None:
+    block_id = uuid4()
+    row = SimpleNamespace(
+        id=block_id,
+        purpose="consultation_booking",
+        block_date=date(2026, 5, 1),
+        period="am",
+        note=None,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        created_by="creator",
+    )
+    repo = MagicMock()
+    repo.get_by_id.return_value = row
+    repo.delete_by_id.return_value = True
+    monkeypatch.setattr(cal_blocks, "CalendarManualBlockRepository", MagicMock(return_value=repo))
+    audit = MagicMock()
+    monkeypatch.setattr(cal_blocks, "AuditService", MagicMock(return_value=audit))
+
+    event = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/calendar/manual-blocks/{block_id}",
+        authorizer_context=admin_identity,
+    )
+    resp = cal_blocks.handle_admin_calendar_manual_blocks_request(
+        event, "DELETE", f"/v1/admin/calendar/manual-blocks/{block_id}"
+    )
+    assert resp["statusCode"] == 200
+    audit.log_delete.assert_called_once()

--- a/tests/test_calendar_blockers.py
+++ b/tests/test_calendar_blockers.py
@@ -1,19 +1,28 @@
-"""Tests for consultation calendar blocker classification and blocking."""
+"""Tests for calendar blocker merge, reservation checks, and classification."""
 
 from __future__ import annotations
 
-import pytest
-from datetime import date
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
 
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.db.models.calendar_manual_block import CalendarManualBlock
 from app.exceptions import ValidationError
 from app.services.calendar_blockers import (
     classify_consultation_start_local_half_day,
     consultation_booking_purpose,
+    is_consultation_half_day_blocked,
+    merge_calendar_blockers_for_purpose,
+    raise_if_consultation_reservation_blocked,
+    validate_session_slot_chronology,
 )
 
 
 def test_classify_am_accepts_non_zero_minute_same_day() -> None:
-    """A4: hour-based AM classification (not tied to 09:00:00 exactly)."""
     day, period = classify_consultation_start_local_half_day(
         start_iso="2026-04-07T09:30:00+08:00",
         wall_zone="Asia/Hong_Kong",
@@ -51,3 +60,257 @@ def test_classify_invalid_iso_raises() -> None:
 
 def test_purpose_constant() -> None:
     assert consultation_booking_purpose() == "consultation_booking"
+
+
+def test_validate_session_slot_chronology_end_before_start() -> None:
+    assert (
+        validate_session_slot_chronology(
+            [
+                {
+                    "start_iso": "2026-04-07T10:00:00+08:00",
+                    "end_iso": "2026-04-07T09:00:00+08:00",
+                },
+            ]
+        )
+        == "session_slot_end_before_start"
+    )
+
+
+def test_validate_session_slot_chronology_invalid_iso() -> None:
+    assert (
+        validate_session_slot_chronology(
+            [{"start_iso": "not-iso", "end_iso": "2026-04-07T11:00:00+08:00"}]
+        )
+        == "invalid_session_slot_iso"
+    )
+
+
+def test_validate_session_slot_chronology_ok() -> None:
+    assert (
+        validate_session_slot_chronology(
+            [
+                {
+                    "start_iso": "2026-04-07T10:00:00+08:00",
+                    "end_iso": "2026-04-07T11:00:00+08:00",
+                },
+            ]
+        )
+        is None
+    )
+
+
+def test_raise_if_consultation_reservation_blocked_multi_slot_second_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+
+    def fake_half_day(
+        s: Session,
+        *,
+        purpose: str,
+        day_local: date,
+        period: str,
+    ) -> bool:
+        _ = s, purpose
+        return day_local == date(2026, 4, 10) and period == "am"
+
+    session.__class__ = Session
+
+    monkeypatch.setattr(
+        "app.services.calendar_blockers.is_consultation_half_day_blocked",
+        fake_half_day,
+    )
+    with pytest.raises(ValidationError) as exc:
+        raise_if_consultation_reservation_blocked(
+            session=session,  # type: ignore[arg-type]
+            purpose=consultation_booking_purpose(),
+            primary_start_iso="2026-04-07T10:00:00+08:00",
+            session_slots=[
+                {
+                    "start_iso": "2026-04-10T10:00:00+08:00",
+                    "end_iso": "2026-04-10T11:00:00+08:00",
+                },
+            ],
+        )
+    assert exc.value.field == "sessionSlots[0].startIso"
+
+
+def test_raise_if_consultation_reservation_blocked_primary_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+
+    def fake_half_day(
+        s: Session,
+        *,
+        purpose: str,
+        day_local: date,
+        period: str,
+    ) -> bool:
+        _ = s, purpose
+        return day_local == date(2026, 4, 7) and period == "pm"
+
+    monkeypatch.setattr(
+        "app.services.calendar_blockers.is_consultation_half_day_blocked",
+        fake_half_day,
+    )
+    with pytest.raises(ValidationError) as exc:
+        raise_if_consultation_reservation_blocked(
+            session=session,  # type: ignore[arg-type]
+            purpose=consultation_booking_purpose(),
+            primary_start_iso="2026-04-07T15:00:00+08:00",
+            session_slots=None,
+        )
+    assert exc.value.field == "primarySessionStartIso"
+
+
+def test_is_consultation_half_day_blocked_manual_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.calendar_blockers._session_blocks_half_day",
+        lambda *a, **k: False,
+    )
+    engine = create_engine("sqlite:///:memory:")
+    CalendarManualBlock.__table__.create(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    purpose = consultation_booking_purpose()
+    now = datetime.now(tz=UTC)
+    with SessionLocal() as session:
+        session.add(
+            CalendarManualBlock(
+                id=uuid4(),
+                purpose=purpose,
+                block_date=date(2026, 5, 1),
+                period="am",
+                note=None,
+                created_by=None,
+                updated_by=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.commit()
+    with SessionLocal() as session:
+        assert is_consultation_half_day_blocked(
+            session, purpose=purpose, day_local=date(2026, 5, 1), period="am"
+        )
+        assert not is_consultation_half_day_blocked(
+            session, purpose=purpose, day_local=date(2026, 5, 1), period="pm"
+        )
+
+
+def test_is_consultation_half_day_blocked_session_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+    monkeypatch.setattr(
+        "app.services.calendar_blockers._manual_block_exists_for_half_day",
+        lambda *a, **k: False,
+    )
+    monkeypatch.setattr(
+        "app.services.calendar_blockers._session_blocks_half_day",
+        lambda *a, **k: True,
+    )
+    assert is_consultation_half_day_blocked(
+        session,  # type: ignore[arg-type]
+        purpose=consultation_booking_purpose(),
+        day_local=date(2026, 5, 1),
+        period="pm",
+    )
+
+
+def test_is_consultation_half_day_blocked_both_manual_and_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+    monkeypatch.setattr(
+        "app.services.calendar_blockers._manual_block_exists_for_half_day",
+        lambda *a, **k: True,
+    )
+    monkeypatch.setattr(
+        "app.services.calendar_blockers._session_blocks_half_day",
+        lambda *a, **k: True,
+    )
+    assert is_consultation_half_day_blocked(
+        session,  # type: ignore[arg-type]
+        purpose=consultation_booking_purpose(),
+        day_local=date(2026, 5, 1),
+        period="am",
+    )
+
+
+def test_is_consultation_half_day_blocked_neither(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock()
+    monkeypatch.setattr(
+        "app.services.calendar_blockers._manual_block_exists_for_half_day",
+        lambda *a, **k: False,
+    )
+    monkeypatch.setattr(
+        "app.services.calendar_blockers._session_blocks_half_day",
+        lambda *a, **k: False,
+    )
+    assert not is_consultation_half_day_blocked(
+        session,  # type: ignore[arg-type]
+        purpose=consultation_booking_purpose(),
+        day_local=date(2026, 5, 1),
+        period="am",
+    )
+
+
+def test_merge_calendar_blockers_range_includes_boundary_manual(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sqlalchemy import false, literal, select as sa_select
+
+    def _empty_slots(**_kwargs: object) -> object:
+        return sa_select(literal(None), literal(None)).where(false())
+
+    monkeypatch.setattr(
+        "app.services.calendar_blockers.select_public_calendar_blocker_session_slots",
+        _empty_slots,
+    )
+    engine = create_engine("sqlite:///:memory:")
+    CalendarManualBlock.__table__.create(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    purpose = consultation_booking_purpose()
+    d0 = date(2026, 6, 1)
+    d1 = date(2026, 6, 3)
+    now = datetime.now(tz=UTC)
+    with SessionLocal() as session:
+        session.add(
+            CalendarManualBlock(
+                id=uuid4(),
+                purpose=purpose,
+                block_date=d0,
+                period="both",
+                note=None,
+                created_by=None,
+                updated_by=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.add(
+            CalendarManualBlock(
+                id=uuid4(),
+                purpose=purpose,
+                block_date=d1,
+                period="pm",
+                note=None,
+                created_by=None,
+                updated_by=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.commit()
+    with SessionLocal() as session:
+        out = merge_calendar_blockers_for_purpose(
+            session, purpose=purpose, from_date=d0, to_date=d1
+        )
+    by_date = {row["date"]: row["period"] for row in out}
+    assert by_date.get(d0.isoformat()) == "both"
+    assert by_date.get(d1.isoformat()) == "pm"

--- a/tests/test_calendar_blockers.py
+++ b/tests/test_calendar_blockers.py
@@ -1,0 +1,53 @@
+"""Tests for consultation calendar blocker classification and blocking."""
+
+from __future__ import annotations
+
+import pytest
+from datetime import date
+
+from app.exceptions import ValidationError
+from app.services.calendar_blockers import (
+    classify_consultation_start_local_half_day,
+    consultation_booking_purpose,
+)
+
+
+def test_classify_am_accepts_non_zero_minute_same_day() -> None:
+    """A4: hour-based AM classification (not tied to 09:00:00 exactly)."""
+    day, period = classify_consultation_start_local_half_day(
+        start_iso="2026-04-07T09:30:00+08:00",
+        wall_zone="Asia/Hong_Kong",
+    )
+    assert day == date(2026, 4, 7)
+    assert period == "am"
+
+
+def test_classify_pm_accepts_14_15() -> None:
+    day, period = classify_consultation_start_local_half_day(
+        start_iso="2026-04-07T14:15:00+08:00",
+        wall_zone="Asia/Hong_Kong",
+    )
+    assert day == date(2026, 4, 7)
+    assert period == "pm"
+
+
+def test_classify_noon_gap_raises_400() -> None:
+    with pytest.raises(ValidationError) as exc:
+        classify_consultation_start_local_half_day(
+            start_iso="2026-04-07T12:30:00+08:00",
+            wall_zone="Asia/Hong_Kong",
+            field="primarySessionStartIso",
+        )
+    assert exc.value.field == "primarySessionStartIso"
+
+
+def test_classify_invalid_iso_raises() -> None:
+    with pytest.raises(ValidationError):
+        classify_consultation_start_local_half_day(
+            start_iso="not-a-date",
+            field="sessionSlots[0].startIso",
+        )
+
+
+def test_purpose_constant() -> None:
+    assert consultation_booking_purpose() == "consultation_booking"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Review follow-ups (commit `18e8f8ac`)

### Backend tests
- **`tests/test_calendar_blockers.py`:** `validate_session_slot_chronology` (ok / end-before-start / invalid ISO), `raise_if_consultation_reservation_blocked` (multi-slot + primary field), `is_consultation_half_day_blocked` (manual-only with session stubbed false, session-only, both, neither), `merge_calendar_blockers_for_purpose` boundary dates with session query stubbed to empty.
- **`tests/test_admin_calendar_manual_blocks.py`:** duplicate create → **409**; PATCH note-only + `log_update`; DELETE + `log_delete`.

### Contract / handler
- **409 vs OpenAPI:** `IntegrityError` on create/update now raises `ValidationError(..., status_code=409)`.
- **`allowed_manual_block_creation_purposes()`** in `calendar_blockers.py`; admin create uses it (single source with public allowlist).

### UX / frontend
- **Loading aria:** `datePickerLoadingDayTemplate` in locale JSON + picker uses it when `interactionDisabled && !cell.isDisabled`.
- **Status before modal:** CTA opens modal first, then sets `loading` so tests (and users) see loading immediately.
- **`consultations-booking.test.tsx`:** Mocks `ConsultationBookingModal` directly (no `next/dynamic` noop); tests loading→ready and error paths via `data-calendar-blockers-status`.
- **`noonSiteOnYmd`:** Derives site-zone midnight via `Intl` + hour scan, then +12h (no hardcoded `+08:00`).

### Other
- **`public_calendar_blockers`:** `today` from wall zone; `logger.debug` for per-request line.
- **`_delete_block`:** removed `_ = event`.
- **`list_public_offerings`:** dropped redundant `slug != ""` where predicates already enforce it.
- **`public.yaml`:** `from` default described as wall-zone today, not UTC-only.

`pre-commit run --all-files` and `apps/public_www` `npm run lint` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc10f174-3ba7-4be0-8691-f082d6ffda78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc10f174-3ba7-4be0-8691-f082d6ffda78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

