### PR TITLE
Admin web: customer invoice table without Invoice column

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -60,6 +60,15 @@ function formatTruncatedId(id: string | undefined): string {
   return `${id.slice(0, 8)}…`;
 }
 
+/** List table: capitalize first letter of API status (for example `draft` → `Draft`). */
+function formatCustomerInvoiceStatusLabel(status: string | undefined): string {
+  const t = status?.trim() ?? '';
+  if (t === '') {
+    return '—';
+  }
+  return t.charAt(0).toUpperCase() + t.slice(1);
+}
+
 function currencySelectValue(
   code: string,
   options: readonly { value: string }[],
@@ -1050,10 +1059,9 @@ export function ClientInvoicesPanel() {
         }
       >
         <section aria-label='Customer invoices list'>
-        <AdminDataTable tableClassName='min-w-[980px]'>
+        <AdminDataTable tableClassName='min-w-[900px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-3 py-2'>Invoice</th>
               <th className='px-3 py-2'>Status</th>
               <th className='px-3 py-2'>Number</th>
               <th className='px-3 py-2'>Bill to</th>
@@ -1078,24 +1086,18 @@ export function ClientInvoicesPanel() {
               return (
                 <tr
                   key={id || `invoice-row-${String(index)}`}
-                  className={selected ? 'bg-sky-50' : undefined}
+                  className={selected ? 'cursor-pointer bg-sky-50' : id ? 'cursor-pointer' : undefined}
+                  onClick={() => {
+                    setSelectedInvoiceId(id || null);
+                    if (id) {
+                      setInvoiceIdInput(id);
+                      setAllocateInvoiceId(id);
+                    }
+                  }}
                 >
                   <td className='px-3 py-2'>
-                    <button
-                      type='button'
-                      className='font-mono text-left text-xs text-sky-800 underline decoration-sky-300 hover:decoration-sky-600'
-                      onClick={() => {
-                        setSelectedInvoiceId(id || null);
-                        if (id) {
-                          setInvoiceIdInput(id);
-                          setAllocateInvoiceId(id);
-                        }
-                      }}
-                    >
-                      {formatTruncatedId(id)}
-                    </button>
+                    {formatCustomerInvoiceStatusLabel(inv.status)}
                   </td>
-                  <td className='px-3 py-2'>{inv.status}</td>
                   <td className='px-3 py-2 text-xs'>{inv.invoiceNumber ?? '—'}</td>
                   <td className='px-3 py-2 text-xs text-slate-700'>
                     {inv.billToDisplayName ?? inv.billToEmail ?? '—'}
@@ -1103,7 +1105,12 @@ export function ClientInvoicesPanel() {
                   <td className='px-3 py-2'>{totalDisplay}</td>
                   <td className='px-3 py-2'>{inv.lineCount ?? 0}</td>
                   <td className='px-3 py-2'>{formatDate(inv.createdAt ?? null)}</td>
-                  <td className='px-3 py-2 text-right'>
+                  <td
+                    className='px-3 py-2 text-right'
+                    onClick={(event) => {
+                      event.stopPropagation();
+                    }}
+                  >
                     <div className='flex flex-wrap justify-end gap-1'>
                       <Button
                         type='button'

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -25,6 +25,11 @@ vi.mock('@/lib/billing-api', () => ({
 
 import { ClientInvoicesPanel } from '@/components/admin/finance/client-invoices-panel';
 
+function firstCustomerInvoiceDataRow(invoiceTable: HTMLElement): HTMLElement {
+  const rows = within(invoiceTable).getAllByRole('row');
+  return rows[1] as HTMLElement;
+}
+
 describe('ClientInvoicesPanel', () => {
   beforeEach(() => {
     window.history.replaceState(null, '', '/finance?tab=client-invoices');
@@ -88,7 +93,9 @@ describe('ClientInvoicesPanel', () => {
 
     const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
     const invoiceTable = within(invoiceRegion).getByRole('table');
-    await userEvent.click(within(invoiceTable).getByRole('button', { name: /aaaaaaaa/i }));
+    expect(within(invoiceTable).queryByRole('columnheader', { name: 'Invoice' })).not.toBeInTheDocument();
+    expect(within(invoiceTable).getByText('Draft')).toBeInTheDocument();
+    await userEvent.click(firstCustomerInvoiceDataRow(invoiceTable));
 
     await waitFor(() => {
       expect(billingMocks.getCustomerInvoice).toHaveBeenCalledWith(invId, expect.any(AbortSignal));
@@ -333,7 +340,7 @@ describe('ClientInvoicesPanel', () => {
     await waitFor(() => {
       expect(within(invoiceTable).getAllByRole('button').length).toBeGreaterThan(0);
     });
-    await userEvent.click(within(invoiceTable).getByRole('button', { name: /aaaaaaaa/i }));
+    await userEvent.click(firstCustomerInvoiceDataRow(invoiceTable));
 
     await waitFor(() => {
       expect(screen.getByTitle(lineId)).toBeInTheDocument();
@@ -539,7 +546,7 @@ describe('ClientInvoicesPanel', () => {
     await waitFor(() => {
       expect(within(invoiceTable).getAllByRole('button').length).toBeGreaterThan(0);
     });
-    await userEvent.click(within(invoiceTable).getByRole('button', { name: /aaaaaaaa/i }));
+    await userEvent.click(firstCustomerInvoiceDataRow(invoiceTable));
     await waitFor(() => {
       expect((document.getElementById('billing-allocate-invoice') as HTMLInputElement).value).toBe(invId);
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change updates the Finance **Customer invoices** table in `ClientInvoicesPanel`.

- Removes the **Invoice** column (truncated UUID link).
- Row selection still loads detail and syncs UUID fields: click anywhere on the row; **Operations** uses `stopPropagation` so preview/issue/email/void do not change selection.
- **Status** is shown with the first letter capitalized (for example `draft` → `Draft`) using the same plain cell styling as **Lines**.
- Slightly reduces table `min-w` after dropping a column.

## Tests

- Updated `client-invoices-panel.test.tsx` to assert no **Invoice** column header, status display, and row selection via first data row.
- Vitest was not executed in this environment (Node/npm unavailable on the runner). Please run `npm test` in `apps/admin_web` locally or in CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edae8731-2383-4575-8aa8-9effeecea9b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edae8731-2383-4575-8aa8-9effeecea9b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

