### PR TITLE
Customer invoices: table UX, PDF preview API, icon actions

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -15,6 +15,7 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { CheckIcon, EmailIcon, ViewIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
 import {
   confirmCustomerPayment,
   createCustomerRefund,
@@ -23,6 +24,7 @@ import {
   emailInvoice,
   exportBillingCsv,
   getCustomerInvoice,
+  getCustomerInvoicePdfDownload,
   getCustomerPayment,
   issueInvoice,
   listCustomerInvoices,
@@ -39,6 +41,7 @@ import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import {
   getCurrencyOptions,
   INSTANCE_TABLE_TIER_COHORT_HEADER,
+  formatDate,
   formatTierCohortDisplay,
 } from '@/lib/format';
 import { formatAmountInCurrency } from '@/lib/vendor-spend';
@@ -544,6 +547,19 @@ export function ClientInvoicesPanel() {
     }
   };
 
+  const handleOpenInvoicePdfPreview = async (invoiceId: string) => {
+    setActionError('');
+    setBusy('pdf');
+    try {
+      const { downloadUrl } = await getCustomerInvoicePdfDownload(invoiceId);
+      window.open(downloadUrl, '_blank', 'noopener,noreferrer');
+    } catch (caught) {
+      setActionError(caught instanceof Error ? caught.message : 'Could not open invoice preview.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
   const openConfirmPaymentDialog = (paymentId: string) => {
     setConfirmPaymentId(paymentId);
     setConfirmPaymentExternalRef('');
@@ -1014,19 +1030,11 @@ export function ClientInvoicesPanel() {
                 <option value=''>All currencies</option>
                 {currencyOptions.map((o) => (
                   <option key={o.value} value={o.value}>
-                    {o.value}
+                    {o.label}
                   </option>
                 ))}
               </Select>
             </div>
-            <Button
-              type='button'
-              variant='outline'
-              onClick={() => void loadInvoicesFirstPage()}
-              disabled={invoiceListLoading}
-            >
-              Refresh invoices
-            </Button>
           </div>
         }
       >
@@ -1048,6 +1056,14 @@ export function ClientInvoicesPanel() {
             {invoices.map((inv, index) => {
               const id = inv.id ?? '';
               const selected = id && selectedInvoiceId === id;
+              const totalRaw = inv.total?.trim() ?? '';
+              const parsedTotal = Number.parseFloat(totalRaw);
+              const currencyCode =
+                (inv.currency ?? defaultCurrency).trim().toUpperCase() || defaultCurrency;
+              const totalDisplay =
+                totalRaw !== '' && Number.isFinite(parsedTotal)
+                  ? formatAmountInCurrency(parsedTotal, currencyCode)
+                  : '—';
               return (
                 <tr
                   key={id || `invoice-row-${String(index)}`}
@@ -1073,22 +1089,49 @@ export function ClientInvoicesPanel() {
                   <td className='px-3 py-2 text-xs text-slate-700'>
                     {inv.billToDisplayName ?? inv.billToEmail ?? '—'}
                   </td>
-                  <td className='px-3 py-2'>
-                    {inv.total} {inv.currency}
-                  </td>
+                  <td className='px-3 py-2'>{totalDisplay}</td>
                   <td className='px-3 py-2'>{inv.lineCount ?? 0}</td>
-                  <td className='px-3 py-2 text-xs text-slate-600'>{inv.createdAt?.slice(0, 19) ?? '—'}</td>
+                  <td className='px-3 py-2'>{formatDate(inv.createdAt ?? null)}</td>
                   <td className='px-3 py-2 text-right'>
                     <div className='flex flex-wrap justify-end gap-1'>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='outline'
+                        disabled={editorBusy || !id}
+                        onClick={() => void handleOpenInvoicePdfPreview(id)}
+                        aria-label='Preview invoice PDF'
+                        title='Preview invoice PDF'
+                        aria-busy={busyAction === 'pdf'}
+                      >
+                        {busyAction === 'pdf' ? (
+                          <span
+                            className='inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-slate-600 border-t-transparent'
+                            aria-hidden
+                          />
+                        ) : (
+                          <ViewIcon className='h-4 w-4' aria-hidden />
+                        )}
+                      </Button>
                       {inv.status === 'draft' ? (
                         <Button
                           type='button'
                           size='sm'
                           variant='secondary'
-                          disabled={editorBusy}
+                          disabled={editorBusy || !id}
                           onClick={() => void handleIssueRow(id)}
+                          aria-label='Issue invoice'
+                          title='Issue invoice'
+                          aria-busy={busyAction === 'issue'}
                         >
-                          {busyAction === 'issue' ? '…' : 'Issue'}
+                          {busyAction === 'issue' ? (
+                            <span
+                              className='inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-slate-600 border-t-transparent'
+                              aria-hidden
+                            />
+                          ) : (
+                            <CheckIcon className='h-4 w-4' aria-hidden />
+                          )}
                         </Button>
                       ) : null}
                       {inv.status === 'issued' ? (
@@ -1096,10 +1139,12 @@ export function ClientInvoicesPanel() {
                           type='button'
                           size='sm'
                           variant='secondary'
-                          disabled={editorBusy}
+                          disabled={editorBusy || !id}
                           onClick={() => openEmailInvoiceDialog(id, inv.billToEmail)}
+                          aria-label='Email invoice PDF'
+                          title='Email invoice PDF'
                         >
-                          Email…
+                          <EmailIcon className='h-4 w-4' aria-hidden />
                         </Button>
                       ) : null}
                       {inv.status !== 'void' ? (
@@ -1107,10 +1152,12 @@ export function ClientInvoicesPanel() {
                           type='button'
                           size='sm'
                           variant='danger'
-                          disabled={editorBusy}
+                          disabled={editorBusy || !id}
                           onClick={() => openVoidInvoiceDialog(id)}
+                          aria-label='Void invoice'
+                          title='Void invoice'
                         >
-                          Void…
+                          <VoidExpenseIcon className='h-4 w-4' aria-hidden />
                         </Button>
                       ) : null}
                     </div>

--- a/apps/admin_web/src/lib/billing-api.ts
+++ b/apps/admin_web/src/lib/billing-api.ts
@@ -66,6 +66,24 @@ export async function getCustomerInvoice(id: string, signal?: AbortSignal): Prom
   return root.invoice;
 }
 
+export async function getCustomerInvoicePdfDownload(
+  id: string,
+  signal?: AbortSignal,
+): Promise<{ downloadUrl: string; expiresAt: string }> {
+  const payload = await adminApiRequest<{ downloadUrl?: string; expiresAt?: string }>({
+    endpointPath: `/v1/admin/billing/invoices/${id}/pdf`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  const downloadUrl = root.downloadUrl;
+  const expiresAt = root.expiresAt;
+  if (!downloadUrl || !expiresAt) {
+    throw new Error('Invoice PDF response missing download URL.');
+  }
+  return { downloadUrl, expiresAt };
+}
+
 export async function listCustomerPayments(signal?: AbortSignal): Promise<CustomerPaymentSummary[]> {
   const payload = await adminApiRequest<{ items?: CustomerPaymentSummary[] }>({
     endpointPath: '/v1/admin/billing/payments',

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4276,6 +4276,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/billing/invoices/{id}/pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get time-limited URL to open invoice PDF
+         * @description Returns a CloudFront-signed GET URL for the invoice PDF. Issued invoices use the canonical stored object; draft and void invoices render current lines to a preview key without mutating issued PDF metadata.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Signed download URL and expiry. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uri */
+                            downloadUrl: string;
+                            /** Format: date-time */
+                            expiresAt: string;
+                        };
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/billing/invoices/{id}/issue": {
         parameters: {
             query?: never;

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const billingMocks = vi.hoisted(() => ({
   listCustomerInvoices: vi.fn(),
   getCustomerInvoice: vi.fn(),
+  getCustomerInvoicePdfDownload: vi.fn(),
   listCustomerPayments: vi.fn(),
   getCustomerPayment: vi.fn(),
   issueInvoice: vi.fn(),
@@ -37,6 +38,10 @@ describe('ClientInvoicesPanel', () => {
       id: 'placeholder',
       status: 'draft',
       lines: [],
+    });
+    billingMocks.getCustomerInvoicePdfDownload.mockResolvedValue({
+      downloadUrl: 'https://example.com/signed.pdf',
+      expiresAt: '2026-12-31T00:00:00Z',
     });
   });
 
@@ -164,13 +169,58 @@ describe('ClientInvoicesPanel', () => {
 
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => screen.getByRole('button', { name: /^issue$/i }));
+    await waitFor(() => screen.getByRole('button', { name: /issue invoice/i }));
 
-    await userEvent.click(screen.getByRole('button', { name: /^issue$/i }));
+    await userEvent.click(screen.getByRole('button', { name: /issue invoice/i }));
 
     await waitFor(() => {
       expect(billingMocks.issueInvoice).toHaveBeenCalledWith(invId);
     });
+  });
+
+  it('preview row action opens invoice PDF URL in a new tab', async () => {
+    const invId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    billingMocks.listCustomerInvoices.mockResolvedValue({
+      items: [
+        {
+          id: invId,
+          status: 'draft',
+          currency: 'HKD',
+          total: '1',
+          lineCount: 0,
+          createdAt: '2026-01-01T00:00:00+00:00',
+        },
+      ],
+      next_cursor: null,
+    });
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<ClientInvoicesPanel />);
+
+    const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
+    const invoiceTable = within(invoiceRegion).getByRole('table');
+
+    await waitFor(() =>
+      within(invoiceTable).getByRole('button', { name: /preview invoice pdf/i }),
+    );
+
+    await userEvent.click(
+      within(invoiceTable).getByRole('button', { name: /preview invoice pdf/i }),
+    );
+
+    await waitFor(() => {
+      expect(billingMocks.getCustomerInvoicePdfDownload).toHaveBeenCalledWith(
+        invId,
+        expect.any(AbortSignal),
+      );
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://example.com/signed.pdf',
+        '_blank',
+        'noopener,noreferrer',
+      );
+    });
+
+    openSpy.mockRestore();
   });
 
   it('void dialog calls voidInvoice with reason', async () => {
@@ -192,9 +242,14 @@ describe('ClientInvoicesPanel', () => {
 
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => screen.getByRole('button', { name: /void/i }));
+    const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
+    const invoiceTable = within(invoiceRegion).getByRole('table');
 
-    await userEvent.click(screen.getByRole('button', { name: /void/i }));
+    await waitFor(() =>
+      within(invoiceTable).getByRole('button', { name: /void invoice/i }),
+    );
+
+    await userEvent.click(within(invoiceTable).getByRole('button', { name: /void invoice/i }));
 
     await userEvent.type(screen.getByLabelText(/reason/i), 'Customer cancelled');
     await userEvent.click(screen.getByRole('button', { name: /void invoice$/i }));
@@ -315,9 +370,9 @@ describe('ClientInvoicesPanel', () => {
 
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => screen.getByRole('button', { name: /email/i }));
+    await waitFor(() => screen.getByRole('button', { name: /email invoice pdf/i }));
 
-    await userEvent.click(screen.getByRole('button', { name: /email/i }));
+    await userEvent.click(screen.getByRole('button', { name: /email invoice pdf/i }));
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /email invoice pdf/i })).toBeInTheDocument();
@@ -357,8 +412,8 @@ describe('ClientInvoicesPanel', () => {
 
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => screen.getByRole('button', { name: /email/i }));
-    await userEvent.click(screen.getByRole('button', { name: /email/i }));
+    await waitFor(() => screen.getByRole('button', { name: /email invoice pdf/i }));
+    await userEvent.click(screen.getByRole('button', { name: /email invoice pdf/i }));
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /email invoice pdf/i })).toBeInTheDocument();
@@ -589,8 +644,8 @@ describe('ClientInvoicesPanel', () => {
 
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => screen.getByRole('button', { name: /^issue$/i }));
-    await userEvent.click(screen.getByRole('button', { name: /^issue$/i }));
+    await waitFor(() => screen.getByRole('button', { name: /issue invoice/i }));
+    await userEvent.click(screen.getByRole('button', { name: /issue invoice/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Invoice is not draft')).toBeInTheDocument();

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -209,10 +209,7 @@ describe('ClientInvoicesPanel', () => {
     );
 
     await waitFor(() => {
-      expect(billingMocks.getCustomerInvoicePdfDownload).toHaveBeenCalledWith(
-        invId,
-        expect.any(AbortSignal),
-      );
+      expect(billingMocks.getCustomerInvoicePdfDownload).toHaveBeenCalledWith(invId);
       expect(openSpy).toHaveBeenCalledWith(
         'https://example.com/signed.pdf',
         '_blank',
@@ -252,7 +249,10 @@ describe('ClientInvoicesPanel', () => {
     await userEvent.click(within(invoiceTable).getByRole('button', { name: /void invoice/i }));
 
     await userEvent.type(screen.getByLabelText(/reason/i), 'Customer cancelled');
-    await userEvent.click(screen.getByRole('button', { name: /void invoice$/i }));
+    const voidDialog = screen.getByRole('alertdialog');
+    await userEvent.click(
+      within(voidDialog).getByRole('button', { name: /^void invoice$/i }),
+    );
 
     await waitFor(() => {
       expect(billingMocks.voidInvoice).toHaveBeenCalledWith(invId, 'Customer cancelled');

--- a/backend/src/app/api/admin_billing.py
+++ b/backend/src/app/api/admin_billing.py
@@ -7,7 +7,11 @@ from collections.abc import Mapping
 
 from app.api.admin_billing_allocations import _create_allocation
 from app.api.admin_billing_export import _export_csv
-from app.api.admin_billing_invoice_queries import get_invoice, list_invoices
+from app.api.admin_billing_invoice_queries import (
+    get_invoice,
+    get_invoice_pdf_download,
+    list_invoices,
+)
 from app.api.admin_billing_enrollment_queries import (
     list_recent_enrollments_for_invoicing,
 )
@@ -123,6 +127,10 @@ def handle_admin_billing_request(
             )
         if action == "email" and method == "POST":
             return _email_invoice(
+                event, inv_id, user_sub=identity.user_sub, request_id=req
+            )
+        if action == "pdf" and method == "GET":
+            return get_invoice_pdf_download(
                 event, inv_id, user_sub=identity.user_sub, request_id=req
             )
 

--- a/backend/src/app/api/admin_billing_invoice_queries.py
+++ b/backend/src/app/api/admin_billing_invoice_queries.py
@@ -21,8 +21,13 @@ from app.api.admin_request import (
     parse_limit,
     query_param,
 )
+from app.api.assets.assets_common import (
+    generate_download_url,
+    signed_link_no_cache_headers,
+)
 from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
 from app.exceptions import NotFoundError, ValidationError
+from app.services.customer_billing import ensure_invoice_pdf_storage
 from app.utils import json_response
 
 
@@ -111,5 +116,36 @@ def get_invoice(
         return json_response(
             200,
             {"invoice": serialize_invoice_detail(inv)},
+            event=event,
+        )
+
+
+def get_invoice_pdf_download(
+    event: Mapping[str, Any],
+    invoice_id: UUID,
+    *,
+    user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    """Return a time-limited CloudFront-signed URL to open the invoice PDF in a browser."""
+    with _session_with_audit(user_sub, request_id) as session:
+        stmt = (
+            select(CustomerInvoice)
+            .where(CustomerInvoice.id == invoice_id)
+            .options(selectinload(CustomerInvoice.lines))
+        )
+        inv = session.execute(stmt).scalar_one_or_none()
+        if inv is None:
+            raise NotFoundError("CustomerInvoice", str(invoice_id))
+        s3_key = ensure_invoice_pdf_storage(session, inv)
+        download = generate_download_url(s3_key=s3_key)
+        extra = signed_link_no_cache_headers()
+        return json_response(
+            200,
+            {
+                "downloadUrl": download["download_url"],
+                "expiresAt": download["expires_at"],
+            },
+            headers=extra,
             event=event,
         )

--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -19,6 +19,7 @@ from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
 from app.db.models.customer_payment import CustomerPayment
 from app.db.models.customer_receipt import CustomerReceipt
 from app.db.models.enums import (
+    BillingInvoiceStatus,
     BillingPaymentDirection,
     BillingPaymentStatus,
 )
@@ -467,6 +468,45 @@ def refresh_invoice_pdf(session: Session, invoice: CustomerInvoice) -> None:
     invoice.issued_pdf_sha256 = digest
     invoice.pdf_template_version = PDF_TEMPLATE_VERSION
     session.flush()
+
+
+def _invoice_preview_s3_key(invoice_id: UUID) -> str:
+    return f"billing/invoices/preview/{invoice_id}.pdf"
+
+
+def upload_invoice_preview_pdf(session: Session, invoice: CustomerInvoice) -> str:
+    """Render invoice lines to PDF and store under a non-canonical preview key (no DB mutation)."""
+    lines = list(
+        session.execute(
+            select(CustomerInvoiceLine).where(
+                CustomerInvoiceLine.invoice_id == invoice.id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    pdf_bytes = render_invoice_pdf(invoice=invoice, lines=lines)
+    key = _invoice_preview_s3_key(invoice.id)
+    store_pdf_in_assets_bucket(
+        s3_key=key, body=pdf_bytes, content_type="application/pdf"
+    )
+    return key
+
+
+def ensure_invoice_pdf_storage(session: Session, invoice: CustomerInvoice) -> str:
+    """Return S3 object key for opening the invoice PDF (issued artifact or preview upload).
+
+    Issued invoices reuse ``issued_pdf_s3_key`` when set. Draft and void invoices
+    upload to ``billing/invoices/preview/{id}.pdf`` so preview does not overwrite
+    issued PDF metadata or hashes.
+    """
+    if (
+        invoice.status == BillingInvoiceStatus.ISSUED
+        and invoice.issued_pdf_s3_key
+        and invoice.issued_pdf_s3_key.strip()
+    ):
+        return invoice.issued_pdf_s3_key.strip()
+    return upload_invoice_preview_pdf(session, invoice)
 
 
 def send_invoice_email(session: Session, *, invoice_id: UUID, to_email: str) -> None:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -62,6 +62,7 @@ info:
     - `GET /v1/admin/billing/enrollments/recent-for-invoicing`
     - `GET|POST /v1/admin/billing/invoices` (GET optional `status`, `currency`, `cursor`, `limit`; POST `currency` optional when derived from enrollments)
     - `GET /v1/admin/billing/invoices/{id}`
+    - `GET /v1/admin/billing/invoices/{id}/pdf`
     - `POST /v1/admin/billing/invoices/{id}/issue`
     - `POST /v1/admin/billing/invoices/{id}/void`
     - `POST /v1/admin/billing/invoices/{id}/email`
@@ -3108,6 +3109,44 @@ paths:
                 properties:
                   invoice:
                     $ref: "#/components/schemas/CustomerInvoiceDetail"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/billing/invoices/{id}/pdf:
+    get:
+      summary: Get time-limited URL to open invoice PDF
+      description: >
+        Returns a CloudFront-signed GET URL for the invoice PDF. Issued invoices use the canonical
+        stored object; draft and void invoices render current lines to a preview key without mutating
+        issued PDF metadata.
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Signed download URL and expiry.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - downloadUrl
+                  - expiresAt
+                properties:
+                  downloadUrl:
+                    type: string
+                    format: uri
+                  expiresAt:
+                    type: string
+                    format: date-time
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -113,7 +113,8 @@ their primary responsibilities.
   must be greater than `0`),
   `/v1/admin/expenses/*`,
   `/v1/admin/billing/*` (customer AR: payments, invoices list/detail, draft-from-enrollments,
-  `GET /v1/admin/billing/enrollments/recent-for-invoicing`, allocations, export;
+  `GET /v1/admin/billing/enrollments/recent-for-invoicing`, `GET /v1/admin/billing/invoices/{id}/pdf`,
+  allocations, export;
   handler code split across `admin_billing*.py` modules under `app.api`, same Lambda),
   `/v1/user/assets/*`,
   `/v1/assets/public/*`, `/v1/assets/share/*`, `/v1/assets/email-download/*`,

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -962,6 +962,59 @@ def test_get_invoice_returns_detail_with_lines(
     assert body["invoice"]["lines"][0]["id"] == str(line_id)
 
 
+def test_get_invoice_pdf_returns_signed_url(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inv_id = uuid4()
+
+    class _Inv:
+        id = inv_id
+        status = BillingInvoiceStatus.DRAFT
+        lines = []
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+        s.execute.return_value.scalar_one_or_none.return_value = _Inv()
+        yield s
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+
+    monkeypatch.setattr(
+        admin_billing_invoice_queries_mod,
+        "ensure_invoice_pdf_storage",
+        lambda _session, _inv: "billing/invoices/preview/x.pdf",
+    )
+
+    def _fake_download(*, s3_key: str) -> dict[str, str]:
+        assert s3_key == "billing/invoices/preview/x.pdf"
+        return {
+            "download_url": "https://cdn.example.com/signed",
+            "expires_at": "2026-12-31T00:00:00+00:00",
+        }
+
+    monkeypatch.setattr(
+        admin_billing_invoice_queries_mod,
+        "generate_download_url",
+        _fake_download,
+    )
+
+    ev = api_gateway_event(
+        method="GET",
+        path=f"/v1/admin/billing/invoices/{inv_id}/pdf",
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "GET", f"/v1/admin/billing/invoices/{inv_id}/pdf"
+    )
+    assert r["statusCode"] == 200
+    body = json.loads(r["body"])
+    assert body["downloadUrl"] == "https://cdn.example.com/signed"
+    assert body["expiresAt"] == "2026-12-31T00:00:00+00:00"
+
+
 def test_export_csv_rejects_invalid_export_version(
     api_gateway_event: Any,
     admin_identity: dict[str, str],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Customer invoices toolbar**: Removed the redundant "Refresh invoices" button. The list still reloads when status/currency filters change and after mutations (issue, void, email, draft, etc.).
- **Currency filter**: Options now use the same **code + name** labels as the expense editor / vendors (`getCurrencyOptions().label`).
- **Total column**: Uses `formatAmountInCurrency` like the enrollments **Amount** column; shows **—** when the amount is missing or not parseable.
- **Created column**: Uses `formatDate` (locale date/time) instead of slicing the ISO string.
- **Operations**: Icon-only buttons with `aria-label` / `title`: **Preview** (eye), **Issue** (check), **Email**, **Void**. Preview opens the PDF in a **new tab** via a signed URL.

## Backend

- New **`GET /v1/admin/billing/invoices/{id}/pdf`** returns JSON `{ downloadUrl, expiresAt }` using the same CloudFront signing as asset downloads.
- **Issued** invoices: reuse the canonical stored PDF key when present.
- **Draft / void** previews: render lines to PDF and upload to `billing/invoices/preview/{invoice_id}.pdf` without updating `issued_pdf_*` on the invoice row (draft preview approved).

## Docs / types

- `docs/api/admin.yaml` and `docs/architecture/lambdas.md` updated; admin API types regenerated from OpenAPI where applicable.

## Tests

- `tests/test_admin_billing.py`: new test for the PDF route.
- `client-invoices-panel.test.tsx`: updated for icon-only actions; preview assertion matches API call signature; void confirm scoped to `alertdialog`.

## CI fix (follow-up)

- Vitest failures: `getCustomerInvoicePdfDownload` is invoked with only the invoice id; void confirm button query scoped to the dialog to avoid duplicate "Void invoice" matches.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9c4301a-18ac-4fed-9e26-5aeafd6dfa18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9c4301a-18ac-4fed-9e26-5aeafd6dfa18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

