### PR TITLE
feat(admin): delete draft expenses from Submitted Expenses table

### DIFF
--- a/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
@@ -4,7 +4,7 @@ import type { KeyboardEvent } from 'react';
 import { useState } from 'react';
 
 import { OpenAdminAssetInNewTabButton } from '@/components/admin/shared/open-admin-asset-in-new-tab-button';
-import { MarkPaidIcon, RotateIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
+import { DeleteIcon, MarkPaidIcon, RotateIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -54,6 +54,7 @@ interface ExpensesListPanelProps {
   isVoidingId: string | null;
   isMarkingPaidId: string | null;
   isReparsingId: string | null;
+  isDeletingDraftId: string | null;
   onLoadMore: () => Promise<void> | void;
   onSelectExpense: (expenseId: string) => void;
   onQueryChange: (value: string) => void;
@@ -62,6 +63,7 @@ interface ExpensesListPanelProps {
   onReparse: (expenseId: string) => Promise<void> | void;
   onMarkPaid: (expenseId: string) => Promise<void> | void;
   onVoidExpense: (expenseId: string, reason: string) => Promise<void> | void;
+  onDeleteDraft: (expenseId: string) => Promise<void> | void;
 }
 
 export function ExpensesListPanel({
@@ -77,6 +79,7 @@ export function ExpensesListPanel({
   isVoidingId,
   isMarkingPaidId,
   isReparsingId,
+  isDeletingDraftId,
   onLoadMore,
   onSelectExpense,
   onQueryChange,
@@ -85,8 +88,12 @@ export function ExpensesListPanel({
   onReparse,
   onMarkPaid,
   onVoidExpense,
+  onDeleteDraft,
 }: ExpensesListPanelProps) {
   const { openingAssetId, openError: documentOpenError, openAssetInNewTab } = useOpenAdminAssetInNewTab();
+  const [deleteDraftDialogOpen, setDeleteDraftDialogOpen] = useState(false);
+  const [deleteDraftExpenseId, setDeleteDraftExpenseId] = useState<string | null>(null);
+  const [deleteDraftError, setDeleteDraftError] = useState('');
   const [voidDialogOpen, setVoidDialogOpen] = useState(false);
   const [voidExpenseId, setVoidExpenseId] = useState<string | null>(null);
   const [voidReason, setVoidReason] = useState('');
@@ -130,6 +137,31 @@ export function ExpensesListPanel({
       closeVoidDialog();
     } catch (caught) {
       setVoidError(caught instanceof Error ? caught.message : 'Could not void this expense.');
+    }
+  };
+
+  const openDeleteDraftDialog = (expenseId: string) => {
+    setDeleteDraftExpenseId(expenseId);
+    setDeleteDraftError('');
+    setDeleteDraftDialogOpen(true);
+  };
+
+  const closeDeleteDraftDialog = () => {
+    setDeleteDraftDialogOpen(false);
+    setDeleteDraftExpenseId(null);
+    setDeleteDraftError('');
+  };
+
+  const confirmDeleteDraft = async () => {
+    setDeleteDraftError('');
+    if (!deleteDraftExpenseId) {
+      return;
+    }
+    try {
+      await onDeleteDraft(deleteDraftExpenseId);
+      closeDeleteDraftDialog();
+    } catch (caught) {
+      setDeleteDraftError(caught instanceof Error ? caught.message : 'Could not delete this expense.');
     }
   };
 
@@ -329,6 +361,27 @@ export function ExpensesListPanel({
                           <VoidExpenseIcon className='h-4 w-4' />
                         )}
                       </Button>
+                      {expense.status === 'draft' ? (
+                        <Button
+                          type='button'
+                          size='sm'
+                          variant='danger'
+                          disabled={isDeletingDraftId === expense.id}
+                          onClick={() => openDeleteDraftDialog(expense.id)}
+                          aria-label='Delete draft expense'
+                          title='Delete draft expense'
+                          aria-busy={isDeletingDraftId === expense.id}
+                        >
+                          {isDeletingDraftId === expense.id ? (
+                            <span
+                              className='inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-white border-t-transparent'
+                              aria-hidden
+                            />
+                          ) : (
+                            <DeleteIcon className='h-4 w-4' />
+                          )}
+                        </Button>
+                      ) : null}
                     </div>
                   </td>
                 </tr>
@@ -363,6 +416,20 @@ export function ExpensesListPanel({
           />
           {voidError ? <AdminInlineError>{voidError}</AdminInlineError> : null}
         </div>
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={deleteDraftDialogOpen}
+        title='Delete draft expense'
+        description='This permanently removes the draft from the list. You cannot undo this action.'
+        confirmLabel='Delete expense'
+        cancelLabel='Cancel'
+        variant='danger'
+        confirmDisabled={Boolean(deleteDraftExpenseId && isDeletingDraftId === deleteDraftExpenseId)}
+        onCancel={closeDeleteDraftDialog}
+        onConfirm={() => void confirmDeleteDraft()}
+      >
+        {deleteDraftError ? <AdminInlineError>{deleteDraftError}</AdminInlineError> : null}
       </ConfirmDialog>
     </>
   );

--- a/apps/admin_web/src/components/admin/finance/finance-page.tsx
+++ b/apps/admin_web/src/components/admin/finance/finance-page.tsx
@@ -141,6 +141,7 @@ export function FinancePage() {
         isVoidingId={expenses.isDeletingId}
         isMarkingPaidId={expenses.isMarkingPaidId}
         isReparsingId={expenses.isReparsingId}
+        isDeletingDraftId={expenses.isDeletingDraftId}
         onLoadMore={expenses.loadMore}
         onSelectExpense={expenses.selectExpense}
         onQueryChange={(value) => expenses.setFilter('query', value)}
@@ -149,6 +150,7 @@ export function FinancePage() {
         onReparse={expenses.reparseExpenseEntry}
         onMarkPaid={expenses.markPaidExpenseEntry}
         onVoidExpense={expenses.cancelExpenseEntry}
+        onDeleteDraft={expenses.deleteDraftExpenseEntry}
       />
     </div>
   );

--- a/apps/admin_web/src/hooks/use-expenses.ts
+++ b/apps/admin_web/src/hooks/use-expenses.ts
@@ -7,6 +7,7 @@ import {
   amendAdminExpense,
   cancelAdminExpense,
   createAdminExpense,
+  deleteAdminDraftExpense,
   listAdminExpenses,
   markAdminExpensePaid,
   reparseAdminExpense,
@@ -37,6 +38,7 @@ export function useExpenses() {
   const [isSaving, setIsSaving] = useState(false);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const [isDeletingId, setIsDeletingId] = useState<string | null>(null);
+  const [isDeletingDraftId, setIsDeletingDraftId] = useState<string | null>(null);
   const [isMarkingPaidId, setIsMarkingPaidId] = useState<string | null>(null);
   const [isReparsingId, setIsReparsingId] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState('');
@@ -240,6 +242,24 @@ export function useExpenses() {
     [cleanupUploadedAssets, list, uploadExpenseFiles]
   );
 
+  const deleteDraftExpenseEntry = useCallback(
+    async (expenseId: string) => {
+      setIsDeletingDraftId(expenseId);
+      setMutationError('');
+      try {
+        await deleteAdminDraftExpense(expenseId);
+        await list.refetch();
+        setSelectedExpenseId((current) => (current === expenseId ? null : current));
+      } catch (error) {
+        setMutationError(toErrorMessage(error, 'Failed to delete draft expense.'));
+        throw error;
+      } finally {
+        setIsDeletingDraftId(null);
+      }
+    },
+    [list]
+  );
+
   const cancelExpenseEntry = useCallback(
     async (expenseId: string, reason: string) => {
       setIsDeletingId(expenseId);
@@ -298,6 +318,7 @@ export function useExpenses() {
     isSaving,
     isUploadingFiles,
     isDeletingId,
+    isDeletingDraftId,
     isMarkingPaidId,
     isReparsingId,
     mutationError,
@@ -308,6 +329,7 @@ export function useExpenses() {
     updateExpenseEntry,
     amendExpenseEntry,
     cancelExpenseEntry,
+    deleteDraftExpenseEntry,
     markPaidExpenseEntry,
     reparseExpenseEntry,
   };

--- a/apps/admin_web/src/lib/expenses-api.ts
+++ b/apps/admin_web/src/lib/expenses-api.ts
@@ -274,6 +274,14 @@ export async function reparseAdminExpense(expenseId: string): Promise<void> {
   });
 }
 
+export async function deleteAdminDraftExpense(expenseId: string): Promise<void> {
+  await adminApiRequest({
+    endpointPath: `/v1/admin/expenses/${expenseId}`,
+    method: 'DELETE',
+    expectedSuccessStatuses: [204],
+  });
+}
+
 export async function safeGetAdminExpense(expenseId: string): Promise<Expense | null> {
   try {
     return await getAdminExpense(expenseId);

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4642,7 +4642,34 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete draft expense
+         * @description Hard-deletes the expense row when its status is `draft`. Returns **400** when the expense is not a draft or when other expense rows reference this record as their amendment parent.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Expense identifier. */
+                    id: components["parameters"]["ExpenseId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Expense deleted. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         options?: never;
         head?: never;
         /** Update expense */

--- a/apps/admin_web/tests/components/admin/finance/expenses-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/expenses-list-panel.test.tsx
@@ -51,17 +51,21 @@ function makeRowActions(overrides: {
   isVoidingId?: string | null;
   isMarkingPaidId?: string | null;
   isReparsingId?: string | null;
+  isDeletingDraftId?: string | null;
   onReparse?: () => Promise<void> | void;
   onMarkPaid?: () => Promise<void> | void;
   onVoidExpense?: (expenseId: string, reason: string) => Promise<void> | void;
+  onDeleteDraft?: (expenseId: string) => Promise<void> | void;
 } = {}) {
   return {
     isVoidingId: null as string | null,
     isMarkingPaidId: null as string | null,
     isReparsingId: null as string | null,
+    isDeletingDraftId: null as string | null,
     onReparse: vi.fn().mockResolvedValue(undefined),
     onMarkPaid: vi.fn().mockResolvedValue(undefined),
     onVoidExpense: vi.fn().mockResolvedValue(undefined),
+    onDeleteDraft: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -282,6 +286,37 @@ describe('ExpensesListPanel', () => {
     });
     expect(screen.getByRole('alertdialog')).toBeInTheDocument();
     expect(rowActions.onVoidExpense).toHaveBeenCalledWith('exp-1', 'Bad invoice');
+  });
+
+  it('delete draft opens confirm dialog and calls onDeleteDraft', async () => {
+    const user = userEvent.setup();
+    const rowActions = makeRowActions();
+
+    render(
+      <ExpensesListPanel
+        {...listProps}
+        {...rowActions}
+        expenses={[{ ...baseExpense, status: 'draft' }]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete draft expense' }));
+    expect(screen.getByRole('alertdialog', { name: 'Delete draft expense' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Delete expense' }));
+
+    await waitFor(() => {
+      expect(rowActions.onDeleteDraft).toHaveBeenCalledWith('exp-1');
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('alertdialog', { name: 'Delete draft expense' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not render delete for non-draft expenses', () => {
+    render(<ExpensesListPanel {...listProps} {...makeRowActions()} />);
+
+    expect(screen.queryByRole('button', { name: 'Delete draft expense' })).not.toBeInTheDocument();
   });
 
   it('disables void confirm while void mutation is in flight for that expense', async () => {

--- a/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
@@ -25,6 +25,7 @@ const {
     isSaving: false,
     isUploadingFiles: false,
     isDeletingId: null as string | null,
+    isDeletingDraftId: null as string | null,
     isMarkingPaidId: null as string | null,
     isReparsingId: null as string | null,
     mutationError: '',
@@ -35,6 +36,7 @@ const {
     updateExpenseEntry: vi.fn(),
     amendExpenseEntry: vi.fn(),
     cancelExpenseEntry: vi.fn(),
+    deleteDraftExpenseEntry: vi.fn(),
     markPaidExpenseEntry: vi.fn(),
     reparseExpenseEntry: vi.fn(),
   };

--- a/backend/src/app/api/admin_expenses.py
+++ b/backend/src/app/api/admin_expenses.py
@@ -38,6 +38,7 @@ from app.db.engine import get_engine
 from app.db.models import ExpenseParseStatus, ExpenseStatus
 from app.db.repositories import ExpenseRepository
 from app.exceptions import NotFoundError, ValidationError
+from app.services.asset_expense_tagging import sync_expense_attachment_tags_for_assets
 from app.services.expense_events import enqueue_expense_parse
 from app.utils import json_response
 from app.utils.logging import get_logger
@@ -75,6 +76,10 @@ def handle_admin_expenses_request(
             return _get_expense(event, expense_id=expense_id)
         if method == "PATCH":
             return _update_expense(
+                event, expense_id=expense_id, actor_sub=identity.user_sub
+            )
+        if method == "DELETE":
+            return _delete_draft_expense(
                 event, expense_id=expense_id, actor_sub=identity.user_sub
             )
         return json_response(405, {"error": "Method not allowed"}, event=event)
@@ -201,6 +206,42 @@ def _get_expense(event: Mapping[str, Any], *, expense_id: UUID) -> dict[str, Any
         if expense is None:
             raise NotFoundError("Expense", str(expense_id))
         return json_response(200, {"expense": serialize_expense(expense)}, event=event)
+
+
+def _delete_draft_expense(
+    event: Mapping[str, Any],
+    *,
+    expense_id: UUID,
+    actor_sub: str,
+) -> dict[str, Any]:
+    logger.info(
+        "Deleting draft expense",
+        extra={"expense_id": str(expense_id), "actor": actor_sub},
+    )
+    req_id = request_id(event)
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
+        repository = ExpenseRepository(session)
+        expense = repository.get_with_attachments(expense_id)
+        if expense is None:
+            raise NotFoundError("Expense", str(expense_id))
+        if expense.status != ExpenseStatus.DRAFT:
+            raise ValidationError(
+                "Only draft expenses can be deleted",
+                field="status",
+            )
+        if repository.count_amendments_targeting(expense_id) > 0:
+            raise ValidationError(
+                "Cannot delete an expense that has linked amendment records",
+                field="amends_expense_id",
+            )
+        asset_ids = {row.asset_id for row in expense.attachments}
+        repository.delete(expense)
+        session.flush()
+        sync_expense_attachment_tags_for_assets(session, asset_ids)
+        session.commit()
+    return json_response(204, {}, event=event)
 
 
 def _update_expense(

--- a/backend/src/app/db/repositories/expense.py
+++ b/backend/src/app/db/repositories/expense.py
@@ -121,6 +121,15 @@ class ExpenseRepository(BaseRepository[Expense]):
         )
         return self._session.execute(statement).scalar_one_or_none()
 
+    def count_amendments_targeting(self, expense_id: UUID) -> int:
+        """Count expense rows that reference this expense as their amendment parent."""
+        stmt = (
+            select(func.count())
+            .select_from(Expense)
+            .where(Expense.amends_expense_id == expense_id)
+        )
+        return int(self._session.execute(stmt).scalar_one() or 0)
+
     def create_expense(
         self,
         *,

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -49,7 +49,7 @@ info:
     - `PATCH /v1/admin/organizations/{id}/members/{memberId}`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
     - `GET|POST /v1/admin/expenses`
-    - `GET|PATCH /v1/admin/expenses/{id}`
+    - `GET|PATCH|DELETE /v1/admin/expenses/{id}`
     - `POST /v1/admin/expenses/{id}/cancel`
     - `POST /v1/admin/expenses/{id}/mark-paid`
     - `POST /v1/admin/expenses/{id}/reparse`
@@ -3432,6 +3432,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ExpenseResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete draft expense
+      description: >
+        Hard-deletes the expense row when its status is `draft`. Returns **400** when the expense is
+        not a draft or when other expense rows reference this record as their amendment parent.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "204":
+          description: Expense deleted.
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -223,7 +223,7 @@ their primary responsibilities.
   CRM contact/family/organization management with soft-archive, locations, tags,
   and family/organization membership rows,
   sales pipeline lead management (list/detail/create/update/notes/export/analytics),
-  vendor management, expense invoice ingestion/listing/amendment/void/pay flows
+  vendor management, expense invoice ingestion/listing/amendment/void/pay/draft-delete flows
   (mark-paid requires vendor, invoice date, currency, and total), and admin-user
   listing for lead assignment and instructor-group listing for service instances
   (service list items may include nullable `training_details` for training courses

--- a/tests/test_admin_expenses_delete_draft.py
+++ b/tests/test_admin_expenses_delete_draft.py
@@ -1,0 +1,197 @@
+"""Tests for DELETE /v1/admin/expenses/{id} (draft-only hard delete)."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID, uuid4
+
+from app.api import admin_expenses
+from app.db.models.enums import ExpenseStatus
+
+
+def test_delete_draft_expense_removes_row_and_syncs_tags(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    """Successful delete returns 204 and runs attachment tag sync."""
+    expense_id = uuid4()
+    asset_a = uuid4()
+    sync_calls: list[set[UUID]] = []
+
+    class _Att:
+        def __init__(self, asset_id: UUID) -> None:
+            self.asset_id = asset_id
+
+    class _FakeExpense:
+        def __init__(self) -> None:
+            self.id = expense_id
+            self.status = ExpenseStatus.DRAFT
+            self.attachments = [_Att(asset_a)]
+
+    class _FakeRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_with_attachments(self, eid: UUID) -> _FakeExpense | None:
+            if eid == expense_id:
+                return _FakeExpense()
+            return None
+
+        def count_amendments_targeting(self, eid: UUID) -> int:
+            assert eid == expense_id
+            return 0
+
+        def delete(self, _expense: _FakeExpense) -> None:
+            return None
+
+    class _FakeSession:
+        def flush(self) -> None:
+            return None
+
+        def commit(self) -> None:
+            return None
+
+    class _FakeSessionCtx:
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def _sync(session: object, asset_ids: set[UUID]) -> None:
+        sync_calls.append(asset_ids)
+
+    monkeypatch.setattr(admin_expenses, "ExpenseRepository", _FakeRepo)
+    monkeypatch.setattr(admin_expenses, "Session", lambda _engine: _FakeSessionCtx())
+    monkeypatch.setattr(admin_expenses, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        admin_expenses,
+        "sync_expense_attachment_tags_for_assets",
+        _sync,
+    )
+    monkeypatch.setattr(admin_expenses, "set_audit_context", lambda *args, **kwargs: None)
+    monkeypatch.setattr(admin_expenses, "request_id", lambda _e: "req-1")
+    monkeypatch.setattr(
+        admin_expenses,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    out = admin_expenses.handle_admin_expenses_request(
+        api_gateway_event(method="DELETE", path=f"/v1/admin/expenses/{expense_id}"),
+        "DELETE",
+        f"/v1/admin/expenses/{expense_id}",
+    )
+
+    assert out["statusCode"] == 204
+    assert sync_calls == [{asset_a}]
+
+
+def test_delete_draft_expense_rejects_non_draft(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    expense_id = uuid4()
+
+    class _FakeExpense:
+        def __init__(self) -> None:
+            self.id = expense_id
+            self.status = ExpenseStatus.SUBMITTED
+            self.attachments = []
+
+    class _FakeRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_with_attachments(self, eid: UUID) -> _FakeExpense | None:
+            if eid == expense_id:
+                return _FakeExpense()
+            return None
+
+    class _FakeSessionCtx:
+        def __enter__(self) -> object:
+            return object()
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(admin_expenses, "ExpenseRepository", _FakeRepo)
+    monkeypatch.setattr(admin_expenses, "Session", lambda _engine: _FakeSessionCtx())
+    monkeypatch.setattr(admin_expenses, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_expenses, "set_audit_context", lambda *args, **kwargs: None)
+    monkeypatch.setattr(admin_expenses, "request_id", lambda _e: "req-1")
+    monkeypatch.setattr(
+        admin_expenses,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    from app.exceptions import ValidationError
+
+    try:
+        admin_expenses.handle_admin_expenses_request(
+            api_gateway_event(method="DELETE", path=f"/v1/admin/expenses/{expense_id}"),
+            "DELETE",
+            f"/v1/admin/expenses/{expense_id}",
+        )
+    except ValidationError as exc:
+        assert exc.field == "status"
+    else:
+        raise AssertionError("expected ValidationError")
+
+
+def test_delete_draft_expense_rejects_when_amendments_exist(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    expense_id = uuid4()
+
+    class _FakeExpense:
+        def __init__(self) -> None:
+            self.id = expense_id
+            self.status = ExpenseStatus.DRAFT
+            self.attachments = []
+
+    class _FakeRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def get_with_attachments(self, eid: UUID) -> _FakeExpense | None:
+            if eid == expense_id:
+                return _FakeExpense()
+            return None
+
+        def count_amendments_targeting(self, eid: UUID) -> int:
+            assert eid == expense_id
+            return 1
+
+    class _FakeSessionCtx:
+        def __enter__(self) -> object:
+            return object()
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(admin_expenses, "ExpenseRepository", _FakeRepo)
+    monkeypatch.setattr(admin_expenses, "Session", lambda _engine: _FakeSessionCtx())
+    monkeypatch.setattr(admin_expenses, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_expenses, "set_audit_context", lambda *args, **kwargs: None)
+    monkeypatch.setattr(admin_expenses, "request_id", lambda _e: "req-1")
+    monkeypatch.setattr(
+        admin_expenses,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    from app.exceptions import ValidationError
+
+    try:
+        admin_expenses.handle_admin_expenses_request(
+            api_gateway_event(method="DELETE", path=f"/v1/admin/expenses/{expense_id}"),
+            "DELETE",
+            f"/v1/admin/expenses/{expense_id}",
+        )
+    except ValidationError as exc:
+        assert exc.field == "amends_expense_id"
+    else:
+        raise AssertionError("expected ValidationError")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a destructive delete control (trash icon) to the **Submitted Expenses** table for rows in **draft** status. The action opens the standard confirmation dialog, calls the new admin API, refreshes the list, and clears the editor selection when the deleted row was selected.

## Backend

- `DELETE /v1/admin/expenses/{id}` returns **204** when the expense exists and `status` is `draft`.
- Returns **400** if not draft or if other expense rows reference this row as an amendment parent (cannot orphan amendments).
- Hard-deletes the row (attachments cascade), then runs `sync_expense_attachment_tags_for_assets` for linked asset IDs.

## Docs / contract

- OpenAPI (`docs/api/admin.yaml`), regenerated admin TS types, `docs/architecture/lambdas.md`.

## Tests

- Python: `tests/test_admin_expenses_delete_draft.py`
- Admin web: extended `expenses-list-panel` tests

### Validation

- `npm run lint` (admin_web)
- `pytest tests/test_admin_expenses_delete_draft.py`
- `bash scripts/validate-cursorrules.sh`
- `pre-commit run ruff-format` / `ruff`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dbc41d2-a061-4c36-aa3f-9f6facb1d009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dbc41d2-a061-4c36-aa3f-9f6facb1d009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

