### PR TITLE
feat(db): add Alembic migration for audit_log table and triggers

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -123,7 +123,7 @@ repo root
 
 - Alembic revision IDs must be <= 32 characters.
   - Format: `NNNN_short_description`
-  - Example: `0010_add_audit_logging`
+  - Example: `0054_add_audit_log`
   - Validate length with:
     `echo -n "revision_id" | wc -c`
 - Seed-data assessment is required for EVERY DB change.

--- a/backend/db/alembic/versions/0054_add_audit_log.py
+++ b/backend/db/alembic/versions/0054_add_audit_log.py
@@ -1,0 +1,219 @@
+"""Create ``audit_log`` table and triggers on asset tables.
+
+Recreates the storage and trigger-based auditing removed when the migration
+baseline was reset (legacy ``0010_add_audit_logging``). Triggers apply only to
+tables that exist in the current schema: ``assets`` and ``asset_access_grants``.
+
+Seed-data assessment:
+1. Seed compatibility: new table; seed does not insert into ``audit_log``.
+2. NOT NULL: only on columns with defaults or required fields; no seed impact.
+3. N/A.
+4. No seed rows for ``audit_log`` (append-only operational data).
+5. N/A.
+6. N/A.
+
+Result: No seed updates are required for this migration.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0054_add_audit_log"
+down_revision: Union[str, None] = "0053_manual_block_audit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+AUDITED_TABLES: tuple[str, ...] = ("assets", "asset_access_grants")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_log",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "timestamp",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("table_name", sa.Text(), nullable=False),
+        sa.Column("record_id", sa.Text(), nullable=False),
+        sa.Column(
+            "action",
+            sa.Text(),
+            nullable=False,
+            comment="INSERT, UPDATE, or DELETE",
+        ),
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            nullable=True,
+            comment="Cognito user sub who made the change",
+        ),
+        sa.Column(
+            "request_id",
+            sa.Text(),
+            nullable=True,
+            comment="Lambda request ID for correlation",
+        ),
+        sa.Column(
+            "old_values",
+            postgresql.JSONB(),
+            nullable=True,
+            comment="Previous values (for UPDATE/DELETE)",
+        ),
+        sa.Column(
+            "new_values",
+            postgresql.JSONB(),
+            nullable=True,
+            comment="New values (for INSERT/UPDATE)",
+        ),
+        sa.Column(
+            "changed_fields",
+            postgresql.ARRAY(sa.Text()),
+            nullable=True,
+            comment="List of fields that changed (for UPDATE)",
+        ),
+        sa.Column(
+            "source",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'trigger'"),
+            comment="Source of the audit entry: trigger or application",
+        ),
+        sa.Column(
+            "ip_address",
+            sa.Text(),
+            nullable=True,
+            comment="Client IP address if available",
+        ),
+        sa.Column(
+            "user_agent",
+            sa.Text(),
+            nullable=True,
+            comment="Client user agent if available",
+        ),
+    )
+    op.create_index(
+        "audit_log_table_record_idx",
+        "audit_log",
+        ["table_name", "record_id"],
+    )
+    op.create_index(
+        "audit_log_timestamp_idx",
+        "audit_log",
+        ["timestamp"],
+    )
+    op.create_index(
+        "audit_log_user_id_idx",
+        "audit_log",
+        ["user_id"],
+    )
+    op.create_index(
+        "audit_log_action_idx",
+        "audit_log",
+        ["action"],
+    )
+
+    op.execute("""
+        CREATE OR REPLACE FUNCTION audit_trigger_func()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            record_id_val TEXT;
+            old_data JSONB;
+            new_data JSONB;
+            changed_cols TEXT[];
+            col_name TEXT;
+            current_user_id TEXT;
+            current_request_id TEXT;
+        BEGIN
+            current_user_id := current_setting('app.current_user_id', true);
+            current_request_id := current_setting('app.current_request_id', true);
+
+            IF TG_OP = 'DELETE' THEN
+                record_id_val := OLD.id::text;
+            ELSE
+                record_id_val := NEW.id::text;
+            END IF;
+
+            IF TG_OP IN ('UPDATE', 'DELETE') THEN
+                old_data := to_jsonb(OLD);
+            END IF;
+
+            IF TG_OP IN ('INSERT', 'UPDATE') THEN
+                new_data := to_jsonb(NEW);
+            END IF;
+
+            IF TG_OP = 'UPDATE' THEN
+                changed_cols := ARRAY[]::TEXT[];
+                FOR col_name IN
+                    SELECT key FROM jsonb_object_keys(new_data) AS key
+                LOOP
+                    IF (old_data->col_name) IS DISTINCT FROM (new_data->col_name) THEN
+                        changed_cols := array_append(changed_cols, col_name);
+                    END IF;
+                END LOOP;
+
+                IF array_length(changed_cols, 1) IS NULL THEN
+                    RETURN NEW;
+                END IF;
+            END IF;
+
+            INSERT INTO audit_log (
+                table_name,
+                record_id,
+                action,
+                user_id,
+                request_id,
+                old_values,
+                new_values,
+                changed_fields,
+                source
+            ) VALUES (
+                TG_TABLE_NAME,
+                record_id_val,
+                TG_OP,
+                NULLIF(current_user_id, ''),
+                NULLIF(current_request_id, ''),
+                old_data,
+                new_data,
+                changed_cols,
+                'trigger'
+            );
+
+            RETURN COALESCE(NEW, OLD);
+        END;
+        $$ LANGUAGE plpgsql;
+    """)
+
+    for table_name in AUDITED_TABLES:
+        op.execute(f"""
+            CREATE TRIGGER {table_name}_audit_trigger
+            AFTER INSERT OR UPDATE OR DELETE ON {table_name}
+            FOR EACH ROW EXECUTE FUNCTION audit_trigger_func();
+        """)
+
+
+def downgrade() -> None:
+    for table_name in AUDITED_TABLES:
+        op.execute(
+            f"DROP TRIGGER IF EXISTS {table_name}_audit_trigger ON {table_name};"
+        )
+
+    op.execute("DROP FUNCTION IF EXISTS audit_trigger_func();")
+
+    op.drop_index("audit_log_action_idx", table_name="audit_log")
+    op.drop_index("audit_log_user_id_idx", table_name="audit_log")
+    op.drop_index("audit_log_timestamp_idx", table_name="audit_log")
+    op.drop_index("audit_log_table_record_idx", table_name="audit_log")
+    op.drop_table("audit_log")

--- a/docs/architecture/audit-logging.md
+++ b/docs/architecture/audit-logging.md
@@ -214,7 +214,11 @@ current public reservation OpenAPI (`docs/api/public.yaml`).
 
 ## Migration
 
-The audit logging is added via Alembic migration `0010_add_audit_logging.py`.
+The `audit_log` table and trigger function are created by Alembic revision
+`0054_add_audit_log` in `backend/db/alembic/versions/0054_add_audit_log.py`
+(`down_revision`: `0053_manual_block_audit`). That revision replaces the legacy
+pre-baseline migration `0010_add_audit_logging` (removed when the migration
+chain was reset); triggers attach only to `assets` and `asset_access_grants`.
 
 To apply:
 ```bash
@@ -222,7 +226,8 @@ cd backend/db
 alembic upgrade head
 ```
 
-To rollback:
+To rollback (drops `audit_log` and triggers; leaves prior revisions applied):
 ```bash
-alembic downgrade 0009_rename_owner_to_manager
+cd backend/db
+alembic downgrade 0053_manual_block_audit
 ```

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -150,6 +150,21 @@ Indexes:
 - `access_grants_unique` unique index on
   (`asset_id`, `grant_type`, `COALESCE(grantee_id, '')`)
 
+## Table: audit_log
+
+Purpose: Append-only change history. Rows are written by PostgreSQL triggers on
+`assets` and `asset_access_grants` (when `set_audit_context` supplies session
+variables) and by application code via `AuditService` (`source` = `trigger` or
+`application`). Created by migration `0054_add_audit_log`.
+
+Columns (summary): `id` (UUID), `timestamp` (timestamptz), `table_name`, `record_id`,
+`action`, optional `user_id` / `request_id`, JSONB `old_values` / `new_values`,
+`changed_fields` (text array, updates only), `source`, optional `ip_address` /
+`user_agent`.
+
+Indexes: `audit_log_table_record_idx`, `audit_log_timestamp_idx`,
+`audit_log_user_id_idx`, `audit_log_action_idx`.
+
 ## Table: asset_share_links
 
 Purpose: Stores stable bearer links for assets that can be shared externally.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Alembic revision **`0054_add_audit_log`** (`backend/db/alembic/versions/0054_add_audit_log.py`) as the new migration head after `0053_manual_block_audit`.

## What the migration does

- Creates **`audit_log`** with columns and indexes aligned to `backend/src/app/db/models/audit_log.py` and `set_audit_context` / `AuditService` usage.
- Defines **`audit_trigger_func()`** (reads `app.current_user_id` / `app.current_request_id` from session) and **`AFTER INSERT OR UPDATE OR DELETE`** triggers on **`assets`** and **`asset_access_grants`** only (tables that exist in the current schema; no legacy CRM tables from the pre-baseline migration).
- **No `GRANT`** statements (not used elsewhere in the current Alembic tree; role naming is environment-specific).

## Docs

- **`docs/architecture/audit-logging.md`**: Points to `0054_add_audit_log` and correct rollback command (`downgrade 0053_manual_block_audit`).
- **`docs/architecture/database-schema.md`**: New **`audit_log`** table section after `asset_access_grants`.
- **`.cursorrules`**: Example revision id updated to `0054_add_audit_log`.

## Verification

- `python3 -m alembic -c backend/db/alembic.ini heads` → single head `0054_add_audit_log`.
- `pre-commit run ruff-format` on the new migration file passed.
- `bash scripts/validate-cursorrules.sh` passed.
- Full `alembic upgrade head` was not run here (no `DATABASE_URL` in the agent environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc10f174-3ba7-4be0-8691-f082d6ffda78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc10f174-3ba7-4be0-8691-f082d6ffda78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

