### PR TITLE
Align intro-call-slots GET with public edge cache headers

### DIFF
--- a/backend/src/app/api/public_calendar_intro_call_slots.py
+++ b/backend/src/app/api/public_calendar_intro_call_slots.py
@@ -1,4 +1,10 @@
-"""Public GET /v1/calendar/intro-call-slots (15-minute availability, no PII)."""
+"""Public GET /v1/calendar/intro-call-slots (15-minute availability, no PII).
+
+GET responses for routes reachable via the public website CloudFront ``/www/*``
+proxy must include a ``Cache-Control`` header: use a shared-cache friendly value
+on success (200) and ``no-store`` on errors so CloudFront never retains unsafe
+responses.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +21,7 @@ from app.services.intro_call_slots import (
     compute_available_intro_call_slots,
     resolve_intro_call_wall_timezone,
 )
-from app.utils import json_response
+from app.utils import public_cacheable_json_response
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -44,7 +50,9 @@ def handle_public_calendar_intro_call_slots(
 ) -> dict[str, Any]:
     """Return available intro-call slots as UTC ISO instants."""
     if method != "GET":
-        return json_response(405, {"error": "Method not allowed"}, event=event)
+        return public_cacheable_json_response(
+            405, {"error": "Method not allowed"}, event=event
+        )
 
     query = event.get("queryStringParameters") or {}
     if not isinstance(query, Mapping):
@@ -57,26 +65,32 @@ def handle_public_calendar_intro_call_slots(
     to_raw = query.get("to")
     from_date = _parse_iso_date(from_raw, default=today)
     if from_date is None:
-        return json_response(400, {"error": "Invalid from date"}, event=event)
+        return public_cacheable_json_response(
+            400, {"error": "Invalid from date"}, event=event
+        )
 
     default_to = from_date + timedelta(days=21)
     to_date = _parse_iso_date(to_raw, default=default_to)
     if to_date is None:
-        return json_response(400, {"error": "Invalid to date"}, event=event)
+        return public_cacheable_json_response(
+            400, {"error": "Invalid to date"}, event=event
+        )
 
     if to_date < from_date:
-        return json_response(400, {"error": "to must be on or after from"}, event=event)
+        return public_cacheable_json_response(
+            400, {"error": "to must be on or after from"}, event=event
+        )
 
     span = (to_date - from_date).days
     if span > _MAX_SPAN_DAYS:
-        return json_response(
+        return public_cacheable_json_response(
             400,
             {"error": f"Date range exceeds maximum of {_MAX_SPAN_DAYS} days"},
             event=event,
         )
 
     if (from_date - today).days > _MAX_FORWARD_DAYS:
-        return json_response(
+        return public_cacheable_json_response(
             400,
             {"error": "from is too far in the future"},
             event=event,
@@ -97,4 +111,4 @@ def handle_public_calendar_intro_call_slots(
             for s0, s1 in slots
         ]
     }
-    return json_response(200, body, event=event)
+    return public_cacheable_json_response(200, body, event=event)

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -525,26 +525,23 @@ paths:
       responses:
         "200":
           description: Slot list.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              description: >
+                `public, max-age=60, s-maxage=300, stale-while-revalidate=600` for
+                CloudFront edge caching on `/www/*` (TTL capped by cache policy).
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/IntroCallSlotsResponse"
         "400":
-          $ref: "#/components/responses/BadRequest"
+          $ref: "#/components/responses/PublicWebsiteCacheableGetBadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
         "405":
-          description: Method not allowed.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Server error.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
+          $ref: "#/components/responses/PublicWebsiteCacheableGetMethodNotAllowed"
 
   /www/v1/calendar/intro-call-slots:
     get:
@@ -568,12 +565,19 @@ paths:
       responses:
         "200":
           description: Slot list.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              description: >
+                `public, max-age=60, s-maxage=300, stale-while-revalidate=600` for
+                CloudFront edge caching on `/www/*` (TTL capped by cache policy).
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/IntroCallSlotsResponse"
         "400":
-          $ref: "#/components/responses/BadRequest"
+          $ref: "#/components/responses/PublicWebsiteCacheableGetBadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
         "405":
@@ -1111,6 +1115,17 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
     NotFound:
       description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    PublicWebsiteCacheableGetBadRequest:
+      description: Validation error; must not be cached at the edge.
+      headers:
+        Cache-Control:
+          schema:
+            type: string
+            enum: [no-store]
       content:
         application/json:
           schema:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -42,7 +42,8 @@ their primary responsibilities.
   as `GET /v1/calendar/public`),
   `/v1/calendar/intro-call-slots` (GET; free intro-call availability as UTC ISO instants;
   15-minute call duration with 30-minute-aligned start times; same contract as
-  `/www/v1/calendar/intro-call-slots`; no PII),
+  `/www/v1/calendar/intro-call-slots`; no PII; `Cache-Control` on 200 matches other public
+  cacheable GETs, `no-store` on handler errors),
   `/v1/discounts/validate`,
   `/v1/contact-us`,
   `/v1/admin/geographic-areas`,

--- a/tests/test_public_calendar_intro_call_slots.py
+++ b/tests/test_public_calendar_intro_call_slots.py
@@ -11,6 +11,9 @@ import pytest
 from app.api.public_calendar_intro_call_slots import (
     handle_public_calendar_intro_call_slots,
 )
+from app.utils import CACHE_CONTROL_EDGE_CACHEABLE_GET
+
+_EXPECTED_CACHE_CONTROL_SUCCESS = CACHE_CONTROL_EDGE_CACHEABLE_GET
 
 
 class _Ctx:
@@ -24,11 +27,15 @@ class _Ctx:
         return None
 
 
-def test_get_returns_sorted_slots(monkeypatch: pytest.MonkeyPatch, api_gateway_event: Any) -> None:
+def test_get_returns_sorted_slots(
+    monkeypatch: pytest.MonkeyPatch, api_gateway_event: Any
+) -> None:
     monkeypatch.setattr(
         "app.api.public_calendar_intro_call_slots.Session", lambda _e: _Ctx()
     )
-    monkeypatch.setattr("app.api.public_calendar_intro_call_slots.get_engine", lambda: object())
+    monkeypatch.setattr(
+        "app.api.public_calendar_intro_call_slots.get_engine", lambda: object()
+    )
 
     t0 = datetime(2026, 5, 4, 2, 0, tzinfo=UTC)
     t1 = datetime(2026, 5, 4, 2, 15, tzinfo=UTC)
@@ -47,6 +54,7 @@ def test_get_returns_sorted_slots(monkeypatch: pytest.MonkeyPatch, api_gateway_e
     )
     resp = handle_public_calendar_intro_call_slots(event, "GET")
     assert resp["statusCode"] == 200
+    assert resp["headers"]["Cache-Control"] == _EXPECTED_CACHE_CONTROL_SUCCESS
     body = json.loads(resp["body"])
     assert body["slots"][0]["start_iso"].endswith("Z")
 
@@ -55,6 +63,7 @@ def test_post_returns_405(api_gateway_event: Any) -> None:
     event = api_gateway_event(method="POST", path="/v1/calendar/intro-call-slots")
     resp = handle_public_calendar_intro_call_slots(event, "POST")
     assert resp["statusCode"] == 405
+    assert resp["headers"]["Cache-Control"] == "no-store"
 
 
 def test_invalid_from_returns_400(api_gateway_event: Any) -> None:
@@ -65,6 +74,7 @@ def test_invalid_from_returns_400(api_gateway_event: Any) -> None:
     )
     resp = handle_public_calendar_intro_call_slots(event, "GET")
     assert resp["statusCode"] == 400
+    assert resp["headers"]["Cache-Control"] == "no-store"
 
 
 def test_span_too_large_returns_400(api_gateway_event: Any) -> None:
@@ -75,3 +85,4 @@ def test_span_too_large_returns_400(api_gateway_event: Any) -> None:
     )
     resp = handle_public_calendar_intro_call_slots(event, "GET")
     assert resp["statusCode"] == 400
+    assert resp["headers"]["Cache-Control"] == "no-store"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GET /v1/calendar/intro-call-slots` (and `/www/...`) now uses `public_cacheable_json_response` like other allowlisted public GETs: **200** responses emit `public, max-age=60, s-maxage=300, stale-while-revalidate=600` for CloudFront `/www/*` caching (TTL still capped by the existing cache policy), and **non-200** handler paths use `no-store`.

## Changes

- **Handler:** `backend/src/app/api/public_calendar_intro_call_slots.py` — module docstring + all responses via `public_cacheable_json_response`.
- **Tests:** `tests/test_public_calendar_intro_call_slots.py` — assert `Cache-Control` on success and error paths.
- **OpenAPI:** `docs/api/public.yaml` — document 200 `Cache-Control`; add `PublicWebsiteCacheableGetBadRequest` for 400 with `no-store`; drop ad-hoc 405/500 blocks on the direct path in favor of shared cacheable-get responses (405 uses existing `PublicWebsiteCacheableGetMethodNotAllowed`).
- **Docs:** `docs/architecture/lambdas.md` — note cache header contract for intro-call-slots.

## Validation

- `python3 -m pytest tests/test_public_calendar_intro_call_slots.py`
- `python3 -m ruff format` on touched Python files
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68998fdc-1b98-441c-83a7-6d100010f74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68998fdc-1b98-441c-83a7-6d100010f74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

