### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,54 @@ The repository enforces a `.cursorrules` contract via
 `scripts/validate-cursorrules.sh` (wired into pre-commit and CI lint checks).
 This does not alter runtime prompt precedence, but it blocks merges when
 mandatory `.cursorrules` integration anchors are removed or weakened.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Path | Dev command | Port |
+|---------|------|-------------|------|
+| Admin Web (Next.js) | `apps/admin_web/` | `npm run dev -- --webpack --port 3000` | 3000 |
+| Public Website (Next.js) | `apps/public_www/` | `npm run dev -- --port 3001` | 3001 |
+| Backend (Python/Lambda) | `backend/` | Tests only (`pytest tests/`) | N/A |
+| CDK Infrastructure (TS) | `backend/infrastructure/` | `npx tsc --noEmit` | N/A |
+
+### Running lint
+
+- **Python backend**: `ruff check backend/ tests/ --config=backend/pyproject.toml`
+- **Admin web**: `cd apps/admin_web && npm run lint`
+- **Public website**: `cd apps/public_www && npm run lint`
+- **Pre-commit (all)**: `pre-commit run --all-files` (requires `pre-commit install` first)
+
+### Running tests
+
+- **Python backend**: `pytest tests/ -x` (926 tests, ~7s, no DB needed for unit tests)
+- **Admin web**: `cd apps/admin_web && npx vitest run` (443 tests)
+- **Public website**: `cd apps/public_www && npx vitest run` (739 tests)
+- **CDK infra**: `cd backend/infrastructure && npm run test:infra`
+
+### Environment variables for dev servers
+
+- **Admin web** requires Cognito env vars (`NEXT_PUBLIC_COGNITO_*`) for auth
+  flows. Without them, the app renders but sign-in won't work.
+- **Public website** requires `NEXT_PUBLIC_SITE_ORIGIN` and
+  `NEXT_PUBLIC_EMAIL` at minimum. Create `apps/public_www/.env.local` with:
+  ```
+  NEXT_PUBLIC_SITE_ORIGIN=http://localhost:3001
+  NEXT_PUBLIC_EMAIL=dev@example.com
+  NEXT_PUBLIC_BUSINESS_NAME=Evolve Sprouts
+  NEXT_PUBLIC_BUSINESS_ADDRESS=Hong Kong
+  NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+  NEXT_PUBLIC_API_BASE_URL=/www
+  ```
+
+### Non-obvious caveats
+
+- Admin web uses `--webpack` flag for dev/build (required for SVGR support):
+  `next dev --webpack` / `next build --webpack`.
+- The backend has no running server locally; it is Lambda-based. Tests use
+  `moto` to mock AWS services.
+- `backend/infrastructure` has a `postinstall` script that patches bundled CDK
+  dependencies; `npm ci` is sufficient.
+- Python formatting must use `pre-commit run ruff-format --all-files` before
+  committing any Python changes (per `.cursorrules`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment guidance for future cloud agents.

### What's included

- **Services overview table** — dev commands and ports for admin_web, public_www, backend, and CDK infrastructure
- **Lint commands** — per-service lint instructions
- **Test commands** — per-service test instructions with expected counts
- **Environment variables** — minimum `.env.local` config needed for public_www dev server
- **Non-obvious caveats** — webpack flag requirement, Lambda-only backend, CDK postinstall behavior, ruff formatting rule

### Evidence of working environment

[Public website homepage running on localhost:3001](https://cursor.com/agents/bc-852b3ead-e208-4221-9e22-6a2945f061fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublic_www_homepage.webp)
[Admin web app running on localhost:3000](https://cursor.com/agents/bc-852b3ead-e208-4221-9e22-6a2945f061fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_web_signin.webp)

### Test results

- Python backend: 926 passed, 12 skipped
- Admin web: 443 passed (77 test files)
- Public website: 739 passed (154 test files)
- All lints pass (ruff, ESLint admin_web, ESLint public_www)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-852b3ead-e208-4221-9e22-6a2945f061fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-852b3ead-e208-4221-9e22-6a2945f061fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

