### PR TITLE
Admin web: Tax tab title, FY dropdown labels, table tweaks

### DIFF
--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -21,9 +21,23 @@ import {
 } from '@/lib/tax-fiscal-year-report';
 import type { Expense } from '@/types/expenses';
 
+/** Earliest Hong Kong FY start year offered in the selector (April Y → March Y+1). */
+const MIN_FISCAL_YEAR_START = 2024;
+
+function isTaxDisplayedAsDash(tax: string | undefined): boolean {
+  const t = tax?.trim() ?? '';
+  if (t === '') {
+    return true;
+  }
+  const n = Number.parseFloat(t.replace(/,/g, ''));
+  return Number.isFinite(n) && n === 0;
+}
+
 export function TaxFiscalYearPanel() {
   const fySelectId = useId();
-  const [fyStartYear, setFyStartYear] = useState(() => defaultFiscalYearStartYear());
+  const [fyStartYear, setFyStartYear] = useState(
+    () => Math.max(MIN_FISCAL_YEAR_START, defaultFiscalYearStartYear()),
+  );
   const [loadError, setLoadError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [expensesPayload, setExpensesPayload] = useState<Expense[] | null>(null);
@@ -71,7 +85,8 @@ export function TaxFiscalYearPanel() {
 
   const fyYearOptions = useMemo(() => {
     const cur = defaultFiscalYearStartYear();
-    return enumerateFiscalYearStartYears(cur - 15, cur + 1);
+    const throughYear = Math.max(cur + 1, MIN_FISCAL_YEAR_START);
+    return enumerateFiscalYearStartYears(MIN_FISCAL_YEAR_START, throughYear);
   }, []);
 
   const downloadCsv = useCallback(() => {
@@ -90,7 +105,7 @@ export function TaxFiscalYearPanel() {
 
   return (
     <PaginatedTableCard
-      title='Tax (fiscal year)'
+      title='Tax'
       description={`Hong Kong fiscal year ${fyMeta.start} to ${fyMeta.end}. Expenses use invoice date when set; otherwise paid date. Revenue uses issued invoice totals by issue date.`}
       isLoading={isLoading}
       isLoadingMore={false}
@@ -108,14 +123,11 @@ export function TaxFiscalYearPanel() {
               onChange={(event) => setFyStartYear(Number.parseInt(event.target.value, 10))}
               disabled={isLoading || Boolean(tableError)}
             >
-              {fyYearOptions.map((y) => {
-                const meta = getFiscalYearRangeInclusive(y);
-                return (
-                  <option key={y} value={y}>
-                    {meta.label} ({meta.start} – {meta.end})
-                  </option>
-                );
-              })}
+              {fyYearOptions.map((y) => (
+                <option key={y} value={y}>
+                  {y} - {y + 1}
+                </option>
+              ))}
             </Select>
           </div>
           <Button
@@ -167,7 +179,6 @@ export function TaxFiscalYearPanel() {
               </td>
               <td className='px-4 py-3'>
                 <p className='font-medium text-slate-900'>{row.description}</p>
-                <p className='mt-0.5 font-mono text-xs text-slate-500'>{row.referenceId}</p>
               </td>
               <td className='px-4 py-3'>
                 {!row.amount ? (
@@ -181,7 +192,7 @@ export function TaxFiscalYearPanel() {
                 )}
               </td>
               <td className='px-4 py-3'>
-                {!row.tax ? (
+                {isTaxDisplayedAsDash(row.tax) ? (
                   '—'
                 ) : row.currency ? (
                   <span className='tabular-nums'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Finance **Tax** tab in admin web:

- Card title is **Tax** (replacing “Tax (fiscal year)”).
- Fiscal year selector lists Hong Kong FYs from **2024** onward through next year (relative to “today” in HK), with option labels **`{startYear} - {endYear}`** (e.g. `2026 - 2027`).
- Description column no longer shows the reference UUID under the text (CSV export still includes `reference_id`).
- Tax column shows an empty-style dash for zero numeric tax values (`0`, `0.00`, etc.), matching empty cells (em dash, consistent with other columns).

## Tests

- `cd apps/admin_web && npm run lint`
- `npx vitest run tests/lib/tax-fiscal-year-report.test.ts tests/components/admin/finance/finance-page.test.tsx`
- `bash scripts/validate-cursorrules.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00ab7c11-bc1f-4c90-80ed-3ed4251bcd8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00ab7c11-bc1f-4c90-80ed-3ed4251bcd8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

