### PR TITLE
Book a free call: mobile perf, trimmed layout, deferred Turnstile

### DIFF
--- a/apps/public_www/src/components/pages/landing-pages/landing-page.tsx
+++ b/apps/public_www/src/components/pages/landing-pages/landing-page.tsx
@@ -90,22 +90,6 @@ export function LandingPage({
               sectionClassName='es-section-bg-overlay es-book-a-free-call-good-to-know-section'
             />
             {introCallSectionBeforeCta}
-            <LandingPageDescription
-              content={pageContent.description}
-              ariaLabel={
-                siteContent.landingPages.common.a11y.descriptionSectionLabel
-              }
-            />
-            <Testimonials
-              content={siteContent.testimonials}
-              commonAccessibility={siteContent.common.accessibility}
-            />
-            <AboutUsIdaCoach
-              content={siteContent.aboutUs.coaches.ida}
-              ariaLabel={
-                siteContent.landingPages.common.a11y.aboutUsIdaCoachSectionLabel
-              }
-            />
             <LandingPageFaq
               content={pageContent.faq}
               ariaLabel={siteContent.landingPages.common.a11y.faqSectionLabel}

--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -98,6 +98,20 @@ function isMorningSlot(slot: IntroCallSlot): boolean {
   return wallClockHourFromIso(slot.startIso) < 12;
 }
 
+function DayStripEdgeFade({ side, visible }: { side: 'left' | 'right'; visible: boolean }) {
+  const isRight = side === 'right';
+  return (
+    <span
+      aria-hidden='true'
+      className={`pointer-events-none absolute inset-y-0 w-10 transition-opacity duration-200 ${
+        isRight
+          ? 'right-0 bg-gradient-to-l from-[var(--es-color-surface-peach,#FFEEE3)] to-transparent'
+          : 'left-0 bg-gradient-to-r from-[var(--es-color-surface-peach,#FFEEE3)] to-transparent'
+      } ${visible ? 'opacity-100' : 'opacity-0'}`}
+    />
+  );
+}
+
 export function IntroCallSlotPicker({
   locale,
   commonAccessibility,
@@ -117,6 +131,8 @@ export function IntroCallSlotPicker({
   const slotRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const dayCarouselRef = useRef<HTMLDivElement | null>(null);
   const lastReportedStatusRef = useRef<FetchStatus | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
 
   const slotTimeFormatter = useMemo(
     () =>
@@ -166,6 +182,16 @@ export function IntroCallSlotPicker({
       params: { status },
     });
   }, [status]);
+
+  const updateDayStripScrollHints = useCallback(() => {
+    const el = dayCarouselRef.current;
+    if (!el) {
+      return;
+    }
+    const { scrollLeft, clientWidth, scrollWidth } = el;
+    setCanScrollLeft(scrollLeft > 1);
+    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1);
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -221,6 +247,23 @@ export function IntroCallSlotPicker({
     const sorted = Array.from(slotsByDayFull.keys()).sort();
     return sorted.slice(0, MAX_VISIBLE_BOOKING_DAYS);
   }, [slotsByDayFull]);
+
+  useEffect(() => {
+    if (status !== 'ready' || slots.length === 0) {
+      return;
+    }
+    const el = dayCarouselRef.current;
+    if (!el) {
+      return;
+    }
+    updateDayStripScrollHints();
+    el.addEventListener('scroll', updateDayStripScrollHints, { passive: true });
+    window.addEventListener('resize', updateDayStripScrollHints);
+    return () => {
+      el.removeEventListener('scroll', updateDayStripScrollHints);
+      window.removeEventListener('resize', updateDayStripScrollHints);
+    };
+  }, [dayKeys, slots.length, status, updateDayStripScrollHints]);
 
   const slotsByDay = useMemo(() => {
     const map = new Map<string, IntroCallSlot[]>();
@@ -367,7 +410,7 @@ export function IntroCallSlotPicker({
               variant='selection'
               state={pressed ? 'active' : 'inactive'}
               aria-pressed={pressed}
-              className='es-intro-call-slot-selection-btn rounded-md px-2 py-2 text-sm'
+              className='es-intro-call-slot-selection-btn rounded-md min-h-11 px-3 py-2.5 text-base sm:text-sm'
               onClick={() => {
                 setSelectedSlotIso(slot.startIso);
                 onSelect(slot);
@@ -428,10 +471,10 @@ export function IntroCallSlotPicker({
                   setSelectedSlotIso(null);
                 }}
                 onKeyDown={(e) => handleDayKeyDown(e, idx)}
-                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative min-w-0 w-[calc((100%-1.5rem)/2.5)] shrink-0 snap-center text-center sm:w-[134.4px]`}
+                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative min-h-[88px] w-[120px] shrink-0 snap-center text-center sm:min-h-0 sm:w-[134.4px]`}
               >
                 <div className='flex w-full flex-col items-center gap-2'>
-                  <div className='flex items-center justify-center gap-1.5'>
+                  <div className='flex items-center justify-center gap-2'>
                     <span
                       className={`h-6 w-6 shrink-0 es-mask-calendar-current ${isSelected ? 'es-btn-selection-icon-active' : 'es-btn-selection-icon-inactive'}`}
                       aria-hidden='true'
@@ -440,12 +483,14 @@ export function IntroCallSlotPicker({
                       {weekdayShort}
                     </p>
                   </div>
-                  <p className='text-center text-sm es-text-heading'>{dateLine}</p>
+                  <p className='text-center text-sm sm:text-sm es-text-heading'>{dateLine}</p>
                 </div>
               </ButtonPrimitive>
             );
           })}
         </CarouselTrack>
+        <DayStripEdgeFade side='left' visible={canScrollLeft} />
+        <DayStripEdgeFade side='right' visible={canScrollRight} />
       </div>
 
       {resolvedDayYmd && daySlots.length > 0 ? (

--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -53,14 +53,39 @@ const WALL_HOUR_FORMATTER = new Intl.DateTimeFormat('en-GB', {
   hourCycle: 'h23',
 });
 
-function ymdForSlot(slot: IntroCallSlot): string {
-  const d = new Date(slot.startIso);
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(d);
+const SITE_YMD_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const WEEKDAY_SHORT_FORMATTERS: Record<string, Intl.DateTimeFormat> = {};
+const DAY_MONTH_SHORT_FORMATTERS: Record<string, Intl.DateTimeFormat> = {};
+
+function getWeekdayShortFormatter(resolvedLocale: string): Intl.DateTimeFormat {
+  let fmt = WEEKDAY_SHORT_FORMATTERS[resolvedLocale];
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat(resolvedLocale, {
+      timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+      weekday: 'short',
+    });
+    WEEKDAY_SHORT_FORMATTERS[resolvedLocale] = fmt;
+  }
+  return fmt;
+}
+
+function getDayMonthShortFormatter(resolvedLocale: string): Intl.DateTimeFormat {
+  let fmt = DAY_MONTH_SHORT_FORMATTERS[resolvedLocale];
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat(resolvedLocale, {
+      timeZone: PUBLIC_SITE_IANA_TIMEZONE,
+      day: '2-digit',
+      month: 'short',
+    });
+    DAY_MONTH_SHORT_FORMATTERS[resolvedLocale] = fmt;
+  }
+  return fmt;
 }
 
 function wallClockHourFromIso(iso: string): number {
@@ -71,37 +96,6 @@ function wallClockHourFromIso(iso: string): number {
 
 function isMorningSlot(slot: IntroCallSlot): boolean {
   return wallClockHourFromIso(slot.startIso) < 12;
-}
-
-function formatIntroCallDayButtonAccessibleLabel(iso: string, locale: Locale): string {
-  const d = new Date(iso);
-  const weekday = new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
-    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-    weekday: 'short',
-  }).format(d);
-  const dayMonth = new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
-    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-    day: '2-digit',
-    month: 'short',
-  }).format(d);
-  return `${weekday} ${dayMonth}`;
-}
-
-function formatIntroCallDayWeekdayShort(iso: string, locale: Locale): string {
-  const d = new Date(iso);
-  return new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
-    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-    weekday: 'short',
-  }).format(d);
-}
-
-function formatIntroCallDayDateLine(iso: string, locale: Locale): string {
-  const d = new Date(iso);
-  return new Intl.DateTimeFormat(resolveDateTimeLocale(locale), {
-    timeZone: PUBLIC_SITE_IANA_TIMEZONE,
-    day: '2-digit',
-    month: 'short',
-  }).format(d);
 }
 
 export function IntroCallSlotPicker({
@@ -122,6 +116,7 @@ export function IntroCallSlotPicker({
   const dayRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const slotRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const dayCarouselRef = useRef<HTMLDivElement | null>(null);
+  const lastReportedStatusRef = useRef<FetchStatus | null>(null);
 
   const slotTimeFormatter = useMemo(
     () =>
@@ -134,6 +129,24 @@ export function IntroCallSlotPicker({
     [locale],
   );
 
+  const dayFormatters = useMemo(() => {
+    const resolved = resolveDateTimeLocale(locale);
+    const weekdayFmt = getWeekdayShortFormatter(resolved);
+    const dayMonthFmt = getDayMonthShortFormatter(resolved);
+    return {
+      accessibleLabel(iso: string): string {
+        const d = new Date(iso);
+        return `${weekdayFmt.format(d)} ${dayMonthFmt.format(d)}`;
+      },
+      weekdayShort(iso: string): string {
+        return weekdayFmt.format(new Date(iso));
+      },
+      dateLine(iso: string): string {
+        return dayMonthFmt.format(new Date(iso));
+      },
+    };
+  }, [locale]);
+
   const setStatusBoth = useCallback(
     (next: FetchStatus) => {
       setStatus(next);
@@ -143,6 +156,10 @@ export function IntroCallSlotPicker({
   );
 
   useEffect(() => {
+    if (lastReportedStatusRef.current === status) {
+      return;
+    }
+    lastReportedStatusRef.current = status;
     trackAnalyticsEvent('intro_call_slot_picker_status_change', {
       sectionId: 'intro-call-booking',
       ctaLocation: 'intro_call_slot_picker',
@@ -189,7 +206,7 @@ export function IntroCallSlotPicker({
   const slotsByDayFull = useMemo(() => {
     const map = new Map<string, IntroCallSlot[]>();
     for (const s of slots) {
-      const ymd = ymdForSlot(s);
+      const ymd = SITE_YMD_FORMATTER.format(new Date(s.startIso));
       const arr = map.get(ymd) ?? [];
       arr.push(s);
       map.set(ymd, arr);
@@ -389,9 +406,9 @@ export function IntroCallSlotPicker({
             if (!sample) {
               return null;
             }
-            const dayAccessibleLabel = formatIntroCallDayButtonAccessibleLabel(sample.startIso, locale);
-            const weekdayShort = formatIntroCallDayWeekdayShort(sample.startIso, locale);
-            const dateLine = formatIntroCallDayDateLine(sample.startIso, locale);
+            const dayAccessibleLabel = dayFormatters.accessibleLabel(sample.startIso);
+            const weekdayShort = dayFormatters.weekdayShort(sample.startIso);
+            const dateLine = dayFormatters.dateLine(sample.startIso);
             const isSelected = ymd === resolvedDayYmd;
             return (
               <ButtonPrimitive

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -125,6 +125,7 @@ export function LandingPageFreeIntroCall({
   const [phone, setPhone] = useState('');
   const [interestedTopics, setInterestedTopics] = useState('');
   const [marketingOptIn, setMarketingOptIn] = useState(false);
+  const [hasFormInteracted, setHasFormInteracted] = useState(false);
   const [isFullNameTouched, setIsFullNameTouched] = useState(false);
   const [isEmailTouched, setIsEmailTouched] = useState(false);
   const [isPhoneTouched, setIsPhoneTouched] = useState(false);
@@ -181,6 +182,7 @@ export function LandingPageFreeIntroCall({
   }, [locale, selectedSlot]);
 
   const handleSelectSlot = useCallback((slot: IntroCallSlot) => {
+    setHasFormInteracted(true);
     setSelectedSlot(slot);
     setRecentCooldownMessage(false);
     clearSubmissionError();
@@ -197,6 +199,7 @@ export function LandingPageFreeIntroCall({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    setHasFormInteracted(true);
     if (isSubmitting || isSuccess) {
       return;
     }
@@ -526,10 +529,14 @@ export function LandingPageFreeIntroCall({
                   </a>
                 </p>
               ) : null}
+              {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- defer Turnstile until focus enters booking fields */}
               <form
                 id='intro-call-booking-form'
                 aria-labelledby='intro-call-booking-heading'
                 noValidate
+                onFocus={() => {
+                  setHasFormInteracted(true);
+                }}
                 onSubmit={(e) => {
                   void handleSubmit(e);
                 }}
@@ -557,14 +564,29 @@ export function LandingPageFreeIntroCall({
                     placeholder: introContent.topicsFieldPlaceholder,
                     required: false,
                   }}
-                  onFullNameChange={setFullName}
+                  onFullNameChange={(v) => {
+                    setHasFormInteracted(true);
+                    setFullName(v);
+                  }}
                   onFullNameBlur={() => setIsFullNameTouched(true)}
-                  onEmailChange={setEmail}
+                  onEmailChange={(v) => {
+                    setHasFormInteracted(true);
+                    setEmail(v);
+                  }}
                   onEmailBlur={() => setIsEmailTouched(true)}
-                  onPhoneCountryChange={setPhoneCountry}
-                  onPhoneChange={setPhone}
+                  onPhoneCountryChange={(v) => {
+                    setHasFormInteracted(true);
+                    setPhoneCountry(v);
+                  }}
+                  onPhoneChange={(v) => {
+                    setHasFormInteracted(true);
+                    setPhone(v);
+                  }}
                   onPhoneBlur={() => setIsPhoneTouched(true)}
-                  onTopicsChange={setInterestedTopics}
+                  onTopicsChange={(v) => {
+                    setHasFormInteracted(true);
+                    setInterestedTopics(v);
+                  }}
                   onTopicsBlur={() => {}}
                 />
                 <label className='flex cursor-pointer items-start gap-2.5 py-1'>
@@ -573,6 +595,7 @@ export function LandingPageFreeIntroCall({
                     required
                     checked={hasTermsAgreement}
                     onChange={(event) => {
+                      setHasFormInteracted(true);
                       setHasTermsAgreement(event.target.checked);
                     }}
                     className='es-focus-ring mt-1 h-4 w-4 shrink-0 es-accent-brand'
@@ -602,19 +625,31 @@ export function LandingPageFreeIntroCall({
                 ) : null}
                 <MarketingOptInCheckbox
                   checked={marketingOptIn}
-                  onChange={setMarketingOptIn}
+                  onChange={(checked) => {
+                    setHasFormInteracted(true);
+                    setMarketingOptIn(checked);
+                  }}
                   label={paymentModalContent.marketingOptInLabel}
                 />
                 <label className='block'>
                   <span className='mb-1 block text-sm font-semibold es-text-heading'>
                     {captchaContent.captchaLabel}
                   </span>
-                  <TurnstileCaptcha
-                    siteKey={turnstileSiteKey}
-                    widgetAction='intro_call_booking_submit'
-                    onTokenChange={handleCaptchaTokenChange}
-                    onLoadError={handleCaptchaLoadError}
-                  />
+                  {hasFormInteracted ? (
+                    <TurnstileCaptcha
+                      siteKey={turnstileSiteKey}
+                      widgetAction='intro_call_booking_submit'
+                      onTokenChange={handleCaptchaTokenChange}
+                      onLoadError={handleCaptchaLoadError}
+                    />
+                  ) : (
+                    <p
+                      className='es-type-body-sm text-neutral-600'
+                      data-testid='intro-call-captcha-placeholder'
+                    >
+                      {captchaContent.deferredHint}
+                    </p>
+                  )}
                 </label>
                 {captchaInlineError ? (
                   <p className='es-form-field-error' role='alert'>
@@ -635,7 +670,6 @@ export function LandingPageFreeIntroCall({
                     isSubmitting
                     || isSuccess
                     || isCaptchaUnavailable
-                    || !captchaToken
                   }
                 >
                   <SubmitButtonLoadingContent

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -490,7 +490,7 @@ export function LandingPageFreeIntroCall({
             </div>
           </div>
         ) : (
-          <div className='grid gap-10 lg:grid-cols-2 lg:gap-12'>
+          <div className='grid gap-8 lg:grid-cols-2 lg:gap-12'>
             <div ref={pickerWrapRef}>
               <IntroCallSlotPicker
                 locale={locale}

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-hero.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-hero.tsx
@@ -274,7 +274,9 @@ export function LandingPageHero({
             alt={content.imageAlt}
             width={1200}
             height={900}
-            sizes='(max-width: 1024px) 120vw, 60vw'
+            priority
+            fetchPriority='high'
+            sizes='(max-width: 1024px) 100vw, 60vw'
             className='relative z-10 h-auto w-full rounded-panel'
           />
         </div>

--- a/apps/public_www/src/content/en.json
+++ b/apps/public_www/src/content/en.json
@@ -1142,6 +1142,7 @@
     },
     "captcha": {
       "captchaLabel": "Verification",
+      "deferredHint": "We'll verify you're not a robot when you start filling the form.",
       "requiredError": "Please complete CAPTCHA verification before submitting.",
       "loadError": "CAPTCHA failed to load. Please refresh and try again.",
       "unavailableError": "CAPTCHA is temporarily unavailable. Please try again later."

--- a/apps/public_www/src/content/zh-CN.json
+++ b/apps/public_www/src/content/zh-CN.json
@@ -1142,6 +1142,7 @@
     },
     "captcha": {
       "captchaLabel": "验证",
+      "deferredHint": "开始填写表单时，我们会进行验证。",
       "requiredError": "提交前请先完成 CAPTCHA 验证。",
       "loadError": "CAPTCHA 加载失败，请刷新页面后重试。",
       "unavailableError": "CAPTCHA 暂时不可用，请稍后再试。"

--- a/apps/public_www/src/content/zh-HK.json
+++ b/apps/public_www/src/content/zh-HK.json
@@ -1142,6 +1142,7 @@
     },
     "captcha": {
       "captchaLabel": "驗證",
+      "deferredHint": "當你開始填寫表單時，我哋會做驗證。",
       "requiredError": "提交前請先完成 CAPTCHA 驗證。",
       "loadError": "CAPTCHA 載入失敗，請重新整理頁面後再試。",
       "unavailableError": "CAPTCHA 暫時不可用，請稍後再試。"

--- a/apps/public_www/tests/components/pages/landing-pages/book-a-free-call.test.tsx
+++ b/apps/public_www/tests/components/pages/landing-pages/book-a-free-call.test.tsx
@@ -77,7 +77,7 @@ describe('BookFreeCallLandingPage', () => {
     spy.mockRestore();
   });
 
-  it('lays out sections: before you book → pick a time → how it works before testimonials', () => {
+  it('lays out sections: hero → before you book → pick a time → faq, with no description/testimonials/coach', () => {
     render(
       <BookFreeCallLandingPage
         locale='en'
@@ -98,22 +98,28 @@ describe('BookFreeCallLandingPage', () => {
       name: bookAFreeCall.en.introCall.bookingSectionTitle,
     });
     expect(bookingRegion).toHaveClass('es-book-a-free-call-booking-section');
-    const howItWorksHeading = screen.getByRole('heading', {
-      name: bookAFreeCall.en.description.title,
-    });
-    const testimonialsHeading = screen.getByRole('heading', {
-      name: enContent.testimonials.title,
+
+    const faqHeading = screen.getByRole('heading', {
+      name: bookAFreeCall.en.faq.title,
     });
 
     expect(
       beforeYouBookHeading.compareDocumentPosition(bookingRegion),
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(
-      bookingRegion.compareDocumentPosition(howItWorksHeading),
+      bookingRegion.compareDocumentPosition(faqHeading),
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
     expect(
-      howItWorksHeading.compareDocumentPosition(testimonialsHeading),
-    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      screen.queryByRole('heading', { name: bookAFreeCall.en.description.title }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole('heading', { name: enContent.testimonials.title }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole('heading', { name: enContent.aboutUs.coaches.ida.title }),
+    ).toBeNull();
+    expect(document.querySelector('[data-figma-node="about-us-ida-coach"]')).toBeNull();
 
     expect(document.getElementById('landing-page-cta')).toBeNull();
   });
@@ -135,7 +141,7 @@ describe('BookFreeCallLandingPage', () => {
     });
     expect(
       pickTimeLinks.filter((link) => link.getAttribute('href') === localizedBookingHref),
-    ).toHaveLength(3);
+    ).toHaveLength(2);
   });
 
   it('renders hero anchor CTA to the booking section and no booking modal shell', () => {

--- a/apps/public_www/tests/components/sections/landing-pages/landing-page-free-intro-call.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/landing-page-free-intro-call.test.tsx
@@ -92,6 +92,11 @@ describe('LandingPageFreeIntroCall', () => {
       expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument();
     });
 
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+    expect(screen.getByTestId('intro-call-captcha-placeholder')).toHaveTextContent(
+      enContent.common.captcha.deferredHint,
+    );
+
     fireEvent.click(screen.getByRole('button', { name: '09:00' }));
 
     fireEvent.change(screen.getByLabelText(/Full Name/i), {
@@ -104,6 +109,10 @@ describe('LandingPageFreeIntroCall', () => {
     const form = screen.getByRole('form', { name: bookAFreeCall.en.introCall.bookingSectionTitle });
     const terms = within(form).getByRole('checkbox', { name: /Terms/i });
     fireEvent.click(terms);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
 
     fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
 
@@ -156,7 +165,13 @@ describe('LandingPageFreeIntroCall', () => {
       expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument();
     });
 
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
     fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
 
     fireEvent.change(screen.getByLabelText(/Full Name/i), {
       target: { value: 'Test Parent' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Book-free-call layout only**: Removed Description, Testimonials, and About Ida Coach sections so the page flows Hero → Before you book → Pick a time → FAQ (default landing pages unchanged).
- **Intro call slot picker**: Reused module-level `Intl.DateTimeFormat` instances for day labels and Y-m-d grouping; deduplicated analytics status events; mobile day cards at 120px width with min height 88px, left/right edge fades on scroll (no arrow controls), larger slot button tap targets (`min-h-11`, larger padding/text on mobile).
- **Booking section**: Tighter mobile grid gap (`gap-8` vs `gap-10`).
- **Hero**: `priority` + `fetchPriority="high"` and `sizes` adjusted to `100vw` below `lg` to reduce over-fetching on phones.
- **Turnstile**: Widget mounts only after form interaction (slot select, field changes, form focus, or submit attempt); submit button no longer stays disabled without a token so users can trigger validation and see the widget. Added `common.captcha.deferredHint` in **en**, **zh-CN**, and **zh-HK**.

## Tests

- `cd apps/public_www && npm run lint`
- `cd apps/public_www && npx vitest run` (750 tests)
- `bash scripts/validate-cursorrules.sh`

## Manual QA (local dev)

Dev server used `apps/public_www/.env.local` (not committed). Intro-call slots API did not return data in this environment (calendar fetch error in console), so full slot selection + submit could not be completed end-to-end. Screenshots and a screen recording still document hero, booking layout, and desktop two-column layout.

### Artifacts

[Mobile hero](https://cursor.com/agents/bc-615c479b-8e84-41b9-87de-70322cde9ef1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbook_a_free_call_mobile_hero_after.png)

[Mobile booking / day strip area](https://cursor.com/agents/bc-615c479b-8e84-41b9-87de-70322cde9ef1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbook_a_free_call_mobile_day_strip_after.png)

[Mobile slot area](https://cursor.com/agents/bc-615c479b-8e84-41b9-87de-70322cde9ef1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbook_a_free_call_mobile_slot_buttons_after.png)

[Desktop booking layout](https://cursor.com/agents/bc-615c479b-8e84-41b9-87de-70322cde9ef1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbook_a_free_call_desktop_booking_after.png)

[book_a_free_call_mobile_demo.mp4](https://cursor.com/agents/bc-615c479b-8e84-41b9-87de-70322cde9ef1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbook_a_free_call_mobile_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-615c479b-8e84-41b9-87de-70322cde9ef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-615c479b-8e84-41b9-87de-70322cde9ef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

