### PR TITLE
Use family-consultation service key for consultation reservations

### DIFF
--- a/apps/public_www/src/content/family-consultations.json
+++ b/apps/public_www/src/content/family-consultations.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "tier_id": "essentials",
-      "service_key": "consultations",
+      "service_key": "family-consultation",
       "instance_slug": "consultation-essentials-package",
       "location_name": "Your Home",
       "location_address": "Hong Kong",
@@ -11,7 +11,7 @@
     },
     {
       "tier_id": "deep_dive",
-      "service_key": "consultations",
+      "service_key": "family-consultation",
       "instance_slug": "consultation-deep-dive-package",
       "location_name": "Your Home",
       "location_address": "Hong Kong",

--- a/apps/public_www/tests/components/sections/consultation-booking-modal-free.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal-free.test.tsx
@@ -244,7 +244,7 @@ describe('ConsultationBookingModal free price', () => {
         payload: expect.objectContaining({
           paymentMethod: 'free',
           totalAmount: 0,
-          serviceKey: 'consultations',
+          serviceKey: 'family-consultation',
           serviceInstanceSlug: 'consultation-essentials-package',
         }),
       }),

--- a/apps/public_www/tests/content/family-consultations.test.ts
+++ b/apps/public_www/tests/content/family-consultations.test.ts
@@ -6,14 +6,14 @@ describe('family-consultations.json', () => {
   it('resolves tier rows with snake_case location fields', () => {
     const essentials = resolveFamilyConsultationTier('essentials');
     expect(essentials?.tier_id).toBe('essentials');
-    expect(essentials?.service_key).toBe('consultations');
+    expect(essentials?.service_key).toBe('family-consultation');
     expect(essentials?.instance_slug).toBe('consultation-essentials-package');
     expect(essentials?.location_name?.trim().length).toBeGreaterThan(0);
     expect(essentials?.location_address?.trim().length).toBeGreaterThan(0);
 
     const deepDive = resolveFamilyConsultationTier('deepDive');
     expect(deepDive?.tier_id).toBe('deep_dive');
-    expect(deepDive?.service_key).toBe('consultations');
+    expect(deepDive?.service_key).toBe('family-consultation');
     expect(deepDive?.instance_slug).toBe('consultation-deep-dive-package');
   });
 });

--- a/apps/public_www/tests/lib/consultations-booking-modal-payload.test.ts
+++ b/apps/public_www/tests/lib/consultations-booking-modal-payload.test.ts
@@ -13,7 +13,7 @@ describe('buildConsultationsBookingModalPayload', () => {
 
     expect(payload.variant).toBe('event');
     expect(payload.bookingSystem).toBe(CONSULTATION_BOOKING_SYSTEM);
-    expect(payload.serviceKey).toBe('consultations');
+    expect(payload.serviceKey).toBe('family-consultation');
     expect(payload.instanceSlug).toBe('consultation-essentials-package');
     expect(payload.locationName).toBe('Your Home');
     expect(payload.locationAddress).toBe('Hong Kong');
@@ -33,7 +33,7 @@ describe('buildConsultationsBookingModalPayload', () => {
     };
     const payload = buildConsultationsBookingModalPayload(reservation, 'en');
 
-    expect(payload.serviceKey).toBe('consultations');
+    expect(payload.serviceKey).toBe('family-consultation');
     expect(payload.instanceSlug).toBe('consultation-deep-dive-package');
     expect(payload.originalAmount).toBe(reservation.deepDive.priceHkd);
     expect(payload.dateParts).toHaveLength(reservation.deepDive.dateParts.length);

--- a/backend/db/seed/seed_data.sql
+++ b/backend/db/seed/seed_data.sql
@@ -47,7 +47,7 @@ WHERE lower(trim(coalesce(s.service_key, ''))) = 'my-best-auntie'
   );
 
 UPDATE services s
-SET service_key = 'consultations'
+SET service_key = 'family-consultation'
 FROM (
   SELECT id
   FROM services
@@ -61,6 +61,12 @@ WHERE s.id = pick.id
     WHERE service_key IS NULL
       AND service_type = 'consultation'
   ) = 1;
+
+-- Align legacy consultation service key with public_www `family-consultations.json` (`service_key`).
+UPDATE services
+SET service_key = 'family-consultation'
+WHERE service_type = 'consultation'
+  AND lower(trim(coalesce(service_key, ''))) = 'consultations';
 
 -- ───────────────────────────────────────────────────────────────────────
 -- DEPENDENCY: requires migration `0059_intro_call_service_type`, which

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1759,6 +1759,8 @@ components:
             Optional booking flow code. When set, must be exactly one of the enum values
             (case-insensitive on input; stored lowercased). Drives confirmation email formatting
             (schedule/details); not used for booking identity (use `serviceKey` + `serviceInstanceSlug`).
+            `consultation-booking` on the public site pairs with `serviceKey=family-consultation`
+            and tier instance slugs from `family-consultations.json`.
             `intro-call-booking` requires `serviceKey=intro-call`, `serviceInstanceSlug=intro-call-free-15min`,
             `totalAmount=0`, `paymentMethod=free` (or omit payment method to default to free), and
             `primarySessionStartIso` / `primarySessionEndIso` for a valid 15-minute slot at a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames the public family-consultation **`serviceKey`** sent with reservations from `consultations` to **`family-consultation`**, aligned with Aurora `services.service_key`.

## Changes

- **`apps/public_www/src/content/family-consultations.json`**: Both tiers now use `service_key` `family-consultation` (this JSON feeds `buildConsultationsBookingModalPayload` → reservation payload).
- **`backend/db/seed/seed_data.sql`**: New installs get `family-consultation` when backfilling NULL consultation service keys; added idempotent `UPDATE` so existing rows still keyed `consultations` migrate on seed replay.
- **`docs/api/public.yaml`**: Notes that `consultation-booking` pairs with `serviceKey=family-consultation` and `family-consultations.json` instance slugs.
- **Tests**: Assertions updated for payload and content fixtures.

## Operational note

Production databases should either run updated seed (if applicable) or execute:

`UPDATE services SET service_key = 'family-consultation' WHERE service_type = 'consultation' AND lower(trim(service_key)) = 'consultations';`

(admin parity with admin-set keys).

## Verification

- `npm run lint` in `apps/public_www`
- Vitest: `consultations-booking-modal-payload`, `family-consultations`, `consultation-booking-modal-free`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe5c9e70-0d0e-47fa-91ea-1ae6a0be7252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe5c9e70-0d0e-47fa-91ea-1ae6a0be7252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

