### PR TITLE
fix(admin): Allow zero-dollar draft invoices from enrollments

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -72,7 +72,7 @@ function enrollmentNeedsAmountConfirmation(row: BillingEnrollmentPickerRow): boo
     return true;
   }
   const n = Number.parseFloat(ap);
-  return Number.isNaN(n) || n === 0;
+  return Number.isNaN(n);
 }
 
 function parseAmountInput(raw: string): number | null {
@@ -278,13 +278,10 @@ export function ClientInvoicesPanel() {
 
   const draftAmountIssue = useMemo(() => {
     for (const row of selectedEnrollmentRows) {
-      if (!enrollmentNeedsAmountConfirmation(row)) {
-        continue;
-      }
       const raw = lineOverrideByEnrollmentId[row.enrollmentId] ?? defaultLineAmount(row);
       const amt = parseAmountInput(raw);
-      if (amt === null || amt === 0) {
-        return 'Enter a non-zero line total for enrollments with no recorded amount.';
+      if (amt === null) {
+        return 'Enter a valid number for every line total (0 is allowed).';
       }
     }
     return '';
@@ -945,8 +942,7 @@ export function ClientInvoicesPanel() {
                     <span className='font-mono text-xs text-slate-600'>{row.enrollmentId}</span>
                     {needsAmt ? (
                       <p className='w-full text-xs text-amber-900'>
-                        This enrollment has no recorded amount (or amount is zero); set a value or it will create a
-                        0.00 line.
+                        This enrollment has no recorded amount; enter a line total (use 0 for a zero-dollar line).
                       </p>
                     ) : null}
                     <div className='flex items-center gap-2'>

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -765,6 +765,65 @@ describe('ClientInvoicesPanel', () => {
     expect(arg.lineTotalsByEnrollmentId).toBeUndefined();
   });
 
+  it('create draft allows zero-dollar enrollments with recorded amount 0', async () => {
+    const id1 = 'aaaaaaaa-bbbb-cccc-dddd-111111111111';
+    billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
+      items: [
+        pickerRow({
+          enrollmentId: id1,
+          billToMergeKey: 'family||fam-1||',
+          amountPaid: '0',
+        }),
+      ],
+      truncated: false,
+    });
+    billingMocks.createDraftInvoice.mockResolvedValue({ invoiceId: 'inv-zero', status: 'draft' });
+
+    render(<ClientInvoicesPanel />);
+
+    await waitFor(() => screen.getByRole('checkbox', { name: /Select enrollment/i }));
+    await userEvent.click(screen.getByRole('checkbox', { name: /Select enrollment/i }));
+
+    const createBtn = screen.getByRole('button', { name: /create draft invoice/i });
+    expect(createBtn).not.toBeDisabled();
+
+    await userEvent.click(createBtn);
+
+    await waitFor(() => {
+      expect(billingMocks.createDraftInvoice).toHaveBeenCalled();
+    });
+    const arg = billingMocks.createDraftInvoice.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.enrollmentIds).toEqual([id1]);
+    expect(arg.lineTotalsByEnrollmentId).toBeUndefined();
+  });
+
+  it('create draft is disabled when line total override is not a valid number', async () => {
+    const id1 = 'aaaaaaaa-bbbb-cccc-dddd-111111111111';
+    billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
+      items: [
+        pickerRow({
+          enrollmentId: id1,
+          billToMergeKey: 'family||fam-1||',
+          amountPaid: '50.00',
+        }),
+      ],
+      truncated: false,
+    });
+
+    render(<ClientInvoicesPanel />);
+
+    await waitFor(() => screen.getByRole('checkbox', { name: /Select enrollment/i }));
+    await userEvent.click(screen.getByRole('checkbox', { name: /Select enrollment/i }));
+
+    const override1 = document.getElementById(`billing-line-override-${id1}`) as HTMLInputElement;
+    await userEvent.clear(override1);
+    await userEvent.type(override1, 'not-a-number');
+
+    expect(screen.getByRole('button', { name: /create draft invoice/i })).toBeDisabled();
+    expect(screen.getByText(/Enter a valid number for every line total/i)).toBeInTheDocument();
+    expect(billingMocks.createDraftInvoice).not.toHaveBeenCalled();
+  });
+
   it('create draft sends lineTotalsByEnrollmentId when override differs', async () => {
     const id1 = 'aaaaaaaa-bbbb-cccc-dddd-111111111111';
     billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finance admin could not create draft invoices when selected enrollments had a recorded amount of **0** because the UI treated zero like “missing amount” and blocked submit unless the line total was non-zero.

## Changes

- **`enrollmentNeedsAmountConfirmation`**: Only flag enrollments with **empty or non-numeric** `amountPaid`. Explicit **0** is treated as a valid recorded amount (no amber warning row).
- **`draftAmountIssue`**: For **every** selected enrollment, require the effective line total to parse as a **number** (`parseAmountInput` not `null`). **0 is allowed.** Empty input still fails (reject non-values). Junk input like `not-a-number` fails.
- **Copy**: Clarify that staff must enter a line total when there is no recorded amount, and that **0** is valid for a zero-dollar line.

## Tests

- Zero recorded amount (`amountPaid: '0'`) enables **Create draft invoice** and calls the API without overrides.
- Invalid override text disables the button and shows the validation message.

Backend create-draft behavior was already correct; no API or OpenAPI changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0b93829-bf0e-4ef5-8c53-c688289f0e4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0b93829-bf0e-4ef5-8c53-c688289f0e4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

