### PR TITLE
Remove draft-invoice enrollment picker "x selected" label

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -786,9 +786,6 @@ export function ClientInvoicesPanel() {
                 disabled={editorBusy}
               />
             </div>
-            <span className='text-sm text-slate-600' aria-live='polite'>
-              {selectedEnrollmentIds.size} selected
-            </span>
           </div>
           {enrollmentPickerTruncated ? (
             <p className='text-sm text-amber-800' role='status'>

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -916,7 +916,8 @@ describe('ClientInvoicesPanel', () => {
     await userEvent.click(screen.getByRole('checkbox', { name: /Select all visible enrollments/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('2 selected')).toBeInTheDocument();
+      const rowChecks = screen.getAllByRole('checkbox', { name: /^Select enrollment /i });
+      expect(rowChecks.filter((el) => (el as HTMLInputElement).checked)).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `{count} selected` span next to the enrollment filter on **Create draft invoice from enrollments**. Selection is still visible via row checkboxes and the line-totals override section.

## Testing

- Updated `client-invoices-panel.test.tsx` to assert two row checkboxes are checked after "select all" instead of expecting the removed label.
- Vitest was not run in this environment (Node/npm unavailable in the agent shell).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8e51975-70a2-4196-92e8-206f9547e758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8e51975-70a2-4196-92e8-206f9547e758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

