### PR TITLE
fix(admin_web): remove redundant Client Invoices tab title

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -582,8 +582,6 @@ export function ClientInvoicesPanel() {
 
   return (
     <div className='space-y-6'>
-      <h2 className='text-lg font-semibold text-slate-900'>Client Invoices</h2>
-
       {actionMessage ? (
         <StatusBanner variant='success' title='Billing'>
           {actionMessage}

--- a/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
@@ -103,8 +103,9 @@ describe('FinancePage', () => {
     expect(window.location.search).toBe('?tab=vendors');
 
     await user.click(screen.getByRole('button', { name: 'Client Invoices' }));
-    expect(screen.getByRole('heading', { name: 'Client Invoices' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Create draft invoice from enrollments' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Create draft invoice from enrollments' })
+    ).toBeInTheDocument();
     expect(window.location.search).toBe('?tab=client-invoices');
 
     await user.click(screen.getByRole('button', { name: 'Expenses' }));
@@ -116,7 +117,7 @@ describe('FinancePage', () => {
     render(<FinancePage />);
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: 'Client Invoices' })
+        screen.getByRole('heading', { name: 'Create draft invoice from enrollments' })
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the duplicate **Client Invoices** `h2` above the finance client-invoices panel so the tab content starts with the **Create draft invoice from enrollments** `AdminEditorCard` (the first visible heading).

## Changes

- `client-invoices-panel.tsx`: drop the panel-level heading.
- `finance-page.test.tsx`: assert the draft-invoice card heading when on the Client Invoices tab (including URL-seeded tab).

## Testing

- `npm test` for the touched test file was not run in this environment (Node/npm unavailable in the agent shell). Please run `npm test -- --run tests/components/admin/finance/finance-page.test.tsx` in `apps/admin_web` locally or in CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d3a813-f007-41c1-9eba-41295b0f1902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d3a813-f007-41c1-9eba-41295b0f1902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

