### PR TITLE
Fix admin audit logs 500 when list is empty

### DIFF
--- a/backend/src/app/api/admin_audit_logs.py
+++ b/backend/src/app/api/admin_audit_logs.py
@@ -299,13 +299,13 @@ def _list_audit_logs(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, A
     distinct_subs = sorted({r.user_id for r in trimmed if r.user_id})
     email_map = _cognito_emails_for_subs(distinct_subs)
 
-    last_row = trimmed[-1]
-    last_id = last_row.id if isinstance(last_row.id, UUID) else UUID(str(last_row.id))
-    next_cursor = (
-        encode_created_cursor(last_row.timestamp, last_id)
-        if has_more and trimmed
-        else None
-    )
+    next_cursor: str | None = None
+    if has_more and trimmed:
+        last_row = trimmed[-1]
+        last_id = (
+            last_row.id if isinstance(last_row.id, UUID) else UUID(str(last_row.id))
+        )
+        next_cursor = encode_created_cursor(last_row.timestamp, last_id)
     return json_response(
         200,
         {

--- a/tests/test_admin_audit_logs_api.py
+++ b/tests/test_admin_audit_logs_api.py
@@ -488,6 +488,51 @@ def test_next_cursor_null_when_not_full_page(
     assert body["next_cursor"] is None
 
 
+def test_recent_list_empty_returns_200(
+    api_gateway_event: Any, admin_identity: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: empty result must not IndexError when building next_cursor."""
+
+    class _Session:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        def __enter__(self) -> "_Session":
+            return self
+
+        def __exit__(self, *_a: object) -> None:
+            return None
+
+        def execute(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _Repo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_recent_activity(self, **_kwargs: Any) -> list[AuditLog]:
+            return []
+
+    monkeypatch.setattr(admin_audit_logs, "Session", _Session)
+    monkeypatch.setattr(admin_audit_logs, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_audit_logs, "AuditLogRepository", _Repo)
+    monkeypatch.setattr(admin_audit_logs, "_cognito_emails_for_subs", lambda _s: {})
+
+    r = admin_audit_logs.handle_admin_audit_logs_request(
+        api_gateway_event(
+            method="GET",
+            path="/v1/admin/audit-logs",
+            authorizer_context=admin_identity,
+        ),
+        "GET",
+        "/v1/admin/audit-logs",
+    )
+    assert r["statusCode"] == 200
+    body = json.loads(r["body"])
+    assert body["items"] == []
+    assert body["next_cursor"] is None
+
+
 def test_email_filter_resolves_sub(
     api_gateway_event: Any, admin_identity: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CloudWatch showed `IndexError: list index out of range` in `admin_audit_logs._list_audit_logs` when `GET /v1/admin/audit-logs` returned zero rows (for example a time range with no matching audit entries). The handler always accessed `trimmed[-1]` to build `next_cursor` before checking for an empty page.

## Changes

- Only encode `next_cursor` when `has_more` and `trimmed` is non-empty.
- Add regression test `test_recent_list_empty_returns_200`.

## Validation

- `pytest tests/test_admin_audit_logs_api.py`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`

No OpenAPI or CDK updates: response shape unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e802ea56-237c-4236-bf8c-ab8a45f0b5bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e802ea56-237c-4236-bf8c-ab8a45f0b5bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

