### PR TITLE
Finance: Tax tab with HK fiscal year report and CSV export

### DIFF
--- a/apps/admin_web/src/components/admin/finance/finance-header.tsx
+++ b/apps/admin_web/src/components/admin/finance/finance-header.tsx
@@ -2,12 +2,13 @@
 
 import { AdminTabStrip, type AdminTabItem } from '@/components/ui/admin-tab-strip';
 
-export type FinanceView = 'expenses' | 'vendors' | 'client-invoices';
+export type FinanceView = 'expenses' | 'vendors' | 'client-invoices' | 'tax';
 
 export const FINANCE_TAB_ITEMS: readonly AdminTabItem<FinanceView>[] = [
   { key: 'expenses', label: 'Expenses' },
   { key: 'vendors', label: 'Vendors' },
   { key: 'client-invoices', label: 'Client Invoices' },
+  { key: 'tax', label: 'Tax' },
 ] as const;
 
 export const FINANCE_TAB_KEYS: readonly FinanceView[] = FINANCE_TAB_ITEMS.map(

--- a/apps/admin_web/src/components/admin/finance/finance-page.tsx
+++ b/apps/admin_web/src/components/admin/finance/finance-page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { Card } from '@/components/ui/card';
 import { toErrorMessage } from '@/hooks/hook-errors';
 import { useExpenses } from '@/hooks/use-expenses';
 import { useQueryTabState } from '@/hooks/use-query-tab-state';
@@ -20,6 +19,7 @@ import {
   type FinanceView,
 } from './finance-header';
 import { ClientInvoicesPanel } from './client-invoices-panel';
+import { TaxFiscalYearPanel } from './tax-fiscal-year-panel';
 import { VendorsPanel } from './vendors-panel';
 
 export function FinancePage() {
@@ -75,6 +75,15 @@ export function FinancePage() {
       <div className='space-y-6'>
         <FinanceHeader activeView={activeView} onSetView={setFinanceView} />
         <ClientInvoicesPanel />
+      </div>
+    );
+  }
+
+  if (activeView === 'tax') {
+    return (
+      <div className='space-y-6'>
+        <FinanceHeader activeView={activeView} onSetView={setFinanceView} />
+        <TaxFiscalYearPanel />
       </div>
     );
   }

--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+
+import { WarningTriangleIcon } from '@/components/icons/action-icons';
+import { Button } from '@/components/ui/button';
+import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import { Label } from '@/components/ui/label';
+import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { Select } from '@/components/ui/select';
+import { toErrorMessage } from '@/hooks/hook-errors';
+import { listAllCustomerInvoices, type CustomerInvoiceSummary } from '@/lib/billing-api';
+import { listAllAdminExpenses } from '@/lib/expenses-api';
+import { enumerateFiscalYearStartYears, getFiscalYearRangeInclusive } from '@/lib/fiscal-year';
+import { formatDateOnly, formatEnumLabel } from '@/lib/format';
+import {
+  buildTaxFiscalYearRows,
+  defaultFiscalYearStartYear,
+  taxFiscalYearRowsToCsv,
+  type TaxFiscalYearRow,
+} from '@/lib/tax-fiscal-year-report';
+import type { Expense } from '@/types/expenses';
+
+export function TaxFiscalYearPanel() {
+  const fySelectId = useId();
+  const [fyStartYear, setFyStartYear] = useState(() => defaultFiscalYearStartYear());
+  const [loadError, setLoadError] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [expensesPayload, setExpensesPayload] = useState<Expense[] | null>(null);
+  const [issuedInvoicesPayload, setIssuedInvoicesPayload] = useState<CustomerInvoiceSummary[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setIsLoading(true);
+      setLoadError('');
+      try {
+        const [expenses, invoices] = await Promise.all([
+          listAllAdminExpenses(),
+          listAllCustomerInvoices({ status: 'issued' }),
+        ]);
+        if (!cancelled) {
+          setExpensesPayload(expenses);
+          setIssuedInvoicesPayload(invoices);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setLoadError(toErrorMessage(error, 'Could not load tax fiscal-year data.'));
+          setExpensesPayload([]);
+          setIssuedInvoicesPayload([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const rows = useMemo<TaxFiscalYearRow[]>(() => {
+    if (!expensesPayload || !issuedInvoicesPayload) {
+      return [];
+    }
+    return buildTaxFiscalYearRows(expensesPayload, issuedInvoicesPayload, fyStartYear);
+  }, [expensesPayload, issuedInvoicesPayload, fyStartYear]);
+
+  const fyMeta = useMemo(() => getFiscalYearRangeInclusive(fyStartYear), [fyStartYear]);
+
+  const fyYearOptions = useMemo(() => {
+    const cur = defaultFiscalYearStartYear();
+    return enumerateFiscalYearStartYears(cur - 15, cur + 1);
+  }, []);
+
+  const downloadCsv = useCallback(() => {
+    const csv = taxFiscalYearRowsToCsv(rows);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `tax-fiscal-year-${fyStartYear}-${fyStartYear + 1}.csv`;
+    anchor.rel = 'noopener';
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }, [rows, fyStartYear]);
+
+  const tableError = loadError;
+
+  return (
+    <PaginatedTableCard
+      title='Tax (fiscal year)'
+      description={`Hong Kong fiscal year ${fyMeta.start} to ${fyMeta.end}. Expenses use invoice date when set; otherwise paid date. Revenue uses issued invoice totals by issue date.`}
+      isLoading={isLoading}
+      isLoadingMore={false}
+      hasMore={false}
+      error={tableError}
+      loadingLabel='Loading expenses and invoices…'
+      onLoadMore={() => {}}
+      toolbar={
+        <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <div className='min-w-[220px]'>
+            <Label htmlFor={fySelectId}>Fiscal year</Label>
+            <Select
+              id={fySelectId}
+              value={String(fyStartYear)}
+              onChange={(event) => setFyStartYear(Number.parseInt(event.target.value, 10))}
+              disabled={isLoading || Boolean(tableError)}
+            >
+              {fyYearOptions.map((y) => {
+                const meta = getFiscalYearRangeInclusive(y);
+                return (
+                  <option key={y} value={y}>
+                    {meta.label} ({meta.start} – {meta.end})
+                  </option>
+                );
+              })}
+            </Select>
+          </div>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={() => downloadCsv()}
+            disabled={isLoading || Boolean(tableError) || rows.length === 0}
+          >
+            Download CSV
+          </Button>
+        </div>
+      }
+    >
+      <AdminDataTable tableClassName='min-w-[920px]'>
+        <AdminDataTableHead>
+          <tr>
+            <th className='px-4 py-3 font-semibold'>Type</th>
+            <th className='px-4 py-3 font-semibold'>Date</th>
+            <th className='px-4 py-3 font-semibold'>Description</th>
+            <th className='px-4 py-3 font-semibold'>Amount</th>
+            <th className='px-4 py-3 font-semibold'>Tax</th>
+            <th className='px-4 py-3 font-semibold'>Expense status</th>
+          </tr>
+        </AdminDataTableHead>
+        <AdminDataTableBody>
+          {!isLoading && !tableError && rows.length === 0 ? (
+            <tr>
+              <td className='px-4 py-6 text-slate-600' colSpan={6}>
+                No expense or revenue rows in this fiscal year.
+              </td>
+            </tr>
+          ) : null}
+          {rows.map((row) => (
+            <tr key={`${row.kind}:${row.referenceId}`}>
+              <td className='px-4 py-3'>{row.kind === 'revenue' ? 'Revenue' : 'Expense'}</td>
+              <td className='px-4 py-3'>
+                <div className='flex flex-wrap items-center gap-2'>
+                  <span>{formatDateOnly(row.classificationDate)}</span>
+                  {row.needsInvoiceDateWarning ? (
+                    <span
+                      className='inline-flex items-center gap-1 text-xs font-medium text-amber-700'
+                      title='Vendor invoice date missing — classified using paid date'
+                    >
+                      <WarningTriangleIcon className='h-4 w-4 shrink-0 text-amber-600' aria-hidden />
+                      Needs date
+                    </span>
+                  ) : null}
+                </div>
+              </td>
+              <td className='px-4 py-3'>
+                <p className='font-medium text-slate-900'>{row.description}</p>
+                <p className='mt-0.5 font-mono text-xs text-slate-500'>{row.referenceId}</p>
+              </td>
+              <td className='px-4 py-3'>
+                {!row.amount ? (
+                  '—'
+                ) : row.currency ? (
+                  <span className='tabular-nums'>
+                    {row.amount} {row.currency}
+                  </span>
+                ) : (
+                  <span className='tabular-nums'>{row.amount}</span>
+                )}
+              </td>
+              <td className='px-4 py-3'>
+                {!row.tax ? (
+                  '—'
+                ) : row.currency ? (
+                  <span className='tabular-nums'>
+                    {row.tax} {row.currency}
+                  </span>
+                ) : (
+                  <span className='tabular-nums'>{row.tax}</span>
+                )}
+              </td>
+              <td className='px-4 py-3'>
+                {row.kind === 'expense' && row.expenseStatus ? formatEnumLabel(row.expenseStatus) : '—'}
+              </td>
+            </tr>
+          ))}
+        </AdminDataTableBody>
+      </AdminDataTable>
+    </PaginatedTableCard>
+  );
+}

--- a/apps/admin_web/src/lib/billing-api.ts
+++ b/apps/admin_web/src/lib/billing-api.ts
@@ -16,6 +16,8 @@ export type CustomerInvoiceSummary = ApiSchemas['CustomerInvoiceSummary'];
 
 export type CustomerInvoiceDetail = ApiSchemas['CustomerInvoiceDetail'];
 
+const CUSTOMER_INVOICE_LIST_PAGE_LIMIT = 100;
+
 export async function listCustomerInvoices(
   params: {
     status?: 'draft' | 'issued' | 'void';
@@ -36,7 +38,10 @@ export async function listCustomerInvoices(
     query.set('cursor', params.cursor);
   }
   if (params.limit != null) {
-    query.set('limit', String(params.limit));
+    query.set(
+      'limit',
+      String(Math.min(Math.floor(params.limit), CUSTOMER_INVOICE_LIST_PAGE_LIMIT)),
+    );
   }
   const qs = query.toString();
   const payload = await adminApiRequest<{
@@ -52,6 +57,31 @@ export async function listCustomerInvoices(
     items: Array.isArray(root.items) ? root.items : [],
     next_cursor: root.next_cursor ?? null,
   };
+}
+
+/** Fetches every invoice page (for fiscal-year tax summaries). */
+export async function listAllCustomerInvoices(
+  params: Omit<
+    Parameters<typeof listCustomerInvoices>[0],
+    'cursor' | 'limit'
+  > = {},
+  signal?: AbortSignal,
+): Promise<CustomerInvoiceSummary[]> {
+  const all: CustomerInvoiceSummary[] = [];
+  let cursor: string | null = null;
+  do {
+    const page = await listCustomerInvoices(
+      {
+        ...params,
+        cursor,
+        limit: CUSTOMER_INVOICE_LIST_PAGE_LIMIT,
+      },
+      signal,
+    );
+    all.push(...page.items);
+    cursor = page.next_cursor;
+  } while (cursor);
+  return all;
 }
 
 export async function getCustomerInvoice(id: string, signal?: AbortSignal): Promise<CustomerInvoiceDetail> {

--- a/apps/admin_web/src/lib/fiscal-year.ts
+++ b/apps/admin_web/src/lib/fiscal-year.ts
@@ -1,0 +1,92 @@
+/** Hong Kong civil calendar for fiscal-year classification (April–March). */
+export const HONG_KONG_IANA_TIMEZONE = 'Asia/Hong_Kong';
+
+/** First calendar year of the FY interval (1 April Y → 31 March Y+1). */
+export function getFiscalYearRangeInclusive(startYear: number): { start: string; end: string; label: string } {
+  const y = Math.floor(startYear);
+  const start = `${y}-04-01`;
+  const end = `${y + 1}-03-31`;
+  const label = `FY${String(y).slice(-2)}–${String(y + 1).slice(-2)}`;
+  return { start, end, label };
+}
+
+/** ISO `YYYY-MM-DD` comparison valid for same-calendar convention. */
+export function isDateInInclusiveRange(date: string, start: string, end: string): boolean {
+  return date >= start && date <= end;
+}
+
+export function formatInstantAsHongKongDateString(iso: string | null | undefined): string | null {
+  const raw = iso?.trim() ?? '';
+  if (raw === '') {
+    return null;
+  }
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) {
+    return null;
+  }
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: HONG_KONG_IANA_TIMEZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d);
+}
+
+/** Validates `YYYY-MM-DD` and rejects impossible calendar dates. */
+export function parseIsoDateOnly(raw: string | null | undefined): string | null {
+  const t = raw?.trim() ?? '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(t)) {
+    return null;
+  }
+  const [ys, ms, ds] = t.split('-');
+  const y = Number(ys);
+  const m = Number(ms);
+  const day = Number(ds);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(day)) {
+    return null;
+  }
+  const dt = new Date(Date.UTC(y, m - 1, day));
+  if (
+    dt.getUTCFullYear() !== y ||
+    dt.getUTCMonth() !== m - 1 ||
+    dt.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return t;
+}
+
+/** Fiscal year start year Y such that `hongKongToday` falls in [April Y, March Y+1]. */
+export function inferCurrentFiscalYearStartYear(hongKongDateStr: string): number {
+  const parsed = parseIsoDateOnly(hongKongDateStr);
+  if (!parsed) {
+    return new Date().getUTCFullYear();
+  }
+  const y = Number(parsed.slice(0, 4));
+  const monthDay = parsed.slice(5);
+  if (monthDay >= '04-01') {
+    return y;
+  }
+  return y - 1;
+}
+
+/** Today’s date string in Hong Kong (for default FY selection). */
+export function todayHongKongDateString(now: Date = new Date()): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: HONG_KONG_IANA_TIMEZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+}
+
+/** Year options: `startYear` from `fromYear` through `throughYear` inclusive. */
+export function enumerateFiscalYearStartYears(fromYear: number, throughYear: number): number[] {
+  const lo = Math.min(fromYear, throughYear);
+  const hi = Math.max(fromYear, throughYear);
+  const out: number[] = [];
+  for (let y = lo; y <= hi; y += 1) {
+    out.push(y);
+  }
+  return out.reverse();
+}

--- a/apps/admin_web/src/lib/tax-fiscal-year-report.ts
+++ b/apps/admin_web/src/lib/tax-fiscal-year-report.ts
@@ -1,0 +1,154 @@
+import type { CustomerInvoiceSummary } from '@/lib/billing-api';
+import {
+  formatInstantAsHongKongDateString,
+  getFiscalYearRangeInclusive,
+  inferCurrentFiscalYearStartYear,
+  isDateInInclusiveRange,
+  parseIsoDateOnly,
+  todayHongKongDateString,
+} from '@/lib/fiscal-year';
+import type { Expense } from '@/types/expenses';
+
+export interface TaxFiscalYearRow {
+  kind: 'expense' | 'revenue';
+  classificationDate: string;
+  description: string;
+  currency: string;
+  amount: string;
+  tax: string;
+  expenseStatus?: string;
+  referenceId: string;
+  needsInvoiceDateWarning: boolean;
+  invoiceNumber: string | null;
+}
+
+function expenseClassificationDate(expense: Expense): {
+  date: string | null;
+  needsInvoiceDateWarning: boolean;
+} {
+  const invoiceOk = parseIsoDateOnly(expense.invoiceDate);
+  if (invoiceOk) {
+    return { date: invoiceOk, needsInvoiceDateWarning: false };
+  }
+  const paid = formatInstantAsHongKongDateString(expense.paidAt ?? null);
+  return { date: paid, needsInvoiceDateWarning: true };
+}
+
+function expenseIncludedStatuses(expense: Expense): boolean {
+  return expense.status !== 'voided';
+}
+
+export function buildTaxFiscalYearRows(
+  expenses: Expense[],
+  issuedInvoices: CustomerInvoiceSummary[],
+  fyStartYear: number,
+): TaxFiscalYearRow[] {
+  const { start, end } = getFiscalYearRangeInclusive(fyStartYear);
+
+  const expenseRows: TaxFiscalYearRow[] = [];
+  for (const expense of expenses) {
+    if (!expenseIncludedStatuses(expense)) {
+      continue;
+    }
+    const { date, needsInvoiceDateWarning } = expenseClassificationDate(expense);
+    if (!date || !isDateInInclusiveRange(date, start, end)) {
+      continue;
+    }
+    const vendor = expense.vendorName?.trim() ?? '';
+    expenseRows.push({
+      kind: 'expense',
+      classificationDate: date,
+      description: vendor !== '' ? vendor : 'Expense',
+      currency: expense.currency?.trim().toUpperCase() ?? '',
+      amount: expense.total?.trim() ?? '',
+      tax: expense.tax?.trim() ?? '',
+      expenseStatus: expense.status,
+      referenceId: expense.id,
+      needsInvoiceDateWarning,
+      invoiceNumber: expense.invoiceNumber?.trim() ?? null,
+    });
+  }
+
+  const revenueRows: TaxFiscalYearRow[] = [];
+  for (const inv of issuedInvoices) {
+    const invId = inv.id?.trim() ?? '';
+    if (invId === '') {
+      continue;
+    }
+    if (inv.status !== 'issued') {
+      continue;
+    }
+    const issued = formatInstantAsHongKongDateString(inv.issuedAt ?? null);
+    if (!issued || !isDateInInclusiveRange(issued, start, end)) {
+      continue;
+    }
+    const name = inv.billToDisplayName?.trim() ?? '';
+    const num = inv.invoiceNumber?.trim() ?? '';
+    const description =
+      name !== '' && num !== '' ? `${name} (${num})` : name !== '' ? name : num !== '' ? num : 'Invoice';
+    revenueRows.push({
+      kind: 'revenue',
+      classificationDate: issued,
+      description,
+      currency: inv.currency?.trim().toUpperCase() ?? '',
+      amount: inv.total?.trim() ?? '',
+      tax: inv.taxTotal?.trim() ?? '',
+      referenceId: invId,
+      needsInvoiceDateWarning: false,
+      invoiceNumber: inv.invoiceNumber ?? null,
+    });
+  }
+
+  const merged = [...expenseRows, ...revenueRows];
+  merged.sort((a, b) => {
+    const d = a.classificationDate.localeCompare(b.classificationDate);
+    if (d !== 0) {
+      return d;
+    }
+    return `${a.kind}:${a.referenceId}`.localeCompare(`${b.kind}:${b.referenceId}`);
+  });
+  return merged;
+}
+
+export function defaultFiscalYearStartYear(now: Date = new Date()): number {
+  return inferCurrentFiscalYearStartYear(todayHongKongDateString(now));
+}
+
+function csvEscape(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function taxFiscalYearRowsToCsv(rows: TaxFiscalYearRow[]): string {
+  const headers = [
+    'kind',
+    'classification_date',
+    'description',
+    'currency',
+    'amount',
+    'tax',
+    'expense_status',
+    'invoice_number',
+    'reference_id',
+    'needs_invoice_date_warning',
+  ];
+  const lines = [headers.join(',')];
+  for (const row of rows) {
+    const cells = [
+      row.kind,
+      row.classificationDate,
+      row.description,
+      row.currency,
+      row.amount,
+      row.tax,
+      row.expenseStatus ?? '',
+      row.invoiceNumber ?? '',
+      row.referenceId,
+      row.needsInvoiceDateWarning ? 'yes' : 'no',
+    ].map((c) => csvEscape(c));
+    lines.push(cells.join(','));
+  }
+  return `${lines.join('\r\n')}\r\n`;
+}

--- a/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
@@ -92,6 +92,10 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
   }),
 }));
 
+vi.mock('@/components/admin/finance/tax-fiscal-year-panel', () => ({
+  TaxFiscalYearPanel: () => <h2>Tax fiscal snapshot</h2>,
+}));
+
 import { FinancePage } from '@/components/admin/finance/finance-page';
 
 describe('FinancePage', () => {
@@ -110,6 +114,7 @@ describe('FinancePage', () => {
     expect(screen.getByRole('button', { name: 'Expenses' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Vendors' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Client Invoices' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tax' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Expense Details' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Vendors' }));
@@ -120,6 +125,10 @@ describe('FinancePage', () => {
     await user.click(screen.getByRole('button', { name: 'Client Invoices' }));
     expect(screen.getByRole('heading', { name: 'Create draft invoice' })).toBeInTheDocument();
     expect(window.location.search).toBe('?tab=client-invoices');
+
+    await user.click(screen.getByRole('button', { name: 'Tax' }));
+    expect(screen.getByRole('heading', { name: 'Tax fiscal snapshot' })).toBeInTheDocument();
+    expect(window.location.search).toBe('?tab=tax');
 
     await user.click(screen.getByRole('button', { name: 'Expenses' }));
     expect(window.location.search).toBe('');

--- a/apps/admin_web/tests/lib/fiscal-year.test.ts
+++ b/apps/admin_web/tests/lib/fiscal-year.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  enumerateFiscalYearStartYears,
+  formatInstantAsHongKongDateString,
+  getFiscalYearRangeInclusive,
+  inferCurrentFiscalYearStartYear,
+  isDateInInclusiveRange,
+  parseIsoDateOnly,
+  todayHongKongDateString,
+} from '@/lib/fiscal-year';
+
+describe('fiscal-year', () => {
+  it('returns FY range and label', () => {
+    expect(getFiscalYearRangeInclusive(2025)).toEqual({
+      start: '2025-04-01',
+      end: '2026-03-31',
+      label: 'FY25–26',
+    });
+  });
+
+  it('checks inclusive date range lexicographically', () => {
+    expect(isDateInInclusiveRange('2025-04-01', '2025-04-01', '2026-03-31')).toBe(true);
+    expect(isDateInInclusiveRange('2026-03-31', '2025-04-01', '2026-03-31')).toBe(true);
+    expect(isDateInInclusiveRange('2025-03-31', '2025-04-01', '2026-03-31')).toBe(false);
+    expect(isDateInInclusiveRange('2026-04-01', '2025-04-01', '2026-03-31')).toBe(false);
+  });
+
+  it('validates ISO date-only strings', () => {
+    expect(parseIsoDateOnly('2025-02-29')).toBe(null);
+    expect(parseIsoDateOnly('2024-02-29')).toBe('2024-02-29');
+    expect(parseIsoDateOnly('not-a-date')).toBe(null);
+  });
+
+  it('infers fiscal start year from HK calendar date', () => {
+    expect(inferCurrentFiscalYearStartYear('2025-04-01')).toBe(2025);
+    expect(inferCurrentFiscalYearStartYear('2025-03-31')).toBe(2024);
+  });
+
+  it('formats instants in Hong Kong civil date', () => {
+    expect(formatInstantAsHongKongDateString('2026-06-01T00:00:00.000Z')).toBe('2026-06-01');
+  });
+
+  it('enumerates fiscal start years descending', () => {
+    expect(enumerateFiscalYearStartYears(2023, 2025)).toEqual([2025, 2024, 2023]);
+  });
+
+  it('returns today in Hong Kong as YYYY-MM-DD', () => {
+    const s = todayHongKongDateString(new Date('2026-01-15T12:00:00.000Z'));
+    expect(s).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/apps/admin_web/tests/lib/tax-fiscal-year-report.test.ts
+++ b/apps/admin_web/tests/lib/tax-fiscal-year-report.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CustomerInvoiceSummary } from '@/lib/billing-api';
+import {
+  buildTaxFiscalYearRows,
+  defaultFiscalYearStartYear,
+  taxFiscalYearRowsToCsv,
+} from '@/lib/tax-fiscal-year-report';
+import type { Expense } from '@/types/expenses';
+
+function expenseStub(partial: Partial<Expense> & Pick<Expense, 'id' | 'status'>): Expense {
+  return {
+    amendsExpenseId: null,
+    parseStatus: 'not_requested',
+    vendorId: null,
+    vendorName: null,
+    invoiceNumber: null,
+    invoiceDate: null,
+    dueDate: null,
+    currency: 'HKD',
+    subtotal: null,
+    tax: '0',
+    total: '100',
+    lineItems: [],
+    parseConfidence: null,
+    notes: null,
+    voidReason: null,
+    createdBy: '',
+    updatedBy: null,
+    createdAt: '',
+    updatedAt: '',
+    submittedAt: null,
+    paidAt: null,
+    voidedAt: null,
+    attachments: [],
+    ...partial,
+  } as Expense;
+}
+
+describe('tax-fiscal-year-report', () => {
+  it('defaultFiscalYearStartYear mirrors FY boundaries', () => {
+    expect(defaultFiscalYearStartYear(new Date('2026-05-06T12:00:00.000Z'))).toBe(2026);
+    expect(defaultFiscalYearStartYear(new Date('2026-03-20T12:00:00.000Z'))).toBe(2025);
+  });
+
+  it('excludes voided expenses', () => {
+    const rows = buildTaxFiscalYearRows(
+      [
+        expenseStub({
+          id: 'x',
+          status: 'voided',
+          invoiceDate: '2025-06-01',
+          total: '50',
+        }),
+      ],
+      [],
+      2025,
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('includes non-void expenses in range and revenue by issued date', () => {
+    const rows = buildTaxFiscalYearRows(
+      [
+        expenseStub({
+          id: 'e1',
+          status: 'draft',
+          vendorName: 'Paper Co',
+          invoiceDate: '2025-06-10',
+          total: '200',
+          tax: '10',
+        }),
+      ],
+      [
+        {
+          id: 'i1',
+          status: 'issued',
+          invoiceNumber: 'INV-1',
+          currency: 'HKD',
+          subtotal: '900',
+          taxTotal: '50',
+          total: '950',
+          billToDisplayName: 'Family A',
+          issuedAt: '2025-08-01T08:00:00.000Z',
+        } satisfies CustomerInvoiceSummary,
+      ],
+      2025,
+    );
+    expect(rows.map((r) => r.kind)).toEqual(['expense', 'revenue']);
+    expect(rows[0]?.kind).toBe('expense');
+    expect(rows[1]?.kind).toBe('revenue');
+  });
+
+  it('flags missing invoice date when using paid date', () => {
+    const rows = buildTaxFiscalYearRows(
+      [
+        expenseStub({
+          id: 'e2',
+          status: 'paid',
+          invoiceDate: null,
+          paidAt: '2025-07-01T00:00:00.000Z',
+          vendorName: 'Vendor',
+          total: '10',
+        }),
+      ],
+      [],
+      2025,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.needsInvoiceDateWarning).toBe(true);
+  });
+
+  it('serializes CSV with escaping', () => {
+    const csv = taxFiscalYearRowsToCsv([
+      {
+        kind: 'expense',
+        classificationDate: '2025-06-01',
+        description: 'Hello, world',
+        currency: 'HKD',
+        amount: '1',
+        tax: '0',
+        expenseStatus: 'paid',
+        referenceId: 'id',
+        needsInvoiceDateWarning: false,
+        invoiceNumber: null,
+      },
+    ]);
+    expect(csv).toContain('"Hello, world"');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Tax** tab under **Finance** that shows expenses and **revenue** (issued customer invoices) for a selectable Hong Kong fiscal year (1 April–31 March). Dates are classified using **Asia/Hong_Kong**: invoice `issued_at` for revenue; expense `invoice_date` when valid, otherwise expense `paid_at` with a visible **Needs date** warning (amber warning triangle icon pattern reused from Services).

## Behaviour

- Expenses: includes **all statuses except voided** (draft, submitted, paid, amended).
- Revenue: **issued** invoices only; amount/tax from invoice totals.
- CSV download matches the on-screen fiscal-year slice (`tax-fiscal-year-{start}-{end}.csv`).

## Implementation notes

- New helpers in `fiscal-year.ts` and `tax-fiscal-year-report.ts`; `listAllCustomerInvoices` added alongside existing expense listing.

## Testing

- `npm run lint` (apps/admin_web)
- `npx vitest run` on new lib tests and updated `finance-page` test
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3420c2b-aeb4-42f0-a8e8-84a4b4d6c1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3420c2b-aeb4-42f0-a8e8-84a4b4d6c1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

