### PR TITLE
Book a free call: date strip UX and WhatsApp copy

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react';
 
 import { BOOKING_SELECTOR_CARD_CLASSNAME } from '@/components/sections/shared/booking-selector-layout';
-import { CarouselHorizontalArrowControls } from '@/components/sections/shared/carousel-horizontal-arrow-controls';
 import { CarouselTrack } from '@/components/sections/shared/carousel-track';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import { SectionSpinnerStatus } from '@/components/shared/section-spinner-status';
@@ -25,10 +24,10 @@ import {
   CALENDAR_PUBLIC_CLIENT_FETCH_TIMEOUT_MS,
   fetchIntroCallSlots,
 } from '@/lib/intro-call-slots-api';
-import { useHorizontalCarousel } from '@/lib/hooks/use-horizontal-carousel';
 import {
   formatPartDateTimeLabel,
   PUBLIC_SITE_IANA_TIMEZONE,
+  resolveDateTimeLocale,
 } from '@/lib/site-datetime';
 import { trackAnalyticsEvent } from '@/lib/analytics';
 import { resolvePublicSiteConfig } from '@/lib/site-config';
@@ -46,16 +45,7 @@ export interface IntroCallSlotPickerProps {
 
 type FetchStatus = 'idle' | 'loading' | 'ready' | 'error';
 
-const DAY_STRIP_FORMATTER = new Intl.DateTimeFormat('en-US', {
-  timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-  weekday: 'short',
-});
-
-const DAY_NUM_FORMATTER = new Intl.DateTimeFormat('en-GB', {
-  timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-  day: '2-digit',
-  month: 'short',
-});
+const MAX_VISIBLE_BOOKING_DAYS = 5;
 
 const WALL_HOUR_FORMATTER = new Intl.DateTimeFormat('en-GB', {
   timeZone: PUBLIC_SITE_IANA_TIMEZONE,
@@ -83,6 +73,20 @@ function isMorningSlot(slot: IntroCallSlot): boolean {
   return wallClockHourFromIso(slot.startIso) < 12;
 }
 
+function formatIntroCallDayButtonLabel(iso: string, locale: Locale): string {
+  const d = new Date(iso);
+  const weekday = new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
+    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+    weekday: 'short',
+  }).format(d);
+  const dayMonth = new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
+    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+    day: '2-digit',
+    month: 'short',
+  }).format(d);
+  return `${weekday} ${dayMonth}`;
+}
+
 export function IntroCallSlotPicker({
   locale,
   commonAccessibility,
@@ -100,6 +104,7 @@ export function IntroCallSlotPicker({
   const [rovingDayIndex, setRovingDayIndex] = useState(0);
   const dayRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const slotRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const dayCarouselRef = useRef<HTMLDivElement | null>(null);
 
   const slotTimeFormatter = useMemo(
     () =>
@@ -164,7 +169,7 @@ export function IntroCallSlotPicker({
     };
   }, [refreshToken, setStatusBoth]);
 
-  const slotsByDay = useMemo(() => {
+  const slotsByDayFull = useMemo(() => {
     const map = new Map<string, IntroCallSlot[]>();
     for (const s of slots) {
       const ymd = ymdForSlot(s);
@@ -178,23 +183,21 @@ export function IntroCallSlotPicker({
     return map;
   }, [slots]);
 
-  const dayKeys = useMemo(
-    () => Array.from(slotsByDay.keys()).sort(),
-    [slotsByDay],
-  );
+  const dayKeys = useMemo(() => {
+    const sorted = Array.from(slotsByDayFull.keys()).sort();
+    return sorted.slice(0, MAX_VISIBLE_BOOKING_DAYS);
+  }, [slotsByDayFull]);
 
-  const {
-    carouselRef: dayCarouselRef,
-    hasNavigation: hasDayNavigation,
-    canScrollPrevious: canScrollDayLeft,
-    canScrollNext: canScrollDayRight,
-    scrollByDirection: scrollDayCarouselByDirection,
-    scrollItemIntoView,
-  } = useHorizontalCarousel<HTMLDivElement>({
-    itemCount: dayKeys.length,
-    minItemsForNavigation: 3,
-    loop: false,
-  });
+  const slotsByDay = useMemo(() => {
+    const map = new Map<string, IntroCallSlot[]>();
+    for (const ymd of dayKeys) {
+      const arr = slotsByDayFull.get(ymd);
+      if (arr) {
+        map.set(ymd, arr);
+      }
+    }
+    return map;
+  }, [dayKeys, slotsByDayFull]);
 
   const resolvedDayYmd = useMemo(() => {
     if (dayKeys.length === 0) {
@@ -210,11 +213,6 @@ export function IntroCallSlotPicker({
     () => Math.min(rovingDayIndex, Math.max(0, dayKeys.length - 1)),
     [dayKeys.length, rovingDayIndex],
   );
-
-  useEffect(() => {
-    const el = dayRefs.current[safeRovingDayIndex];
-    scrollItemIntoView(el);
-  }, [resolvedDayYmd, safeRovingDayIndex, scrollItemIntoView]);
 
   const daySlots = useMemo(
     () => (resolvedDayYmd ? slotsByDay.get(resolvedDayYmd) ?? [] : []),
@@ -272,17 +270,19 @@ export function IntroCallSlotPicker({
 
   if (status === 'error') {
     const message =
-      pickerContent.loadErrorMessage ?? pickerContent.emptySlotsMessage;
+      pickerContent.loadErrorMessage ?? pickerContent.emptySlotsMessagePrefix;
     return (
       <div className='space-y-3' role='alert'>
-        <p className='es-type-body'>{message}</p>
-        <a
-          href={whatsappUrl}
-          className='es-focus-ring es-inline-cta-link text-sm font-semibold'
-          rel='noopener noreferrer'
-        >
-          {pickerContent.whatsappHelpCtaLabel}
-        </a>
+        <p className='es-type-body'>
+          {message}{' '}
+          <a
+            href={whatsappUrl}
+            className='es-focus-ring es-inline-cta-link font-semibold'
+            rel='noopener noreferrer'
+          >
+            {pickerContent.whatsappAfterBookLabel}
+          </a>
+        </p>
       </div>
     );
   }
@@ -290,14 +290,16 @@ export function IntroCallSlotPicker({
   if (slots.length === 0) {
     return (
       <div className='space-y-3'>
-        <p className='es-type-body'>{pickerContent.emptySlotsMessage}</p>
-        <a
-          href={whatsappUrl}
-          className='es-focus-ring es-inline-cta-link text-sm font-semibold'
-          rel='noopener noreferrer'
-        >
-          {pickerContent.whatsappHelpCtaLabel}
-        </a>
+        <p className='es-type-body'>
+          {pickerContent.emptySlotsMessagePrefix}{' '}
+          <a
+            href={whatsappUrl}
+            className='es-focus-ring es-inline-cta-link font-semibold'
+            rel='noopener noreferrer'
+          >
+            {pickerContent.whatsappAfterBookLabel}
+          </a>
+        </p>
       </div>
     );
   }
@@ -352,21 +354,11 @@ export function IntroCallSlotPicker({
 
   return (
     <div className='space-y-4'>
-      <CarouselHorizontalArrowControls
-        showPrevious={Boolean(hasDayNavigation && canScrollDayLeft)}
-        showNext={Boolean(hasDayNavigation && canScrollDayRight)}
-        onPrevious={() => {
-          scrollDayCarouselByDirection('prev');
-        }}
-        onNext={() => {
-          scrollDayCarouselByDirection('next');
-        }}
-        previousAriaLabel={pickerContent.scrollDatesLeftAriaLabel}
-        nextAriaLabel={pickerContent.scrollDatesRightAriaLabel}
-      >
+      <div className='relative w-full min-w-0 overflow-visible'>
         <CarouselTrack
           carouselRef={dayCarouselRef}
           testId='intro-call-day-carousel'
+          presentation='group'
           ariaLabel={pickerContent.bookingSectionTitle}
           ariaRoleDescription={commonAccessibility.carouselRoleDescription}
           className='flex min-w-0 gap-2 pb-2'
@@ -380,9 +372,7 @@ export function IntroCallSlotPicker({
             if (!sample) {
               return null;
             }
-            const d = new Date(sample.startIso);
-            const wd = DAY_STRIP_FORMATTER.format(d);
-            const dm = DAY_NUM_FORMATTER.format(d);
+            const dayLabel = formatIntroCallDayButtonLabel(sample.startIso, locale);
             const isSelected = ymd === resolvedDayYmd;
             return (
               <ButtonPrimitive
@@ -401,15 +391,14 @@ export function IntroCallSlotPicker({
                   setSelectedSlotIso(null);
                 }}
                 onKeyDown={(e) => handleDayKeyDown(e, idx)}
-                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} w-[140px] shrink-0 snap-center text-left text-sm sm:w-[168px]`}
+                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} w-[140px] shrink-0 snap-center text-left text-sm font-semibold sm:w-[168px]`}
               >
-                <div className='font-semibold'>{wd}</div>
-                <div className='text-sm es-text-neutral-strong'>{dm}</div>
+                {dayLabel}
               </ButtonPrimitive>
             );
           })}
         </CarouselTrack>
-      </CarouselHorizontalArrowControls>
+      </div>
 
       {resolvedDayYmd && daySlots.length > 0 ? (
         <div className='space-y-4'>

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -500,7 +500,7 @@ export function LandingPageFreeIntroCall({
                 refreshToken={slotRefreshToken}
               />
               <p className='mt-4 es-type-body-sm text-neutral-600'>
-                {introContent.emptySlotsMessage}{' '}
+                {introContent.emptySlotsMessagePrefix}{' '}
                 <a
                   href={whatsappHref}
                   className='es-focus-ring font-semibold underline'
@@ -512,7 +512,7 @@ export function LandingPageFreeIntroCall({
                     });
                   }}
                 >
-                  {introContent.whatsappHelpCtaLabel}
+                  {introContent.whatsappAfterBookLabel}
                 </a>
               </p>
             </div>

--- a/apps/public_www/src/content/index.ts
+++ b/apps/public_www/src/content/index.ts
@@ -152,7 +152,8 @@ export interface LandingPageLocaleContent {
   };
   introCall?: {
     bookingSectionTitle: string;
-    emptySlotsMessage: string;
+    /** Shown before the WhatsApp link when no slots load or as helper copy under the picker. */
+    emptySlotsMessagePrefix: string;
     whatsappHelpCtaLabel: string;
     thankYouTitle: string;
     thankYouBody: string;
@@ -166,8 +167,6 @@ export interface LandingPageLocaleContent {
     phoneFieldLabel: string;
     loadErrorMessage?: string;
     loadingLabel: string;
-    scrollDatesLeftAriaLabel: string;
-    scrollDatesRightAriaLabel: string;
     morningSectionLabel: string;
     afternoonSectionLabel: string;
     slotGroupAriaLabelTemplate: string;

--- a/apps/public_www/src/content/landing-pages/book-a-free-call.json
+++ b/apps/public_www/src/content/landing-pages/book-a-free-call.json
@@ -89,8 +89,8 @@
     },
     "introCall": {
       "bookingSectionTitle": "Pick a time that works for you",
-      "emptySlotsMessage": "No times available in this window — please reach out on WhatsApp.",
-      "loadErrorMessage": "We could not load available times. Please refresh, or message us on WhatsApp.",
+      "emptySlotsMessagePrefix": "If none of these time slots work for you, please",
+      "loadErrorMessage": "We could not load available times. Please refresh, or",
       "whatsappHelpCtaLabel": "Message on WhatsApp",
       "thankYouTitle": "You are booked",
       "thankYouBody": "We will email you a confirmation with your call time.",
@@ -103,8 +103,6 @@
       "submitLabel": "Book my free call",
       "phoneFieldLabel": "Phone number (optional)",
       "loadingLabel": "Loading available times…",
-      "scrollDatesLeftAriaLabel": "Scroll dates left",
-      "scrollDatesRightAriaLabel": "Scroll dates right",
       "morningSectionLabel": "Morning",
       "afternoonSectionLabel": "Afternoon",
       "slotGroupAriaLabelTemplate": "{period} · {section}"
@@ -200,8 +198,8 @@
     },
     "introCall": {
       "bookingSectionTitle": "选择适合您的时间",
-      "emptySlotsMessage": "该时段暂无可预约时间 — 请通过 WhatsApp 联系我们。",
-      "loadErrorMessage": "无法加载可预约时间。请刷新页面，或通过 WhatsApp 联系我们。",
+      "emptySlotsMessagePrefix": "如果以上时间都不合适，请",
+      "loadErrorMessage": "无法加载可预约时间。请刷新页面，或",
       "whatsappHelpCtaLabel": "在 WhatsApp 联系",
       "thankYouTitle": "预约成功",
       "thankYouBody": "我们将向您发送确认邮件，内含通话时间。",
@@ -214,8 +212,6 @@
       "submitLabel": "预约免费通话",
       "phoneFieldLabel": "电话号码（可选）",
       "loadingLabel": "正在加载可预约时间…",
-      "scrollDatesLeftAriaLabel": "向左滚动日期",
-      "scrollDatesRightAriaLabel": "向右滚动日期",
       "morningSectionLabel": "早上",
       "afternoonSectionLabel": "下午",
       "slotGroupAriaLabelTemplate": "{period} · {section}"
@@ -311,8 +307,8 @@
     },
     "introCall": {
       "bookingSectionTitle": "揀個啱你嘅時間",
-      "emptySlotsMessage": "呢個時段暫時冇位 — 請透過 WhatsApp 聯絡我哋。",
-      "loadErrorMessage": "暫時載唔到可預約時間。請重新整理頁面，或者透過 WhatsApp 聯絡我哋。",
+      "emptySlotsMessagePrefix": "如果以上時間都唔啱，請",
+      "loadErrorMessage": "暫時載唔到可預約時間。請重新整理頁面，或者",
       "whatsappHelpCtaLabel": "WhatsApp 聯絡",
       "thankYouTitle": "預約成功",
       "thankYouBody": "我哋會發確認電郵俾你，入面有通話時間。",
@@ -325,8 +321,6 @@
       "submitLabel": "預約免費通話",
       "phoneFieldLabel": "電話號碼（選填）",
       "loadingLabel": "正在載入可預約時間…",
-      "scrollDatesLeftAriaLabel": "向左捲動日期",
-      "scrollDatesRightAriaLabel": "向右捲動日期",
       "morningSectionLabel": "朝早",
       "afternoonSectionLabel": "下午",
       "slotGroupAriaLabelTemplate": "{period} · {section}"

--- a/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
@@ -100,9 +100,9 @@ describe('IntroCallSlotPicker', () => {
     const dayPressedTrue = screen.getAllByRole('button', { pressed: true });
     expect(dayPressedTrue.length).toBe(1);
     const firstDay = dayPressedTrue[0] as HTMLButtonElement;
-    expect(firstDay).toHaveTextContent('Tue');
+    expect(firstDay).toHaveTextContent(/Tue\s+05\s+May/i);
 
-    const wedButton = screen.getByRole('button', { name: /Wed/i });
+    const wedButton = screen.getByRole('button', { name: /Wed\s+06\s+May/i });
     expect(wedButton).toHaveAttribute('aria-pressed', 'false');
     fireEvent.click(wedButton);
 
@@ -143,11 +143,11 @@ describe('IntroCallSlotPicker', () => {
       />,
     );
 
-    const tueButton = await screen.findByRole('button', { name: /Tue/i });
+    const tueButton = await screen.findByRole('button', { name: /Tue\s+05\s+May/i });
     expect(tueButton).toHaveAttribute('tabIndex', '0');
     expect(tueButton).toHaveAttribute('aria-pressed', 'true');
 
-    const wedButton = screen.getByRole('button', { name: /Wed/i });
+    const wedButton = screen.getByRole('button', { name: /Wed\s+06\s+May/i });
     expect(wedButton).toHaveAttribute('tabIndex', '-1');
 
     fireEvent.keyDown(tueButton, { key: 'ArrowRight' });
@@ -160,37 +160,7 @@ describe('IntroCallSlotPicker', () => {
     expect(wedButton).toHaveFocus();
   });
 
-  it('does not render date carousel arrows when fewer than three days have slots', async () => {
-    vi.mocked(fetchIntroCallSlots).mockResolvedValue({
-      slots: [
-        { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
-        { startIso: '2026-05-05T02:30:00.000Z', endIso: '2026-05-05T02:45:00.000Z' },
-      ],
-      fetchFailed: false,
-    });
-
-    render(
-      <IntroCallSlotPicker
-        locale='en'
-        commonAccessibility={enContent.common.accessibility}
-        pickerContent={bookAFreeCall.en.introCall}
-        onSelect={vi.fn()}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument();
-    });
-
-    expect(
-      screen.queryByRole('button', { name: bookAFreeCall.en.introCall.scrollDatesLeftAriaLabel }),
-    ).toBeNull();
-    expect(
-      screen.queryByRole('button', { name: bookAFreeCall.en.introCall.scrollDatesRightAriaLabel }),
-    ).toBeNull();
-  });
-
-  it('renders date carousel arrows with localized labels when enough days and overflow', async () => {
+  it('does not render date carousel arrow controls', async () => {
     vi.mocked(fetchIntroCallSlots).mockResolvedValue({
       slots: [
         { startIso: '2026-05-04T01:00:00.000Z', endIso: '2026-05-04T01:15:00.000Z' },
@@ -210,28 +180,48 @@ describe('IntroCallSlotPicker', () => {
       />,
     );
 
-    const track = await screen.findByTestId('intro-call-day-carousel');
-    let scrollLeft = 100;
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument();
+    });
+
+    const track = screen.getByTestId('intro-call-day-carousel');
     Object.defineProperty(track, 'clientWidth', { configurable: true, get: () => 200 });
     Object.defineProperty(track, 'scrollWidth', { configurable: true, get: () => 800 });
-    Object.defineProperty(track, 'scrollLeft', {
-      configurable: true,
-      get: () => scrollLeft,
-      set: (v: number) => {
-        scrollLeft = v;
-      },
-    });
-
     fireEvent(window, new Event('resize'));
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: bookAFreeCall.en.introCall.scrollDatesLeftAriaLabel }),
-      ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /scroll dates/i })).toBeNull();
+  });
+
+  it('shows at most five future days in the date strip', async () => {
+    vi.mocked(fetchIntroCallSlots).mockResolvedValue({
+      slots: [
+        { startIso: '2026-05-04T01:00:00.000Z', endIso: '2026-05-04T01:15:00.000Z' },
+        { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
+        { startIso: '2026-05-06T01:00:00.000Z', endIso: '2026-05-06T01:15:00.000Z' },
+        { startIso: '2026-05-07T01:00:00.000Z', endIso: '2026-05-07T01:15:00.000Z' },
+        { startIso: '2026-05-08T01:00:00.000Z', endIso: '2026-05-08T01:15:00.000Z' },
+        { startIso: '2026-05-09T01:00:00.000Z', endIso: '2026-05-09T01:15:00.000Z' },
+      ],
+      fetchFailed: false,
     });
-    expect(
-      screen.getByRole('button', { name: bookAFreeCall.en.introCall.scrollDatesRightAriaLabel }),
-    ).toBeInTheDocument();
+
+    render(
+      <IntroCallSlotPicker
+        locale='en'
+        commonAccessibility={enContent.common.accessibility}
+        pickerContent={bookAFreeCall.en.introCall}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Mon\s+04\s+May/i })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /Sat\s+09\s+May/i })).toBeNull();
+    const dayStrip = screen.getByTestId('intro-call-day-carousel');
+    const dayButtons = within(dayStrip).getAllByRole('button');
+    expect(dayButtons).toHaveLength(5);
   });
 
   it('groups morning and afternoon slots with section labels', async () => {
@@ -273,7 +263,7 @@ describe('IntroCallSlotPicker', () => {
 
     const onSelect = vi.fn();
     const loadError =
-      'We could not load available times. Please refresh, or message us on WhatsApp.';
+      'We could not load available times. Please refresh, or';
 
     render(
       <IntroCallSlotPicker
@@ -289,7 +279,7 @@ describe('IntroCallSlotPicker', () => {
     );
 
     expect(await screen.findByText(loadError, { exact: false })).toBeInTheDocument();
-    const link = screen.getByRole('link', { name: bookAFreeCall.en.introCall.whatsappHelpCtaLabel });
+    const link = screen.getByRole('link', { name: bookAFreeCall.en.introCall.whatsappAfterBookLabel });
     expect(link).toHaveAttribute('href', 'https://wa.me/85290000000');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the book-a-free-call intro slot picker on the public site:

- **Date strip**: Removed horizontal arrow controls. The strip now shows at most the **five earliest calendar days** that have available slots (remaining API days are not shown in the picker).
- **Day buttons**: Single bold line with a space between weekday and date (e.g. `Tue 05 May` in en-GB), using the page locale’s date formatting in Hong Kong time.
- **Empty / error messaging**: Replaced the old single-sentence empty message with an inline pattern: prefix text + **“Message me on WhatsApp”** link (reusing `whatsappAfterBookLabel`). The helper line under the picker matches the same pattern.
- **Content**: Renamed `introCall.emptySlotsMessage` to `emptySlotsMessagePrefix` and shortened `loadErrorMessage` in each locale so it flows into the link. Removed unused `scrollDatesLeftAriaLabel` / `scrollDatesRightAriaLabel` from the book-a-free-call JSON (still present in main locale files for other flows).

## Tests

- `cd apps/public_www && npm run lint`
- `npx vitest run` on `intro-call-slot-picker.test.tsx`, `book-a-free-call.test.ts`, and `landing-page-free-intro-call.test.tsx`
- `bash scripts/validate-cursorrules.sh`

## Note

Limiting to five days hides later slots from the UI only; the booking API is unchanged. If product needs those days bookable, we can follow up with pagination or “show more” behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac3a9804-728f-4953-89bc-178299c3aacf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac3a9804-728f-4953-89bc-178299c3aacf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

