### PR TITLE
admin web: rename manual blocks table title and Period column

### DIFF
--- a/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
+++ b/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
@@ -252,7 +252,7 @@ export function CalendarManualBlocksPage() {
       </AdminEditorCard>
 
       <PaginatedTableCard
-        title='Consultation manual blocks'
+        title='Manual blocks'
         isLoading={isLoading}
         isLoadingMore={false}
         hasMore={false}
@@ -289,7 +289,7 @@ export function CalendarManualBlocksPage() {
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Date</th>
-              <th className='px-4 py-3 font-semibold'>Period</th>
+              <th className='px-4 py-3 font-semibold'>AM/PM</th>
               <th className='px-4 py-3 font-semibold'>Note</th>
               <th className='px-4 py-3 text-right font-semibold'>Operations</th>
             </tr>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the consultation manual blocks UI on the Calendar admin page:

- **PaginatedTableCard** title: `Consultation manual blocks` → `Manual blocks`
- **Table header** for the period column: `Period` → `AM/PM`

The inline editor form still uses the label **Period** for the half-day selector (unchanged), since the request targeted the table column only.

## Validation

- `bash scripts/validate-cursorrules.sh`
- `npm run lint` in `apps/admin_web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b93a019d-4b3f-4c67-a0be-f365d6c9e42f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b93a019d-4b3f-4c67-a0be-f365d6c9e42f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

