### PR TITLE
Reorder book-a-free-call landing sections and trim JSON

### DIFF
--- a/apps/public_www/src/components/pages/landing-pages/book-a-free-call.tsx
+++ b/apps/public_www/src/components/pages/landing-pages/book-a-free-call.tsx
@@ -39,6 +39,7 @@ export function BookFreeCallLandingPage({
       heroEventContent={null}
       bookingEventContent={null}
       structuredDataContent={null}
+      layoutVariant='book-free-call'
       introCallSectionBeforeCta={(
         <LandingPageFreeIntroCall
           locale={locale}

--- a/apps/public_www/src/components/pages/landing-pages/landing-page-cta-bridge.tsx
+++ b/apps/public_www/src/components/pages/landing-pages/landing-page-cta-bridge.tsx
@@ -5,7 +5,7 @@ import { useContext } from 'react';
 import { LandingPageCta } from '@/components/sections/landing-pages/landing-page-cta';
 import type {
   LandingPagesCommonContent,
-  LandingPageLocaleContent,
+  LandingPageCtaContent,
   Locale,
 } from '@/content';
 import { resolveLandingPageCtaEyebrow } from '@/lib/landing-page-cta-resolve';
@@ -14,7 +14,7 @@ import { LandingPageCalendarContext } from '@/lib/landing-page-calendar-context'
 interface LandingPageCtaBridgeProps {
   locale: Locale;
   slug: string;
-  content: LandingPageLocaleContent['cta'];
+  content: LandingPageCtaContent;
   commonContent: LandingPagesCommonContent;
   ariaLabel?: string;
 }

--- a/apps/public_www/src/components/pages/landing-pages/landing-page-hero-bridge.tsx
+++ b/apps/public_www/src/components/pages/landing-pages/landing-page-hero-bridge.tsx
@@ -6,6 +6,7 @@ import { LandingPageHero } from '@/components/sections/landing-pages/landing-pag
 import type {
   BookingModalContent,
   LandingPagesCommonContent,
+  LandingPageCtaContent,
   LandingPageLocaleContent,
   Locale,
 } from '@/content';
@@ -14,7 +15,7 @@ import { LandingPageCalendarContext } from '@/lib/landing-page-calendar-context'
 interface LandingPageHeroBridgeProps {
   slug: string;
   content: LandingPageLocaleContent['hero'];
-  ctaContent: LandingPageLocaleContent['cta'];
+  ctaContent: LandingPageCtaContent;
   commonContent: LandingPagesCommonContent;
   locale: Locale;
   metaTitle: string;

--- a/apps/public_www/src/components/pages/landing-pages/landing-page.tsx
+++ b/apps/public_www/src/components/pages/landing-pages/landing-page.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from 'react';
 
-import type {
-  Locale,
-  LandingPageLocaleContent,
-  SiteContent,
+import {
+  MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR,
+  type Locale,
+  type LandingPageLocaleContent,
+  type SiteContent,
 } from '@/content';
 import { PageLayout } from '@/components/shared/page-layout';
 import { AboutUsIdaCoach } from '@/components/sections/about-us-ida-coach';
@@ -23,6 +24,8 @@ import type {
   LandingPageStructuredDataContent,
 } from '@/lib/events-data';
 
+export type LandingPageLayoutVariant = 'default' | 'book-free-call';
+
 export interface LandingPageProps {
   locale: Locale;
   slug: string;
@@ -34,6 +37,8 @@ export interface LandingPageProps {
   structuredDataContent: LandingPageStructuredDataContent | null;
   /** Optional slot between testimonials and the CTA bridge (e.g. intro-call booking). */
   introCallSectionBeforeCta?: ReactNode;
+  /** Reorders sections for the intro-call landing page (no outline / mid-page CTA strip). */
+  layoutVariant?: LandingPageLayoutVariant;
 }
 
 export function LandingPage({
@@ -46,8 +51,10 @@ export function LandingPage({
   bookingEventContent,
   structuredDataContent,
   introCallSectionBeforeCta,
+  layoutVariant = 'default',
 }: LandingPageProps) {
   const publicSiteConfig = resolvePublicSiteConfig();
+  const heroCtaContent = pageContent.cta ?? MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR;
 
   return (
     <LandingPageRehydrateRoot
@@ -68,45 +75,85 @@ export function LandingPage({
         <LandingPageHeroBridge
           slug={slug}
           content={pageContent.hero}
-          ctaContent={pageContent.cta}
+          ctaContent={heroCtaContent}
           commonContent={siteContent.landingPages.common}
           locale={locale}
           metaTitle={pageContent.meta.title}
           bookingModalContent={siteContent.bookingModal}
           ariaLabel={siteContent.landingPages.common.a11y.heroSectionLabel}
         />
-        <LandingPageOutline
-          content={pageContent.outline}
-          ariaLabel={siteContent.landingPages.common.a11y.outlineSectionLabel}
-        />
-        <LandingPageDescription
-          content={pageContent.description}
-          ariaLabel={siteContent.landingPages.common.a11y.descriptionSectionLabel}
-        />
-        <LandingPageDetails
-          content={pageContent.details}
-          ariaLabel={siteContent.landingPages.common.a11y.detailsSectionLabel}
-        />
-        <Testimonials
-          content={siteContent.testimonials}
-          commonAccessibility={siteContent.common.accessibility}
-        />
-        {introCallSectionBeforeCta}
-        <LandingPageCtaBridge
-          locale={locale}
-          slug={slug}
-          content={pageContent.cta}
-          commonContent={siteContent.landingPages.common}
-          ariaLabel={siteContent.landingPages.common.a11y.ctaSectionLabel}
-        />
-        <AboutUsIdaCoach
-          content={siteContent.aboutUs.coaches.ida}
-          ariaLabel={siteContent.landingPages.common.a11y.aboutUsIdaCoachSectionLabel}
-        />
-        <LandingPageFaq
-          content={pageContent.faq}
-          ariaLabel={siteContent.landingPages.common.a11y.faqSectionLabel}
-        />
+        {layoutVariant === 'book-free-call' ? (
+          <>
+            <LandingPageDetails
+              content={pageContent.details}
+              ariaLabel={siteContent.landingPages.common.a11y.detailsSectionLabel}
+            />
+            {introCallSectionBeforeCta}
+            <LandingPageDescription
+              content={pageContent.description}
+              ariaLabel={
+                siteContent.landingPages.common.a11y.descriptionSectionLabel
+              }
+            />
+            <Testimonials
+              content={siteContent.testimonials}
+              commonAccessibility={siteContent.common.accessibility}
+            />
+            <AboutUsIdaCoach
+              content={siteContent.aboutUs.coaches.ida}
+              ariaLabel={
+                siteContent.landingPages.common.a11y.aboutUsIdaCoachSectionLabel
+              }
+            />
+            <LandingPageFaq
+              content={pageContent.faq}
+              ariaLabel={siteContent.landingPages.common.a11y.faqSectionLabel}
+            />
+          </>
+        ) : (
+          <>
+            {pageContent.outline ? (
+              <LandingPageOutline
+                content={pageContent.outline}
+                ariaLabel={siteContent.landingPages.common.a11y.outlineSectionLabel}
+              />
+            ) : null}
+            <LandingPageDescription
+              content={pageContent.description}
+              ariaLabel={
+                siteContent.landingPages.common.a11y.descriptionSectionLabel
+              }
+            />
+            <LandingPageDetails
+              content={pageContent.details}
+              ariaLabel={siteContent.landingPages.common.a11y.detailsSectionLabel}
+            />
+            <Testimonials
+              content={siteContent.testimonials}
+              commonAccessibility={siteContent.common.accessibility}
+            />
+            {introCallSectionBeforeCta}
+            {pageContent.cta ? (
+              <LandingPageCtaBridge
+                locale={locale}
+                slug={slug}
+                content={pageContent.cta}
+                commonContent={siteContent.landingPages.common}
+                ariaLabel={siteContent.landingPages.common.a11y.ctaSectionLabel}
+              />
+            ) : null}
+            <AboutUsIdaCoach
+              content={siteContent.aboutUs.coaches.ida}
+              ariaLabel={
+                siteContent.landingPages.common.a11y.aboutUsIdaCoachSectionLabel
+              }
+            />
+            <LandingPageFaq
+              content={pageContent.faq}
+              ariaLabel={siteContent.landingPages.common.a11y.faqSectionLabel}
+            />
+          </>
+        )}
       </PageLayout>
       <LandingPageEventJsonLd
         locale={locale}

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-cta.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-cta.tsx
@@ -8,7 +8,7 @@ import { LandingPageBookingCtaAction } from '@/components/sections/landing-pages
 import type {
   BookingModalContent,
   LandingPagesCommonContent,
-  LandingPageLocaleContent,
+  LandingPageCtaContent,
   Locale,
 } from '@/content';
 import type { EventBookingModalPayload } from '@/lib/events-data';
@@ -16,7 +16,7 @@ import type { EventBookingModalPayload } from '@/lib/events-data';
 interface LandingPageCtaProps {
   locale: Locale;
   slug: string;
-  content: LandingPageLocaleContent['cta'];
+  content: LandingPageCtaContent;
   eyebrow?: string | null;
   ctaPriceLabel?: string;
   commonContent: LandingPagesCommonContent;

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-hero.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-hero.tsx
@@ -19,6 +19,7 @@ import { LandingPageBookingCtaAction } from '@/components/sections/landing-pages
 import type {
   BookingModalContent,
   LandingPagesCommonContent,
+  LandingPageCtaContent,
   LandingPageLocaleContent,
   Locale,
 } from '@/content';
@@ -35,7 +36,7 @@ import {
 interface LandingPageHeroProps {
   slug: string;
   content: LandingPageLocaleContent['hero'];
-  ctaContent: LandingPageLocaleContent['cta'];
+  ctaContent: LandingPageCtaContent;
   ctaPriceLabel?: string;
   commonContent: LandingPagesCommonContent;
   locale: Locale;

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-outline.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-outline.tsx
@@ -3,10 +3,10 @@ import { SectionHeader } from '@/components/sections/shared/section-header';
 import { SectionShell } from '@/components/sections/shared/section-shell';
 import { renderQuotedDescriptionText } from '@/components/sections/shared/render-highlighted-text';
 import { LandingPageInlineCalendarCta } from '@/components/sections/landing-pages/shared/landing-page-inline-calendar-cta';
-import type { LandingPageLocaleContent } from '@/content';
+import type { LandingPageOutlineContent } from '@/content';
 
 interface LandingPageOutlineProps {
-  content: LandingPageLocaleContent['outline'];
+  content: LandingPageOutlineContent;
   ariaLabel?: string;
 }
 

--- a/apps/public_www/src/components/sections/landing-pages/shared/landing-page-booking-cta-action.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/shared/landing-page-booking-cta-action.tsx
@@ -12,7 +12,7 @@ import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import type {
   BookingModalContent,
   LandingPagesCommonContent,
-  LandingPageLocaleContent,
+  LandingPageCtaContent,
   Locale,
 } from '@/content';
 import { formatContentTemplate } from '@/content/content-field-utils';
@@ -40,7 +40,7 @@ const EventThankYouModal = dynamic(
 export interface LandingPageBookingCtaActionProps {
   locale: Locale;
   slug: string;
-  content: LandingPageLocaleContent['cta'];
+  content: LandingPageCtaContent;
   ctaPriceLabel?: string;
   commonContent: LandingPagesCommonContent;
   bookingPayload: EventBookingModalPayload | null;
@@ -61,7 +61,7 @@ export type LandingPageSharedCtaProps = Omit<
 >;
 
 function resolveCtaLabel(
-  content: LandingPageLocaleContent['cta'],
+  content: LandingPageCtaContent,
   commonContent: LandingPagesCommonContent,
   ctaPriceLabel: string | undefined,
 ): string {
@@ -79,7 +79,7 @@ function resolveCtaLabel(
 }
 
 function resolveFullyBookedCtaLabel(
-  content: LandingPageLocaleContent['cta'],
+  content: LandingPageCtaContent,
   commonContent: LandingPagesCommonContent,
   overrideLabel: string | undefined,
 ): string {

--- a/apps/public_www/src/content/index.ts
+++ b/apps/public_www/src/content/index.ts
@@ -170,6 +170,10 @@ export interface LandingPageLocaleContent {
 
 export type LandingPageCtaContent = NonNullable<LandingPageLocaleContent['cta']>;
 
+export type LandingPageOutlineContent = NonNullable<
+  LandingPageLocaleContent['outline']
+>;
+
 /**
  * Minimal CTA fields for calendar context + hero fallbacks when a landing page
  * omits `cta` in JSON (e.g. book-a-free-call uses hero anchor CTAs only).

--- a/apps/public_www/src/content/index.ts
+++ b/apps/public_www/src/content/index.ts
@@ -100,7 +100,7 @@ export interface LandingPageLocaleContent {
     ctaAnchorHref?: string;
     ctaAnchorLabel?: string;
   };
-  outline: {
+  outline?: {
     eyebrow?: string;
     title: string;
     description: string;
@@ -132,7 +132,7 @@ export interface LandingPageLocaleContent {
       answer: string;
     }>;
   };
-  cta: {
+  cta?: {
     eyebrow?: string;
     eyebrowShowLogo?: boolean;
     title: string;
@@ -167,6 +167,19 @@ export interface LandingPageLocaleContent {
     loadErrorMessage?: string;
   };
 }
+
+export type LandingPageCtaContent = NonNullable<LandingPageLocaleContent['cta']>;
+
+/**
+ * Minimal CTA fields for calendar context + hero fallbacks when a landing page
+ * omits `cta` in JSON (e.g. book-a-free-call uses hero anchor CTAs only).
+ */
+export const MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR: LandingPageCtaContent = {
+  eyebrow: '',
+  title: '',
+  description: '',
+  buttonLabel: '',
+};
 
 /** Intro-call booking block; present only on landing pages that embed the picker (e.g. book-a-free-call). */
 export type LandingPageIntroCallContent = NonNullable<

--- a/apps/public_www/src/content/landing-pages/book-a-free-call.json
+++ b/apps/public_www/src/content/landing-pages/book-a-free-call.json
@@ -17,12 +17,6 @@
       "ctaAnchorHref": "#intro-call-booking",
       "ctaAnchorLabel": "Pick a time"
     },
-    "outline": {
-      "eyebrow": "What you'll get",
-      "title": "A real conversation — in just 15 minutes",
-      "description": "This call is for parents who want clarity before committing to anything longer.\n\nYou'll get focused time with Ida, a clear sense of how Evolve Sprouts works, and honest guidance on next steps — whether or not you decide to continue.",
-      "highlightPhrase": "Evolve Sprouts"
-    },
     "description": {
       "eyebrow": "How it works",
       "title": "What this call is (and isn't)",
@@ -93,14 +87,6 @@
         }
       ]
     },
-    "cta": {
-      "eyebrow": "Ready when you are",
-      "title": "Pick a time below",
-      "description": "Choose a slot, add your details, and we will send a confirmation email with your call time.",
-      "buttonLabel": "Scroll to booking",
-      "ctaAnchorHref": "#intro-call-booking",
-      "ctaAnchorLabel": "Scroll to booking"
-    },
     "introCall": {
       "bookingSectionTitle": "Pick a time that works for you",
       "emptySlotsMessage": "No times available in this window — please reach out on WhatsApp.",
@@ -135,12 +121,6 @@
       "imageMaxWidthPercent": 90,
       "ctaAnchorHref": "#intro-call-booking",
       "ctaAnchorLabel": "选择时间"
-    },
-    "outline": {
-      "eyebrow": "您将获得",
-      "title": "真实对话——只需 15 分钟",
-      "description": "这通电话适合希望在投入更长时间前先厘清方向的家长。\n\n您将与 Ida 专注交流，了解 Evolve Sprouts 的运作方式，并获得诚实的下一步建议——无论您是否继续。",
-      "highlightPhrase": "Evolve Sprouts"
     },
     "description": {
       "eyebrow": "流程说明",
@@ -212,14 +192,6 @@
         }
       ]
     },
-    "cta": {
-      "eyebrow": "准备好就开始",
-      "title": "在下方选择时间",
-      "description": "选择时段、填写资料后，您将收到含通话时间的确认邮件。",
-      "buttonLabel": "前往预约",
-      "ctaAnchorHref": "#intro-call-booking",
-      "ctaAnchorLabel": "前往预约"
-    },
     "introCall": {
       "bookingSectionTitle": "选择适合您的时间",
       "emptySlotsMessage": "该时段暂无可预约时间 — 请通过 WhatsApp 联系我们。",
@@ -254,12 +226,6 @@
       "imageMaxWidthPercent": 90,
       "ctaAnchorHref": "#intro-call-booking",
       "ctaAnchorLabel": "揀時間"
-    },
-    "outline": {
-      "eyebrow": "你會得到",
-      "title": "真實對話——只需 15 分鐘",
-      "description": "呢通電話適合想喺投入更長時間前先釐清方向嘅家長。\n\n你會同 Ida 專注傾偈，了解 Evolve Sprouts 點運作，並獲得誠實嘅下一步建議——無論你之後繼唔繼續。",
-      "highlightPhrase": "Evolve Sprouts"
     },
     "description": {
       "eyebrow": "流程說明",
@@ -330,14 +296,6 @@
           "answer": "英文同粵語都得——揀你最舒服嘅就得。"
         }
       ]
-    },
-    "cta": {
-      "eyebrow": "準備好就開始",
-      "title": "喺下面揀時間",
-      "description": "揀時段、填資料之後，你會收到有通話時間嘅確認電郵。",
-      "buttonLabel": "去預約",
-      "ctaAnchorHref": "#intro-call-booking",
-      "ctaAnchorLabel": "去預約"
     },
     "introCall": {
       "bookingSectionTitle": "揀個啱你嘅時間",

--- a/apps/public_www/src/lib/events-data.ts
+++ b/apps/public_www/src/lib/events-data.ts
@@ -406,7 +406,7 @@ function resolveBookingTopicsFieldFromLandingPage(
   }
 
   const pageLocale = getLandingPageContent(landingPageSlug, locale);
-  const field = pageLocale?.cta.bookingTopicsField;
+  const field = pageLocale?.cta?.bookingTopicsField;
   if (!field) {
     return undefined;
   }

--- a/apps/public_www/src/lib/landing-page-calendar-context.tsx
+++ b/apps/public_www/src/lib/landing-page-calendar-context.tsx
@@ -3,7 +3,12 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 import type { LandingPageSharedCtaProps } from '@/components/sections/landing-pages/shared/landing-page-booking-cta-action';
-import type { Locale, LandingPageLocaleContent, SiteContent } from '@/content';
+import {
+  MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR,
+  type Locale,
+  type LandingPageLocaleContent,
+  type SiteContent,
+} from '@/content';
 import { buildLandingPageSharedCtaPropsFromCalendar } from '@/lib/landing-page-cta-resolve';
 import type {
   LandingPageBookingEventContent,
@@ -70,7 +75,7 @@ export function LandingPageRehydrateRoot({
       buildLandingPageSharedCtaPropsFromCalendar(
         locale,
         slug,
-        pageContent.cta,
+        pageContent.cta ?? MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR,
         siteContent,
         pageContent.meta.title,
         heroEventContent,
@@ -80,7 +85,7 @@ export function LandingPageRehydrateRoot({
     [
       locale,
       slug,
-      pageContent.cta,
+      pageContent.cta ?? MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR,
       pageContent.meta.title,
       siteContent,
       heroEventContent,

--- a/apps/public_www/src/lib/landing-page-calendar-context.tsx
+++ b/apps/public_www/src/lib/landing-page-calendar-context.tsx
@@ -70,12 +70,15 @@ export function LandingPageRehydrateRoot({
     initialStructuredData,
   });
 
+  const landingPageCtaForCalendar =
+    pageContent.cta ?? MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR;
+
   const sharedCtaProps = useMemo(
     () =>
       buildLandingPageSharedCtaPropsFromCalendar(
         locale,
         slug,
-        pageContent.cta ?? MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR,
+        landingPageCtaForCalendar,
         siteContent,
         pageContent.meta.title,
         heroEventContent,
@@ -85,7 +88,7 @@ export function LandingPageRehydrateRoot({
     [
       locale,
       slug,
-      pageContent.cta ?? MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR,
+      landingPageCtaForCalendar,
       pageContent.meta.title,
       siteContent,
       heroEventContent,

--- a/apps/public_www/src/lib/landing-page-cta-resolve.ts
+++ b/apps/public_www/src/lib/landing-page-cta-resolve.ts
@@ -3,7 +3,12 @@ import type {
   LandingPageBookingEventContent,
   LandingPageHeroEventContent,
 } from '@/lib/events-data';
-import type { LandingPageLocaleContent, Locale, SiteContent } from '@/content';
+import {
+  MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR,
+  type LandingPageLocaleContent,
+  type Locale,
+  type SiteContent,
+} from '@/content';
 import { formatContentTemplate } from '@/content/content-field-utils';
 import { buildWhatsappPrefilledHref } from '@/lib/site-config';
 
@@ -66,31 +71,32 @@ export function resolveFullyBookedWaitlistHref(
 export function buildLandingPageSharedCtaPropsFromCalendar(
   locale: Locale,
   slug: string,
-  pageContentCta: LandingPageLocaleContent['cta'],
+  pageContentCta: LandingPageLocaleContent['cta'] | undefined,
   siteContent: SiteContent,
   heroTitleFallback: string,
   heroEventContent: LandingPageHeroEventContent | null,
   bookingEventContent: LandingPageBookingEventContent | null,
   thankYouWhatsappHref: string | undefined,
 ): LandingPageSharedCtaProps {
+  const cta = pageContentCta ?? MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR;
   const isFullyBooked = bookingEventContent?.status === 'fully_booked';
   const waitlistEventTitle = heroEventContent?.title ?? heroTitleFallback;
   const fullyBookedWaitlistHref = resolveFullyBookedWaitlistHref(
     isFullyBooked,
     siteContent.navbar.bookNow.href,
     siteContent.navbar.bookNow.phoneNumber,
-    pageContentCta.fullyBookedWaitlistMessageTemplate,
+    cta.fullyBookedWaitlistMessageTemplate,
     waitlistEventTitle,
   );
   return {
     locale,
     slug,
-    content: pageContentCta,
+    content: cta,
     ctaPriceLabel: bookingEventContent?.ctaPriceLabel,
     commonContent: siteContent.landingPages.common,
     bookingPayload: bookingEventContent?.bookingPayload ?? null,
     isFullyBooked,
-    fullyBookedCtaLabel: pageContentCta.fullyBookedButtonLabel,
+    fullyBookedCtaLabel: cta.fullyBookedButtonLabel,
     fullyBookedWaitlistHref,
     bookingModalContent: siteContent.bookingModal,
     thankYouWhatsappHref,

--- a/apps/public_www/tests/components/pages/landing-pages/book-a-free-call.test.tsx
+++ b/apps/public_www/tests/components/pages/landing-pages/book-a-free-call.test.tsx
@@ -76,6 +76,42 @@ describe('BookFreeCallLandingPage', () => {
     spy.mockRestore();
   });
 
+  it('lays out sections: before you book → pick a time → how it works before testimonials', () => {
+    render(
+      <BookFreeCallLandingPage
+        locale='en'
+        pagePath='/book-a-free-call'
+        siteContent={enContent}
+        pageContent={pageContent}
+      />,
+    );
+
+    const beforeYouBookHeading = screen.getByRole('heading', {
+      name: bookAFreeCall.en.details.title,
+    });
+    const bookingRegion = screen.getByRole('region', {
+      name: bookAFreeCall.en.introCall.bookingSectionTitle,
+    });
+    const howItWorksHeading = screen.getByRole('heading', {
+      name: bookAFreeCall.en.description.title,
+    });
+    const testimonialsHeading = screen.getByRole('heading', {
+      name: enContent.testimonials.title,
+    });
+
+    expect(
+      beforeYouBookHeading.compareDocumentPosition(bookingRegion),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      bookingRegion.compareDocumentPosition(howItWorksHeading),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      howItWorksHeading.compareDocumentPosition(testimonialsHeading),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    expect(document.getElementById('landing-page-cta')).toBeNull();
+  });
+
   it('renders hero anchor CTA to the booking section and no booking modal shell', () => {
     render(
       <BookFreeCallLandingPage

--- a/apps/public_www/tests/content/landing-pages/book-a-free-call.test.ts
+++ b/apps/public_www/tests/content/landing-pages/book-a-free-call.test.ts
@@ -9,13 +9,19 @@ describe('book-a-free-call landing page locale JSON', () => {
     expect(Object.keys(bookAFreeCall['zh-HK'].introCall).sort()).toEqual(keysEn);
   });
 
-  it('includes anchor CTA href and label for hero and CTA section in every locale', () => {
+  it('includes anchor CTA href and label on hero in every locale', () => {
     for (const loc of ['en', 'zh-CN', 'zh-HK'] as const) {
       const block = bookAFreeCall[loc];
       expect(block.hero.ctaAnchorHref).toBe('#intro-call-booking');
       expect(block.hero.ctaAnchorLabel?.trim()).toBeTruthy();
-      expect(block.cta.ctaAnchorHref).toBe('#intro-call-booking');
-      expect(block.cta.ctaAnchorLabel?.trim()).toBeTruthy();
+    }
+  });
+
+  it('does not define outline or cta blocks (hero anchors only)', () => {
+    for (const loc of ['en', 'zh-CN', 'zh-HK'] as const) {
+      const block = bookAFreeCall[loc] as Record<string, unknown>;
+      expect(block.outline).toBeUndefined();
+      expect(block.cta).toBeUndefined();
     }
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `/book-a-free-call` landing page now renders sections in product order: hero → Before you book → Pick a time → How it works → Testimonials → Your coach → FAQ. The duplicate mid-page “Pick a time below” CTA strip and the outline block are removed for this page only.

## Changes

- **Layout**: Added `layoutVariant='book-free-call'` on `BookFreeCallLandingPage`, implemented in shared `LandingPage` so other landing pages keep the previous order.
- **Content**: Removed unused `outline` and `cta` objects from `book-a-free-call.json` for all locales (hero retains `#intro-call-booking` anchor CTAs).
- **Types/runtime**: `outline` and `cta` are optional on `LandingPageLocaleContent`; when `cta` is absent, `MINIMAL_LANDING_PAGE_CTA_FOR_CALENDAR` feeds hero/calendar context so TypeScript and booking-topic resolution stay safe.
- **Tests**: Updated JSON contract tests and added a DOM-order assertion on the page component.

## Validation

- `bash scripts/validate-cursorrules.sh` passed.
- `npm run test` was not executed here (Node/npm unavailable in this environment); CI should run the public_www Vitest suite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f6e1945-27d2-4284-8cad-b96bddc6a412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f6e1945-27d2-4284-8cad-b96bddc6a412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

