### PR TITLE
Invoice PDF v5 layout remediation (billing-invoice-v5)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,11 +18,11 @@ dependencies = [
   "pycountry==26.2.16",
   "reportlab==4.4.6",
   "pypdf==6.10.2",
-  "pymupdf==1.27.2",
 ]
 
 [project.optional-dependencies]
 test = [
+  "pymupdf==1.26.0",
   "pytest>=9.0.3",
   "pytest-cov>=5.0.0",
   "pytest-mock>=3.14.0",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "pycountry==26.2.16",
   "reportlab==4.4.6",
   "pypdf==6.10.2",
+  "pymupdf==1.27.2",
 ]
 
 [project.optional-dependencies]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,4 +8,3 @@ phonenumbers==9.0.29
 pycountry==26.2.16
 reportlab==4.4.6
 pypdf==6.10.2
-pymupdf==1.27.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ phonenumbers==9.0.29
 pycountry==26.2.16
 reportlab==4.4.6
 pypdf==6.10.2
+pymupdf==1.27.2

--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -31,7 +31,7 @@ from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v4"
+INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v5"
 RECEIPT_PDF_TEMPLATE_VERSION = "billing-receipt-v1"
 _SCOPE_DEFAULT = "default"
 _DOC_INVOICE = "invoice"

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -67,14 +67,15 @@ _INV_TEXT = colors.HexColor("#1c3542")
 _INV_MUTED = colors.HexColor("#5a6b73")
 _INV_GRID = colors.HexColor("#d4dce0")
 _INV_TITLE = colors.HexColor("#2c3e50")  # Title navy used in reference
-_INV_HEADER_FILL = colors.HexColor("#2c3e50")  # Items table header dark fill
+_INV_HEADER_FILL = colors.HexColor("#33495d")  # Items table header dark fill
 _INV_HEADER_TEXT = colors.white  # Items table header text
 _INV_BODY_TEXT = colors.HexColor("#333333")  # Body text colour
 _INV_LABEL_TEXT = colors.HexColor("#555555")  # "From:", "Bill To:", "Terms…" etc.
 _INV_PANEL_FILL = colors.HexColor(
-    "#eef2f5"
+    "#f7f9fa"
 )  # Soft blue-grey card fill (dates / totals)
 _INV_RULE = colors.HexColor("#cfd6da")  # Thin rules under header band & above Total
+_INV_DIVIDER = colors.HexColor("#1c2a36")  # Strong horizontal rule under title
 _INV_FOOTER_TEXT = colors.HexColor("#7f8c8d")  # Footer muted grey
 _INV_LOGO_PATH = (
     Path(__file__).resolve().parent.parent
@@ -89,8 +90,8 @@ def _invoice_logo_flowable() -> Image | Paragraph:
         return Paragraph("", _SAMPLE_STYLES["Normal"])
     img = Image(
         str(_INV_LOGO_PATH),
-        width=38 * mm,
-        height=38 * mm,
+        width=35 * mm,
+        height=35 * mm,
         kind="proportional",
     )
     img.hAlign = "LEFT"
@@ -358,10 +359,11 @@ def render_invoice_pdf(
         TableStyle(
             [
                 ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("LEFTPADDING", (0, 0), (0, 0), 18),
+                ("LEFTPADDING", (1, 0), (1, 0), 0),
                 ("RIGHTPADDING", (0, 0), (-1, -1), 0),
-                ("TOPPADDING", (0, 0), (-1, -1), 0),
-                ("BOTTOMPADDING", (0, 0), (-1, -1), 10),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 18),
             ]
         )
     )
@@ -370,11 +372,12 @@ def render_invoice_pdf(
     divider_table = Table(
         [[Paragraph(" ", body_text_style)]],
         colWidths=[190 * mm],
+        rowHeights=[1],
     )
     divider_table.setStyle(
         TableStyle(
             [
-                ("LINEBELOW", (0, 0), (-1, -1), 0.6, _INV_RULE),
+                ("LINEBELOW", (0, 0), (-1, -1), 1.0, _INV_DIVIDER),
                 ("LEFTPADDING", (0, 0), (-1, -1), 0),
                 ("RIGHTPADDING", (0, 0), (-1, -1), 0),
                 ("TOPPADDING", (0, 0), (-1, -1), 0),
@@ -383,13 +386,19 @@ def render_invoice_pdf(
         )
     )
     story.append(divider_table)
-    story.append(Spacer(1, 8))
+    story.append(Spacer(1, 30))
 
     from_body_parts: list[str] = []
     if business_name:
         from_body_parts.append(business_name)
     from_body_parts.extend(address_lines)
     from_body_html = "<br/>".join(from_body_parts) if from_body_parts else ""
+
+    from_lines = min(
+        6,
+        max(2, (1 if business_name else 0) + len(address_lines)),
+    )
+    header_row_pt = 14 + (from_lines * 14) + 4
 
     from_cell = Table(
         [
@@ -459,11 +468,11 @@ def render_invoice_pdf(
         TableStyle(
             [
                 ("BACKGROUND", (0, 0), (-1, -1), _INV_PANEL_FILL),
-                ("VALIGN", (0, 0), (-1, -1), "TOP"),
-                ("LEFTPADDING", (0, 0), (-1, -1), 8),
-                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
-                ("TOPPADDING", (0, 0), (-1, -1), 8),
-                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 14),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 14),
+                ("TOPPADDING", (0, 0), (-1, -1), 10),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 10),
             ]
         )
     )
@@ -471,6 +480,7 @@ def render_invoice_pdf(
     header_band = Table(
         [[from_cell, bill_cell, dates_inner]],
         colWidths=[70 * mm, 60 * mm, 60 * mm],
+        rowHeights=[header_row_pt],
     )
     header_band.setStyle(
         TableStyle(
@@ -484,7 +494,7 @@ def render_invoice_pdf(
         )
     )
     story.append(header_band)
-    story.append(Spacer(1, 14))
+    story.append(Spacer(1, 24))
 
     header_row = [
         Paragraph("<b>Description</b>", header_label_style),
@@ -494,7 +504,7 @@ def render_invoice_pdf(
     ]
 
     first_line_item = True
-    for line in ordered:
+    for line_idx, line in enumerate(ordered):
         desc = line.description or ""
         qty = line.quantity.quantize(Decimal("0.0001")).normalize()
         unit = format_money(line.unit_amount, inv_currency)
@@ -531,7 +541,7 @@ def render_invoice_pdf(
                 ("LEFTPADDING", (0, 0), (-1, -1), 5),
                 ("RIGHTPADDING", (0, 0), (-1, -1), 5),
                 ("TOPPADDING", (0, 0), (-1, -1), 5),
-                ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
             ]
             if has_header:
                 hdr = 0
@@ -569,7 +579,12 @@ def render_invoice_pdf(
                         ("SPAN", (col, row_body_start), (col, last_body_row))
                     )
 
+            is_last_line_last_slice = line_idx == len(ordered) - 1 and seg_end == len(
+                chunks
+            )
             for r in range(body_start, n_rows):
+                if is_last_line_last_slice and r == n_rows - 1:
+                    continue
                 style_cmds.append(
                     ("LINEBELOW", (0, r), (-1, r), 0.4, _INV_RULE),
                 )
@@ -615,17 +630,17 @@ def render_invoice_pdf(
     last_row = len(inner_totals_rows) - 1
     inner_totals = Table(
         inner_totals_rows,
-        colWidths=[44 * mm, 36 * mm],
+        colWidths=[55 * mm, 32 * mm],
     )
     inner_totals.setStyle(
         TableStyle(
             [
                 ("BACKGROUND", (0, 0), (-1, -1), _INV_PANEL_FILL),
-                ("VALIGN", (0, 0), (-1, -1), "TOP"),
-                ("LEFTPADDING", (0, 0), (-1, -1), 10),
-                ("RIGHTPADDING", (0, 0), (-1, -1), 10),
-                ("TOPPADDING", (0, 0), (-1, -1), 8),
-                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 14),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 14),
+                ("TOPPADDING", (0, 0), (-1, -1), 12),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 12),
                 ("LINEABOVE", (0, last_row), (-1, last_row), 0.5, _INV_RULE),
             ]
         )
@@ -638,7 +653,7 @@ def render_invoice_pdf(
                 inner_totals,
             ]
         ],
-        colWidths=[110 * mm, 80 * mm],
+        colWidths=[103 * mm, 87 * mm],
     )
     totals_outer.setStyle(
         TableStyle(
@@ -646,35 +661,41 @@ def render_invoice_pdf(
                 ("VALIGN", (0, 0), (-1, -1), "TOP"),
                 ("LEFTPADDING", (0, 0), (-1, -1), 0),
                 ("RIGHTPADDING", (0, 0), (-1, -1), 0),
-                ("TOPPADDING", (0, 0), (-1, -1), 0),
+                ("TOPPADDING", (0, 0), (0, 0), 14),
                 ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
                 ("ALIGN", (1, 0), (1, 0), "RIGHT"),
             ]
         )
     )
     story.append(totals_outer)
-    story.append(Spacer(1, 16))
+    story.append(Spacer(1, 28))
 
     terms_intro = (
         f"Payment is due within {terms_days} days from the issue of the invoice."
     )
     story.append(Paragraph("Terms &amp; Conditions:", label_heading_style))
+    story.append(Spacer(1, 4))
     story.append(Paragraph(_esc(terms_intro), body_text_style))
     if has_bank_block:
+        story.append(Spacer(1, 4))
         story.append(
             Paragraph(
                 _esc("Please make payments using the bank details below:"),
                 body_text_style,
             )
         )
-        story.append(Spacer(1, 8))
-        for bl in (
+        story.append(Spacer(1, 12))
+        bank_lines = [
             f"<b>Bank:</b> {_esc(bank_name)}" if bank_name else "",
             f"<b>Account Number:</b> {_esc(bank_number)}" if bank_number else "",
             f"<b>Account Name:</b> {_esc(bank_holder)}" if bank_holder else "",
-        ):
-            if bl:
-                story.append(Paragraph(bl, body_text_style))
+        ]
+        for idx, bl in enumerate(bank_lines):
+            if not bl:
+                continue
+            if idx > 0:
+                story.append(Spacer(1, 2))
+            story.append(Paragraph(bl, body_text_style))
 
     footer_text = invoice_pdf_footer_text()
 
@@ -684,7 +705,7 @@ def render_invoice_pdf(
         canvas_obj.saveState()
         canvas_obj.setFont("Helvetica", 9)
         canvas_obj.setFillColor(_INV_FOOTER_TEXT)
-        y_footer = 12 * mm
+        y_footer = 14 * mm
         canvas_obj.drawCentredString(A4[0] / 2, y_footer, footer_text)
         canvas_obj.restoreState()
 

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -467,7 +467,6 @@ def render_invoice_pdf(
     dates_inner.setStyle(
         TableStyle(
             [
-                ("BACKGROUND", (0, 0), (-1, -1), _INV_PANEL_FILL),
                 ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
                 ("LEFTPADDING", (0, 0), (-1, -1), 14),
                 ("RIGHTPADDING", (0, 0), (-1, -1), 14),
@@ -477,8 +476,26 @@ def render_invoice_pdf(
         )
     )
 
+    dates_wrapped = Table(
+        [[dates_inner]],
+        colWidths=[60 * mm],
+        rowHeights=[header_row_pt],
+    )
+    dates_wrapped.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, -1), _INV_PANEL_FILL),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+                ("TOPPADDING", (0, 0), (-1, -1), 0),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+
     header_band = Table(
-        [[from_cell, bill_cell, dates_inner]],
+        [[from_cell, bill_cell, dates_wrapped]],
         colWidths=[70 * mm, 60 * mm, 60 * mm],
         rowHeights=[header_row_pt],
     )

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -204,7 +204,7 @@ their primary responsibilities.
   `ADMIN_GROUP`, `AWS_PROXY_FUNCTION_ARN` (sales recap recipient resolution via Cognito group),
   `SALES_RECAP_DISPLAY_TIMEZONE` (optional IANA id for recap **Submitted at**; CDK `SalesRecapDisplayTimezone` parameter, empty = app default),
   `MAILCHIMP_*` welcome journey vars (see `aws-messaging.md`)
-- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v4`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
+- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v5`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
 - **Invoice currency display:** `HKD` amounts render with the `HK$` prefix in AR invoice PDFs.
 - **AR invoice footer (Option B):** when both legal/trading and registration are set, the centered footer is `{legal_name} | Proudly registered in Hong Kong | BR: {reg}` with `legal_name` = `PUBLIC_WWW_BUSINESS_LEGAL_NAME` or `PUBLIC_WWW_BUSINESS_NAME`, and with fallbacks: legal only → legal; registration only → `BR: {reg}`; both empty → no footer. The **"Proudly registered in Hong Kong"** fragment is fixed product copy (see `.cursorrules` exception).
 - **Snapshot dates:** on issue, `customer_invoices.invoice_date` and `customer_invoices.due_date` are persisted (see `docs/architecture/database-schema.md`); the PDF uses these when present; draft previews compute dates in **UTC** when columns are null.

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -155,7 +155,7 @@ def test_v5_dates_panel_full_height_via_image_render(
 
     page = fitz.open(stream=pdf, filetype="pdf")[0]
     pix, s = _pixmap_pt_coords(page)
-    x_pt, y_pt = 480, 250
+    x_pt, y_pt = 480, 280
     rgb = pix.pixel(int(x_pt * s), int(y_pt * s))
     assert _rgb_close(rgb, (247, 249, 250))
 

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -50,8 +50,324 @@ def _inv_line(**kwargs: object) -> SimpleNamespace:
     return SimpleNamespace(**defaults)
 
 
+def _pdf_layout(pdf: bytes):
+    import fitz
+
+    doc = fitz.open(stream=pdf, filetype="pdf")
+    page = doc[0]
+    blocks = page.get_text("dict")["blocks"]
+    spans, images = [], []
+    for b in blocks:
+        if b["type"] == 0:
+            for ln in b["lines"]:
+                for sp in ln["spans"]:
+                    spans.append(sp)
+        else:
+            images.append(b)
+    return doc, page, spans, images
+
+
+def _v5_standard_invoice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[SimpleNamespace, SimpleNamespace]:
+    monkeypatch.setenv("INVOICE_DISPLAY_TIMEZONE", "Asia/Hong_Kong")
+    monkeypatch.setenv("INVOICE_PAYMENT_TERMS_DAYS", "7")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_NAME", "Evolve Sprouts")
+    monkeypatch.setenv(
+        "PUBLIC_WWW_BUSINESS_ADDRESS",
+        "507, 5/F, Arion Commercial Centre\n2-12 Queen's Road West\n"
+        "Sheung Wan\nHong Kong SAR",
+    )
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_LEGAL_NAME", "Evolve Sprouts Ltd")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_REGISTRATION", "41492636-000-02-25-0")
+    monkeypatch.setenv("PUBLIC_WWW_BANK_NAME", "389 - Mox Bank Limited")
+    monkeypatch.setenv("PUBLIC_WWW_BANK_ACCOUNT_NUMBER", "749 86477821")
+    monkeypatch.setenv("PUBLIC_WWW_BANK_ACCOUNT_HOLDER", "IDA DE GREGORIO")
+    inv = SimpleNamespace(
+        invoice_number="I-2603-027",
+        currency="HKD",
+        subtotal=Decimal("583.33"),
+        tax_total=Decimal("0"),
+        total=Decimal("583.33"),
+        bill_to_display_name="Bump and Co",
+        bill_to_email=None,
+        issued_at=datetime(2026, 3, 25, 12, 0, tzinfo=UTC),
+        invoice_date=date(2026, 3, 25),
+        due_date=date(2026, 4, 1),
+        status=BillingInvoiceStatus.ISSUED,
+    )
+    line = SimpleNamespace(
+        line_order=0,
+        description="Weaning Workshop for Bump & Co",
+        quantity=Decimal("1"),
+        unit_amount=Decimal("583.33"),
+        line_total=Decimal("583.33"),
+        currency="HKD",
+    )
+    return inv, line
+
+
+def _pixmap_pt_coords(page, dpi: int = 120):
+    """Return (pix, s) where pixel row for PDF pt y is int(y * s)."""
+    pix = page.get_pixmap(dpi=dpi)
+    s = pix.width / page.rect.width
+    return pix, s
+
+
+def _rgb_close(
+    rgb: tuple[int, int, int], target: tuple[int, int, int], tol: int = 4
+) -> bool:
+    return all(abs(a - b) <= tol for a, b in zip(rgb, target))
+
+
+def test_v5_logo_size_and_position(monkeypatch: pytest.MonkeyPatch) -> None:
+    inv, line = _v5_standard_invoice(monkeypatch)
+    pdf = render_invoice_pdf(invoice=inv, lines=[line], preview=False)
+    _doc, _page, _spans, images = _pdf_layout(pdf)
+    if not images:
+        pytest.skip("invoice logo asset not present in test environment")
+    assert len(images) == 1
+    bbox = images[0]["bbox"]
+    w = bbox[2] - bbox[0]
+    h = bbox[3] - bbox[1]
+    assert 95 <= w <= 105
+    assert 95 <= h <= 105
+    assert 42 <= bbox[0] <= 60
+
+
+def test_v5_invoice_title_centred_with_logo(monkeypatch: pytest.MonkeyPatch) -> None:
+    inv, line = _v5_standard_invoice(monkeypatch)
+    pdf = render_invoice_pdf(invoice=inv, lines=[line], preview=False)
+    _doc, _page, spans, _images = _pdf_layout(pdf)
+    inv_spans = [s for s in spans if "INVOICE" in s["text"]]
+    assert inv_spans
+    bb = inv_spans[0]["bbox"]
+    assert 85 <= bb[1] <= 110
+    assert bb[2] > 540
+
+
+def test_v5_dates_panel_full_height_via_image_render(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inv, line = _v5_standard_invoice(monkeypatch)
+    pdf = render_invoice_pdf(invoice=inv, lines=[line], preview=False)
+    import fitz
+
+    page = fitz.open(stream=pdf, filetype="pdf")[0]
+    pix, s = _pixmap_pt_coords(page)
+    x_pt, y_pt = 480, 250
+    rgb = pix.pixel(int(x_pt * s), int(y_pt * s))
+    assert _rgb_close(rgb, (247, 249, 250))
+
+
+def test_v5_items_header_navy_fill(monkeypatch: pytest.MonkeyPatch) -> None:
+    inv, line = _v5_standard_invoice(monkeypatch)
+    pdf = render_invoice_pdf(invoice=inv, lines=[line], preview=False)
+    import fitz
+
+    page = fitz.open(stream=pdf, filetype="pdf")[0]
+    pix, s = _pixmap_pt_coords(page)
+    rgb = pix.pixel(int(200 * s), int(325 * s))
+    assert _rgb_close(rgb, (51, 73, 93))
+
+
+def test_v5_totals_card_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    from reportlab.lib.units import mm
+
+    inv, line = _v5_standard_invoice(monkeypatch)
+    pdf = render_invoice_pdf(invoice=inv, lines=[line], preview=False)
+    import fitz
+
+    page = fitz.open(stream=pdf, filetype="pdf")[0]
+    pix, s = _pixmap_pt_coords(page)
+    W = pix.width
+    y_pt = 369
+    y = int(y_pt * s)
+
+    def matches_panel(rgb: tuple[int, int, int]) -> bool:
+        return _rgb_close(rgb, (247, 249, 250))
+
+    longest = 0.0
+    left_pt = 0.0
+    in_run = False
+    start = 0
+    for x in range(W):
+        if matches_panel(pix.pixel(x, y)):
+            if not in_run:
+                start = x
+                in_run = True
+        else:
+            if in_run:
+                w_pt = (x - 1 - start + 1) / s
+                if w_pt > longest:
+                    longest = w_pt
+                    left_pt = start / s
+                in_run = False
+    if in_run:
+        w_pt = (W - 1 - start + 1) / s
+        if w_pt > longest:
+            longest = w_pt
+            left_pt = start / s
+
+    assert 82 * mm <= longest <= 92 * mm
+    assert 110 * mm <= left_pt <= 130 * mm
+
+
+def test_v5_no_rule_below_last_item_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    inv, line = _v5_standard_invoice(monkeypatch)
+    pdf = render_invoice_pdf(invoice=inv, lines=[line], preview=False)
+    import fitz
+
+    page = fitz.open(stream=pdf, filetype="pdf")[0]
+    thin_grey_between = 0
+    for d in page.get_drawings():
+        if d.get("type") != "s":
+            continue
+        r = d["rect"]
+        w = d.get("width") or 0
+        c = d.get("color")
+        if abs(float(w) - 0.4) > 0.05 or not c or len(c) != 3:
+            continue
+        if max(c) < 0.75:
+            continue
+        y = r.y0
+        if 460 <= y <= 500:
+            thin_grey_between += 1
+    assert thin_grey_between == 0
+
+
+def test_v5_footer_y_anchor(monkeypatch: pytest.MonkeyPatch) -> None:
+    inv, line = _v5_standard_invoice(monkeypatch)
+    pdf = render_invoice_pdf(invoice=inv, lines=[line], preview=False)
+    _doc, _page, spans, _images = _pdf_layout(pdf)
+    foot = [
+        s for s in spans if "Proudly registered" in s["text"] or "BR:" in s["text"]
+    ]
+    assert foot
+    y0 = foot[0]["bbox"][1]
+    assert 780 <= y0 <= 795
+
+
+def test_v5_multiline_last_chunk_skips_rule(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INVOICE_DISPLAY_TIMEZONE", "Asia/Hong_Kong")
+    monkeypatch.setenv("INVOICE_PAYMENT_TERMS_DAYS", "7")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_NAME", "Co")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_ADDRESS", "addr")
+    monkeypatch.delenv("PUBLIC_WWW_BANK_NAME", raising=False)
+    monkeypatch.delenv("PUBLIC_WWW_BANK_ACCOUNT_NUMBER", raising=False)
+    monkeypatch.delenv("PUBLIC_WWW_BANK_ACCOUNT_HOLDER", raising=False)
+    desc = ("a " * 51).rstrip()
+    from app.services.customer_invoice_pdf import _description_row_strings
+
+    assert len(_description_row_strings(desc)) == 2
+    inv = SimpleNamespace(
+        invoice_number="N1",
+        currency="HKD",
+        subtotal=Decimal("3"),
+        tax_total=Decimal("0"),
+        total=Decimal("3"),
+        bill_to_display_name="X",
+        bill_to_email=None,
+        issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+        invoice_date=date(2026, 1, 1),
+        due_date=date(2026, 1, 8),
+        status=BillingInvoiceStatus.ISSUED,
+    )
+    lines = [
+        SimpleNamespace(
+            line_order=i,
+            description=desc,
+            quantity=Decimal("1"),
+            unit_amount=Decimal("1"),
+            line_total=Decimal("1"),
+            currency="HKD",
+        )
+        for i in range(3)
+    ]
+    pdf = render_invoice_pdf(invoice=inv, lines=lines, preview=False)
+    import fitz
+
+    page = fitz.open(stream=pdf, filetype="pdf")[0]
+    thin = 0
+    for d in page.get_drawings():
+        if d.get("type") != "s":
+            continue
+        w = d.get("width") or 0
+        if abs(float(w) - 0.4) <= 0.05:
+            thin += 1
+    assert thin == 5
+
+
+def test_v5_tax_total_line_above_rule(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INVOICE_DISPLAY_TIMEZONE", "Asia/Hong_Kong")
+    monkeypatch.setenv("INVOICE_PAYMENT_TERMS_DAYS", "7")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_NAME", "Co")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_ADDRESS", "a")
+    monkeypatch.setenv("PUBLIC_WWW_BANK_NAME", "B")
+    inv = SimpleNamespace(
+        invoice_number="N1",
+        currency="HKD",
+        subtotal=Decimal("100"),
+        tax_total=Decimal("10"),
+        total=Decimal("110"),
+        bill_to_display_name="X",
+        bill_to_email=None,
+        issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+        invoice_date=date(2026, 1, 1),
+        due_date=date(2026, 1, 8),
+        status=BillingInvoiceStatus.ISSUED,
+    )
+    pdf = render_invoice_pdf(invoice=inv, lines=[_inv_line()], preview=False)
+    import fitz
+
+    page = fitz.open(stream=pdf, filetype="pdf")[0]
+    mid_rules = [
+        d["rect"].y0
+        for d in page.get_drawings()
+        if d.get("type") == "s"
+        and abs((d.get("width") or 0) - 0.5) < 0.05
+        and d.get("rect")
+    ]
+    assert len(mid_rules) >= 1
+
+
+def test_v5_wide_hkd_amount_fits(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INVOICE_DISPLAY_TIMEZONE", "Asia/Hong_Kong")
+    monkeypatch.setenv("INVOICE_PAYMENT_TERMS_DAYS", "7")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_NAME", "Co")
+    monkeypatch.setenv("PUBLIC_WWW_BUSINESS_ADDRESS", "a")
+    monkeypatch.setenv("PUBLIC_WWW_BANK_NAME", "B")
+    inv = SimpleNamespace(
+        invoice_number="N1",
+        currency="HKD",
+        subtotal=Decimal("1234567.89"),
+        tax_total=Decimal("0"),
+        total=Decimal("1234567.89"),
+        bill_to_display_name="X",
+        bill_to_email=None,
+        issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+        invoice_date=date(2026, 1, 1),
+        due_date=date(2026, 1, 8),
+        status=BillingInvoiceStatus.ISSUED,
+    )
+    pdf = render_invoice_pdf(
+        invoice=inv,
+        lines=[
+            _inv_line(
+                unit_amount=Decimal("1234567.89"),
+                line_total=Decimal("1234567.89"),
+            )
+        ],
+        preview=False,
+    )
+    text = _pdf_text(pdf)
+    assert "HK$" in text
+    assert "1,234" in text
+    assert "567.89" in text
+
+
 def test_invoice_pdf_versions_distinct() -> None:
-    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v4"
+    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v5"
     assert customer_billing.RECEIPT_PDF_TEMPLATE_VERSION == "billing-receipt-v1"
     assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION != (
         customer_billing.RECEIPT_PDF_TEMPLATE_VERSION


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements the v5 customer AR invoice PDF layout remediation: updated colour tokens, hero row (35 mm logo, left padding, top/bottom padding), full-width 1.0 pt divider and 30 pt spacer, fixed-height header band for From/Bill To/Dates, items table body padding and conditional last-row rule, wider totals card (103+87 mm, inner 55+32 mm), terms/bank spacing, footer at 14 mm, and `billing-invoice-v5` template version.

## CI fix
`pymupdf` was listed only in `requirements.txt`; **Test Python** installs `pip install -e "backend[test]"` from `backend/pyproject.toml`, which omitted PyMuPDF and broke tests that import `fitz`. Added `pymupdf==1.27.2` to project dependencies.

## Tests
- `cd backend && PYTHONPATH=src python3 -m pytest tests/test_customer_invoice_pdf.py -q`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74e059f6-5b27-4a31-bb5a-050f972756aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74e059f6-5b27-4a31-bb5a-050f972756aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

