### PR TITLE
Fix nested stack deploy: keep path-segment API Gateway resources in parent stack

### DIFF
--- a/backend/infrastructure/lib/api-admin-crm-stack.ts
+++ b/backend/infrastructure/lib/api-admin-crm-stack.ts
@@ -4,29 +4,59 @@ import { Construct } from "constructs";
 
 export interface ApiAdminCrmStackProps extends cdk.NestedStackProps {
   restApi: apigateway.IRestApi;
-  adminResource: apigateway.IResource;
+  /** The `/v1/admin/contacts` resource created in the parent stack. */
+  contactsResource: apigateway.IResource;
+  /** The `/v1/admin/families` resource created in the parent stack. */
+  familiesResource: apigateway.IResource;
+  /** The `/v1/admin/organizations` resource created in the parent stack. */
+  organizationsResource: apigateway.IResource;
   adminIntegration: apigateway.Integration;
   adminAuthorizer: apigateway.IAuthorizer;
 }
 
 /**
- * Admin CRM routes (`/v1/admin/contacts/**`, `/families/**`, `/organizations/**`) in a
- * nested stack to keep the parent ApiStack under CloudFormation's 500-resource quota.
+ * Admin CRM methods and sub-resources (`/v1/admin/contacts/**`, `/families/**`,
+ * `/organizations/**`) in a nested stack to keep the parent ApiStack under
+ * CloudFormation's 500-resource quota.
+ *
+ * The top-level `contacts`, `families`, and `organizations` resources live in the parent
+ * stack so their CloudFormation logical IDs are stable across the migration from inline
+ * routes to a nested stack.
  */
 export class ApiAdminCrmStack extends cdk.NestedStack {
   public constructor(scope: Construct, id: string, props: ApiAdminCrmStackProps) {
     super(scope, id, props);
 
-    const { restApi, adminResource, adminIntegration, adminAuthorizer } = props;
-
-    const adminAttach = apigateway.Resource.fromResourceAttributes(this, "AdminRouteParent", {
+    const {
       restApi,
-      resourceId: adminResource.resourceId,
-      path: adminResource.path,
-    });
+      contactsResource,
+      familiesResource,
+      organizationsResource,
+      adminIntegration,
+      adminAuthorizer,
+    } = props;
 
-    // Admin CRM contacts / families / organizations (non-vendor)
-    const adminContacts = adminAttach.addResource("contacts");
+    this.wireContacts(restApi, contactsResource, adminIntegration, adminAuthorizer);
+    this.wireFamilies(restApi, familiesResource, adminIntegration, adminAuthorizer);
+    this.wireOrganizations(restApi, organizationsResource, adminIntegration, adminAuthorizer);
+  }
+
+  private wireContacts(
+    restApi: apigateway.IRestApi,
+    contactsResource: apigateway.IResource,
+    adminIntegration: apigateway.Integration,
+    adminAuthorizer: apigateway.IAuthorizer,
+  ): void {
+    const adminContacts = apigateway.Resource.fromResourceAttributes(
+      this,
+      "ContactsRouteParent",
+      {
+        restApi,
+        resourceId: contactsResource.resourceId,
+        path: contactsResource.path,
+      },
+    );
+
     adminContacts.addMethod("GET", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,
@@ -76,8 +106,24 @@ export class ApiAdminCrmStack extends cdk.NestedStack {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,
     });
+  }
 
-    const adminFamilies = adminAttach.addResource("families");
+  private wireFamilies(
+    restApi: apigateway.IRestApi,
+    familiesResource: apigateway.IResource,
+    adminIntegration: apigateway.Integration,
+    adminAuthorizer: apigateway.IAuthorizer,
+  ): void {
+    const adminFamilies = apigateway.Resource.fromResourceAttributes(
+      this,
+      "FamiliesRouteParent",
+      {
+        restApi,
+        resourceId: familiesResource.resourceId,
+        path: familiesResource.path,
+      },
+    );
+
     const adminFamiliesPicker = adminFamilies.addResource("picker");
     adminFamiliesPicker.addMethod("GET", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
@@ -118,8 +164,24 @@ export class ApiAdminCrmStack extends cdk.NestedStack {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,
     });
+  }
 
-    const adminOrganizationsCrm = adminAttach.addResource("organizations");
+  private wireOrganizations(
+    restApi: apigateway.IRestApi,
+    organizationsResource: apigateway.IResource,
+    adminIntegration: apigateway.Integration,
+    adminAuthorizer: apigateway.IAuthorizer,
+  ): void {
+    const adminOrganizationsCrm = apigateway.Resource.fromResourceAttributes(
+      this,
+      "OrganizationsRouteParent",
+      {
+        restApi,
+        resourceId: organizationsResource.resourceId,
+        path: organizationsResource.path,
+      },
+    );
+
     const adminOrganizationsCrmPicker = adminOrganizationsCrm.addResource("picker");
     adminOrganizationsCrmPicker.addMethod("GET", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,

--- a/backend/infrastructure/lib/api-admin-services-stack.ts
+++ b/backend/infrastructure/lib/api-admin-services-stack.ts
@@ -4,30 +4,35 @@ import { Construct } from "constructs";
 
 export interface ApiAdminServicesStackProps extends cdk.NestedStackProps {
   restApi: apigateway.IRestApi;
-  /** Parent `v1.addResource("admin")` — only `resourceId` / `path` are used for import. */
-  adminResource: apigateway.IResource;
+  /** The `/v1/admin/services` resource created in the parent stack. */
+  servicesResource: apigateway.IResource;
   adminIntegration: apigateway.Integration;
   adminAuthorizer: apigateway.IAuthorizer;
 }
 
 /**
- * `/v1/admin/services/**` API Gateway routes (nested stack) to keep the parent ApiStack
- * under CloudFormation's 500-resource quota.
+ * `/v1/admin/services/**` API Gateway methods and sub-resources (nested stack) to keep the
+ * parent ApiStack under CloudFormation's 500-resource quota.
+ *
+ * The top-level `services` resource lives in the parent stack so its CloudFormation logical
+ * ID is stable across the migration from inline routes to a nested stack.
  */
 export class ApiAdminServicesStack extends cdk.NestedStack {
   public constructor(scope: Construct, id: string, props: ApiAdminServicesStackProps) {
     super(scope, id, props);
 
-    const { restApi, adminResource, adminIntegration, adminAuthorizer } = props;
+    const { restApi, servicesResource, adminIntegration, adminAuthorizer } = props;
 
-    const adminAttach = apigateway.Resource.fromResourceAttributes(this, "AdminRouteParent", {
-      restApi,
-      resourceId: adminResource.resourceId,
-      path: adminResource.path,
-    });
+    const adminServices = apigateway.Resource.fromResourceAttributes(
+      this,
+      "ServicesRouteParent",
+      {
+        restApi,
+        resourceId: servicesResource.resourceId,
+        path: servicesResource.path,
+      },
+    );
 
-    // Admin service routes
-    const adminServices = adminAttach.addResource("services");
     adminServices.addMethod("GET", adminIntegration, {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: adminAuthorizer,

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -3035,15 +3035,22 @@ export class ApiStack extends cdk.Stack {
       authorizer: adminAuthorizer,
     });
 
+    const adminServices = admin.addResource("services");
+    const adminContacts = admin.addResource("contacts");
+    const adminFamilies = admin.addResource("families");
+    const adminOrganizations = admin.addResource("organizations");
+
     new ApiAdminServicesStack(this, "ApiAdminServicesStack", {
       restApi: api,
-      adminResource: admin,
+      servicesResource: adminServices,
       adminIntegration,
       adminAuthorizer,
     });
     new ApiAdminCrmStack(this, "ApiAdminCrmStack", {
       restApi: api,
-      adminResource: admin,
+      contactsResource: adminContacts,
+      familiesResource: adminFamilies,
+      organizationsResource: adminOrganizations,
       adminIntegration,
       adminAuthorizer,
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The CDK deploy in [run #25157823988](https://github.com/lcacchiani/evolvesprouts/actions/runs/25157823988) failed with `AlreadyExists` errors:

```
Resource handler returned message: "Another resource with the same parent
already has this name: services" (HandlerErrorCode: AlreadyExists)
```

The same error occurred for `contacts`, `families`, and `organizations`.

## Root Cause

Commit `8fd5354e` moved admin API routes (`services`, `contacts`, `families`, `organizations`) from the parent `ApiStack` into new nested stacks (`ApiAdminServicesStack` and `ApiAdminCrmStack`). The nested stacks used `Resource.fromResourceAttributes` to import the `/v1/admin` parent resource and then called `addResource("services")` etc.

During CloudFormation update, the nested stacks tried to **create** these path-segment API Gateway resources before CloudFormation could **delete** the old ones from the parent stack, causing 409 conflicts.

## Fix

Keep the top-level path-segment resources (`services`, `contacts`, `families`, `organizations`) in the **parent stack** where they were originally defined. This preserves their CloudFormation logical IDs, so CloudFormation sees them as unchanged rather than as delete-and-recreate.

The nested stacks now receive the already-created resources and only add **methods and sub-resources** to them via `fromResourceAttributes`.

### Files changed

- `backend/infrastructure/lib/api-stack.ts` — create `services`, `contacts`, `families`, `organizations` resources in parent; pass to nested stacks
- `backend/infrastructure/lib/api-admin-services-stack.ts` — accept `servicesResource` instead of `adminResource`; import via `fromResourceAttributes`
- `backend/infrastructure/lib/api-admin-crm-stack.ts` — accept `contactsResource`, `familiesResource`, `organizationsResource`; import each via `fromResourceAttributes`

## Testing

- `npm run build` — compiles cleanly
- `npm run test:infra` — all CDK synthesis and assertion tests pass (including nested stack existence and 500-resource cap)
- `bash scripts/validate-cursorrules.sh` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e88f35a-0aa3-477b-8c68-a48bacc53774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e88f35a-0aa3-477b-8c68-a48bacc53774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

