### PR TITLE
Align intro-call booking date/time buttons with My Best Auntie

### DIFF
--- a/apps/public_www/src/app/styles/original/components-core.css
+++ b/apps/public_www/src/app/styles/original/components-core.css
@@ -613,6 +613,15 @@
     background-color: var(--es-color-surface-soft);
   }
 
+  /**
+   * Intro-call time-slot grid: match inactive border width to active (2px) so
+   * toggling selection does not change cell size.
+   */
+  .es-btn--selection.es-intro-call-slot-selection-btn.es-btn--state-inactive {
+    border-width: 2px;
+    border-color: var(--es-color-border-date);
+  }
+
   .es-btn-selection-icon-active {
     color: var(--es-color-text-brand-strong);
   }

--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -73,7 +73,7 @@ function isMorningSlot(slot: IntroCallSlot): boolean {
   return wallClockHourFromIso(slot.startIso) < 12;
 }
 
-function formatIntroCallDayButtonLabel(iso: string, locale: Locale): string {
+function formatIntroCallDayButtonAccessibleLabel(iso: string, locale: Locale): string {
   const d = new Date(iso);
   const weekday = new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
     timeZone: PUBLIC_SITE_IANA_TIMEZONE,
@@ -85,6 +85,23 @@ function formatIntroCallDayButtonLabel(iso: string, locale: Locale): string {
     month: 'short',
   }).format(d);
   return `${weekday} ${dayMonth}`;
+}
+
+function formatIntroCallDayWeekdayShort(iso: string, locale: Locale): string {
+  const d = new Date(iso);
+  return new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
+    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+    weekday: 'short',
+  }).format(d);
+}
+
+function formatIntroCallDayDateLine(iso: string, locale: Locale): string {
+  const d = new Date(iso);
+  return new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
+    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+    day: '2-digit',
+    month: 'short',
+  }).format(d);
 }
 
 export function IntroCallSlotPicker({
@@ -314,7 +331,7 @@ export function IntroCallSlotPicker({
   function renderSlotGrid(slotsChunk: IntroCallSlot[], offsetIndex: number, partLabel: string) {
     return (
       <div
-        className='grid grid-cols-2 gap-2 sm:grid-cols-3'
+        className='grid grid-cols-2 gap-3 sm:grid-cols-3'
         role='group'
         aria-label={slotGridAriaLabel(partLabel)}
       >
@@ -333,7 +350,7 @@ export function IntroCallSlotPicker({
               variant='selection'
               state={pressed ? 'active' : 'inactive'}
               aria-pressed={pressed}
-              className='rounded-md px-2 py-2 text-sm'
+              className='es-intro-call-slot-selection-btn rounded-md px-2 py-2 text-sm'
               onClick={() => {
                 setSelectedSlotIso(slot.startIso);
                 onSelect(slot);
@@ -361,7 +378,7 @@ export function IntroCallSlotPicker({
           presentation='group'
           ariaLabel={pickerContent.bookingSectionTitle}
           ariaRoleDescription={commonAccessibility.carouselRoleDescription}
-          className='flex min-w-0 gap-2 pb-2'
+          className='flex min-w-0 gap-3 pb-2 pr-1'
         >
           {dayKeys.map((ymd, idx) => {
             const count = slotsByDay.get(ymd)?.length ?? 0;
@@ -372,7 +389,9 @@ export function IntroCallSlotPicker({
             if (!sample) {
               return null;
             }
-            const dayLabel = formatIntroCallDayButtonLabel(sample.startIso, locale);
+            const dayAccessibleLabel = formatIntroCallDayButtonAccessibleLabel(sample.startIso, locale);
+            const weekdayShort = formatIntroCallDayWeekdayShort(sample.startIso, locale);
+            const dateLine = formatIntroCallDayDateLine(sample.startIso, locale);
             const isSelected = ymd === resolvedDayYmd;
             return (
               <ButtonPrimitive
@@ -384,6 +403,7 @@ export function IntroCallSlotPicker({
                 variant='selection'
                 state={isSelected ? 'active' : 'inactive'}
                 aria-pressed={isSelected}
+                aria-label={dayAccessibleLabel}
                 tabIndex={safeRovingDayIndex === idx ? 0 : -1}
                 onClick={() => {
                   setCursorDayYmd(ymd);
@@ -391,9 +411,20 @@ export function IntroCallSlotPicker({
                   setSelectedSlotIso(null);
                 }}
                 onKeyDown={(e) => handleDayKeyDown(e, idx)}
-                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} w-[140px] shrink-0 snap-center text-left text-sm font-semibold sm:w-[168px]`}
+                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative w-[140px] shrink-0 snap-center text-center sm:w-[168px]`}
               >
-                {dayLabel}
+                <div className='flex w-full flex-col items-center gap-2'>
+                  <div className='flex items-center justify-center gap-1.5'>
+                    <span
+                      className={`h-6 w-6 shrink-0 es-mask-calendar-current ${isSelected ? 'es-btn-selection-icon-active' : 'es-btn-selection-icon-inactive'}`}
+                      aria-hidden='true'
+                    />
+                    <p className='text-base font-semibold es-text-heading whitespace-nowrap'>
+                      {weekdayShort}
+                    </p>
+                  </div>
+                  <p className='text-center text-sm es-text-heading'>{dateLine}</p>
+                </div>
               </ButtonPrimitive>
             );
           })}

--- a/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
@@ -99,8 +99,8 @@ describe('IntroCallSlotPicker', () => {
 
     const dayPressedTrue = screen.getAllByRole('button', { pressed: true });
     expect(dayPressedTrue.length).toBe(1);
-    const firstDay = dayPressedTrue[0] as HTMLButtonElement;
-    expect(firstDay).toHaveTextContent(/Tue\s+05\s+May/i);
+    const firstDay = screen.getByRole('button', { name: /Tue\s+05\s+May/i });
+    expect(firstDay).toHaveAttribute('aria-pressed', 'true');
 
     const wedButton = screen.getByRole('button', { name: /Wed\s+06\s+May/i });
     expect(wedButton).toHaveAttribute('aria-pressed', 'false');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the **Book a free call** (`IntroCallSlotPicker`) booking strip so day tiles match the **My Best Auntie** booking section: same selector card surface, calendar mask icon, centered two-line layout (weekday row + date row), and matching carousel spacing (`gap-3`, trailing `pr-1`).

For **time slots**, inactive buttons now use the same **2px border width** as the active state via a scoped class (`.es-intro-call-slot-selection-btn`), avoiding the layout jump caused by switching between 1px and 2px borders on `.es-btn--selection`. The time grid gap is increased (`gap-3`) for clearer separation.

## Testing

- `cd apps/public_www && npx vitest run tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx`
- `cd apps/public_www && npm run lint`
- `bash scripts/validate-cursorrules.sh`

No locale JSON changes (visible copy remains derived from date formatting).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b4e1258-5572-4e65-9092-118871d4f905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b4e1258-5572-4e65-9092-118871d4f905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

