### PR TITLE
fix(billing): bust CloudFront cache for invoice PDF downloads

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -26,6 +26,7 @@ on:
     paths:
       - 'backend/**'
       - 'scripts/**'
+      - '.github/workflows/deploy-backend.yml'
 
 permissions:
   contents: read

--- a/backend/src/app/api/admin_billing_invoice_queries.py
+++ b/backend/src/app/api/admin_billing_invoice_queries.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 from collections.abc import Mapping
 from uuid import UUID
@@ -138,7 +139,10 @@ def get_invoice_pdf_download(
         if inv is None:
             raise NotFoundError("CustomerInvoice", str(invoice_id))
         s3_key = ensure_invoice_pdf_storage(session, inv)
-        download = generate_download_url(s3_key=s3_key)
+        download = generate_download_url(
+            s3_key=s3_key,
+            cache_bust_key=str(time.time_ns()),
+        )
         extra = signed_link_no_cache_headers()
         return json_response(
             200,

--- a/backend/src/app/api/assets/assets_common.py
+++ b/backend/src/app/api/assets/assets_common.py
@@ -473,11 +473,17 @@ def generate_upload_url(*, s3_key: str, content_type: str | None) -> dict[str, A
     }
 
 
-def generate_download_url(*, s3_key: str) -> dict[str, Any]:
+def generate_download_url(
+    *, s3_key: str, cache_bust_key: str | None = None
+) -> dict[str, Any]:
     """Generate a CloudFront-signed GET URL for download."""
     expiry_days = _download_link_expiry_days()
     expires_at = datetime.now(UTC) + timedelta(days=expiry_days)
-    url = generate_signed_download_url(s3_key=s3_key, expires_at=expires_at)
+    url = generate_signed_download_url(
+        s3_key=s3_key,
+        expires_at=expires_at,
+        cache_bust_key=cache_bust_key,
+    )
     return {
         "download_url": url,
         "expires_at": expires_at.isoformat(),

--- a/backend/src/app/services/cloudfront_signing.py
+++ b/backend/src/app/services/cloudfront_signing.py
@@ -31,8 +31,17 @@ class _SignerCacheEntry:
 _SIGNER_CACHE: _SignerCacheEntry | None = None
 
 
-def generate_signed_download_url(*, s3_key: str, expires_at: datetime) -> str:
-    """Generate a CloudFront signed URL for an S3-backed object key."""
+def generate_signed_download_url(
+    *,
+    s3_key: str,
+    expires_at: datetime,
+    cache_bust_key: str | None = None,
+) -> str:
+    """Generate a CloudFront signed URL for an S3-backed object key.
+
+    ``cache_bust_key`` is appended as a ``cb`` query parameter so repeated uploads
+    to the same key (e.g. invoice preview PDFs) do not serve a stale edge copy.
+    """
     if expires_at.tzinfo is None:
         raise RuntimeError("expires_at must be timezone-aware")
 
@@ -47,6 +56,10 @@ def generate_signed_download_url(*, s3_key: str, expires_at: datetime) -> str:
     resource_url = (
         f"https://{distribution_domain}/{quote(normalized_key, safe='/_.-~')}"
     )
+    if cache_bust_key is not None and str(cache_bust_key).strip() != "":
+        safe_cb = quote(str(cache_bust_key).strip(), safe="")
+        sep = "&" if "?" in resource_url else "?"
+        resource_url = f"{resource_url}{sep}cb={safe_cb}"
     signer = _get_signer(key_pair_id=key_pair_id, secret_arn=secret_arn)
     return signer.generate_presigned_url(resource_url, date_less_than=expires_at)
 

--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -56,6 +56,7 @@ def store_pdf_in_assets_bucket(*, s3_key: str, body: bytes, content_type: str) -
         Key=s3_key,
         Body=body,
         ContentType=content_type,
+        CacheControl="private, max-age=0, must-revalidate",
     )
 
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -113,7 +113,10 @@ their primary responsibilities.
   must be greater than `0`),
   `/v1/admin/expenses/*`,
   `/v1/admin/billing/*` (customer AR: payments, invoices list/detail, draft-from-enrollments,
-  `GET /v1/admin/billing/enrollments/recent-for-invoicing`, `GET /v1/admin/billing/invoices/{id}/pdf`,
+  `GET /v1/admin/billing/enrollments/recent-for-invoicing`, `GET /v1/admin/billing/invoices/{id}/pdf`
+  (returns a CloudFront-signed URL; each response includes a unique cache-bust query on the
+  signed resource so draft/void preview PDFs re-uploaded to the same S3 key are not edge-cached
+  as an older file),
   allocations, export;
   handler code split across `admin_billing*.py` modules under `app.api`, same Lambda),
   `/v1/user/assets/*`,

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -988,8 +988,9 @@ def test_get_invoice_pdf_returns_signed_url(
         lambda _session, _inv: "billing/invoices/preview/x.pdf",
     )
 
-    def _fake_download(*, s3_key: str) -> dict[str, str]:
+    def _fake_download(*, s3_key: str, cache_bust_key: str | None = None) -> dict[str, str]:
         assert s3_key == "billing/invoices/preview/x.pdf"
+        assert cache_bust_key is not None and cache_bust_key.isdigit()
         return {
             "download_url": "https://cdn.example.com/signed",
             "expires_at": "2026-12-31T00:00:00+00:00",

--- a/tests/test_cloudfront_signing.py
+++ b/tests/test_cloudfront_signing.py
@@ -47,6 +47,30 @@ def test_generate_signed_download_url_uses_cloudfront_signer(
     assert cloudfront_dummy_signer.date_less_than == expires_at
 
 
+def test_generate_signed_download_url_includes_cache_bust_query(
+    monkeypatch: Any,
+    cloudfront_dummy_signer: Any,
+) -> None:
+    monkeypatch.setenv("ASSET_DOWNLOAD_CLOUDFRONT_DOMAIN", "d111111abcdef8.cloudfront.net")
+    monkeypatch.setenv("ASSET_DOWNLOAD_CLOUDFRONT_KEY_PAIR_ID", "K123EXAMPLE")
+    monkeypatch.setenv(
+        "ASSET_DOWNLOAD_CLOUDFRONT_PRIVATE_KEY_SECRET_ARN",
+        "arn:aws:secretsmanager:ap-southeast-1:111111111111:secret:cf/private",
+    )
+    monkeypatch.setattr(cloudfront_signing, "_get_signer", lambda **_: cloudfront_dummy_signer)
+
+    expires_at = datetime(2035, 1, 1, 12, 0, tzinfo=UTC)
+    cloudfront_signing.generate_signed_download_url(
+        s3_key="billing/invoices/preview/abc.pdf",
+        expires_at=expires_at,
+        cache_bust_key="1700000000000000000",
+    )
+    assert (
+        cloudfront_dummy_signer.resource_url
+        == "https://d111111abcdef8.cloudfront.net/billing/invoices/preview/abc.pdf?cb=1700000000000000000"
+    )
+
+
 def test_generate_signed_download_url_requires_timezone_aware_datetime(
     monkeypatch: Any,
     cloudfront_dummy_signer: Any,


### PR DESCRIPTION
Draft previews overwrite the same S3 key; CloudFront could serve an older PDF even after upload. Add optional cb query to signed URLs for GET invoice PDF, pass nanosecond cache key from admin billing, set Cache-Control on PDF puts.

Also trigger deploy-backend on workflow file changes so Lambda env fixes ship.

Tests: extend CloudFront signing spec; admin billing PDF URL mock.