### PR TITLE
feat(public_www): lazy-load Turnstile until form interaction

### DIFF
--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -124,6 +124,7 @@ interface BookingReservationFormProps {
    * as the form renders. Pass `true` when the form is rendered inside a
    * modal that opens on user intent (the modal-open click already implies
    * interaction). Defaults to `false`.
+   * When false, Turnstile (and the Stripe PaymentIntent prefetch that depends on its token) will only initialise after the user begins interacting with the form.
    */
   initiallyInteracted?: boolean;
   onSubmitReservation: (summary: ReservationSummary) => void;

--- a/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
+++ b/apps/public_www/src/components/sections/booking-modal/reservation-form.tsx
@@ -33,6 +33,7 @@ import {
   resolveCaptchaErrorMessage,
   useFormSubmission,
 } from '@/components/sections/shared/use-form-submission';
+import { useFormInteractionGate } from '@/components/sections/shared/use-form-interaction';
 import { ButtonPrimitive } from '@/components/shared/button-primitive';
 import {
   SubmitButtonLoadingContent,
@@ -118,6 +119,13 @@ interface BookingReservationFormProps {
   prefilledDiscountCode?: string;
   referralAppliedNote?: string;
   referralAppliedAnnouncement?: string;
+  /**
+   * Pre-flips the captcha-load gate so the Turnstile widget mounts as soon
+   * as the form renders. Pass `true` when the form is rendered inside a
+   * modal that opens on user intent (the modal-open click already implies
+   * interaction). Defaults to `false`.
+   */
+  initiallyInteracted?: boolean;
   onSubmitReservation: (summary: ReservationSummary) => void;
 }
 
@@ -458,6 +466,7 @@ export function BookingReservationForm({
   prefilledDiscountCode = '',
   referralAppliedNote = '',
   referralAppliedAnnouncement = '',
+  initiallyInteracted = false,
   onSubmitReservation,
 }: BookingReservationFormProps) {
   const dialCodeOptionTemplate = getContent(locale).common.phoneDialCodeOptionTemplate;
@@ -503,6 +512,8 @@ export function BookingReservationForm({
   } = useFormSubmission({
     turnstileSiteKey,
   });
+  const { hasFormInteracted, markFormInteracted, formInteractionProps } =
+    useFormInteractionGate({ initiallyInteracted });
   const paymentMethodFlags = useMemo(() => {
     return resolvePaymentMethodFlags(resolvePublicBookingPaymentOptionFlags());
   }, []);
@@ -987,6 +998,7 @@ export function BookingReservationForm({
     }
     setIsAcknowledgementsTouched(true);
     markCaptchaTouched();
+    markFormInteracted();
     clearSubmissionError();
 
     trackPublicFormOutcome('booking_submit_attempt', {
@@ -1466,6 +1478,7 @@ export function BookingReservationForm({
         </p>
 
         <form
+          {...formInteractionProps}
           noValidate
           className='relative z-10 mt-4 space-y-3'
           onSubmit={handleSubmit}
@@ -1484,20 +1497,35 @@ export function BookingReservationForm({
             hasPhoneInvalidForCountry={hasPhoneInvalidForCountry}
             hasTopicsError={hasTopicsError}
             topicsFieldConfig={topicsFieldConfig}
-            onFullNameChange={setFullName}
+            onFullNameChange={(value) => {
+              markFormInteracted();
+              setFullName(value);
+            }}
             onFullNameBlur={() => {
               setIsFullNameTouched(true);
             }}
-            onEmailChange={setEmail}
+            onEmailChange={(value) => {
+              markFormInteracted();
+              setEmail(value);
+            }}
             onEmailBlur={() => {
               setIsEmailTouched(true);
             }}
-            onPhoneCountryChange={setPhoneCountry}
-            onPhoneChange={setPhone}
+            onPhoneCountryChange={(value) => {
+              markFormInteracted();
+              setPhoneCountry(value);
+            }}
+            onPhoneChange={(value) => {
+              markFormInteracted();
+              setPhone(value);
+            }}
             onPhoneBlur={() => {
               setIsPhoneTouched(true);
             }}
-            onTopicsChange={setInterestedTopics}
+            onTopicsChange={(value) => {
+              markFormInteracted();
+              setInterestedTopics(value);
+            }}
             onTopicsBlur={() => {
               setIsTopicsTouched(true);
             }}
@@ -1510,6 +1538,7 @@ export function BookingReservationForm({
             hasDiscountRule={Boolean(discountRule)}
             isDiscountValidationSubmitting={isDiscountValidationSubmitting}
             onDiscountCodeChange={(value) => {
+              markFormInteracted();
               setDiscountCode(value);
               setDiscountError('');
             }}
@@ -1577,6 +1606,7 @@ export function BookingReservationForm({
                             value={PAYMENT_METHOD_FPS}
                             checked={selectedPaymentMethod === PAYMENT_METHOD_FPS}
                             onChange={() => {
+                              markFormInteracted();
                               setSelectedPaymentMethod(PAYMENT_METHOD_FPS);
                               trackAnalyticsEvent('booking_payment_method_selected', {
                                 sectionId: analyticsSectionId,
@@ -1625,6 +1655,7 @@ export function BookingReservationForm({
                             value={PAYMENT_METHOD_BANK_TRANSFER}
                             checked={selectedPaymentMethod === PAYMENT_METHOD_BANK_TRANSFER}
                             onChange={() => {
+                              markFormInteracted();
                               setSelectedPaymentMethod(PAYMENT_METHOD_BANK_TRANSFER);
                               trackAnalyticsEvent('booking_payment_method_selected', {
                                 sectionId: analyticsSectionId,
@@ -1675,6 +1706,7 @@ export function BookingReservationForm({
                             value={PAYMENT_METHOD_STRIPE}
                             checked={selectedPaymentMethod === PAYMENT_METHOD_STRIPE}
                             onChange={() => {
+                              markFormInteracted();
                               setSelectedPaymentMethod(PAYMENT_METHOD_STRIPE);
                               trackAnalyticsEvent('booking_payment_method_selected', {
                                 sectionId: analyticsSectionId,
@@ -1800,6 +1832,7 @@ export function BookingReservationForm({
                 required
                 checked={hasPendingReservationAcknowledgement}
                 onChange={(event) => {
+                  markFormInteracted();
                   setHasPendingReservationAcknowledgement(event.target.checked);
                 }}
                 className='es-focus-ring mt-1 h-4 w-4 shrink-0 es-accent-brand'
@@ -1819,6 +1852,7 @@ export function BookingReservationForm({
                 required
                 checked={hasTermsAgreement}
                 onChange={(event) => {
+                  markFormInteracted();
                   setHasTermsAgreement(event.target.checked);
                 }}
                 className='es-focus-ring mt-1 h-4 w-4 shrink-0 es-accent-brand'
@@ -1855,6 +1889,7 @@ export function BookingReservationForm({
                 type='checkbox'
                 checked={marketingOptIn}
                 onChange={(event) => {
+                  markFormInteracted();
                   setMarketingOptIn(event.target.checked);
                 }}
                 className='es-focus-ring mt-1 h-4 w-4 shrink-0 es-accent-brand'
@@ -1865,17 +1900,19 @@ export function BookingReservationForm({
             </label>
           </div>
 
-          <label className='relative z-20 block overflow-visible'>
-            <span className='mb-1 block text-sm font-semibold es-text-heading'>
-              {content.captchaLabel}
-            </span>
-            <TurnstileCaptcha
-              siteKey={turnstileSiteKey}
-              widgetAction={captchaWidgetAction}
-              onTokenChange={handleCaptchaTokenChange}
-              onLoadError={handleCaptchaLoadError}
-            />
-          </label>
+          {hasFormInteracted ? (
+            <label className='relative z-20 block overflow-visible'>
+              <span className='mb-1 block text-sm font-semibold es-text-heading'>
+                {content.captchaLabel}
+              </span>
+              <TurnstileCaptcha
+                siteKey={turnstileSiteKey}
+                widgetAction={captchaWidgetAction}
+                onTokenChange={handleCaptchaTokenChange}
+                onLoadError={handleCaptchaLoadError}
+              />
+            </label>
+          ) : null}
           {captchaErrorMessage ? (
             <p
               id={CAPTCHA_ERROR_MESSAGE_ID}

--- a/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/consultations/consultation-booking-modal.tsx
@@ -523,6 +523,8 @@ export function ConsultationBookingModal({
         subtitleSlot={subtitleSlot}
       />
       <BookingReservationForm
+        // Modal open implies user intent; pre-mount Turnstile to keep Stripe PaymentIntent prefetch.
+        initiallyInteracted
         locale={locale}
         content={paymentModalContent}
         eventTitle={bookingPayload.title}

--- a/apps/public_www/src/components/sections/contact-us-form-fields.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form-fields.tsx
@@ -35,6 +35,9 @@ interface ContactFormFieldsProps {
   hasFirstNameError: boolean;
   hasMessageError: boolean;
   marketingOptIn: boolean;
+  hasFormInteracted: boolean;
+  formInteractionProps: { onFocus: () => void };
+  onMarkFormInteracted: () => void;
   captchaErrorMessage: string;
   submitErrorMessage: string;
   turnstileSiteKey: string;
@@ -60,6 +63,9 @@ export function ContactFormFields({
   hasFirstNameError,
   hasMessageError,
   marketingOptIn,
+  hasFormInteracted,
+  formInteractionProps,
+  onMarkFormInteracted: _onMarkFormInteracted,
   captchaErrorMessage,
   submitErrorMessage,
   turnstileSiteKey,
@@ -89,7 +95,7 @@ export function ContactFormFields({
       : undefined;
 
   return (
-    <form noValidate onSubmit={onSubmit} className='relative z-10 space-y-3'>
+    <form noValidate {...formInteractionProps} onSubmit={onSubmit} className='relative z-10 space-y-3'>
       <label className='block'>
         <span className='mb-1 block text-sm font-semibold es-text-heading'>
           {content.firstNameLabel}
@@ -223,17 +229,19 @@ export function ContactFormFields({
         onChange={onMarketingOptInChange}
       />
 
-      <label className='block'>
-        <span className='mb-1 block text-sm font-semibold es-text-heading'>
-          {content.captchaLabel}
-        </span>
-        <TurnstileCaptcha
-          siteKey={turnstileSiteKey}
-          widgetAction='contact_us_form_submit'
-          onTokenChange={onCaptchaTokenChange}
-          onLoadError={onCaptchaLoadError}
-        />
-      </label>
+      {hasFormInteracted ? (
+        <label className='block'>
+          <span className='mb-1 block text-sm font-semibold es-text-heading'>
+            {content.captchaLabel}
+          </span>
+          <TurnstileCaptcha
+            siteKey={turnstileSiteKey}
+            widgetAction='contact_us_form_submit'
+            onTokenChange={onCaptchaTokenChange}
+            onLoadError={onCaptchaLoadError}
+          />
+        </label>
+      ) : null}
       {captchaErrorMessage ? (
         <p
           id={CAPTCHA_ERROR_MESSAGE_ID}

--- a/apps/public_www/src/components/sections/contact-us-form-fields.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form-fields.tsx
@@ -37,7 +37,6 @@ interface ContactFormFieldsProps {
   marketingOptIn: boolean;
   hasFormInteracted: boolean;
   formInteractionProps: { onFocus: () => void };
-  onMarkFormInteracted: () => void;
   captchaErrorMessage: string;
   submitErrorMessage: string;
   turnstileSiteKey: string;
@@ -65,7 +64,6 @@ export function ContactFormFields({
   marketingOptIn,
   hasFormInteracted,
   formInteractionProps,
-  onMarkFormInteracted: _onMarkFormInteracted,
   captchaErrorMessage,
   submitErrorMessage,
   turnstileSiteKey,

--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -375,7 +375,6 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
                 marketingOptIn={marketingOptIn}
                 hasFormInteracted={hasFormInteracted}
                 formInteractionProps={formInteractionProps}
-                onMarkFormInteracted={markFormInteracted}
                 captchaErrorMessage={captchaErrorMessage}
                 submitErrorMessage={submitErrorMessage}
                 turnstileSiteKey={turnstileSiteKey}

--- a/apps/public_www/src/components/sections/contact-us-form.tsx
+++ b/apps/public_www/src/components/sections/contact-us-form.tsx
@@ -10,6 +10,7 @@ import {
   type ContactUsFormState,
 } from '@/components/sections/contact-us-form-fields';
 import { ContactFormSuccess } from '@/components/sections/contact-us-form-success';
+import { useFormInteractionGate } from '@/components/sections/shared/use-form-interaction';
 import {
   resolveCaptchaErrorMessage,
   useFormSubmission,
@@ -85,6 +86,8 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
   } = useFormSubmission({
     turnstileSiteKey,
   });
+  const { hasFormInteracted, markFormInteracted, formInteractionProps } =
+    useFormInteractionGate();
 
   const hasEmailError = isEmailTouched && !isValidEmail(formState.email);
   const phoneNationalDigits = formState.phone.replace(/\D/g, '');
@@ -110,6 +113,7 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
   const isSubmitDisabled = isCaptchaUnavailable || isSubmitting;
   const whatsappHref = contactConfig.whatsappUrl?.trim() ?? '';
   function updateField(field: keyof ContactUsFormState, value: string) {
+    markFormInteracted();
     setFormState((currentState) => ({
       ...currentState,
       [field]: value,
@@ -133,6 +137,7 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
     setIsFirstNameTouched(true);
     setIsMessageTouched(true);
     markCaptchaTouched();
+    markFormInteracted();
 
     if (
       !sanitizeSingleLineValue(formState.firstName) ||
@@ -368,6 +373,9 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
                 hasFirstNameError={hasFirstNameError}
                 hasMessageError={hasMessageError}
                 marketingOptIn={marketingOptIn}
+                hasFormInteracted={hasFormInteracted}
+                formInteractionProps={formInteractionProps}
+                onMarkFormInteracted={markFormInteracted}
                 captchaErrorMessage={captchaErrorMessage}
                 submitErrorMessage={submitErrorMessage}
                 turnstileSiteKey={turnstileSiteKey}
@@ -387,7 +395,10 @@ export function ContactUsForm({ content, locale, contactConfig }: ContactUsFormP
                 onMessageBlur={() => {
                   setIsMessageTouched(true);
                 }}
-                onMarketingOptInChange={setMarketingOptIn}
+                onMarketingOptInChange={(checked) => {
+                  markFormInteracted();
+                  setMarketingOptIn(checked);
+                }}
                 onCaptchaTokenChange={handleCaptchaTokenChange}
                 onCaptchaLoadError={handleCaptchaLoadError}
               />

--- a/apps/public_www/src/components/sections/event-notification.tsx
+++ b/apps/public_www/src/components/sections/event-notification.tsx
@@ -9,6 +9,7 @@ import {
   submitButtonClassName,
 } from '@/components/shared/submit-button-loading-content';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
+import { useFormInteractionGate } from '@/components/sections/shared/use-form-interaction';
 import { SectionContainer } from '@/components/sections/shared/section-container';
 import { renderQuotedDescriptionText } from '@/components/sections/shared/render-highlighted-text';
 import {
@@ -75,6 +76,8 @@ export function EventNotification({
   } = useFormSubmission({
     turnstileSiteKey,
   });
+  const { hasFormInteracted, markFormInteracted, formInteractionProps } =
+    useFormInteractionGate();
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const submitCtaLabel = content.formSubmitLabel ?? content.ctaLabel;
   const submitLoadingLabel = commonFormActionsContent.submittingLabel;
@@ -122,6 +125,7 @@ export function EventNotification({
     clearSubmissionError();
     setIsEmailTouched(true);
     markCaptchaTouched();
+    markFormInteracted();
 
     trackPublicFormOutcome('community_signup_submit_attempt', {
       formKind: 'community',
@@ -263,6 +267,7 @@ export function EventNotification({
                 }`}
               >
                 <form
+                  {...formInteractionProps}
                   onSubmit={handleSubmit}
                   noValidate
                   className={`flex min-h-0 flex-col gap-3 overflow-hidden transition-opacity duration-300 ease-out motion-reduce:transition-none ${
@@ -301,6 +306,7 @@ export function EventNotification({
                           autoComplete='email'
                           value={email}
                           onChange={(event) => {
+                            markFormInteracted();
                             setEmail(event.target.value);
                           }}
                           onBlur={() => {
@@ -325,22 +331,24 @@ export function EventNotification({
                           {content.emailValidationMessage}
                         </p>
                       ) : null}
-                      <label className='block'>
-                        <span className='mb-1 block text-sm font-semibold es-text-heading'>
-                          {captchaLabel}
-                        </span>
-                        <TurnstileCaptcha
-                          siteKey={turnstileSiteKey}
-                          widgetAction='event_notification_submit'
-                          onTokenChange={handleCaptchaTokenChange}
-                          onLoadError={() => {
-                            handleCaptchaLoadError();
-                            setSubmissionError(
-                              content.captchaLoadError ?? commonCaptchaContent.loadError,
-                            );
-                          }}
-                        />
-                      </label>
+                      {hasFormInteracted ? (
+                        <label className='block'>
+                          <span className='mb-1 block text-sm font-semibold es-text-heading'>
+                            {captchaLabel}
+                          </span>
+                          <TurnstileCaptcha
+                            siteKey={turnstileSiteKey}
+                            widgetAction='event_notification_submit'
+                            onTokenChange={handleCaptchaTokenChange}
+                            onLoadError={() => {
+                              handleCaptchaLoadError();
+                              setSubmissionError(
+                                content.captchaLoadError ?? commonCaptchaContent.loadError,
+                              );
+                            }}
+                          />
+                        </label>
+                      ) : null}
                       {captchaErrorMessage ? (
                         <p
                           id={CAPTCHA_ERROR_MESSAGE_ID}

--- a/apps/public_www/src/components/sections/events/event-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/events/event-booking-modal.tsx
@@ -102,6 +102,8 @@ export function EventBookingModal({
         detailsVariant='event'
       />
       <BookingReservationForm
+        // Modal open implies user intent; pre-mount Turnstile to keep Stripe PaymentIntent prefetch.
+        initiallyInteracted
         locale={locale}
         content={paymentModalContent}
         eventTitle={bookingPayload.title}

--- a/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
+++ b/apps/public_www/src/components/sections/landing-pages/landing-page-free-intro-call.tsx
@@ -43,7 +43,11 @@ import { trackMetaPixelEvent } from '@/lib/meta-pixel';
 import { PIXEL_CONTENT_NAME } from '@/lib/meta-pixel-taxonomy';
 import { isValidPhoneForRegion } from '@/lib/public-phone-validation';
 import { submitReservation, type ReservationSubmissionPayload } from '@/lib/reservations-data';
-import { resolveCaptchaErrorMessage, useFormSubmission } from '@/components/sections/shared/use-form-submission';
+import { useFormInteractionGate } from '@/components/sections/shared/use-form-interaction';
+import {
+  resolveCaptchaErrorMessage,
+  useFormSubmission,
+} from '@/components/sections/shared/use-form-submission';
 import { formatSitePartDate, formatSiteTimeOfDay } from '@/lib/site-datetime';
 import { isValidEmail, sanitizeSingleLineValue } from '@/lib/validation';
 
@@ -119,7 +123,6 @@ export function LandingPageFreeIntroCall({
   const [phone, setPhone] = useState('');
   const [interestedTopics, setInterestedTopics] = useState('');
   const [marketingOptIn, setMarketingOptIn] = useState(false);
-  const [hasFormInteracted, setHasFormInteracted] = useState(false);
   const [isFullNameTouched, setIsFullNameTouched] = useState(false);
   const [isEmailTouched, setIsEmailTouched] = useState(false);
   const [isPhoneTouched, setIsPhoneTouched] = useState(false);
@@ -143,6 +146,8 @@ export function LandingPageFreeIntroCall({
     submitErrorMessage,
     withSubmitting,
   } = useFormSubmission({ turnstileSiteKey });
+  const { hasFormInteracted, markFormInteracted, formInteractionProps } =
+    useFormInteractionGate();
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -178,11 +183,11 @@ export function LandingPageFreeIntroCall({
   }, [introContent.selectedSlotSummaryTemplate, locale, selectedSlot]);
 
   const handleSelectSlot = useCallback((slot: IntroCallSlot | null) => {
-    setHasFormInteracted(true);
+    markFormInteracted();
     setSelectedSlot(slot);
     setRecentCooldownMessage(false);
     clearSubmissionError();
-  }, [clearSubmissionError]);
+  }, [clearSubmissionError, markFormInteracted]);
 
   const captchaInlineError = resolveCaptchaErrorMessage(
     {
@@ -195,7 +200,7 @@ export function LandingPageFreeIntroCall({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setHasFormInteracted(true);
+    markFormInteracted();
     if (isSubmitting || isSuccess) {
       return;
     }
@@ -506,14 +511,11 @@ export function LandingPageFreeIntroCall({
                   </a>
                 </p>
               ) : null}
-              {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- defer Turnstile until focus enters booking fields */}
               <form
+                {...formInteractionProps}
                 id='intro-call-booking-form'
                 aria-labelledby='intro-call-booking-heading'
                 noValidate
-                onFocus={() => {
-                  setHasFormInteracted(true);
-                }}
                 onSubmit={(e) => {
                   void handleSubmit(e);
                 }}
@@ -548,26 +550,26 @@ export function LandingPageFreeIntroCall({
                     required: false,
                   }}
                   onFullNameChange={(v) => {
-                    setHasFormInteracted(true);
+                    markFormInteracted();
                     setFullName(v);
                   }}
                   onFullNameBlur={() => setIsFullNameTouched(true)}
                   onEmailChange={(v) => {
-                    setHasFormInteracted(true);
+                    markFormInteracted();
                     setEmail(v);
                   }}
                   onEmailBlur={() => setIsEmailTouched(true)}
                   onPhoneCountryChange={(v) => {
-                    setHasFormInteracted(true);
+                    markFormInteracted();
                     setPhoneCountry(v);
                   }}
                   onPhoneChange={(v) => {
-                    setHasFormInteracted(true);
+                    markFormInteracted();
                     setPhone(v);
                   }}
                   onPhoneBlur={() => setIsPhoneTouched(true)}
                   onTopicsChange={(v) => {
-                    setHasFormInteracted(true);
+                    markFormInteracted();
                     setInterestedTopics(v);
                   }}
                   onTopicsBlur={() => {}}
@@ -578,7 +580,7 @@ export function LandingPageFreeIntroCall({
                     required
                     checked={hasTermsAgreement}
                     onChange={(event) => {
-                      setHasFormInteracted(true);
+                      markFormInteracted();
                       setHasTermsAgreement(event.target.checked);
                     }}
                     className='es-focus-ring mt-1 h-4 w-4 shrink-0 es-accent-brand'
@@ -609,7 +611,7 @@ export function LandingPageFreeIntroCall({
                 <MarketingOptInCheckbox
                   checked={marketingOptIn}
                   onChange={(checked) => {
-                    setHasFormInteracted(true);
+                    markFormInteracted();
                     setMarketingOptIn(checked);
                   }}
                   label={paymentModalContent.marketingOptInLabel}

--- a/apps/public_www/src/components/sections/media-form.tsx
+++ b/apps/public_www/src/components/sections/media-form.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/shared/submit-button-loading-content';
 import { MarketingOptInCheckbox } from '@/components/shared/marketing-opt-in-checkbox';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
+import { useFormInteractionGate } from '@/components/sections/shared/use-form-interaction';
 import {
   resolveCaptchaErrorMessage,
   useFormSubmission,
@@ -119,6 +120,8 @@ export function MediaForm({
   } = useFormSubmission({
     turnstileSiteKey,
   });
+  const { hasFormInteracted, markFormInteracted, formInteractionProps } =
+    useFormInteractionGate();
   const isServiceUnavailable = !crmApiClient || isCaptchaUnavailable;
   const hasFirstNameError = isFirstNameTouched && !sanitizeSingleLineValue(firstName);
   const hasEmailError = isEmailTouched && !isValidEmail(email);
@@ -192,6 +195,7 @@ export function MediaForm({
     setIsFirstNameTouched(true);
     setIsEmailTouched(true);
     markCaptchaTouched();
+    markFormInteracted();
 
     const normalizedResourceKey = normalizeResourceKey(resourceKey ?? '');
     trackPublicFormOutcome('media_form_submit_attempt', {
@@ -314,6 +318,7 @@ export function MediaForm({
 
   return (
     <form
+      {...formInteractionProps}
       onSubmit={handleSubmit}
       className={mergeClassNames(
         'mt-7 w-full max-w-[420px] space-y-3 opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none',
@@ -335,6 +340,7 @@ export function MediaForm({
           autoComplete='given-name'
           value={firstName}
           onChange={(event) => {
+            markFormInteracted();
             setFirstName(event.target.value);
           }}
           onBlur={() => {
@@ -366,6 +372,7 @@ export function MediaForm({
           autoComplete='email'
           value={email}
           onChange={(event) => {
+            markFormInteracted();
             setEmail(event.target.value);
           }}
           onBlur={() => {
@@ -387,20 +394,25 @@ export function MediaForm({
       <MarketingOptInCheckbox
         label={formMarketingOptInLabel}
         checked={marketingOptIn}
-        onChange={setMarketingOptIn}
+        onChange={(checked) => {
+          markFormInteracted();
+          setMarketingOptIn(checked);
+        }}
       />
 
-      <label className='block'>
-        <span className='mb-1 block text-sm font-semibold es-text-heading'>
-          {formCaptchaLabel}
-        </span>
-        <TurnstileCaptcha
-          siteKey={turnstileSiteKey}
-          widgetAction='media_submit'
-          onTokenChange={handleCaptchaTokenChange}
-          onLoadError={handleCaptchaLoadError}
-        />
-      </label>
+      {hasFormInteracted ? (
+        <label className='block'>
+          <span className='mb-1 block text-sm font-semibold es-text-heading'>
+            {formCaptchaLabel}
+          </span>
+          <TurnstileCaptcha
+            siteKey={turnstileSiteKey}
+            widgetAction='media_submit'
+            onTokenChange={handleCaptchaTokenChange}
+            onLoadError={handleCaptchaLoadError}
+          />
+        </label>
+      ) : null}
 
       {captchaErrorMessage ? (
         <p id={captchaErrorId} className='es-form-submit-error' role='alert'>

--- a/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking-modal.tsx
+++ b/apps/public_www/src/components/sections/my-best-auntie/my-best-auntie-booking-modal.tsx
@@ -174,6 +174,8 @@ export function MyBestAuntieBookingModal({
               detailsVariant='my-best-auntie'
             />
             <BookingReservationForm
+              // Modal open implies user intent; pre-mount Turnstile to keep Stripe PaymentIntent prefetch.
+              initiallyInteracted
               locale={locale}
               content={paymentModalContent}
               eventTitle={modalContent.title}

--- a/apps/public_www/src/components/sections/shared/use-form-interaction.ts
+++ b/apps/public_www/src/components/sections/shared/use-form-interaction.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react';
+
+interface UseFormInteractionGateOptions {
+  initiallyInteracted?: boolean;
+}
+
+interface FormInteractionGate {
+  hasFormInteracted: boolean;
+  markFormInteracted: () => void;
+  // Spread onto the <form> element. Captures the bubbled focus from any
+  // descendant (input, select, textarea, checkbox, etc.) on the first
+  // interaction and ignores subsequent focus changes.
+  formInteractionProps: { onFocus: () => void };
+}
+
+export function useFormInteractionGate(
+  options?: UseFormInteractionGateOptions,
+): FormInteractionGate {
+  const [hasFormInteracted, setHasFormInteracted] = useState(
+    options?.initiallyInteracted ?? false,
+  );
+  const markFormInteracted = useCallback(() => {
+    setHasFormInteracted((current) => (current ? current : true));
+  }, []);
+  return {
+    hasFormInteracted,
+    markFormInteracted,
+    formInteractionProps: { onFocus: markFormInteracted },
+  };
+}

--- a/apps/public_www/src/components/sections/sprouts-squad-community.tsx
+++ b/apps/public_www/src/components/sections/sprouts-squad-community.tsx
@@ -10,6 +10,7 @@ import {
   submitButtonClassName,
 } from '@/components/shared/submit-button-loading-content';
 import { TurnstileCaptcha } from '@/components/shared/turnstile-captcha';
+import { useFormInteractionGate } from '@/components/sections/shared/use-form-interaction';
 import { SectionContainer } from '@/components/sections/shared/section-container';
 import { renderQuotedDescriptionText } from '@/components/sections/shared/render-highlighted-text';
 import {
@@ -81,6 +82,8 @@ export function SproutsSquadCommunity({
   } = useFormSubmission({
     turnstileSiteKey,
   });
+  const { hasFormInteracted, markFormInteracted, formInteractionProps } =
+    useFormInteractionGate();
   const hasEmailError = isEmailTouched && !isValidEmail(email);
   const submitCtaLabel = content.formSubmitLabel ?? content.ctaLabel;
   const submitLoadingLabel = commonFormActionsContent.submittingLabel;
@@ -128,6 +131,7 @@ export function SproutsSquadCommunity({
     clearSubmissionError();
     setIsEmailTouched(true);
     markCaptchaTouched();
+    markFormInteracted();
 
     trackPublicFormOutcome('community_signup_submit_attempt', {
       formKind: 'community',
@@ -280,6 +284,7 @@ export function SproutsSquadCommunity({
                 }`}
               >
                 <form
+                  {...formInteractionProps}
                   onSubmit={handleSubmit}
                   noValidate
                   className={`flex min-h-0 flex-col gap-3 overflow-hidden transition-opacity duration-300 ease-out motion-reduce:transition-none ${
@@ -320,6 +325,7 @@ export function SproutsSquadCommunity({
                           autoComplete='email'
                           value={email}
                           onChange={(event) => {
+                            markFormInteracted();
                             setEmail(event.target.value);
                           }}
                           onBlur={() => {
@@ -344,22 +350,24 @@ export function SproutsSquadCommunity({
                           {content.emailValidationMessage}
                         </p>
                       ) : null}
-                      <label className='block'>
-                        <span className='mb-1 block text-sm font-semibold es-text-heading'>
-                          {captchaLabel}
-                        </span>
-                        <TurnstileCaptcha
-                          siteKey={turnstileSiteKey}
-                          widgetAction='sprouts_squad_community_submit'
-                          onTokenChange={handleCaptchaTokenChange}
-                          onLoadError={() => {
-                            handleCaptchaLoadError();
-                            setSubmissionError(
-                              content.captchaLoadError ?? commonCaptchaContent.loadError,
-                            );
-                          }}
-                        />
-                      </label>
+                      {hasFormInteracted ? (
+                        <label className='block'>
+                          <span className='mb-1 block text-sm font-semibold es-text-heading'>
+                            {captchaLabel}
+                          </span>
+                          <TurnstileCaptcha
+                            siteKey={turnstileSiteKey}
+                            widgetAction='sprouts_squad_community_submit'
+                            onTokenChange={handleCaptchaTokenChange}
+                            onLoadError={() => {
+                              handleCaptchaLoadError();
+                              setSubmissionError(
+                                content.captchaLoadError ?? commonCaptchaContent.loadError,
+                              );
+                            }}
+                          />
+                        </label>
+                      ) : null}
                       {captchaErrorMessage ? (
                         <p
                           id={CAPTCHA_ERROR_MESSAGE_ID}

--- a/apps/public_www/tests/components/sections/booking-modal/reservation-form.test.tsx
+++ b/apps/public_www/tests/components/sections/booking-modal/reservation-form.test.tsx
@@ -1,0 +1,236 @@
+/* eslint-disable @next/next/no-img-element */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { BookingReservationForm } from '@/components/sections/booking-modal/reservation-form';
+import { buildThankYouRecapLabels } from '@/components/sections/booking-modal/thank-you-recap-labels';
+import enContent from '@/content/en.json';
+import type { EventCalendarBookingModalPayload } from '@/lib/events-data';
+
+vi.mock('@/lib/crm-api-client', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/crm-api-client')>(
+    '@/lib/crm-api-client',
+  );
+
+  return {
+    ...actual,
+    createPublicApiClient: vi.fn(() => null),
+    createPublicCrmApiClient: vi.fn(() => null),
+    isAbortRequestError: (error: unknown) =>
+      error instanceof Error && error.name === 'AbortError',
+  };
+});
+
+vi.mock('@/lib/fps-qr-code', () => ({
+  generateFpsQrImageDataUrl: vi.fn(() =>
+    Promise.resolve(
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    ),
+  ),
+  hasFpsQrConfiguration: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/discounts-data', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/discounts-data')>(
+    '@/lib/discounts-data',
+  );
+
+  return {
+    ...actual,
+    validateDiscountCode: vi.fn(() => Promise.resolve(null)),
+  };
+});
+
+vi.mock('@/lib/reservation-payments-data', () => ({
+  createReservationPaymentIntent: vi.fn(() =>
+    Promise.resolve({
+      payment_intent_id: 'pi_mock_123',
+      client_secret: 'pi_mock_123_secret_abc',
+    })),
+}));
+
+vi.mock('@/lib/reservations-data', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/reservations-data')>();
+  return {
+    ...actual,
+    submitReservation: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/analytics', () => ({
+  trackAnalyticsEvent: vi.fn(),
+  trackPublicFormOutcome: vi.fn(),
+  trackEcommerceEvent: vi.fn(),
+}));
+
+vi.mock('@/components/shared/turnstile-captcha', () => ({
+  TurnstileCaptcha: ({
+    onTokenChange,
+  }: {
+    onTokenChange: (token: string | null) => void;
+  }) => (
+    <div data-testid='mock-turnstile-captcha'>
+      <button
+        data-testid='mock-turnstile-captcha-solve'
+        type='button'
+        onClick={() => {
+          onTokenChange('mock-turnstile-token');
+        }}
+      >
+        Solve CAPTCHA
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({
+    alt,
+    ...props
+  }: {
+    alt?: string;
+  } & Record<string, unknown>) => <img alt={alt ?? ''} {...props} />,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  } & Record<string, unknown>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@stripe/stripe-js', () => ({
+  loadStripe: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock('@stripe/react-stripe-js', () => ({
+  Elements: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PaymentElement: () => <div data-testid='mock-stripe-payment-element' />,
+  useElements: () => ({}),
+  useStripe: () => ({
+    confirmPayment: vi.fn(async () => ({
+      paymentIntent: { id: 'pi_test', status: 'succeeded' },
+    })),
+  }),
+}));
+
+const paymentModal = enContent.bookingModal.paymentModal;
+const thankYouModalContent = enContent.bookingModal.thankYouModal;
+const mapsUrl = 'https://maps.example.com/dir?q=venue';
+
+const eventPayload: EventCalendarBookingModalPayload = {
+  variant: 'event',
+  bookingSystem: 'event-booking',
+  serviceKey: 'test-event-1',
+  instanceSlug: 'test-event-instance-slug',
+  title: 'Test Event',
+  subtitle: 'Event subtitle',
+  originalAmount: 100,
+  locationName: 'Venue Name',
+  locationAddress: '1 Test St, Hong Kong',
+  directionHref: mapsUrl,
+  dateParts: [
+    {
+      id: 'part-1',
+      startDateTime: '2026-06-15T10:00:00.000Z',
+      endDateTime: '2026-06-15T11:00:00.000Z',
+      description: 'Part one',
+    },
+  ],
+  selectedDateLabel: '15 Jun 2026',
+  selectedDateStartTime: '2026-06-15T10:00:00.000Z',
+};
+
+describe('BookingReservationForm', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = 'test-turnstile-site-key';
+    process.env.NEXT_PUBLIC_FPS_MERCHANT_NAME = 'Test FPS Merchant';
+    process.env.NEXT_PUBLIC_FPS_MOBILE_NUMBER = '85200000000';
+    process.env.NEXT_PUBLIC_BANK_NAME = 'Test Bank';
+    process.env.NEXT_PUBLIC_BANK_ACCOUNT_HOLDER = 'Test Holder';
+    process.env.NEXT_PUBLIC_BANK_ACCOUNT_NUMBER = '123';
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test_mock_123';
+  });
+
+  it('does not render Turnstile until the user focuses a field by default', async () => {
+    render(
+      <BookingReservationForm
+        locale='en'
+        content={paymentModal}
+        eventTitle={eventPayload.title}
+        serviceKey={eventPayload.serviceKey}
+        bookingSystem={eventPayload.bookingSystem}
+        serviceTypeLabelKey='event'
+        serviceInstanceSlug={eventPayload.instanceSlug}
+        selectedServiceTierLabel=''
+        selectedCohortDateLabel={eventPayload.selectedDateLabel}
+        selectedDateStartTime={eventPayload.selectedDateStartTime}
+        originalPriceAmount={eventPayload.originalAmount}
+        venueName={eventPayload.locationName}
+        venueAddress={eventPayload.locationAddress}
+        venueDirectionHref={eventPayload.directionHref}
+        dateEndTime={eventPayload.dateParts[0].endDateTime}
+        eventSubtitle={eventPayload.subtitle}
+        sessionSlots={eventPayload.dateParts.map((part) => ({
+          dateStartTime: part.startDateTime,
+          dateEndTime: part.endDateTime,
+        }))}
+        descriptionId='booking-test-description'
+        thankYouRecapLabels={buildThankYouRecapLabels(thankYouModalContent)}
+        onSubmitReservation={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.focus(
+      screen.getByLabelText(new RegExp(`^${paymentModal.fullNameLabel}`)),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Turnstile on initial mount when initiallyInteracted is true', () => {
+    render(
+      <BookingReservationForm
+        initiallyInteracted
+        locale='en'
+        content={paymentModal}
+        eventTitle={eventPayload.title}
+        serviceKey={eventPayload.serviceKey}
+        bookingSystem={eventPayload.bookingSystem}
+        serviceTypeLabelKey='event'
+        serviceInstanceSlug={eventPayload.instanceSlug}
+        selectedServiceTierLabel=''
+        selectedCohortDateLabel={eventPayload.selectedDateLabel}
+        selectedDateStartTime={eventPayload.selectedDateStartTime}
+        originalPriceAmount={eventPayload.originalAmount}
+        venueName={eventPayload.locationName}
+        venueAddress={eventPayload.locationAddress}
+        venueDirectionHref={eventPayload.directionHref}
+        dateEndTime={eventPayload.dateParts[0].endDateTime}
+        eventSubtitle={eventPayload.subtitle}
+        sessionSlots={eventPayload.dateParts.map((part) => ({
+          dateStartTime: part.startDateTime,
+          dateEndTime: part.endDateTime,
+        }))}
+        descriptionId='booking-test-description'
+        thankYouRecapLabels={buildThankYouRecapLabels(thankYouModalContent)}
+        onSubmitReservation={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+  });
+});

--- a/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/components/shared/turnstile-captcha', () => ({
 function ContactFormFieldsWithGate(
   props: Omit<
     ComponentProps<typeof ContactFormFields>,
-    'hasFormInteracted' | 'formInteractionProps' | 'onMarkFormInteracted'
+    'hasFormInteracted' | 'formInteractionProps'
   >,
 ) {
   const { hasFormInteracted, markFormInteracted, formInteractionProps } =
@@ -51,7 +51,6 @@ function ContactFormFieldsWithGate(
       {...props}
       hasFormInteracted={hasFormInteracted}
       formInteractionProps={formInteractionProps}
-      onMarkFormInteracted={markFormInteracted}
       onUpdateField={(field, value) => {
         markFormInteracted();
         props.onUpdateField(field, value);

--- a/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form-fields.test.tsx
@@ -1,10 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
   ContactFormFields,
   type ContactUsFormState,
 } from '@/components/sections/contact-us-form-fields';
+import { useFormInteractionGate } from '@/components/sections/shared/use-form-interaction';
 import enContent from '@/content/en.json';
 
 vi.mock('@/components/shared/turnstile-captcha', () => ({
@@ -15,10 +17,10 @@ vi.mock('@/components/shared/turnstile-captcha', () => ({
     onTokenChange: (token: string | null) => void;
     onLoadError: () => void;
   }) => (
-    <div>
+    <div data-testid='mock-turnstile-captcha'>
       <button
         type='button'
-        data-testid='captcha-solve'
+        data-testid='mock-turnstile-captcha-solve'
         onClick={() => {
           onTokenChange('test-token');
         }}
@@ -27,7 +29,7 @@ vi.mock('@/components/shared/turnstile-captcha', () => ({
       </button>
       <button
         type='button'
-        data-testid='captcha-fail'
+        data-testid='mock-turnstile-captcha-fail'
         onClick={onLoadError}
       >
         fail
@@ -35,6 +37,28 @@ vi.mock('@/components/shared/turnstile-captcha', () => ({
     </div>
   ),
 }));
+
+function ContactFormFieldsWithGate(
+  props: Omit<
+    ComponentProps<typeof ContactFormFields>,
+    'hasFormInteracted' | 'formInteractionProps' | 'onMarkFormInteracted'
+  >,
+) {
+  const { hasFormInteracted, markFormInteracted, formInteractionProps } =
+    useFormInteractionGate();
+  return (
+    <ContactFormFields
+      {...props}
+      hasFormInteracted={hasFormInteracted}
+      formInteractionProps={formInteractionProps}
+      onMarkFormInteracted={markFormInteracted}
+      onUpdateField={(field, value) => {
+        markFormInteracted();
+        props.onUpdateField(field, value);
+      }}
+    />
+  );
+}
 
 describe('ContactFormFields', () => {
   it('renders validation errors and emits field + captcha events', () => {
@@ -56,7 +80,7 @@ describe('ContactFormFields', () => {
     );
 
     render(
-      <ContactFormFields
+      <ContactFormFieldsWithGate
         content={enContent.contactUs.form}
         dialCodeOptionTemplate={enContent.common.phoneDialCodeOptionTemplate}
         formState={formState}
@@ -82,6 +106,10 @@ describe('ContactFormFields', () => {
       />,
     );
 
+    fireEvent.focus(
+      screen.getByLabelText(new RegExp(`^${enContent.contactUs.form.firstNameLabel}`)),
+    );
+
     fireEvent.change(screen.getByLabelText(/Email/i), {
       target: { value: 'valid@example.com' },
     });
@@ -99,8 +127,8 @@ describe('ContactFormFields', () => {
         name: new RegExp(`^${enContent.contactUs.form.phoneLabel}`),
       }),
     );
-    fireEvent.click(screen.getByTestId('captcha-solve'));
-    fireEvent.click(screen.getByTestId('captcha-fail'));
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-solve'));
+    fireEvent.click(screen.getByTestId('mock-turnstile-captcha-fail'));
 
     const submitButton = screen.getByRole('button', {
       name: enContent.contactUs.form.submitLabel,
@@ -125,5 +153,100 @@ describe('ContactFormFields', () => {
     expect(
       screen.getByText(enContent.contactUs.form.phoneInvalidForCountry),
     ).toBeInTheDocument();
+  });
+
+  it('does not render Turnstile until the user focuses a field', async () => {
+    const formState: ContactUsFormState = {
+      firstName: '',
+      email: '',
+      phoneCountry: 'HK',
+      phone: '',
+      message: '',
+    };
+
+    render(
+      <ContactFormFieldsWithGate
+        content={enContent.contactUs.form}
+        dialCodeOptionTemplate={enContent.common.phoneDialCodeOptionTemplate}
+        formState={formState}
+        hasEmailError={false}
+        hasPhoneError={false}
+        hasFirstNameError={false}
+        hasMessageError={false}
+        marketingOptIn={false}
+        captchaErrorMessage=''
+        submitErrorMessage=''
+        turnstileSiteKey='site-key'
+        isSubmitting={false}
+        isSubmitDisabled={false}
+        onSubmit={(e) => e.preventDefault()}
+        onUpdateField={vi.fn()}
+        onEmailBlur={vi.fn()}
+        onPhoneBlur={vi.fn()}
+        onFirstNameBlur={vi.fn()}
+        onMessageBlur={vi.fn()}
+        onMarketingOptInChange={vi.fn()}
+        onCaptchaTokenChange={vi.fn()}
+        onCaptchaLoadError={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.focus(
+      screen.getByLabelText(new RegExp(`^${enContent.contactUs.form.firstNameLabel}`)),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Turnstile after a typed field change', async () => {
+    const formState: ContactUsFormState = {
+      firstName: '',
+      email: '',
+      phoneCountry: 'HK',
+      phone: '',
+      message: '',
+    };
+
+    render(
+      <ContactFormFieldsWithGate
+        content={enContent.contactUs.form}
+        dialCodeOptionTemplate={enContent.common.phoneDialCodeOptionTemplate}
+        formState={formState}
+        hasEmailError={false}
+        hasPhoneError={false}
+        hasFirstNameError={false}
+        hasMessageError={false}
+        marketingOptIn={false}
+        captchaErrorMessage=''
+        submitErrorMessage=''
+        turnstileSiteKey='site-key'
+        isSubmitting={false}
+        isSubmitDisabled={false}
+        onSubmit={(e) => e.preventDefault()}
+        onUpdateField={vi.fn()}
+        onEmailBlur={vi.fn()}
+        onPhoneBlur={vi.fn()}
+        onFirstNameBlur={vi.fn()}
+        onMessageBlur={vi.fn()}
+        onMarketingOptInChange={vi.fn()}
+        onCaptchaTokenChange={vi.fn()}
+        onCaptchaLoadError={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(`^${enContent.contactUs.form.firstNameLabel}`)),
+      { target: { value: 'Pat' } },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/public_www/tests/components/sections/contact-us-form.test.tsx
+++ b/apps/public_www/tests/components/sections/contact-us-form.test.tsx
@@ -110,6 +110,35 @@ describe('ContactUsForm section', () => {
 
   });
 
+  it('does not render Turnstile until the user focuses a field', async () => {
+    renderContactUsForm();
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.focus(
+      screen.getByLabelText(new RegExp(`^${enContent.contactUs.form.firstNameLabel}`)),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Turnstile after a typed field change', async () => {
+    renderContactUsForm();
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(`^${enContent.contactUs.form.firstNameLabel}`)),
+      { target: { value: 'Pat' } },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
+  });
+
   it('removes mobile top padding while preserving responsive section spacing', () => {
     renderContactUsForm();
 

--- a/apps/public_www/tests/components/sections/event-notification.test.tsx
+++ b/apps/public_www/tests/components/sections/event-notification.test.tsx
@@ -105,7 +105,7 @@ describe('EventNotification section', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('reveals email input and captcha after initial CTA click', () => {
+  it('reveals email input after initial CTA click without mounting Turnstile yet', () => {
     render(
       <EventNotification
         content={enContent.events.notification}
@@ -124,13 +124,67 @@ describe('EventNotification section', () => {
     expect(
       screen.getByLabelText(new RegExp(enContent.events.notification.emailLabel)),
     ).toBeInTheDocument();
-    expect(screen.getByText(enContent.common.captcha.captchaLabel)).toBeInTheDocument();
-    expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
     expect(
       screen.getByRole('button', {
         name: enContent.events.notification.formSubmitLabel,
       }),
     ).toBeInTheDocument();
+  });
+
+  it('does not render Turnstile after reveal CTA alone; mounts after field focus', async () => {
+    render(
+      <EventNotification
+        content={enContent.events.notification}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.events.notification.ctaLabel,
+      }),
+    );
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.focus(
+      screen.getByLabelText(new RegExp(enContent.events.notification.emailLabel)),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Turnstile after email field change once the form is visible', async () => {
+    render(
+      <EventNotification
+        content={enContent.events.notification}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.events.notification.ctaLabel,
+      }),
+    );
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(enContent.events.notification.emailLabel)),
+      { target: { value: 'events@example.com' } },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
   });
 
   it('shows the loading gear on the submit button while the request is in flight', async () => {

--- a/apps/public_www/tests/components/sections/media-form.test.tsx
+++ b/apps/public_www/tests/components/sections/media-form.test.tsx
@@ -260,8 +260,10 @@ describe('MediaForm', () => {
     expect(
       screen.getByLabelText(new RegExp(enContent.resources.formFirstNameLabel)),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(new RegExp(enContent.resources.formEmailLabel))).toBeInTheDocument();
-    expect(screen.getByText(enContent.resources.formCaptchaLabel)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(new RegExp(enContent.resources.formEmailLabel)),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
     expect(mockedTrackPublicFormOutcome).toHaveBeenCalledWith('media_form_open', {
       formKind: 'media_request',
       formId: 'media-form__media-form',
@@ -438,6 +440,39 @@ describe('MediaForm', () => {
           error_type: 'api_error',
         },
       });
+    });
+  });
+
+  it('does not render Turnstile after reveal CTA alone; mounts after field focus', async () => {
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.focus(
+      screen.getByLabelText(new RegExp(enContent.resources.formFirstNameLabel)),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Turnstile after a typed field change once the form is visible', async () => {
+    renderMediaForm();
+
+    fireEvent.click(screen.getByRole('button', { name: enContent.resources.ctaLabel }));
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(enContent.resources.formFirstNameLabel)),
+      { target: { value: 'Ida' } },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
     });
   });
 

--- a/apps/public_www/tests/components/sections/shared/use-form-interaction.test.ts
+++ b/apps/public_www/tests/components/sections/shared/use-form-interaction.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useFormInteractionGate } from '@/components/sections/shared/use-form-interaction';
+
+describe('useFormInteractionGate', () => {
+  it('defaults hasFormInteracted to false', () => {
+    const { result } = renderHook(() => useFormInteractionGate());
+    expect(result.current.hasFormInteracted).toBe(false);
+  });
+
+  it('starts true when initiallyInteracted is true', () => {
+    const { result } = renderHook(() =>
+      useFormInteractionGate({ initiallyInteracted: true }),
+    );
+    expect(result.current.hasFormInteracted).toBe(true);
+  });
+
+  it('sets hasFormInteracted true when markFormInteracted is called', () => {
+    const { result } = renderHook(() => useFormInteractionGate());
+    act(() => {
+      result.current.markFormInteracted();
+    });
+    expect(result.current.hasFormInteracted).toBe(true);
+  });
+
+  it('sets hasFormInteracted true when formInteractionProps.onFocus is called', () => {
+    const { result } = renderHook(() => useFormInteractionGate());
+    act(() => {
+      result.current.formInteractionProps.onFocus();
+    });
+    expect(result.current.hasFormInteracted).toBe(true);
+  });
+
+  it('only transitions once when markFormInteracted and onFocus run twice', () => {
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount++;
+      return useFormInteractionGate();
+    });
+    const initialRenderCount = renderCount;
+    act(() => {
+      result.current.markFormInteracted();
+      result.current.markFormInteracted();
+      result.current.formInteractionProps.onFocus();
+    });
+    expect(result.current.hasFormInteracted).toBe(true);
+    expect(renderCount - initialRenderCount).toBe(1);
+  });
+});

--- a/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
+++ b/apps/public_www/tests/components/sections/sprouts-squad-community.test.tsx
@@ -149,7 +149,7 @@ describe('SproutsSquadCommunity section', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('reveals email input and captcha after initial CTA click', () => {
+  it('reveals email input after initial CTA click without mounting Turnstile yet', () => {
     render(
       <SproutsSquadCommunity
         content={enContent.sproutsSquadCommunity}
@@ -170,13 +170,67 @@ describe('SproutsSquadCommunity section', () => {
     );
     expect(emailField).toBeInTheDocument();
     expect(emailField.closest('form')).toHaveClass('gap-3');
-    expect(screen.getByText(enContent.common.captcha.captchaLabel)).toBeInTheDocument();
-    expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
     expect(
       screen.getByRole('button', {
         name: enContent.sproutsSquadCommunity.formSubmitLabel,
       }),
     ).toBeInTheDocument();
+  });
+
+  it('does not render Turnstile after reveal CTA alone; mounts after field focus', async () => {
+    render(
+      <SproutsSquadCommunity
+        content={enContent.sproutsSquadCommunity}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.ctaLabel,
+      }),
+    );
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.focus(
+      screen.getByLabelText(new RegExp(enContent.sproutsSquadCommunity.emailLabel)),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Turnstile after email field change once the form is visible', async () => {
+    render(
+      <SproutsSquadCommunity
+        content={enContent.sproutsSquadCommunity}
+        commonCaptchaContent={enContent.common.captcha}
+        commonFormActionsContent={enContent.common.formActions}
+        locale='en'
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: enContent.sproutsSquadCommunity.ctaLabel,
+      }),
+    );
+
+    expect(screen.queryByTestId('mock-turnstile-captcha')).toBeNull();
+
+    fireEvent.change(
+      screen.getByLabelText(new RegExp(enContent.sproutsSquadCommunity.emailLabel)),
+      { target: { value: 'a@b.co' } },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-turnstile-captcha')).toBeInTheDocument();
+    });
   });
 
   it('opens with empty email when sessionStorage has no prefill data', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces `useFormInteractionGate` in `apps/public_www/src/components/sections/shared/use-form-interaction.ts` so Turnstile mounts only after real form interaction (bubbled `focus` on `<form>`, field changes, or submit). Contact Us, Media, Sprouts Squad, and Event Notification forms gate the captcha widget while leaving captcha error copy visible when validation runs.

**Follow-ups (N1–N3):** Removed unused `onMarkFormInteracted` from `ContactFormFields`. `LandingPageFreeIntroCall` now uses the same hook + `formInteractionProps` on `<form>` with defensive `markFormInteracted()` in handlers. Extended `initiallyInteracted` JSDoc on `BookingReservationForm`.

Booking flows keep prior behaviour: `BookingReservationForm` accepts optional `initiallyInteracted` (default `false`). All three booking modals pass `initiallyInteracted` so Turnstile still loads immediately when the modal opens, preserving Stripe PaymentIntent prefetch that depends on `captchaToken`.

## Tests

- `npx vitest run` (full suite in CI)
- `npm run lint`
- Contact Us + intro-call focused tests run locally

## Manual verification (reviewer)

Per plan §8: Network tab on `/contact-us` — no Turnstile script until first field focus; My Best Auntie booking modal — script loads on modal open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaf537c7-2fdc-4f3f-a25c-e97448423288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaf537c7-2fdc-4f3f-a25c-e97448423288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

