### PR TITLE
Align intro-call terms checkbox with booking modal

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -19,6 +19,7 @@ import { SectionCtaAnchor } from '@/components/sections/shared/section-cta-link'
 import { SectionContainer } from '@/components/sections/shared/section-container';
 import { SectionHeader } from '@/components/sections/shared/section-header';
 import { SectionShell } from '@/components/sections/shared/section-shell';
+import { SmartLink } from '@/components/shared/smart-link';
 import type {
   BookingPaymentModalContent,
   CommonAccessibilityContent,
@@ -566,27 +567,32 @@ export function LandingPageFreeIntroCall({
                   onTopicsChange={setInterestedTopics}
                   onTopicsBlur={() => {}}
                 />
-                <MarketingOptInCheckbox
-                  checked={marketingOptIn}
-                  onChange={setMarketingOptIn}
-                  label={paymentModalContent.marketingOptInLabel}
-                />
-                <label className='flex items-start gap-2 es-type-body'>
+                <label className='flex cursor-pointer items-start gap-2.5 py-1'>
                   <input
                     type='checkbox'
+                    required
                     checked={hasTermsAgreement}
-                    onChange={(ev) => setHasTermsAgreement(ev.target.checked)}
-                    className='es-focus-ring mt-1'
+                    onChange={(event) => {
+                      setHasTermsAgreement(event.target.checked);
+                    }}
+                    className='es-focus-ring mt-1 h-4 w-4 shrink-0 es-accent-brand'
                     aria-invalid={isAckTouched && !hasTermsAgreement}
                   />
-                  <span>
+                  <span className='text-sm leading-[1.45] es-text-heading'>
                     {paymentModalContent.termsAgreementLabel}{' '}
-                    <a
+                    <SmartLink
                       href={paymentModalContent.termsHref}
-                      className='es-focus-ring font-semibold underline'
+                      openInNewTab
+                      className='es-focus-ring rounded-[2px] es-text-brand underline underline-offset-4'
+                      onClick={(event) => {
+                        event.stopPropagation();
+                      }}
                     >
                       {paymentModalContent.termsLinkLabel}
-                    </a>
+                    </SmartLink>
+                    <span className='es-form-required-marker ml-0.5' aria-hidden='true'>
+                      *
+                    </span>
                   </span>
                 </label>
                 {isAckTouched && !hasTermsAgreement ? (
@@ -594,6 +600,11 @@ export function LandingPageFreeIntroCall({
                     {paymentModalContent.acknowledgementRequiredError}
                   </p>
                 ) : null}
+                <MarketingOptInCheckbox
+                  checked={marketingOptIn}
+                  onChange={setMarketingOptIn}
+                  label={paymentModalContent.marketingOptInLabel}
+                />
                 <label className='block'>
                   <span className='mb-1 block text-sm font-semibold es-text-heading'>
                     {captchaContent.captchaLabel}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Book a Free Call intro booking form so the Terms & Conditions acknowledgement matches the main booking modal (`reservation-form.tsx`): same label typography (`text-sm leading-[1.45] es-text-heading`), `SmartLink` styling for the terms link, trailing required asterisk (`es-form-required-marker`), and checkbox sizing/classes. The terms row is moved above the “Keep me up to date” marketing checkbox. The checkbox is `required` and keeps existing submit validation and inline error messaging.

## Testing

- `cd apps/public_www && npm run lint`
- `npx vitest run tests/components/sections/landing-pages/landing-page-free-intro-call.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5a2df42-ba62-4a9b-b6e8-368adbed0513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5a2df42-ba62-4a9b-b6e8-368adbed0513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

