### PR TITLE
Expose intro_call service type in admin web

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -31,6 +31,7 @@ import {
 
 import type { components } from '@/types/generated/admin-api.generated';
 import {
+  isConsultationLikeServiceType,
   normalizeEventCategoryFromApi,
   type EventCategory,
   type EventTicketTier,
@@ -144,7 +145,7 @@ function mergeServiceIntoConsultationForm(
   prev: ConsultationFormState,
   service: ServiceSummary
 ): ConsultationFormState {
-  if (service.serviceType !== 'consultation') {
+  if (!isConsultationLikeServiceType(service.serviceType)) {
     return prev;
   }
   if (!service.consultationDetails) {
@@ -824,7 +825,15 @@ export function InstanceDetailPanel({
         </>
       ) : null}
 
-      {effectiveServiceType === 'consultation' ? (
+      {effectiveServiceType === 'intro_call' ? (
+        <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
+          <p className='md:col-span-4 text-sm text-slate-500'>
+            Intro-call instances use the parent service pricing defaults. Session slots here drive the public booking grid.
+          </p>
+        </div>
+      ) : null}
+
+      {isConsultationLikeServiceType(effectiveServiceType) ? (
         <>
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
             <InstanceInstructorField

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -19,7 +19,7 @@ import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
 import { getServiceDiscountCodeUsageSummary } from '@/lib/services-api';
 
 import type { components } from '@/types/generated/admin-api.generated';
-import { SERVICE_DELIVERY_MODES, SERVICE_STATUSES, SERVICE_TYPES } from '@/types/services';
+import { SERVICE_DELIVERY_MODES, SERVICE_STATUSES, SERVICE_TYPES, isConsultationLikeServiceType } from '@/types/services';
 import type { ServiceDeliveryMode } from '@/types/services';
 import type { LocationSummary, ServiceDetail, ServiceType } from '@/types/services';
 
@@ -327,7 +327,11 @@ export function ServiceDetailPanel({
     if (serviceForm.status !== 'published') {
       return false;
     }
-    if (serviceType !== 'event' && serviceType !== 'training_course') {
+    if (
+      serviceType !== 'event' &&
+      serviceType !== 'training_course' &&
+      serviceType !== 'intro_call'
+    ) {
       return false;
     }
     return serviceForm.serviceKey.trim() === '';
@@ -671,7 +675,7 @@ export function ServiceDetailPanel({
             }
             serviceKeyConflictError={serviceKeyConflictInline}
             publishedBookableKeyWarning={
-              (serviceType === 'event' || serviceType === 'training_course') &&
+              (serviceType === 'event' || serviceType === 'training_course' || serviceType === 'intro_call') &&
               serviceForm.status === 'published' &&
               !serviceForm.serviceKey.trim()
                 ? 'A service key is required to take public bookings (discount validation and reservation submission). Set one before publishing.'
@@ -770,7 +774,7 @@ export function ServiceDetailPanel({
           </div>
         ) : null}
 
-        {serviceType === 'consultation' ? (
+        {isConsultationLikeServiceType(serviceType) ? (
           <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
             {deliveryModeSelect}
             <ServiceTierControl
@@ -784,7 +788,7 @@ export function ServiceDetailPanel({
           </div>
         ) : null}
 
-        {serviceType === 'consultation' ? (
+        {isConsultationLikeServiceType(serviceType) ? (
           <>
             <div className='grid grid-cols-1 gap-3 md:grid-cols-4'>
               <ConsultationPricingModelControl value={consultationForm} onChange={setConsultationForm} />

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -495,7 +495,7 @@ export function formatServiceListPriceLabel(service: ServiceSummary): string {
     }
     return formatAmountInCurrency(amount, resolveIsoCurrencyCode(d.defaultCurrency));
   }
-  if (service.serviceType === 'consultation') {
+  if (service.serviceType === 'consultation' || service.serviceType === 'intro_call') {
     const d = service.consultationDetails;
     if (!d) {
       return '—';

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5214,8 +5214,13 @@ export interface components {
                 conversion_rate: number;
             }[];
         };
-        /** @enum {string} */
-        ServiceType: "training_course" | "event" | "consultation";
+        /**
+         * @description Product category for a service template. `intro_call` is the free public intro-call flow
+         *     (`service_key` / instance slug pair used by public reservations); it stores consultation-style
+         *     pricing defaults like `consultation`.
+         * @enum {string}
+         */
+        ServiceType: "training_course" | "event" | "consultation" | "intro_call";
         /** @enum {string} */
         ServiceStatus: "draft" | "published" | "archived";
         /** @enum {string} */

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -8,8 +8,13 @@ function defineEnumValues<T extends string>() {
 
 export type ServiceType = ApiSchemas['ServiceType'];
 export const SERVICE_TYPES = defineEnumValues<ServiceType>()(
-  ['training_course', 'event', 'consultation'] as const satisfies readonly ServiceType[]
+  ['training_course', 'event', 'consultation', 'intro_call'] as const satisfies readonly ServiceType[]
 );
+
+/** Service templates that use consultation-style defaults (`consultation_details`). */
+export function isConsultationLikeServiceType(serviceType: ServiceType): boolean {
+  return serviceType === 'consultation' || serviceType === 'intro_call';
+}
 
 export type ServiceStatus = ApiSchemas['ServiceStatus'];
 export const SERVICE_STATUSES = defineEnumValues<ServiceStatus>()(

--- a/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/service-detail-panel.test.tsx
@@ -692,7 +692,7 @@ describe('ServiceDetailPanel', () => {
       />
     );
 
-    for (const typeLabel of ['training_course', 'event', 'consultation'] as const) {
+    for (const typeLabel of ['training_course', 'event', 'consultation', 'intro_call'] as const) {
       await user.selectOptions(screen.getByLabelText('Type'), typeLabel);
       await user.selectOptions(screen.getByLabelText('Delivery mode'), 'Online');
       expect(screen.queryByLabelText('Default location')).not.toBeInTheDocument();

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -60,6 +60,7 @@ function baseSummary(overrides: Partial<ServiceSummary> = {}): ServiceSummary {
 describe('format helpers', () => {
   it('formats snake_case values into title case labels', () => {
     expect(formatEnumLabel('training_course')).toBe('Training Course');
+    expect(formatEnumLabel('intro_call')).toBe('Intro Call');
     expect(formatEnumLabel('in_person')).toBe('In Person');
   });
 
@@ -701,6 +702,25 @@ describe('format helpers', () => {
             consultationFormat: 'one_on_one',
             maxGroupSize: null,
             durationMinutes: 60,
+            pricingModel: 'free',
+            defaultHourlyRate: null,
+            defaultPackagePrice: null,
+            defaultPackageSessions: null,
+            defaultCurrency: 'HKD',
+          },
+        })
+      )
+    ).toBe('Free');
+
+    expect(
+      formatServiceListPriceLabel(
+        baseSummary({
+          serviceType: 'intro_call',
+          trainingDetails: null,
+          consultationDetails: {
+            consultationFormat: 'one_on_one',
+            maxGroupSize: null,
+            durationMinutes: 15,
             pricingModel: 'free',
             defaultHourlyRate: null,
             defaultPackagePrice: null,

--- a/apps/admin_web/tests/types/services.test.ts
+++ b/apps/admin_web/tests/types/services.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { isConsultationLikeServiceType } from '@/types/services';
+
+describe('service type helpers', () => {
+  it('treats intro_call as consultation-like for admin UI branching', () => {
+    expect(isConsultationLikeServiceType('consultation')).toBe(true);
+    expect(isConsultationLikeServiceType('intro_call')).toBe(true);
+    expect(isConsultationLikeServiceType('training_course')).toBe(false);
+    expect(isConsultationLikeServiceType('event')).toBe(false);
+  });
+});

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -182,7 +182,10 @@ def _resolved_consultation_details(
             "package_sessions": cd.package_sessions,
         }
     scd = service.consultation_details
-    if service.service_type != ServiceType.CONSULTATION or scd is None:
+    if (
+        service.service_type not in (ServiceType.CONSULTATION, ServiceType.INTRO_CALL)
+        or scd is None
+    ):
         return None
     pm = scd.pricing_model
     resolved_price = _decimal_to_string(

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -4324,7 +4324,11 @@ components:
                 type: number
     ServiceType:
       type: string
-      enum: [training_course, event, consultation]
+      enum: [training_course, event, consultation, intro_call]
+      description: |
+        Product category for a service template. `intro_call` is the free public intro-call flow
+        (`service_key` / instance slug pair used by public reservations); it stores consultation-style
+        pricing defaults like `consultation`.
     ServiceStatus:
       type: string
       enum: [draft, published, archived]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the PostgreSQL/backend `intro_call` service category to the admin API contract and admin web so operators can create and edit intro-call services without seed-only workflows.

## Changes

- **`docs/api/admin.yaml`**: Extend `ServiceType` enum with `intro_call` and a short description (aligned with public intro-call reservations).
- **`apps/admin_web`**: Regenerate OpenAPI types; add `intro_call` to `SERVICE_TYPES`; introduce `isConsultationLikeServiceType()` so intro-call uses the same consultation-style fields as `consultation`; treat `intro_call` like bookable services that require a **service key** when **published**; instance editor shows a brief note for intro-call rows.
- **`backend/src/app/api/admin_services_serializers.py`**: When resolving instance consultation pricing from the parent service, include `ServiceType.INTRO_CALL` (same storage pattern as consultation).

## Tests

- `npm run lint` (admin web)
- Focused Vitest: `format.test`, `service-detail-panel.test`, new `services.test`
- `python3 -m ruff format` on the touched Python file
- `bash scripts/validate-cursorrules.sh`

## Notes

Intro-call services still store pricing via `consultation_details` in the API (unchanged server shape); the new type is primarily a product discriminator and admin visibility fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe5c9e70-0d0e-47fa-91ea-1ae6a0be7252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe5c9e70-0d0e-47fa-91ea-1ae6a0be7252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

