### PR TITLE
feat(admin_web): partner bill-to and collapsible invoice line editor

### DIFF
--- a/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
+++ b/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
@@ -3,11 +3,12 @@
 import type { FormEvent } from 'react';
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 
+import { DeleteIcon } from '@/components/icons/action-icons';
+import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
 import { useEnrollmentParentPickers } from '@/hooks/use-enrollment-parent-pickers';
 import { createDraftInvoice } from '@/lib/billing-api';
 
@@ -15,7 +16,7 @@ export const CUSTOMIZED_DRAFT_INVOICE_FORM_ID = 'client-billing-customized-draft
 const CUSTOMIZED_FORM_ID = CUSTOMIZED_DRAFT_INVOICE_FORM_ID;
 const MAX_CUSTOMIZED_LINES = 50;
 
-type CustomizedBillKind = 'contact' | 'family' | 'organization';
+type CustomizedBillKind = 'contact' | 'family' | 'organization' | 'partner';
 
 type CustomizedLineDraftRow = {
   id: string;
@@ -57,6 +58,9 @@ function parseAmountInput(raw: string): number | null {
   return Number.isNaN(n) ? null : n;
 }
 
+const lineGridClassName =
+  'grid grid-cols-1 gap-x-3 gap-y-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,5.5rem)_minmax(0,6.5rem)_minmax(0,6rem)_minmax(0,5.5rem)_minmax(0,6.5rem)_auto] sm:items-end';
+
 export interface CustomizedDraftInvoiceCardProps {
   defaultCurrency: string;
   currencyOptions: readonly { value: string; label: string }[];
@@ -87,6 +91,7 @@ export function CustomizedDraftInvoiceCard({
     contactOptions,
     families,
     organizations,
+    partnerOrganizations,
     loading: customizedPickerLoading,
     error: customizedPickerError,
   } = useEnrollmentParentPickers(loadParents);
@@ -113,8 +118,11 @@ export function CustomizedDraftInvoiceCard({
     if (customizedBillKind === 'family') {
       return families;
     }
+    if (customizedBillKind === 'partner') {
+      return partnerOrganizations;
+    }
     return organizations;
-  }, [contactOptions, customizedBillKind, families, organizations]);
+  }, [contactOptions, customizedBillKind, families, organizations, partnerOrganizations]);
 
   const customizedIssue = useMemo(() => {
     if (!loadParents || customizedPickerLoading) {
@@ -264,6 +272,15 @@ export function CustomizedDraftInvoiceCard({
     }
   };
 
+  const entityFieldLabel =
+    customizedBillKind === 'contact'
+      ? 'Contact'
+      : customizedBillKind === 'family'
+        ? 'Family'
+        : customizedBillKind === 'partner'
+          ? 'Partner organization'
+          : 'Organization';
+
   return (
     <div className='space-y-4'>
       <form id={CUSTOMIZED_FORM_ID} className='space-y-4' onSubmit={(e) => void handleCreateCustomizedDraft(e)}>
@@ -285,16 +302,11 @@ export function CustomizedDraftInvoiceCard({
               <option value='contact'>Contact</option>
               <option value='family'>Family</option>
               <option value='organization'>Organization</option>
+              <option value='partner'>Partner</option>
             </Select>
           </div>
           <div className='min-w-[260px] flex-1'>
-            <Label htmlFor={customizedBillEntitySelectId}>
-              {customizedBillKind === 'contact'
-                ? 'Contact'
-                : customizedBillKind === 'family'
-                  ? 'Family'
-                  : 'Organization'}
-            </Label>
+            <Label htmlFor={customizedBillEntitySelectId}>{entityFieldLabel}</Label>
             <Select
               id={customizedBillEntitySelectId}
               className='mt-1 w-full'
@@ -329,146 +341,202 @@ export function CustomizedDraftInvoiceCard({
             </Select>
           </div>
         </div>
-        <div>
-          <Button
-            type='button'
-            variant='secondary'
-            disabled={editorBusy || customizedLines.length >= MAX_CUSTOMIZED_LINES}
-            onClick={() => {
-              customizedLineIdSeq.current += 1;
-              setCustomizedLines((prev) => [...prev, makeCustomizedLineRow(customizedLineIdSeq.current)]);
-            }}
-          >
-            Add line
-          </Button>
-        </div>
-        <section aria-label='Custom invoice lines' className='space-y-3'>
-          {customizedLines.map((ln, index) => (
-            <div
-              key={ln.id}
-              className='flex flex-col gap-2 border border-slate-200 px-3 py-3 sm:flex-row sm:flex-wrap sm:items-end'
-            >
-              <div className='min-w-[200px] flex-1'>
-                <Label htmlFor={`${CUSTOMIZED_FORM_ID}-desc-${ln.id}`}>Description</Label>
-                <Textarea
-                  id={`${CUSTOMIZED_FORM_ID}-desc-${ln.id}`}
-                  className='mt-1 min-h-[4rem]'
-                  value={ln.description}
-                  onChange={(e) =>
-                    setCustomizedLines((prev) =>
-                      prev.map((row) =>
-                        row.id === ln.id ? { ...row, description: e.target.value } : row,
-                      ),
-                    )
-                  }
-                  disabled={editorBusy}
-                  rows={2}
-                />
-              </div>
-              <div className='w-full sm:w-28'>
-                <Label htmlFor={`${CUSTOMIZED_FORM_ID}-qty-${ln.id}`}>Quantity</Label>
-                <Input
-                  id={`${CUSTOMIZED_FORM_ID}-qty-${ln.id}`}
-                  className='mt-1 font-mono tabular-nums'
-                  inputMode='decimal'
-                  value={ln.quantity}
-                  onChange={(e) =>
-                    setCustomizedLines((prev) =>
-                      prev.map((row) =>
-                        row.id === ln.id ? { ...row, quantity: e.target.value } : row,
-                      ),
-                    )
-                  }
-                  disabled={editorBusy}
-                />
-              </div>
-              <div className='w-full sm:w-36'>
-                <Label htmlFor={`${CUSTOMIZED_FORM_ID}-unit-${ln.id}`}>Unit price</Label>
-                <Input
-                  id={`${CUSTOMIZED_FORM_ID}-unit-${ln.id}`}
-                  className='mt-1 font-mono tabular-nums'
-                  inputMode='decimal'
-                  value={ln.unitAmount}
-                  onChange={(e) =>
-                    setCustomizedLines((prev) =>
-                      prev.map((row) =>
-                        row.id === ln.id ? { ...row, unitAmount: e.target.value } : row,
-                      ),
-                    )
-                  }
-                  disabled={editorBusy}
-                />
-              </div>
-              <div className='w-full sm:w-32'>
-                <Label htmlFor={`${CUSTOMIZED_FORM_ID}-disc-${ln.id}`}>Discount</Label>
-                <Input
-                  id={`${CUSTOMIZED_FORM_ID}-disc-${ln.id}`}
-                  className='mt-1 font-mono tabular-nums'
-                  inputMode='decimal'
-                  value={ln.discountAmount}
-                  onChange={(e) =>
-                    setCustomizedLines((prev) =>
-                      prev.map((row) =>
-                        row.id === ln.id ? { ...row, discountAmount: e.target.value } : row,
-                      ),
-                    )
-                  }
-                  disabled={editorBusy}
-                  placeholder='0'
-                />
-              </div>
-              <div className='w-full sm:w-28'>
-                <Label htmlFor={`${CUSTOMIZED_FORM_ID}-tr-${ln.id}`}>Tax rate</Label>
-                <Input
-                  id={`${CUSTOMIZED_FORM_ID}-tr-${ln.id}`}
-                  className='mt-1 font-mono tabular-nums'
-                  inputMode='decimal'
-                  value={ln.taxRate}
-                  onChange={(e) =>
-                    setCustomizedLines((prev) =>
-                      prev.map((row) =>
-                        row.id === ln.id ? { ...row, taxRate: e.target.value } : row,
-                      ),
-                    )
-                  }
-                  disabled={editorBusy}
-                  placeholder='—'
-                />
-              </div>
-              <div className='w-full sm:w-32'>
-                <Label htmlFor={`${CUSTOMIZED_FORM_ID}-ta-${ln.id}`}>Tax amount</Label>
-                <Input
-                  id={`${CUSTOMIZED_FORM_ID}-ta-${ln.id}`}
-                  className='mt-1 font-mono tabular-nums'
-                  inputMode='decimal'
-                  value={ln.taxAmount}
-                  onChange={(e) =>
-                    setCustomizedLines((prev) =>
-                      prev.map((row) =>
-                        row.id === ln.id ? { ...row, taxAmount: e.target.value } : row,
-                      ),
-                    )
-                  }
-                  disabled={editorBusy}
-                  placeholder='—'
-                />
-              </div>
-              <div className='flex items-end pb-1'>
-                <Button
-                  type='button'
-                  variant='secondary'
-                  disabled={editorBusy || customizedLines.length <= 1}
-                  onClick={() =>
-                    setCustomizedLines((prev) => prev.filter((row) => row.id !== ln.id))
-                  }
-                >
-                  Remove
-                </Button>
-              </div>
-              <p className='w-full text-xs text-slate-600'>Line {index + 1}</p>
+        <AdminCollapsibleSection
+          id='customized-draft-invoice-lines'
+          title='Line items'
+          disabled={editorBusy}
+        >
+          <div className='grid grid-rows-[auto_1fr_auto] gap-3'>
+            <div className='min-h-0' />
+            <div className='flex min-h-0 flex-col gap-3 overflow-y-auto'>
+              {customizedLines.map((ln, index) => (
+                <div key={ln.id} className={lineGridClassName}>
+                  <div className='space-y-1'>
+                    {index === 0 ? (
+                      <Label
+                        className='text-xs font-medium text-slate-600'
+                        htmlFor={`${CUSTOMIZED_FORM_ID}-desc-${ln.id}`}
+                      >
+                        Description
+                      </Label>
+                    ) : null}
+                    <Input
+                      id={`${CUSTOMIZED_FORM_ID}-desc-${ln.id}`}
+                      disabled={editorBusy}
+                      aria-label='Description'
+                      value={ln.description}
+                      onChange={(e) =>
+                        setCustomizedLines((prev) =>
+                          prev.map((row) =>
+                            row.id === ln.id ? { ...row, description: e.target.value } : row,
+                          ),
+                        )
+                      }
+                    />
+                  </div>
+                  <div className='space-y-1'>
+                    {index === 0 ? (
+                      <Label
+                        className='text-xs font-medium text-slate-600'
+                        htmlFor={`${CUSTOMIZED_FORM_ID}-qty-${ln.id}`}
+                      >
+                        Quantity
+                      </Label>
+                    ) : null}
+                    <Input
+                      id={`${CUSTOMIZED_FORM_ID}-qty-${ln.id}`}
+                      className='font-mono tabular-nums'
+                      inputMode='decimal'
+                      disabled={editorBusy}
+                      aria-label='Quantity'
+                      value={ln.quantity}
+                      onChange={(e) =>
+                        setCustomizedLines((prev) =>
+                          prev.map((row) =>
+                            row.id === ln.id ? { ...row, quantity: e.target.value } : row,
+                          ),
+                        )
+                      }
+                    />
+                  </div>
+                  <div className='space-y-1'>
+                    {index === 0 ? (
+                      <Label
+                        className='text-xs font-medium text-slate-600'
+                        htmlFor={`${CUSTOMIZED_FORM_ID}-unit-${ln.id}`}
+                      >
+                        Unit price
+                      </Label>
+                    ) : null}
+                    <Input
+                      id={`${CUSTOMIZED_FORM_ID}-unit-${ln.id}`}
+                      className='font-mono tabular-nums'
+                      inputMode='decimal'
+                      disabled={editorBusy}
+                      aria-label='Unit price'
+                      value={ln.unitAmount}
+                      onChange={(e) =>
+                        setCustomizedLines((prev) =>
+                          prev.map((row) =>
+                            row.id === ln.id ? { ...row, unitAmount: e.target.value } : row,
+                          ),
+                        )
+                      }
+                    />
+                  </div>
+                  <div className='space-y-1'>
+                    {index === 0 ? (
+                      <Label
+                        className='text-xs font-medium text-slate-600'
+                        htmlFor={`${CUSTOMIZED_FORM_ID}-disc-${ln.id}`}
+                      >
+                        Discount
+                      </Label>
+                    ) : null}
+                    <Input
+                      id={`${CUSTOMIZED_FORM_ID}-disc-${ln.id}`}
+                      className='font-mono tabular-nums'
+                      inputMode='decimal'
+                      disabled={editorBusy}
+                      aria-label='Discount'
+                      value={ln.discountAmount}
+                      onChange={(e) =>
+                        setCustomizedLines((prev) =>
+                          prev.map((row) =>
+                            row.id === ln.id ? { ...row, discountAmount: e.target.value } : row,
+                          ),
+                        )
+                      }
+                      placeholder='0'
+                    />
+                  </div>
+                  <div className='space-y-1'>
+                    {index === 0 ? (
+                      <Label
+                        className='text-xs font-medium text-slate-600'
+                        htmlFor={`${CUSTOMIZED_FORM_ID}-tr-${ln.id}`}
+                      >
+                        Tax rate
+                      </Label>
+                    ) : null}
+                    <Input
+                      id={`${CUSTOMIZED_FORM_ID}-tr-${ln.id}`}
+                      className='font-mono tabular-nums'
+                      inputMode='decimal'
+                      disabled={editorBusy}
+                      aria-label='Tax rate'
+                      value={ln.taxRate}
+                      onChange={(e) =>
+                        setCustomizedLines((prev) =>
+                          prev.map((row) =>
+                            row.id === ln.id ? { ...row, taxRate: e.target.value } : row,
+                          ),
+                        )
+                      }
+                      placeholder='—'
+                    />
+                  </div>
+                  <div className='space-y-1'>
+                    {index === 0 ? (
+                      <Label
+                        className='text-xs font-medium text-slate-600'
+                        htmlFor={`${CUSTOMIZED_FORM_ID}-ta-${ln.id}`}
+                      >
+                        Tax amount
+                      </Label>
+                    ) : null}
+                    <Input
+                      id={`${CUSTOMIZED_FORM_ID}-ta-${ln.id}`}
+                      className='font-mono tabular-nums'
+                      inputMode='decimal'
+                      disabled={editorBusy}
+                      aria-label='Tax amount'
+                      value={ln.taxAmount}
+                      onChange={(e) =>
+                        setCustomizedLines((prev) =>
+                          prev.map((row) =>
+                            row.id === ln.id ? { ...row, taxAmount: e.target.value } : row,
+                          ),
+                        )
+                      }
+                      placeholder='—'
+                    />
+                  </div>
+                  <div className='flex justify-end pb-0.5 sm:justify-start'>
+                    <Button
+                      type='button'
+                      variant='danger'
+                      size='sm'
+                      disabled={editorBusy || customizedLines.length <= 1}
+                      className='min-w-8 px-2'
+                      aria-label='Delete line'
+                      title='Delete line'
+                      onClick={() =>
+                        setCustomizedLines((prev) => prev.filter((row) => row.id !== ln.id))
+                      }
+                    >
+                      <DeleteIcon className='h-4 w-4' />
+                    </Button>
+                  </div>
+                </div>
+              ))}
             </div>
-          ))}
-        </section>
+            <div className='flex justify-start justify-self-start'>
+              <Button
+                type='button'
+                variant='secondary'
+                size='sm'
+                disabled={editorBusy || customizedLines.length >= MAX_CUSTOMIZED_LINES}
+                onClick={() => {
+                  customizedLineIdSeq.current += 1;
+                  setCustomizedLines((prev) => [...prev, makeCustomizedLineRow(customizedLineIdSeq.current)]);
+                }}
+              >
+                Add line
+              </Button>
+            </div>
+          </div>
+        </AdminCollapsibleSection>
         {customizedIssue && loadParents && !customizedPickerLoading ? (
           <p className='text-sm text-amber-800'>{customizedIssue}</p>
         ) : null}

--- a/apps/admin_web/src/hooks/use-enrollment-parent-pickers.ts
+++ b/apps/admin_web/src/hooks/use-enrollment-parent-pickers.ts
@@ -7,6 +7,7 @@ import {
   listAdminContacts,
   listEntityFamilyPicker,
   listEntityOrganizationPicker,
+  listEntityPartnerOrganizationPicker,
 } from '@/lib/entity-api';
 import { DEFAULT_CONTACT_LIST_FILTERS } from '@/types/entity-list';
 
@@ -33,6 +34,7 @@ export function useEnrollmentParentPickers(canCreate: boolean) {
   const [contacts, setContacts] = useState<AdminContact[]>([]);
   const [families, setFamilies] = useState<EnrollmentParentPickerOption[]>([]);
   const [organizations, setOrganizations] = useState<EnrollmentParentPickerOption[]>([]);
+  const [partnerOrganizations, setPartnerOrganizations] = useState<EnrollmentParentPickerOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -41,6 +43,7 @@ export function useEnrollmentParentPickers(canCreate: boolean) {
       setContacts([]);
       setFamilies([]);
       setOrganizations([]);
+      setPartnerOrganizations([]);
       setLoading(false);
       setError('');
       return;
@@ -55,9 +58,10 @@ export function useEnrollmentParentPickers(canCreate: boolean) {
       try {
         const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
 
-        const [familyItems, orgItems] = await Promise.all([
+        const [familyItems, orgItems, partnerOrgItems] = await Promise.all([
           listEntityFamilyPicker(signal),
           listEntityOrganizationPicker(undefined, signal),
+          listEntityPartnerOrganizationPicker(signal),
         ]);
 
         const sortedFamilies = [...familyItems].sort((a, b) =>
@@ -66,9 +70,13 @@ export function useEnrollmentParentPickers(canCreate: boolean) {
         const sortedOrgs = [...orgItems].sort((a, b) =>
           collator.compare(a.label.toLowerCase(), b.label.toLowerCase())
         );
+        const sortedPartnerOrgs = [...partnerOrgItems].sort((a, b) =>
+          collator.compare(a.label.toLowerCase(), b.label.toLowerCase())
+        );
 
         setFamilies(sortedFamilies.map((row) => ({ id: row.id, label: row.label })));
         setOrganizations(sortedOrgs.map((row) => ({ id: row.id, label: row.label })));
+        setPartnerOrganizations(sortedPartnerOrgs.map((row) => ({ id: row.id, label: row.label })));
 
         const contactRows: AdminContact[] = [];
         let cursor: string | null = null;
@@ -96,6 +104,7 @@ export function useEnrollmentParentPickers(canCreate: boolean) {
         setContacts([]);
         setFamilies([]);
         setOrganizations([]);
+        setPartnerOrganizations([]);
       } finally {
         if (!signal.aborted) {
           setLoading(false);
@@ -137,14 +146,24 @@ export function useEnrollmentParentPickers(canCreate: boolean) {
     return map;
   }, [organizations]);
 
+  const labelByPartnerOrganizationId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const row of partnerOrganizations) {
+      map.set(row.id, row.label);
+    }
+    return map;
+  }, [partnerOrganizations]);
+
   return {
     contactOptions,
     families,
     organizations,
+    partnerOrganizations,
     loading,
     error,
     labelByContactId,
     labelByFamilyId,
     labelByOrganizationId,
+    labelByPartnerOrganizationId,
   };
 }

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -24,11 +24,13 @@ const enrollmentPickerMocks = vi.hoisted(() => ({
     contactOptions: [{ id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', label: 'Pat Contact' }],
     families: [{ id: 'dddddddd-dddd-dddd-dddd-dddddddddddd', label: 'Fam One' }],
     organizations: [{ id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', label: 'Org One' }],
+    partnerOrganizations: [],
     loading: false,
     error: '',
     labelByContactId: new Map(),
     labelByFamilyId: new Map(),
     labelByOrganizationId: new Map(),
+    labelByPartnerOrganizationId: new Map(),
   })),
 }));
 

--- a/apps/admin_web/tests/components/admin/finance/customized-draft-invoice-card.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/customized-draft-invoice-card.test.tsx
@@ -15,11 +15,13 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
     contactOptions: [{ id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', label: 'Pat Contact' }],
     families: [],
     organizations: [],
+    partnerOrganizations: [{ id: 'ffffffff-ffff-ffff-ffff-ffffffffffff', label: 'Partner Org' }],
     loading: false,
     error: '',
     labelByContactId: new Map(),
     labelByFamilyId: new Map(),
     labelByOrganizationId: new Map(),
+    labelByPartnerOrganizationId: new Map(),
   }),
 }));
 
@@ -66,5 +68,46 @@ describe('CustomizedDraftInvoiceCard', () => {
       lines: [{ description: 'Line A', quantity: '1', unitAmount: '25' }],
     });
     expect(onCreated).toHaveBeenCalledWith('inv-x');
+  });
+
+  it('submits partner bill-to as organization with selected partner org id', async () => {
+    billingMocks.createDraftInvoice.mockResolvedValue({ invoiceId: 'inv-p', status: 'draft' });
+
+    render(
+      <CustomizedDraftInvoiceCard
+        defaultCurrency='HKD'
+        currencyOptions={[{ value: 'HKD', label: 'HKD' }]}
+        editorBusy={false}
+        loadParents
+        onCreated={vi.fn()}
+      />,
+    );
+
+    const form = document.getElementById('client-billing-customized-draft-form');
+    expect(form).toBeTruthy();
+
+    await userEvent.selectOptions(screen.getByLabelText(/^Bill to$/i), 'partner');
+    await userEvent.selectOptions(
+      screen.getByLabelText(/^Partner organization$/i),
+      'ffffffff-ffff-ffff-ffff-ffffffffffff',
+    );
+
+    const desc = within(form as HTMLElement).getByLabelText(/^Description/i);
+    await userEvent.type(desc, 'Partner fee');
+
+    const unit = within(form as HTMLElement).getByLabelText(/^Unit price/i);
+    await userEvent.clear(unit);
+    await userEvent.type(unit, '99');
+
+    fireEvent.submit(form as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(billingMocks.createDraftInvoice).toHaveBeenCalled();
+    });
+    expect(billingMocks.createDraftInvoice.mock.calls[0][0]).toMatchObject({
+      draftKind: 'customized_manual',
+      billTo: { kind: 'organization', organizationId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
+      lines: [{ description: 'Partner fee', quantity: '1', unitAmount: '99' }],
+    });
   });
 });

--- a/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
@@ -82,11 +82,13 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
     contactOptions: [],
     families: [],
     organizations: [],
+    partnerOrganizations: [],
     loading: false,
     error: '',
     labelByContactId: new Map(),
     labelByFamilyId: new Map(),
     labelByOrganizationId: new Map(),
+    labelByPartnerOrganizationId: new Map(),
   }),
 }));
 

--- a/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
@@ -14,11 +14,13 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
     contactOptions: [{ id: 'contact-1', label: 'Jane Doe' }],
     families: [{ id: 'family-1', label: 'Smith family' }],
     organizations: [{ id: 'org-1', label: 'Acme Org' }],
+    partnerOrganizations: [],
     loading: false,
     error: '',
     labelByContactId: new Map([['contact-1', 'Jane Doe']]),
     labelByFamilyId: new Map([['family-1', 'Smith family']]),
     labelByOrganizationId: new Map([['org-1', 'Acme Org']]),
+    labelByPartnerOrganizationId: new Map(),
   }),
 }));
 

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -19,11 +19,13 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
     contactOptions: [{ id: 'contact-1', label: 'Resolved contact label' }],
     families: [],
     organizations: [],
+    partnerOrganizations: [],
     loading: false,
     error: '',
     labelByContactId: new Map([['contact-1', 'Resolved contact label']]),
     labelByFamilyId: new Map(),
     labelByOrganizationId: new Map(),
+    labelByPartnerOrganizationId: new Map(),
   }),
 }));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Bill to → Partner**: Customized draft invoice creation now includes a Partner option. The second control becomes "Partner organization" and lists rows from the admin organizations picker filtered to `relationship_type=partner`. The API payload still uses `billTo: { kind: 'organization', organizationId }` (same as billing today; partner orgs are organizations).
- **Line items UI**: Manual lines are wrapped in a single `AdminCollapsibleSection` titled "Line items", mirroring the service instance session slot editor: column labels only on the first row (`text-xs font-medium text-slate-600`), all values as `Input` (including description), danger `DeleteIcon` button with bottom-left **Add line** (`variant='secondary' size='sm'`).

## Hook change

- `useEnrollmentParentPickers` loads partner organizations in parallel (`listEntityPartnerOrganizationPicker`) and exposes `partnerOrganizations` plus `labelByPartnerOrganizationId` for future use.

## Tests

- Extended `customized-draft-invoice-card.test.tsx` with a partner submission case.
- Updated mocks that stub `useEnrollmentParentPickers` to include the new fields.

## Validation

- `bash scripts/validate-cursorrules.sh` passed locally.
- Vitest was not run in this environment (Node/npx unavailable in the agent shell).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b859337-f9bc-4991-ba8b-a5e1985aafb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b859337-f9bc-4991-ba8b-a5e1985aafb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

