### PR TITLE
fix(remediation): per-booking instances migration and booking resilience

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -161,6 +161,15 @@ export function EnrollmentListPanel({
     [discountOptions, selectedEnrollment?.discountCodeId]
   );
 
+  const showBookingInstanceSlugColumn = useMemo(
+    () => enrollments.some((row) => Boolean(row.bookingInstanceSlug?.trim())),
+    [enrollments]
+  );
+  const showScheduledStartColumn = useMemo(
+    () => enrollments.some((row) => Boolean(row.scheduledStartAt?.trim())),
+    [enrollments]
+  );
+
   const formatEnrollmentParentCell = (enrollment: Enrollment): string => {
     if (enrollment.contactId) {
       return labelByContactId.get(enrollment.contactId) ?? enrollment.contactId;
@@ -444,10 +453,16 @@ export function EnrollmentListPanel({
         loadingLabel='Loading enrollments...'
         onLoadMore={onLoadMore}
       >
-        <AdminDataTable tableClassName='min-w-[840px]'>
+        <AdminDataTable tableClassName='min-w-[1040px]'>
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Parent</th>
+              {showBookingInstanceSlugColumn ? (
+                <th className='px-4 py-3 font-semibold'>Booking slug</th>
+              ) : null}
+              {showScheduledStartColumn ? (
+                <th className='px-4 py-3 font-semibold'>Scheduled start</th>
+              ) : null}
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Amount</th>
               <th className='px-4 py-3 font-semibold'>Discount</th>
@@ -474,6 +489,18 @@ export function EnrollmentListPanel({
                   onClick={() => applyEnrollmentSelection(enrollment)}
                 >
                   <td className='px-4 py-3'>{formatEnrollmentParentCell(enrollment)}</td>
+                  {showBookingInstanceSlugColumn ? (
+                    <td className='px-4 py-3 font-mono text-xs'>
+                      {enrollment.bookingInstanceSlug?.trim() || '—'}
+                    </td>
+                  ) : null}
+                  {showScheduledStartColumn ? (
+                    <td className='px-4 py-3'>
+                      {enrollment.scheduledStartAt?.trim()
+                        ? formatDate(enrollment.scheduledStartAt)
+                        : '—'}
+                    </td>
+                  ) : null}
                   <td className='px-4 py-3'>{formatEnumLabel(enrollment.status)}</td>
                   <td className='px-4 py-3'>{amountDisplay}</td>
                   <td className='px-4 py-3'>

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -234,7 +234,16 @@ export function InstanceListPanel({
                 >
                   {showServiceColumn ? (
                     <td className='w-[20%] min-w-0 break-words px-4 py-3'>
-                      {instanceTableTitle.trim() !== '' ? instanceTableTitle : '\u00a0'}
+                      <span className='inline-flex flex-wrap items-center gap-2'>
+                        <span>
+                          {instanceTableTitle.trim() !== '' ? instanceTableTitle : '\u00a0'}
+                        </span>
+                        {instance.isTemplate === false ? (
+                          <span className='rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900'>
+                            Booking
+                          </span>
+                        ) : null}
+                      </span>
                     </td>
                   ) : null}
                   {showServiceColumn ? (

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -312,6 +312,8 @@ function parseInstance(value: unknown): ServiceInstance {
     parentServiceKey: asNullableString(item.parent_service_key),
     title: asNullableString(item.title),
     slug,
+    parentInstanceId: asNullableString(item.parent_instance_id),
+    isTemplate: typeof item.is_template === 'boolean' ? item.is_template : undefined,
     description: asNullableString(item.description),
     coverImageS3Key: asNullableString(item.cover_image_s3_key),
     status: (asNullableString(item.status) ?? 'scheduled') as ServiceInstance['status'],

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -385,6 +385,8 @@ function parseEnrollment(value: unknown): Enrollment {
     createdBy: asNullableString(item.created_by) ?? '',
     createdAt: asNullableString(item.created_at),
     updatedAt: asNullableString(item.updated_at),
+    bookingInstanceSlug: asNullableString(item.booking_instance_slug),
+    scheduledStartAt: asNullableString(item.scheduled_start_at),
   };
 }
 

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -1555,6 +1555,8 @@ export interface paths {
                     service_id?: string;
                     /** @description When set, only instances whose parent service has this type. */
                     service_type?: components["schemas"]["ServiceType"];
+                    /** @description When true, includes per-booking child instances (`parent_instance_id` set, `is_template=false`) normally omitted from admin listings. */
+                    include_bookings?: boolean;
                 };
                 header?: never;
                 path?: never;
@@ -1850,7 +1852,10 @@ export interface paths {
         /** List service instances */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description When true, includes per-booking child instances (`parent_instance_id` set, `is_template=false`) normally omitted from admin listings. */
+                    include_bookings?: boolean;
+                };
                 header?: never;
                 path: {
                     /** @description Service identifier. */
@@ -5435,8 +5440,15 @@ export interface components {
             id: string;
             /** Format: uuid */
             service_id: string;
+            /**
+             * Format: uuid
+             * @description When set, this instance is a child booking row whose template tier is the parent id.
+             */
+            parent_instance_id?: string | null;
+            /** @description True for catalog tier instances (consultation packages / intro-call template). False for event cohorts, training runs, and per-public-booking child instances. */
+            is_template?: boolean;
             title?: string | null;
-            /** @description Public instance slug (required for all service types). URL-safe: lowercase letters, digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized to lowercase. Must be unique among instances. */
+            /** @description Public instance slug (required for all service types). URL-safe: lowercase letters, digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized to lowercase. Uniqueness is enforced separately for template rows (`is_template=true`) and non-template rows (`is_template=false`). */
             slug: string;
             description?: string | null;
             cover_image_s3_key?: string | null;
@@ -5590,6 +5602,13 @@ export interface components {
             created_at?: string | null;
             /** Format: date-time */
             updated_at?: string | null;
+            /** @description Returned by enrollment list when present: `service_instances.slug` for the enrollment's instance. */
+            booking_instance_slug?: string | null;
+            /**
+             * Format: date-time
+             * @description Returned by enrollment list when present: earliest session slot `starts_at` on the enrollment's instance (UTC).
+             */
+            scheduled_start_at?: string | null;
         };
         EnrollmentListResponse: {
             items: components["schemas"]["Enrollment"][];

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -307,6 +307,10 @@ export interface ServiceInstance {
   consultationDetails: ConsultationInstanceDetailsRow | null;
   /** Effective consultation pricing including parent service defaults. */
   resolvedConsultationDetails: ConsultationInstanceDetailsRow | null;
+  /** False when this row is a per-booking child instance (consultation / intro). */
+  isTemplate?: boolean;
+  /** Parent template instance id when this row is a per-booking child. */
+  parentInstanceId?: string | null;
 }
 
 export type TrainingInstanceDetailsRow = {

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -340,6 +340,9 @@ export interface Enrollment {
   createdBy: string;
   createdAt: string | null;
   updatedAt: string | null;
+  /** Present when the admin enrollment list includes booking-instance metadata. */
+  bookingInstanceSlug?: string | null;
+  scheduledStartAt?: string | null;
 }
 
 export interface DiscountCode {

--- a/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
@@ -79,6 +79,35 @@ describe('EnrollmentListPanel', () => {
     expect(screen.getByLabelText('Organization')).toBeDisabled();
   });
 
+  it('shows booking slug and scheduled start columns when enrollment rows include them', () => {
+    const enrollmentWithBookingMeta: Enrollment = {
+      ...ENROLLMENT_FIXTURE,
+      bookingInstanceSlug: 'consultation-essentials-package-20260506103000-aabbccdd',
+      scheduledStartAt: '2026-06-15T01:00:00Z',
+    };
+    render(
+      <EnrollmentListPanel
+        enrollments={[enrollmentWithBookingMeta]}
+        serviceId='service-1'
+        instanceId='instance-1'
+        canCreate={true}
+        isLoading={false}
+        isLoadingMore={false}
+        hasMore={false}
+        error=''
+        isMutating={false}
+        onLoadMore={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Booking slug' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Scheduled start' })).toBeInTheDocument();
+    expect(screen.getByText('consultation-essentials-package-20260506103000-aabbccdd')).toBeInTheDocument();
+  });
+
   it('uses selectable currency options in the enrollment editor', () => {
     render(
       <EnrollmentListPanel

--- a/backend/db/alembic/versions/0061_per_booking_instances.py
+++ b/backend/db/alembic/versions/0061_per_booking_instances.py
@@ -1,0 +1,155 @@
+"""Per-booking service instances for consultations and intro calls.
+
+Templates (consultation / intro_call tiers with no parent) gain ``is_template`` and
+optional ``parent_instance_id`` on booking-only rows. Session slots gain
+``template_instance_id`` so concurrent bookings race on
+``(template_instance_id, starts_at)`` instead of a shared instance row.
+
+Seed compatibility: ``backend/db/seed/seed_data.sql`` needs no row edits; the
+backfill sets ``is_template = TRUE`` for existing consultation and intro_call tier
+instances (including ``intro-call-free-15min``).
+
+Revision id length: 28 chars (<= 32).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+revision: str = "0061_per_booking_instances"
+down_revision: Union[str, None] = "0060_intro_call_starts_uniq"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "service_instances",
+        sa.Column("parent_instance_id", PG_UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "service_instances",
+        sa.Column(
+            "is_template",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE service_instances AS si
+            SET is_template = TRUE
+            FROM services AS s
+            WHERE si.service_id = s.id
+              AND si.parent_instance_id IS NULL
+              AND s.service_type IN ('consultation', 'intro_call')
+            """
+        )
+    )
+
+    op.create_foreign_key(
+        "service_instances_parent_instance_id_fkey",
+        "service_instances",
+        "service_instances",
+        ["parent_instance_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "svc_instances_parent_idx",
+        "service_instances",
+        ["parent_instance_id"],
+    )
+
+    op.drop_index("svc_instances_slug_uq", table_name="service_instances")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX svc_instances_slug_uq_template
+        ON service_instances (slug)
+        WHERE is_template IS TRUE
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX svc_instances_slug_uq_booking
+        ON service_instances (slug)
+        WHERE is_template IS FALSE
+        """
+    )
+
+    op.drop_index(
+        "instance_session_slots_instance_starts_uidx",
+        table_name="instance_session_slots",
+    )
+
+    op.add_column(
+        "instance_session_slots",
+        sa.Column("template_instance_id", PG_UUID(as_uuid=True), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE instance_session_slots AS iss
+            SET template_instance_id = si.parent_instance_id
+            FROM service_instances AS si
+            WHERE iss.instance_id = si.id
+            """
+        )
+    )
+    op.create_foreign_key(
+        "instance_session_slots_template_instance_id_fkey",
+        "instance_session_slots",
+        "service_instances",
+        ["template_instance_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX instance_session_slots_template_starts_uidx
+        ON instance_session_slots (template_instance_id, starts_at)
+        WHERE template_instance_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS instance_session_slots_template_starts_uidx")
+    op.drop_constraint(
+        "instance_session_slots_template_instance_id_fkey",
+        "instance_session_slots",
+        type_="foreignkey",
+    )
+    op.drop_column("instance_session_slots", "template_instance_id")
+
+    op.create_index(
+        "instance_session_slots_instance_starts_uidx",
+        "instance_session_slots",
+        ["instance_id", "starts_at"],
+        unique=True,
+    )
+
+    op.execute("DROP INDEX IF EXISTS svc_instances_slug_uq_booking")
+    op.execute("DROP INDEX IF EXISTS svc_instances_slug_uq_template")
+    op.create_index(
+        "svc_instances_slug_uq",
+        "service_instances",
+        ["slug"],
+        unique=True,
+    )
+
+    op.drop_index("svc_instances_parent_idx", table_name="service_instances")
+    op.drop_constraint(
+        "service_instances_parent_instance_id_fkey",
+        "service_instances",
+        type_="foreignkey",
+    )
+    op.drop_column("service_instances", "is_template")
+    op.drop_column("service_instances", "parent_instance_id")

--- a/backend/db/alembic/versions/0061_per_booking_instances.py
+++ b/backend/db/alembic/versions/0061_per_booking_instances.py
@@ -4,6 +4,8 @@ Templates (consultation / intro_call tiers with no parent) gain ``is_template`` 
 optional ``parent_instance_id`` on booking-only rows. Session slots gain
 ``template_instance_id`` so concurrent bookings race on
 ``(template_instance_id, starts_at)`` instead of a shared instance row.
+Legacy template-tier slot rows are self-tagged with ``template_instance_id = instance_id``
+so the new partial unique applies to intro-call tier slots.
 
 Seed compatibility: ``backend/db/seed/seed_data.sql`` needs no row edits; the
 backfill sets ``is_template = TRUE`` for existing consultation and intro_call tier
@@ -67,6 +69,12 @@ def upgrade() -> None:
         "service_instances",
         ["parent_instance_id"],
     )
+    op.create_check_constraint(
+        "service_instances_template_consistency_chk",
+        "service_instances",
+        "(is_template IS TRUE AND parent_instance_id IS NULL) "
+        "OR (is_template IS FALSE)",
+    )
 
     op.drop_index("svc_instances_slug_uq", table_name="service_instances")
     op.execute(
@@ -97,7 +105,10 @@ def upgrade() -> None:
         sa.text(
             """
             UPDATE instance_session_slots AS iss
-            SET template_instance_id = si.parent_instance_id
+            SET template_instance_id = COALESCE(
+                si.parent_instance_id,
+                CASE WHEN si.is_template THEN si.id END
+            )
             FROM service_instances AS si
             WHERE iss.instance_id = si.id
             """
@@ -150,6 +161,11 @@ def downgrade() -> None:
         "service_instances_parent_instance_id_fkey",
         "service_instances",
         type_="foreignkey",
+    )
+    op.drop_constraint(
+        "service_instances_template_consistency_chk",
+        "service_instances",
+        type_="check",
     )
     op.drop_column("service_instances", "is_template")
     op.drop_column("service_instances", "parent_instance_id")

--- a/backend/src/app/api/admin_enrollments.py
+++ b/backend/src/app/api/admin_enrollments.py
@@ -25,7 +25,7 @@ from app.api.admin_services_common import (
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
-from app.db.models import Enrollment
+from app.db.models import Enrollment, ServiceInstance
 from app.db.models.enums import EnrollmentStatus
 from app.api.instance_capacity_status import bulk_reconcile_instance_capacity_status
 from app.db.repositories import (
@@ -38,6 +38,16 @@ from app.utils import json_response
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def _enrollment_visible_under_instance_anchor(
+    session: Session, enrollment: Enrollment, anchor_instance_id: UUID
+) -> bool:
+    """True when the enrollment row belongs to ``anchor_instance_id`` or its bookings."""
+    if enrollment.instance_id == anchor_instance_id:
+        return True
+    row = session.get(ServiceInstance, enrollment.instance_id)
+    return row is not None and row.parent_instance_id == anchor_instance_id
 
 
 def handle_admin_enrollments_request(
@@ -100,8 +110,8 @@ def _list_enrollments(event: Mapping[str, Any], *, instance_id: UUID) -> dict[st
     )
     with Session(get_engine()) as session:
         repository = EnrollmentRepository(session)
-        rows = repository.list_enrollments(
-            instance_id=instance_id,
+        rows = repository.list_enrollments_for_instance_scope(
+            anchor_instance_id=instance_id,
             limit=limit + 1,
             status=filters["status"],
             cursor_created_at=filters["cursor_created_at"],
@@ -112,13 +122,23 @@ def _list_enrollments(event: Mapping[str, Any], *, instance_id: UUID) -> dict[st
         next_cursor = (
             encode_enrollment_cursor(page_rows[-1]) if has_more and page_rows else None
         )
-        total_count = repository.count_enrollments(
-            instance_id=instance_id, status=filters["status"]
+        total_count = repository.count_enrollments_for_instance_scope(
+            anchor_instance_id=instance_id, status=filters["status"]
+        )
+        slug_map, start_map = repository.booking_rows_slug_and_first_session_start(
+            [row.instance_id for row in page_rows]
         )
         return json_response(
             200,
             {
-                "items": [serialize_enrollment(row) for row in page_rows],
+                "items": [
+                    serialize_enrollment(
+                        row,
+                        booking_instance_slug=slug_map.get(row.instance_id),
+                        scheduled_start_at=start_map.get(row.instance_id),
+                    )
+                    for row in page_rows
+                ],
                 "next_cursor": next_cursor,
                 "total_count": total_count,
             },
@@ -207,7 +227,9 @@ def _update_enrollment(
         set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = EnrollmentRepository(session)
         enrollment = repository.get_by_id(enrollment_id)
-        if enrollment is None or enrollment.instance_id != instance_id:
+        if enrollment is None or not _enrollment_visible_under_instance_anchor(
+            session, enrollment, instance_id
+        ):
             raise NotFoundError("Enrollment", str(enrollment_id))
 
         if "status" in payload:
@@ -283,7 +305,9 @@ def _delete_enrollment(
         set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
         repository = EnrollmentRepository(session)
         enrollment = repository.get_by_id(enrollment_id)
-        if enrollment is None or enrollment.instance_id != instance_id:
+        if enrollment is None or not _enrollment_visible_under_instance_anchor(
+            session, enrollment, instance_id
+        ):
             raise NotFoundError("Enrollment", str(enrollment_id))
         discount_repo = DiscountCodeRepository(session)
         if enrollment.discount_code_id is not None:
@@ -295,7 +319,7 @@ def _delete_enrollment(
         repository.delete(enrollment)
         if hasattr(session, "get"):
             instance_repository = ServiceInstanceRepository(session)
-            instance_row = instance_repository.get_by_id(instance_id)
+            instance_row = instance_repository.get_by_id(enrollment.instance_id)
             if instance_row is not None:
                 bulk_reconcile_instance_capacity_status(session, [instance_row])
         session.commit()

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -275,6 +275,7 @@ def handle_admin_all_service_instances_request(
                 raise NotFoundError("Service", str(service_id_filter))
 
         repository = ServiceInstanceRepository(session)
+        include_bookings = bool(filters.get("include_bookings", False))
         rows = repository.list_instances_global(
             limit=limit + 1,
             status=filters["status"],
@@ -282,13 +283,13 @@ def handle_admin_all_service_instances_request(
             service_type=service_type_filter,
             cursor_created_at=filters["cursor_created_at"],
             cursor_id=filters["cursor_id"],
-            include_bookings=filters["include_bookings"],
+            include_bookings=include_bookings,
         )
         total_count = repository.count_instances_global(
             status=filters["status"],
             service_id=service_id_filter,
             service_type=service_type_filter,
-            include_bookings=filters["include_bookings"],
+            include_bookings=include_bookings,
         )
         has_more = len(rows) > limit
         page_rows = rows[:limit]
@@ -385,18 +386,19 @@ def _list_instances(event: Mapping[str, Any], *, service_id: UUID) -> dict[str, 
             raise NotFoundError("Service", str(service_id))
 
         repository = ServiceInstanceRepository(session)
+        include_bookings = bool(filters.get("include_bookings", False))
         rows = repository.list_instances(
             service_id=service_id,
             limit=limit + 1,
             status=filters["status"],
             cursor_created_at=filters["cursor_created_at"],
             cursor_id=filters["cursor_id"],
-            include_bookings=filters["include_bookings"],
+            include_bookings=include_bookings,
         )
         total_count = repository.count_instances(
             service_id=service_id,
             status=filters["status"],
-            include_bookings=filters["include_bookings"],
+            include_bookings=include_bookings,
         )
         has_more = len(rows) > limit
         page_rows = rows[:limit]

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -68,9 +68,21 @@ def _is_service_instance_slug_unique_violation(exc: IntegrityError) -> bool:
     orig = getattr(exc.orig, "__cause__", None) or exc.orig
     diag = getattr(orig, "diag", None)
     constraint = getattr(diag, "constraint_name", None) if diag else None
-    if constraint == "svc_instances_slug_uq":
+    if constraint in (
+        "svc_instances_slug_uq",
+        "svc_instances_slug_uq_template",
+        "svc_instances_slug_uq_booking",
+    ):
         return True
-    return "svc_instances_slug_uq" in str(exc).lower()
+    lowered = str(exc).lower()
+    return any(
+        name in lowered
+        for name in (
+            "svc_instances_slug_uq",
+            "svc_instances_slug_uq_template",
+            "svc_instances_slug_uq_booking",
+        )
+    )
 
 
 def _event_category_name(service: Service) -> str:
@@ -270,11 +282,13 @@ def handle_admin_all_service_instances_request(
             service_type=service_type_filter,
             cursor_created_at=filters["cursor_created_at"],
             cursor_id=filters["cursor_id"],
+            include_bookings=filters["include_bookings"],
         )
         total_count = repository.count_instances_global(
             status=filters["status"],
             service_id=service_id_filter,
             service_type=service_type_filter,
+            include_bookings=filters["include_bookings"],
         )
         has_more = len(rows) > limit
         page_rows = rows[:limit]
@@ -377,10 +391,12 @@ def _list_instances(event: Mapping[str, Any], *, service_id: UUID) -> dict[str, 
             status=filters["status"],
             cursor_created_at=filters["cursor_created_at"],
             cursor_id=filters["cursor_id"],
+            include_bookings=filters["include_bookings"],
         )
         total_count = repository.count_instances(
             service_id=service_id,
             status=filters["status"],
+            include_bookings=filters["include_bookings"],
         )
         has_more = len(rows) > limit
         page_rows = rows[:limit]
@@ -445,6 +461,9 @@ def _create_instance(
             notes=payload["notes"],
             external_url=payload["external_url"],
             created_by=actor_sub,
+            parent_instance_id=None,
+            is_template=service.service_type
+            in (ServiceType.CONSULTATION, ServiceType.INTRO_CALL),
         )
         type_details_raw = payload["type_details"]
         if service.service_type == ServiceType.EVENT:

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -148,6 +148,12 @@ def parse_instance_filters(event: Mapping[str, Any]) -> dict[str, Any]:
     logger.debug("Parsing service instance list filters")
     limit = parse_limit(event)
     cursor_created_at, cursor_id = parse_created_cursor(query_param(event, "cursor"))
+    include_raw = query_param(event, "include_bookings")
+    include_bookings = str(include_raw or "").strip().lower() in (
+        "true",
+        "1",
+        "yes",
+    )
     return {
         "limit": limit,
         "cursor_created_at": cursor_created_at,
@@ -157,6 +163,7 @@ def parse_instance_filters(event: Mapping[str, Any]) -> dict[str, Any]:
             InstanceStatus,
             "status",
         ),
+        "include_bookings": include_bookings,
     }
 
 
@@ -165,6 +172,12 @@ def parse_global_instance_list_filters(event: Mapping[str, Any]) -> dict[str, An
     logger.debug("Parsing global service instance list filters")
     limit = parse_limit(event)
     cursor_created_at, cursor_id = parse_created_cursor(query_param(event, "cursor"))
+    include_raw = query_param(event, "include_bookings")
+    include_bookings = str(include_raw or "").strip().lower() in (
+        "true",
+        "1",
+        "yes",
+    )
     return {
         "limit": limit,
         "cursor_created_at": cursor_created_at,
@@ -182,6 +195,7 @@ def parse_global_instance_list_filters(event: Mapping[str, Any]) -> dict[str, An
             ServiceType,
             "service_type",
         ),
+        "include_bookings": include_bookings,
     }
 
 

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
@@ -173,8 +174,13 @@ def _resolved_training_details(
 def _resolved_consultation_details(
     instance: ServiceInstance, service: Service
 ) -> dict[str, Any] | None:
-    if instance.consultation_details is not None:
-        cd = instance.consultation_details
+    chain_detail = instance.consultation_details
+    if chain_detail is None and instance.parent_instance_id is not None:
+        parent = instance.parent
+        if parent is not None and parent.consultation_details is not None:
+            chain_detail = parent.consultation_details
+    if chain_detail is not None:
+        cd = chain_detail
         return {
             "pricing_model": cd.pricing_model.value,
             "price": _decimal_to_string(cd.price),
@@ -316,6 +322,10 @@ def serialize_instance(
         "created_by": instance.created_by,
         "created_at": instance.created_at.isoformat() if instance.created_at else None,
         "updated_at": instance.updated_at.isoformat() if instance.updated_at else None,
+        "parent_instance_id": str(instance.parent_instance_id)
+        if instance.parent_instance_id
+        else None,
+        "is_template": instance.is_template,
         "resolved_title": resolved_title,
         "resolved_slug": resolved_slug,
         "resolved_description": resolved_description,
@@ -382,9 +392,14 @@ def serialize_event_ticket_tier(tier: EventTicketTier) -> dict[str, Any]:
     }
 
 
-def serialize_enrollment(enrollment: Enrollment) -> dict[str, Any]:
+def serialize_enrollment(
+    enrollment: Enrollment,
+    *,
+    booking_instance_slug: str | None = None,
+    scheduled_start_at: datetime | None = None,
+) -> dict[str, Any]:
     """Serialize enrollment payload."""
-    return {
+    payload: dict[str, Any] = {
         "id": str(enrollment.id),
         "instance_id": str(enrollment.instance_id),
         "contact_id": str(enrollment.contact_id) if enrollment.contact_id else None,
@@ -416,6 +431,11 @@ def serialize_enrollment(enrollment: Enrollment) -> dict[str, Any]:
         if enrollment.updated_at
         else None,
     }
+    if booking_instance_slug is not None:
+        payload["booking_instance_slug"] = booking_instance_slug
+    if scheduled_start_at is not None:
+        payload["scheduled_start_at"] = scheduled_start_at.isoformat()
+    return payload
 
 
 def serialize_discount_code(code: DiscountCode) -> dict[str, Any]:

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import secrets
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from decimal import InvalidOperation
@@ -37,7 +38,12 @@ from app.api.public_form_hooks import (
 )
 from app.db.audit import AuditService, set_audit_context
 from app.db.engine import get_engine
-from app.db.models import Enrollment, InstanceSessionSlot, ServiceInstance
+from app.db.models import (
+    CustomerPayment,
+    Enrollment,
+    InstanceSessionSlot,
+    ServiceInstance,
+)
 from app.db.repositories import (
     DiscountCodeRepository,
     EnrollmentRepository,
@@ -52,7 +58,9 @@ from app.db.models.enums import (
     ContactType,
     DiscountType,
     EnrollmentStatus,
+    EventbriteSyncStatus,
     FunnelStage,
+    InstanceStatus,
     LeadEventType,
     LeadType,
     ServiceType,
@@ -130,6 +138,166 @@ _PUBLIC_RESERVATION_BOOKING_SYSTEM_CODES = frozenset(
         "intro-call-booking",
     }
 )
+_PER_BOOKING_BOOKING_SYSTEMS = frozenset({"consultation-booking", "intro-call-booking"})
+
+
+def _generate_booking_instance_slug(*, template_slug: str, now_utc: datetime) -> str:
+    slug_part = template_slug.strip().lower()
+    suffix = secrets.token_hex(4)
+    raw = f"{slug_part}-{now_utc:%Y%m%d%H%M%S}-{suffix}"
+    if len(raw) > _MAX_INSTANCE_SLUG_LENGTH:
+        raw = raw[:_MAX_INSTANCE_SLUG_LENGTH]
+    if not PUBLIC_INSTANCE_SLUG_PATTERN.fullmatch(raw):
+        raise ValidationError(
+            "Unable to allocate a valid booking instance slug",
+            field="serviceInstanceSlug",
+            status_code=500,
+        )
+    return raw
+
+
+def _create_booking_instance_for_template(
+    session: Session,
+    instance_repo: ServiceInstanceRepository,
+    template: ServiceInstance,
+    payload: Mapping[str, Any],
+    *,
+    now_utc: datetime,
+) -> ServiceInstance:
+    locked = instance_repo.lock_template_for_booking(template.id)
+    if locked is None:
+        raise ValidationError(
+            "service_instance_slug_mismatch",
+            field="serviceInstanceSlug",
+            status_code=400,
+        )
+    slug = _generate_booking_instance_slug(
+        template_slug=locked.slug,
+        now_utc=now_utc,
+    )
+    attendee = str(payload.get("attendee_name") or "").strip()
+    title = f"{locked.title or locked.slug} – {attendee}" if attendee else locked.title
+    booking = ServiceInstance(
+        service_id=locked.service_id,
+        parent_instance_id=locked.id,
+        is_template=False,
+        title=title,
+        slug=slug,
+        description=None,
+        cover_image_s3_key=None,
+        status=InstanceStatus.OPEN,
+        delivery_mode=locked.delivery_mode,
+        location_id=locked.location_id,
+        max_capacity=1,
+        waitlist_enabled=False,
+        instructor_id=locked.instructor_id,
+        cohort=None,
+        notes=None,
+        created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
+        external_url=None,
+        eventbrite_sync_status=EventbriteSyncStatus.PENDING,
+    )
+    return instance_repo.create_instance(booking, type_details=None, session_slots=None)
+
+
+def _consultation_booking_slot_rows(
+    payload: Mapping[str, Any],
+) -> list[tuple[datetime, datetime, int]]:
+    raw_start = payload.get("primary_session_start_iso")
+    raw_end = payload.get("primary_session_end_iso")
+    if not raw_start or not raw_end:
+        raise ValidationError(
+            "primarySessionStartIso and primarySessionEndIso are required for "
+            "consultation bookings",
+            field="primarySessionStartIso",
+        )
+    ps = _parse_iso_datetime_utc(str(raw_start))
+    pe = _parse_iso_datetime_utc(str(raw_end))
+    if ps is None or pe is None:
+        raise ValidationError(
+            "Invalid consultation session ISO timestamps",
+            field="primarySessionStartIso",
+        )
+    if pe <= ps:
+        raise ValidationError(
+            "Consultation primary session must end after it starts",
+            field="primarySessionEndIso",
+        )
+    rows: list[tuple[datetime, datetime, int]] = [(ps, pe, 0)]
+    seen: set[datetime] = {ps}
+    extras = payload.get("session_slots") or []
+    for idx, row in enumerate(extras):
+        start_s = row.get("start_iso")
+        end_s = row.get("end_iso")
+        if not isinstance(start_s, str) or not start_s.strip():
+            continue
+        if not isinstance(end_s, str) or not end_s.strip():
+            raise ValidationError(
+                "Each consultation session slot must include an end time",
+                field="sessionSlots",
+            )
+        ss = _parse_iso_datetime_utc(start_s.strip())
+        es = _parse_iso_datetime_utc(end_s.strip())
+        if ss is None or es is None:
+            raise ValidationError(
+                "Invalid consultation session slot timestamps",
+                field="sessionSlots",
+            )
+        if es <= ss:
+            raise ValidationError(
+                "Each session slot must end after its start time",
+                field="sessionSlots",
+            )
+        if ss in seen:
+            continue
+        seen.add(ss)
+        rows.append((ss, es, idx + 1))
+    return rows
+
+
+def _persist_session_slots_for_booking_instance(
+    session: Session,
+    *,
+    booking_instance_id: UUID,
+    template_id: UUID,
+    slots: list[tuple[datetime, datetime, int]],
+    reservation_payload: Mapping[str, Any],
+    now_utc: datetime,
+    is_intro_booking: bool,
+) -> None:
+    for start_u, end_u, sort_order in slots:
+        session.add(
+            InstanceSessionSlot(
+                instance_id=booking_instance_id,
+                template_instance_id=template_id,
+                location_id=None,
+                starts_at=start_u,
+                ends_at=end_u,
+                sort_order=sort_order,
+            )
+        )
+    try:
+        session.flush()
+    except IntegrityError as exc:
+        logger.info(
+            "booking_template_slot_unique_violation",
+            extra={
+                "attendee_email": mask_email(
+                    str(reservation_payload.get("attendee_email"))
+                ),
+            },
+        )
+        raise ConflictError("slot_unavailable") from exc
+    if is_intro_booking and slots:
+        s0, s1 = slots[0][0], slots[0][1]
+        if not is_intro_call_slot_available(
+            session,
+            start_utc=s0,
+            end_utc=s1,
+            now=now_utc,
+            ignore_intro_slot=(s0, s1),
+        ):
+            raise ConflictError("slot_unavailable")
 
 
 def _resolve_booking_identity(
@@ -522,22 +690,26 @@ def _handle_public_reservation(
                 resolved_instance = _resolve_booking_identity(
                     session, reservation_payload
                 )
+                template_instance = resolved_instance
                 reservation_payload = {
                     **reservation_payload,
-                    "service_type": resolved_instance.service.service_type.value,
+                    "service_type": template_instance.service.service_type.value,
                 }
                 now_utc = datetime.now(tz=UTC)
+                booking_system = reservation_payload.get("booking_system")
+                per_booking = booking_system in _PER_BOOKING_BOOKING_SYSTEMS
                 intro_slot_bounds: tuple[datetime, datetime] | None = None
-                if reservation_payload.get("booking_system") == "intro-call-booking":
+                consultation_slot_rows: list[tuple[datetime, datetime, int]] | None = (
+                    None
+                )
+                if booking_system == "intro-call-booking":
                     intro_slot_bounds = _enforce_intro_call_invariants(
                         session,
                         reservation_payload,
-                        resolved_instance,
+                        template_instance,
                         now=now_utc,
                     )
-                elif (
-                    reservation_payload.get("booking_system") == "consultation-booking"
-                ):
+                elif booking_system == "consultation-booking":
                     start_iso = reservation_payload.get("primary_session_start_iso")
                     if not start_iso:
                         raise ValidationError(
@@ -563,182 +735,75 @@ def _handle_public_reservation(
                         primary_start_iso=str(start_iso),
                         session_slots=reservation_payload.get("session_slots"),
                     )
+                    consultation_slot_rows = _consultation_booking_slot_rows(
+                        reservation_payload
+                    )
                 _validate_discount_code_redemption_scope(
-                    session, reservation_payload, resolved_instance=resolved_instance
-                )
-                contact_repo = ContactRepository(session)
-                lead_repo = SalesLeadRepository(session)
-                src_detail: str = "public-www-booking"
-                ma_obj = reservation_payload.get("marketing_attribution")
-                if reservation_payload.get("booking_system") == "intro-call-booking":
-                    if isinstance(ma_obj, dict) and ma_obj:
-                        src_detail = json.dumps(
-                            {"source": "public-www-booking", **ma_obj},
-                            separators=(",", ":"),
-                        )
-                    else:
-                        src_detail = json.dumps(
-                            {"source": "public-www-booking"}, separators=(",", ":")
-                        )
-                contact, _created = contact_repo.upsert_by_email(
-                    reservation_payload["attendee_email"],
-                    first_name=first_name_from_full_name(
-                        reservation_payload["attendee_name"]
-                    ),
-                    source=ContactSource.RESERVATION,
-                    source_detail=src_detail,
-                    contact_type=ContactType.PARENT,
-                )
-                new_region = reservation_payload["phone_region"]
-                new_national = reservation_payload["phone_national_number"]
-                if (
-                    new_region is not None
-                    and new_national is not None
-                    and (
-                        contact.phone_region is None
-                        or contact.phone_national_number is None
-                    )
-                ):
-                    contact.phone_region = new_region
-                    contact.phone_national_number = new_national
-                contact_repo.update(contact)
-
-                _validate_public_bill_to_membership(
-                    session,
-                    {
-                        "bill_to_kind": reservation_payload["bill_to_kind"],
-                        "bill_to_family_id": reservation_payload["bill_to_family_id"],
-                        "bill_to_organization_id": reservation_payload[
-                            "bill_to_organization_id"
-                        ],
-                    },
-                    contact_id=contact.id,
+                    session, reservation_payload, template_instance=template_instance
                 )
 
-                dc_text = reservation_payload.get("discount_code")
-                dc_row = None
-                if dc_text:
-                    dc_lookup = DiscountCodeRepository(session)
-                    dc_row = dc_lookup.get_by_code(str(dc_text))
-
-                instance_id_resolved = resolved_instance.id
-
-                enrollment_repo = EnrollmentRepository(session)
-                discount_repo = DiscountCodeRepository(session)
-                has_enrollment = enrollment_repo.contact_has_enrollment_for_instance(
-                    instance_id=instance_id_resolved,
-                    contact_id=contact.id,
-                )
-                is_intro_booking = (
-                    reservation_payload.get("booking_system") == "intro-call-booking"
-                )
-
-                def _persist_intro_call_slot_for_enrollment() -> None:
-                    bounds = intro_slot_bounds
-                    if bounds is None:
-                        raise RuntimeError("intro_call_slot_bounds_missing_for_persist")
-                    s0, s1 = bounds
-                    session.add(
-                        InstanceSessionSlot(
-                            instance_id=instance_id_resolved,
-                            location_id=None,
-                            starts_at=s0,
-                            ends_at=s1,
+                stripe_pi = str(
+                    reservation_payload.get("stripe_payment_intent_id") or ""
+                ).strip()
+                skip_persistence = False
+                if per_booking and stripe_pi:
+                    existing_pi_payment = session.execute(
+                        select(CustomerPayment).where(
+                            CustomerPayment.stripe_payment_intent_id == stripe_pi
                         )
-                    )
-                    try:
-                        session.flush()
-                    except IntegrityError as exc:
-                        logger.info(
-                            "intro_call_slot_unique_violation",
-                            extra={
-                                "attendee_email": mask_email(
-                                    str(reservation_payload.get("attendee_email"))
-                                ),
-                            },
-                        )
-                        raise ConflictError("slot_unavailable") from exc
-                    if not is_intro_call_slot_available(
-                        session,
-                        start_utc=s0,
-                        end_utc=s1,
-                        now=now_utc,
-                        ignore_intro_slot=(s0, s1),
-                    ):
-                        raise ConflictError("slot_unavailable")
-
-                if (
-                    is_intro_booking
-                    and has_enrollment
-                    and intro_slot_bounds is not None
-                ):
-                    existing_enrollment_id = session.execute(
-                        select(Enrollment.id)
-                        .where(
-                            Enrollment.instance_id == instance_id_resolved,
-                            Enrollment.contact_id == contact.id,
-                        )
-                        .limit(1)
                     ).scalar_one_or_none()
-                    if existing_enrollment_id is None:
-                        raise ValidationError(
-                            "Enrollment not found for intro-call instance",
-                            field="serviceInstanceSlug",
-                        )
-                    created_enrollment_id = existing_enrollment_id
-                    # Slot insert first: avoids writing a free payment row if the slot is taken.
-                    _persist_intro_call_slot_for_enrollment()
-                    _pay, _, _dup_pi = record_reservation_customer_payment(
-                        session,
-                        enrollment_id=existing_enrollment_id,
-                        contact_id=contact.id,
-                        currency=reservation_payload["currency"],
-                        total_amount=reservation_payload["total_amount"],
-                        payment_method=reservation_payload["payment_method"],
-                        stripe_payment_intent_id=reservation_payload.get(
-                            "stripe_payment_intent_id"
-                        ),
-                        stripe_currency=reservation_payload.get("stripe_currency"),
-                    )
-                    if _dup_pi and _pay is not None:
+                    if existing_pi_payment is not None:
                         stripe_pi_idempotent_hit = True
-                        stripe_pi_existing_payment_id = _pay.id
-                    existing_enrollment_row = session.get(
-                        Enrollment, existing_enrollment_id
+                        stripe_pi_existing_payment_id = existing_pi_payment.id
+                        skip_persistence = True
+
+                instance_id_for_audit: UUID = template_instance.id
+                booking_instance_slug_for_lead: str | None = None
+                dc_row = None
+                dc_text = reservation_payload.get("discount_code")
+
+                if not skip_persistence:
+                    contact_repo = ContactRepository(session)
+                    lead_repo = SalesLeadRepository(session)
+                    src_detail = "public-www-booking"
+                    ma_obj = reservation_payload.get("marketing_attribution")
+                    if booking_system == "intro-call-booking":
+                        if isinstance(ma_obj, dict) and ma_obj:
+                            src_detail = json.dumps(
+                                {"source": "public-www-booking", **ma_obj},
+                                separators=(",", ":"),
+                            )
+                        else:
+                            src_detail = json.dumps(
+                                {"source": "public-www-booking"}, separators=(",", ":")
+                            )
+                    contact, _created = contact_repo.upsert_by_email(
+                        reservation_payload["attendee_email"],
+                        first_name=first_name_from_full_name(
+                            reservation_payload["attendee_name"]
+                        ),
+                        source=ContactSource.RESERVATION,
+                        source_detail=src_detail,
+                        contact_type=ContactType.PARENT,
                     )
-                    if existing_enrollment_row is not None:
-                        existing_enrollment_row.updated_at = now_utc
-                        session.flush()
-                elif not has_enrollment:
-                    instance_service_id = resolved_instance.service.id
-                    if dc_row is not None:
-                        ensure_discount_code_eligible_for_instance(
-                            session,
-                            discount_code_id=dc_row.id,
-                            service_id=instance_service_id,
-                            instance_id=instance_id_resolved,
+                    new_region = reservation_payload["phone_region"]
+                    new_national = reservation_payload["phone_national_number"]
+                    if (
+                        new_region is not None
+                        and new_national is not None
+                        and (
+                            contact.phone_region is None
+                            or contact.phone_national_number is None
                         )
-                    enrollment_row = Enrollment(
-                        instance_id=instance_id_resolved,
-                        contact_id=contact.id,
-                        family_id=None,
-                        organization_id=None,
-                        ticket_tier_id=None,
-                        discount_code_id=None,
-                        status=EnrollmentStatus.REGISTERED,
-                        amount_paid=reservation_payload["total_amount"],
-                        currency=reservation_payload["currency"],
-                        notes=None,
-                        created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
-                    )
-                    _apply_enrollment_bill_to(
-                        enrollment_row,
-                        contact_id=contact.id,
-                        bill={
+                    ):
+                        contact.phone_region = new_region
+                        contact.phone_national_number = new_national
+                    contact_repo.update(contact)
+
+                    _validate_public_bill_to_membership(
+                        session,
+                        {
                             "bill_to_kind": reservation_payload["bill_to_kind"],
-                            "bill_to_contact_id": reservation_payload[
-                                "bill_to_contact_id"
-                            ],
                             "bill_to_family_id": reservation_payload[
                                 "bill_to_family_id"
                             ],
@@ -746,104 +811,204 @@ def _handle_public_reservation(
                                 "bill_to_organization_id"
                             ],
                         },
+                        contact_id=contact.id,
                     )
-                    created_enrollment, create_err = (
-                        enrollment_repo.try_create_enrollment_with_capacity_guard(
-                            enrollment_row
-                        )
-                    )
-                    if create_err == "capacity_full":
-                        raise ValidationError(
-                            "This cohort is full and is not accepting a waitlist for "
-                            "public bookings. Your payment was processed; contact support "
-                            "if you need a refund.",
-                            field="serviceInstanceSlug",
-                            status_code=409,
-                        )
-                    if create_err != "duplicate" and created_enrollment is not None:
-                        created_enrollment_id = created_enrollment.id
-                        if dc_row is not None:
-                            if not discount_repo.validate_and_increment(dc_row.id):
-                                session.delete(created_enrollment)
-                                session.flush()
-                                raise ValidationError(
-                                    "Discount code is invalid, inactive, expired, or exhausted",
-                                    field="discountCode",
-                                )
-                            created_enrollment.discount_code_id = dc_row.id
-                            session.flush()
-                        # Slot insert first: avoids writing a free payment row if the slot is taken.
-                        if is_intro_booking and intro_slot_bounds is not None:
-                            _persist_intro_call_slot_for_enrollment()
-                        _pay, _, _dup_pi = record_reservation_customer_payment(
-                            session,
-                            enrollment_id=created_enrollment.id,
-                            contact_id=contact.id,
-                            currency=reservation_payload["currency"],
-                            total_amount=reservation_payload["total_amount"],
-                            payment_method=reservation_payload["payment_method"],
-                            stripe_payment_intent_id=reservation_payload.get(
-                                "stripe_payment_intent_id"
-                            ),
-                            stripe_currency=reservation_payload.get("stripe_currency"),
-                        )
-                        if _dup_pi and _pay is not None:
-                            stripe_pi_idempotent_hit = True
-                            stripe_pi_existing_payment_id = _pay.id
 
-                lead_metadata: dict[str, object] = {
-                    "payment_method": reservation_payload["payment_method"],
-                    "title": reservation_payload["title"],
-                    "locale": reservation_payload["locale"],
-                }
-                if reservation_payload.get("service_key"):
-                    lead_metadata["service_key"] = reservation_payload["service_key"]
-                if reservation_payload.get("service_type"):
-                    lead_metadata["service_type"] = reservation_payload["service_type"]
-                if reservation_payload.get("service_instance_slug"):
-                    lead_metadata["service_instance_slug"] = reservation_payload[
-                        "service_instance_slug"
-                    ]
-                if reservation_payload.get("service_instance_cohort"):
-                    lead_metadata["service_instance_cohort"] = reservation_payload[
-                        "service_instance_cohort"
-                    ]
-                if reservation_payload.get("booking_system"):
-                    lead_metadata["booking_system"] = reservation_payload[
-                        "booking_system"
-                    ]
-                if dc_text and str(dc_text).strip():
-                    lead_metadata["discount_code"] = str(dc_text).strip()
-                    if dc_row is not None:
-                        lead_metadata["discount_code_id"] = str(dc_row.id)
-                ma_meta = reservation_payload.get("marketing_attribution")
-                if isinstance(ma_meta, dict) and ma_meta:
-                    lead_metadata["marketing_attribution"] = ma_meta
-                lead = SalesLead(
-                    contact_id=contact.id,
-                    lead_type=LeadType.PROGRAM_ENROLLMENT,
-                    funnel_stage=FunnelStage.NEW,
-                )
-                lead_repo.create_with_event(
-                    lead,
-                    LeadEventType.CREATED,
-                    metadata=lead_metadata,
-                )
-                if created_enrollment_id is not None:
-                    audit = AuditService(
-                        session,
-                        user_id=None,
-                        request_id=request_id_str or None,
+                    if dc_text:
+                        dc_lookup = DiscountCodeRepository(session)
+                        dc_row = dc_lookup.get_by_code(str(dc_text))
+
+                    instance_repo = ServiceInstanceRepository(session)
+                    enrollment_repo = EnrollmentRepository(session)
+                    discount_repo = DiscountCodeRepository(session)
+
+                    target_instance_id = template_instance.id
+                    if per_booking:
+                        booking_row = _create_booking_instance_for_template(
+                            session,
+                            instance_repo,
+                            template_instance,
+                            reservation_payload,
+                            now_utc=now_utc,
+                        )
+                        target_instance_id = booking_row.id
+                        instance_id_for_audit = booking_row.id
+                        booking_instance_slug_for_lead = booking_row.slug
+
+                    has_enrollment = (
+                        enrollment_repo.contact_has_enrollment_for_instance(
+                            instance_id=target_instance_id,
+                            contact_id=contact.id,
+                        )
                     )
-                    audit.log_custom(
-                        table_name="enrollments",
-                        record_id=created_enrollment_id,
-                        action="PUBLIC_RESERVATION_PERSISTED",
-                        new_values={
-                            "instance_id": str(instance_id_resolved),
-                            "contact_id": str(contact.id),
-                        },
+                    is_intro_booking = booking_system == "intro-call-booking"
+
+                    if not has_enrollment:
+                        instance_service_id = template_instance.service.id
+                        if dc_row is not None:
+                            ensure_discount_code_eligible_for_instance(
+                                session,
+                                discount_code_id=dc_row.id,
+                                service_id=instance_service_id,
+                                instance_id=template_instance.id,
+                            )
+                        enrollment_row = Enrollment(
+                            instance_id=target_instance_id,
+                            contact_id=contact.id,
+                            family_id=None,
+                            organization_id=None,
+                            ticket_tier_id=None,
+                            discount_code_id=None,
+                            status=EnrollmentStatus.REGISTERED,
+                            amount_paid=reservation_payload["total_amount"],
+                            currency=reservation_payload["currency"],
+                            notes=None,
+                            created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
+                        )
+                        _apply_enrollment_bill_to(
+                            enrollment_row,
+                            contact_id=contact.id,
+                            bill={
+                                "bill_to_kind": reservation_payload["bill_to_kind"],
+                                "bill_to_contact_id": reservation_payload[
+                                    "bill_to_contact_id"
+                                ],
+                                "bill_to_family_id": reservation_payload[
+                                    "bill_to_family_id"
+                                ],
+                                "bill_to_organization_id": reservation_payload[
+                                    "bill_to_organization_id"
+                                ],
+                            },
+                        )
+                        created_enrollment, create_err = (
+                            enrollment_repo.try_create_enrollment_with_capacity_guard(
+                                enrollment_row
+                            )
+                        )
+                        if create_err == "capacity_full":
+                            raise ValidationError(
+                                "This cohort is full and is not accepting a waitlist for "
+                                "public bookings. Your payment was processed; contact support "
+                                "if you need a refund.",
+                                field="serviceInstanceSlug",
+                                status_code=409,
+                            )
+                        if create_err != "duplicate" and created_enrollment is not None:
+                            created_enrollment_id = created_enrollment.id
+                            if dc_row is not None:
+                                if not discount_repo.validate_and_increment(dc_row.id):
+                                    session.delete(created_enrollment)
+                                    session.flush()
+                                    raise ValidationError(
+                                        "Discount code is invalid, inactive, expired, or exhausted",
+                                        field="discountCode",
+                                    )
+                                created_enrollment.discount_code_id = dc_row.id
+                                session.flush()
+                            if is_intro_booking and intro_slot_bounds is not None:
+                                s0, s1 = intro_slot_bounds
+                                _persist_session_slots_for_booking_instance(
+                                    session,
+                                    booking_instance_id=target_instance_id,
+                                    template_id=template_instance.id,
+                                    slots=[(s0, s1, 0)],
+                                    reservation_payload=reservation_payload,
+                                    now_utc=now_utc,
+                                    is_intro_booking=True,
+                                )
+                            elif (
+                                booking_system == "consultation-booking"
+                                and consultation_slot_rows is not None
+                            ):
+                                _persist_session_slots_for_booking_instance(
+                                    session,
+                                    booking_instance_id=target_instance_id,
+                                    template_id=template_instance.id,
+                                    slots=consultation_slot_rows,
+                                    reservation_payload=reservation_payload,
+                                    now_utc=now_utc,
+                                    is_intro_booking=False,
+                                )
+                            _pay, _, _dup_pi = record_reservation_customer_payment(
+                                session,
+                                enrollment_id=created_enrollment.id,
+                                contact_id=contact.id,
+                                currency=reservation_payload["currency"],
+                                total_amount=reservation_payload["total_amount"],
+                                payment_method=reservation_payload["payment_method"],
+                                stripe_payment_intent_id=reservation_payload.get(
+                                    "stripe_payment_intent_id"
+                                ),
+                                stripe_currency=reservation_payload.get(
+                                    "stripe_currency"
+                                ),
+                            )
+                            if _dup_pi and _pay is not None:
+                                stripe_pi_idempotent_hit = True
+                                stripe_pi_existing_payment_id = _pay.id
+
+                    lead_metadata: dict[str, object] = {
+                        "payment_method": reservation_payload["payment_method"],
+                        "title": reservation_payload["title"],
+                        "locale": reservation_payload["locale"],
+                    }
+                    if reservation_payload.get("service_key"):
+                        lead_metadata["service_key"] = reservation_payload[
+                            "service_key"
+                        ]
+                    if reservation_payload.get("service_type"):
+                        lead_metadata["service_type"] = reservation_payload[
+                            "service_type"
+                        ]
+                    if reservation_payload.get("service_instance_slug"):
+                        lead_metadata["service_instance_slug"] = reservation_payload[
+                            "service_instance_slug"
+                        ]
+                    if booking_instance_slug_for_lead:
+                        lead_metadata["booking_instance_slug"] = (
+                            booking_instance_slug_for_lead
+                        )
+                    if reservation_payload.get("service_instance_cohort"):
+                        lead_metadata["service_instance_cohort"] = reservation_payload[
+                            "service_instance_cohort"
+                        ]
+                    if reservation_payload.get("booking_system"):
+                        lead_metadata["booking_system"] = reservation_payload[
+                            "booking_system"
+                        ]
+                    if dc_text and str(dc_text).strip():
+                        lead_metadata["discount_code"] = str(dc_text).strip()
+                        if dc_row is not None:
+                            lead_metadata["discount_code_id"] = str(dc_row.id)
+                    ma_meta = reservation_payload.get("marketing_attribution")
+                    if isinstance(ma_meta, dict) and ma_meta:
+                        lead_metadata["marketing_attribution"] = ma_meta
+                    lead = SalesLead(
+                        contact_id=contact.id,
+                        lead_type=LeadType.PROGRAM_ENROLLMENT,
+                        funnel_stage=FunnelStage.NEW,
                     )
+                    lead_repo.create_with_event(
+                        lead,
+                        LeadEventType.CREATED,
+                        metadata=lead_metadata,
+                    )
+                    if created_enrollment_id is not None:
+                        audit = AuditService(
+                            session,
+                            user_id=None,
+                            request_id=request_id_str or None,
+                        )
+                        audit.log_custom(
+                            table_name="enrollments",
+                            record_id=created_enrollment_id,
+                            action="PUBLIC_RESERVATION_PERSISTED",
+                            new_values={
+                                "instance_id": str(instance_id_for_audit),
+                                "contact_id": str(contact.id),
+                            },
+                        )
     except ConflictError as exc:
         return json_response(exc.status_code, exc.to_dict(), event=event)
     except ValidationError as exc:
@@ -1287,7 +1452,7 @@ def _validate_discount_code_redemption_scope(
     session: Session,
     payload: Mapping[str, Any],
     *,
-    resolved_instance: ServiceInstance,
+    template_instance: ServiceInstance,
 ) -> None:
     """Ensure discount code scope matches the reservation context."""
     code = payload.get("discount_code")
@@ -1303,7 +1468,7 @@ def _validate_discount_code_redemption_scope(
         raise ValidationError("Invalid discount code", field="discountCode")
 
     if row.instance_id is not None:
-        if resolved_instance.id != row.instance_id:
+        if template_instance.id != row.instance_id:
             raise ValidationError(
                 "Discount code is not valid for this booking",
                 field="discountCode",
@@ -1313,7 +1478,7 @@ def _validate_discount_code_redemption_scope(
     if row.service_id is None:
         return
 
-    if resolved_instance.service.id != row.service_id:
+    if template_instance.service.id != row.service_id:
         raise ValidationError(
             "Discount code is not valid for this booking",
             field="discountCode",

--- a/backend/src/app/api/public_reservations.py
+++ b/backend/src/app/api/public_reservations.py
@@ -171,33 +171,49 @@ def _create_booking_instance_for_template(
             field="serviceInstanceSlug",
             status_code=400,
         )
-    slug = _generate_booking_instance_slug(
-        template_slug=locked.slug,
-        now_utc=now_utc,
-    )
     attendee = str(payload.get("attendee_name") or "").strip()
-    title = f"{locked.title or locked.slug} – {attendee}" if attendee else locked.title
-    booking = ServiceInstance(
-        service_id=locked.service_id,
-        parent_instance_id=locked.id,
-        is_template=False,
-        title=title,
-        slug=slug,
-        description=None,
-        cover_image_s3_key=None,
-        status=InstanceStatus.OPEN,
-        delivery_mode=locked.delivery_mode,
-        location_id=locked.location_id,
-        max_capacity=1,
-        waitlist_enabled=False,
-        instructor_id=locked.instructor_id,
-        cohort=None,
-        notes=None,
-        created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
-        external_url=None,
-        eventbrite_sync_status=EventbriteSyncStatus.PENDING,
+    title_base = (
+        f"{locked.title or locked.slug} – {attendee}" if attendee else locked.title
     )
-    return instance_repo.create_instance(booking, type_details=None, session_slots=None)
+    last_exc: IntegrityError | None = None
+    for _attempt in range(3):
+        slug = _generate_booking_instance_slug(
+            template_slug=locked.slug,
+            now_utc=now_utc,
+        )
+        booking = ServiceInstance(
+            service_id=locked.service_id,
+            parent_instance_id=locked.id,
+            is_template=False,
+            title=title_base,
+            slug=slug,
+            description=None,
+            cover_image_s3_key=None,
+            status=InstanceStatus.OPEN,
+            delivery_mode=locked.delivery_mode,
+            location_id=locked.location_id,
+            max_capacity=1,
+            waitlist_enabled=False,
+            instructor_id=locked.instructor_id,
+            cohort=None,
+            notes=None,
+            created_by=_PUBLIC_RESERVATION_ENROLLMENT_ACTOR,
+            external_url=None,
+            eventbrite_sync_status=EventbriteSyncStatus.PENDING,
+        )
+        try:
+            with session.begin_nested():
+                return instance_repo.create_instance(
+                    booking, type_details=None, session_slots=None
+                )
+        except IntegrityError as exc:
+            last_exc = exc
+            continue
+    raise ValidationError(
+        "Unable to allocate booking instance",
+        field="serviceInstanceSlug",
+        status_code=500,
+    ) from last_exc
 
 
 def _consultation_booking_slot_rows(

--- a/backend/src/app/db/models/service_instance.py
+++ b/backend/src/app/db/models/service_instance.py
@@ -65,7 +65,19 @@ class ServiceInstance(Base):
         Index("svc_instances_service_idx", "service_id"),
         Index("svc_instances_status_idx", "status"),
         Index("svc_instances_instructor_idx", "instructor_id"),
-        Index("svc_instances_slug_uq", "slug", unique=True),
+        Index("svc_instances_parent_idx", "parent_instance_id"),
+        Index(
+            "svc_instances_slug_uq_template",
+            "slug",
+            unique=True,
+            postgresql_where=text("is_template IS TRUE"),
+        ),
+        Index(
+            "svc_instances_slug_uq_booking",
+            "slug",
+            unique=True,
+            postgresql_where=text("is_template IS FALSE"),
+        ),
         CheckConstraint(
             "max_capacity IS NULL OR max_capacity > 0",
             name="service_instances_capacity_positive",
@@ -81,6 +93,15 @@ class ServiceInstance(Base):
         PG_UUID(as_uuid=True),
         ForeignKey("services.id", ondelete="CASCADE"),
         nullable=False,
+    )
+    parent_instance_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("service_instances.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    is_template: Mapped[bool] = mapped_column(
+        nullable=False,
+        server_default=text("false"),
     )
     title: Mapped[str | None] = mapped_column(String(255), nullable=True)
     slug: Mapped[str] = mapped_column(String(128), nullable=False)
@@ -163,11 +184,23 @@ class ServiceInstance(Base):
         "Service",
         back_populates="instances",
     )
+    parent: Mapped[ServiceInstance | None] = relationship(
+        "ServiceInstance",
+        remote_side="ServiceInstance.id",
+        foreign_keys=[parent_instance_id],
+        back_populates="bookings",
+    )
+    bookings: Mapped[list[ServiceInstance]] = relationship(
+        "ServiceInstance",
+        back_populates="parent",
+        foreign_keys=[parent_instance_id],
+    )
     location: Mapped[Location | None] = relationship("Location")
     session_slots: Mapped[list[InstanceSessionSlot]] = relationship(
         "InstanceSessionSlot",
         back_populates="instance",
         cascade="all, delete-orphan",
+        foreign_keys=lambda: [InstanceSessionSlot.instance_id],
     )
     training_details: Mapped[TrainingInstanceDetails | None] = relationship(
         "TrainingInstanceDetails",
@@ -284,6 +317,13 @@ class InstanceSessionSlot(Base):
     __tablename__ = "instance_session_slots"
     __table_args__ = (
         Index("session_slots_instance_idx", "instance_id"),
+        Index(
+            "instance_session_slots_template_starts_uidx",
+            "template_instance_id",
+            "starts_at",
+            unique=True,
+            postgresql_where=text("template_instance_id IS NOT NULL"),
+        ),
         CheckConstraint(
             "ends_at > starts_at",
             name="instance_session_slots_valid_range",
@@ -299,6 +339,11 @@ class InstanceSessionSlot(Base):
         PG_UUID(as_uuid=True),
         ForeignKey("service_instances.id", ondelete="CASCADE"),
         nullable=False,
+    )
+    template_instance_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("service_instances.id", ondelete="CASCADE"),
+        nullable=True,
     )
     location_id: Mapped[UUID | None] = mapped_column(
         PG_UUID(as_uuid=True),
@@ -323,6 +368,11 @@ class InstanceSessionSlot(Base):
     instance: Mapped[ServiceInstance] = relationship(
         "ServiceInstance",
         back_populates="session_slots",
+        foreign_keys=[instance_id],
+    )
+    template_instance: Mapped[ServiceInstance | None] = relationship(
+        "ServiceInstance",
+        foreign_keys=[template_instance_id],
     )
     location: Mapped[Location | None] = relationship("Location")
 

--- a/backend/src/app/db/models/service_instance.py
+++ b/backend/src/app/db/models/service_instance.py
@@ -82,6 +82,11 @@ class ServiceInstance(Base):
             "max_capacity IS NULL OR max_capacity > 0",
             name="service_instances_capacity_positive",
         ),
+        CheckConstraint(
+            "(is_template IS TRUE AND parent_instance_id IS NULL) "
+            "OR (is_template IS FALSE)",
+            name="service_instances_template_consistency_chk",
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(

--- a/backend/src/app/db/repositories/enrollment.py
+++ b/backend/src/app/db/repositories/enrollment.py
@@ -9,7 +9,12 @@ from sqlalchemy import and_, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
-from app.db.models import Enrollment, EnrollmentStatus, ServiceInstance
+from app.db.models import (
+    Enrollment,
+    EnrollmentStatus,
+    InstanceSessionSlot,
+    ServiceInstance,
+)
 from app.db.models.enums import CAPACITY_ENROLLMENT_STATUSES
 from app.db.repositories.base import BaseRepository
 
@@ -57,6 +62,95 @@ class EnrollmentRepository(BaseRepository[Enrollment]):
             Enrollment.created_at.desc(), Enrollment.id.desc()
         ).limit(limit)
         return list(self._session.execute(statement).unique().scalars().all())
+
+    def list_enrollments_for_instance_scope(
+        self,
+        *,
+        anchor_instance_id: UUID,
+        limit: int,
+        status: EnrollmentStatus | None = None,
+        cursor_created_at: datetime | None = None,
+        cursor_id: UUID | None = None,
+    ) -> list[Enrollment]:
+        """List enrollments on ``anchor_instance_id`` or its per-booking child instances."""
+        scope_ids = select(ServiceInstance.id).where(
+            or_(
+                ServiceInstance.id == anchor_instance_id,
+                ServiceInstance.parent_instance_id == anchor_instance_id,
+            )
+        )
+        statement = (
+            select(Enrollment)
+            .where(Enrollment.instance_id.in_(scope_ids))
+            .options(
+                joinedload(Enrollment.contact),
+                joinedload(Enrollment.family),
+                joinedload(Enrollment.organization),
+                joinedload(Enrollment.ticket_tier),
+                joinedload(Enrollment.discount_code),
+            )
+        )
+        if status is not None:
+            statement = statement.where(Enrollment.status == status)
+        if cursor_created_at is not None and cursor_id is not None:
+            statement = statement.where(
+                or_(
+                    Enrollment.created_at < cursor_created_at,
+                    and_(
+                        Enrollment.created_at == cursor_created_at,
+                        Enrollment.id < cursor_id,
+                    ),
+                )
+            )
+        statement = statement.order_by(
+            Enrollment.created_at.desc(), Enrollment.id.desc()
+        ).limit(limit)
+        return list(self._session.execute(statement).unique().scalars().all())
+
+    def count_enrollments_for_instance_scope(
+        self,
+        *,
+        anchor_instance_id: UUID,
+        status: EnrollmentStatus | None = None,
+    ) -> int:
+        scope_ids = select(ServiceInstance.id).where(
+            or_(
+                ServiceInstance.id == anchor_instance_id,
+                ServiceInstance.parent_instance_id == anchor_instance_id,
+            )
+        )
+        statement = select(func.count(Enrollment.id)).where(
+            Enrollment.instance_id.in_(scope_ids)
+        )
+        if status is not None:
+            statement = statement.where(Enrollment.status == status)
+        count = self._session.execute(statement).scalar_one_or_none()
+        return int(count or 0)
+
+    def booking_rows_slug_and_first_session_start(
+        self, instance_ids: list[UUID]
+    ) -> tuple[dict[UUID, str], dict[UUID, datetime]]:
+        """Map instance id -> slug and earliest session ``starts_at`` for list enrichment."""
+        if not instance_ids:
+            return {}, {}
+        slug_stmt = select(ServiceInstance.id, ServiceInstance.slug).where(
+            ServiceInstance.id.in_(instance_ids)
+        )
+        slug_map = {row[0]: row[1] for row in self._session.execute(slug_stmt).all()}
+        slot_stmt = (
+            select(
+                InstanceSessionSlot.instance_id,
+                func.min(InstanceSessionSlot.starts_at),
+            )
+            .where(InstanceSessionSlot.instance_id.in_(instance_ids))
+            .group_by(InstanceSessionSlot.instance_id)
+        )
+        start_map = {
+            row[0]: row[1]
+            for row in self._session.execute(slot_stmt).all()
+            if row[1] is not None
+        }
+        return slug_map, start_map
 
     def count_enrollments(
         self,

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -38,6 +38,18 @@ _PUBLIC_CALENDAR_BLOCKER_DEFAULT_TYPES: tuple[ServiceType, ...] = (
 )
 
 
+def _instances_list_visibility_predicate(
+    *, include_bookings: bool
+) -> ColumnElement[bool] | None:
+    """Hide per-booking child rows from admin/default listings unless requested."""
+    if include_bookings:
+        return None
+    return or_(
+        ServiceInstance.parent_instance_id.is_(None),
+        ServiceInstance.is_template.is_(True),
+    )
+
+
 def public_calendar_blocker_instance_predicates(
     *,
     service_types: tuple[ServiceType, ...] | None = None,
@@ -110,6 +122,7 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         status: InstanceStatus | None = None,
         cursor_created_at: datetime | None = None,
         cursor_id: UUID | None = None,
+        include_bookings: bool = False,
     ) -> list[ServiceInstance]:
         """List instances for a service with stable cursor pagination."""
         statement = (
@@ -128,6 +141,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                 ),
             )
         )
+        vis = _instances_list_visibility_predicate(include_bookings=include_bookings)
+        if vis is not None:
+            statement = statement.where(vis)
         if status is not None:
             statement = statement.where(ServiceInstance.status == status)
         if cursor_created_at is not None and cursor_id is not None:
@@ -150,11 +166,15 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         *,
         service_id: UUID,
         status: InstanceStatus | None = None,
+        include_bookings: bool = False,
     ) -> int:
         """Count instances by service and optional status."""
         statement = select(func.count(ServiceInstance.id)).where(
             ServiceInstance.service_id == service_id
         )
+        vis = _instances_list_visibility_predicate(include_bookings=include_bookings)
+        if vis is not None:
+            statement = statement.where(vis)
         if status is not None:
             statement = statement.where(ServiceInstance.status == status)
         count = self._session.execute(statement).scalar_one_or_none()
@@ -169,6 +189,7 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         service_type: ServiceType | None = None,
         cursor_created_at: datetime | None = None,
         cursor_id: UUID | None = None,
+        include_bookings: bool = False,
     ) -> list[ServiceInstance]:
         """List instances across services with optional filters and cursor pagination."""
         statement = select(ServiceInstance).options(
@@ -184,6 +205,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             ),
             joinedload(ServiceInstance.service),
         )
+        vis = _instances_list_visibility_predicate(include_bookings=include_bookings)
+        if vis is not None:
+            statement = statement.where(vis)
         if service_type is not None:
             statement = statement.join(
                 Service, ServiceInstance.service_id == Service.id
@@ -215,9 +239,13 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         status: InstanceStatus | None = None,
         service_id: UUID | None = None,
         service_type: ServiceType | None = None,
+        include_bookings: bool = False,
     ) -> int:
         """Count instances matching optional filters."""
         statement = select(func.count(ServiceInstance.id))
+        vis = _instances_list_visibility_predicate(include_bookings=include_bookings)
+        if vis is not None:
+            statement = statement.where(vis)
         if service_type is not None:
             statement = statement.join(
                 Service, ServiceInstance.service_id == Service.id
@@ -237,6 +265,7 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             select(ServiceInstance)
             .where(ServiceInstance.id == instance_id)
             .options(
+                joinedload(ServiceInstance.parent),
                 selectinload(ServiceInstance.session_slots),
                 joinedload(ServiceInstance.training_details),
                 joinedload(ServiceInstance.consultation_details),
@@ -260,6 +289,7 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         service_types: set[ServiceType] | None = None,
         slug: str | None = None,
         service_key: str | None = None,
+        include_bookings: bool = False,
     ) -> list[ServiceInstance]:
         """List public calendar rows for published event and training services.
 
@@ -294,7 +324,12 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                     )
                 )
             )
-            .where(
+        )
+        vis = _instances_list_visibility_predicate(include_bookings=include_bookings)
+        if vis is not None:
+            statement = statement.where(vis)
+        statement = (
+            statement.where(
                 ServiceInstance.session_slots.any(
                     InstanceSessionSlot.ends_at >= now - datetime.resolution
                 )
@@ -339,6 +374,8 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             select(ServiceInstance)
             .join(Service, ServiceInstance.service_id == Service.id)
             .where(func.lower(ServiceInstance.slug) == normalized.lower())
+            .order_by(ServiceInstance.parent_instance_id.is_(None).desc())
+            .limit(1)
             .options(joinedload(ServiceInstance.service))
         )
         return self._session.execute(statement).unique().scalar_one_or_none()
@@ -348,8 +385,11 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
         normalized = slug.strip()
         if not normalized:
             return None
-        statement = select(ServiceInstance.id).where(
-            func.lower(ServiceInstance.slug) == normalized.lower()
+        statement = (
+            select(ServiceInstance.id)
+            .where(func.lower(ServiceInstance.slug) == normalized.lower())
+            .order_by(ServiceInstance.parent_instance_id.is_(None).desc())
+            .limit(1)
         )
         return self._session.execute(statement).scalar_one_or_none()
 
@@ -392,6 +432,15 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             .limit(limit)
         )
         return list(self._session.execute(statement).unique().scalars().all())
+
+    def lock_template_for_booking(self, template_id: UUID) -> ServiceInstance | None:
+        """Load and row-lock a template instance for serialized booking creation."""
+        statement = (
+            select(ServiceInstance)
+            .where(ServiceInstance.id == template_id)
+            .with_for_update()
+        )
+        return self._session.execute(statement).scalar_one_or_none()
 
     def create_instance(
         self,

--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -129,6 +129,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             select(ServiceInstance)
             .where(ServiceInstance.service_id == service_id)
             .options(
+                joinedload(ServiceInstance.parent).joinedload(
+                    ServiceInstance.consultation_details
+                ),
                 selectinload(ServiceInstance.session_slots),
                 joinedload(ServiceInstance.training_details),
                 joinedload(ServiceInstance.consultation_details),
@@ -193,6 +196,9 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
     ) -> list[ServiceInstance]:
         """List instances across services with optional filters and cursor pagination."""
         statement = select(ServiceInstance).options(
+            joinedload(ServiceInstance.parent).joinedload(
+                ServiceInstance.consultation_details
+            ),
             selectinload(ServiceInstance.session_slots),
             joinedload(ServiceInstance.training_details),
             joinedload(ServiceInstance.consultation_details),
@@ -374,24 +380,19 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
             select(ServiceInstance)
             .join(Service, ServiceInstance.service_id == Service.id)
             .where(func.lower(ServiceInstance.slug) == normalized.lower())
-            .order_by(ServiceInstance.parent_instance_id.is_(None).desc())
-            .limit(1)
             .options(joinedload(ServiceInstance.service))
         )
-        return self._session.execute(statement).unique().scalar_one_or_none()
+        return self._session.execute(statement).unique().scalars().first()
 
     def get_id_by_slug(self, slug: str) -> UUID | None:
         """Resolve ``service_instances.id`` from public slug (case-insensitive)."""
         normalized = slug.strip()
         if not normalized:
             return None
-        statement = (
-            select(ServiceInstance.id)
-            .where(func.lower(ServiceInstance.slug) == normalized.lower())
-            .order_by(ServiceInstance.parent_instance_id.is_(None).desc())
-            .limit(1)
+        statement = select(ServiceInstance.id).where(
+            func.lower(ServiceInstance.slug) == normalized.lower()
         )
-        return self._session.execute(statement).scalar_one_or_none()
+        return self._session.execute(statement).scalars().first()
 
     def list_event_instances_for_public_feed(
         self,

--- a/backend/src/app/services/intro_call_slots.py
+++ b/backend/src/app/services/intro_call_slots.py
@@ -20,6 +20,7 @@ from app.db.models import (
     Service,
     ServiceInstance,
 )
+from app.db.models.enums import ServiceType
 from app.db.repositories.service_instance import (
     public_calendar_blocker_instance_predicates,
 )
@@ -45,7 +46,8 @@ _INTRO_CALL_SLOT_DURATION_MINUTES = 15
 _INTRO_CALL_LEAD_HOURS = 2
 _INTRO_CALL_HORIZON_DAYS = 21
 _INTRO_CALL_PURPOSE = "intro_call_booking"
-_INTRO_CALL_INSTANCE_SLUG = "intro-call-free-15min"
+# Intro-call busy intervals include every booked slot on instances whose parent service is
+# ``intro_call`` (template tier rows and per-booking child instances).
 
 _MANUAL_BLOCK_PURPOSES: frozenset[str] = frozenset(
     {"consultation_booking", _INTRO_CALL_PURPOSE}
@@ -197,7 +199,7 @@ def _non_intro_session_busy_intervals_utc(
         .where(
             InstanceSessionSlot.starts_at < range_end_utc,
             InstanceSessionSlot.ends_at > range_start_utc,
-            ServiceInstance.slug != _INTRO_CALL_INSTANCE_SLUG,
+            Service.service_type != ServiceType.INTRO_CALL,
             *public_calendar_blocker_instance_predicates(),
         )
     )
@@ -220,8 +222,9 @@ def _intro_instance_busy_intervals_utc(
     stmt = (
         select(InstanceSessionSlot.starts_at, InstanceSessionSlot.ends_at)
         .join(ServiceInstance, InstanceSessionSlot.instance_id == ServiceInstance.id)
+        .join(Service, ServiceInstance.service_id == Service.id)
         .where(
-            ServiceInstance.slug == _INTRO_CALL_INSTANCE_SLUG,
+            Service.service_type == ServiceType.INTRO_CALL,
             InstanceSessionSlot.starts_at < range_end_utc,
             InstanceSessionSlot.ends_at > range_start_utc,
         )
@@ -381,10 +384,7 @@ def recent_intro_call_enrollment_last_booked_at(
     within_days: int = 30,
     now: datetime,
 ) -> datetime | None:
-    """Latest ``Enrollment.updated_at`` for intro-call instance + normalized email.
-
-    Rebook flows reuse the same enrollment row; ``updated_at`` is bumped after each
-    successful slot booking so the rolling cooldown reflects the last booking time.
+    """Latest ``Enrollment.updated_at`` for intro-call service enrollments + normalized email.
 
     ``within_days`` documents the cooldown window for callers; the query returns
     the enrollment timestamp regardless of age so callers can apply a rolling window
@@ -396,8 +396,9 @@ def recent_intro_call_enrollment_last_booked_at(
         select(Enrollment.updated_at)
         .join(Contact, Enrollment.contact_id == Contact.id)
         .join(ServiceInstance, Enrollment.instance_id == ServiceInstance.id)
+        .join(Service, ServiceInstance.service_id == Service.id)
         .where(
-            ServiceInstance.slug == _INTRO_CALL_INSTANCE_SLUG,
+            Service.service_type == ServiceType.INTRO_CALL,
             Contact.email.isnot(None),
             func.lower(Contact.email) == em,
         )

--- a/backend/src/app/services/intro_call_slots.py
+++ b/backend/src/app/services/intro_call_slots.py
@@ -47,7 +47,7 @@ _INTRO_CALL_LEAD_HOURS = 2
 _INTRO_CALL_HORIZON_DAYS = 21
 _INTRO_CALL_PURPOSE = "intro_call_booking"
 # Intro-call busy intervals include every booked slot on instances whose parent service is
-# ``intro_call`` (template tier rows and per-booking child instances).
+# ``intro_call``, whether the slot row belongs to the catalog tier or a per-booking child.
 
 _MANUAL_BLOCK_PURPOSES: frozenset[str] = frozenset(
     {"consultation_booking", _INTRO_CALL_PURPOSE}

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1278,6 +1278,15 @@ paths:
           description: When set, only instances whose parent service has this type.
           schema:
             $ref: "#/components/schemas/ServiceType"
+        - name: include_bookings
+          in: query
+          required: false
+          description: >
+            When true, includes per-booking child instances (`parent_instance_id` set,
+            `is_template=false`) normally omitted from admin listings.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: Service instance list response.
@@ -1453,6 +1462,16 @@ paths:
       - $ref: "#/components/parameters/ServiceId"
     get:
       summary: List service instances
+      parameters:
+        - name: include_bookings
+          in: query
+          required: false
+          description: >
+            When true, includes per-booking child instances (`parent_instance_id` set,
+            `is_template=false`) normally omitted from admin listings.
+          schema:
+            type: boolean
+            default: false
       security:
         - AdminBearerAuth: []
       responses:
@@ -4797,6 +4816,17 @@ components:
         service_id:
           type: string
           format: uuid
+        parent_instance_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: >
+            When set, this instance is a child booking row whose template tier is the parent id.
+        is_template:
+          type: boolean
+          description: >
+            True for catalog tier instances (consultation packages / intro-call template).
+            False for event cohorts, training runs, and per-public-booking child instances.
         title:
           type: string
           nullable: true
@@ -4805,7 +4835,8 @@ components:
           description: >
             Public instance slug (required for all service types). URL-safe: lowercase letters,
             digits, and single hyphens between segments (e.g. spring-workshop). Stored normalized
-            to lowercase. Must be unique among instances.
+            to lowercase. Uniqueness is enforced separately for template rows (`is_template=true`)
+            and non-template rows (`is_template=false`).
         description:
           type: string
           nullable: true
@@ -5181,6 +5212,17 @@ components:
           type: string
           format: date-time
           nullable: true
+        booking_instance_slug:
+          type: string
+          nullable: true
+          description: >
+            Returned by enrollment list when present: `service_instances.slug` for the enrollment's instance.
+        scheduled_start_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: >
+            Returned by enrollment list when present: earliest session slot `starts_at` on the enrollment's instance (UTC).
     EnrollmentListResponse:
       type: object
       required: [items, total_count]

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -816,10 +816,11 @@ paths:
         Persists the attendee as a CRM contact, creates a program-enrollment
         sales lead (lead event metadata may include `discount_code` and
         `discount_code_id` when a valid non-referral code was supplied), and when
-        `serviceInstanceSlug` resolves to a `service_instances` row and the
-        contact has no existing enrollment for that instance, inserts an
-        `enrollments` row (`created_by`: `public-reservation`) with optional
-        `discount_code_id` and paid amount, currency, optional bill-to fields, then returns **202** on success.
+        `serviceInstanceSlug` resolves to a `service_instances` row and the contact has no
+        existing enrollment on the **target booking instance** (for consultation-booking and
+        intro-call-booking this is a freshly created child instance; for other flows it is the
+        resolved instance row), inserts an `enrollments` row (`created_by`: `public-reservation`)
+        with optional `discount_code_id` and paid amount, currency, optional bill-to fields, then returns **202** on success.
         When enrollment is created, records a **`customer_payments`** row (Stripe succeeded,
         free, or pending for offline rails). Receipt PDF upload for succeeded inbound
         payments is finalized after staff confirm via admin billing (not at booking time).
@@ -832,7 +833,10 @@ paths:
         **sales recap** to `ADMIN_GROUP` verified emails run after commit (hook
         failures are logged; HTTP **202** is still returned for normal submissions, **200**
         when `duplicateStripePaymentIntent` applies). Returns **500** when
-        Aurora persistence fails. Requires Turnstile, `agreedToTermsAndConditions:
+        Aurora persistence fails. When `bookingSystem` is `consultation-booking` or
+        `intro-call-booking`, Stripe PaymentIntent idempotency is enforced **before**
+        allocating the booking instance so retries cannot double-create tier children for the
+        same PaymentIntent. Requires Turnstile, `agreedToTermsAndConditions:
         true`, and Stripe PaymentIntent verification when the payment method implies
         Stripe.
       security:
@@ -855,7 +859,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReservationSubmissionAccepted"
         "202":
-          description: Reservation submitted.
+          description: >
+            Reservation submitted. For `consultation-booking` and `intro-call-booking`,
+            the server creates a booking-specific `service_instances` row (child of the resolved
+            template tier), inserts scheduled session slots with tier linkage, and attaches the
+            enrollment to that booking instance.
           content:
             application/json:
               schema:
@@ -903,7 +911,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReservationSubmissionAccepted"
         "202":
-          description: Reservation submitted.
+          description: >
+            Reservation submitted. For `consultation-booking` and `intro-call-booking`,
+            the server creates a booking-specific `service_instances` row (child of the resolved
+            template tier), inserts scheduled session slots with tier linkage, and attaches the
+            enrollment to that booking instance.
           content:
             application/json:
               schema:
@@ -1721,9 +1733,11 @@ components:
           pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
           maxLength: 128
           description: >
-            Public `service_instances.slug` for the booked cohort/instance. Required with
-            `serviceKey` to resolve booking identity; backend resolves to the instance id for
-            enrollment and discount scope checks.
+            Public `service_instances.slug` for the booked cohort/instance (event/training)
+            or **template tier** (consultation packages / intro-call). Required with
+            `serviceKey` to resolve booking identity. For `consultation-booking` and
+            `intro-call-booking`, the server allocates a dedicated booking instance child row;
+            the slug here remains the template tier slug for discount validation and lead metadata.
         serviceInstanceCohort:
           type: string
           maxLength: 200
@@ -1765,6 +1779,8 @@ components:
             `totalAmount=0`, `paymentMethod=free` (or omit payment method to default to free), and
             `primarySessionStartIso` / `primarySessionEndIso` for a valid 15-minute slot at a
             30-minute-aligned start time (Asia/Hong_Kong office-hours template; end 15 minutes after start).
+            Successful submissions allocate a new booking-specific service instance (child of the tier template)
+            with session slots and enrollment attached to that instance (race protection uses the tier template id + slot start).
         marketingAttribution:
           type: object
           additionalProperties: false

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -517,11 +517,22 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 - Template fields can be overridden per instance (`title`, `description`,
   `cover_image_s3_key`, `delivery_mode`).
 - Required public-site field: `slug` (varchar(128), `NOT NULL` from migration
-  `0049_inst_slug_not_null`; unique via `svc_instances_slug_uq`; **canonical public
-  identifier** for calendar/discount/reservation instance scope and public website
-  marketing routes). Legacy NULL slugs for events and training courses were backfilled by
-  migration `0043_backfill_inst_slug`; consultation NULL/empty slugs were backfilled by
-  migration `0048_inst_slug_backfill_consult` before the NOT NULL constraint landed.
+  `0049_inst_slug_not_null`; uniqueness is enforced by partial unique indexes from migration
+  `0061_per_booking_instances`: `svc_instances_slug_uq_template` on `slug` where
+  `is_template IS TRUE`, and `svc_instances_slug_uq_booking` on `slug` where
+  `is_template IS FALSE`. **Canonical public identifier** for calendar/discount/reservation
+  template scope and public website marketing routes. Legacy NULL slugs for events and
+  training courses were backfilled by migration `0043_backfill_inst_slug`; consultation
+  NULL/empty slugs were backfilled by migration `0048_inst_slug_backfill_consult` before
+  the NOT NULL constraint landed.
+- Optional self-FK `parent_instance_id` → `service_instances.id` (`ON DELETE RESTRICT`)
+  with btree index `svc_instances_parent_idx`: child rows are **per-booking instances**
+  for consultation and intro-call public reservations; catalog/template tiers keep
+  `parent_instance_id` NULL.
+- Boolean `is_template` (`NOT NULL`, default `FALSE`): migration `0061_per_booking_instances`
+  backfills `TRUE` for existing consultation and intro_call tier instances (no parent).
+  Admin-created consultation/intro tier instances set `is_template` at insert time; booking
+  children use `is_template = FALSE`.
 - Optional `cohort` varchar(128): admin label stored with the same normalization rules as
   instance referral slugs (lowercase letters, digits, single hyphens between segments).
 - Optional `external_url` varchar(500): operator-provided external registration/info URL
@@ -535,13 +546,17 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
     `eventbrite_retry_count`
 - Scheduling/detail tables:
   - `instance_session_slots` (time blocks + optional location; `starts_at` / `ends_at`
-    are `timestamptz` in Aurora). Migration `0060_intro_call_starts_uniq` adds a unique
-    index on `(instance_id, starts_at)` (`instance_session_slots_instance_starts_uidx`)
-    so two rows cannot share the same start instant on one instance (race-safe public
-    bookings including intro-call). The admin API rejects naive datetimes in
-    `session_slots` payloads so only explicit instants are stored. The public calendar feed
-    eager-loads `Service.location` only in `list_public_offerings`; venue resolution is
-    slot location, then instance `location_id`, then parent `services.location_id`.
+    are `timestamptz` in Aurora). Migration `0061_per_booking_instances` drops the
+    composite unique index `(instance_id, starts_at)` from `0060_intro_call_starts_uniq`
+    and adds nullable `template_instance_id` → `service_instances.id` (`ON DELETE CASCADE`),
+    backfilled from the booking row's `parent_instance_id`. Partial unique index
+    `instance_session_slots_template_starts_uidx` on `(template_instance_id, starts_at)`
+    where `template_instance_id IS NOT NULL` serializes concurrent consultation/intro public
+    bookings against the same template tier and start instant. The admin API rejects naive
+    datetimes in `session_slots` payloads so only explicit instants are stored. The public
+    calendar feed eager-loads `Service.location` only in `list_public_offerings`; venue
+    resolution is slot location, then instance `location_id`, then parent
+    `services.location_id`.
   - `training_instance_details`
   - `event_ticket_tiers`
   - `consultation_instance_details` (Calendly event URL column removed in migration

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -533,6 +533,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   backfills `TRUE` for existing consultation and intro_call tier instances (no parent).
   Admin-created consultation/intro tier instances set `is_template` at insert time; booking
   children use `is_template = FALSE`.
+- Check constraint `service_instances_template_consistency_chk`: template rows require
+  `is_template IS TRUE AND parent_instance_id IS NULL`; non-template rows (`is_template IS FALSE`)
+  may have any `parent_instance_id` (NULL for cohort/event rows or set for booking children).
 - Optional `cohort` varchar(128): admin label stored with the same normalization rules as
   instance referral slugs (lowercase letters, digits, single hyphens between segments).
 - Optional `external_url` varchar(500): operator-provided external registration/info URL
@@ -549,7 +552,9 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
     are `timestamptz` in Aurora). Migration `0061_per_booking_instances` drops the
     composite unique index `(instance_id, starts_at)` from `0060_intro_call_starts_uniq`
     and adds nullable `template_instance_id` → `service_instances.id` (`ON DELETE CASCADE`),
-    backfilled from the booking row's `parent_instance_id`. Partial unique index
+    backfilled as ``COALESCE(service_instances.parent_instance_id,
+    CASE WHEN service_instances.is_template THEN service_instances.id END)`` for each slot's
+    owning instance so legacy template-tier rows self-reference the tier id. Partial unique index
     `instance_session_slots_template_starts_uidx` on `(template_instance_id, starts_at)`
     where `template_instance_id IS NOT NULL` serializes concurrent consultation/intro public
     bookings against the same template tier and start instant. The admin API rejects naive

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -628,6 +628,11 @@ schedule rows, and enrollment without sharing one overcrowded tier row.
 **Exclusions:** `event-booking` and `my-best-auntie-booking` keep attaching enrollments to
 the resolved scheduled instance (no child row allocation).
 
+**Stripe idempotency:** When a per-booking submission is retried with the same
+``stripe_payment_intent_id`` after a prior successful allocation, the handler short-circuits
+persistence and does not create an additional ``PROGRAM_ENROLLMENT`` sales lead; the first
+successful request still records the lead.
+
 ## Keeping Documentation Up to Date
 
 **Decision:** Architecture documentation in `docs/architecture/` describes

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -610,6 +610,24 @@ TTL on any cacheable reads and `no-store` for the consultation purpose.
 **CloudFront path allowlist:** The viewer function matches the path segment **exactly**
 (e.g. `/www/v1/calendar/blockers`); trailing slash variants are not allowlisted.
 
+## Per-booking service instances for consultations and intro calls
+
+**Decision:** Public `consultation-booking` and `intro-call-booking` submissions resolve the
+**template tier** `service_instances` row by slug (`serviceInstanceSlug`), row-lock it,
+allocate a new **booking instance** child (`parent_instance_id`, `is_template = false`)
+with a generated unique slug, attach session slots on that child with denormalized
+`template_instance_id`, and insert exactly one `enrollments` row on the booking instance.
+Concurrent bookings against the same tier + same start instant collide on the partial unique
+index `(template_instance_id, starts_at)` where `template_instance_id` is not null.
+
+**Why:** Event and training reservations remain modeled as enrollments on long-lived
+scheduled instances; consultation packages and the free intro tier instead behave like
+catalog templates with many logical bookings, each needing its own instance container,
+schedule rows, and enrollment without sharing one overcrowded tier row.
+
+**Exclusions:** `event-booking` and `my-best-auntie-booking` keep attaching enrollments to
+the resolved scheduled instance (no child row allocation).
+
 ## Keeping Documentation Up to Date
 
 **Decision:** Architecture documentation in `docs/architecture/` describes

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -257,13 +257,16 @@ their primary responsibilities.
   `POST /v1/reservations` (and `/www/v1/reservations`) accepts camelCase booking-modal
   fields, persists contact + program-enrollment lead (including discount metadata when
   applicable; referral-type codes are rejected). Requires `serviceKey` and
-  `serviceInstanceSlug`; the server resolves the instance and parent service, derives
-  `service_type`, and may insert an `enrollments` row for the
-  resolved instance when capacity allows (or returns **409** when the instance is
-  full with waitlist disabled). Admin enrollment APIs validate discount code scope to
-  the instance's service before incrementing usage. Then sends booking confirmation
-  (SES), optional Mailchimp subscribe, and a plain-text **sales recap** with extended
-  booking context when provided, and signed upload/download URL generation in
+  `serviceInstanceSlug`; the server resolves the **template tier** instance and parent
+  service, derives `service_type`, and for `consultation-booking` / `intro-call-booking`
+  creates a dedicated **booking** `service_instances` child row (generated slug), inserts
+  session slots tied to the template tier id for race-safe uniqueness, then attaches the
+  enrollment and payment rows to that booking instance. Other booking systems attach the
+  enrollment directly to the resolved instance when capacity allows (or returns **409**
+  when the instance is full with waitlist disabled). Admin enrollment APIs validate discount
+  code scope to the template tier instance id when codes are instance-scoped. Then sends
+  booking confirmation (SES), optional Mailchimp subscribe, and a plain-text **sales recap**
+  with extended booking context when provided, and signed upload/download URL generation in
   `backend/src/app/api/admin.py`.
 
 ### Health check

--- a/tests/test_admin_service_instances_api.py
+++ b/tests/test_admin_service_instances_api.py
@@ -88,6 +88,7 @@ def test_list_instances_returns_repository_total_count(
             "status": None,
             "cursor_created_at": None,
             "cursor_id": None,
+            "include_bookings": False,
         },
     )
     monkeypatch.setattr(admin_service_instances, "Session", _SessionCtx)
@@ -121,6 +122,7 @@ def test_list_instances_returns_repository_total_count(
     body = json.loads(response["body"])
     assert body["total_count"] == 42
     assert captured["list_kwargs"]["limit"] == 2
+    assert captured["list_kwargs"]["include_bookings"] is False
     assert captured["count_kwargs"]["service_id"] == service_id
 
 
@@ -166,6 +168,7 @@ def test_handle_admin_all_service_instances_lists_global(
             "cursor_id": None,
             "service_id": None,
             "service_type": None,
+            "include_bookings": False,
         },
     )
     monkeypatch.setattr(admin_service_instances, "Session", _SessionCtx)
@@ -202,4 +205,5 @@ def test_handle_admin_all_service_instances_lists_global(
     assert response["statusCode"] == 200
     assert body["total_count"] == 7
     assert captured["list_kwargs"]["limit"] == 2
+    assert captured["list_kwargs"]["include_bookings"] is False
     assert captured["count_kwargs"]["service_id"] is None

--- a/tests/test_admin_services_instance_metadata.py
+++ b/tests/test_admin_services_instance_metadata.py
@@ -14,6 +14,7 @@ from app.api.admin_services_payloads import (
 )
 from app.db.models import (
     ConsultationDetails,
+    ConsultationInstanceDetails,
     EventDetails,
     Service,
     ServiceInstance,
@@ -378,4 +379,109 @@ def test_serialize_instance_resolves_event_and_consultation_from_service() -> No
         "price": "120.00",
         "currency": "HKD",
         "package_sessions": None,
+    }
+
+
+def test_serialize_booking_instance_parent_consultation_fallback() -> None:
+    """Booking instances without consultation_instance_details inherit parent tier pricing."""
+    from app.api.admin_services_serializers import serialize_instance
+
+    sid = uuid4()
+    template_id = uuid4()
+    booking_id = uuid4()
+
+    service = Service(
+        id=sid,
+        service_type=ServiceType.CONSULTATION,
+        title="Cons",
+        service_key="cons-template",
+        booking_system=None,
+        description=None,
+        cover_image_s3_key=None,
+        delivery_mode=ServiceDeliveryMode.ONLINE,
+        status=ServiceStatus.PUBLISHED,
+        created_by="t",
+    )
+    service.consultation_details = ConsultationDetails(
+        service_id=sid,
+        consultation_format=ConsultationFormat.ONE_ON_ONE,
+        max_group_size=None,
+        duration_minutes=60,
+        pricing_model=ConsultationPricingModel.PACKAGE,
+        default_hourly_rate=None,
+        default_package_price=Decimal("900.00"),
+        default_package_sessions=3,
+        default_currency="HKD",
+    )
+
+    parent = ServiceInstance(
+        id=template_id,
+        service_id=sid,
+        title="Tier",
+        slug="consultation-essentials-package",
+        description=None,
+        cover_image_s3_key=None,
+        status=InstanceStatus.SCHEDULED,
+        delivery_mode=None,
+        location_id=None,
+        max_capacity=None,
+        waitlist_enabled=False,
+        instructor_id=None,
+        cohort=None,
+        notes=None,
+        created_by="t",
+        external_url=None,
+        parent_instance_id=None,
+        is_template=True,
+    )
+    parent.service = service
+    parent.consultation_details = ConsultationInstanceDetails(
+        instance_id=template_id,
+        pricing_model=ConsultationPricingModel.PACKAGE,
+        price=Decimal("900.00"),
+        currency="HKD",
+        package_sessions=3,
+    )
+    parent.instance_tags = []
+    parent.session_slots = []
+    parent.ticket_tiers = []
+    parent.partner_organization_links = []
+
+    booking = ServiceInstance(
+        id=booking_id,
+        service_id=sid,
+        title="Tier – Pat",
+        slug="consultation-essentials-package-20260506103000-aabbccdd",
+        description=None,
+        cover_image_s3_key=None,
+        status=InstanceStatus.OPEN,
+        delivery_mode=None,
+        location_id=None,
+        max_capacity=1,
+        waitlist_enabled=False,
+        instructor_id=None,
+        cohort=None,
+        notes=None,
+        created_by="public-reservation",
+        external_url=None,
+        parent_instance_id=template_id,
+        is_template=False,
+    )
+    booking.service = service
+    booking.parent = parent
+    booking.consultation_details = None
+    booking.instance_tags = []
+    booking.session_slots = []
+    booking.ticket_tiers = []
+    booking.partner_organization_links = []
+
+    payload = serialize_instance(booking)
+    assert payload["parent_instance_id"] == str(template_id)
+    assert payload["is_template"] is False
+    assert payload["consultation_details"] is None
+    assert payload["resolved_consultation_details"] == {
+        "pricing_model": "package",
+        "price": "900.00",
+        "currency": "HKD",
+        "package_sessions": 3,
     }

--- a/tests/test_intro_call_slot_race_postgres.py
+++ b/tests/test_intro_call_slot_race_postgres.py
@@ -1,10 +1,9 @@
-"""PostgreSQL: partial unique index rejects duplicate intro-call ``starts_at``.
+"""PostgreSQL: unique (template_instance_id, starts_at) rejects duplicate bookings.
 
 Skipped unless ``TEST_DATABASE_URL`` is set.
 
-A full two-session blocking probe is brittle in pytest; we assert the index
-exists by observing ``IntegrityError`` on a second insert of the same start time
-after the first row is committed.
+Two contestants insert session slots on different booking instances but sharing the
+same ``template_instance_id`` and ``starts_at``; exactly one row may exist after both attempts.
 """
 
 from __future__ import annotations
@@ -35,8 +34,8 @@ def _sqlalchemy_engine_url(url: str) -> str:
 
 
 @pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
-def test_intro_call_instance_unique_starts_at_rejects_duplicate() -> None:
-    """Second insert with same ``starts_at`` on intro-call instance raises IntegrityError."""
+def test_intro_call_template_slot_unique_starts_at_rejects_duplicate() -> None:
+    """Second insert with same ``(template_instance_id, starts_at)`` raises IntegrityError."""
     url = _database_url()
     assert url is not None
     engine = create_engine(_sqlalchemy_engine_url(url))
@@ -47,70 +46,97 @@ def test_intro_call_instance_unique_starts_at_rejects_duplicate() -> None:
     with engine.connect() as setup:
         row = setup.execute(
             text(
-                "SELECT id FROM service_instances WHERE slug = 'intro-call-free-15min' LIMIT 1"
+                "SELECT id FROM service_instances WHERE slug = "
+                "'intro-call-free-15min' LIMIT 1"
             )
         ).first()
         if row is None:
             pytest.skip("intro-call-free-15min instance missing in test database")
-        real_id = row[0]
+        template_id = row[0]
         setup.execute(
             text(
-                "DELETE FROM instance_session_slots WHERE instance_id = :iid AND starts_at = :st"
+                "DELETE FROM instance_session_slots WHERE template_instance_id = :tid "
+                "AND starts_at = :st"
             ),
-            {"iid": str(real_id), "st": starts},
+            {"tid": str(template_id), "st": starts},
         )
         setup.commit()
 
+    booking_a = None
+    booking_b = None
     try:
         with engine.begin() as conn:
-            row = conn.execute(
+            booking_a = conn.execute(
                 text(
-                    "SELECT id FROM service_instances WHERE slug = "
-                    "'intro-call-free-15min' LIMIT 1"
-                )
-            ).first()
-            assert row is not None
-            iid = row[0]
+                    "INSERT INTO service_instances (service_id, slug, created_by, "
+                    "parent_instance_id, is_template, status, waitlist_enabled, "
+                    "eventbrite_sync_status) "
+                    "SELECT service_id, "
+                    "'race-test-booking-a-' || substr(md5(random()::text), 1, 16), "
+                    "'pytest', id, FALSE, 'open', FALSE, 'pending' "
+                    "FROM service_instances WHERE id = :tid RETURNING id"
+                ),
+                {"tid": str(template_id)},
+            ).scalar_one()
+            booking_b = conn.execute(
+                text(
+                    "INSERT INTO service_instances (service_id, slug, created_by, "
+                    "parent_instance_id, is_template, status, waitlist_enabled, "
+                    "eventbrite_sync_status) "
+                    "SELECT service_id, "
+                    "'race-test-booking-b-' || substr(md5(random()::text), 1, 16), "
+                    "'pytest', id, FALSE, 'open', FALSE, 'pending' "
+                    "FROM service_instances WHERE id = :tid RETURNING id"
+                ),
+                {"tid": str(template_id)},
+            ).scalar_one()
             conn.execute(
                 text(
                     "INSERT INTO instance_session_slots "
-                    "(instance_id, location_id, starts_at, ends_at, sort_order) "
-                    "VALUES (:iid, NULL, :st, :en, 0)"
+                    "(instance_id, template_instance_id, location_id, starts_at, ends_at, "
+                    "sort_order) "
+                    "VALUES (:iid, :tid, NULL, :st, :en, 0)"
                 ),
-                {"iid": str(iid), "st": starts, "en": ends},
+                {
+                    "iid": str(booking_a),
+                    "tid": str(template_id),
+                    "st": starts,
+                    "en": ends,
+                },
             )
 
         with pytest.raises(IntegrityError):
             with engine.begin() as conn2:
-                row2 = conn2.execute(
-                    text(
-                        "SELECT id FROM service_instances WHERE slug = "
-                        "'intro-call-free-15min' LIMIT 1"
-                    )
-                ).first()
-                assert row2 is not None
                 conn2.execute(
                     text(
                         "INSERT INTO instance_session_slots "
-                        "(instance_id, location_id, starts_at, ends_at, sort_order) "
-                        "VALUES (:iid, NULL, :st, :en, 0)"
+                        "(instance_id, template_instance_id, location_id, starts_at, ends_at, "
+                        "sort_order) "
+                        "VALUES (:iid, :tid, NULL, :st, :en, 0)"
                     ),
-                    {"iid": str(row2[0]), "st": starts, "en": ends},
+                    {
+                        "iid": str(booking_b),
+                        "tid": str(template_id),
+                        "st": starts,
+                        "en": ends,
+                    },
                 )
     finally:
-        with engine.connect() as cleanup:
-            row = cleanup.execute(
+        with engine.begin() as cleanup:
+            cleanup.execute(
                 text(
-                    "SELECT id FROM service_instances WHERE slug = "
-                    "'intro-call-free-15min' LIMIT 1"
-                )
-            ).first()
-            if row is not None:
+                    "DELETE FROM instance_session_slots WHERE template_instance_id = :tid "
+                    "AND starts_at = :st"
+                ),
+                {"tid": str(template_id), "st": starts},
+            )
+            if booking_a is not None:
                 cleanup.execute(
-                    text(
-                        "DELETE FROM instance_session_slots WHERE instance_id = :iid "
-                        "AND starts_at = :st"
-                    ),
-                    {"iid": str(row[0]), "st": starts},
+                    text("DELETE FROM service_instances WHERE id = :id"),
+                    {"id": str(booking_a)},
                 )
-                cleanup.commit()
+            if booking_b is not None:
+                cleanup.execute(
+                    text("DELETE FROM service_instances WHERE id = :id"),
+                    {"id": str(booking_b)},
+                )

--- a/tests/test_intro_call_slot_race_postgres.py
+++ b/tests/test_intro_call_slot_race_postgres.py
@@ -140,3 +140,96 @@ def test_intro_call_template_slot_unique_starts_at_rejects_duplicate() -> None:
                     text("DELETE FROM service_instances WHERE id = :id"),
                     {"id": str(booking_b)},
                 )
+
+
+@pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
+def test_intro_call_template_slot_blocks_child_booking_at_same_start() -> None:
+    """Legacy slot on the tier row shares ``template_instance_id`` with child bookings."""
+    url = _database_url()
+    assert url is not None
+    engine = create_engine(_sqlalchemy_engine_url(url))
+
+    starts = datetime(2036, 6, 16, 1, 0, 0, tzinfo=UTC)
+    ends = starts + timedelta(minutes=15)
+
+    with engine.connect() as setup:
+        row = setup.execute(
+            text(
+                "SELECT id FROM service_instances WHERE slug = "
+                "'intro-call-free-15min' LIMIT 1"
+            )
+        ).first()
+        if row is None:
+            pytest.skip("intro-call-free-15min instance missing in test database")
+        template_id = row[0]
+        setup.execute(
+            text(
+                "DELETE FROM instance_session_slots WHERE template_instance_id = :tid "
+                "AND starts_at = :st"
+            ),
+            {"tid": str(template_id), "st": starts},
+        )
+        setup.commit()
+
+    booking_child = None
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO instance_session_slots "
+                    "(instance_id, template_instance_id, location_id, starts_at, ends_at, "
+                    "sort_order) "
+                    "VALUES (:iid, :tid, NULL, :st, :en, 0)"
+                ),
+                {
+                    "iid": str(template_id),
+                    "tid": str(template_id),
+                    "st": starts,
+                    "en": ends,
+                },
+            )
+
+        with engine.begin() as conn:
+            booking_child = conn.execute(
+                text(
+                    "INSERT INTO service_instances (service_id, slug, created_by, "
+                    "parent_instance_id, is_template, status, waitlist_enabled, "
+                    "eventbrite_sync_status) "
+                    "SELECT service_id, "
+                    "'race-test-template-vs-child-' || substr(md5(random()::text), 1, 16), "
+                    "'pytest', id, FALSE, 'open', FALSE, 'pending' "
+                    "FROM service_instances WHERE id = :tid RETURNING id"
+                ),
+                {"tid": str(template_id)},
+            ).scalar_one()
+
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn2:
+                conn2.execute(
+                    text(
+                        "INSERT INTO instance_session_slots "
+                        "(instance_id, template_instance_id, location_id, starts_at, ends_at, "
+                        "sort_order) "
+                        "VALUES (:iid, :tid, NULL, :st, :en, 0)"
+                    ),
+                    {
+                        "iid": str(booking_child),
+                        "tid": str(template_id),
+                        "st": starts,
+                        "en": ends,
+                    },
+                )
+    finally:
+        with engine.begin() as cleanup:
+            cleanup.execute(
+                text(
+                    "DELETE FROM instance_session_slots WHERE template_instance_id = :tid "
+                    "AND starts_at = :st"
+                ),
+                {"tid": str(template_id), "st": starts},
+            )
+            if booking_child is not None:
+                cleanup.execute(
+                    text("DELETE FROM service_instances WHERE id = :id"),
+                    {"id": str(booking_child)},
+                )

--- a/tests/test_intro_call_slots_availability.py
+++ b/tests/test_intro_call_slots_availability.py
@@ -121,12 +121,14 @@ def test_ignore_intro_slot_excludes_existing(fake_session: object) -> None:
     assert ok is True
 
 
-def test_non_intro_busy_query_excludes_cancelled_instances() -> None:
+def test_non_intro_busy_query_excludes_intro_call_service_type() -> None:
     from sqlalchemy import select
 
     from app.db.models import InstanceSessionSlot, Service, ServiceInstance
-    from app.db.repositories.service_instance import public_calendar_blocker_instance_predicates
-    from app.services.intro_call_slots import _INTRO_CALL_INSTANCE_SLUG
+    from app.db.models.enums import ServiceType
+    from app.db.repositories.service_instance import (
+        public_calendar_blocker_instance_predicates,
+    )
 
     range_start = datetime(2026, 5, 4, 0, 0, tzinfo=UTC)
     range_end = datetime(2026, 5, 5, 0, 0, tzinfo=UTC)
@@ -137,7 +139,7 @@ def test_non_intro_busy_query_excludes_cancelled_instances() -> None:
         .where(
             InstanceSessionSlot.starts_at < range_end,
             InstanceSessionSlot.ends_at > range_start,
-            ServiceInstance.slug != _INTRO_CALL_INSTANCE_SLUG,
+            Service.service_type != ServiceType.INTRO_CALL,
             *public_calendar_blocker_instance_predicates(),
         )
     )

--- a/tests/test_public_events_repository.py
+++ b/tests/test_public_events_repository.py
@@ -14,7 +14,9 @@ from app.db.repositories.service_instance import ServiceInstanceRepository
 
 def _compiled_sql(stmt: object) -> str:
     return str(
-        stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+        stmt.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
     )
 
 
@@ -68,7 +70,9 @@ def test_list_public_offerings_service_key_filter() -> None:
 
     repo = ServiceInstanceRepository(mock_session)
     now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
-    repo.list_public_offerings(limit=5, now=now, service_key="my-best-auntie-training-course")
+    repo.list_public_offerings(
+        limit=5, now=now, service_key="my-best-auntie-training-course"
+    )
 
     stmt = mock_session.execute.call_args[0][0]
     sql = _compiled_sql(stmt)
@@ -190,7 +194,9 @@ def test_get_enrollment_counts_for_instances_groups_by_instance() -> None:
 def test_get_id_by_slug_compiles_lower_match() -> None:
     mock_session = MagicMock()
     exec_result = MagicMock()
-    exec_result.scalar_one_or_none.return_value = UUID(int=99)
+    scalars_result = MagicMock()
+    scalars_result.first.return_value = UUID(int=99)
+    exec_result.scalars.return_value = scalars_result
     mock_session.execute.return_value = exec_result
 
     repo = ServiceInstanceRepository(mock_session)

--- a/tests/test_public_reservation_booking_slug.py
+++ b/tests/test_public_reservation_booking_slug.py
@@ -1,0 +1,37 @@
+"""Booking instance slug generation for public reservations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.api.public_reservations import _generate_booking_instance_slug
+from app.exceptions import ValidationError
+
+
+def test_generate_booking_instance_slug_matches_pattern_and_length() -> None:
+    now = datetime(2026, 5, 6, 8, 15, 30, tzinfo=UTC)
+    slug = _generate_booking_instance_slug(
+        template_slug="consultation-essentials-package",
+        now_utc=now,
+    )
+    assert len(slug) <= 128
+    parts = slug.split("-")
+    assert len(parts) >= 3
+    assert parts[-1].isalnum()
+    assert parts[-2].isdigit()
+
+
+def test_generate_booking_instance_slug_truncates_long_template() -> None:
+    long_template = "x" * 120
+    now = datetime(2026, 5, 6, 8, 15, 30, tzinfo=UTC)
+    slug = _generate_booking_instance_slug(template_slug=long_template, now_utc=now)
+    assert len(slug) == 128
+
+
+def test_generate_booking_instance_slug_rejects_invalid_composition() -> None:
+    now = datetime(2026, 5, 6, 8, 15, 30, tzinfo=UTC)
+    with pytest.raises(ValidationError) as exc:
+        _generate_booking_instance_slug(template_slug="bad_slug_", now_utc=now)
+    assert getattr(exc.value, "field", None) == "serviceInstanceSlug"

--- a/tests/test_public_reservation_booking_slug.py
+++ b/tests/test_public_reservation_booking_slug.py
@@ -3,10 +3,19 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import secrets
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
-from app.api.public_reservations import _generate_booking_instance_slug
+from app.api.public_reservations import (
+    _create_booking_instance_for_template,
+    _generate_booking_instance_slug,
+)
 from app.exceptions import ValidationError
 
 
@@ -35,3 +44,110 @@ def test_generate_booking_instance_slug_rejects_invalid_composition() -> None:
     with pytest.raises(ValidationError) as exc:
         _generate_booking_instance_slug(template_slug="bad_slug_", now_utc=now)
     assert getattr(exc.value, "field", None) == "serviceInstanceSlug"
+
+
+def test_generate_booking_instance_slug_changes_when_token_hex_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Second slug differs when ``secrets.token_hex`` yields a new suffix (collision retry path)."""
+    now = datetime(2026, 5, 6, 8, 15, 30, tzinfo=UTC)
+    tokens = iter(["aaaaaaaa", "bbbbbbbb"])
+    monkeypatch.setattr(secrets, "token_hex", lambda nbytes=4: next(tokens))
+    first = _generate_booking_instance_slug(template_slug="consult-tier", now_utc=now)
+    second = _generate_booking_instance_slug(template_slug="consult-tier", now_utc=now)
+    assert first != second
+
+
+def test_create_booking_instance_for_template_retries_after_integrity_error() -> None:
+    template_id = uuid4()
+    svc_id = uuid4()
+    locked = SimpleNamespace(
+        id=template_id,
+        slug="intro-call-free-15min",
+        title="Intro",
+        service_id=svc_id,
+        delivery_mode=MagicMock(),
+        location_id=None,
+        instructor_id=None,
+    )
+    calls = {"n": 0}
+
+    class _FakeRepo:
+        def lock_template_for_booking(self, tid: object) -> object:
+            assert tid == template_id
+            return locked
+
+        def create_instance(
+            self, booking: object, type_details=None, session_slots=None
+        ):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise IntegrityError("stmt", {}, Exception("dup slug"))
+            booking.id = uuid4()
+            return booking
+
+    class _Nested:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, *_args: object) -> bool:
+            return False
+
+    class _FakeSession:
+        def begin_nested(self) -> _Nested:
+            return _Nested()
+
+    out = _create_booking_instance_for_template(
+        _FakeSession(),
+        _FakeRepo(),
+        SimpleNamespace(id=template_id),
+        {"attendee_name": "Pat"},
+        now_utc=datetime(2026, 5, 6, tzinfo=UTC),
+    )
+    assert calls["n"] == 2
+    assert getattr(out, "id", None) is not None
+
+
+def test_create_booking_instance_for_template_raises_after_three_integrity_errors() -> (
+    None
+):
+    template_id = uuid4()
+    locked = SimpleNamespace(
+        id=template_id,
+        slug="intro-call-free-15min",
+        title="Intro",
+        service_id=uuid4(),
+        delivery_mode=MagicMock(),
+        location_id=None,
+        instructor_id=None,
+    )
+
+    class _FakeRepo:
+        def lock_template_for_booking(self, tid: object) -> object:
+            return locked
+
+        def create_instance(
+            self, _booking: object, type_details=None, session_slots=None
+        ):
+            raise IntegrityError("stmt", {}, Exception("dup slug"))
+
+    class _Nested:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, *_args: object) -> bool:
+            return False
+
+    class _FakeSession:
+        def begin_nested(self) -> _Nested:
+            return _Nested()
+
+    with pytest.raises(ValidationError) as excinfo:
+        _create_booking_instance_for_template(
+            _FakeSession(),
+            _FakeRepo(),
+            SimpleNamespace(id=template_id),
+            {"attendee_name": "Pat"},
+            now_utc=datetime(2026, 5, 6, tzinfo=UTC),
+        )
+    assert excinfo.value.status_code == 500

--- a/tests/test_public_reservations_extended.py
+++ b/tests/test_public_reservations_extended.py
@@ -708,6 +708,272 @@ def test_handle_public_reservation_accepts_missing_service_tier(
     assert payload.get("service_tier") is None
 
 
+def test_handle_public_reservation_event_booking_skips_booking_child_allocation(
+    api_gateway_event: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    booking_child_spy = MagicMock()
+    monkeypatch.setattr(
+        "app.api.public_reservations._create_booking_instance_for_template",
+        booking_child_spy,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.verify_turnstile_token",
+        lambda *_a, **_k: True,
+    )
+    _patch_public_reservation_db_helpers(monkeypatch)
+    hooks = MagicMock()
+    monkeypatch.setattr(
+        "app.api.public_reservations._run_reservation_post_success_hooks",
+        hooks,
+    )
+
+    contact_id = uuid4()
+    template_instance_id = uuid4()
+    service_id = uuid4()
+    enrollment_target: dict[str, Any] = {}
+
+    class _FakeContactRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def upsert_by_email(self, _email: str, **kwargs: object) -> tuple[object, bool]:
+            c = MagicMock()
+            c.id = contact_id
+            c.phone_region = None
+            c.phone_national_number = None
+            return c, True
+
+        def update(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _FakeLeadRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def create_with_event(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _FakeSalesLead:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLead",
+        _FakeSalesLead,
+    )
+
+    class _FakeInstanceRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_with_service_by_slug(self, slug: str) -> SimpleNamespace | None:
+            if slug.strip().lower() == "test-cohort":
+                return _resolved_instance_stub(
+                    template_instance_id, service_id, service_type_value="event"
+                )
+            return None
+
+    class _FakeEnrollmentRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def contact_has_enrollment_for_instance(self, **_kwargs: object) -> bool:
+            return False
+
+        def create_enrollment(self, _enrollment: object) -> object:
+            return _enrollment
+
+        def try_create_enrollment_with_capacity_guard(
+            self, enrollment: object
+        ) -> tuple[object | None, str | None]:
+            enrollment_target["instance_id"] = enrollment.instance_id
+            return enrollment, None
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.ServiceInstanceRepository",
+        _FakeInstanceRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.EnrollmentRepository",
+        _FakeEnrollmentRepo,
+    )
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+        def begin(self) -> _FakeBeginNestedCM:
+            return _FakeBeginNestedCM()
+
+        def begin_nested(self) -> _FakeBeginNestedCM:
+            return _FakeBeginNestedCM()
+
+    class _FakeSessionCM:
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_a: object) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.ContactRepository",
+        _FakeContactRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLeadRepository",
+        _FakeLeadRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.Session",
+        lambda _e: _FakeSessionCM(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.get_engine",
+        lambda: object(),
+    )
+
+    body = _reservation_body(bookingSystem="event-booking")
+    event = _post_event(api_gateway_event, body)
+    resp = _handle_public_reservation(event, "POST")
+    assert resp["statusCode"] == 202
+    booking_child_spy.assert_not_called()
+    assert enrollment_target["instance_id"] == template_instance_id
+
+
+def test_handle_public_reservation_mba_style_skips_booking_child_allocation(
+    api_gateway_event: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitted ``bookingSystem`` is not a per-booking flow; enroll on the template instance."""
+    booking_child_spy = MagicMock()
+    monkeypatch.setattr(
+        "app.api.public_reservations._create_booking_instance_for_template",
+        booking_child_spy,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.verify_turnstile_token",
+        lambda *_a, **_k: True,
+    )
+    _patch_public_reservation_db_helpers(monkeypatch)
+    hooks = MagicMock()
+    monkeypatch.setattr(
+        "app.api.public_reservations._run_reservation_post_success_hooks",
+        hooks,
+    )
+
+    contact_id = uuid4()
+    template_instance_id = uuid4()
+    service_id = uuid4()
+    enrollment_target: dict[str, Any] = {}
+
+    class _FakeContactRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def upsert_by_email(self, _email: str, **kwargs: object) -> tuple[object, bool]:
+            c = MagicMock()
+            c.id = contact_id
+            c.phone_region = None
+            c.phone_national_number = None
+            return c, True
+
+        def update(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _FakeLeadRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def create_with_event(self, *_a: object, **_k: object) -> None:
+            return None
+
+    class _FakeSalesLead:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLead",
+        _FakeSalesLead,
+    )
+
+    class _FakeInstanceRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_with_service_by_slug(self, slug: str) -> SimpleNamespace | None:
+            if slug.strip().lower() == "test-cohort":
+                return _resolved_instance_stub(template_instance_id, service_id)
+            return None
+
+    class _FakeEnrollmentRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def contact_has_enrollment_for_instance(self, **_kwargs: object) -> bool:
+            return False
+
+        def create_enrollment(self, _enrollment: object) -> object:
+            return _enrollment
+
+        def try_create_enrollment_with_capacity_guard(
+            self, enrollment: object
+        ) -> tuple[object | None, str | None]:
+            enrollment_target["instance_id"] = enrollment.instance_id
+            return enrollment, None
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.ServiceInstanceRepository",
+        _FakeInstanceRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.EnrollmentRepository",
+        _FakeEnrollmentRepo,
+    )
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+        def begin(self) -> _FakeBeginNestedCM:
+            return _FakeBeginNestedCM()
+
+        def begin_nested(self) -> _FakeBeginNestedCM:
+            return _FakeBeginNestedCM()
+
+    class _FakeSessionCM:
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *_a: object) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "app.api.public_reservations.ContactRepository",
+        _FakeContactRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.SalesLeadRepository",
+        _FakeLeadRepo,
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.Session",
+        lambda _e: _FakeSessionCM(),
+    )
+    monkeypatch.setattr(
+        "app.api.public_reservations.get_engine",
+        lambda: object(),
+    )
+
+    body = _reservation_body()
+    del body["serviceTier"]
+    event = _post_event(api_gateway_event, body)
+    resp = _handle_public_reservation(event, "POST")
+    assert resp["statusCode"] == 202
+    booking_child_spy.assert_not_called()
+    assert enrollment_target["instance_id"] == template_instance_id
+
+
 def test_handle_public_reservation_validation_rejects_missing_terms(
     api_gateway_event: Any,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_public_reservations_extended.py
+++ b/tests/test_public_reservations_extended.py
@@ -87,7 +87,9 @@ def test_validate_reservation_payload_accepts_service_instance_cohort() -> None:
     assert out["service_instance_cohort"] == "April MBA"
 
 
-def test_validate_reservation_payload_normalizes_mixed_case_service_instance_slug() -> None:
+def test_validate_reservation_payload_normalizes_mixed_case_service_instance_slug() -> (
+    None
+):
     body = _reservation_body(
         serviceInstanceSlug="My-Cohort-Slug",
     )
@@ -758,7 +760,9 @@ def test_discount_redemption_rejects_service_scope_mismatch(
         "booking_system": "my-best-auntie-booking",
     }
     with pytest.raises(ValidationError):
-        _validate_discount_code_redemption_scope(object(), payload, resolved_instance=resolved)
+        _validate_discount_code_redemption_scope(
+            object(), payload, template_instance=resolved
+        )
 
 
 def test_discount_redemption_rejects_instance_scope_mismatch(
@@ -795,12 +799,14 @@ def test_discount_redemption_rejects_instance_scope_mismatch(
     payload = {"discount_code": "SAVE", "service_key": "cohort-1"}
     with pytest.raises(ValidationError) as excinfo:
         _validate_discount_code_redemption_scope(
-            object(), payload, resolved_instance=resolved
+            object(), payload, template_instance=resolved
         )
     assert getattr(excinfo.value, "field", None) == "discountCode"
 
 
-def test_discount_redemption_rejects_referral_type(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_discount_redemption_rejects_referral_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from app.exceptions import ValidationError
 
     class _FakeRow:
@@ -829,7 +835,7 @@ def test_discount_redemption_rejects_referral_type(monkeypatch: pytest.MonkeyPat
         _validate_discount_code_redemption_scope(
             object(),
             {"discount_code": "REF"},
-            resolved_instance=_resolved_instance_stub(uuid4(), uuid4()),
+            template_instance=_resolved_instance_stub(uuid4(), uuid4()),
         )
     assert getattr(excinfo.value, "field", None) == "discountCode"
 
@@ -1048,6 +1054,12 @@ def test_intro_call_new_enrollment_persists_slot_before_free_payment_record(
         "app.api.public_reservations.is_intro_call_slot_available",
         lambda *_a, **_k: True,
     )
+    monkeypatch.setattr(
+        "app.api.public_reservations._create_booking_instance_for_template",
+        lambda *_a, **_k: SimpleNamespace(
+            id=uuid4(), slug="intro-call-free-15min-20360616030000-deadbeef"
+        ),
+    )
 
     slot_start = datetime(2036, 6, 16, 3, 0, 0, tzinfo=UTC)
     slot_end = slot_start + timedelta(minutes=15)
@@ -1101,9 +1113,9 @@ def test_intro_call_new_enrollment_persists_slot_before_free_payment_record(
         ops = ops_holder["ops"]
         assert "add_intro_slot" in ops
         idx_add = ops.index("add_intro_slot")
-        assert any(
-            i > idx_add and op == "flush" for i, op in enumerate(ops)
-        ), "expected flush after intro slot add before payment record"
+        assert any(i > idx_add and op == "flush" for i, op in enumerate(ops)), (
+            "expected flush after intro slot add before payment record"
+        )
         return (None, None, False)
 
     monkeypatch.setattr(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the ordered remediation for per-booking service instances (migration backfill, CHECK invariant, repository/list loading, slug collision retries, documentation for Stripe PI idempotency vs leads, admin parsing/UI, race and flow tests, slug lookup simplification, intro-call comment).

## Notes

- **M1 / Step 8:** Skipped per request (consultation `endIso` behavior unchanged).
- **M4 / Step 7:** No handler change; documented that idempotent Stripe PI retries do not create a second `PROGRAM_ENROLLMENT` lead.

## Verification

- `python3 -m ruff check backend/ tests/ --config=backend/pyproject.toml`
- `python3 -m pytest tests/ -q`
- `cd apps/admin_web && npx vitest run && npm run lint && npm run check:admin-api-types`
- `cd apps/public_www && npx vitest run`
- `bash scripts/validate-cursorrules.sh`

Integration coverage for `tests/test_intro_call_slot_race_postgres.py` requires `TEST_DATABASE_URL`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ba72127-b807-4006-887e-6bf1239f13d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ba72127-b807-4006-887e-6bf1239f13d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

