### PR TITLE
Admin Finance: invoice email in Customer invoices toolbar + multi-recipient API

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -15,7 +15,7 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { CheckIcon, EmailIcon, ViewIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
+import { CheckIcon, ViewIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
 import {
   CUSTOMIZED_DRAFT_INVOICE_FORM_ID,
   CustomizedDraftInvoiceCard,
@@ -27,7 +27,6 @@ import {
   createPaymentAllocation,
   emailInvoice,
   exportBillingCsv,
-  getCustomerInvoice,
   getCustomerInvoicePdfDownload,
   getCustomerPayment,
   issueInvoice,
@@ -36,7 +35,6 @@ import {
   listRecentEnrollmentsForInvoicing,
   voidInvoice,
   type BillingEnrollmentPickerRow,
-  type CustomerInvoiceDetail,
   type CustomerInvoiceSummary,
   type CustomerPaymentDetail,
   type CustomerPaymentSummary,
@@ -128,6 +126,15 @@ function lineAmountsDiffer(input: string, row: BillingEnrollmentPickerRow): bool
   return trimmed !== '' && trimmed !== baseline;
 }
 
+/** Normalize admin-entered CSV/semicolon-separated emails for the billing API (comma-separated). */
+function normalizeInvoiceRecipientList(raw: string): string {
+  return raw
+    .split(/[,;]+/)
+    .map((part) => part.trim())
+    .filter((part) => part !== '')
+    .join(', ');
+}
+
 export function ClientInvoicesPanel() {
   const draftFilterId = useId();
   const draftModeId = useId();
@@ -148,9 +155,8 @@ export function ClientInvoicesPanel() {
   const [invoiceStatusFilter, setInvoiceStatusFilter] = useState<'draft' | 'issued' | 'void' | ''>('');
   const [invoiceCurrencyFilter, setInvoiceCurrencyFilter] = useState('');
   const [selectedInvoiceId, setSelectedInvoiceId] = useState<string | null>(null);
-  const [invoiceDetail, setInvoiceDetail] = useState<CustomerInvoiceDetail | null>(null);
-  const [invoiceDetailLoading, setInvoiceDetailLoading] = useState(false);
-  const [invoiceDetailError, setInvoiceDetailError] = useState('');
+  const [issuedInvoiceEmailCsv, setIssuedInvoiceEmailCsv] = useState('');
+  const [issuedInvoiceEmailError, setIssuedInvoiceEmailError] = useState('');
   const [actionMessage, setActionMessage] = useState('');
   const [actionError, setActionError] = useState('');
   const [busyAction, setBusyAction] = useState<string | null>(null);
@@ -160,11 +166,6 @@ export function ClientInvoicesPanel() {
   const [voidInvoiceTargetId, setVoidInvoiceTargetId] = useState<string | null>(null);
   const [voidReason, setVoidReason] = useState('');
   const [voidError, setVoidError] = useState('');
-
-  const [emailDialogOpen, setEmailDialogOpen] = useState(false);
-  const [emailInvoiceTargetId, setEmailInvoiceTargetId] = useState<string | null>(null);
-  const [emailDialogTo, setEmailDialogTo] = useState('');
-  const [emailDialogError, setEmailDialogError] = useState('');
 
   const [confirmPaymentDialogOpen, setConfirmPaymentDialogOpen] = useState(false);
   const [confirmPaymentId, setConfirmPaymentId] = useState<string | null>(null);
@@ -179,9 +180,6 @@ export function ClientInvoicesPanel() {
   const [selectedEnrollmentIds, setSelectedEnrollmentIds] = useState<Set<string>>(() => new Set());
   const [lineOverrideByEnrollmentId, setLineOverrideByEnrollmentId] = useState<Record<string, string>>({});
 
-  const [invoiceIdInput, setInvoiceIdInput] = useState('');
-  const [emailTo, setEmailTo] = useState('');
-
   const [allocateInvoiceId, setAllocateInvoiceId] = useState('');
   const [allocateLineId, setAllocateLineId] = useState('');
   const [allocateAmount, setAllocateAmount] = useState('');
@@ -194,6 +192,8 @@ export function ClientInvoicesPanel() {
   const [refundStripeId, setRefundStripeId] = useState('');
 
   const lastPaymentSeedIdRef = useRef<string | null>(null);
+  const prevIssuedInvoiceSelectionRef = useRef<string | null>(null);
+  const issuedInvoiceEmailDirtyRef = useRef(false);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<CustomerPaymentDetail | null>(null);
@@ -376,45 +376,38 @@ export function ClientInvoicesPanel() {
     }
   }, [invoiceListCursor, invoiceCurrencyFilter, invoiceStatusFilter]);
 
-  const loadInvoiceDetail = useCallback(async (id: string, signal?: AbortSignal) => {
-    setInvoiceDetailLoading(true);
-    setInvoiceDetailError('');
-    try {
-      const inv = await getCustomerInvoice(id, signal);
-      if (signal?.aborted) {
-        return;
-      }
-      setInvoiceDetail(inv);
-      setEmailTo((prev) => {
-        if (prev.trim() !== '') {
-          return prev;
-        }
-        return inv.billToEmail?.trim() ?? prev;
-      });
-    } catch (caught) {
-      if (caught instanceof Error && caught.name === 'AbortError') {
-        return;
-      }
-      const message = caught instanceof Error ? caught.message : 'Failed to load invoice.';
-      setInvoiceDetailError(message);
-      setInvoiceDetail(null);
-    } finally {
-      if (!signal?.aborted) {
-        setInvoiceDetailLoading(false);
-      }
+  const selectedIssuedInvoice = useMemo(() => {
+    if (!selectedInvoiceId) {
+      return null;
     }
-  }, []);
+    return invoices.find((inv) => inv.id === selectedInvoiceId) ?? null;
+  }, [invoices, selectedInvoiceId]);
 
   useEffect(() => {
-    if (!selectedInvoiceId) {
-      setInvoiceDetail(null);
-      setInvoiceDetailError('');
+    setIssuedInvoiceEmailError('');
+    const inv = selectedIssuedInvoice;
+
+    if (!inv || inv.status !== 'issued') {
+      prevIssuedInvoiceSelectionRef.current = null;
+      issuedInvoiceEmailDirtyRef.current = false;
+      setIssuedInvoiceEmailCsv('');
       return;
     }
-    const ac = new AbortController();
-    void loadInvoiceDetail(selectedInvoiceId, ac.signal);
-    return () => ac.abort();
-  }, [selectedInvoiceId, loadInvoiceDetail]);
+
+    const id = inv.id ?? '';
+    const bill = inv.billToEmail?.trim() ?? '';
+
+    if (prevIssuedInvoiceSelectionRef.current !== id) {
+      prevIssuedInvoiceSelectionRef.current = id;
+      issuedInvoiceEmailDirtyRef.current = false;
+      setIssuedInvoiceEmailCsv(bill);
+      return;
+    }
+
+    if (!issuedInvoiceEmailDirtyRef.current) {
+      setIssuedInvoiceEmailCsv(bill);
+    }
+  }, [selectedIssuedInvoice]);
 
   const loadDetail = useCallback(
     async (id: string, signal?: AbortSignal) => {
@@ -472,7 +465,6 @@ export function ClientInvoicesPanel() {
 
   const openVoidInvoiceDialog = (invoiceId: string) => {
     setVoidInvoiceTargetId(invoiceId);
-    setInvoiceIdInput(invoiceId);
     setVoidReason('');
     setVoidError('');
     setVoidDialogOpen(true);
@@ -502,10 +494,6 @@ export function ClientInvoicesPanel() {
       closeVoidInvoiceDialog();
       await loadPayments();
       await loadInvoicesFirstPage();
-      if (selectedInvoiceId === id) {
-        const ac = new AbortController();
-        await loadInvoiceDetail(id, ac.signal);
-      }
     } catch (caught) {
       setVoidError(caught instanceof Error ? caught.message : 'Void failed.');
     } finally {
@@ -513,43 +501,24 @@ export function ClientInvoicesPanel() {
     }
   };
 
-  const openEmailInvoiceDialog = (invoiceId: string, suggested?: string | null) => {
-    setEmailInvoiceTargetId(invoiceId);
-    setEmailDialogTo(suggested?.trim() ?? emailTo.trim() ?? '');
-    setEmailDialogError('');
-    setEmailDialogOpen(true);
-  };
-
-  const closeEmailInvoiceDialog = () => {
-    setEmailDialogOpen(false);
-    setEmailInvoiceTargetId(null);
-    setEmailDialogTo('');
-    setEmailDialogError('');
-  };
-
-  const submitEmailInvoice = async () => {
-    const id = emailInvoiceTargetId?.trim();
-    if (!id) {
+  const handleEmailIssuedInvoice = async () => {
+    const id = selectedInvoiceId?.trim();
+    if (!id || selectedIssuedInvoice?.status !== 'issued') {
       return;
     }
-    const to = emailDialogTo.trim();
-    if (!to) {
-      setEmailDialogError('Recipient email is required.');
+    const normalized = normalizeInvoiceRecipientList(issuedInvoiceEmailCsv);
+    if (normalized === '') {
+      setIssuedInvoiceEmailError('Enter at least one recipient email (comma-separated).');
       return;
     }
-    setEmailDialogError('');
+    setIssuedInvoiceEmailError('');
     setBusy('email');
     try {
-      const out = await emailInvoice(id, to);
+      const out = await emailInvoice(id, normalized);
       setActionMessage(out.sent ? 'Email send accepted.' : 'Email was not confirmed sent.');
-      closeEmailInvoiceDialog();
       await loadInvoicesFirstPage();
-      if (selectedInvoiceId === id) {
-        const ac = new AbortController();
-        await loadInvoiceDetail(id, ac.signal);
-      }
     } catch (caught) {
-      setEmailDialogError(caught instanceof Error ? caught.message : 'Email failed.');
+      setIssuedInvoiceEmailError(caught instanceof Error ? caught.message : 'Email failed.');
     } finally {
       setBusy(null);
     }
@@ -566,10 +535,6 @@ export function ClientInvoicesPanel() {
           (out.issuedPdfSha256 ? ` (SHA-256: ${out.issuedPdfSha256.slice(0, 16)}…)` : ''),
       );
       await loadInvoicesFirstPage();
-      if (selectedInvoiceId === invoiceId) {
-        const ac = new AbortController();
-        await loadInvoiceDetail(invoiceId, ac.signal);
-      }
     } catch (caught) {
       setActionError(caught instanceof Error ? caught.message : 'Issue failed.');
     } finally {
@@ -678,7 +643,6 @@ export function ClientInvoicesPanel() {
         body.lineTotalsByEnrollmentId = overrides;
       }
       const result = await createDraftInvoice(body);
-      setInvoiceIdInput(result.invoiceId);
       setSelectedInvoiceId(result.invoiceId);
       setAllocateInvoiceId(result.invoiceId);
       setActionMessage(`Draft invoice created: ${result.invoiceId}`);
@@ -724,10 +688,6 @@ export function ClientInvoicesPanel() {
       const ac = new AbortController();
       await loadDetail(selectedId, ac.signal);
       await loadInvoicesFirstPage();
-      if (selectedInvoiceId === invId) {
-        const ac2 = new AbortController();
-        await loadInvoiceDetail(invId, ac2.signal);
-      }
     } catch (caught) {
       setActionError(caught instanceof Error ? caught.message : 'Allocation failed.');
     } finally {
@@ -1085,7 +1045,6 @@ export function ClientInvoicesPanel() {
               onValidityChange={setCustomizedFormSubmitEnabled}
               onCreated={async (invoiceId) => {
                 setActionError('');
-                setInvoiceIdInput(invoiceId);
                 setSelectedInvoiceId(invoiceId);
                 setAllocateInvoiceId(invoiceId);
                 setActionMessage(`Draft invoice created: ${invoiceId}`);
@@ -1099,7 +1058,7 @@ export function ClientInvoicesPanel() {
 
       <PaginatedTableCard
         title='Customer invoices'
-        description='Cursor-paginated invoices (newest first). Use Operations to issue, email, or void. Select a row to load lines and copy ids for allocation.'
+        description='Cursor-paginated invoices (newest first). Use Operations to issue or void. Select a row to set allocation defaults; when the selection is issued, use Email recipients and Send email below.'
         isLoading={invoiceListLoading}
         isLoadingMore={invoiceListLoadingMore}
         hasMore={Boolean(invoiceListCursor)}
@@ -1141,6 +1100,38 @@ export function ClientInvoicesPanel() {
                 ))}
               </Select>
             </div>
+            {selectedIssuedInvoice?.status === 'issued' ? (
+              <div className='ml-auto flex min-w-[min(100%,20rem)] max-w-xl flex-1 flex-col gap-1 sm:min-w-[18rem]'>
+                <Label htmlFor='billing-issued-invoice-emails'>Email recipients (comma-separated)</Label>
+                <div className='flex flex-wrap items-end gap-2'>
+                  <Input
+                    id='billing-issued-invoice-emails'
+                    className='min-w-0 flex-1 font-mono text-sm'
+                    autoComplete='off'
+                    value={issuedInvoiceEmailCsv}
+                    onChange={(e) => {
+                      issuedInvoiceEmailDirtyRef.current = true;
+                      setIssuedInvoiceEmailCsv(e.target.value);
+                      setIssuedInvoiceEmailError('');
+                    }}
+                    disabled={editorBusy}
+                    placeholder='billing@example.com, accounts@example.com'
+                  />
+                  <Button
+                    type='button'
+                    size='sm'
+                    variant='secondary'
+                    disabled={editorBusy || busyAction === 'email'}
+                    onClick={() => void handleEmailIssuedInvoice()}
+                  >
+                    {busyAction === 'email' ? 'Sending…' : 'Send email'}
+                  </Button>
+                </div>
+                {issuedInvoiceEmailError ? (
+                  <AdminInlineError>{issuedInvoiceEmailError}</AdminInlineError>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         }
       >
@@ -1176,7 +1167,6 @@ export function ClientInvoicesPanel() {
                   onClick={() => {
                     setSelectedInvoiceId(id || null);
                     if (id) {
-                      setInvoiceIdInput(id);
                       setAllocateInvoiceId(id);
                     }
                   }}
@@ -1238,19 +1228,6 @@ export function ClientInvoicesPanel() {
                           )}
                         </Button>
                       ) : null}
-                      {inv.status === 'issued' ? (
-                        <Button
-                          type='button'
-                          size='sm'
-                          variant='secondary'
-                          disabled={editorBusy || !id}
-                          onClick={() => openEmailInvoiceDialog(id, inv.billToEmail)}
-                          aria-label='Email invoice PDF'
-                          title='Email invoice PDF'
-                        >
-                          <EmailIcon className='h-4 w-4' aria-hidden />
-                        </Button>
-                      ) : null}
                       {inv.status !== 'void' ? (
                         <Button
                           type='button'
@@ -1274,104 +1251,9 @@ export function ClientInvoicesPanel() {
         </section>
       </PaginatedTableCard>
 
-      <Card
-        title='Selected invoice'
-        className='border-slate-200 bg-slate-50/80 p-3 shadow-none sm:p-4'
-      >
-        {!selectedInvoiceId ? (
-          <p className='text-sm text-slate-600'>Select an invoice row above to load line items and UUIDs.</p>
-        ) : invoiceDetailLoading ? (
-          <p className='text-sm text-slate-600'>Loading invoice…</p>
-        ) : invoiceDetailError ? (
-          <AdminInlineError>{invoiceDetailError}</AdminInlineError>
-        ) : invoiceDetail ? (
-          <div className='space-y-4'>
-            <div className='max-w-xl'>
-              <Label htmlFor='billing-invoice-id'>Invoice UUID (edit or paste)</Label>
-              <Input
-                id='billing-invoice-id'
-                value={invoiceIdInput}
-                onChange={(e) => setInvoiceIdInput(e.target.value)}
-                className='mt-1 font-mono text-sm'
-                disabled={editorBusy}
-              />
-            </div>
-            <div>
-              <Label htmlFor='billing-email-to'>Default email for row “Email…” dialog</Label>
-              <Input
-                id='billing-email-to'
-                type='email'
-                value={emailTo}
-                onChange={(e) => setEmailTo(e.target.value)}
-                className='mt-1 max-w-md'
-                disabled={editorBusy}
-              />
-            </div>
-            <dl className='grid gap-1 text-sm text-slate-700 sm:grid-cols-2'>
-              <div>
-                <dt className='text-xs uppercase text-slate-500'>Status</dt>
-                <dd>{invoiceDetail.status}</dd>
-              </div>
-              <div>
-                <dt className='text-xs uppercase text-slate-500'>Number</dt>
-                <dd>{invoiceDetail.invoiceNumber ?? '—'}</dd>
-              </div>
-              <div>
-                <dt className='text-xs uppercase text-slate-500'>Total</dt>
-                <dd>
-                  {invoiceDetail.total} {invoiceDetail.currency}
-                </dd>
-              </div>
-              <div className='sm:col-span-2'>
-                <dt className='text-xs uppercase text-slate-500'>Bill to</dt>
-                <dd>{invoiceDetail.billToDisplayName ?? invoiceDetail.billToEmail ?? '—'}</dd>
-              </div>
-            </dl>
-            <div>
-              <p className='mb-2 text-xs font-semibold uppercase tracking-wide text-slate-600'>Lines</p>
-              <AdminDataTable tableClassName='min-w-[640px]'>
-                <AdminDataTableHead>
-                  <tr>
-                    <th className='px-2 py-1.5'>Line id</th>
-                    <th className='px-2 py-1.5'>Enrollment</th>
-                    <th className='px-2 py-1.5'>Description</th>
-                    <th className='px-2 py-1.5'>Total</th>
-                  </tr>
-                </AdminDataTableHead>
-                <AdminDataTableBody>
-                  {(invoiceDetail.lines ?? []).map((ln) => (
-                    <tr key={ln.id}>
-                      <td className='px-2 py-1.5'>
-                        <button
-                          type='button'
-                          className='max-w-[140px] truncate font-mono text-left text-xs text-sky-800 underline decoration-sky-300 hover:decoration-sky-600'
-                          title={ln.id}
-                          onClick={() => {
-                            if (ln.id) {
-                              setAllocateLineId(ln.id);
-                            }
-                          }}
-                        >
-                          {formatTruncatedId(ln.id)}
-                        </button>
-                      </td>
-                      <td className='px-2 py-1.5 font-mono text-xs'>{formatTruncatedId(ln.enrollmentId)}</td>
-                      <td className='px-2 py-1.5 text-xs'>{ln.description}</td>
-                      <td className='px-2 py-1.5 text-xs'>
-                        {ln.lineTotal} {ln.currency}
-                      </td>
-                    </tr>
-                  ))}
-                </AdminDataTableBody>
-              </AdminDataTable>
-            </div>
-          </div>
-        ) : null}
-      </Card>
-
       <AdminEditorCard
         title='Allocate selected payment to invoice'
-        description='Select a payment in the table below first. Invoice and line UUIDs can come from the selected invoice panel.'
+        description='Select a payment in the table below first. Paste invoice and optional line UUIDs from your records or billing export.'
         actions={
           <Button type='submit' form={ALLOCATE_FORM_ID} disabled={editorBusy}>
             {busyAction === 'allocate' ? 'Allocating…' : 'Create allocation'}
@@ -1639,31 +1521,6 @@ export function ClientInvoicesPanel() {
             placeholder='Required'
           />
           {voidError ? <AdminInlineError>{voidError}</AdminInlineError> : null}
-        </div>
-      </ConfirmDialog>
-
-      <ConfirmDialog
-        open={emailDialogOpen}
-        title='Email invoice PDF'
-        description='Sends the issued invoice PDF to the address below (best-effort).'
-        confirmLabel='Send email'
-        cancelLabel='Cancel'
-        confirmDisabled={busyAction === 'email'}
-        onCancel={closeEmailInvoiceDialog}
-        onConfirm={() => void submitEmailInvoice()}
-      >
-        <div className='space-y-2'>
-          <Label htmlFor='billing-email-dialog-to'>Recipient email</Label>
-          <Input
-            id='billing-email-dialog-to'
-            type='email'
-            value={emailDialogTo}
-            onChange={(e) => {
-              setEmailDialogTo(e.target.value);
-              setEmailDialogError('');
-            }}
-          />
-          {emailDialogError ? <AdminInlineError>{emailDialogError}</AdminInlineError> : null}
         </div>
       </ConfirmDialog>
 

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4450,7 +4450,10 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        /** Format: email */
+                        /**
+                         * @description Recipient email address(es). Multiple addresses may be given as a comma-separated list (optional semicolons are treated like commas).
+                         * @example billing@example.com, accounts@example.com
+                         */
                         toEmail: string;
                     };
                 };

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const billingMocks = vi.hoisted(() => ({
   listCustomerInvoices: vi.fn(),
-  getCustomerInvoice: vi.fn(),
   getCustomerInvoicePdfDownload: vi.fn(),
   listCustomerPayments: vi.fn(),
   getCustomerPayment: vi.fn(),
@@ -58,11 +57,6 @@ describe('ClientInvoicesPanel', () => {
     billingMocks.listCustomerPayments.mockResolvedValue([]);
     billingMocks.listCustomerInvoices.mockResolvedValue({ items: [], next_cursor: null });
     billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({ items: [], truncated: false });
-    billingMocks.getCustomerInvoice.mockResolvedValue({
-      id: 'placeholder',
-      status: 'draft',
-      lines: [],
-    });
     billingMocks.getCustomerInvoicePdfDownload.mockResolvedValue({
       downloadUrl: 'https://example.com/signed.pdf',
       expiresAt: '2026-12-31T00:00:00Z',
@@ -74,7 +68,7 @@ describe('ClientInvoicesPanel', () => {
     vi.clearAllMocks();
   });
 
-  it('renders invoice rows and selecting a row loads detail', async () => {
+  it('renders invoice rows and selecting a row seeds allocate invoice id', async () => {
     const invId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     billingMocks.listCustomerInvoices.mockResolvedValue({
       items: [
@@ -91,19 +85,6 @@ describe('ClientInvoicesPanel', () => {
       ],
       next_cursor: null,
     });
-    billingMocks.getCustomerInvoice.mockResolvedValue({
-      id: invId,
-      status: 'draft',
-      lines: [
-        {
-          id: '11111111-1111-1111-1111-111111111111',
-          enrollmentId: '22222222-2222-2222-2222-222222222222',
-          description: 'Line',
-          lineTotal: '50',
-          currency: 'HKD',
-        },
-      ],
-    });
 
     render(<ClientInvoicesPanel />);
 
@@ -118,11 +99,8 @@ describe('ClientInvoicesPanel', () => {
     await userEvent.click(firstCustomerInvoiceDataRow(invoiceTable));
 
     await waitFor(() => {
-      expect(billingMocks.getCustomerInvoice).toHaveBeenCalledWith(invId, expect.any(AbortSignal));
+      expect((document.getElementById('billing-allocate-invoice') as HTMLInputElement).value).toBe(invId);
     });
-
-    const uuidInput = document.getElementById('billing-invoice-id') as HTMLInputElement;
-    expect(uuidInput.value).toBe(invId);
   });
 
   it('passes status filter to listCustomerInvoices', async () => {
@@ -323,56 +301,7 @@ describe('ClientInvoicesPanel', () => {
     });
   });
 
-  it('clicking invoice line id sets allocate line id field', async () => {
-    const invId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
-    const lineId = '11111111-1111-1111-1111-111111111111';
-    billingMocks.listCustomerInvoices.mockResolvedValue({
-      items: [
-        {
-          id: invId,
-          status: 'draft',
-          currency: 'HKD',
-          total: '50',
-          lineCount: 1,
-          createdAt: '2026-01-01T00:00:00+00:00',
-        },
-      ],
-      next_cursor: null,
-    });
-    billingMocks.getCustomerInvoice.mockResolvedValue({
-      id: invId,
-      status: 'draft',
-      lines: [
-        {
-          id: lineId,
-          enrollmentId: '22222222-2222-2222-2222-222222222222',
-          description: 'Line',
-          lineTotal: '50',
-          currency: 'HKD',
-        },
-      ],
-    });
-
-    render(<ClientInvoicesPanel />);
-
-    const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
-    const invoiceTable = within(invoiceRegion).getByRole('table');
-    await waitFor(() => {
-      expect(within(invoiceTable).getAllByRole('button').length).toBeGreaterThan(0);
-    });
-    await userEvent.click(firstCustomerInvoiceDataRow(invoiceTable));
-
-    await waitFor(() => {
-      expect(screen.getByTitle(lineId)).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getByTitle(lineId));
-
-    const lineField = document.getElementById('billing-allocate-line') as HTMLInputElement;
-    expect(lineField.value).toBe(lineId);
-  });
-
-  it('email dialog calls emailInvoice with recipient', async () => {
+  it('issued invoice toolbar send email calls emailInvoice with comma-separated recipients', async () => {
     const invId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     billingMocks.listCustomerInvoices.mockResolvedValue({
       items: [
@@ -388,34 +317,32 @@ describe('ClientInvoicesPanel', () => {
       ],
       next_cursor: null,
     });
-    billingMocks.getCustomerInvoice.mockResolvedValue({
-      id: invId,
-      status: 'issued',
-      lines: [],
-    });
     billingMocks.emailInvoice.mockResolvedValue({ sent: true });
 
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => screen.getByRole('button', { name: /email invoice pdf/i }));
+    await waitFor(() => screen.getAllByRole('table'));
 
-    await userEvent.click(screen.getByRole('button', { name: /email invoice pdf/i }));
+    const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
+    const invoiceTable = within(invoiceRegion).getByRole('table');
+    await userEvent.click(firstCustomerInvoiceDataRow(invoiceTable));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /email invoice pdf/i })).toBeInTheDocument();
+      expect(screen.getByLabelText(/email recipients/i)).toBeInTheDocument();
     });
 
-    const toField = document.getElementById('billing-email-dialog-to') as HTMLInputElement;
-    expect(toField.value).toBe('bill@example.com');
+    const emailField = document.getElementById('billing-issued-invoice-emails') as HTMLInputElement;
+    await userEvent.clear(emailField);
+    await userEvent.type(emailField, 'a@example.com, b@example.com');
 
     await userEvent.click(screen.getByRole('button', { name: /^send email$/i }));
 
     await waitFor(() => {
-      expect(billingMocks.emailInvoice).toHaveBeenCalledWith(invId, 'bill@example.com');
+      expect(billingMocks.emailInvoice).toHaveBeenCalledWith(invId, 'a@example.com, b@example.com');
     });
   });
 
-  it('email dialog shows error when recipient is empty', async () => {
+  it('issued invoice toolbar shows error when recipients empty', async () => {
     const invId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     billingMocks.listCustomerInvoices.mockResolvedValue({
       items: [
@@ -431,28 +358,23 @@ describe('ClientInvoicesPanel', () => {
       ],
       next_cursor: null,
     });
-    billingMocks.getCustomerInvoice.mockResolvedValue({
-      id: invId,
-      status: 'issued',
-      lines: [],
-    });
 
     render(<ClientInvoicesPanel />);
 
-    await waitFor(() => screen.getByRole('button', { name: /email invoice pdf/i }));
-    await userEvent.click(screen.getByRole('button', { name: /email invoice pdf/i }));
+    await waitFor(() => screen.getAllByRole('table'));
+
+    const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
+    const invoiceTable = within(invoiceRegion).getByRole('table');
+    await userEvent.click(firstCustomerInvoiceDataRow(invoiceTable));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /email invoice pdf/i })).toBeInTheDocument();
+      expect(screen.getByLabelText(/email recipients/i)).toBeInTheDocument();
     });
-
-    const toField = document.getElementById('billing-email-dialog-to') as HTMLInputElement;
-    await userEvent.clear(toField);
 
     await userEvent.click(screen.getByRole('button', { name: /^send email$/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('Recipient email is required.')).toBeInTheDocument();
+      expect(screen.getByText(/Enter at least one recipient email/i)).toBeInTheDocument();
     });
     expect(billingMocks.emailInvoice).not.toHaveBeenCalled();
   });
@@ -529,11 +451,6 @@ describe('ClientInvoicesPanel', () => {
         },
       ],
       next_cursor: null,
-    });
-    billingMocks.getCustomerInvoice.mockResolvedValue({
-      id: invId,
-      status: 'draft',
-      lines: [],
     });
 
     billingMocks.listCustomerPayments.mockResolvedValue([

--- a/backend/src/app/api/admin_billing_invoices.py
+++ b/backend/src/app/api/admin_billing_invoices.py
@@ -178,6 +178,17 @@ def _validate_to_email(to_email: str) -> None:
         raise ValidationError("toEmail must be a valid email address", field="toEmail")
 
 
+def _parse_to_email_list(raw: str) -> list[str]:
+    """Split comma-separated recipient list and validate each address."""
+    parts = [p.strip() for p in raw.replace(";", ",").split(",")]
+    addresses = [p for p in parts if p != ""]
+    if not addresses:
+        raise ValidationError("toEmail is required", field="toEmail")
+    for addr in addresses:
+        _validate_to_email(addr)
+    return addresses
+
+
 def _email_invoice(
     event: Mapping[str, Any],
     invoice_id: UUID,
@@ -186,10 +197,10 @@ def _email_invoice(
     request_id: str | None,
 ) -> dict[str, Any]:
     body = parse_body(event)
-    to_email = str(body.get("toEmail") or body.get("to_email") or "").strip()
-    if not to_email:
+    to_raw = str(body.get("toEmail") or body.get("to_email") or "").strip()
+    if not to_raw:
         raise ValidationError("toEmail is required", field="toEmail")
-    _validate_to_email(to_email)
+    to_addresses = _parse_to_email_list(to_raw)
     with _session_with_audit(user_sub, request_id) as session:
-        send_invoice_email(session, invoice_id=invoice_id, to_email=to_email)
+        send_invoice_email(session, invoice_id=invoice_id, to_addresses=to_addresses)
         return json_response(200, {"sent": True}, event=event)

--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -425,7 +425,9 @@ def ensure_invoice_pdf_storage(session: Session, invoice: CustomerInvoice) -> st
     return upload_invoice_preview_pdf(session, invoice)
 
 
-def send_invoice_email(session: Session, *, invoice_id: UUID, to_email: str) -> None:
+def send_invoice_email(
+    session: Session, *, invoice_id: UUID, to_addresses: list[str]
+) -> None:
     inv = session.get(CustomerInvoice, invoice_id)
     if inv is None or not inv.issued_pdf_s3_key:
         return
@@ -442,7 +444,7 @@ def send_invoice_email(session: Session, *, invoice_id: UUID, to_email: str) -> 
     body_text = f"Please find invoice {num} attached."
     send_mime_email_with_optional_attachments(
         source=src,
-        to_addresses=[to_email],
+        to_addresses=to_addresses,
         subject=subject,
         body_text=body_text,
         body_html=f"<p>{body_text}</p>",

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3268,7 +3268,10 @@ paths:
               properties:
                 toEmail:
                   type: string
-                  format: email
+                  description: >
+                    Recipient email address(es). Multiple addresses may be given as a
+                    comma-separated list (optional semicolons are treated like commas).
+                  example: "billing@example.com, accounts@example.com"
       responses:
         "200":
           description: Email sent (best-effort).

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -118,7 +118,8 @@ their primary responsibilities.
   (returns a CloudFront-signed URL; each response includes a unique cache-bust query on the
   signed resource so draft/void preview PDFs re-uploaded to the same S3 key are not edge-cached
   as an older file),
-  allocations, export;
+  allocations, `POST /v1/admin/billing/invoices/{id}/email` (comma- or semicolon-separated
+  `toEmail` recipient list), export;
   handler code split across `admin_billing*.py` modules under `app.api`, same Lambda),
   `/v1/user/assets/*`,
   `/v1/assets/public/*`, `/v1/assets/share/*`, `/v1/assets/email-download/*`,

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -1476,6 +1476,44 @@ def test_list_invoices_filters_by_currency_and_status(
     assert "customer_invoices.status" in stmt_text
 
 
+def test_email_invoice_accepts_comma_separated_recipients(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inv_id = uuid4()
+    captured: dict[str, Any] = {}
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        yield MagicMock()
+
+    def _fake_send_invoice_email(
+        _session: Any, *, invoice_id: UUID, to_addresses: list[str]
+    ) -> None:
+        captured["invoice_id"] = invoice_id
+        captured["to_addresses"] = to_addresses
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+    monkeypatch.setattr(
+        "app.api.admin_billing_invoices.send_invoice_email",
+        _fake_send_invoice_email,
+    )
+
+    ev = api_gateway_event(
+        method="POST",
+        path=f"/v1/admin/billing/invoices/{inv_id}/email",
+        body=json.dumps({"toEmail": " a@example.com ; b@example.com "}),
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "POST", f"/v1/admin/billing/invoices/{inv_id}/email"
+    )
+    assert r["statusCode"] == 200
+    assert captured["invoice_id"] == inv_id
+    assert captured["to_addresses"] == ["a@example.com", "b@example.com"]
+
+
 def test_email_invoice_rejects_invalid_email(
     api_gateway_event: Any,
     admin_identity: dict[str, str],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removes the **Selected invoice** card (detail fetch, line shortcuts, UUID mirrors).
- Adds **Email recipients (comma-separated)** and **Send email** on the **Customer invoices** toolbar `ml-auto` when the selected row is **issued** (same wrap row as Status/Currency filters).
- Removes the row envelope button and the email **ConfirmDialog**; sending uses the toolbar field + button for the **currently selected** issued invoice.
- **Backend**: `POST .../invoices/{id}/email` accepts a comma- or semicolon-separated `toEmail` string; each segment is validated and SES sends one message with **To** listing all recipients.

## Docs / types

- OpenAPI `toEmail` schema updated; `npm run generate:admin-api-types` run.
- `docs/architecture/lambdas.md` notes multi-recipient email.

## Tests

- Python: `test_email_invoice_accepts_comma_separated_recipients` plus existing invalid-email test.
- Admin Vitest file updated (Vitest did not run locally here due to Node 18 / jsdom ESM fork issue; CI should use the repo Node version).

## Notes / risks

- **Line-id click → allocate** shortcut was removed with the Selected invoice panel; allocation UUIDs are paste-only (copy from CSV/export elsewhere).
- Selecting a **draft** row still seeds **Allocate** invoice id only when that draft exists in the current **loaded** invoice list (unchanged behavior aside from removed detail fetch).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66c705cf-5033-4368-a1e4-956e40953f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66c705cf-5033-4368-a1e4-956e40953f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

