### PR TITLE
Admin: draft invoice enrollment picker instance/service column and tier

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -44,8 +44,10 @@ import {
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import {
   getCurrencyOptions,
+  ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER,
   INSTANCE_TABLE_TIER_COHORT_HEADER,
   formatDate,
+  formatEnrollmentPickerInstanceServiceDisplay,
   formatTierCohortDisplay,
 } from '@/lib/format';
 import { formatAmountInCurrency } from '@/lib/vendor-spend';
@@ -1091,7 +1093,7 @@ export function ClientInvoicesPanel() {
                         />
                       </th>
                       <th className='px-3 py-2'>Party</th>
-                      <th className='px-3 py-2'>Instance</th>
+                      <th className='px-3 py-2'>{ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER}</th>
                       <th className='max-w-[14rem] px-3 py-2'>{INSTANCE_TABLE_TIER_COHORT_HEADER}</th>
                       <th className='px-3 py-2 text-right'>Price</th>
                       <th className='px-3 py-2'>Enrolled</th>
@@ -1128,6 +1130,8 @@ export function ClientInvoicesPanel() {
                           row.serviceTierName,
                           row.instanceCohort,
                         );
+                        const instanceServiceDisplay =
+                          formatEnrollmentPickerInstanceServiceDisplay(row);
                         const partyCellDisplay = formatEnrollmentPartyCellDisplay(row);
                         return (
                           <tr
@@ -1163,7 +1167,9 @@ export function ClientInvoicesPanel() {
                             <td className='min-w-0 max-w-[22rem] break-words px-3 py-2 align-top text-sm'>
                               {partyCellDisplay !== '' ? partyCellDisplay : '—'}
                             </td>
-                            <td className='px-3 py-2 align-top text-sm'>{row.instanceTitle ?? '—'}</td>
+                            <td className='px-3 py-2 align-top text-sm'>
+                              {instanceServiceDisplay !== '' ? instanceServiceDisplay : '—'}
+                            </td>
                             <td className='max-w-[14rem] min-w-0 break-words px-3 py-2 align-top text-sm'>
                               {tierCohortDisplay !== '' ? tierCohortDisplay : '—'}
                             </td>

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -137,6 +137,28 @@ export function formatInstanceTableTitle(instance: ServiceInstance): string {
 /** Column header for the instances table tier + cohort column (space, interpunct, space between words). */
 export const INSTANCE_TABLE_TIER_COHORT_HEADER = `Tier${DISPLAY_PART_SEP}Cohort`;
 
+/** Billing enrollment picker — column header for instance title vs parent service name. */
+export const ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER = `Instance${DISPLAY_PART_SEP}Service`;
+
+/**
+ * Billing enrollment picker cell: instance title when non-empty, otherwise parent service title.
+ * Returns empty string when neither is present (caller may render an em dash).
+ */
+export function formatEnrollmentPickerInstanceServiceDisplay(row: {
+  instanceTitle?: string | null;
+  parentServiceTitle?: string | null;
+}): string {
+  const own = row.instanceTitle?.trim();
+  if (own) {
+    return own;
+  }
+  const parent = row.parentServiceTitle?.trim();
+  if (parent) {
+    return parent;
+  }
+  return '';
+}
+
 /**
  * Tier and cohort on one line (instances table, billing enrollment picker, and similar).
  * Uses space + interpunct + space only when both tier and cohort are non-empty after trim.

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -6076,7 +6076,11 @@ export interface components {
             partyDisplayName: string;
             /** Format: email */
             partyEmail?: string | null;
+            /** @description Trimmed instance-specific title when set. */
             instanceTitle?: string | null;
+            /** @description Parent service template title from the instance's service (for display when `instanceTitle` is empty). */
+            parentServiceTitle?: string | null;
+            /** @description Display tier label: event ticket tier name when the enrollment has a ticket tier; otherwise the parent service's `service_tier` when present. */
             serviceTierName?: string | null;
             instanceCohort?: string | null;
             /** @description Decimal amount as string; mirrors enrollment `amount_paid`. */

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -11,6 +11,8 @@ import {
   formatInstanceTableTierCohort,
   formatInstanceTableTitle,
   formatTierCohortDisplay,
+  ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER,
+  formatEnrollmentPickerInstanceServiceDisplay,
   INSTANCE_TABLE_TIER_COHORT_HEADER,
   formatIsoForDatetimeLocalInput,
   formatServiceListPriceLabel,
@@ -485,6 +487,7 @@ describe('format helpers', () => {
       resolvedConsultationDetails: null,
     });
     expect(INSTANCE_TABLE_TIER_COHORT_HEADER).toBe('Tier \u00b7 Cohort');
+    expect(ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER).toBe('Instance \u00b7 Service');
     expect(formatInstanceTableTierCohort(base())).toBe('tier-a');
     expect(formatInstanceTableTierCohort({ ...base(), cohort: 'spring-2024' })).toBe('tier-a \u00b7 spring-2024');
     expect(
@@ -501,6 +504,22 @@ describe('format helpers', () => {
         cohort: null,
       })
     ).toBe('');
+  });
+
+  it('formatEnrollmentPickerInstanceServiceDisplay prefers instance title then parent service', () => {
+    expect(
+      formatEnrollmentPickerInstanceServiceDisplay({
+        instanceTitle: '  Spring cohort  ',
+        parentServiceTitle: 'Ignored',
+      })
+    ).toBe('Spring cohort');
+    expect(
+      formatEnrollmentPickerInstanceServiceDisplay({
+        instanceTitle: null,
+        parentServiceTitle: 'Parent Name',
+      })
+    ).toBe('Parent Name');
+    expect(formatEnrollmentPickerInstanceServiceDisplay({ instanceTitle: '', parentServiceTitle: null })).toBe('');
   });
 
   it('formatTierCohortDisplay mirrors instance tier/cohort cell rules', () => {

--- a/backend/src/app/api/admin_billing_enrollment_queries.py
+++ b/backend/src/app/api/admin_billing_enrollment_queries.py
@@ -31,6 +31,7 @@ from app.db.models.enums import (
 )
 from app.db.models.family import Family
 from app.db.models.organization import Organization
+from app.db.models.service import Service
 from app.db.models.service_instance import EventTicketTier, ServiceInstance
 from app.exceptions import ValidationError
 from app.utils import json_response
@@ -97,6 +98,16 @@ def _party_email(
 
 
 _PICKER_MAX_LIMIT = 500
+
+
+def _trimmed_str_or_none(value: object | None) -> str | None:
+    """Return stripped non-empty string, or None; ignores non-strings (avoids MagicMock in tests)."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    t = value.strip()
+    return t or None
 
 
 def _parse_enrolled_at_cursor(raw: str | None) -> tuple[datetime | None, UUID | None]:
@@ -244,7 +255,7 @@ def list_recent_enrollments_for_invoicing(
 
         stmt = (
             stmt.options(
-                joinedload(Enrollment.instance),
+                joinedload(Enrollment.instance).joinedload(ServiceInstance.service),
                 joinedload(Enrollment.contact),
                 joinedload(Enrollment.family),
                 joinedload(Enrollment.organization),
@@ -293,11 +304,19 @@ def list_recent_enrollments_for_invoicing(
         items: list[dict[str, Any]] = []
         for en in page_rows:
             inst = en.instance
-            title = (inst.title or "").strip() if inst else ""
-            cohort = (inst.cohort or "").strip() if inst else ""
-            tier_name = None
-            if en.ticket_tier_id and en.ticket_tier:
-                tier_name = en.ticket_tier.name
+            title = _trimmed_str_or_none(inst.title) if inst else None
+            cohort = _trimmed_str_or_none(inst.cohort) if inst else None
+            parent_service_title = None
+            svc_obj: Service | None = None
+            if inst is not None:
+                svc_obj = getattr(inst, "service", None)
+                if svc_obj is not None:
+                    parent_service_title = _trimmed_str_or_none(svc_obj.title)
+            tier_name: str | None = None
+            if en.ticket_tier_id and en.ticket_tier is not None:
+                tier_name = _trimmed_str_or_none(en.ticket_tier.name)
+            if tier_name is None and svc_obj is not None:
+                tier_name = _trimmed_str_or_none(svc_obj.service_tier)
             currency = (en.currency or default_ccy).upper()[:3]
             email = _party_email(session, en, fam_emails, org_emails)
             items.append(
@@ -305,7 +324,8 @@ def list_recent_enrollments_for_invoicing(
                     "enrollmentId": str(en.id),
                     "partyDisplayName": _party_display_name(en),
                     "partyEmail": email,
-                    "instanceTitle": title or None,
+                    "instanceTitle": title,
+                    "parentServiceTitle": parent_service_title,
                     "serviceTierName": tier_name,
                     "instanceCohort": cohort or None,
                     "amountPaid": _decimal_to_string(en.amount_paid),

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -6283,9 +6283,17 @@ components:
         instanceTitle:
           type: string
           nullable: true
+          description: Trimmed instance-specific title when set.
+        parentServiceTitle:
+          type: string
+          nullable: true
+          description: Parent service template title from the instance's service (for display when `instanceTitle` is empty).
         serviceTierName:
           type: string
           nullable: true
+          description: >
+            Display tier label: event ticket tier name when the enrollment has a ticket tier;
+            otherwise the parent service's `service_tier` when present.
         instanceCohort:
           type: string
           nullable: true

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -1059,6 +1059,96 @@ def test_list_recent_enrollments_org_bill_to_primary_email(
     assert body["items"][0]["partyEmail"] == "org.primary@example.com"
 
 
+def test_list_recent_enrollments_parent_service_title_and_service_tier_fallback(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty instance title exposes parent service title; tier falls back to service.service_tier."""
+
+    iid = uuid4()
+    ts = datetime(2026, 2, 1, tzinfo=UTC)
+    eid = uuid4()
+
+    svc = MagicMock()
+    svc.title = "Parent Course"
+    svc.service_tier = "Standard"
+
+    inst = MagicMock()
+    inst.title = ""
+    inst.cohort = "Cohort A"
+    inst.service = svc
+
+    en = Enrollment(
+        instance_id=iid,
+        contact_id=None,
+        family_id=None,
+        organization_id=None,
+        ticket_tier_id=None,
+        discount_code_id=None,
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact_id=None,
+        bill_to_family_id=None,
+        bill_to_organization_id=None,
+        status=EnrollmentStatus.CONFIRMED,
+        amount_paid=Decimal("10"),
+        currency="HKD",
+        enrolled_at=ts,
+        cancelled_at=None,
+        notes=None,
+        created_by="test",
+    )
+    en.id = eid
+    en.instance = inst
+    en.ticket_tier = None
+    en.contact = MagicMock(email="x@example.com", first_name="X", last_name="Y")
+    en.family = None
+    en.organization = None
+    en.bill_to_contact = None
+    en.bill_to_family = None
+    en.bill_to_organization = None
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _exec(stmt: Any, *a: Any, **k: Any) -> MagicMock:
+            out = MagicMock()
+            sql = str(stmt)
+            if "FROM enrollments" in sql or "enrollments." in sql:
+                out.unique.return_value.scalars.return_value.all.return_value = [en]
+            elif "customer_invoice_lines" in sql:
+                out.scalars.return_value.all.return_value = []
+            else:
+                out.unique.return_value.scalars.return_value.all.return_value = []
+                out.scalars.return_value.all.return_value = []
+                out.all.return_value = []
+            return out
+
+        s.execute.side_effect = _exec
+        yield s
+
+    monkeypatch.setattr(
+        admin_billing_enrollment_queries_mod, "_session_with_audit", _fake_session
+    )
+
+    ev = api_gateway_event(
+        method="GET",
+        path="/v1/admin/billing/enrollments/recent-for-invoicing",
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "GET", "/v1/admin/billing/enrollments/recent-for-invoicing"
+    )
+    assert r["statusCode"] == 200
+    body = json.loads(r["body"])
+    row = body["items"][0]
+    assert row["instanceTitle"] is None
+    assert row["parentServiceTitle"] == "Parent Course"
+    assert row["serviceTierName"] == "Standard"
+    assert row["instanceCohort"] == "Cohort A"
+
+
 def test_confirm_payment_creates_receipt_for_pending_inbound(
     api_gateway_event: Any,
     admin_identity: dict[str, str],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the **Create draft invoice** enrollment picker table so the instance column matches the product naming pattern used elsewhere (interpunct between labels), shows **instance title** with a fallback to the **parent service title**, and surfaces **tier** for non–ticket-tier enrollments.

## Changes

- **API** (`GET /v1/admin/billing/enrollments/recent-for-invoicing`): response rows include optional `parentServiceTitle` (parent service template title). `serviceTierName` is the event ticket tier name when present; otherwise the parent service’s `service_tier`. Eager-load `instance.service` for these fields.
- **Admin web**: column header `Instance · Service`; cell uses `formatEnrollmentPickerInstanceServiceDisplay`. Tier/cohort column continues to use `formatTierCohortDisplay` but now receives the resolved tier from the API.
- **Tests**: backend coverage for parent title + service-tier fallback; Vitest for the new format helper and header constant.

## Validation

- `python3 -m pytest tests/test_admin_billing.py::test_list_recent_enrollments_parent_service_title_and_service_tier_fallback`
- `npx vitest run tests/lib/format.test.ts`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccb2e735-cd2f-40e5-a11c-f10cf81b7e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccb2e735-cd2f-40e5-a11c-f10cf81b7e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

