### PR TITLE
Merge Party/Email in draft-invoice enrollment picker

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -88,6 +88,19 @@ function defaultLineAmount(row: BillingEnrollmentPickerRow): string {
   return row.amountPaid != null && row.amountPaid.trim() !== '' ? row.amountPaid.trim() : '0';
 }
 
+/** Party column: `name · email` when email is non-empty; otherwise party name only. */
+function formatEnrollmentPartyCellDisplay(row: BillingEnrollmentPickerRow): string {
+  const party = row.partyDisplayName?.trim() ?? '';
+  const email = row.partyEmail?.trim() ?? '';
+  if (email === '') {
+    return party;
+  }
+  if (party === '') {
+    return email;
+  }
+  return `${party} \u00b7 ${email}`;
+}
+
 function lineAmountsDiffer(input: string, row: BillingEnrollmentPickerRow): boolean {
   const trimmed = input.trim();
   const baseline = defaultLineAmount(row);
@@ -786,9 +799,6 @@ export function ClientInvoicesPanel() {
                 disabled={editorBusy}
               />
             </div>
-            <span className='text-sm text-slate-600' aria-live='polite'>
-              {selectedEnrollmentIds.size} selected
-            </span>
           </div>
           {enrollmentPickerTruncated ? (
             <p className='text-sm text-amber-800' role='status'>
@@ -796,7 +806,7 @@ export function ClientInvoicesPanel() {
             </p>
           ) : null}
           <section aria-label='Enrollment picker'>
-          <AdminDataTable tableClassName='min-w-[1120px]'>
+          <AdminDataTable>
             <AdminDataTableHead>
               <tr>
                 <th className='px-3 py-2'>
@@ -829,7 +839,6 @@ export function ClientInvoicesPanel() {
                   />
                 </th>
                 <th className='px-3 py-2'>Party</th>
-                <th className='px-3 py-2'>Email</th>
                 <th className='px-3 py-2'>Instance</th>
                 <th className='max-w-[14rem] px-3 py-2'>{INSTANCE_TABLE_TIER_COHORT_HEADER}</th>
                 <th className='px-3 py-2 text-right'>Price</th>
@@ -840,13 +849,13 @@ export function ClientInvoicesPanel() {
             <AdminDataTableBody>
               {enrollmentPickerLoading ? (
                 <tr>
-                  <td colSpan={8} className='px-3 py-6 text-sm text-slate-600'>
+                  <td colSpan={7} className='px-3 py-6 text-sm text-slate-600'>
                     Loading enrollments…
                   </td>
                 </tr>
               ) : enrollmentPickerRows.length === 0 ? (
                 <tr>
-                  <td colSpan={8} className='px-3 py-6 text-sm text-slate-600'>
+                  <td colSpan={7} className='px-3 py-6 text-sm text-slate-600'>
                     No enrollments match this filter.
                   </td>
                 </tr>
@@ -863,6 +872,7 @@ export function ClientInvoicesPanel() {
                       ? formatAmountInCurrency(parsedAmount, currencyCode)
                       : '—';
                   const tierCohortDisplay = formatTierCohortDisplay(row.serviceTierName, row.instanceCohort);
+                  const partyCellDisplay = formatEnrollmentPartyCellDisplay(row);
                   return (
                     <tr
                       key={row.enrollmentId}
@@ -894,8 +904,9 @@ export function ClientInvoicesPanel() {
                           </span>
                         ) : null}
                       </td>
-                      <td className='px-3 py-2 align-top text-sm'>{row.partyDisplayName}</td>
-                      <td className='px-3 py-2 align-top text-sm'>{row.partyEmail ?? '—'}</td>
+                      <td className='min-w-0 max-w-[22rem] break-words px-3 py-2 align-top text-sm'>
+                        {partyCellDisplay !== '' ? partyCellDisplay : '—'}
+                      </td>
                       <td className='px-3 py-2 align-top text-sm'>{row.instanceTitle ?? '—'}</td>
                       <td className='max-w-[14rem] min-w-0 break-words px-3 py-2 align-top text-sm'>
                         {tierCohortDisplay !== '' ? tierCohortDisplay : '—'}

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -621,7 +621,7 @@ describe('ClientInvoicesPanel', () => {
   ) => ({
     enrollmentId: overrides.enrollmentId ?? 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
     partyDisplayName: overrides.partyDisplayName ?? 'Pat',
-    partyEmail: overrides.partyEmail ?? 'pat@example.com',
+    partyEmail: overrides.partyEmail !== undefined ? overrides.partyEmail : 'pat@example.com',
     instanceTitle: 'Inst',
     serviceTierName: null,
     instanceCohort: null,
@@ -944,6 +944,7 @@ describe('ClientInvoicesPanel', () => {
       expect(screen.getByText('Sam Sample · sam@example.com')).toBeInTheDocument();
     });
     expect(screen.getByText('No Email Party')).toBeInTheDocument();
-    expect(screen.queryByRole('columnheader', { name: 'Email' })).not.toBeInTheDocument();
+    const enrollmentPicker = screen.getByRole('region', { name: 'Enrollment picker' });
+    expect(within(enrollmentPicker).queryByRole('columnheader', { name: 'Email' })).not.toBeInTheDocument();
   });
 });

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -613,6 +613,7 @@ describe('ClientInvoicesPanel', () => {
     overrides: Partial<{
       enrollmentId: string;
       partyDisplayName: string;
+      partyEmail: string | null;
       billToMergeKey: string;
       invoiceLinked: boolean;
       amountPaid: string | null;
@@ -620,7 +621,7 @@ describe('ClientInvoicesPanel', () => {
   ) => ({
     enrollmentId: overrides.enrollmentId ?? 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
     partyDisplayName: overrides.partyDisplayName ?? 'Pat',
-    partyEmail: 'pat@example.com',
+    partyEmail: overrides.partyEmail ?? 'pat@example.com',
     instanceTitle: 'Inst',
     serviceTierName: null,
     instanceCohort: null,
@@ -659,7 +660,7 @@ describe('ClientInvoicesPanel', () => {
     });
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => expect(screen.getByText('Alice Alpha')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Alice Alpha/)).toBeInTheDocument());
 
     const filterInput = screen.getByPlaceholderText(/Search name, email, title, tier, cohort/i);
     await userEvent.type(filterInput, 'Bob');
@@ -674,9 +675,9 @@ describe('ClientInvoicesPanel', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText('Alice Alpha')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Alice Alpha/)).not.toBeInTheDocument();
     });
-    expect(screen.getByText('Bob Beta')).toBeInTheDocument();
+    expect(screen.getByText(/Bob Beta/)).toBeInTheDocument();
   });
 
   it('server-side filter matches enrollment id substring', async () => {
@@ -706,7 +707,7 @@ describe('ClientInvoicesPanel', () => {
     });
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => expect(screen.getByText('Alice Alpha')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Alice Alpha/)).toBeInTheDocument());
 
     const filterInput = screen.getByPlaceholderText(/Search name, email, title, tier, cohort/i);
     await userEvent.type(filterInput, '22222222');
@@ -721,9 +722,9 @@ describe('ClientInvoicesPanel', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText('Alice Alpha')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Alice Alpha/)).not.toBeInTheDocument();
     });
-    expect(screen.getByText('Bob Beta')).toBeInTheDocument();
+    expect(screen.getByText(/Bob Beta/)).toBeInTheDocument();
   });
 
   it('create draft omits currency when selection is valid', async () => {
@@ -916,7 +917,33 @@ describe('ClientInvoicesPanel', () => {
     await userEvent.click(screen.getByRole('checkbox', { name: /Select all visible enrollments/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('2 selected')).toBeInTheDocument();
+      const rowChecks = screen.getAllByRole('checkbox', { name: /^Select enrollment /i });
+      expect(rowChecks.filter((el) => (el as HTMLInputElement).checked)).toHaveLength(2);
     });
+  });
+
+  it('draft enrollment picker Party column merges name and email with middle dot', async () => {
+    billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
+      items: [
+        pickerRow({
+          enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-111111111111',
+          partyDisplayName: 'Sam Sample',
+          partyEmail: 'sam@example.com',
+        }),
+        pickerRow({
+          enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-222222222222',
+          partyDisplayName: 'No Email Party',
+          partyEmail: null,
+        }),
+      ],
+      truncated: false,
+    });
+    render(<ClientInvoicesPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Sam Sample · sam@example.com')).toBeInTheDocument();
+    });
+    expect(screen.getByText('No Email Party')).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Email' })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the earlier plan for **Create draft invoice from enrollments**:

- **Merged Party column:** Header remains **Party**. Cell shows `partyDisplayName · partyEmail` (Unicode middle dot U+00B7, spaces around it) when email is non-empty after trim; when email is empty/null/whitespace, **only** the party name is shown (no `·` and no placeholder email).
- **Table width:** Removed `min-w-[1120px]` from the enrollment picker `AdminDataTable` so the table can use the card width; Party cell uses `min-w-0`, `max-w-[22rem]`, and `break-words` for long combined strings.
- **UX:** Removed the `{n} selected` span next to the filter.

## Follow-up (CI)

- **Test fix:** `pickerRow` used `partyEmail: overrides.partyEmail ?? 'pat@example.com'`, which treated **`partyEmail: null`** like “unset” and substituted the default email—so the “No Email Party” assertion failed. Now `null` is preserved when explicitly passed.
- **Robustness:** The “no Email column header” check is scoped to the **Enrollment picker** region so it does not collide with other tables (e.g. invoice list **Bill to** can expose an **Email** columnheader via bill-to email).

## Validation

- `bash scripts/validate-cursorrules.sh` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8e51975-70a2-4196-92e8-206f9547e758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8e51975-70a2-4196-92e8-206f9547e758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

