### PR TITLE
Admin web: draft invoice enrollments table UX and shared formatting

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -36,7 +36,12 @@ import {
   type CustomerPaymentSummary,
 } from '@/lib/billing-api';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
-import { getCurrencyOptions } from '@/lib/format';
+import {
+  getCurrencyOptions,
+  INSTANCE_TABLE_TIER_COHORT_HEADER,
+  formatTierCohortDisplay,
+} from '@/lib/format';
+import { formatAmountInCurrency } from '@/lib/vendor-spend';
 
 const DRAFT_FORM_ID = 'client-billing-draft-invoice-form';
 const ALLOCATE_FORM_ID = 'client-billing-allocate-form';
@@ -595,7 +600,7 @@ export function ClientInvoicesPanel() {
     for (const id of ids) {
       const row = rowsById.get(id);
       if (!row || row.invoiceLinked) {
-        setActionError('Selection is out of date; refresh enrollments and try again.');
+        setActionError('The enrollment list changed; update your selection and try again.');
         return;
       }
     }
@@ -784,32 +789,13 @@ export function ClientInvoicesPanel() {
                 disabled={editorBusy}
               />
             </div>
-            <Button
-              type='button'
-              variant='outline'
-              disabled={editorBusy}
-              onClick={() => {
-                setSelectedEnrollmentIds(new Set());
-                setLineOverrideByEnrollmentId({});
-              }}
-            >
-              Clear selection
-            </Button>
             <span className='text-sm text-slate-600' aria-live='polite'>
               {selectedEnrollmentIds.size} selected
             </span>
-            <Button
-              type='button'
-              variant='outline'
-              disabled={editorBusy || enrollmentPickerLoading}
-              onClick={() => void loadEnrollmentPicker(undefined, enrollmentFilter.trim())}
-            >
-              Refresh enrollments
-            </Button>
           </div>
           {enrollmentPickerTruncated ? (
             <p className='text-sm text-amber-800' role='status'>
-              Enrollment list may be incomplete (server capped additional pages). Refresh after filtering or contact support for full exports.
+              Enrollment list may be incomplete (server capped additional pages). Narrow your filter or contact support for full exports.
             </p>
           ) : null}
           <section aria-label='Enrollment picker'>
@@ -848,8 +834,7 @@ export function ClientInvoicesPanel() {
                 <th className='px-3 py-2'>Party</th>
                 <th className='px-3 py-2'>Email</th>
                 <th className='px-3 py-2'>Instance</th>
-                <th className='px-3 py-2'>Tier</th>
-                <th className='px-3 py-2'>Cohort</th>
+                <th className='max-w-[14rem] px-3 py-2'>{INSTANCE_TABLE_TIER_COHORT_HEADER}</th>
                 <th className='px-3 py-2 text-right'>Price</th>
                 <th className='px-3 py-2'>Enrolled</th>
                 <th className='px-3 py-2'>Invoice</th>
@@ -858,13 +843,13 @@ export function ClientInvoicesPanel() {
             <AdminDataTableBody>
               {enrollmentPickerLoading ? (
                 <tr>
-                  <td colSpan={9} className='px-3 py-6 text-sm text-slate-600'>
+                  <td colSpan={8} className='px-3 py-6 text-sm text-slate-600'>
                     Loading enrollments…
                   </td>
                 </tr>
               ) : enrollmentPickerRows.length === 0 ? (
                 <tr>
-                  <td colSpan={9} className='px-3 py-6 text-sm text-slate-600'>
+                  <td colSpan={8} className='px-3 py-6 text-sm text-slate-600'>
                     No enrollments match this filter.
                   </td>
                 </tr>
@@ -873,10 +858,14 @@ export function ClientInvoicesPanel() {
                   const blocked = row.invoiceLinked;
                   const checked = selectedEnrollmentIds.has(row.enrollmentId);
                   const blockedNoteId = `billing-enrollment-blocked-note-${row.enrollmentId}`;
+                  const amountPaidTrimmed = row.amountPaid?.trim() ?? '';
+                  const currencyCode = (row.currency ?? defaultCurrency).trim().toUpperCase() || defaultCurrency;
+                  const parsedAmount = Number.parseFloat(amountPaidTrimmed);
                   const priceLabel =
-                    row.amountPaid != null && row.amountPaid.trim() !== ''
-                      ? `${row.amountPaid} ${row.currency}`
-                      : `— ${row.currency}`;
+                    amountPaidTrimmed !== '' && Number.isFinite(parsedAmount)
+                      ? formatAmountInCurrency(parsedAmount, currencyCode)
+                      : '—';
+                  const tierCohortDisplay = formatTierCohortDisplay(row.serviceTierName, row.instanceCohort);
                   return (
                     <tr
                       key={row.enrollmentId}
@@ -908,16 +897,17 @@ export function ClientInvoicesPanel() {
                           </span>
                         ) : null}
                       </td>
-                      <td className='px-3 py-2 align-top'>{row.partyDisplayName}</td>
-                      <td className='px-3 py-2 align-top font-mono text-xs'>{row.partyEmail ?? '—'}</td>
-                      <td className='px-3 py-2 align-top'>{row.instanceTitle ?? '—'}</td>
-                      <td className='px-3 py-2 align-top'>{row.serviceTierName ?? '—'}</td>
-                      <td className='px-3 py-2 align-top'>{row.instanceCohort ?? '—'}</td>
-                      <td className='px-3 py-2 align-top text-right tabular-nums'>{priceLabel}</td>
-                      <td className='px-3 py-2 align-top whitespace-nowrap font-mono text-xs'>
+                      <td className='px-3 py-2 align-top text-sm'>{row.partyDisplayName}</td>
+                      <td className='px-3 py-2 align-top text-sm'>{row.partyEmail ?? '—'}</td>
+                      <td className='px-3 py-2 align-top text-sm'>{row.instanceTitle ?? '—'}</td>
+                      <td className='max-w-[14rem] min-w-0 break-words px-3 py-2 align-top text-sm'>
+                        {tierCohortDisplay !== '' ? tierCohortDisplay : '—'}
+                      </td>
+                      <td className='px-3 py-2 align-top text-right text-sm tabular-nums'>{priceLabel}</td>
+                      <td className='px-3 py-2 align-top whitespace-nowrap text-sm'>
                         {row.enrolledAt ? row.enrolledAt.slice(0, 10) : '—'}
                       </td>
-                      <td className='px-3 py-2 align-top text-xs'>
+                      <td className='px-3 py-2 align-top text-sm'>
                         {blocked ? 'On draft/issued invoice' : '—'}
                       </td>
                     </tr>

--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -14,8 +14,10 @@ import { Textarea } from '@/components/ui/textarea';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useEnrollmentParentPickers } from '@/hooks/use-enrollment-parent-pickers';
+import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { formatDate, formatEnumLabel, getCurrencyOptions } from '@/lib/format';
 import { isAbortRequestError, listEnrollmentDiscountOptions } from '@/lib/services-api';
+import { formatAmountInCurrency } from '@/lib/vendor-spend';
 
 import type { components } from '@/types/generated/admin-api.generated';
 import type { DiscountCode, Enrollment } from '@/types/services';
@@ -74,6 +76,7 @@ export function EnrollmentListPanel({
   onUpdate,
   onDelete,
 }: EnrollmentListPanelProps) {
+  const defaultCurrencyCode = getAdminDefaultCurrencyCode();
   const currencyOptions = getCurrencyOptions();
   const {
     contactOptions,
@@ -453,44 +456,52 @@ export function EnrollmentListPanel({
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
-            {enrollments.map((enrollment) => (
-              <tr
-                key={enrollment.id}
-                className={`cursor-pointer transition ${
-                  selectedEnrollmentId === enrollment.id ? 'bg-slate-100' : 'hover:bg-slate-50'
-                }`}
-                onClick={() => applyEnrollmentSelection(enrollment)}
-              >
-                <td className='px-4 py-3'>{formatEnrollmentParentCell(enrollment)}</td>
-                <td className='px-4 py-3'>{formatEnumLabel(enrollment.status)}</td>
-                <td className='px-4 py-3'>
-                  {enrollment.amountPaid ? `${enrollment.amountPaid} ${enrollment.currency ?? ''}` : '-'}
-                </td>
-                <td className='px-4 py-3'>
-                  {enrollment.discountCodeId
-                    ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
-                        enrollment.discountCodeId)
-                    : '-'}
-                </td>
-                <td className='px-4 py-3'>{formatDate(enrollment.enrolledAt)}</td>
-                <td className='px-4 py-3 text-right'>
-                  <Button
-                    type='button'
-                    size='sm'
-                    variant='danger'
-                    disabled={isMutating}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      void handleDeleteEnrollment(enrollment);
-                    }}
-                    aria-label='Delete enrollment'
-                    title='Delete enrollment'
-                  >
-                    <DeleteIcon className='h-4 w-4' />
-                  </Button>
-                </td>
-              </tr>
-            ))}
+            {enrollments.map((enrollment) => {
+              const amountRaw = enrollment.amountPaid?.trim() ?? '';
+              const parsedAmount = Number.parseFloat(amountRaw);
+              const currencyCode =
+                (enrollment.currency ?? defaultCurrencyCode).trim().toUpperCase() || defaultCurrencyCode;
+              const amountDisplay =
+                amountRaw !== '' && Number.isFinite(parsedAmount)
+                  ? formatAmountInCurrency(parsedAmount, currencyCode)
+                  : '—';
+              return (
+                <tr
+                  key={enrollment.id}
+                  className={`cursor-pointer transition ${
+                    selectedEnrollmentId === enrollment.id ? 'bg-slate-100' : 'hover:bg-slate-50'
+                  }`}
+                  onClick={() => applyEnrollmentSelection(enrollment)}
+                >
+                  <td className='px-4 py-3'>{formatEnrollmentParentCell(enrollment)}</td>
+                  <td className='px-4 py-3'>{formatEnumLabel(enrollment.status)}</td>
+                  <td className='px-4 py-3'>{amountDisplay}</td>
+                  <td className='px-4 py-3'>
+                    {enrollment.discountCodeId
+                      ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
+                          enrollment.discountCodeId)
+                      : '-'}
+                  </td>
+                  <td className='px-4 py-3'>{formatDate(enrollment.enrolledAt)}</td>
+                  <td className='px-4 py-3 text-right'>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='danger'
+                      disabled={isMutating}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void handleDeleteEnrollment(enrollment);
+                      }}
+                      aria-label='Delete enrollment'
+                      title='Delete enrollment'
+                    >
+                      <DeleteIcon className='h-4 w-4' />
+                    </Button>
+                  </td>
+                </tr>
+              );
+            })}
           </AdminDataTableBody>
         </AdminDataTable>
       </PaginatedTableCard>

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -138,11 +138,29 @@ export function formatInstanceTableTitle(instance: ServiceInstance): string {
 export const INSTANCE_TABLE_TIER_COHORT_HEADER = `Tier${DISPLAY_PART_SEP}Cohort`;
 
 /**
- * Instances table: parent service tier and cohort.
+ * Tier and cohort on one line (instances table, billing enrollment picker, and similar).
  * Uses space + interpunct + space only when both tier and cohort are non-empty after trim.
  * If only one is present, returns that value alone (no interpunct).
  * Returns empty string when neither is present (UI should show a single placeholder dash).
  */
+export function formatTierCohortDisplay(
+  tier: string | null | undefined,
+  cohort: string | null | undefined,
+): string {
+  const t = tier?.trim() ?? '';
+  const c = cohort?.trim() ?? '';
+  if (t && c) {
+    return `${t}${DISPLAY_PART_SEP}${c}`;
+  }
+  if (t) {
+    return t;
+  }
+  if (c) {
+    return c;
+  }
+  return '';
+}
+
 /** Instances table: seats remaining / max when capped; otherwise unlimited label. */
 export function formatInstanceTableCapacity(instance: ServiceInstance): string {
   const max = instance.maxCapacity;
@@ -155,18 +173,7 @@ export function formatInstanceTableCapacity(instance: ServiceInstance): string {
 }
 
 export function formatInstanceTableTierCohort(instance: ServiceInstance): string {
-  const tier = instance.parentServiceTier?.trim() ?? '';
-  const cohort = instance.cohort?.trim() ?? '';
-  if (tier && cohort) {
-    return `${tier}${DISPLAY_PART_SEP}${cohort}`;
-  }
-  if (tier) {
-    return tier;
-  }
-  if (cohort) {
-    return cohort;
-  }
-  return '';
+  return formatTierCohortDisplay(instance.parentServiceTier, instance.cohort);
 }
 
 /** Full venue label: address (when present) plus geographic area name. */

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -6,6 +6,7 @@ import { EnrollmentListPanel } from '@/components/admin/services/enrollment-list
 import { InstanceListPanel } from '@/components/admin/services/instance-list-panel';
 import { ServiceListPanel } from '@/components/admin/services/service-list-panel';
 import { formatDate } from '@/lib/format';
+import { formatAmountInCurrency } from '@/lib/vendor-spend';
 import type { DiscountCode, Enrollment, ServiceInstance, ServiceSummary } from '@/types/services';
 
 vi.mock('@/lib/services-api', () => ({
@@ -391,6 +392,11 @@ describe('services tables value formatting', () => {
 
     const table = screen.getByRole('table');
     expect(within(table).getByText('Waitlisted')).toBeInTheDocument();
+    expect(
+      within(table).getByText(
+        formatAmountInCurrency(Number.parseFloat(ENROLLMENT_FIXTURE.amountPaid), ENROLLMENT_FIXTURE.currency!),
+      ),
+    ).toBeInTheDocument();
     expect(within(table).getByText(formatDate(ENROLLMENT_FIXTURE.enrolledAt))).toBeInTheDocument();
   });
 });

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -10,6 +10,7 @@ import {
   formatInstanceTableCapacity,
   formatInstanceTableTierCohort,
   formatInstanceTableTitle,
+  formatTierCohortDisplay,
   INSTANCE_TABLE_TIER_COHORT_HEADER,
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
@@ -499,6 +500,14 @@ describe('format helpers', () => {
         cohort: null,
       })
     ).toBe('');
+  });
+
+  it('formatTierCohortDisplay mirrors instance tier/cohort cell rules', () => {
+    expect(formatTierCohortDisplay('tier-a', null)).toBe('tier-a');
+    expect(formatTierCohortDisplay(null, 'spring-2024')).toBe('spring-2024');
+    expect(formatTierCohortDisplay('t1', 'c1')).toBe('t1 \u00b7 c1');
+    expect(formatTierCohortDisplay('  ', null)).toBe('');
+    expect(formatTierCohortDisplay(null, '  spring-2024  ')).toBe('spring-2024');
   });
 
   it('summarizes instance locations including partner org venues', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change updates the **Create draft invoice from enrollments** picker table and aligns money and tier/cohort display with existing admin patterns.

## Changes

- Removed **Clear selection** and **Refresh enrollments** from the draft-invoice enrollment toolbar (list still reloads on filter debounce and after a successful draft create).
- Merged **Tier** and **Cohort** into one column using `INSTANCE_TABLE_TIER_COHORT_HEADER` and a shared `formatTierCohortDisplay` helper; `formatInstanceTableTierCohort` now delegates to it (instances behavior unchanged).
- **Price** in the billing picker and **Amount** in the Services enrollments table use `formatAmountInCurrency` from `vendor-spend` (same as Vendors). Missing or non-numeric amounts show `—`.
- Normalized table body typography (`text-sm`); removed `font-mono text-xs` from email and enrolled date in the picker.
- Reworded stale-selection and truncation helper text so they do not reference a refresh control.

## Testing

- `bash scripts/validate-cursorrules.sh` passed locally.
- Vitest was not run in this agent environment (Node/npm unavailable). Please run `npm run test` in `apps/admin_web` in CI or locally.

## Seed / migrations

- Not applicable (admin web only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7d4ff2d-3c43-4135-b2bc-d099dbb24e16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7d4ff2d-3c43-4135-b2bc-d099dbb24e16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

