### PR TITLE
Book free call landing: English-only intro call copy

### DIFF
--- a/apps/public_www/src/content/landing-pages/book-a-free-call.json
+++ b/apps/public_www/src/content/landing-pages/book-a-free-call.json
@@ -49,7 +49,7 @@
         {
           "icon": "🌏",
           "title": "Languages",
-          "description": "We can run the call in English or Cantonese — whichever you prefer."
+          "description": "The intro call is conducted in English."
         },
         {
           "icon": "📅",
@@ -82,8 +82,8 @@
           "answer": "We will explain how the programme works if it is relevant. There is no hard sell — the goal is to help you decide what is right for your family."
         },
         {
-          "question": "What languages do you speak on the call?",
-          "answer": "English and Cantonese are both fine — choose what is most comfortable for you."
+          "question": "What language is the intro call in?",
+          "answer": "The intro call is in English."
         }
       ]
     },
@@ -154,7 +154,7 @@
         {
           "icon": "🌏",
           "title": "语言",
-          "description": "可使用英语或粤语——按您最舒适的语言进行。"
+          "description": "介绍通话以英语进行。"
         },
         {
           "icon": "📅",
@@ -187,8 +187,8 @@
           "answer": "若相关，我们会说明课程如何运作。没有强硬推销——目标是帮助您判断什么对家庭最合适。"
         },
         {
-          "question": "通话可用哪些语言？",
-          "answer": "英语与粤语均可，请选择您最自在的语言。"
+          "question": "介绍通话使用什么语言？",
+          "answer": "介绍通话以英语进行。"
         }
       ]
     },
@@ -259,7 +259,7 @@
         {
           "icon": "🌏",
           "title": "語言",
-          "description": "可用英文或粵語——跟住你最自在嘅語言。"
+          "description": "介紹通話以英文進行。"
         },
         {
           "icon": "📅",
@@ -292,8 +292,8 @@
           "answer": "若相關，我哋會解釋課程點運作。冇硬銷——目標係幫你判斷咩先最啱你家庭。"
         },
         {
-          "question": "通話可用咩語言？",
-          "answer": "英文同粵語都得——揀你最舒服嘅就得。"
+          "question": "介紹通話用咩語言？",
+          "answer": "介紹通話以英文進行。"
         }
       ]
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `/book-a-free-call` landing page locale content so it no longer presents Cantonese as an option for the intro conversation.

## Changes

- **Details — Languages:** States the intro call is conducted in English (`en`, `zh-CN`, `zh-HK`).
- **FAQ:** Replaced the bilingual-choice Q&A with a single question/answer that the intro call is in English, with aligned translations for Simplified and Traditional Chinese locales.

## Testing

- `bash scripts/validate-cursorrules.sh` (passed).
- Vitest for `apps/public_www` was not run in this environment (Node/npm unavailable on the runner).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddd6ddfe-c984-48f9-a30b-d8643f99cd61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddd6ddfe-c984-48f9-a30b-d8643f99cd61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

