### PR TITLE
fix(public_www): intro-call mobile date strip and time slot grid

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -331,7 +331,7 @@ export function IntroCallSlotPicker({
   function renderSlotGrid(slotsChunk: IntroCallSlot[], offsetIndex: number, partLabel: string) {
     return (
       <div
-        className='grid grid-cols-2 gap-3 sm:grid-cols-3'
+        className='grid grid-cols-2 gap-3 md:grid-cols-3'
         role='group'
         aria-label={slotGridAriaLabel(partLabel)}
       >
@@ -411,7 +411,7 @@ export function IntroCallSlotPicker({
                   setSelectedSlotIso(null);
                 }}
                 onKeyDown={(e) => handleDayKeyDown(e, idx)}
-                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative w-[112px] shrink-0 snap-center text-center sm:w-[134.4px]`}
+                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative min-w-0 w-[calc((100%-1.5rem)/2.5)] shrink-0 snap-center text-center sm:w-[134.4px]`}
               >
                 <div className='flex w-full flex-col items-center gap-2'>
                   <div className='flex items-center justify-center gap-1.5'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the free intro call booking picker's left column on narrow viewports.

- **Date strip:** Each day card is sized with `w-[calc((100%-1.5rem)/2.5)]` so the first row shows two full day buttons and about half of a third (with the existing `gap-3` between cards), making horizontal scroll and the next day more discoverable. From the `sm` breakpoint up, cards keep the previous fixed `134.4px` width.
- **Time slots:** The slot grid stays at **two columns** from mobile through `sm`, and only switches to three columns from **`md` and up** (replacing `sm:grid-cols-3` with `md:grid-cols-3`), matching the expectation of two slots per row on typical phone widths.

## Validation

- `cd apps/public_www && npm run lint`
- `cd apps/public_www && npx vitest run tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-337abc48-58cf-401a-a890-428369651470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-337abc48-58cf-401a-a890-428369651470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

