### PR TITLE
fix(admin-web): drop Customer payments Refresh; show FPS acronym for …

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -66,6 +66,11 @@ function formatTruncatedId(id: string | null | undefined): string {
   return `${id.slice(0, 8)}…`;
 }
 
+/** Customer payments Method column: snake_case label with FPS acronym spelled out. */
+function formatPaymentMethodLabel(raw: string | null | undefined): string {
+  return formatEnumLabel(raw ?? '').replace(/\bFps\b/g, 'FPS');
+}
+
 type CustomerInvoiceLineRow = NonNullable<CustomerInvoiceDetail['lines']>[number];
 
 function invoiceLineSortKey(line: CustomerInvoiceLineRow): number {
@@ -1731,9 +1736,6 @@ export function ClientInvoicesPanel() {
         onLoadMore={() => {}}
         toolbar={
           <div className='mb-3 flex flex-wrap gap-2'>
-            <Button type='button' variant='outline' onClick={() => void loadPayments()} disabled={listLoading}>
-              Refresh
-            </Button>
             <Button type='button' variant='outline' onClick={() => void handleExport()} disabled={exportBusy}>
               {exportBusy ? 'Exporting…' : 'Download CSV export (v2)'}
             </Button>
@@ -1777,7 +1779,7 @@ export function ClientInvoicesPanel() {
                 >
                   <td className='px-3 py-2'>{formatEnumLabel(p.direction ?? '')}</td>
                   <td className='px-3 py-2'>{formatEnumLabel(p.status ?? '')}</td>
-                  <td className='px-3 py-2'>{formatEnumLabel(p.method ?? '')}</td>
+                  <td className='px-3 py-2'>{formatPaymentMethodLabel(p.method)}</td>
                   <td className='px-3 py-2'>{amountDisplay}</td>
                   <td className='px-3 py-2'>{formatDate(p.createdAt ?? null)}</td>
                   <td

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -448,6 +448,43 @@ describe('ClientInvoicesPanel', () => {
     });
   });
 
+  it('does not render Customer payments Refresh control', async () => {
+    billingMocks.listCustomerPayments.mockResolvedValue([]);
+    render(<ClientInvoicesPanel />);
+    await waitFor(() => expect(billingMocks.listCustomerPayments).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: /^refresh$/i })).not.toBeInTheDocument();
+  });
+
+  it('capitalizes fps payment method as FPS', async () => {
+    billingMocks.listCustomerPayments.mockResolvedValue([
+      {
+        id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        direction: 'inbound',
+        status: 'succeeded',
+        method: 'fps',
+        amount: '1',
+        currency: 'HKD',
+        createdAt: '2026-01-01T00:00:00+00:00',
+      },
+      {
+        id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        direction: 'inbound',
+        status: 'succeeded',
+        method: 'bank_fps',
+        amount: '2',
+        currency: 'HKD',
+        createdAt: '2026-01-01T00:00:00+00:00',
+      },
+    ]);
+    render(<ClientInvoicesPanel />);
+    const paymentTable = screen.getAllByRole('table').at(-1) as HTMLElement;
+    await waitFor(() => {
+      const cells = within(paymentTable).getAllByRole('cell');
+      expect(cells.some((c) => c.textContent === 'FPS')).toBe(true);
+      expect(cells.some((c) => c.textContent === 'Bank FPS')).toBe(true);
+    });
+  });
+
   it('submitting allocate form calls createPaymentAllocation', async () => {
     const invId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     const lineId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';


### PR DESCRIPTION
…methods

Remove Refresh from the Customer payments toolbar (list still loads on mount and after mutations). Add payment-method label helper so fps segments render as FPS (e.g. bank_fps → Bank FPS). Cover with panel tests.