### PR TITLE
fix(public_www): stable width for book-a-free-call submit CTA

### DIFF
--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -13,7 +13,10 @@ import { ReservationFormFields } from '@/components/sections/booking-modal/reser
 import { IntroCallSlotPicker } from '@/components/sections/landing-pages/intro-call-slot-picker';
 import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
-import { SubmitButtonLoadingContent } from '@/components/shared/submit-button-loading-content';
+import {
+  submitButtonClassName,
+  SubmitButtonLoadingContent,
+} from '@/components/shared/submit-button-loading-content';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
 import { SectionCtaAnchor } from '@/components/sections/shared/section-cta-link';
 import { SectionContainer } from '@/components/sections/shared/section-container';
@@ -693,7 +696,7 @@ export function LandingPageFreeIntroCall({
                 <ButtonPrimitive
                   type='submit'
                   variant='primary'
-                  className='w-fit'
+                  className={submitButtonClassName(isSubmitting)}
                   state={isSubmitting ? 'inactive' : 'default'}
                   disabled={
                     isSubmitting
@@ -705,6 +708,7 @@ export function LandingPageFreeIntroCall({
                     isSubmitting={isSubmitting}
                     idleLabel={introContent.submitLabel}
                     submittingLabel={paymentModalContent.submittingLabel}
+                    loadingGearTestId='intro-call-submit-loading-gear'
                   />
                 </ButtonPrimitive>
               </form>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The book-a-free-call landing intro form used `w-fit` on the primary submit button, so when `SubmitButtonLoadingContent` swapped the label for the spinning gear the button shrank.

## Changes

- Import and apply `submitButtonClassName` from the same helper used by `reservation-form.tsx` in the booking modal (`w-full` idle; `inline-flex w-full items-center justify-center` while submitting).
- Add `loadingGearTestId='intro-call-submit-loading-gear'` for parity with the modal submit control.

## Validation

- `npx vitest run tests/components/sections/landing-pages/landing-page-free-intro-call.test.tsx`
- `npm run lint` (apps/public_www)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bd21cb9-b2fa-487d-a307-553a1a8dd06b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bd21cb9-b2fa-487d-a307-553a1a8dd06b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

