### PR TITLE
Customer AR billing: payments, invoices, receipts, audit triggers

### DIFF
--- a/backend/db/alembic/versions/0052_customer_billing_audit.py
+++ b/backend/db/alembic/versions/0052_customer_billing_audit.py
@@ -1,0 +1,554 @@
+"""Customer billing (AR), audit_log table, triggers, enrollment bill-to.
+
+Adds ``audit_log`` (hybrid trigger context per docs/architecture/audit-logging.md),
+customer payment/allocation/invoice/receipt tables, document counters, enrollment
+billing columns, and audit triggers on new billing tables.
+
+Seed-data assessment (``backend/db/seed/seed_data.sql``):
+1. Compatible: new nullable columns on enrollments; no seed enrollments required.
+2. NOT NULL: none added without defaults on existing rows beyond nullable bill-to.
+3. N/A for dropped columns.
+4. New tables start empty.
+5. N/A.
+6. FK order: contacts/families/organizations exist before enrollments reference bill-to.
+
+Revision id length: 22 chars (<= 32).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0052_customer_billing_ar"
+down_revision: Union[str, None] = "0051_backfill_event_service_key"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+                table_name TEXT NOT NULL,
+                record_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                user_id TEXT,
+                request_id TEXT,
+                old_values JSONB,
+                new_values JSONB,
+                changed_fields TEXT[],
+                source TEXT NOT NULL DEFAULT 'trigger',
+                ip_address TEXT,
+                user_agent TEXT
+            )
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX IF NOT EXISTS audit_log_table_record_idx
+            ON audit_log (table_name, record_id)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX IF NOT EXISTS audit_log_timestamp_idx
+            ON audit_log (timestamp DESC)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX IF NOT EXISTS audit_log_user_id_idx
+            ON audit_log (user_id)
+            WHERE user_id IS NOT NULL
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX IF NOT EXISTS audit_log_action_idx
+            ON audit_log (action)
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE OR REPLACE FUNCTION billing_audit_row_change()
+            RETURNS TRIGGER AS $$
+            DECLARE
+                v_uid TEXT := NULLIF(current_setting('app.current_user_id', true), '');
+                v_rid TEXT := NULLIF(current_setting('app.current_request_id', true), '');
+            BEGIN
+                IF TG_OP = 'INSERT' THEN
+                    INSERT INTO audit_log (
+                        table_name, record_id, action,
+                        new_values, user_id, request_id, source
+                    ) VALUES (
+                        TG_TABLE_NAME,
+                        NEW.id::text,
+                        'INSERT',
+                        to_jsonb(NEW),
+                        NULLIF(v_uid, ''),
+                        NULLIF(v_rid, ''),
+                        'trigger'
+                    );
+                    RETURN NEW;
+                ELSIF TG_OP = 'UPDATE' THEN
+                    INSERT INTO audit_log (
+                        table_name, record_id, action,
+                        old_values, new_values, changed_fields,
+                        user_id, request_id, source
+                    ) VALUES (
+                        TG_TABLE_NAME,
+                        NEW.id::text,
+                        'UPDATE',
+                        to_jsonb(OLD),
+                        to_jsonb(NEW),
+                        NULL,
+                        NULLIF(v_uid, ''),
+                        NULLIF(v_rid, ''),
+                        'trigger'
+                    );
+                    RETURN NEW;
+                ELSIF TG_OP = 'DELETE' THEN
+                    INSERT INTO audit_log (
+                        table_name, record_id, action,
+                        old_values, user_id, request_id, source
+                    ) VALUES (
+                        TG_TABLE_NAME,
+                        OLD.id::text,
+                        'DELETE',
+                        to_jsonb(OLD),
+                        NULLIF(v_uid, ''),
+                        NULLIF(v_rid, ''),
+                        'trigger'
+                    );
+                    RETURN OLD;
+                END IF;
+                RETURN NULL;
+            END;
+            $$ LANGUAGE plpgsql
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            DO $$ BEGIN
+                CREATE TYPE billing_payment_direction AS ENUM ('inbound', 'refund');
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            DO $$ BEGIN
+                CREATE TYPE billing_payment_status AS ENUM ('pending', 'succeeded', 'failed');
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            DO $$ BEGIN
+                CREATE TYPE billing_bill_to_kind AS ENUM ('contact', 'family', 'organization');
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            DO $$ BEGIN
+                CREATE TYPE billing_invoice_status AS ENUM ('draft', 'issued', 'void');
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE TABLE document_counters (
+                document_type TEXT NOT NULL,
+                scope_key TEXT NOT NULL DEFAULT 'default',
+                year SMALLINT NOT NULL,
+                last_number INTEGER NOT NULL DEFAULT 0,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                PRIMARY KEY (document_type, scope_key, year)
+            )
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER document_counters_set_updated_at
+            BEFORE UPDATE ON document_counters
+            FOR EACH ROW EXECUTE FUNCTION set_updated_at()
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE TABLE customer_payments (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                direction billing_payment_direction NOT NULL DEFAULT 'inbound',
+                status billing_payment_status NOT NULL DEFAULT 'pending',
+                method TEXT NOT NULL,
+                amount NUMERIC(14, 4) NOT NULL,
+                currency CHAR(3) NOT NULL,
+                original_payment_id UUID REFERENCES customer_payments(id) ON DELETE SET NULL,
+                stripe_payment_intent_id VARCHAR(128),
+                stripe_refund_id VARCHAR(128),
+                external_reference TEXT,
+                succeeded_at TIMESTAMPTZ,
+                confirmed_by TEXT,
+                enrollment_id UUID REFERENCES enrollments(id) ON DELETE SET NULL,
+                contact_id UUID REFERENCES contacts(id) ON DELETE SET NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                CONSTRAINT customer_payments_amount_positive CHECK (amount >= 0),
+                CONSTRAINT customer_payments_stripe_pi_unique UNIQUE (stripe_payment_intent_id),
+                CONSTRAINT customer_payments_stripe_refund_unique UNIQUE (stripe_refund_id)
+            )
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX customer_payments_original_idx
+            ON customer_payments (original_payment_id)
+            WHERE original_payment_id IS NOT NULL
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX customer_payments_enrollment_idx
+            ON customer_payments (enrollment_id)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER customer_payments_set_updated_at
+            BEFORE UPDATE ON customer_payments
+            FOR EACH ROW EXECUTE FUNCTION set_updated_at()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER customer_payments_audit
+            AFTER INSERT OR UPDATE OR DELETE ON customer_payments
+            FOR EACH ROW EXECUTE FUNCTION billing_audit_row_change()
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE TABLE customer_invoices (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                status billing_invoice_status NOT NULL DEFAULT 'draft',
+                invoice_number TEXT,
+                invoice_sequence INTEGER,
+                currency CHAR(3) NOT NULL,
+                subtotal NUMERIC(14, 4) NOT NULL DEFAULT 0,
+                tax_total NUMERIC(14, 4) NOT NULL DEFAULT 0,
+                total NUMERIC(14, 4) NOT NULL DEFAULT 0,
+                bill_to_kind billing_bill_to_kind NOT NULL DEFAULT 'contact',
+                bill_to_contact_id UUID REFERENCES contacts(id) ON DELETE SET NULL,
+                bill_to_family_id UUID REFERENCES families(id) ON DELETE SET NULL,
+                bill_to_organization_id UUID REFERENCES organizations(id) ON DELETE SET NULL,
+                bill_to_display_name TEXT,
+                bill_to_email TEXT,
+                bill_to_snapshot JSONB,
+                issued_at TIMESTAMPTZ,
+                voided_at TIMESTAMPTZ,
+                void_reason TEXT,
+                issued_pdf_s3_key TEXT,
+                issued_pdf_sha256 CHAR(64),
+                pdf_template_version TEXT,
+                email_sent_at TIMESTAMPTZ,
+                ses_message_id TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                CONSTRAINT customer_invoices_bill_to_one_chk CHECK (
+                    (bill_to_kind = 'contact' AND bill_to_contact_id IS NOT NULL)
+                    OR (bill_to_kind = 'family' AND bill_to_family_id IS NOT NULL)
+                    OR (bill_to_kind = 'organization' AND bill_to_organization_id IS NOT NULL)
+                    OR status = 'draft'
+                )
+            )
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE UNIQUE INDEX customer_invoices_number_unique
+            ON customer_invoices (invoice_number)
+            WHERE invoice_number IS NOT NULL
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER customer_invoices_set_updated_at
+            BEFORE UPDATE ON customer_invoices
+            FOR EACH ROW EXECUTE FUNCTION set_updated_at()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER customer_invoices_audit
+            AFTER INSERT OR UPDATE OR DELETE ON customer_invoices
+            FOR EACH ROW EXECUTE FUNCTION billing_audit_row_change()
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE TABLE customer_invoice_lines (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                invoice_id UUID NOT NULL REFERENCES customer_invoices(id) ON DELETE CASCADE,
+                enrollment_id UUID NOT NULL REFERENCES enrollments(id) ON DELETE RESTRICT,
+                line_order SMALLINT NOT NULL DEFAULT 0,
+                description TEXT NOT NULL,
+                quantity NUMERIC(14, 4) NOT NULL DEFAULT 1,
+                unit_amount NUMERIC(14, 4) NOT NULL,
+                line_total NUMERIC(14, 4) NOT NULL,
+                discount_amount NUMERIC(14, 4),
+                tax_rate NUMERIC(10, 6),
+                tax_amount NUMERIC(14, 4),
+                currency CHAR(3) NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX customer_invoice_lines_invoice_idx
+            ON customer_invoice_lines (invoice_id)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER customer_invoice_lines_set_updated_at
+            BEFORE UPDATE ON customer_invoice_lines
+            FOR EACH ROW EXECUTE FUNCTION set_updated_at()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER customer_invoice_lines_audit
+            AFTER INSERT OR UPDATE OR DELETE ON customer_invoice_lines
+            FOR EACH ROW EXECUTE FUNCTION billing_audit_row_change()
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE TABLE payment_allocations (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                payment_id UUID NOT NULL REFERENCES customer_payments(id) ON DELETE CASCADE,
+                invoice_id UUID NOT NULL REFERENCES customer_invoices(id) ON DELETE CASCADE,
+                invoice_line_id UUID REFERENCES customer_invoice_lines(id) ON DELETE SET NULL,
+                allocated_amount NUMERIC(14, 4) NOT NULL,
+                currency CHAR(3) NOT NULL,
+                reversal_of_allocation_id UUID REFERENCES payment_allocations(id) ON DELETE SET NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                CONSTRAINT payment_allocations_nonzero CHECK (allocated_amount <> 0)
+            )
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX payment_allocations_payment_idx
+            ON payment_allocations (payment_id)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX payment_allocations_invoice_idx
+            ON payment_allocations (invoice_id)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER payment_allocations_set_updated_at
+            BEFORE UPDATE ON payment_allocations
+            FOR EACH ROW EXECUTE FUNCTION set_updated_at()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER payment_allocations_audit
+            AFTER INSERT OR UPDATE OR DELETE ON payment_allocations
+            FOR EACH ROW EXECUTE FUNCTION billing_audit_row_change()
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE TABLE customer_receipts (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                customer_payment_id UUID NOT NULL UNIQUE REFERENCES customer_payments(id) ON DELETE CASCADE,
+                receipt_number TEXT NOT NULL,
+                receipt_sequence INTEGER NOT NULL,
+                currency CHAR(3) NOT NULL,
+                total_amount NUMERIC(14, 4) NOT NULL,
+                issued_pdf_s3_key TEXT,
+                issued_pdf_sha256 CHAR(64),
+                pdf_template_version TEXT,
+                email_sent_at TIMESTAMPTZ,
+                ses_message_id TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE UNIQUE INDEX customer_receipts_number_unique
+            ON customer_receipts (receipt_number)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER customer_receipts_set_updated_at
+            BEFORE UPDATE ON customer_receipts
+            FOR EACH ROW EXECUTE FUNCTION set_updated_at()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER customer_receipts_audit
+            AFTER INSERT OR UPDATE OR DELETE ON customer_receipts
+            FOR EACH ROW EXECUTE FUNCTION billing_audit_row_change()
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE enrollments
+            ADD COLUMN IF NOT EXISTS bill_to_kind billing_bill_to_kind,
+            ADD COLUMN IF NOT EXISTS bill_to_contact_id UUID REFERENCES contacts(id) ON DELETE SET NULL,
+            ADD COLUMN IF NOT EXISTS bill_to_family_id UUID REFERENCES families(id) ON DELETE SET NULL,
+            ADD COLUMN IF NOT EXISTS bill_to_organization_id UUID REFERENCES organizations(id) ON DELETE SET NULL
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE enrollments
+            DROP COLUMN IF EXISTS bill_to_organization_id,
+            DROP COLUMN IF EXISTS bill_to_family_id,
+            DROP COLUMN IF EXISTS bill_to_contact_id,
+            DROP COLUMN IF EXISTS bill_to_kind
+            """
+        )
+    )
+
+    op.execute(sa.text("DROP TRIGGER IF EXISTS customer_receipts_audit ON customer_receipts"))
+    op.execute(sa.text("DROP TRIGGER IF EXISTS customer_receipts_set_updated_at ON customer_receipts"))
+    op.execute(sa.text("DROP TABLE IF EXISTS customer_receipts"))
+
+    op.execute(sa.text("DROP TRIGGER IF EXISTS payment_allocations_audit ON payment_allocations"))
+    op.execute(sa.text("DROP TRIGGER IF EXISTS payment_allocations_set_updated_at ON payment_allocations"))
+    op.execute(sa.text("DROP TABLE IF EXISTS payment_allocations"))
+
+    op.execute(sa.text("DROP TRIGGER IF EXISTS customer_invoice_lines_audit ON customer_invoice_lines"))
+    op.execute(sa.text("DROP TRIGGER IF EXISTS customer_invoice_lines_set_updated_at ON customer_invoice_lines"))
+    op.execute(sa.text("DROP TABLE IF EXISTS customer_invoice_lines"))
+
+    op.execute(sa.text("DROP TRIGGER IF EXISTS customer_invoices_audit ON customer_invoices"))
+    op.execute(sa.text("DROP TRIGGER IF EXISTS customer_invoices_set_updated_at ON customer_invoices"))
+    op.execute(sa.text("DROP TABLE IF EXISTS customer_invoices"))
+
+    op.execute(sa.text("DROP TRIGGER IF EXISTS customer_payments_audit ON customer_payments"))
+    op.execute(sa.text("DROP TRIGGER IF EXISTS customer_payments_set_updated_at ON customer_payments"))
+    op.execute(sa.text("DROP TABLE IF EXISTS customer_payments"))
+
+    op.execute(sa.text("DROP TRIGGER IF EXISTS document_counters_set_updated_at ON document_counters"))
+    op.execute(sa.text("DROP TABLE IF EXISTS document_counters"))
+
+    op.execute(sa.text("DROP FUNCTION IF EXISTS billing_audit_row_change()"))
+
+    op.execute(sa.text("DROP TYPE IF EXISTS billing_invoice_status"))
+    op.execute(sa.text("DROP TYPE IF EXISTS billing_bill_to_kind"))
+    op.execute(sa.text("DROP TYPE IF EXISTS billing_payment_status"))
+    op.execute(sa.text("DROP TYPE IF EXISTS billing_payment_direction"))
+
+    op.execute(sa.text("DROP TABLE IF EXISTS audit_log"))

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -3225,6 +3225,59 @@ export class ApiStack extends cdk.Stack {
       authorizer: adminAuthorizer,
     });
 
+    // Admin customer billing (AR)
+    const adminBilling = admin.addResource("billing");
+    const adminBillingExport = adminBilling.addResource("export");
+    adminBillingExport.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    const adminBillingPayments = adminBilling.addResource("payments");
+    adminBillingPayments.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminBillingPayments.addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    const adminBillingPaymentById = adminBillingPayments.addResource("{id}");
+    adminBillingPaymentById.addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminBillingPaymentById.addResource("unapplied").addMethod("GET", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminBillingPaymentById.addResource("confirm").addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    const adminBillingInvoices = adminBilling.addResource("invoices");
+    adminBillingInvoices.addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    const adminBillingInvoiceById = adminBillingInvoices.addResource("{id}");
+    adminBillingInvoiceById.addResource("issue").addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminBillingInvoiceById.addResource("void").addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    adminBillingInvoiceById.addResource("email").addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+    const adminBillingAllocations = adminBilling.addResource("allocations");
+    adminBillingAllocations.addMethod("POST", adminIntegration, {
+      authorizationType: apigateway.AuthorizationType.CUSTOM,
+      authorizer: adminAuthorizer,
+    });
+
     // User asset routes
     const user = v1.addResource("user");
     const userAssets = user.addResource("assets");

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ psycopg[binary]==3.2.13
 sqlalchemy==2.0.46
 phonenumbers==9.0.29
 pycountry==26.2.16
+reportlab==4.4.6

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -22,6 +22,7 @@ from app.api.admin_users import (
     handle_admin_instructors_request,
     handle_admin_users_request,
 )
+from app.api.admin_billing import handle_admin_billing_request
 from app.api.admin_contacts import handle_admin_contacts_request
 from app.api.admin_tags import handle_admin_tags_request
 from app.api.admin_families import handle_admin_families_request
@@ -167,6 +168,11 @@ _ROUTES: tuple[
         "/v1/admin/expenses",
         False,
         handle_admin_expenses_request,
+    ),
+    (
+        "/v1/admin/billing",
+        False,
+        handle_admin_billing_request,
     ),
     (
         "/v1/admin/tags",

--- a/backend/src/app/api/admin_billing.py
+++ b/backend/src/app/api/admin_billing.py
@@ -1,0 +1,562 @@
+"""Admin customer billing (AR) API."""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from collections.abc import Mapping
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, joinedload
+
+from app.api.admin_request import parse_body, parse_uuid, request_id
+from app.api.assets.assets_common import extract_identity, split_route_parts
+from app.db.audit import AuditService, set_audit_context
+from app.db.engine import get_engine
+from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
+from app.db.models.customer_payment import CustomerPayment
+from app.db.models import Enrollment
+from app.db.models.enums import (
+    BillingBillToKind,
+    BillingInvoiceStatus,
+    BillingPaymentDirection,
+    BillingPaymentStatus,
+)
+from app.db.models.payment_allocation import PaymentAllocation
+from app.exceptions import NotFoundError, ValidationError
+from app.services.customer_billing import (
+    next_invoice_number,
+    payment_unapplied_amount,
+    refresh_invoice_pdf,
+    send_invoice_email,
+)
+from app.utils import json_response
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_LIMIT = 50
+
+
+def handle_admin_billing_request(
+    event: Mapping[str, Any],
+    method: str,
+    path: str,
+) -> dict[str, Any]:
+    """Route /v1/admin/billing/*."""
+    parts = split_route_parts(path)
+    if len(parts) < 2 or parts[0] != "admin" or parts[1] != "billing":
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    identity = extract_identity(event)
+    if not identity.user_sub:
+        raise ValidationError("Authenticated user is required", field="authorization")
+
+    req = request_id(event)
+
+    if len(parts) < 3:
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    sub = parts[2]
+
+    if sub == "export" and method == "GET" and len(parts) == 3:
+        return _export_csv(event, user_sub=identity.user_sub, request_id=req)
+
+    if sub == "payments" and len(parts) == 3:
+        if method == "GET":
+            return _list_payments(event, user_sub=identity.user_sub, request_id=req)
+        if method == "POST":
+            return _create_payment(event, user_sub=identity.user_sub, request_id=req)
+
+    if sub == "payments" and len(parts) == 4:
+        pid = parse_uuid(parts[3])
+        if method == "GET":
+            return _get_payment(pid, user_sub=identity.user_sub, request_id=req)
+
+    if sub == "payments" and len(parts) == 5 and parts[4] == "unapplied":
+        pid = parse_uuid(parts[3])
+        if method == "GET":
+            return _unapplied(pid, user_sub=identity.user_sub, request_id=req)
+
+    if sub == "payments" and len(parts) == 5 and parts[4] == "confirm":
+        pid = parse_uuid(parts[3])
+        if method == "POST":
+            return _confirm_payment(
+                event, pid, user_sub=identity.user_sub, request_id=req
+            )
+
+    if sub == "invoices" and len(parts) == 3:
+        if method == "POST":
+            return _create_invoice_draft(
+                event, user_sub=identity.user_sub, request_id=req
+            )
+
+    if sub == "invoices" and len(parts) == 5:
+        inv_id = parse_uuid(parts[3])
+        action = parts[4]
+        if action == "issue" and method == "POST":
+            return _issue_invoice(
+                event, inv_id, user_sub=identity.user_sub, request_id=req
+            )
+        if action == "void" and method == "POST":
+            return _void_invoice(
+                event, inv_id, user_sub=identity.user_sub, request_id=req
+            )
+        if action == "email" and method == "POST":
+            return _email_invoice(
+                event, inv_id, user_sub=identity.user_sub, request_id=req
+            )
+
+    if sub == "allocations" and len(parts) == 3 and method == "POST":
+        return _create_allocation(event, user_sub=identity.user_sub, request_id=req)
+
+    return json_response(404, {"error": "Not found"}, event=event)
+
+
+def _session_with_audit(user_sub: str, request_id_val: str | None) -> Session:
+    session = Session(get_engine())
+    set_audit_context(session, user_id=user_sub, request_id=request_id_val)
+    return session
+
+
+def _serialize_payment(p: CustomerPayment) -> dict[str, Any]:
+    return {
+        "id": str(p.id),
+        "direction": p.direction.value,
+        "status": p.status.value,
+        "method": p.method,
+        "amount": str(p.amount),
+        "currency": p.currency,
+        "originalPaymentId": str(p.original_payment_id)
+        if p.original_payment_id
+        else None,
+        "stripePaymentIntentId": p.stripe_payment_intent_id,
+        "stripeRefundId": p.stripe_refund_id,
+        "enrollmentId": str(p.enrollment_id) if p.enrollment_id else None,
+        "contactId": str(p.contact_id) if p.contact_id else None,
+        "succeededAt": p.succeeded_at.isoformat() if p.succeeded_at else None,
+        "createdAt": p.created_at.isoformat(),
+    }
+
+
+def _list_payments(
+    event: Mapping[str, Any], *, user_sub: str, request_id: str | None
+) -> dict[str, Any]:
+    with _session_with_audit(user_sub, request_id) as session:
+        stmt = (
+            select(CustomerPayment)
+            .order_by(CustomerPayment.created_at.desc())
+            .limit(_DEFAULT_LIMIT)
+        )
+        rows = list(session.execute(stmt).scalars().all())
+        return json_response(
+            200,
+            {"items": [_serialize_payment(p) for p in rows]},
+            event=event,
+        )
+
+
+def _get_payment(
+    payment_id: UUID, *, user_sub: str, request_id: str | None
+) -> dict[str, Any]:
+    with _session_with_audit(user_sub, request_id) as session:
+        p = session.get(CustomerPayment, payment_id)
+        if p is None:
+            raise NotFoundError("CustomerPayment", str(payment_id))
+        unapplied = str(payment_unapplied_amount(session, payment_id))
+        return json_response(
+            200,
+            {**_serialize_payment(p), "unappliedAmount": unapplied},
+            event=event,
+        )
+
+
+def _unapplied(
+    payment_id: UUID, *, user_sub: str, request_id: str | None
+) -> dict[str, Any]:
+    with _session_with_audit(user_sub, request_id) as session:
+        p = session.get(CustomerPayment, payment_id)
+        if p is None:
+            raise NotFoundError("CustomerPayment", str(payment_id))
+        u = payment_unapplied_amount(session, payment_id)
+        return json_response(
+            200,
+            {"paymentId": str(payment_id), "unappliedAmount": str(u)},
+            event=event,
+        )
+
+
+def _create_payment(
+    event: Mapping[str, Any], *, user_sub: str, request_id: str | None
+) -> dict[str, Any]:
+    body = parse_body(event)
+    direction = str(body.get("direction") or "inbound").strip().lower()
+    if direction != "refund":
+        raise ValidationError(
+            "Only refund creates are supported on this endpoint; "
+            "use POST .../payments/{id}/confirm for pending inbound",
+            field="direction",
+        )
+
+    oid = body.get("originalPaymentId") or body.get("original_payment_id")
+    if not oid:
+        raise ValidationError("originalPaymentId is required", field="originalPaymentId")
+    orig_id = UUID(str(oid))
+    amount = Decimal(str(body.get("amount")))
+    currency = str(body.get("currency") or "").upper()[:3]
+    if len(currency) != 3:
+        raise ValidationError("currency is required", field="currency")
+
+    refund = CustomerPayment(
+        direction=BillingPaymentDirection.REFUND,
+        status=BillingPaymentStatus.SUCCEEDED,
+        method=str(body.get("method") or "refund")[:64],
+        amount=amount,
+        currency=currency,
+        original_payment_id=orig_id,
+        stripe_refund_id=str(body.get("stripeRefundId") or "").strip() or None,
+        succeeded_at=datetime.now(UTC),
+        confirmed_by=user_sub,
+    )
+    with _session_with_audit(user_sub, request_id) as session:
+        session.add(refund)
+        session.flush()
+        audit = AuditService(session, user_id=user_sub, request_id=request_id)
+        audit.log_custom(
+            table_name="customer_payments",
+            record_id=refund.id,
+            action="REFUND_CREATED",
+            new_values={"original_payment_id": str(orig_id), "amount": str(amount)},
+        )
+        payload = _serialize_payment(refund)
+        session.commit()
+    return json_response(201, {"payment": payload}, event=event)
+
+
+def _confirm_payment(
+    event: Mapping[str, Any],
+    payment_id: UUID,
+    *,
+    user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    body = parse_body(event) if event.get("body") else {}
+    with _session_with_audit(user_sub, request_id) as session:
+        p = session.get(CustomerPayment, payment_id)
+        if p is None:
+            raise NotFoundError("CustomerPayment", str(payment_id))
+        if p.status != BillingPaymentStatus.PENDING:
+            raise ValidationError("Payment is not pending", field="paymentId")
+        p.status = BillingPaymentStatus.SUCCEEDED
+        p.succeeded_at = datetime.now(UTC)
+        p.confirmed_by = user_sub
+        p.external_reference = (
+            str(body.get("externalReference") or body.get("external_reference") or "")
+            .strip()
+            or None
+        )
+        session.flush()
+        create_receipt_for_succeeded_inbound_payment(session, payment=p)
+        out = _serialize_payment(p)
+        session.commit()
+    return json_response(200, {"payment": out}, event=event)
+
+
+def _enrollment_merge_key(en: Enrollment) -> tuple[Any, ...]:
+    bk = en.bill_to_kind or BillingBillToKind.CONTACT
+    return (
+        bk,
+        en.bill_to_contact_id,
+        en.bill_to_family_id,
+        en.bill_to_organization_id,
+    )
+
+
+def _create_invoice_draft(
+    event: Mapping[str, Any], *, user_sub: str, request_id: str | None
+) -> dict[str, Any]:
+    body = parse_body(event)
+    raw_ids = body.get("enrollmentIds") or body.get("enrollment_ids")
+    if not isinstance(raw_ids, list) or not raw_ids:
+        raise ValidationError("enrollmentIds is required", field="enrollmentIds")
+    eids = [UUID(str(x)) for x in raw_ids]
+    currency = str(body.get("currency") or "").upper()[:3]
+    if len(currency) != 3:
+        raise ValidationError("currency is required", field="currency")
+
+    with _session_with_audit(user_sub, request_id) as session:
+        enrollments: list[Enrollment] = []
+        for eid in eids:
+            en = session.execute(
+                select(Enrollment)
+                .where(Enrollment.id == eid)
+                .options(
+                    joinedload(Enrollment.instance),
+                    joinedload(Enrollment.contact),
+                )
+            ).unique().scalar_one_or_none()
+            if en is None:
+                raise ValidationError(f"Enrollment not found: {eid}", field="enrollmentIds")
+            ec = (en.currency or "HKD").upper()[:3]
+            if ec != currency:
+                raise ValidationError(
+                    "All enrollments must match invoice currency",
+                    field="currency",
+                )
+            enrollments.append(en)
+
+        keys = {_enrollment_merge_key(e) for e in enrollments}
+        if len(keys) != 1:
+            raise ValidationError(
+                "Merged invoice requires identical bill-to on all enrollments",
+                field="enrollmentIds",
+            )
+
+        first = enrollments[0]
+        bill_kind = first.bill_to_kind or BillingBillToKind.CONTACT
+        inv = CustomerInvoice(
+            status=BillingInvoiceStatus.DRAFT,
+            currency=currency,
+            subtotal=Decimal("0"),
+            tax_total=Decimal("0"),
+            total=Decimal("0"),
+            bill_to_kind=bill_kind,
+            bill_to_contact_id=first.bill_to_contact_id or first.contact_id,
+            bill_to_family_id=first.bill_to_family_id,
+            bill_to_organization_id=first.bill_to_organization_id,
+        )
+        if first.contact and first.contact.email:
+            inv.bill_to_email = first.contact.email
+            inv.bill_to_display_name = " ".join(
+                x for x in [first.contact.first_name, first.contact.last_name] if x
+            ).strip() or None
+
+        session.add(inv)
+        session.flush()
+
+        subtotal = Decimal("0")
+        tax_total = Decimal("0")
+        for order, en in enumerate(enrollments):
+            title = ""
+            if en.instance:
+                title = (en.instance.title or "").strip()
+            line_total = en.amount_paid or Decimal("0")
+            desc = title or "Enrollment"
+            line = CustomerInvoiceLine(
+                invoice_id=inv.id,
+                enrollment_id=en.id,
+                line_order=order,
+                description=desc[:500],
+                quantity=Decimal("1"),
+                unit_amount=line_total,
+                line_total=line_total,
+                currency=currency,
+            )
+            session.add(line)
+            subtotal += line_total
+
+        inv.subtotal = subtotal
+        inv.tax_total = tax_total
+        inv.total = subtotal + tax_total
+        session.flush()
+
+        audit = AuditService(session, user_id=user_sub, request_id=request_id)
+        audit.log_custom(
+            table_name="customer_invoices",
+            record_id=inv.id,
+            action="DRAFT_CREATED",
+            new_values={"enrollment_ids": [str(x) for x in eids]},
+        )
+        session.commit()
+
+        return json_response(
+            201,
+            {"invoiceId": str(inv.id), "status": inv.status.value},
+            event=event,
+        )
+
+
+def _issue_invoice(
+    event: Mapping[str, Any],
+    invoice_id: UUID,
+    *,
+    user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    with _session_with_audit(user_sub, request_id) as session:
+        inv = session.get(CustomerInvoice, invoice_id)
+        if inv is None:
+            raise NotFoundError("CustomerInvoice", str(invoice_id))
+        if inv.status != BillingInvoiceStatus.DRAFT:
+            raise ValidationError("Invoice is not draft", field="invoiceId")
+
+        num, seq = next_invoice_number(session, currency=inv.currency)
+        inv.invoice_number = num
+        inv.invoice_sequence = seq
+        inv.status = BillingInvoiceStatus.ISSUED
+        inv.issued_at = datetime.now(UTC)
+        session.flush()
+        refresh_invoice_pdf(session, inv)
+        session.commit()
+
+        return json_response(
+            200,
+            {
+                "invoiceId": str(inv.id),
+                "invoiceNumber": inv.invoice_number,
+                "issuedPdfSha256": inv.issued_pdf_sha256,
+            },
+            event=event,
+        )
+
+
+def _void_invoice(
+    event: Mapping[str, Any],
+    invoice_id: UUID,
+    *,
+    user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    body = parse_body(event)
+    reason = str(body.get("reason") or "").strip()
+    if not reason:
+        raise ValidationError("reason is required", field="reason")
+    with _session_with_audit(user_sub, request_id) as session:
+        inv = session.get(CustomerInvoice, invoice_id)
+        if inv is None:
+            raise NotFoundError("CustomerInvoice", str(invoice_id))
+        inv.status = BillingInvoiceStatus.VOID
+        inv.voided_at = datetime.now(UTC)
+        inv.void_reason = reason[:2000]
+        session.commit()
+        return json_response(200, {"invoiceId": str(inv.id), "status": "void"}, event=event)
+
+
+def _email_invoice(
+    event: Mapping[str, Any],
+    invoice_id: UUID,
+    *,
+    user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    body = parse_body(event)
+    to_email = str(body.get("toEmail") or body.get("to_email") or "").strip()
+    if not to_email:
+        raise ValidationError("toEmail is required", field="toEmail")
+    with _session_with_audit(user_sub, request_id) as session:
+        send_invoice_email(session, invoice_id=invoice_id, to_email=to_email)
+        session.commit()
+        return json_response(200, {"sent": True}, event=event)
+
+
+def _create_allocation(
+    event: Mapping[str, Any], *, user_sub: str, request_id: str | None
+) -> dict[str, Any]:
+    body = parse_body(event)
+    payment_id = UUID(str(body.get("paymentId") or body.get("payment_id")))
+    invoice_id = UUID(str(body.get("invoiceId") or body.get("invoice_id")))
+    amt = Decimal(str(body.get("allocatedAmount") or body.get("allocated_amount")))
+    currency = str(body.get("currency") or "").upper()[:3]
+    line_id_raw = body.get("invoiceLineId") or body.get("invoice_line_id")
+    line_id = UUID(str(line_id_raw)) if line_id_raw else None
+
+    with _session_with_audit(user_sub, request_id) as session:
+        pay = session.get(CustomerPayment, payment_id)
+        inv = session.get(CustomerInvoice, invoice_id)
+        if pay is None or inv is None:
+            raise NotFoundError(
+                "PaymentAllocationTarget",
+                f"{payment_id}/{invoice_id}",
+            )
+        if pay.currency != currency or inv.currency != currency:
+            raise ValidationError("Currency mismatch", field="currency")
+        unapplied = payment_unapplied_amount(session, payment_id)
+        if amt > unapplied:
+            raise ValidationError(
+                "Allocation exceeds unapplied amount", field="allocatedAmount"
+            )
+        alloc = PaymentAllocation(
+            payment_id=payment_id,
+            invoice_id=invoice_id,
+            invoice_line_id=line_id,
+            allocated_amount=amt,
+            currency=currency,
+        )
+        session.add(alloc)
+        session.flush()
+        session.commit()
+        return json_response(
+            201,
+            {"allocationId": str(alloc.id)},
+            event=event,
+        )
+
+
+def _export_csv(
+    event: Mapping[str, Any], *, user_sub: str, request_id: str | None
+) -> dict[str, Any]:
+    with _session_with_audit(user_sub, request_id) as session:
+        payments = (
+            session.execute(
+                select(CustomerPayment)
+                .order_by(CustomerPayment.created_at.desc())
+                .limit(5000)
+            )
+            .scalars()
+            .all()
+        )
+        allocs = session.execute(select(PaymentAllocation).limit(10000)).scalars().all()
+
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(
+        [
+            "export_version",
+            "document_type",
+            "document_id",
+            "amount",
+            "currency",
+            "stripe_payment_intent_id",
+            "stripe_refund_id",
+            "enrollment_id",
+            "created_at",
+        ]
+    )
+    for p in payments:
+        w.writerow(
+            [
+                "1",
+                "payment",
+                str(p.id),
+                str(p.amount),
+                p.currency,
+                p.stripe_payment_intent_id or "",
+                p.stripe_refund_id or "",
+                str(p.enrollment_id) if p.enrollment_id else "",
+                p.created_at.isoformat(),
+            ]
+        )
+    for a in allocs:
+        w.writerow(
+            [
+                "1",
+                "allocation",
+                str(a.id),
+                str(a.allocated_amount),
+                a.currency,
+                "",
+                "",
+                "",
+                a.created_at.isoformat(),
+            ]
+        )
+
+    return json_response(
+        200,
+        {"csv": buf.getvalue()},
+        event=event,
+    )

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -9,6 +9,7 @@ from decimal import InvalidOperation
 from typing import Any
 from collections.abc import Mapping
 from urllib.parse import quote
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
@@ -30,6 +31,7 @@ from app.api.public_form_hooks import (
     normalize_body_locale,
     send_booking_confirmation_email,
 )
+from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.models import Enrollment, ServiceInstance
 from app.db.repositories import (
@@ -41,6 +43,7 @@ from app.api.discount_enrollment_scope import (
     ensure_discount_code_eligible_for_instance,
 )
 from app.db.models.enums import (
+    BillingBillToKind,
     ContactSource,
     ContactType,
     DiscountType,
@@ -54,6 +57,10 @@ from app.db.repositories.contact import ContactRepository
 from app.db.repositories.sales_lead import SalesLeadRepository
 from app.exceptions import ValidationError
 from app.services.aws_proxy import AwsProxyError, http_invoke
+from app.services.customer_billing import (
+    record_reservation_customer_payment,
+    send_receipt_email,
+)
 from app.services.public_form_internal_notifications import (
     build_reservation_recap_lines,
     send_sales_form_recap_email,
@@ -151,6 +158,86 @@ def _resolve_booking_identity(
     return resolved
 
 
+def _parse_bill_to_fields(
+    body: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Optional bill-to for enrollment (family/organization). Defaults to contact at persist."""
+    raw_kind = body.get("billToKind") or body.get("bill_to_kind")
+    if raw_kind is None or str(raw_kind).strip() == "":
+        return {
+            "bill_to_kind": BillingBillToKind.CONTACT,
+            "bill_to_contact_id": None,
+            "bill_to_family_id": None,
+            "bill_to_organization_id": None,
+        }
+    s = str(raw_kind).strip().lower()
+    if s == "contact":
+        k = BillingBillToKind.CONTACT
+    elif s == "family":
+        k = BillingBillToKind.FAMILY
+    elif s == "organization":
+        k = BillingBillToKind.ORGANIZATION
+    else:
+        raise ValidationError(
+            "billToKind must be contact, family, or organization",
+            field="billToKind",
+        )
+
+    def _opt_uuid(field_camel: str, field_snake: str) -> UUID | None:
+        raw = body.get(field_camel) or body.get(field_snake)
+        if raw is None or str(raw).strip() == "":
+            return None
+        try:
+            return UUID(str(raw).strip())
+        except ValueError as exc:
+            raise ValidationError(
+                f"{field_camel} must be a valid UUID", field=field_camel
+            ) from exc
+
+    return {
+        "bill_to_kind": k,
+        "bill_to_contact_id": _opt_uuid("billToContactId", "bill_to_contact_id"),
+        "bill_to_family_id": _opt_uuid("billToFamilyId", "bill_to_family_id"),
+        "bill_to_organization_id": _opt_uuid(
+            "billToOrganizationId", "bill_to_organization_id"
+        ),
+    }
+
+
+def _apply_enrollment_bill_to(
+    enrollment: Enrollment,
+    *,
+    contact_id: UUID,
+    bill: Mapping[str, Any],
+) -> None:
+    kind: BillingBillToKind = bill["bill_to_kind"]
+    enrollment.bill_to_kind = kind
+    if kind == BillingBillToKind.CONTACT:
+        enrollment.bill_to_contact_id = bill.get("bill_to_contact_id") or contact_id
+        enrollment.bill_to_family_id = None
+        enrollment.bill_to_organization_id = None
+    elif kind == BillingBillToKind.FAMILY:
+        fid = bill.get("bill_to_family_id")
+        if fid is None:
+            raise ValidationError(
+                "billToFamilyId is required when billToKind is family",
+                field="billToFamilyId",
+            )
+        enrollment.bill_to_family_id = fid
+        enrollment.bill_to_contact_id = None
+        enrollment.bill_to_organization_id = None
+    else:
+        oid = bill.get("bill_to_organization_id")
+        if oid is None:
+            raise ValidationError(
+                "billToOrganizationId is required when billToKind is organization",
+                field="billToOrganizationId",
+            )
+        enrollment.bill_to_organization_id = oid
+        enrollment.bill_to_contact_id = None
+        enrollment.bill_to_family_id = None
+
+
 def _handle_public_reservation(
     event: Mapping[str, Any],
     method: str,
@@ -196,7 +283,10 @@ def _handle_public_reservation(
         )
 
     try:
+        request_id_str = str(event.get("requestContext", {}).get("requestId") or "")
+        receipt_email_after_commit: tuple[UUID, str] | None = None
         with Session(get_engine()) as session:
+            set_audit_context(session, user_id=None, request_id=request_id_str or None)
             resolved_instance = _resolve_booking_identity(session, reservation_payload)
             reservation_payload = {
                 **reservation_payload,
@@ -254,10 +344,29 @@ def _handle_public_reservation(
                     discount_code_id=None,
                     status=EnrollmentStatus.REGISTERED,
                     amount_paid=reservation_payload["total_amount"],
-                    currency="HKD",
+                    currency=reservation_payload["currency"],
                     notes=None,
                     created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
                 )
+                try:
+                    _apply_enrollment_bill_to(
+                        enrollment_row,
+                        contact_id=contact.id,
+                        bill={
+                            "bill_to_kind": reservation_payload["bill_to_kind"],
+                            "bill_to_contact_id": reservation_payload[
+                                "bill_to_contact_id"
+                            ],
+                            "bill_to_family_id": reservation_payload[
+                                "bill_to_family_id"
+                            ],
+                            "bill_to_organization_id": reservation_payload[
+                                "bill_to_organization_id"
+                            ],
+                        },
+                    )
+                except ValidationError as exc:
+                    return json_response(exc.status_code, exc.to_dict(), event=event)
                 created_enrollment, create_err = (
                     enrollment_repo.try_create_enrollment_with_capacity_guard(
                         enrollment_row
@@ -282,6 +391,23 @@ def _handle_public_reservation(
                             )
                         created_enrollment.discount_code_id = dc_row.id
                         session.flush()
+                    _pay, receipt_id = record_reservation_customer_payment(
+                        session,
+                        enrollment_id=created_enrollment.id,
+                        contact_id=contact.id,
+                        currency=reservation_payload["currency"],
+                        total_amount=reservation_payload["total_amount"],
+                        payment_method=reservation_payload["payment_method"],
+                        stripe_payment_intent_id=reservation_payload.get(
+                            "stripe_payment_intent_id"
+                        ),
+                        stripe_currency=reservation_payload.get("stripe_currency"),
+                    )
+                    if receipt_id is not None:
+                        receipt_email_after_commit = (
+                            receipt_id,
+                            reservation_payload["attendee_email"],
+                        )
 
             lead_metadata: dict[str, object] = {
                 "payment_method": reservation_payload["payment_method"],
@@ -317,6 +443,18 @@ def _handle_public_reservation(
                 metadata=lead_metadata,
             )
             session.commit()
+
+            if receipt_email_after_commit is not None:
+                rid, r_email = receipt_email_after_commit
+                try:
+                    with Session(get_engine()) as rs:
+                        send_receipt_email(rs, receipt_id=rid, to_email=r_email)
+                        rs.commit()
+                except Exception:
+                    logger.exception(
+                        "Receipt email send failed",
+                        extra={"receipt_id": str(rid)},
+                    )
     except ValidationError as exc:
         return json_response(exc.status_code, exc.to_dict(), event=event)
     except Exception:
@@ -515,6 +653,7 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         _MAX_LABEL_LENGTH,
     )
     total_amount = _parse_total_amount(body.get("totalAmount"))
+    sale_currency = _optional_currency(body.get("currency"))
     stripe_payment_intent_id = _stripe_payment_intent_id_from_body(body)
     schedule_date = _optional_text(
         body.get("scheduleDate"),
@@ -653,6 +792,8 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
     if pm_lower == "free":
         reservation_pending = False
 
+    bill = _parse_bill_to_fields(body)
+
     return {
         "attendee_name": attendee_name,
         "attendee_email": attendee_email,
@@ -663,6 +804,7 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         "service_tier": service_tier,
         "payment_method": payment_method,
         "total_amount": total_amount,
+        "currency": sale_currency,
         "title": title,
         "schedule_date": schedule_date,
         "schedule_time": schedule_time,
@@ -688,6 +830,10 @@ def _validate_reservation_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         "service_instance_cohort": service_instance_cohort,
         "agreed_to_terms_and_conditions": True,
         "reservation_pending_until_payment_confirmed": reservation_pending,
+        "bill_to_kind": bill["bill_to_kind"],
+        "bill_to_contact_id": bill["bill_to_contact_id"],
+        "bill_to_family_id": bill["bill_to_family_id"],
+        "bill_to_organization_id": bill["bill_to_organization_id"],
     }
 
 
@@ -824,9 +970,9 @@ def _optional_fps_qr_data_url(value: Any) -> str | None:
 
 def _validate_payment_confirmation(
     event: Mapping[str, Any],
-    reservation_payload: Mapping[str, Any],
+    reservation_payload: dict[str, Any],
 ) -> None:
-    """Validate Stripe payment confirmation details for Stripe reservations."""
+    """Validate Stripe payment confirmation; attach ``stripe_currency`` when Stripe."""
     payment_method = (
         str(reservation_payload.get("payment_method") or "").strip().lower()
     )
@@ -868,6 +1014,8 @@ def _validate_payment_confirmation(
         stripe_intent=stripe_intent,
         reservation_payload=reservation_payload,
     )
+    cur = str(stripe_intent.get("currency") or "hkd").upper()[:3]
+    reservation_payload["stripe_currency"] = cur
 
 
 def _retrieve_stripe_payment_intent(
@@ -980,6 +1128,19 @@ def _optional_text(value: Any, field_name: str, max_length: int) -> str | None:
         max_length=max_length,
         required=False,
     )
+
+
+def _optional_currency(raw: Any) -> str:
+    """ISO 4217 currency; default HKD for legacy clients."""
+    if raw is None or str(raw).strip() == "":
+        return "HKD"
+    s = str(raw).strip().upper()
+    if len(s) != 3 or not s.isalpha():
+        raise ValidationError(
+            "currency must be a 3-letter ISO 4217 code",
+            field="currency",
+        )
+    return s
 
 
 def _parse_total_amount(value: Any) -> Decimal:

--- a/backend/src/app/db/models/__init__.py
+++ b/backend/src/app/db/models/__init__.py
@@ -3,6 +3,9 @@
 from app.db.models.asset import Asset, AssetAccessGrant, AssetShareLink
 from app.db.models.audit_log import AuditLog
 from app.db.models.contact import Contact
+from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
+from app.db.models.customer_payment import CustomerPayment
+from app.db.models.customer_receipt import CustomerReceipt
 from app.db.models.discount_code import DiscountCode
 from app.db.models.enrollment import Enrollment
 from app.db.models.expense import Expense, ExpenseAttachment
@@ -11,6 +14,10 @@ from app.db.models.enums import (
     AccessGrantType,
     AssetType,
     AssetVisibility,
+    BillingBillToKind,
+    BillingInvoiceStatus,
+    BillingPaymentDirection,
+    BillingPaymentStatus,
     ConsultationFormat,
     ConsultationPricingModel,
     ContactSource,
@@ -43,6 +50,7 @@ from app.db.models.legacy_import_ref import LegacyImportRef
 from app.db.models.location import Location
 from app.db.models.note import Note
 from app.db.models.organization import Organization, OrganizationMember
+from app.db.models.payment_allocation import DocumentCounter, PaymentAllocation
 from app.db.models.sales_lead import SalesLead, SalesLeadEvent
 from app.db.models.service import (
     ConsultationDetails,
@@ -72,6 +80,10 @@ __all__ = [
     "AssetType",
     "AssetVisibility",
     "AuditLog",
+    "BillingBillToKind",
+    "BillingInvoiceStatus",
+    "BillingPaymentDirection",
+    "BillingPaymentStatus",
     "ConsultationDetails",
     "ConsultationFormat",
     "ConsultationInstanceDetails",
@@ -79,9 +91,12 @@ __all__ = [
     "Contact",
     "ContactSource",
     "ContactTag",
-    "ContactType",
-    "DiscountCode",
+    "CustomerInvoice",
+    "CustomerInvoiceLine",
+    "CustomerPayment",
+    "CustomerReceipt",
     "DiscountType",
+    "DocumentCounter",
     "EventbriteSyncStatus",
     "Expense",
     "ExpenseAttachment",
@@ -113,6 +128,7 @@ __all__ = [
     "OrganizationRole",
     "OrganizationTag",
     "OrganizationType",
+    "PaymentAllocation",
     "RelationshipType",
     "SalesLead",
     "SalesLeadEvent",

--- a/backend/src/app/db/models/customer_invoice.py
+++ b/backend/src/app/db/models/customer_invoice.py
@@ -1,0 +1,163 @@
+"""Customer AR invoice and line items."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, TYPE_CHECKING
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy import ForeignKey, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import TIMESTAMP, Numeric
+
+from app.db.base import Base
+from app.db.models.enums import BillingBillToKind, BillingInvoiceStatus
+
+if TYPE_CHECKING:
+    from app.db.models.enrollment import Enrollment
+
+
+def _kind_values(_enum_cls: type[BillingBillToKind] | None = None) -> list[str]:
+    return [e.value for e in BillingBillToKind]
+
+
+def _inv_status_values(_enum_cls: type[BillingInvoiceStatus] | None = None) -> list[str]:
+    return [e.value for e in BillingInvoiceStatus]
+
+
+class CustomerInvoice(Base):
+    """AR invoice (draft, issued, or void)."""
+
+    __tablename__ = "customer_invoices"
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    status: Mapped[BillingInvoiceStatus] = mapped_column(
+        sa.Enum(
+            BillingInvoiceStatus,
+            name="billing_invoice_status",
+            values_callable=_inv_status_values,
+            create_type=False,
+        ),
+        nullable=False,
+        server_default=text("'draft'"),
+    )
+    invoice_number: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    invoice_sequence: Mapped[int | None] = mapped_column(sa.Integer, nullable=True)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    subtotal: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    tax_total: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    total: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    bill_to_kind: Mapped[BillingBillToKind] = mapped_column(
+        sa.Enum(
+            BillingBillToKind,
+            name="billing_bill_to_kind",
+            values_callable=_kind_values,
+            create_type=False,
+        ),
+        nullable=False,
+        server_default=text("'contact'"),
+    )
+    bill_to_contact_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("contacts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    bill_to_family_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    bill_to_organization_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    bill_to_display_name: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    bill_to_email: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    bill_to_snapshot: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB(astext_type=sa.Text()),
+        nullable=True,
+    )
+    issued_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    voided_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    void_reason: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    issued_pdf_s3_key: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    issued_pdf_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    pdf_template_version: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    email_sent_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    ses_message_id: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    lines: Mapped[list[CustomerInvoiceLine]] = relationship(
+        "CustomerInvoiceLine",
+        back_populates="invoice",
+        cascade="all, delete-orphan",
+    )
+
+
+class CustomerInvoiceLine(Base):
+    """Invoice line tied to an enrollment."""
+
+    __tablename__ = "customer_invoice_lines"
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    invoice_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("customer_invoices.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    enrollment_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("enrollments.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    line_order: Mapped[int] = mapped_column(sa.SmallInteger, nullable=False)
+    description: Mapped[str] = mapped_column(Text(), nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    unit_amount: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    line_total: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    discount_amount: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    tax_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    tax_amount: Mapped[Decimal | None] = mapped_column(Numeric(14, 4), nullable=True)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    invoice: Mapped[CustomerInvoice] = relationship(
+        "CustomerInvoice",
+        back_populates="lines",
+    )

--- a/backend/src/app/db/models/customer_payment.py
+++ b/backend/src/app/db/models/customer_payment.py
@@ -1,0 +1,134 @@
+"""Customer (AR) payment and refund rows."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy import CheckConstraint, ForeignKey, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import TIMESTAMP, Numeric
+
+from app.db.base import Base
+from app.db.models.enums import (
+    BillingPaymentDirection,
+    BillingPaymentStatus,
+)
+
+if TYPE_CHECKING:
+    from app.db.models.contact import Contact
+    from app.db.models.enrollment import Enrollment
+
+
+def _billing_dir_values(
+    _enum_cls: type[BillingPaymentDirection] | None = None,
+) -> list[str]:
+    return [e.value for e in BillingPaymentDirection]
+
+
+def _billing_status_values(
+    _enum_cls: type[BillingPaymentStatus] | None = None,
+) -> list[str]:
+    return [e.value for e in BillingPaymentStatus]
+
+
+class CustomerPayment(Base):
+    """Inbound payment or refund (refund links via ``original_payment_id``)."""
+
+    __tablename__ = "customer_payments"
+    __table_args__ = (
+        CheckConstraint("amount >= 0", name="customer_payments_amount_positive"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    direction: Mapped[BillingPaymentDirection] = mapped_column(
+        sa.Enum(
+            BillingPaymentDirection,
+            name="billing_payment_direction",
+            values_callable=_billing_dir_values,
+            create_type=False,
+        ),
+        nullable=False,
+        server_default=text("'inbound'"),
+    )
+    status: Mapped[BillingPaymentStatus] = mapped_column(
+        sa.Enum(
+            BillingPaymentStatus,
+            name="billing_payment_status",
+            values_callable=_billing_status_values,
+            create_type=False,
+        ),
+        nullable=False,
+        server_default=text("'pending'"),
+    )
+    method: Mapped[str] = mapped_column(String(64), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    original_payment_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("customer_payments.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    stripe_payment_intent_id: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, unique=True
+    )
+    stripe_refund_id: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, unique=True
+    )
+    external_reference: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    succeeded_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    confirmed_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    enrollment_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("enrollments.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    contact_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("contacts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    original_payment: Mapped[CustomerPayment | None] = relationship(
+        "CustomerPayment",
+        remote_side="CustomerPayment.id",
+    )
+    enrollment: Mapped[Enrollment | None] = relationship("Enrollment")
+    contact: Mapped[Contact | None] = relationship("Contact")
+
+    def to_audit_dict(self) -> dict[str, Any]:
+        return {
+            "id": str(self.id),
+            "direction": self.direction.value,
+            "status": self.status.value,
+            "method": self.method,
+            "amount": str(self.amount),
+            "currency": self.currency,
+            "original_payment_id": str(self.original_payment_id)
+            if self.original_payment_id
+            else None,
+            "stripe_payment_intent_id": self.stripe_payment_intent_id,
+            "stripe_refund_id": self.stripe_refund_id,
+            "enrollment_id": str(self.enrollment_id) if self.enrollment_id else None,
+            "contact_id": str(self.contact_id) if self.contact_id else None,
+        }

--- a/backend/src/app/db/models/customer_receipt.py
+++ b/backend/src/app/db/models/customer_receipt.py
@@ -1,0 +1,55 @@
+"""Customer receipt (one per succeeded inbound payment)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import TIMESTAMP, Numeric
+
+from app.db.base import Base
+
+
+class CustomerReceipt(Base):
+    """Proof of payment document."""
+
+    __tablename__ = "customer_receipts"
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    customer_payment_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("customer_payments.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    receipt_number: Mapped[str] = mapped_column(Text(), nullable=False)
+    receipt_sequence: Mapped[int] = mapped_column(nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    total_amount: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    issued_pdf_s3_key: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    issued_pdf_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    pdf_template_version: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    email_sent_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    ses_message_id: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    payment = relationship("CustomerPayment", backref="receipt_row")

--- a/backend/src/app/db/models/enrollment.py
+++ b/backend/src/app/db/models/enrollment.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import TIMESTAMP, Numeric
 
 from app.db.base import Base
-from app.db.models.enums import EnrollmentStatus
+from app.db.models.enums import BillingBillToKind, EnrollmentStatus
 
 if TYPE_CHECKING:
     from app.db.models.contact import Contact
@@ -28,6 +28,12 @@ if TYPE_CHECKING:
 def _enum_values(enum_cls: Iterable[EnrollmentStatus]) -> list[str]:
     """Return enum labels stored in PostgreSQL."""
     return [member.value for member in enum_cls]
+
+
+def _billing_bill_to_kind_values(
+    _enum_cls: type[BillingBillToKind] | None = None,
+) -> list[str]:
+    return [member.value for member in BillingBillToKind]
 
 
 class Enrollment(Base):
@@ -88,6 +94,30 @@ class Enrollment(Base):
         ForeignKey("discount_codes.id", ondelete="SET NULL"),
         nullable=True,
     )
+    bill_to_kind: Mapped[BillingBillToKind | None] = mapped_column(
+        Enum(
+            BillingBillToKind,
+            name="billing_bill_to_kind",
+            values_callable=_billing_bill_to_kind_values,
+            create_type=False,
+        ),
+        nullable=True,
+    )
+    bill_to_contact_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("contacts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    bill_to_family_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("families.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    bill_to_organization_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     status: Mapped[EnrollmentStatus] = mapped_column(
         Enum(
             EnrollmentStatus,
@@ -126,9 +156,30 @@ class Enrollment(Base):
         "ServiceInstance",
         back_populates="enrollments",
     )
-    contact: Mapped[Contact | None] = relationship("Contact")
-    family: Mapped[Family | None] = relationship("Family")
-    organization: Mapped[Organization | None] = relationship("Organization")
+    contact: Mapped[Contact | None] = relationship(
+        "Contact",
+        foreign_keys="[Enrollment.contact_id]",
+    )
+    bill_to_contact: Mapped[Contact | None] = relationship(
+        "Contact",
+        foreign_keys="[Enrollment.bill_to_contact_id]",
+    )
+    family: Mapped[Family | None] = relationship(
+        "Family",
+        foreign_keys="[Enrollment.family_id]",
+    )
+    bill_to_family: Mapped[Family | None] = relationship(
+        "Family",
+        foreign_keys="[Enrollment.bill_to_family_id]",
+    )
+    organization: Mapped[Organization | None] = relationship(
+        "Organization",
+        foreign_keys="[Enrollment.organization_id]",
+    )
+    bill_to_organization: Mapped[Organization | None] = relationship(
+        "Organization",
+        foreign_keys="[Enrollment.bill_to_organization_id]",
+    )
     ticket_tier: Mapped[EventTicketTier | None] = relationship(
         "EventTicketTier",
         back_populates="enrollments",

--- a/backend/src/app/db/models/enums.py
+++ b/backend/src/app/db/models/enums.py
@@ -280,3 +280,34 @@ class InboundEmailStatus(str, enum.Enum):
     STORED = "stored"
     SKIPPED = "skipped"
     FAILED = "failed"
+
+
+class BillingPaymentDirection(str, enum.Enum):
+    """Customer payment row direction (matches ``billing_payment_direction``)."""
+
+    INBOUND = "inbound"
+    REFUND = "refund"
+
+
+class BillingPaymentStatus(str, enum.Enum):
+    """Customer payment status (matches ``billing_payment_status``)."""
+
+    PENDING = "pending"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class BillingBillToKind(str, enum.Enum):
+    """Invoice bill-to (matches ``billing_bill_to_kind``)."""
+
+    CONTACT = "contact"
+    FAMILY = "family"
+    ORGANIZATION = "organization"
+
+
+class BillingInvoiceStatus(str, enum.Enum):
+    """Customer invoice status (matches ``billing_invoice_status``)."""
+
+    DRAFT = "draft"
+    ISSUED = "issued"
+    VOID = "void"

--- a/backend/src/app/db/models/payment_allocation.py
+++ b/backend/src/app/db/models/payment_allocation.py
@@ -1,0 +1,83 @@
+"""Links customer payments to invoices (partial allocation support)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy import CheckConstraint, ForeignKey, PrimaryKeyConstraint, String, text
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import TIMESTAMP, Numeric
+
+from app.db.base import Base
+
+
+class PaymentAllocation(Base):
+    """Allocation of payment amount to an invoice (optionally a line)."""
+
+    __tablename__ = "payment_allocations"
+    __table_args__ = (
+        CheckConstraint("allocated_amount <> 0", name="payment_allocations_nonzero"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    payment_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("customer_payments.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    invoice_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("customer_invoices.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    invoice_line_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("customer_invoice_lines.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    allocated_amount: Mapped[Decimal] = mapped_column(Numeric(14, 4), nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    reversal_of_allocation_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("payment_allocations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+
+class DocumentCounter(Base):
+    """Serialized invoice/receipt numbering per scope and year."""
+
+    __tablename__ = "document_counters"
+    __table_args__ = (PrimaryKeyConstraint("document_type", "scope_key", "year"),)
+
+    document_type: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    scope_key: Mapped[str] = mapped_column(
+        sa.Text, nullable=False, server_default=text("'default'")
+    )
+    year: Mapped[int] = mapped_column(sa.SmallInteger, nullable=False)
+    last_number: Mapped[int] = mapped_column(
+        sa.Integer, nullable=False, server_default=text("0")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )

--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -1,0 +1,431 @@
+"""Customer billing (AR): PDF generation, S3, receipts, reservation capture."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+from sqlalchemy import func, select, text
+from sqlalchemy.orm import Session
+
+from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
+from app.db.models.customer_payment import CustomerPayment
+from app.db.models.customer_receipt import CustomerReceipt
+from app.db.models.enums import (
+    BillingPaymentDirection,
+    BillingPaymentStatus,
+)
+from app.db.models.payment_allocation import DocumentCounter, PaymentAllocation
+from app.services.aws_clients import get_s3_client
+from app.services.email import send_mime_email_with_optional_attachments
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+PDF_TEMPLATE_VERSION = "billing-v1"
+_SCOPE_DEFAULT = "default"
+_DOC_INVOICE = "invoice"
+_DOC_RECEIPT = "receipt"
+
+
+def _confirmation_from_address() -> str:
+    return os.getenv("CONFIRMATION_EMAIL_FROM_ADDRESS", "").strip()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def render_invoice_pdf(
+    *,
+    invoice: CustomerInvoice,
+    lines: list[CustomerInvoiceLine],
+) -> bytes:
+    """Render a minimal AR invoice PDF (immutable snapshot)."""
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=A4)
+    width, height = A4
+    y = height - 50
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(50, y, "Invoice")
+    y -= 24
+    c.setFont("Helvetica", 10)
+    if invoice.invoice_number:
+        c.drawString(50, y, f"Number: {invoice.invoice_number}")
+        y -= 14
+    if invoice.issued_at:
+        c.drawString(50, y, f"Issued: {invoice.issued_at.isoformat()}")
+        y -= 14
+    c.drawString(50, y, f"Currency: {invoice.currency}")
+    y -= 14
+    if invoice.bill_to_display_name:
+        c.drawString(50, y, f"Bill to: {invoice.bill_to_display_name}")
+        y -= 14
+    if invoice.bill_to_email:
+        c.drawString(50, y, f"Email: {invoice.bill_to_email}")
+        y -= 20
+    y -= 10
+    c.setFont("Helvetica-Bold", 10)
+    c.drawString(50, y, "Description")
+    c.drawString(320, y, "Amount")
+    y -= 16
+    c.setFont("Helvetica", 9)
+    for line in sorted(lines, key=lambda x: x.line_order):
+        desc = (line.description or "")[:80]
+        c.drawString(50, y, desc)
+        c.drawRightString(540, y, f"{line.line_total} {line.currency}")
+        y -= 14
+        if y < 80:
+            c.showPage()
+            y = height - 50
+    y -= 10
+    c.setFont("Helvetica-Bold", 10)
+    c.drawString(50, y, "Total")
+    c.drawRightString(540, y, f"{invoice.total} {invoice.currency}")
+    c.showPage()
+    c.save()
+    return buf.getvalue()
+
+
+def render_receipt_pdf(
+    *,
+    receipt: CustomerReceipt,
+    payment: CustomerPayment,
+    allocation_invoice_numbers: list[tuple[str, Decimal]],
+) -> bytes:
+    """Render receipt PDF (one per succeeded inbound payment)."""
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=A4)
+    height = A4[1]
+    y = height - 50
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(50, y, "Payment receipt")
+    y -= 24
+    c.setFont("Helvetica", 10)
+    c.drawString(50, y, f"Receipt: {receipt.receipt_number}")
+    y -= 14
+    c.drawString(50, y, f"Amount: {receipt.total_amount} {receipt.currency}")
+    y -= 14
+    c.drawString(50, y, f"Method: {payment.method}")
+    y -= 14
+    if payment.stripe_payment_intent_id:
+        c.drawString(50, y, f"Stripe PI: {payment.stripe_payment_intent_id}")
+        y -= 14
+    if allocation_invoice_numbers:
+        y -= 8
+        c.drawString(50, y, "Applied to invoices:")
+        y -= 14
+        for inv_no, amt in allocation_invoice_numbers:
+            c.drawString(60, y, f"{inv_no}: {amt} {receipt.currency}")
+            y -= 12
+    c.showPage()
+    c.save()
+    return buf.getvalue()
+
+
+def store_pdf_in_assets_bucket(*, s3_key: str, body: bytes, content_type: str) -> None:
+    bucket = os.getenv("ASSETS_BUCKET_NAME", "").strip()
+    if not bucket:
+        logger.warning("ASSETS_BUCKET_NAME not set; skipping PDF upload")
+        return
+    get_s3_client().put_object(
+        Bucket=bucket,
+        Key=s3_key,
+        Body=body,
+        ContentType=content_type,
+    )
+
+
+def next_invoice_number(session: Session, *, currency: str) -> tuple[str, int]:
+    """Atomically allocate next invoice number (counter per currency scope + year)."""
+    now = datetime.now(UTC)
+    year = now.year
+    scope_key = f"inv-{currency.upper()}"
+    session.execute(
+        text(
+            """
+            INSERT INTO document_counters (document_type, scope_key, year, last_number)
+            VALUES (:dt, :sk, :yr, 0)
+            ON CONFLICT (document_type, scope_key, year) DO NOTHING
+            """
+        ),
+        {"dt": _DOC_INVOICE, "sk": scope_key, "yr": year},
+    )
+    row = session.execute(
+        select(DocumentCounter)
+        .where(DocumentCounter.document_type == _DOC_INVOICE)
+        .where(DocumentCounter.scope_key == scope_key)
+        .where(DocumentCounter.year == year)
+        .with_for_update()
+    ).scalar_one()
+    row.last_number += 1
+    seq = row.last_number
+    inv_num = f"INV-{year}-{seq:06d}-{currency.upper()}"
+    session.flush()
+    return inv_num, seq
+
+
+def next_receipt_number(session: Session, *, currency: str) -> tuple[str, int]:
+    now = datetime.now(UTC)
+    year = now.year
+    scope_key = f"rcp-{currency.upper()}"
+    session.execute(
+        text(
+            """
+            INSERT INTO document_counters (document_type, scope_key, year, last_number)
+            VALUES (:dt, :sk, :yr, 0)
+            ON CONFLICT (document_type, scope_key, year) DO NOTHING
+            """
+        ),
+        {"dt": _DOC_RECEIPT, "sk": scope_key, "yr": year},
+    )
+    row = session.execute(
+        select(DocumentCounter)
+        .where(DocumentCounter.document_type == _DOC_RECEIPT)
+        .where(DocumentCounter.scope_key == scope_key)
+        .where(DocumentCounter.year == year)
+        .with_for_update()
+    ).scalar_one()
+    row.last_number += 1
+    seq = row.last_number
+    rnum = f"RCP-{year}-{seq:06d}-{currency.upper()}"
+    session.flush()
+    return rnum, seq
+
+
+def allocation_invoice_labels_for_payment(
+    session: Session, payment_id: UUID
+) -> list[tuple[str, Decimal]]:
+    rows = session.execute(
+        select(CustomerInvoice.invoice_number, PaymentAllocation.allocated_amount)
+        .join(
+            CustomerInvoice,
+            CustomerInvoice.id == PaymentAllocation.invoice_id,
+        )
+        .where(PaymentAllocation.payment_id == payment_id)
+        .where(CustomerInvoice.invoice_number.isnot(None))
+    ).all()
+    out: list[tuple[str, Decimal]] = []
+    for inv_num, amt in rows:
+        if inv_num and amt is not None:
+            out.append((str(inv_num), Decimal(str(amt))))
+    return out
+
+
+def create_receipt_for_succeeded_inbound_payment(
+    session: Session,
+    *,
+    payment: CustomerPayment,
+) -> CustomerReceipt:
+    """Create receipt row + PDF + S3 for an inbound succeeded payment."""
+    if payment.direction != BillingPaymentDirection.INBOUND:
+        raise ValueError("Receipt only for inbound payments")
+    if payment.status != BillingPaymentStatus.SUCCEEDED:
+        raise ValueError("Receipt requires succeeded payment")
+    existing = session.execute(
+        select(CustomerReceipt).where(
+            CustomerReceipt.customer_payment_id == payment.id
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return existing
+
+    rnum, seq = next_receipt_number(session, currency=payment.currency)
+    labels = allocation_invoice_labels_for_payment(session, payment.id)
+    receipt = CustomerReceipt(
+        customer_payment_id=payment.id,
+        receipt_number=rnum,
+        receipt_sequence=seq,
+        currency=payment.currency,
+        total_amount=payment.amount,
+        pdf_template_version=PDF_TEMPLATE_VERSION,
+    )
+    session.add(receipt)
+    session.flush()
+
+    pdf_bytes = render_receipt_pdf(
+        receipt=receipt,
+        payment=payment,
+        allocation_invoice_numbers=labels,
+    )
+    digest = _sha256_bytes(pdf_bytes)
+    key = f"billing/receipts/{receipt.id}.pdf"
+    store_pdf_in_assets_bucket(
+        s3_key=key,
+        body=pdf_bytes,
+        content_type="application/pdf",
+    )
+    receipt.issued_pdf_s3_key = key
+    receipt.issued_pdf_sha256 = digest
+    session.flush()
+    return receipt
+
+
+def send_receipt_email(session: Session, *, receipt_id: UUID, to_email: str) -> None:
+    """Email receipt PDF to customer (best-effort)."""
+    receipt = session.get(CustomerReceipt, receipt_id)
+    if receipt is None or not receipt.issued_pdf_s3_key:
+        return
+    payment = session.get(CustomerPayment, receipt.customer_payment_id)
+    if payment is None:
+        return
+    bucket = os.getenv("ASSETS_BUCKET_NAME", "").strip()
+    if not bucket:
+        logger.warning("ASSETS_BUCKET_NAME missing; cannot attach receipt PDF")
+        return
+    obj = get_s3_client().get_object(Bucket=bucket, Key=receipt.issued_pdf_s3_key)
+    pdf_bytes = obj["Body"].read()
+    src = _confirmation_from_address()
+    if not src:
+        logger.warning("CONFIRMATION_EMAIL_FROM_ADDRESS missing; skip receipt email")
+        return
+    subject = f"Receipt {receipt.receipt_number}"
+    body_text = (
+        f"Thank you. Please find your payment receipt {receipt.receipt_number} attached."
+    )
+    body_html = f"<p>{body_text}</p>"
+    send_mime_email_with_optional_attachments(
+        source=src,
+        to_addresses=[to_email],
+        subject=subject,
+        body_text=body_text,
+        body_html=body_html,
+        attachments=[
+            (
+                f"receipt-{receipt.receipt_number}.pdf",
+                "application/pdf",
+                pdf_bytes,
+            )
+        ],
+    )
+    # SES message id not captured by send_raw_email wrapper; leave ses_message_id null
+    receipt.email_sent_at = datetime.now(UTC)
+    session.flush()
+
+
+def record_reservation_customer_payment(
+    session: Session,
+    *,
+    enrollment_id: UUID,
+    contact_id: UUID,
+    currency: str,
+    total_amount: Decimal,
+    payment_method: str,
+    stripe_payment_intent_id: str | None,
+    stripe_currency: str | None,
+) -> tuple[CustomerPayment | None, UUID | None]:
+    """Insert customer_payment for a new enrollment; return receipt id when generated."""
+    pm_lower = (payment_method or "").strip().lower()
+    is_free = pm_lower == "free" or total_amount == Decimal("0")
+    expects_stripe = "stripe" in pm_lower or "apple pay" in pm_lower
+
+    pay_currency = (stripe_currency or currency or "HKD").upper()[:3]
+
+    if expects_stripe and stripe_payment_intent_id:
+        pay = CustomerPayment(
+            direction=BillingPaymentDirection.INBOUND,
+            status=BillingPaymentStatus.SUCCEEDED,
+            method="stripe_card",
+            amount=total_amount,
+            currency=pay_currency,
+            stripe_payment_intent_id=stripe_payment_intent_id,
+            succeeded_at=datetime.now(UTC),
+            enrollment_id=enrollment_id,
+            contact_id=contact_id,
+        )
+    elif is_free:
+        pay = CustomerPayment(
+            direction=BillingPaymentDirection.INBOUND,
+            status=BillingPaymentStatus.SUCCEEDED,
+            method="free",
+            amount=Decimal("0"),
+            currency=pay_currency,
+            succeeded_at=datetime.now(UTC),
+            enrollment_id=enrollment_id,
+            contact_id=contact_id,
+        )
+    else:
+        pay = CustomerPayment(
+            direction=BillingPaymentDirection.INBOUND,
+            status=BillingPaymentStatus.PENDING,
+            method=payment_method[:64],
+            amount=total_amount,
+            currency=pay_currency,
+            enrollment_id=enrollment_id,
+            contact_id=contact_id,
+        )
+    session.add(pay)
+    session.flush()
+    receipt_id: UUID | None = None
+    if pay.status == BillingPaymentStatus.SUCCEEDED:
+        rcpt = create_receipt_for_succeeded_inbound_payment(session, payment=pay)
+        receipt_id = rcpt.id
+    return pay, receipt_id
+
+
+def refresh_invoice_pdf(session: Session, invoice: CustomerInvoice) -> None:
+    """Generate and store invoice PDF + hash for issued invoice."""
+    lines = list(
+        session.execute(
+            select(CustomerInvoiceLine).where(
+                CustomerInvoiceLine.invoice_id == invoice.id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    pdf_bytes = render_invoice_pdf(invoice=invoice, lines=lines)
+    digest = _sha256_bytes(pdf_bytes)
+    key = f"billing/invoices/{invoice.id}.pdf"
+    store_pdf_in_assets_bucket(s3_key=key, body=pdf_bytes, content_type="application/pdf")
+    invoice.issued_pdf_s3_key = key
+    invoice.issued_pdf_sha256 = digest
+    invoice.pdf_template_version = PDF_TEMPLATE_VERSION
+    session.flush()
+
+
+def send_invoice_email(session: Session, *, invoice_id: UUID, to_email: str) -> None:
+    inv = session.get(CustomerInvoice, invoice_id)
+    if inv is None or not inv.issued_pdf_s3_key:
+        return
+    bucket = os.getenv("ASSETS_BUCKET_NAME", "").strip()
+    if not bucket:
+        return
+    obj = get_s3_client().get_object(Bucket=bucket, Key=inv.issued_pdf_s3_key)
+    pdf_bytes = obj["Body"].read()
+    src = _confirmation_from_address()
+    if not src:
+        return
+    num = inv.invoice_number or str(inv.id)
+    subject = f"Invoice {num}"
+    body_text = f"Please find invoice {num} attached."
+    send_mime_email_with_optional_attachments(
+        source=src,
+        to_addresses=[to_email],
+        subject=subject,
+        body_text=body_text,
+        body_html=f"<p>{body_text}</p>",
+        attachments=[(f"invoice-{num}.pdf", "application/pdf", pdf_bytes)],
+    )
+    inv.email_sent_at = datetime.now(UTC)
+    session.flush()
+
+
+def payment_unapplied_amount(session: Session, payment_id: UUID) -> Decimal:
+    """amount - sum(allocations) for same payment."""
+    pay = session.get(CustomerPayment, payment_id)
+    if pay is None:
+        return Decimal("0")
+    allocated = session.execute(
+        select(func.coalesce(func.sum(PaymentAllocation.allocated_amount), 0)).where(
+            PaymentAllocation.payment_id == payment_id
+        )
+    ).scalar_one()
+    return Decimal(str(pay.amount)) - Decimal(str(allocated))

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -49,6 +49,16 @@ info:
     - `POST /v1/admin/expenses/{id}/mark-paid`
     - `POST /v1/admin/expenses/{id}/reparse`
     - `POST /v1/admin/expenses/{id}/amend`
+    - `GET /v1/admin/billing/export`
+    - `GET|POST /v1/admin/billing/payments`
+    - `GET /v1/admin/billing/payments/{id}`
+    - `GET /v1/admin/billing/payments/{id}/unapplied`
+    - `POST /v1/admin/billing/payments/{id}/confirm`
+    - `POST /v1/admin/billing/invoices`
+    - `POST /v1/admin/billing/invoices/{id}/issue`
+    - `POST /v1/admin/billing/invoices/{id}/void`
+    - `POST /v1/admin/billing/invoices/{id}/email`
+    - `POST /v1/admin/billing/allocations`
     - `GET|POST /v1/admin/leads`
     - `GET|PATCH /v1/admin/leads/{id}`
     - `POST /v1/admin/leads/{id}/notes`
@@ -2485,6 +2495,346 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AdminOrganizationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/billing/export:
+    get:
+      summary: Export billing CSV (payments and allocations)
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Accounting-oriented CSV payload.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - csv
+                properties:
+                  csv:
+                    type: string
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/billing/payments:
+    get:
+      summary: List recent customer payments
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Payment rows.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CustomerPaymentSummary"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      summary: Record refund payment row
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCustomerRefundRequest"
+      responses:
+        "201":
+          description: Refund created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payment:
+                    $ref: "#/components/schemas/CustomerPaymentSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/billing/payments/{id}:
+    get:
+      summary: Get customer payment with unapplied balance
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Payment detail.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CustomerPaymentSummary"
+                  - type: object
+                    properties:
+                      unappliedAmount:
+                        type: string
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/billing/payments/{id}/unapplied:
+    get:
+      summary: Unapplied amount for a payment
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Unapplied remainder.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  paymentId:
+                    type: string
+                    format: uuid
+                  unappliedAmount:
+                    type: string
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/billing/payments/{id}/confirm:
+    post:
+      summary: Confirm pending inbound payment (offline rails)
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                externalReference:
+                  type: string
+      responses:
+        "200":
+          description: Payment confirmed and receipt generated when applicable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payment:
+                    $ref: "#/components/schemas/CustomerPaymentSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/billing/invoices:
+    post:
+      summary: Create draft invoice from enrollments
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDraftInvoiceRequest"
+      responses:
+        "201":
+          description: Draft invoice created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invoiceId:
+                    type: string
+                    format: uuid
+                  status:
+                    type: string
+                    enum: [draft]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/billing/invoices/{id}/issue:
+    post:
+      summary: Issue invoice (assign number, PDF hash)
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Invoice issued.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invoiceId:
+                    type: string
+                    format: uuid
+                  invoiceNumber:
+                    type: string
+                  issuedPdfSha256:
+                    type: string
+                    nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/billing/invoices/{id}/void:
+    post:
+      summary: Void issued invoice
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+      responses:
+        "200":
+          description: Invoice voided.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invoiceId:
+                    type: string
+                    format: uuid
+                  status:
+                    type: string
+                    enum: [void]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/billing/invoices/{id}/email:
+    post:
+      summary: Email issued invoice PDF
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - toEmail
+              properties:
+                toEmail:
+                  type: string
+                  format: email
+      responses:
+        "200":
+          description: Email sent (best-effort).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sent:
+                    type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/billing/allocations:
+    post:
+      summary: Allocate payment amount to invoice
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePaymentAllocationRequest"
+      responses:
+        "201":
+          description: Allocation created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  allocationId:
+                    type: string
+                    format: uuid
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -5139,6 +5489,116 @@ components:
       properties:
         expense:
           $ref: "#/components/schemas/Expense"
+    CustomerPaymentSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        direction:
+          type: string
+          enum: [inbound, refund]
+        status:
+          type: string
+          enum: [pending, succeeded, failed]
+        method:
+          type: string
+        amount:
+          type: string
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+        originalPaymentId:
+          type: string
+          format: uuid
+          nullable: true
+        stripePaymentIntentId:
+          type: string
+          nullable: true
+        stripeRefundId:
+          type: string
+          nullable: true
+        enrollmentId:
+          type: string
+          format: uuid
+          nullable: true
+        contactId:
+          type: string
+          format: uuid
+          nullable: true
+        succeededAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+    CreateCustomerRefundRequest:
+      type: object
+      required:
+        - direction
+        - originalPaymentId
+        - amount
+        - currency
+      properties:
+        direction:
+          type: string
+          enum: [refund]
+        originalPaymentId:
+          type: string
+          format: uuid
+        amount:
+          type: string
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+        method:
+          type: string
+        stripeRefundId:
+          type: string
+          nullable: true
+    CreateDraftInvoiceRequest:
+      type: object
+      required:
+        - enrollmentIds
+        - currency
+      properties:
+        enrollmentIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          minItems: 1
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+    CreatePaymentAllocationRequest:
+      type: object
+      required:
+        - paymentId
+        - invoiceId
+        - allocatedAmount
+        - currency
+      properties:
+        paymentId:
+          type: string
+          format: uuid
+        invoiceId:
+          type: string
+          format: uuid
+        invoiceLineId:
+          type: string
+          format: uuid
+          nullable: true
+        allocatedAmount:
+          type: string
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
     ExpenseListResponse:
       type: object
       required:

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -606,7 +606,10 @@ paths:
         `serviceInstanceSlug` resolves to a `service_instances` row and the
         contact has no existing enrollment for that instance, inserts an
         `enrollments` row (`created_by`: `public-reservation`) with optional
-        `discount_code_id` and paid amount, then returns **202** on success.
+        `discount_code_id` and paid amount, currency, optional bill-to fields, then returns **202** on success.
+        When enrollment is created, records a **`customer_payments`** row (Stripe succeeded,
+        free, or pending for offline rails), generates a **receipt PDF** for succeeded inbound
+        payments when configured, and sends a **best-effort receipt email** after commit.
         Referral-type discount codes are rejected like the public validate endpoint.
         Returns **409** when the instance is full and public bookings may not waitlist.
         Best-effort SES booking
@@ -1341,6 +1344,30 @@ components:
           type: number
           minimum: 0
           maximum: 1000000
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+          description: >
+            ISO 4217 sale currency for enrollment and billing (defaults to HKD when omitted).
+        billToKind:
+          type: string
+          enum: [contact, family, organization]
+          description: >
+            Optional AR bill-to override; defaults to contact (attendee). When `family` or
+            `organization`, send the matching id field.
+        billToContactId:
+          type: string
+          format: uuid
+          nullable: true
+        billToFamilyId:
+          type: string
+          format: uuid
+          nullable: true
+        billToOrganizationId:
+          type: string
+          format: uuid
+          nullable: true
         title:
           type: string
           maxLength: 200

--- a/docs/architecture/audit-logging.md
+++ b/docs/architecture/audit-logging.md
@@ -157,6 +157,13 @@ The following tables have audit triggers:
 
 - `assets`
 - `asset_access_grants`
+- `customer_payments`
+- `customer_invoices`
+- `customer_invoice_lines`
+- `payment_allocations`
+- `customer_receipts`
+
+Application-level `AuditService` entries supplement invoice draft/issue flows where noted in code.
 
 ## Performance Considerations
 
@@ -214,7 +221,8 @@ current public reservation OpenAPI (`docs/api/public.yaml`).
 
 ## Migration
 
-The audit logging is added via Alembic migration `0010_add_audit_logging.py`.
+The original audit logging migration name referenced in older docs may differ; migration
+`0052_customer_billing_audit` creates `audit_log` when missing and wires billing-table triggers.
 
 To apply:
 ```bash
@@ -222,7 +230,6 @@ cd backend/db
 alembic upgrade head
 ```
 
-To rollback:
-```bash
-alembic downgrade 0009_rename_owner_to_manager
-```
+To rollback the billing/audit migration only (after prior head includes it), use the
+revision that immediately precedes `0052_customer_billing_ar` in your branch (for example
+`alembic downgrade 0051_backfill_event_service_key` when that is the down_revision).

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -487,6 +487,16 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | `/v1/admin/expenses/{id}/mark-paid` | POST | Admin Group | `EvolvesproutsAdminFunction` | Mark expense paid |
 | `/v1/admin/expenses/{id}/reparse` | POST | Admin Group | `EvolvesproutsAdminFunction` | Requeue parse |
 | `/v1/admin/expenses/{id}/amend` | POST | Admin Group | `EvolvesproutsAdminFunction` | Create amendment |
+| `/v1/admin/billing/export` | GET | Admin Group | `EvolvesproutsAdminFunction` | Customer AR CSV export |
+| `/v1/admin/billing/payments` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | List payments; record refund |
+| `/v1/admin/billing/payments/{id}` | GET | Admin Group | `EvolvesproutsAdminFunction` | Payment detail + unapplied |
+| `/v1/admin/billing/payments/{id}/unapplied` | GET | Admin Group | `EvolvesproutsAdminFunction` | Unapplied amount |
+| `/v1/admin/billing/payments/{id}/confirm` | POST | Admin Group | `EvolvesproutsAdminFunction` | Confirm pending payment |
+| `/v1/admin/billing/invoices` | POST | Admin Group | `EvolvesproutsAdminFunction` | Create draft invoice |
+| `/v1/admin/billing/invoices/{id}/issue` | POST | Admin Group | `EvolvesproutsAdminFunction` | Issue invoice |
+| `/v1/admin/billing/invoices/{id}/void` | POST | Admin Group | `EvolvesproutsAdminFunction` | Void invoice |
+| `/v1/admin/billing/invoices/{id}/email` | POST | Admin Group | `EvolvesproutsAdminFunction` | Email invoice PDF |
+| `/v1/admin/billing/allocations` | POST | Admin Group | `EvolvesproutsAdminFunction` | Allocate payment to invoice |
 | `/v1/user/assets` | GET | User Auth | `EvolvesproutsAdminFunction` | |
 | `/v1/user/assets/{id}/download` | GET | User Auth | `EvolvesproutsAdminFunction` | |
 | `/v1/assets/public` | GET | Device Attestation + API Key | `EvolvesproutsAdminFunction` | |

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -559,15 +559,34 @@ without breaking existing junction references.
   `0025_discount_codes_value_check` (replace CHECK) are split because PostgreSQL
   does not allow referencing a newly added enum value in the same transaction.
 
+- Migration `0052_customer_billing_ar` adds `audit_log` (if missing), customer billing
+  tables, `document_counters`, enrollment bill-to columns, and audit triggers for billing
+  tables.
+
 ### `enrollments`
 
 - Registration/booking rows linked to a `service_instances` row.
 - Supports parent linkage to one of contact/family/organization.
+- Optional bill-to fields (`bill_to_kind`, `bill_to_contact_id`, `bill_to_family_id`,
+  `bill_to_organization_id`) for AR invoicing (migration `0052_customer_billing_ar`).
 - Optional links to event ticket tiers and discount codes.
 - Migration `0045_enroll_inst_contact_uidx` adds partial unique index
   `enrollments_instance_contact_uidx` on `(instance_id, contact_id)` where
   `contact_id` is not null (at most one enrollment per contact per instance when
   the parent is a contact).
+
+### Customer billing (AR)
+
+Migration `0052_customer_billing_ar` introduces:
+
+- `customer_payments`: inbound payments and refunds (`direction`, `original_payment_id`,
+  `stripe_payment_intent_id`, `stripe_refund_id`), linked optionally to `enrollments` and `contacts`.
+- `customer_invoices` / `customer_invoice_lines`: draft/issued/void invoices with tax-ready line columns.
+- `payment_allocations`: links payments to invoices with allocated amounts (partial allocation).
+- `customer_receipts`: one row per succeeded inbound payment (`customer_payment_id` unique).
+- `document_counters`: serialized invoice/receipt numbering per scope and year.
+- `audit_log`: central audit table (created when missing) with triggers on billing tables via
+  `billing_audit_row_change()`.
 
 ### `service_tags` + `service_assets`
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -103,6 +103,7 @@ their primary responsibilities.
   effective discount type after the update is `referral`, otherwise `discount_value`
   must be greater than `0`),
   `/v1/admin/expenses/*`,
+  `/v1/admin/billing/*` (customer AR: payments, invoices, allocations, export),
   `/v1/user/assets/*`,
   `/v1/assets/public/*`, `/v1/assets/share/*`, `/v1/assets/email-download/*`,
   and `GET /v1/assets/free`,

--- a/tests/test_public_reservations_extended.py
+++ b/tests/test_public_reservations_extended.py
@@ -150,6 +150,18 @@ def _patch_public_reservation_db_helpers(monkeypatch: pytest.MonkeyPatch) -> Non
         "app.api.public_reservations.EnrollmentRepository",
         _FakeEnrollmentRepo,
     )
+    monkeypatch.setattr(
+        "app.api.public_reservations.record_reservation_customer_payment",
+        lambda *a, **k: (None, None),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.send_receipt_email",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.set_audit_context",
+        lambda *a, **k: None,
+    )
 
 
 def test_handle_public_reservation_returns_409_when_instance_capacity_full(
@@ -204,6 +216,18 @@ def test_handle_public_reservation_returns_409_when_instance_capacity_full(
     monkeypatch.setattr(
         "app.api.public_reservations.EnrollmentRepository",
         _FakeEnrollmentRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.record_reservation_customer_payment",
+        lambda *a, **k: (None, None),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.send_receipt_email",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.set_audit_context",
+        lambda *a, **k: None,
     )
 
     class _FakeContactRepo:
@@ -862,6 +886,18 @@ def test_handle_public_reservation_writes_discount_metadata_and_creates_enrollme
     monkeypatch.setattr(
         "app.api.public_reservations.EnrollmentRepository",
         _FakeEnrollmentRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.record_reservation_customer_payment",
+        lambda *a, **k: (None, None),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.send_receipt_email",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.set_audit_context",
+        lambda *a, **k: None,
     )
 
     class _FakeContactRepo:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the agreed customer **accounts receivable** model and wires it into **public reservations** and **admin APIs**.

### Database (Alembic `0052_customer_billing_ar`)

- **`audit_log`** table (created if missing) plus **`billing_audit_row_change()`** triggers on:
  `customer_payments`, `customer_invoices`, `customer_invoice_lines`, `payment_allocations`, `customer_receipts`
- **`customer_payments`**: inbound vs refund (`direction`), Stripe PI/refund ids, status, amounts, optional enrollment/contact link
- **`customer_invoices` / `customer_invoice_lines`**: draft/issued/void, tax-ready line columns, bill-to snapshot fields, PDF S3 key + SHA-256
- **`payment_allocations`**: payment → invoice (optional line), signed amounts for partial allocation
- **`customer_receipts`**: **one per succeeded inbound payment** (`customer_payment_id` unique)
- **`document_counters`**: serialized numbering per document type / scope / year
- **`enrollments`**: `bill_to_kind`, `bill_to_contact_id`, `bill_to_family_id`, `bill_to_organization_id`

### Public API

- `POST /v1/reservations` (and `/www/...`): optional **`currency`** (default HKD), **bill-to** fields; **`set_audit_context`** for trigger user/request correlation
- On new enrollment: creates **`customer_payment`** (Stripe succeeded / free / pending offline), **receipt PDF** to S3 for succeeded inbound, best-effort **receipt email** after commit
- Stripe verification attaches **`stripe_currency`** from the PaymentIntent

### Admin API (`/v1/admin/billing/*`)

- List/get payments, unapplied amount, **confirm** pending payment, **refund** row
- **Create draft invoice** from enrollments (merge requires matching bill-to + currency), **issue** (counter + PDF hash), **void**, **email** PDF
- **Allocate** payment to invoice
- **CSV export** (payments + allocations)
- Uses **`set_audit_context`** + **`AuditService.log_custom`** where appropriate

### Infra & docs

- API Gateway routes in `api-stack.ts`
- `docs/api/admin.yaml`, `docs/api/public.yaml`, `lambdas.md`, `database-schema.md`, `audit-logging.md`, `aws-assets-map.md`
- **reportlab** added for PDF generation

### Tests

- Full `pytest` suite passing; reservation tests updated with mocks for billing + `set_audit_context`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce56a3d4-8fda-4b89-b873-67203e7390f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce56a3d4-8fda-4b89-b873-67203e7390f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

