### PR TITLE
fix(public_www): lowercase "message" on book-a-free-call WhatsApp CTA

### DIFF
--- a/apps/public_www/src/content/landing-pages/book-a-free-call.json
+++ b/apps/public_www/src/content/landing-pages/book-a-free-call.json
@@ -95,7 +95,7 @@
       "thankYouTitle": "You are booked",
       "thankYouBody": "We will email you a confirmation with your call time.",
       "addToCalendarLabel": "Add to calendar (.ics)",
-      "whatsappAfterBookLabel": "Message me on WhatsApp",
+      "whatsappAfterBookLabel": "message me on WhatsApp",
       "slotUnavailableMessage": "That time was just taken. Please pick another slot.",
       "recentIntroMessage": "It looks like you already booked an intro call recently — reply to your previous email or message me on WhatsApp.",
       "topicsFieldLabel": "Anything you want me to know before our call?",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the English `whatsappAfterBookLabel` on the book a free intro call landing page from "Message me on WhatsApp" to "message me on WhatsApp" so the sentence-style capitalization matches product copy.

Tests: `cd apps/public_www && npx vitest run tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a747e54-0394-45a1-8296-0134066cf03b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a747e54-0394-45a1-8296-0134066cf03b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

