### PR TITLE
Book-a-free-call: hash navigation, slot picker UX, 30-minute intro slot cadence

### DIFF
--- a/apps/public_www/src/app/styles/original/components-core.css
+++ b/apps/public_www/src/app/styles/original/components-core.css
@@ -660,6 +660,7 @@
 
   .es-navbar-offset {
     height: 115px;
+    --es-public-navbar-scroll-margin: 115px;
     background-color: var(--es-color-surface-white, #FFFFFF);
     overflow-anchor: none;
   }

--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -1138,14 +1138,7 @@
   .es-my-best-auntie-booking-section,
   .es-book-a-free-call-booking-section {
     background-color: var(--figma-colors-frame-2147235259, #FFEEE3);
-    scroll-margin-top: 7rem;
-  }
-
-  @media (min-width: 1024px) {
-    .es-my-best-auntie-booking-section,
-    .es-book-a-free-call-booking-section {
-      scroll-margin-top: 7.5rem;
-    }
+    scroll-margin-top: var(--es-public-navbar-scroll-margin, 7rem);
   }
 
   #consultations-booking .es-btn--selection.es-btn--state-active {

--- a/apps/public_www/src/app/styles/original/components-sections.css
+++ b/apps/public_www/src/app/styles/original/components-sections.css
@@ -24,6 +24,7 @@
   .es-contact-faq-section,
   .es-my-journey-section,
   .es-testimonials-section,
+  .es-book-a-free-call-good-to-know-section,
   .es-faq-section,
   .es-free-guides-and-resources-hero-section,
   .es-free-resources-section,
@@ -46,6 +47,7 @@
   .es-contact-faq-section,
   .es-my-journey-section,
   .es-testimonials-section,
+  .es-book-a-free-call-good-to-know-section,
   .es-faq-section,
   .es-free-guides-and-resources-hero-section {
     background-color: var(--es-color-surface-white, #FFFFFF);
@@ -1133,8 +1135,17 @@
     color: var(--es-color-surface-white, #FFFFFF);
   }
 
-  .es-my-best-auntie-booking-section {
+  .es-my-best-auntie-booking-section,
+  .es-book-a-free-call-booking-section {
     background-color: var(--figma-colors-frame-2147235259, #FFEEE3);
+    scroll-margin-top: 7rem;
+  }
+
+  @media (min-width: 1024px) {
+    .es-my-best-auntie-booking-section,
+    .es-book-a-free-call-booking-section {
+      scroll-margin-top: 7.5rem;
+    }
   }
 
   #consultations-booking .es-btn--selection.es-btn--state-active {

--- a/apps/public_www/src/components/pages/landing-pages/landing-page.tsx
+++ b/apps/public_www/src/components/pages/landing-pages/landing-page.tsx
@@ -87,6 +87,7 @@ export function LandingPage({
             <LandingPageDetails
               content={pageContent.details}
               ariaLabel={siteContent.landingPages.common.a11y.detailsSectionLabel}
+              sectionClassName='es-section-bg-overlay es-book-a-free-call-good-to-know-section'
             />
             {introCallSectionBeforeCta}
             <LandingPageDescription

--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -9,24 +9,32 @@ import {
   type KeyboardEvent,
 } from 'react';
 
+import { BOOKING_SELECTOR_CARD_CLASSNAME } from '@/components/sections/shared/booking-selector-layout';
+import { CarouselHorizontalArrowControls } from '@/components/sections/shared/carousel-horizontal-arrow-controls';
 import { CarouselTrack } from '@/components/sections/shared/carousel-track';
-import { EventsLoadingState } from '@/components/sections/shared/events-shared';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { SectionSpinnerStatus } from '@/components/shared/section-spinner-status';
 import type {
   CommonAccessibilityContent,
   LandingPageIntroCallContent,
+  Locale,
 } from '@/content';
+import { formatContentTemplate } from '@/content/content-field-utils';
 import type { IntroCallSlot } from '@/lib/intro-call-slots-api';
 import {
   CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS,
   fetchIntroCallSlots,
 } from '@/lib/intro-call-slots-api';
 import { useHorizontalCarousel } from '@/lib/hooks/use-horizontal-carousel';
-import { PUBLIC_SITE_IANA_TIMEZONE } from '@/lib/site-datetime';
+import {
+  formatPartDateTimeLabel,
+  PUBLIC_SITE_IANA_TIMEZONE,
+} from '@/lib/site-datetime';
 import { trackAnalyticsEvent } from '@/lib/analytics';
 import { resolvePublicSiteConfig } from '@/lib/site-config';
 
 export interface IntroCallSlotPickerProps {
+  locale: Locale;
   commonAccessibility: CommonAccessibilityContent;
   pickerContent: LandingPageIntroCallContent;
   /** Same WhatsApp URL as the booking section (falls back to site config when unset). */
@@ -49,29 +57,11 @@ const DAY_NUM_FORMATTER = new Intl.DateTimeFormat('en-GB', {
   month: 'short',
 });
 
-const SLOT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-});
-
 const WALL_HOUR_FORMATTER = new Intl.DateTimeFormat('en-GB', {
   timeZone: PUBLIC_SITE_IANA_TIMEZONE,
   hour: 'numeric',
   hourCycle: 'h23',
 });
-
-function DateArrowIcon({ direction }: { direction: 'left' | 'right' }) {
-  const rotationClass = direction === 'left' ? 'rotate-180' : '';
-
-  return (
-    <span
-      aria-hidden
-      className={`es-ui-icon-mask es-ui-icon-mask--chevron-right inline-block h-7 w-7 shrink-0 es-text-icon ${rotationClass}`}
-    />
-  );
-}
 
 function ymdForSlot(slot: IntroCallSlot): string {
   const d = new Date(slot.startIso);
@@ -94,6 +84,7 @@ function isMorningSlot(slot: IntroCallSlot): boolean {
 }
 
 export function IntroCallSlotPicker({
+  locale,
   commonAccessibility,
   pickerContent,
   whatsappHref,
@@ -109,6 +100,17 @@ export function IntroCallSlotPicker({
   const [rovingDayIndex, setRovingDayIndex] = useState(0);
   const dayRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const slotRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const slotTimeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale === 'en' ? 'en-HK' : locale, {
+        timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      }),
+    [locale],
+  );
 
   const setStatusBoth = useCallback(
     (next: FetchStatus) => {
@@ -240,19 +242,8 @@ export function IntroCallSlotPicker({
     if (!slot) {
       return '';
     }
-    const start = new Date(slot.startIso);
-    const label = new Intl.DateTimeFormat(undefined, {
-      timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    }).format(start);
-    return label;
-  }, [selectedSlotIso, slots]);
+    return formatPartDateTimeLabel(slot.startIso, locale);
+  }, [locale, selectedSlotIso, slots]);
 
   const handleDayKeyDown = (event: KeyboardEvent, index: number) => {
     if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
@@ -272,7 +263,7 @@ export function IntroCallSlotPicker({
 
   if (status === 'loading' || status === 'idle') {
     return (
-      <EventsLoadingState
+      <SectionSpinnerStatus
         label={pickerContent.loadingLabel}
         testId='intro-call-slots-loading'
       />
@@ -311,16 +302,23 @@ export function IntroCallSlotPicker({
     );
   }
 
+  function slotGridAriaLabel(periodLabel: string): string {
+    return formatContentTemplate(pickerContent.slotGroupAriaLabelTemplate, {
+      period: periodLabel,
+      section: pickerContent.bookingSectionTitle,
+    });
+  }
+
   function renderSlotGrid(slotsChunk: IntroCallSlot[], offsetIndex: number, partLabel: string) {
     return (
       <div
         className='grid grid-cols-2 gap-2 sm:grid-cols-3'
         role='group'
-        aria-label={`${partLabel}: ${pickerContent.bookingSectionTitle}`}
+        aria-label={slotGridAriaLabel(partLabel)}
       >
         {slotsChunk.map((slot, sidx) => {
           const start = new Date(slot.startIso);
-          const label = SLOT_TIME_FORMATTER.format(start);
+          const label = slotTimeFormatter.format(start);
           const pressed = selectedSlotIso === slot.startIso;
           const globalIdx = offsetIndex + sidx;
           return (
@@ -354,7 +352,18 @@ export function IntroCallSlotPicker({
 
   return (
     <div className='space-y-4'>
-      <div className='relative w-full min-w-0 overflow-visible'>
+      <CarouselHorizontalArrowControls
+        showPrevious={Boolean(hasDayNavigation && canScrollDayLeft)}
+        showNext={Boolean(hasDayNavigation && canScrollDayRight)}
+        onPrevious={() => {
+          scrollDayCarouselByDirection('prev');
+        }}
+        onNext={() => {
+          scrollDayCarouselByDirection('next');
+        }}
+        previousAriaLabel={pickerContent.scrollDatesLeftAriaLabel}
+        nextAriaLabel={pickerContent.scrollDatesRightAriaLabel}
+      >
         <CarouselTrack
           carouselRef={dayCarouselRef}
           testId='intro-call-day-carousel'
@@ -392,43 +401,15 @@ export function IntroCallSlotPicker({
                   setSelectedSlotIso(null);
                 }}
                 onKeyDown={(e) => handleDayKeyDown(e, idx)}
-                className='w-[140px] shrink-0 snap-center text-left text-sm sm:w-[168px]'
+                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} w-[140px] shrink-0 snap-center text-left text-sm sm:w-[168px]`}
               >
                 <div className='font-semibold'>{wd}</div>
-                <div className='text-slate-600'>{dm}</div>
+                <div className='text-sm es-text-neutral-strong'>{dm}</div>
               </ButtonPrimitive>
             );
           })}
         </CarouselTrack>
-
-        {hasDayNavigation && canScrollDayLeft ? (
-          <ButtonPrimitive
-            variant='control'
-            type='button'
-            onClick={() => {
-              scrollDayCarouselByDirection('prev');
-            }}
-            aria-label={pickerContent.scrollDatesLeftAriaLabel}
-            className='absolute left-0 top-1/2 z-20 hidden -translate-x-1/2 -translate-y-1/2 md:flex'
-          >
-            <DateArrowIcon direction='left' />
-          </ButtonPrimitive>
-        ) : null}
-
-        {hasDayNavigation && canScrollDayRight ? (
-          <ButtonPrimitive
-            variant='control'
-            type='button'
-            onClick={() => {
-              scrollDayCarouselByDirection('next');
-            }}
-            aria-label={pickerContent.scrollDatesRightAriaLabel}
-            className='absolute right-0 top-1/2 z-20 hidden translate-x-1/2 -translate-y-1/2 md:flex'
-          >
-            <DateArrowIcon direction='right' />
-          </ButtonPrimitive>
-        ) : null}
-      </div>
+      </CarouselHorizontalArrowControls>
 
       {resolvedDayYmd && daySlots.length > 0 ? (
         <div className='space-y-4'>

--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -9,6 +9,9 @@ import {
   type KeyboardEvent,
 } from 'react';
 
+import { CarouselTrack } from '@/components/sections/shared/carousel-track';
+import { EventsLoadingState } from '@/components/sections/shared/events-shared';
+import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import type {
   CommonAccessibilityContent,
   LandingPageIntroCallContent,
@@ -18,6 +21,7 @@ import {
   CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS,
   fetchIntroCallSlots,
 } from '@/lib/intro-call-slots-api';
+import { useHorizontalCarousel } from '@/lib/hooks/use-horizontal-carousel';
 import { PUBLIC_SITE_IANA_TIMEZONE } from '@/lib/site-datetime';
 import { trackAnalyticsEvent } from '@/lib/analytics';
 import { resolvePublicSiteConfig } from '@/lib/site-config';
@@ -52,6 +56,23 @@ const SLOT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
   hour12: false,
 });
 
+const WALL_HOUR_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+  hour: 'numeric',
+  hourCycle: 'h23',
+});
+
+function DateArrowIcon({ direction }: { direction: 'left' | 'right' }) {
+  const rotationClass = direction === 'left' ? 'rotate-180' : '';
+
+  return (
+    <span
+      aria-hidden
+      className={`es-ui-icon-mask es-ui-icon-mask--chevron-right inline-block h-7 w-7 shrink-0 es-text-icon ${rotationClass}`}
+    />
+  );
+}
+
 function ymdForSlot(slot: IntroCallSlot): string {
   const d = new Date(slot.startIso);
   return new Intl.DateTimeFormat('en-CA', {
@@ -60,6 +81,16 @@ function ymdForSlot(slot: IntroCallSlot): string {
     month: '2-digit',
     day: '2-digit',
   }).format(d);
+}
+
+function wallClockHourFromIso(iso: string): number {
+  const parts = WALL_HOUR_FORMATTER.formatToParts(new Date(iso));
+  const hourPart = parts.find((p) => p.type === 'hour');
+  return hourPart ? Number.parseInt(hourPart.value, 10) : 0;
+}
+
+function isMorningSlot(slot: IntroCallSlot): boolean {
+  return wallClockHourFromIso(slot.startIso) < 12;
 }
 
 export function IntroCallSlotPicker({
@@ -150,6 +181,19 @@ export function IntroCallSlotPicker({
     [slotsByDay],
   );
 
+  const {
+    carouselRef: dayCarouselRef,
+    hasNavigation: hasDayNavigation,
+    canScrollPrevious: canScrollDayLeft,
+    canScrollNext: canScrollDayRight,
+    scrollByDirection: scrollDayCarouselByDirection,
+    scrollItemIntoView,
+  } = useHorizontalCarousel<HTMLDivElement>({
+    itemCount: dayKeys.length,
+    minItemsForNavigation: 3,
+    loop: false,
+  });
+
   const resolvedDayYmd = useMemo(() => {
     if (dayKeys.length === 0) {
       return null;
@@ -165,7 +209,24 @@ export function IntroCallSlotPicker({
     [dayKeys.length, rovingDayIndex],
   );
 
-  const daySlots = resolvedDayYmd ? slotsByDay.get(resolvedDayYmd) ?? [] : [];
+  useEffect(() => {
+    const el = dayRefs.current[safeRovingDayIndex];
+    scrollItemIntoView(el);
+  }, [resolvedDayYmd, safeRovingDayIndex, scrollItemIntoView]);
+
+  const daySlots = useMemo(
+    () => (resolvedDayYmd ? slotsByDay.get(resolvedDayYmd) ?? [] : []),
+    [resolvedDayYmd, slotsByDay],
+  );
+  const morningSlots = useMemo(
+    () => daySlots.filter((s) => isMorningSlot(s)),
+    [daySlots],
+  );
+  const afternoonSlots = useMemo(
+    () => daySlots.filter((s) => !isMorningSlot(s)),
+    [daySlots],
+  );
+
   const whatsappUrl =
     whatsappHref?.trim()
     || resolvePublicSiteConfig().whatsappUrl?.trim()
@@ -211,9 +272,10 @@ export function IntroCallSlotPicker({
 
   if (status === 'loading' || status === 'idle') {
     return (
-      <p className='es-type-body' role='status'>
-        {commonAccessibility.loadingLabel ?? 'Loading…'}
-      </p>
+      <EventsLoadingState
+        label={pickerContent.loadingLabel}
+        testId='intro-call-slots-loading'
+      />
     );
   }
 
@@ -249,87 +311,147 @@ export function IntroCallSlotPicker({
     );
   }
 
-  return (
-    <div className='space-y-4'>
+  function renderSlotGrid(slotsChunk: IntroCallSlot[], offsetIndex: number, partLabel: string) {
+    return (
       <div
-        className='flex gap-2 overflow-x-auto pb-2 snap-x snap-mandatory'
+        className='grid grid-cols-2 gap-2 sm:grid-cols-3'
         role='group'
-        aria-label={pickerContent.bookingSectionTitle}
+        aria-label={`${partLabel}: ${pickerContent.bookingSectionTitle}`}
       >
-        {dayKeys.map((ymd, idx) => {
-          const count = slotsByDay.get(ymd)?.length ?? 0;
-          if (count === 0) {
-            return null;
-          }
-          const sample = slotsByDay.get(ymd)?.[0];
-          if (!sample) {
-            return null;
-          }
-          const d = new Date(sample.startIso);
-          const wd = DAY_STRIP_FORMATTER.format(d);
-          const dm = DAY_NUM_FORMATTER.format(d);
-          const isSelected = ymd === resolvedDayYmd;
+        {slotsChunk.map((slot, sidx) => {
+          const start = new Date(slot.startIso);
+          const label = SLOT_TIME_FORMATTER.format(start);
+          const pressed = selectedSlotIso === slot.startIso;
+          const globalIdx = offsetIndex + sidx;
           return (
-            <button
-              key={ymd}
+            <ButtonPrimitive
+              key={slot.startIso}
               type='button'
-              ref={(el) => {
-                dayRefs.current[idx] = el;
+              buttonRef={(el) => {
+                slotRefs.current[globalIdx] = el;
               }}
-              tabIndex={safeRovingDayIndex === idx ? 0 : -1}
-              aria-pressed={isSelected}
+              variant='selection'
+              state={pressed ? 'active' : 'inactive'}
+              aria-pressed={pressed}
+              className='rounded-md px-2 py-2 text-sm'
               onClick={() => {
-                setCursorDayYmd(ymd);
-                setRovingDayIndex(idx);
-                setSelectedSlotIso(null);
+                setSelectedSlotIso(slot.startIso);
+                onSelect(slot);
+                trackAnalyticsEvent('intro_call_slot_selected', {
+                  sectionId: 'intro-call-booking',
+                  ctaLocation: 'intro_call_slot_picker',
+                  params: { slot_start: slot.startIso },
+                });
               }}
-              onKeyDown={(e) => handleDayKeyDown(e, idx)}
-              className={`snap-start shrink-0 rounded-lg border px-3 py-2 text-left text-sm ${
-                isSelected ? 'border-brand bg-brand/5' : 'border-slate-200 bg-white'
-              }`}
             >
-              <div className='font-semibold'>{wd}</div>
-              <div className='text-slate-600'>{dm}</div>
-            </button>
+              {label}
+            </ButtonPrimitive>
           );
         })}
       </div>
+    );
+  }
 
-      {resolvedDayYmd && daySlots.length > 0 ? (
-        <div
-          className='grid grid-cols-2 gap-2 sm:grid-cols-3'
-          role='group'
-          aria-label={pickerContent.bookingSectionTitle}
+  return (
+    <div className='space-y-4'>
+      <div className='relative w-full min-w-0 overflow-visible'>
+        <CarouselTrack
+          carouselRef={dayCarouselRef}
+          testId='intro-call-day-carousel'
+          ariaLabel={pickerContent.bookingSectionTitle}
+          ariaRoleDescription={commonAccessibility.carouselRoleDescription}
+          className='flex min-w-0 gap-2 pb-2'
         >
-          {daySlots.map((slot, sidx) => {
-            const start = new Date(slot.startIso);
-            const label = SLOT_TIME_FORMATTER.format(start);
-            const pressed = selectedSlotIso === slot.startIso;
+          {dayKeys.map((ymd, idx) => {
+            const count = slotsByDay.get(ymd)?.length ?? 0;
+            if (count === 0) {
+              return null;
+            }
+            const sample = slotsByDay.get(ymd)?.[0];
+            if (!sample) {
+              return null;
+            }
+            const d = new Date(sample.startIso);
+            const wd = DAY_STRIP_FORMATTER.format(d);
+            const dm = DAY_NUM_FORMATTER.format(d);
+            const isSelected = ymd === resolvedDayYmd;
             return (
-              <button
-                key={slot.startIso}
+              <ButtonPrimitive
+                key={ymd}
                 type='button'
-                ref={(el) => {
-                  slotRefs.current[sidx] = el;
+                buttonRef={(el) => {
+                  dayRefs.current[idx] = el;
                 }}
-                aria-pressed={pressed}
-                className={`rounded-md border px-2 py-2 text-sm ${
-                  pressed ? 'border-brand bg-brand/5' : 'border-slate-200 bg-white'
-                }`}
+                variant='selection'
+                state={isSelected ? 'active' : 'inactive'}
+                aria-pressed={isSelected}
+                tabIndex={safeRovingDayIndex === idx ? 0 : -1}
                 onClick={() => {
-                  setSelectedSlotIso(slot.startIso);
-                  onSelect(slot);
-                  trackAnalyticsEvent('intro_call_slot_selected', {
-                    sectionId: 'intro-call-booking',
-                    ctaLocation: 'intro_call_slot_picker',
-                    params: { slot_start: slot.startIso },
-                  });
+                  setCursorDayYmd(ymd);
+                  setRovingDayIndex(idx);
+                  setSelectedSlotIso(null);
                 }}
+                onKeyDown={(e) => handleDayKeyDown(e, idx)}
+                className='w-[140px] shrink-0 snap-center text-left text-sm sm:w-[168px]'
               >
-                {label}
-              </button>
+                <div className='font-semibold'>{wd}</div>
+                <div className='text-slate-600'>{dm}</div>
+              </ButtonPrimitive>
             );
           })}
+        </CarouselTrack>
+
+        {hasDayNavigation && canScrollDayLeft ? (
+          <ButtonPrimitive
+            variant='control'
+            type='button'
+            onClick={() => {
+              scrollDayCarouselByDirection('prev');
+            }}
+            aria-label={pickerContent.scrollDatesLeftAriaLabel}
+            className='absolute left-0 top-1/2 z-20 hidden -translate-x-1/2 -translate-y-1/2 md:flex'
+          >
+            <DateArrowIcon direction='left' />
+          </ButtonPrimitive>
+        ) : null}
+
+        {hasDayNavigation && canScrollDayRight ? (
+          <ButtonPrimitive
+            variant='control'
+            type='button'
+            onClick={() => {
+              scrollDayCarouselByDirection('next');
+            }}
+            aria-label={pickerContent.scrollDatesRightAriaLabel}
+            className='absolute right-0 top-1/2 z-20 hidden translate-x-1/2 -translate-y-1/2 md:flex'
+          >
+            <DateArrowIcon direction='right' />
+          </ButtonPrimitive>
+        ) : null}
+      </div>
+
+      {resolvedDayYmd && daySlots.length > 0 ? (
+        <div className='space-y-4'>
+          {morningSlots.length > 0 ? (
+            <div className='space-y-2'>
+              <p className='text-sm font-semibold es-text-heading'>
+                {pickerContent.morningSectionLabel}
+              </p>
+              {renderSlotGrid(morningSlots, 0, pickerContent.morningSectionLabel)}
+            </div>
+          ) : null}
+          {afternoonSlots.length > 0 ? (
+            <div className='space-y-2'>
+              <p className='text-sm font-semibold es-text-heading'>
+                {pickerContent.afternoonSectionLabel}
+              </p>
+              {renderSlotGrid(
+                afternoonSlots,
+                morningSlots.length,
+                pickerContent.afternoonSectionLabel,
+              )}
+            </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-details.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-details.tsx
@@ -9,18 +9,24 @@ import type { LandingPageLocaleContent } from '@/content';
 interface LandingPageDetailsProps {
   content: LandingPageLocaleContent['details'];
   ariaLabel?: string;
+  /** When set, replaces the default SectionShell section classes. */
+  sectionClassName?: string;
 }
 
 export function LandingPageDetails({
   content,
   ariaLabel,
+  sectionClassName,
 }: LandingPageDetailsProps) {
+  const shellClassName =
+    sectionClassName ?? 'es-section-bg-overlay es-landing-page-details-section';
+
   return (
     <SectionShell
       id='landing-page-details'
       ariaLabel={ariaLabel ?? content.title}
       dataFigmaNode='landing-page-details'
-      className='es-section-bg-overlay es-landing-page-details-section'
+      className={shellClassName}
     >
       <SectionContainer>
         <SectionHeader

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -458,7 +458,7 @@ export function LandingPageFreeIntroCall({
       id='intro-call-booking'
       ariaLabel={introContent.bookingSectionTitle}
       dataFigmaNode='intro-call-booking'
-      className='es-bg-surface-muted'
+      className='es-book-a-free-call-booking-section'
     >
       <SectionContainer className='py-12 lg:py-16'>
         <SectionHeader

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -492,6 +492,7 @@ export function LandingPageFreeIntroCall({
           <div className='grid gap-10 lg:grid-cols-2 lg:gap-12'>
             <div ref={pickerWrapRef}>
               <IntroCallSlotPicker
+                locale={locale}
                 commonAccessibility={commonAccessibility}
                 pickerContent={introContent}
                 whatsappHref={whatsappHref}

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking.tsx
@@ -7,6 +7,8 @@ import { useEffect, useRef, useState } from 'react';
 import { ExternalLinkInlineContent } from '@/components/shared/external-link-icon';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import { CarouselTrack } from '@/components/sections/shared/carousel-track';
+import { BOOKING_SELECTOR_CARD_CLASSNAME } from '@/components/sections/shared/booking-selector-layout';
+import { CarouselHorizontalArrowControls } from '@/components/sections/shared/carousel-horizontal-arrow-controls';
 import { EventsLoadingState } from '@/components/sections/shared/events-shared';
 import {
   buildSectionSplitLayoutClassName,
@@ -74,17 +76,6 @@ interface MyBestAuntieBookingProps {
   privateProgrammeWhatsappHref?: string;
 }
 
-function DateArrowIcon({ direction }: { direction: 'left' | 'right' }) {
-  const rotationClass = direction === 'left' ? 'rotate-180' : '';
-
-  return (
-    <span
-      aria-hidden
-      className={`es-ui-icon-mask es-ui-icon-mask--chevron-right inline-block h-7 w-7 shrink-0 es-text-icon ${rotationClass}`}
-    />
-  );
-}
-
 function formatCohortPreviewLabel(value: string): string {
   const firstDateSegment = value.split(/\s+-\s+/)[0]?.trim() ?? value.trim();
 
@@ -115,7 +106,6 @@ function formatNextCohortLabel(
   });
 }
 
-const BOOKING_SELECTOR_CARD_CLASSNAME = 'es-my-best-auntie-booking-selector-card';
 const BOOKING_SYSTEM_QUERY_PARAM = 'booking_system';
 const MY_BEST_AUNTIE_BOOKING_SYSTEM = 'my-best-auntie-booking';
 const MAX_VISIBLE_COHORTS_PER_AGE_GROUP = 3;
@@ -507,99 +497,86 @@ export function MyBestAuntieBooking({
               <h3 className='text-sm font-semibold es-text-neutral-strong'>
                 {content.dateSelectorLabel}
               </h3>
-              <div className='relative mt-3 w-full min-w-0 overflow-visible'>
-                <CarouselTrack
-                  carouselRef={dateCarouselRef}
-                  testId='my-best-auntie-booking-date-carousel'
-                  ariaLabel={content.dateSelectorLabel}
-                  ariaRoleDescription={commonAccessibility.carouselRoleDescription}
-                  className='flex min-w-0 gap-3 pb-2 pr-1'
+              <div className='mt-3 w-full min-w-0 overflow-visible'>
+                <CarouselHorizontalArrowControls
+                  showPrevious={Boolean(hasDateNavigation && canScrollDateLeft)}
+                  showNext={Boolean(hasDateNavigation && canScrollDateRight)}
+                  onPrevious={() => {
+                    handleDateCarouselNavigation('prev');
+                  }}
+                  onNext={() => {
+                    handleDateCarouselNavigation('next');
+                  }}
+                  previousAriaLabel={content.scrollDatesLeftAriaLabel}
+                  nextAriaLabel={content.scrollDatesRightAriaLabel}
                 >
-                  {dateOptions.map((option) => {
-                    const isSelected = option.id === selectedDateId;
-                    const isFullyBooked = option.isFullyBooked;
+                  <CarouselTrack
+                    carouselRef={dateCarouselRef}
+                    testId='my-best-auntie-booking-date-carousel'
+                    ariaLabel={content.dateSelectorLabel}
+                    ariaRoleDescription={commonAccessibility.carouselRoleDescription}
+                    className='flex min-w-0 gap-3 pb-2 pr-1'
+                  >
+                    {dateOptions.map((option) => {
+                      const isSelected = option.id === selectedDateId;
+                      const isFullyBooked = option.isFullyBooked;
 
-                    return (
-                      <ButtonPrimitive
-                        key={option.id}
-                        buttonRef={(element) => {
-                          dateCardRefs.current[option.id] = element;
-                        }}
-                        variant='selection'
-                        state={isFullyBooked ? 'inactive' : isSelected ? 'active' : 'inactive'}
-                        aria-pressed={isFullyBooked ? undefined : isSelected}
-                        aria-disabled={isFullyBooked || undefined}
-                        onClick={
-                          isFullyBooked
-                            ? undefined
-                            : () => {
-                                trackAnalyticsEvent('booking_date_selected', {
-                                  sectionId: 'my-best-auntie-booking',
-                                  ctaLocation: 'selector',
-                                  params: {
-                                    service_tier: selectedAgeOption?.label ?? '',
-                                    cohort_label: option.label,
-                                    cohort_date: option.cohort.dates[0]?.start_datetime?.split('T')[0]
-                                      ?? '',
-                                    is_fully_booked: option.isFullyBooked,
-                                  },
-                                });
-                                setPendingDateSelectionSlug(option.id);
-                              }
-                        }
-                        className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative w-[140px] snap-center text-center sm:w-[168px] ${isFullyBooked ? 'pointer-events-none' : ''}`}
-                      >
-                        {isFullyBooked && (
-                          <span className='es-cohort-sold-out-stamp' aria-hidden='true'>
-                            <span className='es-cohort-sold-out-stamp-text'>
-                              {content.soldOutStampLabel}
+                      return (
+                        <ButtonPrimitive
+                          key={option.id}
+                          buttonRef={(element) => {
+                            dateCardRefs.current[option.id] = element;
+                          }}
+                          variant='selection'
+                          state={isFullyBooked ? 'inactive' : isSelected ? 'active' : 'inactive'}
+                          aria-pressed={isFullyBooked ? undefined : isSelected}
+                          aria-disabled={isFullyBooked || undefined}
+                          onClick={
+                            isFullyBooked
+                              ? undefined
+                              : () => {
+                                  trackAnalyticsEvent('booking_date_selected', {
+                                    sectionId: 'my-best-auntie-booking',
+                                    ctaLocation: 'selector',
+                                    params: {
+                                      service_tier: selectedAgeOption?.label ?? '',
+                                      cohort_label: option.label,
+                                      cohort_date: option.cohort.dates[0]?.start_datetime?.split('T')[0]
+                                        ?? '',
+                                      is_fully_booked: option.isFullyBooked,
+                                    },
+                                  });
+                                  setPendingDateSelectionSlug(option.id);
+                                }
+                          }
+                          className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative w-[140px] snap-center text-center sm:w-[168px] ${isFullyBooked ? 'pointer-events-none' : ''}`}
+                        >
+                          {isFullyBooked && (
+                            <span className='es-cohort-sold-out-stamp' aria-hidden='true'>
+                              <span className='es-cohort-sold-out-stamp-text'>
+                                {content.soldOutStampLabel}
+                              </span>
                             </span>
-                          </span>
-                        )}
-                        <div className={`flex w-full flex-col items-center gap-2 ${isFullyBooked ? 'opacity-40' : ''}`}>
-                          <div className='flex items-center justify-center gap-1.5'>
-                            <span
-                              className={`h-6 w-6 shrink-0 es-mask-calendar-current ${isSelected && !isFullyBooked ? 'es-btn-selection-icon-active' : 'es-btn-selection-icon-inactive'}`}
-                              aria-hidden='true'
-                            />
-                            <p className='text-base font-semibold es-text-heading whitespace-nowrap'>
-                              {option.label}
+                          )}
+                          <div className={`flex w-full flex-col items-center gap-2 ${isFullyBooked ? 'opacity-40' : ''}`}>
+                            <div className='flex items-center justify-center gap-1.5'>
+                              <span
+                                className={`h-6 w-6 shrink-0 es-mask-calendar-current ${isSelected && !isFullyBooked ? 'es-btn-selection-icon-active' : 'es-btn-selection-icon-inactive'}`}
+                                aria-hidden='true'
+                              />
+                              <p className='text-base font-semibold es-text-heading whitespace-nowrap'>
+                                {option.label}
+                              </p>
+                            </div>
+                            <p className='text-center text-sm es-text-danger-accent'>
+                              {option.availabilityLabel}
                             </p>
                           </div>
-                          <p className='text-center text-sm es-text-danger-accent'>
-                            {option.availabilityLabel}
-                          </p>
-                        </div>
-                      </ButtonPrimitive>
-                    );
-                  })}
-                </CarouselTrack>
-
-                {hasDateNavigation && canScrollDateLeft && (
-                  <ButtonPrimitive
-                    variant='control'
-                    onClick={() => {
-                      handleDateCarouselNavigation('prev');
-                    }}
-                    aria-label={content.scrollDatesLeftAriaLabel}
-                    className='absolute left-0 top-1/2 z-20 hidden -translate-x-1/2 -translate-y-1/2 md:flex'
-                  >
-                    <DateArrowIcon direction='left' />
-                  </ButtonPrimitive>
-                )}
-
-                {hasDateNavigation && canScrollDateRight && (
-                  <ButtonPrimitive
-                    variant='control'
-                    onClick={() => {
-                      handleDateCarouselNavigation('next');
-                    }}
-                    aria-label={content.scrollDatesRightAriaLabel}
-                    className='absolute right-0 top-1/2 z-20 hidden translate-x-1/2 -translate-y-1/2 md:flex'
-                  >
-                    <DateArrowIcon direction='right' />
-                  </ButtonPrimitive>
-                )}
+                        </ButtonPrimitive>
+                      );
+                    })}
+                  </CarouselTrack>
+                </CarouselHorizontalArrowControls>
               </div>
             </div>
 

--- a/apps/public_www/src/components/sections/navbar.tsx
+++ b/apps/public_www/src/components/sections/navbar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -37,6 +38,7 @@ import {
   localizePath,
   normalizeLocalizedPath,
 } from '@/lib/locale-routing';
+import { buildBookAFreeCallIntroAnchorHref, isBookAFreeCallIntroBookingHref } from '@/lib/book-free-call-intro-href';
 import { ROUTES } from '@/lib/routes';
 
 interface NavbarProps {
@@ -115,10 +117,13 @@ export function Navbar({ content }: NavbarProps) {
   const currentLocale = getLocaleFromPath(pathname);
   const logoSrc = content.logoSrc || LOGO_SRC;
   const localizedHomeHref = localizePath(ROUTES.home, currentLocale);
-  const localizedBookNowHref = localizeHref(
-    resolveBookNowHref(content.bookNow),
-    currentLocale,
-  );
+  const localizedBookNowHref = useMemo(() => {
+    const raw = resolveBookNowHref(content.bookNow);
+    if (isBookAFreeCallIntroBookingHref(raw)) {
+      return buildBookAFreeCallIntroAnchorHref(currentLocale);
+    }
+    return localizeHref(raw, currentLocale);
+  }, [content.bookNow, currentLocale]);
   const languageSelector = resolveLanguageSelectorContent(content);
   const openNavigationMenuAriaLabel = content.openNavigationMenuAriaLabel.trim();
   const closeNavigationMenuAriaLabel = content.closeNavigationMenuAriaLabel.trim();

--- a/apps/public_www/src/components/sections/shared/booking-selector-layout.ts
+++ b/apps/public_www/src/components/sections/shared/booking-selector-layout.ts
@@ -1,0 +1,3 @@
+/** Shared selector card surface class (My Best Auntie booking, intro-call day strip). */
+export const BOOKING_SELECTOR_CARD_CLASSNAME =
+  'es-my-best-auntie-booking-selector-card';

--- a/apps/public_www/src/components/sections/shared/carousel-arrow-icon.tsx
+++ b/apps/public_www/src/components/sections/shared/carousel-arrow-icon.tsx
@@ -1,0 +1,22 @@
+import { mergeClassNames } from '@/lib/class-name-utils';
+
+const DEFAULT_ICON_CLASS =
+  'es-ui-icon-mask es-ui-icon-mask--chevron-right inline-block h-7 w-7 shrink-0 es-text-icon';
+
+export function CarouselArrowIcon({
+  direction,
+  className,
+}: {
+  direction: 'left' | 'right';
+  /** Optional sizing / tone classes (default matches MBA date carousel). */
+  className?: string;
+}) {
+  const rotationClass = direction === 'left' ? 'rotate-180' : '';
+
+  return (
+    <span
+      aria-hidden
+      className={mergeClassNames(DEFAULT_ICON_CLASS, rotationClass, className)}
+    />
+  );
+}

--- a/apps/public_www/src/components/sections/shared/carousel-horizontal-arrow-controls.tsx
+++ b/apps/public_www/src/components/sections/shared/carousel-horizontal-arrow-controls.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { CarouselArrowIcon } from '@/components/sections/shared/carousel-arrow-icon';
+import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { mergeClassNames } from '@/lib/class-name-utils';
+
+const WRAPPER_BASE =
+  'relative w-full min-w-0 overflow-visible';
+
+const PREV_BUTTON_CLASS =
+  'absolute left-0 top-1/2 z-20 hidden -translate-x-1/2 -translate-y-1/2 md:flex';
+
+const NEXT_BUTTON_CLASS =
+  'absolute right-0 top-1/2 z-20 hidden translate-x-1/2 -translate-y-1/2 md:flex';
+
+export function CarouselHorizontalArrowControls({
+  children,
+  showPrevious,
+  showNext,
+  onPrevious,
+  onNext,
+  previousAriaLabel,
+  nextAriaLabel,
+  wrapperClassName,
+}: {
+  children: ReactNode;
+  showPrevious: boolean;
+  showNext: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+  previousAriaLabel: string;
+  nextAriaLabel: string;
+  /** Extra classes on the relative wrapper (e.g. `mt-3`). */
+  wrapperClassName?: string;
+}) {
+  const wrapClass = mergeClassNames(WRAPPER_BASE, wrapperClassName);
+
+  return (
+    <div className={wrapClass}>
+      {children}
+      {showPrevious ? (
+        <ButtonPrimitive
+          variant='control'
+          type='button'
+          onClick={onPrevious}
+          aria-label={previousAriaLabel}
+          className={PREV_BUTTON_CLASS}
+        >
+          <CarouselArrowIcon direction='left' />
+        </ButtonPrimitive>
+      ) : null}
+      {showNext ? (
+        <ButtonPrimitive
+          variant='control'
+          type='button'
+          onClick={onNext}
+          aria-label={nextAriaLabel}
+          className={NEXT_BUTTON_CLASS}
+        >
+          <CarouselArrowIcon direction='right' />
+        </ButtonPrimitive>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/public_www/src/components/sections/shared/events-shared.tsx
+++ b/apps/public_www/src/components/sections/shared/events-shared.tsx
@@ -13,8 +13,8 @@ import {
 import { SectionCtaAnchor } from '@/components/sections/shared/section-cta-link';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import { ExternalLinkInlineContent } from '@/components/shared/external-link-icon';
-import { LoadingGearIcon } from '@/components/shared/loading-gear-icon';
 import { SmartLink } from '@/components/shared/smart-link';
+import { SectionSpinnerStatus } from '@/components/shared/section-spinner-status';
 import type { EventsContent } from '@/content';
 import {
   createPublicCrmApiClient,
@@ -28,11 +28,6 @@ import {
 
 const CALENDAR_ICON_SRC = '/images/calendar.svg';
 const CLOCK_ICON_SRC = '/images/clock.svg';
-
-interface EventsLoadingStateProps {
-  label: string;
-  testId: string;
-}
 
 interface EventCardsListProps {
   content: EventsContent;
@@ -139,20 +134,8 @@ export function EventsDataProvider({
   );
 }
 
-export function EventsLoadingState({ label, testId }: EventsLoadingStateProps) {
-  return (
-    <div className='flex flex-col items-center gap-3 py-6 text-center sm:py-8'>
-      <span
-        role='status'
-        aria-label={label}
-        className='inline-flex h-12 w-12 items-center justify-center rounded-full border es-border-soft es-loading-gear-bubble'
-      >
-        <LoadingGearIcon className='h-7 w-7 animate-spin' testId={testId} />
-      </span>
-      <p className='es-events-card-body'>{label}</p>
-    </div>
-  );
-}
+/** @deprecated Prefer `SectionSpinnerStatus` from `@/components/shared/section-spinner-status`. */
+export const EventsLoadingState = SectionSpinnerStatus;
 
 export function EventCardsList({
   content,

--- a/apps/public_www/src/components/shared/section-spinner-status.tsx
+++ b/apps/public_www/src/components/shared/section-spinner-status.tsx
@@ -1,0 +1,21 @@
+import { LoadingGearIcon } from '@/components/shared/loading-gear-icon';
+
+export interface SectionSpinnerStatusProps {
+  label: string;
+  testId: string;
+}
+
+export function SectionSpinnerStatus({ label, testId }: SectionSpinnerStatusProps) {
+  return (
+    <div className='flex flex-col items-center gap-3 py-6 text-center sm:py-8'>
+      <span
+        role='status'
+        aria-label={label}
+        className='inline-flex h-12 w-12 items-center justify-center rounded-full border es-border-soft es-loading-gear-bubble'
+      >
+        <LoadingGearIcon className='h-7 w-7 animate-spin' testId={testId} />
+      </span>
+      <p className='es-events-card-body'>{label}</p>
+    </div>
+  );
+}

--- a/apps/public_www/src/components/shared/smart-link.tsx
+++ b/apps/public_www/src/components/shared/smart-link.tsx
@@ -59,10 +59,6 @@ function renderChildren(
   return children;
 }
 
-function shouldScrollToTopOnNavigate(href: string): boolean {
-  return !href.includes('#');
-}
-
 export function SmartLink({
   href,
   className,
@@ -101,13 +97,16 @@ export function SmartLink({
   };
 
   if (hrefKind === 'internal') {
+    if (resolvedHref.includes('#')) {
+      return (
+        <Link href={resolvedHref} prefetch={false} {...sharedProps}>
+          {linkChildren}
+        </Link>
+      );
+    }
+
     return (
-      <Link
-        href={resolvedHref}
-        prefetch={false}
-        scroll={shouldScrollToTopOnNavigate(resolvedHref)}
-        {...sharedProps}
-      >
+      <Link href={resolvedHref} prefetch={false} scroll={false} {...sharedProps}>
         {linkChildren}
       </Link>
     );

--- a/apps/public_www/src/content/index.ts
+++ b/apps/public_www/src/content/index.ts
@@ -165,6 +165,11 @@ export interface LandingPageLocaleContent {
     submitLabel: string;
     phoneFieldLabel: string;
     loadErrorMessage?: string;
+    loadingLabel: string;
+    scrollDatesLeftAriaLabel: string;
+    scrollDatesRightAriaLabel: string;
+    morningSectionLabel: string;
+    afternoonSectionLabel: string;
   };
 }
 

--- a/apps/public_www/src/content/index.ts
+++ b/apps/public_www/src/content/index.ts
@@ -170,6 +170,7 @@ export interface LandingPageLocaleContent {
     scrollDatesRightAriaLabel: string;
     morningSectionLabel: string;
     afternoonSectionLabel: string;
+    slotGroupAriaLabelTemplate: string;
   };
 }
 

--- a/apps/public_www/src/content/landing-pages/book-a-free-call.json
+++ b/apps/public_www/src/content/landing-pages/book-a-free-call.json
@@ -101,7 +101,12 @@
       "topicsFieldLabel": "Anything you want me to know before our call?",
       "topicsFieldPlaceholder": "Optional — share context that will help us make the most of 15 minutes.",
       "submitLabel": "Book my free call",
-      "phoneFieldLabel": "Phone number (optional)"
+      "phoneFieldLabel": "Phone number (optional)",
+      "loadingLabel": "Loading available times…",
+      "scrollDatesLeftAriaLabel": "Scroll dates left",
+      "scrollDatesRightAriaLabel": "Scroll dates right",
+      "morningSectionLabel": "Morning",
+      "afternoonSectionLabel": "Afternoon"
     }
   },
   "zh-CN": {
@@ -206,7 +211,12 @@
       "topicsFieldLabel": "在通话前您想让我了解的内容？",
       "topicsFieldPlaceholder": "选填 — 分享有助于充分利用 15 分钟的背景信息。",
       "submitLabel": "预约免费通话",
-      "phoneFieldLabel": "电话号码（可选）"
+      "phoneFieldLabel": "电话号码（可选）",
+      "loadingLabel": "正在加载可预约时间…",
+      "scrollDatesLeftAriaLabel": "向左滚动日期",
+      "scrollDatesRightAriaLabel": "向右滚动日期",
+      "morningSectionLabel": "上午",
+      "afternoonSectionLabel": "下午"
     }
   },
   "zh-HK": {
@@ -311,7 +321,12 @@
       "topicsFieldLabel": "通話前想我知嘅嘢？",
       "topicsFieldPlaceholder": "選填 — 分享有助用盡 15 分鐘嘅背景。",
       "submitLabel": "預約免費通話",
-      "phoneFieldLabel": "電話號碼（選填）"
+      "phoneFieldLabel": "電話號碼（選填）",
+      "loadingLabel": "正在載入可預約時間…",
+      "scrollDatesLeftAriaLabel": "向左捲動日期",
+      "scrollDatesRightAriaLabel": "向右捲動日期",
+      "morningSectionLabel": "上午",
+      "afternoonSectionLabel": "下午"
     }
   }
 }

--- a/apps/public_www/src/content/landing-pages/book-a-free-call.json
+++ b/apps/public_www/src/content/landing-pages/book-a-free-call.json
@@ -106,7 +106,8 @@
       "scrollDatesLeftAriaLabel": "Scroll dates left",
       "scrollDatesRightAriaLabel": "Scroll dates right",
       "morningSectionLabel": "Morning",
-      "afternoonSectionLabel": "Afternoon"
+      "afternoonSectionLabel": "Afternoon",
+      "slotGroupAriaLabelTemplate": "{period} · {section}"
     }
   },
   "zh-CN": {
@@ -215,8 +216,9 @@
       "loadingLabel": "正在加载可预约时间…",
       "scrollDatesLeftAriaLabel": "向左滚动日期",
       "scrollDatesRightAriaLabel": "向右滚动日期",
-      "morningSectionLabel": "上午",
-      "afternoonSectionLabel": "下午"
+      "morningSectionLabel": "早上",
+      "afternoonSectionLabel": "下午",
+      "slotGroupAriaLabelTemplate": "{period} · {section}"
     }
   },
   "zh-HK": {
@@ -325,8 +327,9 @@
       "loadingLabel": "正在載入可預約時間…",
       "scrollDatesLeftAriaLabel": "向左捲動日期",
       "scrollDatesRightAriaLabel": "向右捲動日期",
-      "morningSectionLabel": "上午",
-      "afternoonSectionLabel": "下午"
+      "morningSectionLabel": "朝早",
+      "afternoonSectionLabel": "下午",
+      "slotGroupAriaLabelTemplate": "{period} · {section}"
     }
   }
 }

--- a/apps/public_www/src/lib/book-free-call-intro-href.ts
+++ b/apps/public_www/src/lib/book-free-call-intro-href.ts
@@ -1,0 +1,13 @@
+import type { Locale } from '@/content';
+
+const BOOK_FREE_CALL_SLUG = 'book-a-free-call';
+const INTRO_BOOKING_HASH = '#intro-call-booking';
+
+/** Stable same-site href for navbar / CTAs that target the intro-call booking anchor. */
+export function buildBookAFreeCallIntroAnchorHref(locale: Locale): string {
+  return `/${locale}/${BOOK_FREE_CALL_SLUG}${INTRO_BOOKING_HASH}`;
+}
+
+export function isBookAFreeCallIntroBookingHref(href: string): boolean {
+  return href.includes(INTRO_BOOKING_HASH);
+}

--- a/apps/public_www/src/lib/hooks/use-horizontal-carousel.ts
+++ b/apps/public_www/src/lib/hooks/use-horizontal-carousel.ts
@@ -254,10 +254,14 @@ export function useHorizontalCarousel<T extends HTMLElement>({
         (itemRect.left + itemRect.width / 2) -
         (containerRect.left + containerRect.width / 2);
 
-      container.scrollTo({
-        left: targetScrollLeft,
-        behavior,
-      });
+      if (typeof container.scrollTo === 'function') {
+        container.scrollTo({
+          left: targetScrollLeft,
+          behavior,
+        });
+      } else {
+        container.scrollLeft = targetScrollLeft;
+      }
 
       if (typeof window !== 'undefined') {
         if (rafIdRef.current !== null) {

--- a/apps/public_www/src/lib/hooks/use-horizontal-carousel.ts
+++ b/apps/public_www/src/lib/hooks/use-horizontal-carousel.ts
@@ -72,6 +72,18 @@ function resolveItemScrollPositions(container: HTMLElement): number[] {
   return positions;
 }
 
+function scrollContainerHorizontally(
+  container: HTMLElement,
+  options: { left: number; behavior?: ScrollBehavior },
+): void {
+  const { left, behavior = 'auto' } = options;
+  if (typeof container.scrollTo === 'function') {
+    container.scrollTo({ left, behavior });
+  } else {
+    container.scrollLeft = left;
+  }
+}
+
 export function useHorizontalCarousel<T extends HTMLElement>({
   itemCount,
   enabled = true,
@@ -192,7 +204,7 @@ export function useHorizontalCarousel<T extends HTMLElement>({
           if (nextPos === undefined) {
             return;
           }
-          carouselElement.scrollTo({
+          scrollContainerHorizontally(carouselElement, {
             left: Math.min(nextPos, maxScrollLeft),
             behavior: 'smooth',
           });
@@ -203,7 +215,7 @@ export function useHorizontalCarousel<T extends HTMLElement>({
           if (prevPos === undefined) {
             return;
           }
-          carouselElement.scrollTo({
+          scrollContainerHorizontally(carouselElement, {
             left: Math.max(prevPos, 0),
             behavior: 'smooth',
           });
@@ -217,11 +229,18 @@ export function useHorizontalCarousel<T extends HTMLElement>({
         minScrollStepPx,
       });
       const leftOffset = direction === 'prev' ? -scrollStep : scrollStep;
-
-      carouselElement.scrollBy({
-        left: leftOffset,
-        behavior: 'smooth',
-      });
+      const nextLeft = carouselElement.scrollLeft + leftOffset;
+      if (typeof carouselElement.scrollBy === 'function') {
+        carouselElement.scrollBy({
+          left: leftOffset,
+          behavior: 'smooth',
+        });
+      } else {
+        scrollContainerHorizontally(carouselElement, {
+          left: nextLeft,
+          behavior: 'smooth',
+        });
+      }
     },
     [
       beginLoopCooldown,
@@ -254,14 +273,10 @@ export function useHorizontalCarousel<T extends HTMLElement>({
         (itemRect.left + itemRect.width / 2) -
         (containerRect.left + containerRect.width / 2);
 
-      if (typeof container.scrollTo === 'function') {
-        container.scrollTo({
-          left: targetScrollLeft,
-          behavior,
-        });
-      } else {
-        container.scrollLeft = targetScrollLeft;
-      }
+      scrollContainerHorizontally(container, {
+        left: targetScrollLeft,
+        behavior,
+      });
 
       if (typeof window !== 'undefined') {
         if (rafIdRef.current !== null) {

--- a/apps/public_www/tests/components/pages/landing-pages/book-a-free-call.test.tsx
+++ b/apps/public_www/tests/components/pages/landing-pages/book-a-free-call.test.tsx
@@ -90,9 +90,14 @@ describe('BookFreeCallLandingPage', () => {
     const beforeYouBookHeading = screen.getByRole('heading', {
       name: bookAFreeCall.en.details.title,
     });
+    const beforeYouBookSection = beforeYouBookHeading.closest('section');
+    expect(beforeYouBookSection).not.toBeNull();
+    expect(beforeYouBookSection).toHaveClass('es-book-a-free-call-good-to-know-section');
+
     const bookingRegion = screen.getByRole('region', {
       name: bookAFreeCall.en.introCall.bookingSectionTitle,
     });
+    expect(bookingRegion).toHaveClass('es-book-a-free-call-booking-section');
     const howItWorksHeading = screen.getByRole('heading', {
       name: bookAFreeCall.en.description.title,
     });

--- a/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { IntroCallSlotPicker } from '@/components/sections/landing-pages/intro-call-slot-picker';
@@ -12,9 +12,38 @@ vi.mock('@/lib/intro-call-slots-api', () => ({
 
 const { fetchIntroCallSlots } = await import('@/lib/intro-call-slots-api');
 
+const MD_UP_MEDIA_QUERY = '(min-width: 768px)';
+const originalMatchMedia = window.matchMedia;
+
+function mockViewportMdUp(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === MD_UP_MEDIA_QUERY ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 afterEach(() => {
   vi.mocked(fetchIntroCallSlots).mockReset();
   vi.unstubAllGlobals();
+  if (originalMatchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  } else {
+    Reflect.deleteProperty(window, 'matchMedia');
+  }
 });
 
 describe('IntroCallSlotPicker', () => {
@@ -24,6 +53,26 @@ describe('IntroCallSlotPicker', () => {
       return 0;
     });
     vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  it('shows loading gear with test id while slots load', async () => {
+    vi.mocked(fetchIntroCallSlots).mockImplementation(
+      () =>
+        new Promise(() => {
+          /* never resolves in this test */
+        }),
+    );
+
+    render(
+      <IntroCallSlotPicker
+        commonAccessibility={enContent.common.accessibility}
+        pickerContent={bookAFreeCall.en.introCall}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId('intro-call-slots-loading')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '09:00' })).toBeNull();
   });
 
   it('renders time buttons after slots load', async () => {
@@ -45,8 +94,170 @@ describe('IntroCallSlotPicker', () => {
     );
 
     await waitFor(() => {
+      expect(screen.queryByTestId('intro-call-slots-loading')).toBeNull();
+    });
+
+    await waitFor(() => {
       expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument();
     });
+  });
+
+  it('toggles aria-pressed on day and time selection without icon masks in buttons', async () => {
+    vi.mocked(fetchIntroCallSlots).mockResolvedValue({
+      slots: [
+        { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
+        { startIso: '2026-05-06T01:00:00.000Z', endIso: '2026-05-06T01:15:00.000Z' },
+      ],
+      fetchFailed: false,
+    });
+
+    const { container } = render(
+      <IntroCallSlotPicker
+        commonAccessibility={enContent.common.accessibility}
+        pickerContent={bookAFreeCall.en.introCall}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument();
+    });
+
+    const dayPressedTrue = screen.getAllByRole('button', { pressed: true });
+    expect(dayPressedTrue.length).toBe(1);
+    const firstDay = dayPressedTrue[0] as HTMLButtonElement;
+    expect(firstDay).toHaveTextContent('Tue');
+
+    const wedButton = screen.getByRole('button', { name: /Wed/i });
+    expect(wedButton).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(wedButton);
+
+    await waitFor(() => {
+      expect(wedButton).toHaveAttribute('aria-pressed', 'true');
+    });
+    expect(firstDay).toHaveAttribute('aria-pressed', 'false');
+
+    const timeBtn = screen.getByRole('button', { name: '09:00' });
+    expect(timeBtn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(timeBtn);
+    await waitFor(() => {
+      expect(timeBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    const selectionButtons = container.querySelectorAll('.es-btn--selection');
+    selectionButtons.forEach((el) => {
+      expect(el.querySelector('svg')).toBeNull();
+      expect(el.querySelector('.es-ui-icon-mask')).toBeNull();
+    });
+  });
+
+  it('does not render date carousel arrows when fewer than three days have slots', async () => {
+    vi.mocked(fetchIntroCallSlots).mockResolvedValue({
+      slots: [
+        { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
+        { startIso: '2026-05-05T02:30:00.000Z', endIso: '2026-05-05T02:45:00.000Z' },
+      ],
+      fetchFailed: false,
+    });
+
+    mockViewportMdUp(true);
+
+    render(
+      <IntroCallSlotPicker
+        commonAccessibility={enContent.common.accessibility}
+        pickerContent={bookAFreeCall.en.introCall}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('button', { name: bookAFreeCall.en.introCall.scrollDatesLeftAriaLabel }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: bookAFreeCall.en.introCall.scrollDatesRightAriaLabel }),
+    ).toBeNull();
+  });
+
+  it('renders date carousel arrows with localized labels when enough days and md viewport', async () => {
+    vi.mocked(fetchIntroCallSlots).mockResolvedValue({
+      slots: [
+        { startIso: '2026-05-04T01:00:00.000Z', endIso: '2026-05-04T01:15:00.000Z' },
+        { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
+        { startIso: '2026-05-06T01:00:00.000Z', endIso: '2026-05-06T01:15:00.000Z' },
+        { startIso: '2026-05-07T01:00:00.000Z', endIso: '2026-05-07T01:15:00.000Z' },
+      ],
+      fetchFailed: false,
+    });
+
+    mockViewportMdUp(true);
+
+    render(
+      <IntroCallSlotPicker
+        commonAccessibility={enContent.common.accessibility}
+        pickerContent={bookAFreeCall.en.introCall}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const track = await screen.findByTestId('intro-call-day-carousel');
+    let scrollLeft = 100;
+    Object.defineProperty(track, 'clientWidth', { configurable: true, get: () => 200 });
+    Object.defineProperty(track, 'scrollWidth', { configurable: true, get: () => 800 });
+    Object.defineProperty(track, 'scrollLeft', {
+      configurable: true,
+      get: () => scrollLeft,
+      set: (v: number) => {
+        scrollLeft = v;
+      },
+    });
+
+    fireEvent(window, new Event('resize'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: bookAFreeCall.en.introCall.scrollDatesLeftAriaLabel }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole('button', { name: bookAFreeCall.en.introCall.scrollDatesRightAriaLabel }),
+    ).toBeInTheDocument();
+  });
+
+  it('groups morning and afternoon slots with section labels', async () => {
+    vi.mocked(fetchIntroCallSlots).mockResolvedValue({
+      slots: [
+        { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
+        { startIso: '2026-05-05T06:30:00.000Z', endIso: '2026-05-05T06:45:00.000Z' },
+      ],
+      fetchFailed: false,
+    });
+
+    render(
+      <IntroCallSlotPicker
+        commonAccessibility={enContent.common.accessibility}
+        pickerContent={bookAFreeCall.en.introCall}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(bookAFreeCall.en.introCall.morningSectionLabel)).toBeInTheDocument();
+    });
+    expect(screen.getByText(bookAFreeCall.en.introCall.afternoonSectionLabel)).toBeInTheDocument();
+
+    const morningGroup = screen.getByRole('group', {
+      name: `Morning: ${bookAFreeCall.en.introCall.bookingSectionTitle}`,
+    });
+    expect(within(morningGroup).getByRole('button', { name: '09:00' })).toBeInTheDocument();
+
+    const afternoonGroup = screen.getByRole('group', {
+      name: `Afternoon: ${bookAFreeCall.en.introCall.bookingSectionTitle}`,
+    });
+    expect(within(afternoonGroup).getByRole('button', { name: '14:30' })).toBeInTheDocument();
   });
 
   it('renders load error message and WhatsApp link when fetch fails', async () => {

--- a/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
@@ -12,38 +12,9 @@ vi.mock('@/lib/intro-call-slots-api', () => ({
 
 const { fetchIntroCallSlots } = await import('@/lib/intro-call-slots-api');
 
-const MD_UP_MEDIA_QUERY = '(min-width: 768px)';
-const originalMatchMedia = window.matchMedia;
-
-function mockViewportMdUp(matches: boolean): void {
-  Object.defineProperty(window, 'matchMedia', {
-    configurable: true,
-    writable: true,
-    value: vi.fn().mockImplementation((query: string) => ({
-      matches: query === MD_UP_MEDIA_QUERY ? matches : false,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  });
-}
-
 afterEach(() => {
   vi.mocked(fetchIntroCallSlots).mockReset();
   vi.unstubAllGlobals();
-  if (originalMatchMedia) {
-    Object.defineProperty(window, 'matchMedia', {
-      configurable: true,
-      writable: true,
-      value: originalMatchMedia,
-    });
-  } else {
-    Reflect.deleteProperty(window, 'matchMedia');
-  }
 });
 
 describe('IntroCallSlotPicker', () => {
@@ -65,6 +36,7 @@ describe('IntroCallSlotPicker', () => {
 
     render(
       <IntroCallSlotPicker
+        locale='en'
         commonAccessibility={enContent.common.accessibility}
         pickerContent={bookAFreeCall.en.introCall}
         onSelect={vi.fn()}
@@ -87,6 +59,7 @@ describe('IntroCallSlotPicker', () => {
 
     render(
       <IntroCallSlotPicker
+        locale='en'
         commonAccessibility={enContent.common.accessibility}
         pickerContent={bookAFreeCall.en.introCall}
         onSelect={onSelect}
@@ -102,7 +75,7 @@ describe('IntroCallSlotPicker', () => {
     });
   });
 
-  it('toggles aria-pressed on day and time selection without icon masks in buttons', async () => {
+  it('toggles aria-pressed on day and time selection without icon masks in selection buttons', async () => {
     vi.mocked(fetchIntroCallSlots).mockResolvedValue({
       slots: [
         { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
@@ -113,6 +86,7 @@ describe('IntroCallSlotPicker', () => {
 
     const { container } = render(
       <IntroCallSlotPicker
+        locale='en'
         commonAccessibility={enContent.common.accessibility}
         pickerContent={bookAFreeCall.en.introCall}
         onSelect={vi.fn()}
@@ -151,6 +125,41 @@ describe('IntroCallSlotPicker', () => {
     });
   });
 
+  it('moves roving tabindex with ArrowRight on the day strip', async () => {
+    vi.mocked(fetchIntroCallSlots).mockResolvedValue({
+      slots: [
+        { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
+        { startIso: '2026-05-06T01:00:00.000Z', endIso: '2026-05-06T01:15:00.000Z' },
+      ],
+      fetchFailed: false,
+    });
+
+    render(
+      <IntroCallSlotPicker
+        locale='en'
+        commonAccessibility={enContent.common.accessibility}
+        pickerContent={bookAFreeCall.en.introCall}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const tueButton = await screen.findByRole('button', { name: /Tue/i });
+    expect(tueButton).toHaveAttribute('tabIndex', '0');
+    expect(tueButton).toHaveAttribute('aria-pressed', 'true');
+
+    const wedButton = screen.getByRole('button', { name: /Wed/i });
+    expect(wedButton).toHaveAttribute('tabIndex', '-1');
+
+    fireEvent.keyDown(tueButton, { key: 'ArrowRight' });
+
+    await waitFor(() => {
+      expect(wedButton).toHaveAttribute('aria-pressed', 'true');
+    });
+    expect(wedButton).toHaveAttribute('tabIndex', '0');
+    expect(tueButton).toHaveAttribute('tabIndex', '-1');
+    expect(wedButton).toHaveFocus();
+  });
+
   it('does not render date carousel arrows when fewer than three days have slots', async () => {
     vi.mocked(fetchIntroCallSlots).mockResolvedValue({
       slots: [
@@ -160,10 +169,9 @@ describe('IntroCallSlotPicker', () => {
       fetchFailed: false,
     });
 
-    mockViewportMdUp(true);
-
     render(
       <IntroCallSlotPicker
+        locale='en'
         commonAccessibility={enContent.common.accessibility}
         pickerContent={bookAFreeCall.en.introCall}
         onSelect={vi.fn()}
@@ -182,7 +190,7 @@ describe('IntroCallSlotPicker', () => {
     ).toBeNull();
   });
 
-  it('renders date carousel arrows with localized labels when enough days and md viewport', async () => {
+  it('renders date carousel arrows with localized labels when enough days and overflow', async () => {
     vi.mocked(fetchIntroCallSlots).mockResolvedValue({
       slots: [
         { startIso: '2026-05-04T01:00:00.000Z', endIso: '2026-05-04T01:15:00.000Z' },
@@ -193,10 +201,9 @@ describe('IntroCallSlotPicker', () => {
       fetchFailed: false,
     });
 
-    mockViewportMdUp(true);
-
     render(
       <IntroCallSlotPicker
+        locale='en'
         commonAccessibility={enContent.common.accessibility}
         pickerContent={bookAFreeCall.en.introCall}
         onSelect={vi.fn()}
@@ -238,6 +245,7 @@ describe('IntroCallSlotPicker', () => {
 
     render(
       <IntroCallSlotPicker
+        locale='en'
         commonAccessibility={enContent.common.accessibility}
         pickerContent={bookAFreeCall.en.introCall}
         onSelect={vi.fn()}
@@ -250,12 +258,12 @@ describe('IntroCallSlotPicker', () => {
     expect(screen.getByText(bookAFreeCall.en.introCall.afternoonSectionLabel)).toBeInTheDocument();
 
     const morningGroup = screen.getByRole('group', {
-      name: `Morning: ${bookAFreeCall.en.introCall.bookingSectionTitle}`,
+      name: `Morning · ${bookAFreeCall.en.introCall.bookingSectionTitle}`,
     });
     expect(within(morningGroup).getByRole('button', { name: '09:00' })).toBeInTheDocument();
 
     const afternoonGroup = screen.getByRole('group', {
-      name: `Afternoon: ${bookAFreeCall.en.introCall.bookingSectionTitle}`,
+      name: `Afternoon · ${bookAFreeCall.en.introCall.bookingSectionTitle}`,
     });
     expect(within(afternoonGroup).getByRole('button', { name: '14:30' })).toBeInTheDocument();
   });
@@ -269,6 +277,7 @@ describe('IntroCallSlotPicker', () => {
 
     render(
       <IntroCallSlotPicker
+        locale='en'
         commonAccessibility={enContent.common.accessibility}
         pickerContent={{
           ...bookAFreeCall.en.introCall,

--- a/apps/public_www/tests/components/sections/landing-pages/landing-page-details.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/landing-page-details.test.tsx
@@ -56,6 +56,20 @@ describe('LandingPageDetails section', () => {
     );
   });
 
+  it('applies sectionClassName on SectionShell when provided', () => {
+    render(
+      <LandingPageDetails
+        content={easterWorkshopContent.en.details}
+        sectionClassName='es-section-bg-overlay es-book-a-free-call-good-to-know-section'
+      />,
+    );
+
+    const section = document.getElementById('landing-page-details');
+    expect(section).not.toBeNull();
+    expect(section).toHaveClass('es-book-a-free-call-good-to-know-section');
+    expect(section).not.toHaveClass('es-landing-page-details-section');
+  });
+
   it('renders shared CTA action at the bottom when calendar context is provided', () => {
     const sharedCtaProps = buildLandingPageSharedCtaPropsFromCalendar(
       'en',

--- a/apps/public_www/tests/components/sections/navbar.test.tsx
+++ b/apps/public_www/tests/components/sections/navbar.test.tsx
@@ -108,6 +108,11 @@ describe('Navbar desktop submenu accessibility', () => {
       name: enContent.navbar.bookNow.label,
     });
     expect(desktopBookNowLink).toBeInTheDocument();
+    expect(desktopBookNowLink).toHaveAttribute(
+      'href',
+      '/en/book-a-free-call#intro-call-booking',
+    );
+    expect(desktopBookNowLink).not.toHaveAttribute('data-scroll');
 
     const logoLink = header?.querySelector('a.shrink-0[href="/en/"]');
     expect(logoLink).not.toBeNull();

--- a/apps/public_www/tests/components/shared/button-primitive.test.tsx
+++ b/apps/public_www/tests/components/shared/button-primitive.test.tsx
@@ -62,9 +62,21 @@ describe('ButtonPrimitive', () => {
     expect(link).toHaveAttribute('href', '/about-us');
     expect(link).toHaveAttribute('data-mocked-next-link', 'true');
     expect(link).toHaveAttribute('data-prefetch', 'false');
-    expect(link).toHaveAttribute('data-scroll', 'true');
+    expect(link).toHaveAttribute('data-scroll', 'false');
     expect(link.className).toContain('es-btn');
     expect(link.className).toContain('es-btn--pill');
+  });
+
+  it('omits scroll prop on Next Link for internal href with hash', () => {
+    render(
+      <ButtonPrimitive variant='pill' href='/about-us#team'>
+        About team
+      </ButtonPrimitive>,
+    );
+
+    const link = screen.getByRole('link', { name: 'About team' });
+    expect(link).toHaveAttribute('href', '/about-us#team');
+    expect(link).not.toHaveAttribute('data-scroll');
   });
 
   it('opens external links in a new tab by default', () => {

--- a/apps/public_www/tests/components/shared/smart-link.test.tsx
+++ b/apps/public_www/tests/components/shared/smart-link.test.tsx
@@ -70,17 +70,17 @@ describe('SmartLink', () => {
     expect(link).toHaveAttribute('href', '/about-us');
     expect(link).toHaveAttribute('data-mocked-next-link', 'true');
     expect(link).toHaveAttribute('data-prefetch', 'false');
-    expect(link).toHaveAttribute('data-scroll', 'true');
+    expect(link).toHaveAttribute('data-scroll', 'false');
     expect(link).not.toHaveAttribute('target');
   });
 
-  it('does not force top scroll for internal hash anchors', () => {
+  it('does not pass scroll={false} for internal cross-page hash links', () => {
     render(<SmartLink href='/about-us#team'>About team</SmartLink>);
 
     const link = screen.getByRole('link', { name: 'About team' });
     expect(link).toHaveAttribute('href', '/about-us#team');
     expect(link).toHaveAttribute('data-mocked-next-link', 'true');
-    expect(link).toHaveAttribute('data-scroll', 'false');
+    expect(link).not.toHaveAttribute('data-scroll');
   });
 
   it('allows explicit internal new-tab override', () => {

--- a/backend/src/app/services/intro_call_slots.py
+++ b/backend/src/app/services/intro_call_slots.py
@@ -1,4 +1,7 @@
-"""15-minute intro-call slot generation and availability (Asia/Hong_Kong office hours)."""
+"""Intro-call slot generation and availability (Asia/Hong_Kong office hours).
+
+Candidate starts use a 30-minute cadence; each bookable interval is 15 minutes long.
+"""
 
 from __future__ import annotations
 
@@ -37,7 +40,8 @@ _INTRO_CALL_WALL_TIMEZONE_DEFAULT = "Asia/Hong_Kong"
 _INTRO_CALL_OPEN_HOUR = 9
 _INTRO_CALL_CLOSE_HOUR = 18
 _INTRO_CALL_OPEN_DAYS: frozenset[int] = frozenset({0, 1, 2, 3, 4})
-_INTRO_CALL_SLOT_MINUTES = 15
+_INTRO_CALL_SLOT_STEP_MINUTES = 30
+_INTRO_CALL_SLOT_DURATION_MINUTES = 15
 _INTRO_CALL_LEAD_HOURS = 2
 _INTRO_CALL_HORIZON_DAYS = 21
 _INTRO_CALL_PURPOSE = "intro_call_booking"
@@ -66,7 +70,11 @@ def intro_call_window(*, now: datetime) -> tuple[date, date]:
 
 
 def _slot_step() -> timedelta:
-    return timedelta(minutes=_INTRO_CALL_SLOT_MINUTES)
+    return timedelta(minutes=_INTRO_CALL_SLOT_STEP_MINUTES)
+
+
+def _slot_duration() -> timedelta:
+    return timedelta(minutes=_INTRO_CALL_SLOT_DURATION_MINUTES)
 
 
 def _lead_delta() -> timedelta:
@@ -79,11 +87,12 @@ def enumerate_intro_call_candidate_slots(
     *,
     now: datetime,
 ) -> list[tuple[datetime, datetime]]:
-    """Enumerate UTC instants for each 15-minute candidate in the weekly template."""
+    """Enumerate UTC instants for each candidate start in the weekly template."""
     zone = ZoneInfo(resolve_intro_call_wall_timezone())
     now_u = now if now.tzinfo else now.replace(tzinfo=UTC)
     earliest_start = now_u + _lead_delta()
     step = _slot_step()
+    duration = _slot_duration()
     out: list[tuple[datetime, datetime]] = []
     cur = from_date
     while cur <= to_date:
@@ -97,13 +106,13 @@ def enumerate_intro_call_candidate_slots(
         )
         last_start = datetime.combine(
             cur,
-            time(hour=_INTRO_CALL_CLOSE_HOUR - 1, minute=45),
+            time(hour=_INTRO_CALL_CLOSE_HOUR - 1, minute=30),
             tzinfo=zone,
         )
         t = day_start
         while t <= last_start:
             start_utc = t.astimezone(UTC)
-            end_utc = (t + step).astimezone(UTC)
+            end_utc = (t + duration).astimezone(UTC)
             if end_utc > now_u and start_utc >= earliest_start:
                 out.append((start_utc, end_utc))
             t += step

--- a/backend/src/app/services/intro_call_slots.py
+++ b/backend/src/app/services/intro_call_slots.py
@@ -104,10 +104,15 @@ def enumerate_intro_call_candidate_slots(
             time(hour=_INTRO_CALL_OPEN_HOUR, minute=0),
             tzinfo=zone,
         )
-        last_start = datetime.combine(
-            cur,
-            time(hour=_INTRO_CALL_CLOSE_HOUR - 1, minute=30),
-            tzinfo=zone,
+        open_minutes = _INTRO_CALL_OPEN_HOUR * 60
+        close_minutes = _INTRO_CALL_CLOSE_HOUR * 60
+        max_start_minutes = close_minutes - _INTRO_CALL_SLOT_DURATION_MINUTES
+        step_m = _INTRO_CALL_SLOT_STEP_MINUTES
+        last_start_minute_of_day = (
+            open_minutes + ((max_start_minutes - open_minutes) // step_m) * step_m
+        )
+        last_start = day_start + timedelta(
+            minutes=last_start_minute_of_day - open_minutes
         )
         t = day_start
         while t <= last_start:

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -499,10 +499,11 @@ paths:
 
   /v1/calendar/intro-call-slots:
     get:
-      summary: Available 15-minute intro-call slots
+      summary: Available intro-call slots (15-minute calls, 30-minute start cadence)
       description: >
-        Returns bookable 15-minute UTC slots for the free intro-call flow (Mon–Fri
-        09:00–18:00 `Asia/Hong_Kong`, minus manual half-day blocks for
+        Returns bookable UTC intervals for the free intro-call flow: each slot is a
+        15-minute call with start times on a 30-minute grid (Mon–Fri 09:00–18:00
+        `Asia/Hong_Kong`, minus manual half-day blocks for
         `consultation_booking` and `intro_call_booking`, minus overlapping session slots).
         No PII; no Turnstile. `from` / `to` are `YYYY-MM-DD` in the server intro-call wall
         zone (default `Asia/Hong_Kong`). Span capped at 28 days; `from` not more than 35 days ahead.
@@ -547,7 +548,7 @@ paths:
 
   /www/v1/calendar/intro-call-slots:
     get:
-      summary: Available 15-minute intro-call slots (website proxy path)
+      summary: Available intro-call slots (website proxy path; 15-minute calls, 30-minute starts)
       description: Same as `GET /v1/calendar/intro-call-slots` for same-origin calls from `public_www`.
       security:
         - ApiKeyAuth: []
@@ -1745,7 +1746,8 @@ components:
             (schedule/details); not used for booking identity (use `serviceKey` + `serviceInstanceSlug`).
             `intro-call-booking` requires `serviceKey=intro-call`, `serviceInstanceSlug=intro-call-free-15min`,
             `totalAmount=0`, `paymentMethod=free` (or omit payment method to default to free), and
-            `primarySessionStartIso` / `primarySessionEndIso` for a valid 15-minute slot.
+            `primarySessionStartIso` / `primarySessionEndIso` for a valid 15-minute slot at a
+            30-minute-aligned start time (Asia/Hong_Kong office-hours template; end 15 minutes after start).
         marketingAttribution:
           type: object
           additionalProperties: false

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -607,13 +607,6 @@ runtime, the client cannot call the API and treats the outcome as a fetch failur
 enrollment is not serialised against the calendar blocker rows. Mitigations are short
 TTL on any cacheable reads and `no-store` for the consultation purpose.
 
-## Intro-call public slot cadence
-
-**Decision:** Free intro-call candidate starts advance on a **30-minute** wall-clock grid
-(Mon–Fri 09:00–17:30 `Asia/Hong_Kong` by default); each offered interval remains **15 minutes**
-long (`end = start + 15m`) so copy and the `intro-call-free-15min` instance slug stay aligned
-with call length while halving the number of start times versus a 15-minute grid.
-
 **CloudFront path allowlist:** The viewer function matches the path segment **exactly**
 (e.g. `/www/v1/calendar/blockers`); trailing slash variants are not allowlisted.
 
@@ -630,3 +623,14 @@ When making changes:
 2. Update `docs/architecture/lambdas.md` if adding/changing Lambda functions.
 3. Update `docs/architecture/database-schema.md` if adding/changing tables.
 4. Update other architecture docs if design decisions or patterns change.
+
+## Intro-call public slot cadence
+
+**Decision:** Free intro-call candidate starts advance on a **30-minute** wall-clock grid
+(Mon–Fri 09:00–17:30 `Asia/Hong_Kong` by default); each offered interval remains **15 minutes**
+long (`end = start + 15m`) so copy and the `intro-call-free-15min` instance slug stay aligned
+with call length while halving the number of start times versus a 15-minute grid.
+
+**Maintenance note (section backgrounds):** Some public sections pair a white surface with
+the light watermark treatment by registering the same class name in two CSS selector lists
+(watermark variables vs solid background). Prefer a single utility class when refactoring.

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -607,6 +607,13 @@ runtime, the client cannot call the API and treats the outcome as a fetch failur
 enrollment is not serialised against the calendar blocker rows. Mitigations are short
 TTL on any cacheable reads and `no-store` for the consultation purpose.
 
+## Intro-call public slot cadence
+
+**Decision:** Free intro-call candidate starts advance on a **30-minute** wall-clock grid
+(Mon–Fri 09:00–17:30 `Asia/Hong_Kong` by default); each offered interval remains **15 minutes**
+long (`end = start + 15m`) so copy and the `intro-call-free-15min` instance slug stay aligned
+with call length while halving the number of start times versus a 15-minute grid.
+
 **CloudFront path allowlist:** The viewer function matches the path segment **exactly**
 (e.g. `/www/v1/calendar/blockers`); trailing slash variants are not allowlisted.
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -40,8 +40,9 @@ their primary responsibilities.
   `/www/v1/calendar/blockers`; `purpose=consultation_booking` uses `Cache-Control: no-store`
   on success so admin-driven blockers are not edge-cached; other allowed purposes use the same cache headers
   as `GET /v1/calendar/public`),
-  `/v1/calendar/intro-call-slots` (GET; 15-minute free intro-call availability in UTC ISO instants;
-  same contract as `/www/v1/calendar/intro-call-slots`; no PII),
+  `/v1/calendar/intro-call-slots` (GET; free intro-call availability as UTC ISO instants;
+  15-minute call duration with 30-minute-aligned start times; same contract as
+  `/www/v1/calendar/intro-call-slots`; no PII),
   `/v1/discounts/validate`,
   `/v1/contact-us`,
   `/v1/admin/geographic-areas`,

--- a/tests/test_intro_call_slots.py
+++ b/tests/test_intro_call_slots.py
@@ -54,3 +54,18 @@ def test_month_boundary() -> None:
     )
     assert slots
     assert slots == sorted(slots, key=lambda x: x[0])
+
+
+def test_last_candidate_start_is_close_hour_minus_duration_on_grid() -> None:
+    """Last start must end before close; grid derived from step, not a hardcoded :30."""
+    from zoneinfo import ZoneInfo
+
+    now = datetime(2026, 5, 3, 0, 0, tzinfo=UTC)
+    slots = enumerate_intro_call_candidate_slots(
+        date(2026, 5, 4), date(2026, 5, 4), now=now
+    )
+    assert slots
+    zone = ZoneInfo("Asia/Hong_Kong")
+    last_s0, last_s1 = slots[-1]
+    assert last_s0.astimezone(zone).strftime("%H:%M") == "17:30"
+    assert last_s1.astimezone(zone).strftime("%H:%M") == "17:45"

--- a/tests/test_intro_call_slots.py
+++ b/tests/test_intro_call_slots.py
@@ -11,14 +11,14 @@ from app.services.intro_call_slots import (
 )
 
 
-def test_enumerate_weekday_only_and_quarter_hour_grid() -> None:
+def test_enumerate_weekday_only_and_half_hour_grid() -> None:
     # Monday 2026-05-04 HKT; anchor ``now`` on the prior weekend so the 2h lead
     # does not clip the first 09:00 slot.
     now = datetime(2026, 5, 3, 0, 0, tzinfo=UTC)
     slots = enumerate_intro_call_candidate_slots(
         date(2026, 5, 4), date(2026, 5, 4), now=now
     )
-    assert len(slots) == 36
+    assert len(slots) == 18
     for s0, s1 in slots:
         assert (s1 - s0).total_seconds() == 15 * 60
     assert slots[0][0].hour in (0, 1)  # 09:00 HKT -> UTC


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements free intro-call landing UX, backend 30-minute slot cadence, and follow-up review fixes.

### Recent follow-up (review items A–P)

- **Shared carousel primitives:** `CarouselArrowIcon`, `CarouselHorizontalArrowControls`, and `BOOKING_SELECTOR_CARD_CLASSNAME` (`booking-selector-layout.ts`). Used by intro-call day strip and My Best Auntie date carousel.
- **`SectionSpinnerStatus`** in `components/shared/`; `EventsLoadingState` in `events-shared.tsx` is now an alias for backward compatibility.
- **Locale:** `slotGroupAriaLabelTemplate` + zh-CN/zh-HK morning labels (早上 / 朝早); `IntroCallSlotPicker` takes `locale`, uses `formatPartDateTimeLabel` for screen-reader summary, localized slot time formatter.
- **`useHorizontalCarousel`:** `scrollContainerHorizontally` helper used by `scrollItemIntoView` and `scrollByDirection`; fallback when `scrollBy`/`scrollTo` missing (jsdom).
- **Navbar:** Book Now hrefs that target `#intro-call-booking` resolve to `/{locale}/book-a-free-call#intro-call-booking` so internal SmartLink does not pass `scroll={false}` (navbar test asserts).
- **CSS:** `--es-public-navbar-scroll-margin` set on `.es-navbar-offset`; booking sections use it for `scroll-margin-top`.
- **Backend:** `last_start` derived from open/close, step, and duration; unit test for last slot wall times.
- **docs/architecture/decisions.md:** Intro-call cadence + watermark maintenance note moved after “Keeping Documentation Up to Date” checklist; CloudFront paragraph stays with calendar blockers section.

### Validation

- `npm run lint` (public_www)
- Focused `npx vitest run` (picker, navbar, carousel hook, MBA booking, events, book-a-free-call, free intro call)
- `python3 -m pytest tests/test_intro_call_slots.py`
- `bash scripts/validate-cursorrules.sh`
- `python3 -m ruff format` / `ruff check` on touched Python
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cebc0bd2-4b9c-444e-b68d-56d69d372f6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cebc0bd2-4b9c-444e-b68d-56d69d372f6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

