### PR TITLE
Remove “Showing x entries” from audit logs table

### DIFF
--- a/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
+++ b/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
@@ -281,61 +281,58 @@ export function AuditLogsPanel({ auditableTables }: AuditLogsPanelProps) {
         {items.length === 0 && !isLoading ? (
           <p className='text-sm text-slate-600'>No audit logs match the current filters.</p>
         ) : (
-          <>
-            <AdminDataTable>
-              <AdminDataTableHead>
-                <tr>
-                  <th className='px-4 py-3' scope='col'>
-                    {timestampHeader}
-                  </th>
-                  <th className='px-4 py-3' scope='col'>
-                    Table
-                  </th>
-                  <th className='px-4 py-3' scope='col'>
-                    Action
-                  </th>
-                  <th className='px-4 py-3' scope='col'>
-                    User email
-                  </th>
-                  <th className='hidden px-4 py-3 md:table-cell' scope='col'>
-                    Changed fields
-                  </th>
-                  <th className='px-4 py-3 text-right' scope='col'>
-                    Operations
-                  </th>
+          <AdminDataTable>
+            <AdminDataTableHead>
+              <tr>
+                <th className='px-4 py-3' scope='col'>
+                  {timestampHeader}
+                </th>
+                <th className='px-4 py-3' scope='col'>
+                  Table
+                </th>
+                <th className='px-4 py-3' scope='col'>
+                  Action
+                </th>
+                <th className='px-4 py-3' scope='col'>
+                  User email
+                </th>
+                <th className='hidden px-4 py-3 md:table-cell' scope='col'>
+                  Changed fields
+                </th>
+                <th className='px-4 py-3 text-right' scope='col'>
+                  Operations
+                </th>
+              </tr>
+            </AdminDataTableHead>
+            <AdminDataTableBody>
+              {items.map((item) => (
+                <tr key={item.id} className='hover:bg-slate-50'>
+                  <td className='px-4 py-3 text-slate-600'>{formatDate(item.timestamp)}</td>
+                  <td className='px-4 py-3 font-medium text-slate-900'>{item.table_name}</td>
+                  <td className='px-4 py-3'>
+                    <ActionBadge action={item.action} />
+                  </td>
+                  <td className='px-4 py-3 font-mono text-xs text-slate-600'>
+                    {getUserEmail(item)}
+                  </td>
+                  <td className='hidden px-4 py-3 text-slate-500 md:table-cell'>
+                    {item.changed_fields?.length ? item.changed_fields.join(', ') : '—'}
+                  </td>
+                  <td className='px-4 py-3 text-right'>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='ghost'
+                      onClick={() => setSelectedLog(item)}
+                      aria-label='View details'
+                    >
+                      <ViewIcon className='h-4 w-4' />
+                    </Button>
+                  </td>
                 </tr>
-              </AdminDataTableHead>
-              <AdminDataTableBody>
-                {items.map((item) => (
-                  <tr key={item.id} className='hover:bg-slate-50'>
-                    <td className='px-4 py-3 text-slate-600'>{formatDate(item.timestamp)}</td>
-                    <td className='px-4 py-3 font-medium text-slate-900'>{item.table_name}</td>
-                    <td className='px-4 py-3'>
-                      <ActionBadge action={item.action} />
-                    </td>
-                    <td className='px-4 py-3 font-mono text-xs text-slate-600'>
-                      {getUserEmail(item)}
-                    </td>
-                    <td className='hidden px-4 py-3 text-slate-500 md:table-cell'>
-                      {item.changed_fields?.length ? item.changed_fields.join(', ') : '—'}
-                    </td>
-                    <td className='px-4 py-3 text-right'>
-                      <Button
-                        type='button'
-                        size='sm'
-                        variant='ghost'
-                        onClick={() => setSelectedLog(item)}
-                        aria-label='View details'
-                      >
-                        <ViewIcon className='h-4 w-4' />
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </AdminDataTableBody>
-            </AdminDataTable>
-            <p className='mt-2 text-xs text-slate-500'>Showing {items.length} entries</p>
-          </>
+              ))}
+            </AdminDataTableBody>
+          </AdminDataTable>
         )}
       </PaginatedTableCard>
 

--- a/apps/admin_web/tests/components/admin/audit/audit-logs-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/audit/audit-logs-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -69,13 +69,15 @@ describe('AuditLogsPage', () => {
 
     render(<AuditLogsPage />);
     await waitFor(() => {
-      expect(screen.getByText('assets')).toBeInTheDocument();
+      const table = screen.getByRole('table');
+      expect(within(table).getByText('assets')).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole('button', { name: /load more/i }));
     await waitFor(() => {
       expect(mockListAuditLogs).toHaveBeenNthCalledWith(2, expect.anything(), 'cursor-token', 50);
-      expect(screen.getByText('asset_access_grants')).toBeInTheDocument();
+      const table = screen.getByRole('table');
+      expect(within(table).getByText('asset_access_grants')).toBeInTheDocument();
     });
   });
 });

--- a/apps/admin_web/tests/components/admin/audit/audit-logs-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/audit/audit-logs-page.test.tsx
@@ -75,7 +75,7 @@ describe('AuditLogsPage', () => {
     await user.click(screen.getByRole('button', { name: /load more/i }));
     await waitFor(() => {
       expect(mockListAuditLogs).toHaveBeenNthCalledWith(2, expect.anything(), 'cursor-token', 50);
-      expect(screen.getByText('Showing 2 entries')).toBeInTheDocument();
+      expect(screen.getByText('asset_access_grants')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the footer line that displayed loaded row count (`Showing {n} entries`) under the admin Audit logs data table.

## CI fix (Test Node)

The Vitest `Load more` case used `getByText('assets')` / `getByText('asset_access_grants')`, which matched **both** the Table filter `<option>` labels and the data cells. Testing Library fails when multiple nodes match. Assertions are now scoped with `within(screen.getByRole('table'))` so only table rows are considered.

## Tests

- `npm run test` in `apps/admin_web` (Vitest).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbcda82b-bc50-4924-aed1-9401a1adfe96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbcda82b-bc50-4924-aed1-9401a1adfe96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

