### PR TITLE
fix(public_www): clear intro-call slot when booking date changes

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/intro-call-slot-picker.tsx
@@ -39,7 +39,7 @@ export interface IntroCallSlotPickerProps {
   pickerContent: LandingPageIntroCallContent;
   /** Same WhatsApp URL as the booking section (falls back to site config when unset). */
   whatsappHref?: string;
-  onSelect: (slot: IntroCallSlot) => void;
+  onSelect: (slot: IntroCallSlot | null) => void;
   onBlockersStatusChange?: (status: 'idle' | 'loading' | 'ready' | 'error') => void;
   refreshToken?: number;
 }
@@ -113,6 +113,8 @@ export function IntroCallSlotPicker({
   /** User-picked day; when null or stale, ``resolvedDayYmd`` falls back to the first available day. */
   const [cursorDayYmd, setCursorDayYmd] = useState<string | null>(null);
   const [selectedSlotIso, setSelectedSlotIso] = useState<string | null>(null);
+  /** Mirrors ``selectedSlotIso`` so we can clear without impure setState side effects. */
+  const selectedSlotIsoRef = useRef<string | null>(null);
   const [rovingDayIndex, setRovingDayIndex] = useState(0);
   const dayRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const slotRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -282,18 +284,41 @@ export function IntroCallSlotPicker({
     return formatPartDateTimeLabel(slot.startIso, locale);
   }, [locale, selectedSlotIso, slots]);
 
+  const clearTimeSelection = useCallback(() => {
+    if (selectedSlotIsoRef.current !== null) {
+      selectedSlotIsoRef.current = null;
+      onSelect(null);
+    }
+    setSelectedSlotIso(null);
+  }, [onSelect]);
+
+  const selectDay = useCallback(
+    (ymd: string, index: number) => {
+      if (ymd !== resolvedDayYmd) {
+        clearTimeSelection();
+      }
+      setCursorDayYmd(ymd);
+      setRovingDayIndex(index);
+    },
+    [clearTimeSelection, resolvedDayYmd],
+  );
+
   const handleDayKeyDown = (event: KeyboardEvent, index: number) => {
     if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
       event.preventDefault();
       const next = Math.min(index + 1, dayKeys.length - 1);
-      setRovingDayIndex(next);
-      setCursorDayYmd(dayKeys[next] ?? null);
+      const ymd = dayKeys[next] ?? null;
+      if (ymd) {
+        selectDay(ymd, next);
+      }
       dayRefs.current[next]?.focus();
     } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
       event.preventDefault();
       const next = Math.max(index - 1, 0);
-      setRovingDayIndex(next);
-      setCursorDayYmd(dayKeys[next] ?? null);
+      const ymd = dayKeys[next] ?? null;
+      if (ymd) {
+        selectDay(ymd, next);
+      }
       dayRefs.current[next]?.focus();
     }
   };
@@ -374,6 +399,7 @@ export function IntroCallSlotPicker({
               aria-pressed={pressed}
               className='es-intro-call-slot-selection-btn rounded-md min-h-11 px-3 py-2.5 text-base sm:text-sm'
               onClick={() => {
+                selectedSlotIsoRef.current = slot.startIso;
                 setSelectedSlotIso(slot.startIso);
                 onSelect(slot);
                 trackAnalyticsEvent('intro_call_slot_selected', {
@@ -430,9 +456,7 @@ export function IntroCallSlotPicker({
                     aria-label={dayAccessibleLabel}
                     tabIndex={safeRovingDayIndex === idx ? 0 : -1}
                     onClick={() => {
-                      setCursorDayYmd(ymd);
-                      setRovingDayIndex(idx);
-                      setSelectedSlotIso(null);
+                      selectDay(ymd, idx);
                     }}
                     onKeyDown={(e) => handleDayKeyDown(e, idx)}
                     className={`${BOOKING_SELECTOR_CARD_CLASSNAME} relative min-h-[88px] w-[120px] text-center sm:min-h-0 sm:w-[134.4px]`}

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -195,7 +195,7 @@ export function LandingPageFreeIntroCall({
     });
   }, [introContent.selectedSlotSummaryTemplate, locale, selectedSlot]);
 
-  const handleSelectSlot = useCallback((slot: IntroCallSlot) => {
+  const handleSelectSlot = useCallback((slot: IntroCallSlot | null) => {
     setHasFormInteracted(true);
     setSelectedSlot(slot);
     setRecentCooldownMessage(false);

--- a/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
+++ b/apps/public_www/tests/components/sections/landing-pages/intro-call-slot-picker.test.tsx
@@ -125,6 +125,44 @@ describe('IntroCallSlotPicker', () => {
     });
   });
 
+  it('clears the selected time via onSelect(null) when the date changes', async () => {
+    vi.mocked(fetchIntroCallSlots).mockResolvedValue({
+      slots: [
+        { startIso: '2026-05-05T01:00:00.000Z', endIso: '2026-05-05T01:15:00.000Z' },
+        { startIso: '2026-05-06T02:00:00.000Z', endIso: '2026-05-06T02:15:00.000Z' },
+      ],
+      fetchFailed: false,
+    });
+
+    const onSelect = vi.fn();
+
+    render(
+      <IntroCallSlotPicker
+        locale='en'
+        commonAccessibility={enContent.common.accessibility}
+        pickerContent={bookAFreeCall.en.introCall}
+        onSelect={onSelect}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '09:00' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '09:00' }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+
+    const wedButton = screen.getByRole('button', { name: /Wed\s+06\s+May/i });
+    fireEvent.click(wedButton);
+
+    await waitFor(() => {
+      expect(wedButton).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(2);
+    expect(onSelect.mock.calls[1][0]).toBeNull();
+  });
+
   it('moves roving tabindex with ArrowRight on the day strip', async () => {
     vi.mocked(fetchIntroCallSlots).mockResolvedValue({
       slots: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The intro call slot picker reset the **local** time button state when a different day was selected, but the parent form still held the previous `selectedSlot` because `onSelect` was only called when choosing a time.

## Changes
- `IntroCallSlotPicker` now calls `onSelect(null)` when the **visible** day changes (click or keyboard), using a ref to avoid duplicate `onSelect(null)` on the same day. Time selection still sets the ref and calls `onSelect(slot)`.
- `LandingPageFreeIntroCall` accepts `IntroCallSlot | null` in `handleSelectSlot` to clear the form’s selected slot.
- New Vitest: after picking a time and switching to another day, the second `onSelect` call is `null`.

## Tests
- `npx vitest run` (intro-call-slot-picker + landing-page-free-intro-call)
- `npm run lint` (public_www)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fcd8d4d-687e-417f-8cfb-3ef740649f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fcd8d4d-687e-417f-8cfb-3ef740649f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

