### PR TITLE
Raise AwsApiProxy Lambda timeout to 90s (match expense parser)

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1738,7 +1738,7 @@ export class ApiStack extends cdk.Stack {
     const awsProxyFunction = createPythonFunction("AwsApiProxyFunction", {
       handler: "lambda/aws_proxy/handler.lambda_handler",
       memorySize: 256,
-      timeout: cdk.Duration.seconds(15),
+      timeout: cdk.Duration.seconds(90),
       noVpc: true,
       environment: {
         ALLOWED_ACTIONS: allowedProxyActions.join(","),

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -375,7 +375,7 @@ Each Lambda function created by `PythonLambda` construct includes:
 | Function Logical ID | Handler | Memory | Timeout | VPC | Notes |
 |---------------------|---------|--------|---------|-----|-------|
 | `AdminBootstrapFunction` | `lambda/admin_bootstrap/handler.lambda_handler` | 256 MB | 30s | Yes | Custom resource handler |
-| `AwsApiProxyFunction` | `lambda/aws_proxy/handler.lambda_handler` | 256 MB | 15s | No | AWS/HTTP proxy for in-VPC Lambdas |
+| `AwsApiProxyFunction` | `lambda/aws_proxy/handler.lambda_handler` | 256 MB | 90s | No | AWS/HTTP proxy for in-VPC Lambdas |
 | `ApiKeyRotationFunction` | `lambda/api_key_rotation/handler.lambda_handler` | 256 MB | 60s | Yes | Scheduled API key rotation |
 | `MediaRequestProcessor` | `lambda/media_processor/handler.lambda_handler` | 512 MB | 30s | Yes | SQS-triggered media processor (nested stack `evolvesprouts-Messaging`) |
 | `ExpenseParserFunction` | `lambda/expense_parser/handler.lambda_handler` | 512 MB | 90s | Yes | SQS-triggered expense invoice parser (nested stack `evolvesprouts-Messaging`) |

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -523,6 +523,7 @@ their primary responsibilities.
 - Trigger: Lambda-to-Lambda invocation (from in-VPC Lambdas)
 - Purpose: generic proxy for AWS API calls and outbound HTTP requests
   that cannot be made from inside the VPC
+- Timeout: 90s (aligned with `ExpenseParserFunction`, which invokes this Lambda for OpenRouter)
 - VPC: **No** (runs outside VPC for internet access)
 - Allow-lists:
   - `ALLOWED_ACTIONS`: comma-separated `service:action` pairs for AWS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`AwsApiProxyFunction` was timing out at **15s** during expense invoice parsing when OpenRouter (via `http_invoke`) ran longer than that. **`ExpenseParserFunction`** is configured at **90s**, so the proxy was the bottleneck.

## Changes

- Set **`AwsApiProxyFunction` timeout to 90 seconds** in `backend/infrastructure/lib/api-stack.ts` (same as `ExpenseParserFunction` in the messaging nested stack).
- Updated **`docs/architecture/aws-assets-map.md`** and **`docs/architecture/lambdas.md`** to document the new limit.

## Notes

- After deploy, reparse any expenses that failed with `Sandbox.Timedout` on the proxy.
- `openrouter_expense_parser.http_invoke` still uses a **30s** HTTP client timeout; raising the Lambda ceiling mainly removes the **15s** hard stop from the proxy function itself.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99428406-a01a-49f3-a68b-0bf628dd964f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99428406-a01a-49f3-a68b-0bf628dd964f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

