### PR TITLE
Admin web: Client Invoices Customer payments table UX cleanup

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -8,14 +8,13 @@ import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
-import { Card } from '@/components/ui/card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { CheckIcon, ViewIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
+import { CheckIcon, MarkPaidIcon, ViewIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
 import {
   CUSTOMIZED_DRAFT_INVOICE_FORM_ID,
   CustomizedDraftInvoiceCard,
@@ -64,6 +63,21 @@ function formatTruncatedId(id: string | null | undefined): string {
     return id;
   }
   return `${id.slice(0, 8)}…`;
+}
+
+/** Display payment enum or method slug as camelCase (for example `bank_transfer` → `bankTransfer`). */
+function formatPaymentLabelCamelCase(raw: string | null | undefined): string {
+  const t = raw?.trim() ?? '';
+  if (t === '') {
+    return '';
+  }
+  const parts = t.split(/[\s_\-+/]+/).filter((p) => p !== '');
+  if (parts.length === 0) {
+    return '';
+  }
+  const lower = parts.map((p) => p.toLowerCase());
+  const [head, ...tail] = lower;
+  return head + tail.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join('');
 }
 
 type CustomerInvoiceLineRow = NonNullable<CustomerInvoiceDetail['lines']>[number];
@@ -1732,7 +1746,7 @@ export function ClientInvoicesPanel() {
 
       <PaginatedTableCard
         title='Customer payments'
-        description='Recent customer payments and refunds. Select a row for allocation and refund source. Pending inbound: use Confirm in Operations.'
+        description='Recent customer payments and refunds. Select a row for allocation and refund source. Pending inbound: confirm from Operations.'
         isLoading={listLoading}
         isLoadingMore={false}
         hasMore={false}
@@ -1765,6 +1779,14 @@ export function ClientInvoicesPanel() {
             {payments.map((p, index) => {
               const id = p.id ?? '';
               const selected = id && selectedId === id;
+              const amountRaw = p.amount?.trim() ?? '';
+              const parsedPayAmount = Number.parseFloat(amountRaw);
+              const payCurrencyCode =
+                (p.currency ?? defaultCurrency).trim().toUpperCase() || defaultCurrency;
+              const amountDisplay =
+                amountRaw !== '' && Number.isFinite(parsedPayAmount)
+                  ? formatAmountInCurrency(parsedPayAmount, payCurrencyCode)
+                  : '—';
               return (
                 <tr
                   key={id || `payment-row-${String(index)}`}
@@ -1779,27 +1801,33 @@ export function ClientInvoicesPanel() {
                       {formatTruncatedId(id)}
                     </button>
                   </td>
-                  <td className='px-3 py-2'>{p.direction}</td>
-                  <td className='px-3 py-2'>{p.status}</td>
-                  <td className='px-3 py-2'>{p.method ?? '—'}</td>
-                  <td className='px-3 py-2'>
-                    {p.amount} {p.currency}
-                  </td>
-                  <td className='px-3 py-2 text-xs text-slate-600'>{p.createdAt?.slice(0, 19) ?? '—'}</td>
+                  <td className='px-3 py-2'>{formatPaymentLabelCamelCase(p.direction)}</td>
+                  <td className='px-3 py-2'>{formatPaymentLabelCamelCase(p.status)}</td>
+                  <td className='px-3 py-2'>{formatPaymentLabelCamelCase(p.method)}</td>
+                  <td className='px-3 py-2'>{amountDisplay}</td>
+                  <td className='px-3 py-2'>{formatDate(p.createdAt ?? null)}</td>
                   <td className='px-3 py-2 text-right'>
                     {p.status === 'pending' && p.direction === 'inbound' ? (
                       <Button
                         type='button'
+                        size='sm'
                         variant='secondary'
-                        className='text-xs'
                         disabled={confirmPaymentDialogOpen || busyAction === 'confirm'}
                         onClick={() => openConfirmPaymentDialog(id)}
+                        aria-label='Confirm pending payment'
+                        title='Confirm pending payment'
+                        aria-busy={busyAction === 'confirm' && confirmPaymentId === id}
                       >
-                        Confirm…
+                        {busyAction === 'confirm' && confirmPaymentId === id ? (
+                          <span
+                            className='inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-slate-600 border-t-transparent'
+                            aria-hidden
+                          />
+                        ) : (
+                          <MarkPaidIcon className='h-4 w-4' aria-hidden />
+                        )}
                       </Button>
-                    ) : (
-                      <span className='text-xs text-slate-400'>—</span>
-                    )}
+                    ) : null}
                   </td>
                 </tr>
               );
@@ -1807,46 +1835,6 @@ export function ClientInvoicesPanel() {
           </AdminDataTableBody>
         </AdminDataTable>
       </PaginatedTableCard>
-
-      <Card
-        title='Selected payment'
-        className='border-slate-200 bg-slate-50/80 p-3 shadow-none sm:p-4'
-      >
-        {!selectedId ? (
-          <p className='text-sm text-slate-600'>
-            Select a row in the payments table to load unapplied balance and pre-fill allocation and refund fields.
-          </p>
-        ) : detailLoading ? (
-          <p className='text-sm text-slate-600'>Loading payment…</p>
-        ) : detailError ? (
-          <AdminInlineError>{detailError}</AdminInlineError>
-        ) : detail ? (
-          <dl className='mt-1 grid gap-1 text-sm text-slate-700 sm:grid-cols-2'>
-            <div>
-              <dt className='text-xs uppercase text-slate-500'>Id</dt>
-              <dd className='font-mono text-xs'>{detail.id}</dd>
-            </div>
-            <div>
-              <dt className='text-xs uppercase text-slate-500'>Status</dt>
-              <dd>{detail.status}</dd>
-            </div>
-            <div>
-              <dt className='text-xs uppercase text-slate-500'>Direction</dt>
-              <dd>{detail.direction}</dd>
-            </div>
-            <div>
-              <dt className='text-xs uppercase text-slate-500'>Amount</dt>
-              <dd>
-                {detail.amount} {detail.currency}
-              </dd>
-            </div>
-            <div>
-              <dt className='text-xs uppercase text-slate-500'>Unapplied</dt>
-              <dd>{detail.unappliedAmount ?? '—'}</dd>
-            </div>
-          </dl>
-        ) : null}
-      </Card>
 
       <ConfirmDialog
         open={voidDialogOpen}

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -423,9 +423,9 @@ describe('ClientInvoicesPanel', () => {
     render(<ClientInvoicesPanel />);
 
     const paymentTable = screen.getAllByRole('table').at(-1) as HTMLElement;
-    await waitFor(() => within(paymentTable).getByRole('button', { name: /confirm/i }));
+    await waitFor(() => within(paymentTable).getByRole('button', { name: /confirm pending payment/i }));
 
-    await userEvent.click(within(paymentTable).getByRole('button', { name: /confirm/i }));
+    await userEvent.click(within(paymentTable).getByRole('button', { name: /confirm pending payment/i }));
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /confirm payment/i })).toBeInTheDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the **Customer payments** table on the Finance **Client Invoices** tab:

- Removed the **Selected payment** summary card (selection still drives allocation/refund pre-fill and `getCustomerPayment` in the background).
- **Direction**, **Status**, and **Method** cells use camelCase-style labels (splitting on spaces/underscores/hyphens; e.g. `bank_transfer` → `bankTransfer`).
- **Amount** uses `formatAmountInCurrency` (same pattern as the customer invoices total column).
- **Created** uses `formatDate` so typography matches other columns (no extra `text-xs`).
- **Operations** renders nothing when there is no action (no em dash placeholder).
- Pending inbound **confirm** uses `MarkPaidIcon` with `aria-label` / `title` **Confirm pending payment** (spinner while submit runs).
- Card description text updated so it does not refer to a **Confirm** button label.

Tests: `client-invoices-panel.test.tsx` updated for the new confirm control accessible name.

## Note

There was no **Invoices** column on the **Customer payments** table in this repository. If you meant a different column (for example the enrollment picker **Invoice** column on the same tab), say which table/column and we can follow up.

## Verification

- `cd apps/admin_web && npm run lint`
- `npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx`
- `npx vitest run tests/components/admin/finance/finance-page.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2c00a13-323f-4424-86ea-93c0bd7fb834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2c00a13-323f-4424-86ea-93c0bd7fb834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

