### PR TITLE
Fix intro-call date strip expanding the grid when slots load

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -392,8 +392,8 @@ export function IntroCallSlotPicker({
   }
 
   return (
-    <div className='space-y-4'>
-      <div className='relative mt-0 w-full min-w-0'>
+    <div className='min-w-0 max-w-full space-y-4'>
+      <div className='relative mt-0 w-full min-w-0 max-w-full'>
         <CarouselTrack
           carouselRef={dayCarouselRef}
           testId='intro-call-day-carousel'
@@ -401,9 +401,9 @@ export function IntroCallSlotPicker({
             title: pickerContent.bookingSectionTitle,
           })}
           ariaRoleDescription={commonAccessibility.carouselRoleDescription}
-          className='pb-2 pr-1'
+          className='max-w-full min-w-0 pb-2 pr-1'
         >
-          <ul className='flex min-w-0 list-none gap-3 p-0'>
+          <ul className='flex w-max min-w-full list-none gap-3 p-0'>
             {dayKeys.map((ymd, idx) => {
               const count = slotsByDay.get(ymd)?.length ?? 0;
               if (count === 0) {

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -493,8 +493,8 @@ export function LandingPageFreeIntroCall({
             </div>
           </div>
         ) : (
-          <div className='grid gap-8 lg:grid-cols-2 lg:gap-12'>
-            <div ref={pickerWrapRef}>
+          <div className='grid min-w-0 gap-8 lg:grid-cols-2 lg:gap-12'>
+            <div ref={pickerWrapRef} className='min-w-0'>
               <IntroCallSlotPicker
                 locale={locale}
                 commonAccessibility={commonAccessibility}
@@ -520,7 +520,7 @@ export function LandingPageFreeIntroCall({
                 </a>
               </p>
             </div>
-            <div>
+            <div className='min-w-0'>
               {recentCooldownMessage ? (
                 <p className='mb-4 rounded-inner border border-amber-200 bg-amber-50 px-4 py-3 es-type-body'>
                   {introContent.recentIntroMessage}{' '}


### PR DESCRIPTION
Grid items default to min-width:auto, so the picker column grew to the intrinsic width of the horizontal day list. Add min-w-0 on the booking grid and both columns, max-w-full/min-w-0 on the carousel track, and w-max min-w-full on the day ul so overflow-x scrolls inside a stable viewport width.