### PR TITLE
Narrow book-a-free-call date strip buttons by 20%

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -411,7 +411,7 @@ export function IntroCallSlotPicker({
                   setSelectedSlotIso(null);
                 }}
                 onKeyDown={(e) => handleDayKeyDown(e, idx)}
-                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative w-[140px] shrink-0 snap-center text-center sm:w-[168px]`}
+                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative w-[112px] shrink-0 snap-center text-center sm:w-[134.4px]`}
               >
                 <div className='flex w-full flex-col items-center gap-2'>
                   <div className='flex items-center justify-center gap-1.5'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The intro-call booking day carousel on the book-a-free-call landing page used fixed-width day buttons (`140px` / `168px` at `sm`). Those widths are reduced by 20% to `112px` / `134.4px` so the date strip reads slightly tighter without changing layout or behavior.

## Test plan

- `cd apps/public_www && npx vitest run tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx`
- `cd apps/public_www && npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f79f6e8-fc44-4b93-957a-0e017356a560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f79f6e8-fc44-4b93-957a-0e017356a560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

