### PR TITLE
Admin refund: invoice + allocated payment dropdowns

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -214,7 +214,14 @@ export function ClientInvoicesPanel() {
   const [allocateInvoiceLinesLoading, setAllocateInvoiceLinesLoading] = useState(false);
   const [allocateInvoiceLinesError, setAllocateInvoiceLinesError] = useState('');
 
-  const [refundOriginalId, setRefundOriginalId] = useState('');
+  const [refundInvoiceId, setRefundInvoiceId] = useState('');
+  const [refundPaymentSelectId, setRefundPaymentSelectId] = useState('');
+  const [refundPaymentsForInvoice, setRefundPaymentsForInvoice] = useState<
+    CustomerPaymentSummary[]
+  >([]);
+  const [refundPaymentsLoading, setRefundPaymentsLoading] = useState(false);
+  const [refundPaymentsError, setRefundPaymentsError] = useState('');
+  const [refundInvoicePaymentsRefresh, setRefundInvoicePaymentsRefresh] = useState(0);
   const [refundAmount, setRefundAmount] = useState('');
   const [refundCurrency, setRefundCurrency] = useState(defaultCurrency);
   const [refundMethod, setRefundMethod] = useState('');
@@ -233,7 +240,7 @@ export function ClientInvoicesPanel() {
     setListLoading(true);
     setListError('');
     try {
-      const items = await listCustomerPayments(signal);
+      const items = await listCustomerPayments({}, signal);
       setPayments(items);
     } catch (caught) {
       if (caught instanceof Error && caught.name === 'AbortError') {
@@ -420,6 +427,24 @@ export function ClientInvoicesPanel() {
     [invoices],
   );
 
+  const refundEligiblePayments = useMemo(
+    () =>
+      refundPaymentsForInvoice.filter(
+        (p) => p.direction === 'inbound' && p.status === 'succeeded',
+      ),
+    [refundPaymentsForInvoice],
+  );
+
+  useEffect(() => {
+    if (!selectedInvoiceId) {
+      return;
+    }
+    const inv = invoices.find((i) => i.id === selectedInvoiceId);
+    if (inv?.status === 'issued') {
+      setRefundInvoiceId(selectedInvoiceId);
+    }
+  }, [selectedInvoiceId, invoices]);
+
   const allocateLinesOrdered = useMemo(
     () => [...allocateInvoiceLines].sort((a, b) => invoiceLineSortKey(a) - invoiceLineSortKey(b)),
     [allocateInvoiceLines],
@@ -528,7 +553,7 @@ export function ClientInvoicesPanel() {
           lastPaymentSeedIdRef.current = id;
           const cur = row.currency ?? defaultCurrency;
           setAllocateCurrency(currencySelectValue(cur, currencyOptions, defaultCurrency));
-          setRefundOriginalId(row.id ?? '');
+          setRefundPaymentSelectId(row.id ?? '');
           setRefundCurrency(currencySelectValue(cur, currencyOptions, defaultCurrency));
         }
       } catch (caught) {
@@ -563,6 +588,84 @@ export function ClientInvoicesPanel() {
     void loadDetail(selectedId, ac.signal);
     return () => ac.abort();
   }, [selectedId, loadDetail]);
+
+  useEffect(() => {
+    if (!selectedId || !detail) {
+      return;
+    }
+    const refs = detail.allocationInvoices ?? [];
+    if (refs.length === 0) {
+      return;
+    }
+    const ids = new Set(refs.map((r) => r.invoiceId));
+    setRefundInvoiceId((prev) => {
+      if (prev && ids.has(prev)) {
+        return prev;
+      }
+      const preferred = allocateInvoiceId.trim();
+      if (preferred && ids.has(preferred)) {
+        return preferred;
+      }
+      return refs[0]?.invoiceId ?? '';
+    });
+  }, [selectedId, detail, allocateInvoiceId]);
+
+  useEffect(() => {
+    const trimmed = refundInvoiceId.trim();
+    if (trimmed === '') {
+      setRefundPaymentsForInvoice([]);
+      setRefundPaymentsLoading(false);
+      setRefundPaymentsError('');
+      return;
+    }
+    const ac = new AbortController();
+    setRefundPaymentsLoading(true);
+    setRefundPaymentsError('');
+    void (async () => {
+      try {
+        const items = await listCustomerPayments({ invoiceId: trimmed }, ac.signal);
+        if (ac.signal.aborted) {
+          return;
+        }
+        setRefundPaymentsForInvoice(items);
+        setRefundPaymentSelectId((prev) => {
+          const inboundMatch = items.find(
+            (p) => p.id === prev && p.direction === 'inbound' && p.status === 'succeeded',
+          );
+          if (inboundMatch) {
+            return prev;
+          }
+          const selectedMatch =
+            selectedId &&
+            items.find(
+              (p) => p.id === selectedId && p.direction === 'inbound' && p.status === 'succeeded',
+            );
+          if (selectedMatch) {
+            return selectedId;
+          }
+          return (
+            items.find((p) => p.direction === 'inbound' && p.status === 'succeeded')?.id ?? ''
+          );
+        });
+      } catch (caught) {
+        if (caught instanceof Error && caught.name === 'AbortError') {
+          return;
+        }
+        if (!ac.signal.aborted) {
+          setRefundPaymentsForInvoice([]);
+          setRefundPaymentSelectId('');
+          setRefundPaymentsError(
+            caught instanceof Error ? caught.message : 'Failed to load payments for invoice.',
+          );
+        }
+      } finally {
+        if (!ac.signal.aborted) {
+          setRefundPaymentsLoading(false);
+        }
+      }
+    })();
+    return () => ac.abort();
+  }, [refundInvoiceId, selectedId, refundInvoicePaymentsRefresh]);
 
   const setBusy = (key: string | null) => {
     setBusyAction(key);
@@ -810,9 +913,9 @@ export function ClientInvoicesPanel() {
     event.preventDefault();
     setActionError('');
     setActionMessage('');
-    const orig = refundOriginalId.trim();
+    const orig = refundPaymentSelectId.trim();
     if (!orig) {
-      setActionError('Original payment id is required.');
+      setActionError('Select an inbound payment allocated to the invoice.');
       return;
     }
     const amt = refundAmount.trim();
@@ -832,6 +935,7 @@ export function ClientInvoicesPanel() {
       });
       setActionMessage('Refund payment row recorded.');
       await loadPayments();
+      setRefundInvoicePaymentsRefresh((n) => n + 1);
     } catch (caught) {
       setActionError(caught instanceof Error ? caught.message : 'Refund failed.');
     } finally {
@@ -1476,7 +1580,7 @@ export function ClientInvoicesPanel() {
 
       <AdminEditorCard
         title='Record refund payment row'
-        description='Creates a succeeded refund payment linked to the original payment.'
+        description='Choose an issued invoice, then the inbound payment allocated to it (from allocations). Creates a succeeded refund linked to that payment.'
         actions={
           <Button type='submit' form={REFUND_FORM_ID} disabled={editorBusy} variant='secondary'>
             {busyAction === 'refund' ? 'Recording…' : 'Record refund'}
@@ -1484,15 +1588,90 @@ export function ClientInvoicesPanel() {
         }
       >
         <form id={REFUND_FORM_ID} className='flex max-w-full flex-col gap-3' onSubmit={(e) => void handleRefund(e)}>
-          <div className='max-w-2xl'>
-            <Label htmlFor='billing-refund-original'>Original payment UUID</Label>
-            <Input
-              id='billing-refund-original'
-              value={refundOriginalId}
-              onChange={(e) => setRefundOriginalId(e.target.value)}
-              className='mt-1 font-mono text-sm'
-              disabled={editorBusy}
-            />
+          <div className='grid gap-3 min-[780px]:grid-cols-2 min-[780px]:items-end'>
+            <div className='min-w-0'>
+              <Label htmlFor='billing-refund-invoice'>Issued invoice</Label>
+              <Select
+                id='billing-refund-invoice'
+                className='mt-1 w-full min-w-0 max-w-xl min-[780px]:max-w-none'
+                value={
+                  issuedInvoicesForAllocate.some((i) => i.id === refundInvoiceId)
+                    ? refundInvoiceId
+                    : ''
+                }
+                onChange={(e) => {
+                  setRefundInvoiceId(e.target.value);
+                  setRefundPaymentSelectId('');
+                }}
+                disabled={editorBusy}
+              >
+                <option value=''>Select invoice…</option>
+                {issuedInvoicesForAllocate.map((invOpt) => {
+                  const oid = invOpt.id ?? '';
+                  const num = invOpt.invoiceNumber?.trim() ?? '';
+                  const label = num !== '' ? num : formatTruncatedId(oid);
+                  return (
+                    <option key={oid || 'refund-invoice-option'} value={oid}>
+                      {label}
+                    </option>
+                  );
+                })}
+              </Select>
+            </div>
+            <div className='min-w-0'>
+              <Label htmlFor='billing-refund-payment'>Payment allocated to invoice</Label>
+              <Select
+                id='billing-refund-payment'
+                className='mt-1 w-full min-w-0 max-w-xl min-[780px]:max-w-none'
+                value={
+                  refundEligiblePayments.some((p) => p.id === refundPaymentSelectId)
+                    ? refundPaymentSelectId
+                    : ''
+                }
+                onChange={(e) => setRefundPaymentSelectId(e.target.value)}
+                disabled={
+                  editorBusy ||
+                  refundInvoiceId.trim() === '' ||
+                  refundPaymentsLoading ||
+                  refundEligiblePayments.length === 0
+                }
+              >
+                <option value=''>
+                  {refundPaymentsLoading
+                    ? 'Loading payments…'
+                    : refundEligiblePayments.length === 0
+                      ? 'No inbound succeeded payments with allocations'
+                      : 'Select payment…'}
+                </option>
+                {refundEligiblePayments.map((p) => {
+                  const pid = p.id ?? '';
+                  const amt = p.amount ?? '';
+                  const cur = p.currency ?? '';
+                  const method = p.method?.trim() ?? '';
+                  const methodSuffix = method !== '' ? ` · ${method}` : '';
+                  return (
+                    <option key={pid || 'refund-pay-opt'} value={pid}>
+                      {formatTruncatedId(pid)} · {amt} {cur}
+                      {methodSuffix}
+                    </option>
+                  );
+                })}
+              </Select>
+              {refundPaymentsLoading ? (
+                <p className='mt-1 text-xs text-slate-600'>Loading payments…</p>
+              ) : null}
+              {refundPaymentsError ? (
+                <AdminInlineError className='mt-1'>{refundPaymentsError}</AdminInlineError>
+              ) : null}
+              {!refundPaymentsLoading &&
+              refundInvoiceId.trim() !== '' &&
+              refundEligiblePayments.length === 0 &&
+              !refundPaymentsError ? (
+                <p className='mt-1 text-xs text-slate-600'>
+                  No succeeded inbound payments are allocated to this invoice yet.
+                </p>
+              ) : null}
+            </div>
           </div>
           <div className='grid gap-3 min-[780px]:grid-cols-4 min-[780px]:items-end'>
             <div className='min-w-0'>

--- a/apps/admin_web/src/lib/billing-api.ts
+++ b/apps/admin_web/src/lib/billing-api.ts
@@ -9,6 +9,7 @@ export type CustomerPaymentSummary = ApiSchemas['CustomerPaymentSummary'];
 
 export type CustomerPaymentDetail = CustomerPaymentSummary & {
   unappliedAmount?: string;
+  allocationInvoices?: { invoiceId: string; invoiceNumber: string | null }[];
 };
 
 export type CustomerInvoiceSummary = ApiSchemas['CustomerInvoiceSummary'];
@@ -84,9 +85,18 @@ export async function getCustomerInvoicePdfDownload(
   return { downloadUrl, expiresAt };
 }
 
-export async function listCustomerPayments(signal?: AbortSignal): Promise<CustomerPaymentSummary[]> {
+export async function listCustomerPayments(
+  params: { invoiceId?: string } = {},
+  signal?: AbortSignal,
+): Promise<CustomerPaymentSummary[]> {
+  const query = new URLSearchParams();
+  const inv = params.invoiceId?.trim();
+  if (inv) {
+    query.set('invoice_id', inv);
+  }
+  const qs = query.toString();
   const payload = await adminApiRequest<{ items?: CustomerPaymentSummary[] }>({
-    endpointPath: '/v1/admin/billing/payments',
+    endpointPath: qs ? `/v1/admin/billing/payments?${qs}` : '/v1/admin/billing/payments',
     method: 'GET',
     signal,
   });

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -3907,7 +3907,10 @@ export interface paths {
         /** List recent customer payments */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description When set, return only payments that have at least one allocation to this invoice. */
+                    invoice_id?: string;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;
@@ -3925,6 +3928,7 @@ export interface paths {
                         };
                     };
                 };
+                400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
             };
         };
@@ -3991,6 +3995,8 @@ export interface paths {
                     content: {
                         "application/json": components["schemas"]["CustomerPaymentSummary"] & {
                             unappliedAmount?: string;
+                            /** @description Distinct invoices this payment is allocated to (newest invoice first). */
+                            allocationInvoices?: components["schemas"]["CustomerPaymentAllocationInvoice"][];
                         };
                     };
                 };
@@ -5957,6 +5963,11 @@ export interface components {
         };
         ExpenseResponse: {
             expense: components["schemas"]["Expense"];
+        };
+        CustomerPaymentAllocationInvoice: {
+            /** Format: uuid */
+            invoiceId?: string;
+            invoiceNumber?: string | null;
         };
         CustomerPaymentSummary: {
             /** Format: uuid */

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -529,18 +529,49 @@ describe('ClientInvoicesPanel', () => {
   });
 
   it('submitting refund form calls createCustomerRefund', async () => {
+    const invId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     const payId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
-    billingMocks.listCustomerPayments.mockResolvedValue([
-      {
-        id: payId,
-        direction: 'inbound',
-        status: 'succeeded',
-        method: 'stripe_card',
-        amount: '100',
-        currency: 'HKD',
-        createdAt: '2026-01-01T00:00:00+00:00',
-      },
-    ]);
+    billingMocks.listCustomerInvoices.mockResolvedValue({
+      items: [
+        {
+          id: invId,
+          status: 'issued',
+          invoiceNumber: 'INV-10',
+          currency: 'HKD',
+          total: '100',
+          lineCount: 1,
+          createdAt: '2026-01-01T00:00:00+00:00',
+        },
+      ],
+      next_cursor: null,
+    });
+    billingMocks.listCustomerPayments.mockImplementation(async (params?: { invoiceId?: string }) => {
+      const filtered =
+        params?.invoiceId === invId
+          ? [
+              {
+                id: payId,
+                direction: 'inbound' as const,
+                status: 'succeeded' as const,
+                method: 'stripe_card',
+                amount: '100',
+                currency: 'HKD',
+                createdAt: '2026-01-01T00:00:00+00:00',
+              },
+            ]
+          : [
+              {
+                id: payId,
+                direction: 'inbound' as const,
+                status: 'succeeded' as const,
+                method: 'stripe_card',
+                amount: '100',
+                currency: 'HKD',
+                createdAt: '2026-01-01T00:00:00+00:00',
+              },
+            ];
+      return filtered;
+    });
     billingMocks.getCustomerPayment.mockResolvedValue({
       id: payId,
       direction: 'inbound',
@@ -550,6 +581,7 @@ describe('ClientInvoicesPanel', () => {
       currency: 'HKD',
       unappliedAmount: '0',
       createdAt: '2026-01-01T00:00:00+00:00',
+      allocationInvoices: [{ invoiceId: invId, invoiceNumber: 'INV-10' }],
     });
     billingMocks.createCustomerRefund.mockResolvedValue({
       id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
@@ -562,11 +594,23 @@ describe('ClientInvoicesPanel', () => {
 
     render(<ClientInvoicesPanel />);
 
+    const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
+    const invoiceTable = within(invoiceRegion).getByRole('table');
+    await waitFor(() => {
+      expect(within(invoiceTable).getAllByRole('button').length).toBeGreaterThan(0);
+    });
+    await userEvent.click(firstCustomerInvoiceDataRow(invoiceTable));
+
     const paymentTable = screen.getAllByRole('table').at(-1) as HTMLElement;
     await waitFor(() => {
       expect(within(paymentTable).getAllByRole('button').length).toBeGreaterThan(0);
     });
     await userEvent.click(within(paymentTable).getByRole('button', { name: /bbbbbbbb/i }));
+
+    await waitFor(() => {
+      const invoiceSelect = document.getElementById('billing-refund-invoice') as HTMLSelectElement;
+      expect(invoiceSelect.value).toBe(invId);
+    });
 
     const refundAmount = document.getElementById('billing-refund-amount') as HTMLInputElement;
     await userEvent.clear(refundAmount);

--- a/backend/src/app/api/admin_billing_payments.py
+++ b/backend/src/app/api/admin_billing_payments.py
@@ -12,12 +12,14 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.admin_billing_common import DEFAULT_BILLING_LIST_LIMIT, _session_with_audit
-from app.api.admin_request import parse_body
+from app.api.admin_request import parse_body, query_param
 from app.db.audit import AuditService
 from app.db.engine import get_engine
+from app.db.models.customer_invoice import CustomerInvoice
 from app.db.models.customer_payment import CustomerPayment
 from app.db.models.customer_receipt import CustomerReceipt
 from app.db.models.enums import BillingPaymentDirection, BillingPaymentStatus
+from app.db.models.payment_allocation import PaymentAllocation
 from app.exceptions import NotFoundError, ValidationError
 from app.services.customer_billing import (
     create_receipt_for_succeeded_inbound_payment,
@@ -28,6 +30,46 @@ from app.utils import json_response
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def _payment_allocation_invoice_refs(
+    session: Session, payment_id: UUID
+) -> list[dict[str, str | None]]:
+    """Distinct invoices this payment is allocated to (for admin UI pickers)."""
+    inv_ids = list(
+        session.execute(
+            select(PaymentAllocation.invoice_id)
+            .where(PaymentAllocation.payment_id == payment_id)
+            .distinct()
+        )
+        .scalars()
+        .all()
+    )
+    if not inv_ids:
+        return []
+    rows = session.execute(
+        select(
+            CustomerInvoice.id,
+            CustomerInvoice.invoice_number,
+            CustomerInvoice.created_at,
+        ).where(CustomerInvoice.id.in_(inv_ids))
+    ).all()
+    by_id = {r[0]: (r[1], r[2]) for r in rows}
+    ordered = sorted(
+        inv_ids,
+        key=lambda i: (by_id.get(i, (None, None))[1] or datetime.min.replace(tzinfo=UTC)),
+        reverse=True,
+    )
+    out: list[dict[str, str | None]] = []
+    for iid in ordered:
+        num, _ts = by_id.get(iid, (None, None))
+        out.append(
+            {
+                "invoiceId": str(iid),
+                "invoiceNumber": str(num).strip() if num else None,
+            }
+        )
+    return out
 
 
 def _serialize_payment(p: CustomerPayment) -> dict[str, Any]:
@@ -53,12 +95,31 @@ def _serialize_payment(p: CustomerPayment) -> dict[str, Any]:
 def _list_payments(
     event: Mapping[str, Any], *, user_sub: str, request_id: str | None
 ) -> dict[str, Any]:
+    invoice_raw = query_param(event, "invoice_id") or query_param(event, "invoiceId")
+    inv_filter: UUID | None = None
+    if invoice_raw and str(invoice_raw).strip():
+        try:
+            inv_filter = UUID(str(invoice_raw).strip())
+        except (ValueError, TypeError) as exc:
+            raise ValidationError(
+                "invoice_id must be a UUID", field="invoice_id"
+            ) from exc
+
     with _session_with_audit(user_sub, request_id) as session:
-        stmt = (
-            select(CustomerPayment)
-            .order_by(CustomerPayment.created_at.desc())
-            .limit(DEFAULT_BILLING_LIST_LIMIT)
-        )
+        stmt = select(CustomerPayment).order_by(CustomerPayment.created_at.desc())
+        if inv_filter is not None:
+            subq = (
+                select(PaymentAllocation.payment_id)
+                .where(PaymentAllocation.invoice_id == inv_filter)
+                .distinct()
+                .subquery()
+            )
+            stmt = (
+                select(CustomerPayment)
+                .join(subq, CustomerPayment.id == subq.c.payment_id)
+                .order_by(CustomerPayment.created_at.desc())
+            )
+        stmt = stmt.limit(DEFAULT_BILLING_LIST_LIMIT)
         rows = list(session.execute(stmt).scalars().all())
         return json_response(
             200,
@@ -79,9 +140,14 @@ def _get_payment(
         if p is None:
             raise NotFoundError("CustomerPayment", str(payment_id))
         unapplied = str(payment_unapplied_amount(session, payment_id))
+        allocation_invoices = _payment_allocation_invoice_refs(session, payment_id)
         return json_response(
             200,
-            {**_serialize_payment(p), "unappliedAmount": unapplied},
+            {
+                **_serialize_payment(p),
+                "unappliedAmount": unapplied,
+                "allocationInvoices": allocation_invoices,
+            },
             event=event,
         )
 

--- a/backend/src/app/api/admin_billing_payments.py
+++ b/backend/src/app/api/admin_billing_payments.py
@@ -57,7 +57,9 @@ def _payment_allocation_invoice_refs(
     by_id = {r[0]: (r[1], r[2]) for r in rows}
     ordered = sorted(
         inv_ids,
-        key=lambda i: (by_id.get(i, (None, None))[1] or datetime.min.replace(tzinfo=UTC)),
+        key=lambda i: (
+            by_id.get(i, (None, None))[1] or datetime.min.replace(tzinfo=UTC)
+        ),
         reverse=True,
     )
     out: list[dict[str, str | None]] = []

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -55,8 +55,9 @@ info:
     - `POST /v1/admin/expenses/{id}/reparse`
     - `POST /v1/admin/expenses/{id}/amend`
     - `GET /v1/admin/billing/export`
-    - `GET|POST /v1/admin/billing/payments`
-    - `GET /v1/admin/billing/payments/{id}`
+    - `GET|POST /v1/admin/billing/payments` (list supports optional `?invoice_id=` to return
+      payments with an allocation to that invoice)
+    - `GET /v1/admin/billing/payments/{id}` (includes `allocationInvoices` for linked issued invoices)
     - `GET /v1/admin/billing/payments/{id}/unapplied`
     - `POST /v1/admin/billing/payments/{id}/confirm`
     - `GET /v1/admin/billing/enrollments/recent-for-invoicing`
@@ -2799,6 +2800,14 @@ paths:
       summary: List recent customer payments
       security:
         - AdminBearerAuth: []
+      parameters:
+        - name: invoice_id
+          in: query
+          required: false
+          description: When set, return only payments that have at least one allocation to this invoice.
+          schema:
+            type: string
+            format: uuid
       responses:
         "200":
           description: Payment rows.
@@ -2811,6 +2820,8 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/CustomerPaymentSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
     post:
@@ -2862,6 +2873,11 @@ paths:
                     properties:
                       unappliedAmount:
                         type: string
+                      allocationInvoices:
+                        type: array
+                        description: Distinct invoices this payment is allocated to (newest invoice first).
+                        items:
+                          $ref: "#/components/schemas/CustomerPaymentAllocationInvoice"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
@@ -6032,6 +6048,15 @@ components:
       properties:
         expense:
           $ref: "#/components/schemas/Expense"
+    CustomerPaymentAllocationInvoice:
+      type: object
+      properties:
+        invoiceId:
+          type: string
+          format: uuid
+        invoiceNumber:
+          type: string
+          nullable: true
     CustomerPaymentSummary:
       type: object
       properties:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -112,7 +112,7 @@ their primary responsibilities.
   effective discount type after the update is `referral`, otherwise `discount_value`
   must be greater than `0`),
   `/v1/admin/expenses/*`,
-  `/v1/admin/billing/*` (customer AR: payments, invoices list/detail, draft invoices via
+  `/v1/admin/billing/*` (customer AR: `GET /v1/admin/billing/payments` optional `invoice_id` filters to payments with an allocation to that invoice; `GET /v1/admin/billing/payments/{id}` includes `allocationInvoices`; payments, invoices list/detail, draft invoices via
   `POST /v1/admin/billing/invoices` with `draftKind` `enrollment_merge` or `customized_manual`,
   `GET /v1/admin/billing/enrollments/recent-for-invoicing`, `GET /v1/admin/billing/invoices/{id}/pdf`
   (returns a CloudFront-signed URL; each response includes a unique cache-bust query on the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Finance **Record refund payment row** editor no longer asks for an original payment UUID. It matches **Allocate selected payment to invoice**: **Issued invoice** (same issued-invoice options) and a second dropdown **Payment allocated to invoice**, populated with inbound succeeded payments that have an allocation to the chosen invoice.

## Backend

- `GET /v1/admin/billing/payments?invoice_id=<uuid>` returns payments that have at least one `payment_allocations` row for that invoice.
- `GET /v1/admin/billing/payments/{id}` adds `allocationInvoices` (distinct invoices linked via allocations) so the UI can pre-select the invoice when a payment row is selected.

## Frontend

- Loads invoice-filtered payments when the refund invoice changes; seeds invoice from allocate selection, issued invoice table selection, or payment detail `allocationInvoices`.

## Docs

- OpenAPI and Lambda catalog updated per repo rules.

## Validation

- `bash scripts/validate-cursorrules.sh` passed.
- `npm run generate:admin-api-types` was not run (no `npm` in this environment); `admin-api.generated.ts` was updated manually to match `docs/api/admin.yaml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baa9daf8-0e10-42ae-8463-e87b232029f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baa9daf8-0e10-42ae-8463-e87b232029f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

