### PR TITLE
Admin web: allocate payment — invoice and line selects on one row

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1374,11 +1374,11 @@ export function ClientInvoicesPanel() {
         }
       >
         <form id={ALLOCATE_FORM_ID} className='grid max-w-2xl gap-3 sm:grid-cols-2' onSubmit={(e) => void handleAllocate(e)}>
-          <div className='sm:col-span-2'>
+          <div>
             <Label htmlFor='billing-allocate-invoice'>Issued invoice</Label>
             <Select
               id='billing-allocate-invoice'
-              className='mt-1 max-w-xl'
+              className='mt-1 w-full min-w-0 max-w-xl sm:max-w-none'
               value={
                 issuedInvoicesForAllocate.some((i) => i.id === allocateInvoiceId)
                   ? allocateInvoiceId
@@ -1403,11 +1403,11 @@ export function ClientInvoicesPanel() {
               })}
             </Select>
           </div>
-          <div className='sm:col-span-2'>
+          <div>
             <Label htmlFor='billing-allocate-line'>Invoice line (optional)</Label>
             <Select
               id='billing-allocate-line'
-              className='mt-1 max-w-xl'
+              className='mt-1 w-full min-w-0 max-w-xl sm:max-w-none'
               value={
                 allocateLineId === ''
                   ? ''


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the Finance client invoices panel, the **Allocate selected payment to invoice** inline editor used a two-column grid but forced both **Issued invoice** and **Invoice line (optional)** to span the full width (`sm:col-span-2`), so they stacked vertically.

## Changes

- Remove `sm:col-span-2` from those two fields so each occupies one column on `sm` breakpoints and they sit on the same row.
- Use `w-full min-w-0` on both selects so they fill their grid cells cleanly; on small screens they still stack (one column).

## Testing

- `npm test` for `client-invoices-panel.test.tsx` was not run in this environment (Node/npm unavailable). Please run locally if needed.
- `bash scripts/validate-cursorrules.sh` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f4dfc34-7faf-4081-a6ff-e8658ac88427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f4dfc34-7faf-4081-a6ff-e8658ac88427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

