### PR TITLE
Admin web: Tax tab title, FY dropdown, FX amount formatting

### DIFF
--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -21,9 +21,23 @@ import {
 } from '@/lib/tax-fiscal-year-report';
 import type { Expense } from '@/types/expenses';
 
+/** Earliest Hong Kong FY start year offered in the selector (April Y → March Y+1). */
+const MIN_FISCAL_YEAR_START = 2024;
+
+function isTaxDisplayedAsDash(tax: string | undefined): boolean {
+  const t = tax?.trim() ?? '';
+  if (t === '') {
+    return true;
+  }
+  const n = Number.parseFloat(t.replace(/,/g, ''));
+  return Number.isFinite(n) && n === 0;
+}
+
 export function TaxFiscalYearPanel() {
   const fySelectId = useId();
-  const [fyStartYear, setFyStartYear] = useState(() => defaultFiscalYearStartYear());
+  const [fyStartYear, setFyStartYear] = useState(
+    () => Math.max(MIN_FISCAL_YEAR_START, defaultFiscalYearStartYear()),
+  );
   const [loadError, setLoadError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [expensesPayload, setExpensesPayload] = useState<Expense[] | null>(null);
@@ -71,7 +85,8 @@ export function TaxFiscalYearPanel() {
 
   const fyYearOptions = useMemo(() => {
     const cur = defaultFiscalYearStartYear();
-    return enumerateFiscalYearStartYears(cur - 15, cur + 1);
+    const throughYear = Math.max(cur + 1, MIN_FISCAL_YEAR_START);
+    return enumerateFiscalYearStartYears(MIN_FISCAL_YEAR_START, throughYear);
   }, []);
 
   const downloadCsv = useCallback(() => {
@@ -90,7 +105,7 @@ export function TaxFiscalYearPanel() {
 
   return (
     <PaginatedTableCard
-      title='Tax (fiscal year)'
+      title='Tax'
       description={`Hong Kong fiscal year ${fyMeta.start} to ${fyMeta.end}. Expenses use invoice date when set; otherwise paid date. Revenue uses issued invoice totals by issue date.`}
       isLoading={isLoading}
       isLoadingMore={false}
@@ -108,14 +123,11 @@ export function TaxFiscalYearPanel() {
               onChange={(event) => setFyStartYear(Number.parseInt(event.target.value, 10))}
               disabled={isLoading || Boolean(tableError)}
             >
-              {fyYearOptions.map((y) => {
-                const meta = getFiscalYearRangeInclusive(y);
-                return (
-                  <option key={y} value={y}>
-                    {meta.label} ({meta.start} – {meta.end})
-                  </option>
-                );
-              })}
+              {fyYearOptions.map((y) => (
+                <option key={y} value={y}>
+                  {y} - {y + 1}
+                </option>
+              ))}
             </Select>
           </div>
           <Button
@@ -167,7 +179,6 @@ export function TaxFiscalYearPanel() {
               </td>
               <td className='px-4 py-3'>
                 <p className='font-medium text-slate-900'>{row.description}</p>
-                <p className='mt-0.5 font-mono text-xs text-slate-500'>{row.referenceId}</p>
               </td>
               <td className='px-4 py-3'>
                 {!row.amount ? (
@@ -181,7 +192,7 @@ export function TaxFiscalYearPanel() {
                 )}
               </td>
               <td className='px-4 py-3'>
-                {!row.tax ? (
+                {isTaxDisplayedAsDash(row.tax) ? (
                   '—'
                 ) : row.currency ? (
                   <span className='tabular-nums'>

--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { toErrorMessage } from '@/hooks/hook-errors';
+import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { listAllCustomerInvoices, type CustomerInvoiceSummary } from '@/lib/billing-api';
 import { listAllAdminExpenses } from '@/lib/expenses-api';
 import { enumerateFiscalYearStartYears, getFiscalYearRangeInclusive } from '@/lib/fiscal-year';
@@ -19,6 +20,7 @@ import {
   taxFiscalYearRowsToCsv,
   type TaxFiscalYearRow,
 } from '@/lib/tax-fiscal-year-report';
+import { formatMoneyLineWithFxToDefault, loadFxMultipliersToAdminDefault } from '@/lib/vendor-spend';
 import type { Expense } from '@/types/expenses';
 
 /** Earliest Hong Kong FY start year offered in the selector (April Y → March Y+1). */
@@ -42,6 +44,8 @@ export function TaxFiscalYearPanel() {
   const [isLoading, setIsLoading] = useState(true);
   const [expensesPayload, setExpensesPayload] = useState<Expense[] | null>(null);
   const [issuedInvoicesPayload, setIssuedInvoicesPayload] = useState<CustomerInvoiceSummary[] | null>(null);
+  const [fxMultipliers, setFxMultipliers] = useState<Map<string, number> | null>(null);
+  const [fxError, setFxError] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -81,6 +85,46 @@ export function TaxFiscalYearPanel() {
     return buildTaxFiscalYearRows(expensesPayload, issuedInvoicesPayload, fyStartYear);
   }, [expensesPayload, issuedInvoicesPayload, fyStartYear]);
 
+  const rowsNeedForeignFx = useMemo(() => {
+    const defaultCurrency = getAdminDefaultCurrencyCode();
+    return rows.some((row) => (row.currency?.trim().toUpperCase() || defaultCurrency) !== defaultCurrency);
+  }, [rows]);
+
+  useEffect(() => {
+    if (!expensesPayload || !issuedInvoicesPayload) {
+      return;
+    }
+    let cancelled = false;
+    const defaultCurrency = getAdminDefaultCurrencyCode();
+    const needsFx = rows.some(
+      (row) => (row.currency?.trim().toUpperCase() || defaultCurrency) !== defaultCurrency,
+    );
+    if (!needsFx) {
+      setFxMultipliers(new Map());
+      setFxError('');
+      return;
+    }
+    setFxMultipliers(null);
+    void (async () => {
+      try {
+        const codes = rows.map((row) => row.currency?.trim().toUpperCase()).filter(Boolean);
+        const map = await loadFxMultipliersToAdminDefault(codes);
+        if (!cancelled) {
+          setFxMultipliers(map);
+          setFxError('');
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setFxError(toErrorMessage(error, 'Could not load FX rates for currency conversion.'));
+          setFxMultipliers(new Map());
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [rows, expensesPayload, issuedInvoicesPayload]);
+
   const fyMeta = useMemo(() => getFiscalYearRangeInclusive(fyStartYear), [fyStartYear]);
 
   const fyYearOptions = useMemo(() => {
@@ -101,7 +145,7 @@ export function TaxFiscalYearPanel() {
     URL.revokeObjectURL(url);
   }, [rows, fyStartYear]);
 
-  const tableError = loadError;
+  const tableError = [loadError, fxError].filter(Boolean).join(' ') || undefined;
 
   return (
     <PaginatedTableCard
@@ -181,26 +225,20 @@ export function TaxFiscalYearPanel() {
                 <p className='font-medium text-slate-900'>{row.description}</p>
               </td>
               <td className='px-4 py-3'>
-                {!row.amount ? (
-                  '—'
-                ) : row.currency ? (
-                  <span className='tabular-nums'>
-                    {row.amount} {row.currency}
-                  </span>
-                ) : (
-                  <span className='tabular-nums'>{row.amount}</span>
-                )}
+                <span className='tabular-nums'>
+                  {fxMultipliers === null && rowsNeedForeignFx
+                    ? '…'
+                    : formatMoneyLineWithFxToDefault(row.amount, row.currency, fxMultipliers ?? new Map())}
+                </span>
               </td>
               <td className='px-4 py-3'>
-                {isTaxDisplayedAsDash(row.tax) ? (
-                  '—'
-                ) : row.currency ? (
-                  <span className='tabular-nums'>
-                    {row.tax} {row.currency}
-                  </span>
-                ) : (
-                  <span className='tabular-nums'>{row.tax}</span>
-                )}
+                <span className='tabular-nums'>
+                  {isTaxDisplayedAsDash(row.tax)
+                    ? '—'
+                    : fxMultipliers === null && rowsNeedForeignFx
+                      ? '…'
+                      : formatMoneyLineWithFxToDefault(row.tax, row.currency, fxMultipliers ?? new Map())}
+                </span>
               </td>
               <td className='px-4 py-3'>
                 {row.kind === 'expense' && row.expenseStatus ? formatEnumLabel(row.expenseStatus) : '—'}

--- a/apps/admin_web/src/lib/vendor-spend.ts
+++ b/apps/admin_web/src/lib/vendor-spend.ts
@@ -92,3 +92,70 @@ export function formatAmountInCurrency(value: number, currencyCode: string): str
 export function formatAmountInDefaultCurrency(value: number): string {
   return formatAmountInCurrency(value, getAdminDefaultCurrencyCode());
 }
+
+/**
+ * Parses a decimal amount string from forms/API payloads (commas allowed).
+ * Returns null when empty or unparseable; zero is a valid value for display.
+ */
+export function parseMoneyAmountString(value: string | null | undefined): number | null {
+  if (value == null) {
+    return null;
+  }
+  const trimmed = value.trim().replace(/,/g, '');
+  if (!trimmed) {
+    return null;
+  }
+  const n = Number.parseFloat(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Loads Frankfurter multipliers from each ISO code into the admin default currency (see
+ * {@link getAdminDefaultCurrencyCode}). Same conversion basis as vendor spend totals.
+ */
+export async function loadFxMultipliersToAdminDefault(fromIsoCodes: Iterable<string>): Promise<Map<string, number>> {
+  const targetCurrency = getAdminDefaultCurrencyCode();
+  const unique = Array.from(
+    new Set(
+      Array.from(fromIsoCodes, (raw) => raw.trim().toUpperCase()).filter(
+        (code) => Boolean(code) && code !== targetCurrency,
+      ),
+    ),
+  );
+  const multipliers = new Map<string, number>();
+  await Promise.all(
+    unique.map(async (code) => {
+      multipliers.set(code, await getCurrencyConversionMultiplier(code, targetCurrency));
+    }),
+  );
+  return multipliers;
+}
+
+/**
+ * One-line money display in admin default currency when {@link parseMoneyAmountString} succeeds.
+ * When the row currency differs from default: `{converted default} ({original formatted})`, using the same
+ * {@link formatAmountInCurrency} styling as the Vendors total spend column.
+ */
+export function formatMoneyLineWithFxToDefault(
+  amountStr: string,
+  currencyRaw: string | undefined,
+  multipliers: Map<string, number>,
+): string {
+  const amount = parseMoneyAmountString(amountStr);
+  if (amount == null) {
+    return '—';
+  }
+  const defaultCurrency = getAdminDefaultCurrencyCode();
+  const currency = currencyRaw?.trim().toUpperCase() || defaultCurrency;
+  const originalFormatted = formatAmountInCurrency(amount, currency);
+  if (currency === defaultCurrency) {
+    return originalFormatted;
+  }
+  const mult = multipliers.get(currency);
+  if (mult == null) {
+    return originalFormatted;
+  }
+  const converted = amount * mult;
+  const primary = formatAmountInCurrency(converted, defaultCurrency);
+  return `${primary} (${originalFormatted})`;
+}

--- a/apps/admin_web/tests/lib/vendor-spend.test.ts
+++ b/apps/admin_web/tests/lib/vendor-spend.test.ts
@@ -5,6 +5,8 @@ import {
   computeVendorSpendInDefaultCurrencyByVendorId,
   formatAmountInCurrency,
   formatAmountInDefaultCurrency,
+  formatMoneyLineWithFxToDefault,
+  parseMoneyAmountString,
 } from '@/lib/vendor-spend';
 import type { Expense } from '@/types/expenses';
 
@@ -52,6 +54,29 @@ describe('formatAmountInCurrency', () => {
 describe('formatAmountInDefaultCurrency', () => {
   it('delegates to admin default currency', () => {
     expect(formatAmountInDefaultCurrency(1234.56)).toBe('HK$1,234.56');
+  });
+});
+
+describe('parseMoneyAmountString', () => {
+  it('parses commas and zero', () => {
+    expect(parseMoneyAmountString('')).toBeNull();
+    expect(parseMoneyAmountString('1,234.5')).toBe(1234.5);
+    expect(parseMoneyAmountString('0')).toBe(0);
+  });
+});
+
+describe('formatMoneyLineWithFxToDefault', () => {
+  it('formats default currency only when codes match', () => {
+    expect(formatMoneyLineWithFxToDefault('100', 'HKD', new Map())).toBe('HK$100.00');
+  });
+
+  it('shows converted default with original in parentheses when FX is present', () => {
+    const mult = new Map<string, number>([['GBP', 10]]);
+    expect(formatMoneyLineWithFxToDefault('20', 'GBP', mult)).toBe('HK$200.00 (£20.00)');
+  });
+
+  it('falls back to original only when multiplier is missing', () => {
+    expect(formatMoneyLineWithFxToDefault('20', 'GBP', new Map())).toBe('£20.00');
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Finance **Tax** tab in admin web:

- Card title is **Tax** (replacing “Tax (fiscal year)”).
- Fiscal year selector lists Hong Kong FYs from **2024** onward through next year (relative to “today” in HK), with option labels **`{startYear} - {endYear}`** (e.g. `2026 - 2027`).
- Description column no longer shows the reference UUID under the text (CSV export still includes `reference_id`).
- Tax column shows an empty-style dash for zero numeric tax values (`0`, `0.00`, etc.), matching empty cells.
- **Amount** and **Tax** columns use the same parsing and `Intl` currency formatting as **Vendors → Total spend** (`formatAmountInCurrency` / admin default currency via `NEXT_PUBLIC_ADMIN_DEFAULT_CURRENCY`). Foreign rows convert through Frankfurter (same as vendor spend) and display **`{primary in default currency} ({original formatted})`**, e.g. `HK$200.00 (£20.00)`. While FX rates load for foreign-currency rows, cells show `…`; FX failures surface an error message and cells fall back to the original-currency formatted amount only.

## Tests

- `cd apps/admin_web && npm run lint`
- `npx vitest run tests/lib/vendor-spend.test.ts tests/lib/tax-fiscal-year-report.test.ts tests/components/admin/finance/finance-page.test.tsx`
- `bash scripts/validate-cursorrules.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00ab7c11-bc1f-4c90-80ed-3ed4251bcd8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00ab7c11-bc1f-4c90-80ed-3ed4251bcd8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

