### PR TITLE
Admin web: drop booking slug column from enrollments table

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -161,10 +161,6 @@ export function EnrollmentListPanel({
     [discountOptions, selectedEnrollment?.discountCodeId]
   );
 
-  const showBookingInstanceSlugColumn = useMemo(
-    () => enrollments.some((row) => Boolean(row.bookingInstanceSlug?.trim())),
-    [enrollments]
-  );
   const showScheduledStartColumn = useMemo(
     () => enrollments.some((row) => Boolean(row.scheduledStartAt?.trim())),
     [enrollments]
@@ -457,9 +453,6 @@ export function EnrollmentListPanel({
           <AdminDataTableHead>
             <tr>
               <th className='px-4 py-3 font-semibold'>Parent</th>
-              {showBookingInstanceSlugColumn ? (
-                <th className='px-4 py-3 font-semibold'>Booking slug</th>
-              ) : null}
               {showScheduledStartColumn ? (
                 <th className='px-4 py-3 font-semibold'>Scheduled start</th>
               ) : null}
@@ -489,11 +482,6 @@ export function EnrollmentListPanel({
                   onClick={() => applyEnrollmentSelection(enrollment)}
                 >
                   <td className='px-4 py-3'>{formatEnrollmentParentCell(enrollment)}</td>
-                  {showBookingInstanceSlugColumn ? (
-                    <td className='px-4 py-3 font-mono text-xs'>
-                      {enrollment.bookingInstanceSlug?.trim() || '—'}
-                    </td>
-                  ) : null}
                   {showScheduledStartColumn ? (
                     <td className='px-4 py-3'>
                       {enrollment.scheduledStartAt?.trim()

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -387,7 +387,6 @@ function parseEnrollment(value: unknown): Enrollment {
     createdBy: asNullableString(item.created_by) ?? '',
     createdAt: asNullableString(item.created_at),
     updatedAt: asNullableString(item.updated_at),
-    bookingInstanceSlug: asNullableString(item.booking_instance_slug),
     scheduledStartAt: asNullableString(item.scheduled_start_at),
   };
 }

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -344,8 +344,6 @@ export interface Enrollment {
   createdBy: string;
   createdAt: string | null;
   updatedAt: string | null;
-  /** Present when the admin enrollment list includes booking-instance metadata. */
-  bookingInstanceSlug?: string | null;
   scheduledStartAt?: string | null;
 }
 

--- a/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
@@ -79,15 +79,14 @@ describe('EnrollmentListPanel', () => {
     expect(screen.getByLabelText('Organization')).toBeDisabled();
   });
 
-  it('shows booking slug and scheduled start columns when enrollment rows include them', () => {
-    const enrollmentWithBookingMeta: Enrollment = {
+  it('shows scheduled start column when enrollment rows include scheduled start', () => {
+    const enrollmentWithScheduledStart: Enrollment = {
       ...ENROLLMENT_FIXTURE,
-      bookingInstanceSlug: 'consultation-essentials-package-20260506103000-aabbccdd',
       scheduledStartAt: '2026-06-15T01:00:00Z',
     };
     render(
       <EnrollmentListPanel
-        enrollments={[enrollmentWithBookingMeta]}
+        enrollments={[enrollmentWithScheduledStart]}
         serviceId='service-1'
         instanceId='instance-1'
         canCreate={true}
@@ -103,9 +102,8 @@ describe('EnrollmentListPanel', () => {
       />
     );
 
-    expect(screen.getByRole('columnheader', { name: 'Booking slug' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Scheduled start' })).toBeInTheDocument();
-    expect(screen.getByText('consultation-essentials-package-20260506103000-aabbccdd')).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Booking slug' })).not.toBeInTheDocument();
   });
 
   it('uses selectable currency options in the enrollment editor', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Booking slug** column from the Services instance enrollments table in admin web (`EnrollmentListPanel`). The **Scheduled start** column still appears when any row includes `scheduled_start_at`.

## Details

- Removed conditional header/cell and the `showBookingInstanceSlugColumn` memo from `enrollment-list-panel.tsx`.
- Removed `bookingInstanceSlug` from the `Enrollment` view type in `services.ts` and stopped mapping `booking_instance_slug` in `parseEnrollment` in `services-api.ts` (API may still return the field; it is simply ignored in the UI layer).
- Updated `enrollment-list-panel.test.tsx` to cover scheduled start only and assert the booking slug column is absent.

## Validation

- `npx vitest run` on `enrollment-list-panel.test.tsx` and `table-value-formatting.test.tsx`
- `npm run lint` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb28d988-43ce-4f13-9376-64f90d7920d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb28d988-43ce-4f13-9376-64f90d7920d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

