### PR TITLE
Align intro-call date carousel with Real Talk carousel pattern

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -30,6 +30,7 @@ import {
   resolveDateTimeLocale,
 } from '@/lib/site-datetime';
 import { trackAnalyticsEvent } from '@/lib/analytics';
+import { useHorizontalCarousel } from '@/lib/hooks/use-horizontal-carousel';
 import { resolvePublicSiteConfig } from '@/lib/site-config';
 
 export interface IntroCallSlotPickerProps {
@@ -115,7 +116,6 @@ export function IntroCallSlotPicker({
   const [rovingDayIndex, setRovingDayIndex] = useState(0);
   const dayRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const slotRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const dayCarouselRef = useRef<HTMLDivElement | null>(null);
   const lastReportedStatusRef = useRef<FetchStatus | null>(null);
 
   const slotTimeFormatter = useMemo(
@@ -221,6 +221,11 @@ export function IntroCallSlotPicker({
     const sorted = Array.from(slotsByDayFull.keys()).sort();
     return sorted.slice(0, MAX_VISIBLE_BOOKING_DAYS);
   }, [slotsByDayFull]);
+
+  const { carouselRef: dayCarouselRef } = useHorizontalCarousel<HTMLDivElement>({
+    itemCount: dayKeys.length,
+    enabled: status === 'ready' && slots.length > 0,
+  });
 
   const slotsByDay = useMemo(() => {
     const map = new Map<string, IntroCallSlot[]>();
@@ -388,63 +393,67 @@ export function IntroCallSlotPicker({
 
   return (
     <div className='space-y-4'>
-      <div className='w-full min-w-0'>
+      <div className='relative mt-0 w-full min-w-0'>
         <CarouselTrack
           carouselRef={dayCarouselRef}
           testId='intro-call-day-carousel'
-          presentation='group'
-          ariaLabel={pickerContent.bookingSectionTitle}
-          ariaRoleDescription={commonAccessibility.carouselRoleDescription}
-          className='flex min-w-0 gap-3 pb-2 pr-1'
-        >
-          {dayKeys.map((ymd, idx) => {
-            const count = slotsByDay.get(ymd)?.length ?? 0;
-            if (count === 0) {
-              return null;
-            }
-            const sample = slotsByDay.get(ymd)?.[0];
-            if (!sample) {
-              return null;
-            }
-            const dayAccessibleLabel = dayFormatters.accessibleLabel(sample.startIso);
-            const weekdayShort = dayFormatters.weekdayShort(sample.startIso);
-            const dateLine = dayFormatters.dateLine(sample.startIso);
-            const isSelected = ymd === resolvedDayYmd;
-            return (
-              <ButtonPrimitive
-                key={ymd}
-                type='button'
-                buttonRef={(el) => {
-                  dayRefs.current[idx] = el;
-                }}
-                variant='selection'
-                state={isSelected ? 'active' : 'inactive'}
-                aria-pressed={isSelected}
-                aria-label={dayAccessibleLabel}
-                tabIndex={safeRovingDayIndex === idx ? 0 : -1}
-                onClick={() => {
-                  setCursorDayYmd(ymd);
-                  setRovingDayIndex(idx);
-                  setSelectedSlotIso(null);
-                }}
-                onKeyDown={(e) => handleDayKeyDown(e, idx)}
-                className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative min-h-[88px] w-[120px] shrink-0 snap-center text-center sm:min-h-0 sm:w-[134.4px]`}
-              >
-                <div className='flex w-full flex-col items-center gap-2'>
-                  <div className='flex items-center justify-center gap-2'>
-                    <span
-                      className={`h-6 w-6 shrink-0 es-mask-calendar-current ${isSelected ? 'es-btn-selection-icon-active' : 'es-btn-selection-icon-inactive'}`}
-                      aria-hidden='true'
-                    />
-                    <p className='text-base font-semibold es-text-heading whitespace-nowrap'>
-                      {weekdayShort}
-                    </p>
-                  </div>
-                  <p className='text-center text-sm sm:text-sm es-text-heading'>{dateLine}</p>
-                </div>
-              </ButtonPrimitive>
-            );
+          ariaLabel={formatContentTemplate(commonAccessibility.carouselLabelTemplate, {
+            title: pickerContent.bookingSectionTitle,
           })}
+          ariaRoleDescription={commonAccessibility.carouselRoleDescription}
+          className='pb-2 pr-1'
+        >
+          <ul className='flex min-w-0 list-none gap-3 p-0'>
+            {dayKeys.map((ymd, idx) => {
+              const count = slotsByDay.get(ymd)?.length ?? 0;
+              if (count === 0) {
+                return null;
+              }
+              const sample = slotsByDay.get(ymd)?.[0];
+              if (!sample) {
+                return null;
+              }
+              const dayAccessibleLabel = dayFormatters.accessibleLabel(sample.startIso);
+              const weekdayShort = dayFormatters.weekdayShort(sample.startIso);
+              const dateLine = dayFormatters.dateLine(sample.startIso);
+              const isSelected = ymd === resolvedDayYmd;
+              return (
+                <li key={ymd} className='shrink-0 snap-center'>
+                  <ButtonPrimitive
+                    type='button'
+                    buttonRef={(el) => {
+                      dayRefs.current[idx] = el;
+                    }}
+                    variant='selection'
+                    state={isSelected ? 'active' : 'inactive'}
+                    aria-pressed={isSelected}
+                    aria-label={dayAccessibleLabel}
+                    tabIndex={safeRovingDayIndex === idx ? 0 : -1}
+                    onClick={() => {
+                      setCursorDayYmd(ymd);
+                      setRovingDayIndex(idx);
+                      setSelectedSlotIso(null);
+                    }}
+                    onKeyDown={(e) => handleDayKeyDown(e, idx)}
+                    className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative min-h-[88px] w-[120px] text-center sm:min-h-0 sm:w-[134.4px]`}
+                  >
+                    <div className='flex w-full flex-col items-center gap-2'>
+                      <div className='flex items-center justify-center gap-2'>
+                        <span
+                          className={`h-6 w-6 shrink-0 es-mask-calendar-current ${isSelected ? 'es-btn-selection-icon-active' : 'es-btn-selection-icon-inactive'}`}
+                          aria-hidden='true'
+                        />
+                        <p className='text-base font-semibold es-text-heading whitespace-nowrap'>
+                          {weekdayShort}
+                        </p>
+                      </div>
+                      <p className='text-center text-sm sm:text-sm es-text-heading'>{dateLine}</p>
+                    </div>
+                  </ButtonPrimitive>
+                </li>
+              );
+            })}
+          </ul>
         </CarouselTrack>
       </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the free intro-call **date strip** with the Real Talk mobile carousel pattern and fixes the layout bug where **loading slots expanded the two-column grid** to the full width of all day cards (so the page felt “resized” by the API response).

## Root cause

CSS Grid items default to **`min-width: auto`**, which is the content’s **minimum intrinsic width**. The horizontal day list is wider than the column, so the grid cell (and often the whole grid) grew to fit it instead of keeping column width and scrolling inside `CarouselTrack`.

## Changes

- **`landing-page-free-intro-call.tsx`**: `min-w-0` on the booking **grid** and **both** column wrappers so each column can shrink below intrinsic child width.
- **`intro-call-slot-picker.tsx`**: `min-w-0 max-w-full` on the picker root and carousel track; day **`ul`** uses **`w-max min-w-full`** so the list is at least as wide as the track (for scroll width) while the track stays capped at the column width.

## Earlier PR behavior (same branch)

- `useHorizontalCarousel`, default `CarouselTrack` region presentation, `carouselLabelTemplate` for track `aria-label`, `ul`/`li` structure like Real Talk.

## Validation

- Vitest: `intro-call-slot-picker`, `landing-page-free-intro-call`, `book-a-free-call` page tests
- `npm run lint` in `apps/public_www`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa7c43d0-2034-48e1-ac18-2449439d4f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa7c43d0-2034-48e1-ac18-2449439d4f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

