### PR TITLE
Fix admin slug helper typing for intro_call ServiceType

### DIFF
--- a/apps/admin_web/src/lib/slug-utils.ts
+++ b/apps/admin_web/src/lib/slug-utils.ts
@@ -1,3 +1,5 @@
+import type { ServiceType } from '@/types/services';
+
 /** URL-safe instance slug: lowercase segments of alphanumerics separated by single hyphens. */
 export const INSTANCE_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
@@ -49,9 +51,12 @@ function _firstSessionSlotYmd(slots: SuggestedInstanceSlugSlot[]): string | null
   return /^\d{4}-\d{2}-\d{2}$/.test(ymd) ? ymd : null;
 }
 
-/** Suggested public instance slug for create flows (event / training_course). */
+/**
+ * Suggested public instance slug for create flows.
+ * `event` and `training_course` have deterministic rules; `consultation` and `intro_call` use manual slugs.
+ */
 export function computeSuggestedInstanceSlug(
-  serviceType: 'event' | 'training_course' | 'consultation',
+  serviceType: ServiceType,
   service: {
     title: string;
     serviceKey: string | null | undefined;

--- a/apps/admin_web/tests/lib/slug-utils.test.ts
+++ b/apps/admin_web/tests/lib/slug-utils.test.ts
@@ -93,6 +93,27 @@ describe('computeSuggestedInstanceSlug', () => {
     ).toBe('bla-bla-bla-1-3');
   });
 
+  it('returns empty string for consultation and intro_call (manual slug entry)', () => {
+    expect(
+      computeSuggestedInstanceSlug('consultation', baseService, {
+        title: 'x',
+        cohort: 'y',
+        sessionSlots: [],
+      })
+    ).toBe('');
+    expect(
+      computeSuggestedInstanceSlug(
+        'intro_call',
+        { ...baseService, serviceType: 'intro_call' },
+        {
+          title: 'x',
+          cohort: 'y',
+          sessionSlots: [],
+        }
+      )
+    ).toBe('');
+  });
+
   it('builds event slug from title and first slot date', () => {
     expect(
       computeSuggestedInstanceSlug('event', null, {


### PR DESCRIPTION
computeSuggestedInstanceSlug now accepts full ServiceType; consultation and intro_call keep empty suggestions (manual slug). Adds slug-utils tests.