### PR TITLE
Consultation booking modal: spinner while loading availability

### DIFF
--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -43,6 +43,7 @@ import { useModalLockBody } from '@/lib/hooks/use-modal-lock-body';
 import { useModalFocusManagement } from '@/lib/hooks/use-modal-focus-management';
 import { mergeClassNames } from '@/lib/class-name-utils';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
+import { SectionSpinnerStatus } from '@/components/shared/section-spinner-status';
 
 /** Matches `consultations-booking` level feature list (discs + orange markers via CSS). */
 const CONSULTATION_MODAL_LEVEL_FEATURES_LIST_CLASSNAME =
@@ -384,22 +385,6 @@ export function ConsultationBookingModal({
   const selectedYmd = pickerSelection?.ymd ?? defaultSelection?.ymd ?? '';
   const dayPeriod = pickerSelection?.period ?? defaultSelection?.period ?? 'am';
 
-  const pickerInteractionDisabled = calendarBlockersStatus === 'loading';
-
-  const blockersStatusMessage = useMemo(() => {
-    if (calendarBlockersStatus === 'loading' && calendarBlockersLoadingMessage.trim()) {
-      return calendarBlockersLoadingMessage;
-    }
-    if (calendarBlockersStatus === 'error' && calendarBlockersErrorMessage.trim()) {
-      return calendarBlockersErrorMessage;
-    }
-    return null;
-  }, [
-    calendarBlockersStatus,
-    calendarBlockersLoadingMessage,
-    calendarBlockersErrorMessage,
-  ]);
-
   function handleSelectYmd(ymd: string) {
     setPickerSelection((prev) => {
       const preferredPeriod =
@@ -443,27 +428,38 @@ export function ConsultationBookingModal({
 
   const pickerSlot = (
     <div className='flex flex-col gap-4'>
-      {blockersStatusMessage ? (
+      {calendarBlockersStatus === 'error' && calendarBlockersErrorMessage.trim() ? (
         <p
           className='rounded-lg border border-black/15 px-4 py-3 text-sm font-medium leading-snug es-text-body'
           role='status'
           aria-live='polite'
           data-testid='consultation-calendar-blockers-status'
         >
-          {blockersStatusMessage}
+          {calendarBlockersErrorMessage}
         </p>
       ) : null}
-      <ConsultationDatePickerGrid
-        locale={locale}
-        content={pickerContent}
-        timeZone={timeZone}
-        unavailableByYmd={unavailableByYmd}
-        selectedYmd={selectedYmd}
-        dayPeriod={dayPeriod}
-        interactionDisabled={pickerInteractionDisabled}
-        onSelectYmd={handleSelectYmd}
-        onSelectPeriod={handleSelectPeriod}
-      />
+      {calendarBlockersStatus === 'loading' ? (
+        <SectionSpinnerStatus
+          label={
+            calendarBlockersLoadingMessage.trim()
+              ? calendarBlockersLoadingMessage
+              : '\u00a0'
+          }
+          testId='consultation-calendar-blockers-loading'
+        />
+      ) : (
+        <ConsultationDatePickerGrid
+          locale={locale}
+          content={pickerContent}
+          timeZone={timeZone}
+          unavailableByYmd={unavailableByYmd}
+          selectedYmd={selectedYmd}
+          dayPeriod={dayPeriod}
+          interactionDisabled={false}
+          onSelectYmd={handleSelectYmd}
+          onSelectPeriod={handleSelectPeriod}
+        />
+      )}
     </div>
   );
 

--- a/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
+++ b/apps/public_www/tests/components/sections/consultation-booking-modal.test.tsx
@@ -83,7 +83,7 @@ describe('ConsultationBookingModal', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows loading message and disables date picker while blockers are loading', () => {
+  it('shows the loading gear and message while blockers are loading (calendar hidden)', () => {
     const bookingPayload = buildConsultationsBookingModalPayload(
       enContent.consultations.booking.reservation,
       'en',
@@ -104,11 +104,11 @@ describe('ConsultationBookingModal', () => {
       />,
     );
 
-    expect(screen.getByTestId('consultation-calendar-blockers-status')).toHaveTextContent(
-      loadingMessage,
-    );
-    const day9 = screen.getByRole('button', { name: 'Day 9, loading availability' });
-    expect(day9).toBeDisabled();
+    expect(screen.getByTestId('consultation-calendar-blockers-loading')).toBeInTheDocument();
+    expect(screen.getByText(loadingMessage)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Day 9, loading availability' }),
+    ).not.toBeInTheDocument();
   });
 
   it('shows error message when blockers failed to load but keeps picker interactive', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While consultation calendar blockers are fetched (`calendarBlockersStatus === 'loading'`), the modal now uses the shared **SectionSpinnerStatus** component—the same spinning gear + caption pattern as the intro-call slot picker and events loading states—instead of only a bordered text line above a disabled calendar.

The date grid is not rendered until loading completes, avoiding a flicker of stale availability.

## Changes

- `consultation-booking-modal.tsx`: import `SectionSpinnerStatus`; when loading, render it with `calendarBlockersLoadingMessage`; otherwise render `ConsultationDatePickerGrid` (error banner unchanged).
- `consultation-booking-modal.test.tsx`: assert spinner test id, visible loading copy, and that day buttons are absent while loading.

## Testing

- `cd apps/public_www && npx vitest run tests/components/sections/consultation-booking-modal.test.tsx`
- `cd apps/public_www && npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95653cf6-9a37-444b-ba92-68d2ded8f501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95653cf6-9a37-444b-ba92-68d2ded8f501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

