### PR TITLE
fix(admin_web): constrain enrollments table to section width

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -452,76 +452,106 @@ export function EnrollmentListPanel({
         loadingLabel='Loading enrollments...'
         onLoadMore={onLoadMore}
       >
-        <AdminDataTable tableClassName='min-w-[1040px]'>
-          <AdminDataTableHead>
-            <tr>
-              <th className='px-4 py-3 font-semibold'>Parent</th>
-              {showScheduledStartColumn ? (
-                <th className='px-4 py-3 font-semibold'>Scheduled start</th>
-              ) : null}
-              <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 font-semibold'>Amount</th>
-              <th className='px-4 py-3 font-semibold'>Discount</th>
-              <th className='px-4 py-3 font-semibold'>Enrolled at</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
-            </tr>
-          </AdminDataTableHead>
-          <AdminDataTableBody>
-            {enrollments.map((enrollment) => {
-              const amountRaw = enrollment.amountPaid?.trim() ?? '';
-              const parsedAmount = Number.parseFloat(amountRaw);
-              const currencyCode =
-                (enrollment.currency ?? defaultCurrencyCode).trim().toUpperCase() || defaultCurrencyCode;
-              const amountDisplay =
-                amountRaw !== '' && Number.isFinite(parsedAmount)
-                  ? formatAmountInCurrency(parsedAmount, currencyCode)
-                  : '—';
-              return (
-                <tr
-                  key={enrollment.id}
-                  className={`cursor-pointer transition ${
-                    selectedEnrollmentId === enrollment.id ? 'bg-slate-100' : 'hover:bg-slate-50'
-                  }`}
-                  onClick={() => applyEnrollmentSelection(enrollment)}
+        <div className='min-w-0'>
+          <AdminDataTable tableClassName='w-full table-fixed'>
+            <AdminDataTableHead>
+              <tr>
+                <th
+                  className={
+                    showScheduledStartColumn
+                      ? 'w-[28%] min-w-0 px-4 py-3 font-semibold'
+                      : 'w-[35%] min-w-0 px-4 py-3 font-semibold'
+                  }
                 >
-                  <td className='px-4 py-3'>{formatEnrollmentParentCell(enrollment)}</td>
-                  {showScheduledStartColumn ? (
-                    <td className='px-4 py-3'>
-                      {enrollment.scheduledStartAt?.trim()
-                        ? formatDate(enrollment.scheduledStartAt)
-                        : '—'}
+                  Parent
+                </th>
+                {showScheduledStartColumn ? (
+                  <th className='w-[11%] whitespace-nowrap px-4 py-3 font-semibold'>Scheduled start</th>
+                ) : null}
+                <th
+                  className={
+                    showScheduledStartColumn
+                      ? 'w-[10%] px-4 py-3 font-semibold'
+                      : 'w-[12%] px-4 py-3 font-semibold'
+                  }
+                >
+                  Status
+                </th>
+                <th
+                  className={
+                    showScheduledStartColumn
+                      ? 'w-[10%] whitespace-nowrap px-4 py-3 font-semibold'
+                      : 'w-[12%] whitespace-nowrap px-4 py-3 font-semibold'
+                  }
+                >
+                  Amount
+                </th>
+                <th className='min-w-0 px-4 py-3 font-semibold'>Discount</th>
+                <th className='w-[14%] whitespace-nowrap px-4 py-3 font-semibold'>Enrolled at</th>
+                <th className='w-[4.5rem] whitespace-nowrap px-4 py-3 text-right font-semibold'>
+                  Operations
+                </th>
+              </tr>
+            </AdminDataTableHead>
+            <AdminDataTableBody>
+              {enrollments.map((enrollment) => {
+                const amountRaw = enrollment.amountPaid?.trim() ?? '';
+                const parsedAmount = Number.parseFloat(amountRaw);
+                const currencyCode =
+                  (enrollment.currency ?? defaultCurrencyCode).trim().toUpperCase() || defaultCurrencyCode;
+                const amountDisplay =
+                  amountRaw !== '' && Number.isFinite(parsedAmount)
+                    ? formatAmountInCurrency(parsedAmount, currencyCode)
+                    : '—';
+                return (
+                  <tr
+                    key={enrollment.id}
+                    className={`cursor-pointer transition ${
+                      selectedEnrollmentId === enrollment.id ? 'bg-slate-100' : 'hover:bg-slate-50'
+                    }`}
+                    onClick={() => applyEnrollmentSelection(enrollment)}
+                  >
+                    <td className='min-w-0 break-words px-4 py-3'>
+                      {formatEnrollmentParentCell(enrollment)}
                     </td>
-                  ) : null}
-                  <td className='px-4 py-3'>{formatEnumLabel(enrollment.status)}</td>
-                  <td className='px-4 py-3'>{amountDisplay}</td>
-                  <td className='px-4 py-3'>
-                    {enrollment.discountCodeId
-                      ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
-                          enrollment.discountCodeId)
-                      : '-'}
-                  </td>
-                  <td className='px-4 py-3'>{formatDate(enrollment.enrolledAt)}</td>
-                  <td className='px-4 py-3 text-right'>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant='danger'
-                      disabled={isMutating}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        void handleDeleteEnrollment(enrollment);
-                      }}
-                      aria-label='Delete enrollment'
-                      title='Delete enrollment'
-                    >
-                      <DeleteIcon className='h-4 w-4' />
-                    </Button>
-                  </td>
-                </tr>
-              );
-            })}
-          </AdminDataTableBody>
-        </AdminDataTable>
+                    {showScheduledStartColumn ? (
+                      <td className='whitespace-nowrap px-4 py-3'>
+                        {enrollment.scheduledStartAt?.trim()
+                          ? formatDate(enrollment.scheduledStartAt)
+                          : '—'}
+                      </td>
+                    ) : null}
+                    <td className='px-4 py-3'>{formatEnumLabel(enrollment.status)}</td>
+                    <td className='whitespace-nowrap px-4 py-3'>{amountDisplay}</td>
+                    <td className='min-w-0 break-words px-4 py-3'>
+                      {enrollment.discountCodeId
+                        ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
+                            enrollment.discountCodeId)
+                        : '-'}
+                    </td>
+                    <td className='whitespace-nowrap px-4 py-3'>{formatDate(enrollment.enrolledAt)}</td>
+                    <td className='px-4 py-3 text-right'>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='danger'
+                        disabled={isMutating}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          void handleDeleteEnrollment(enrollment);
+                        }}
+                        aria-label='Delete enrollment'
+                        title='Delete enrollment'
+                      >
+                        <DeleteIcon className='h-4 w-4' />
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </AdminDataTableBody>
+          </AdminDataTable>
+        </div>
       </PaginatedTableCard>
       <ConfirmDialog {...confirmDialogProps} />
     </>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Services → Instances **Enrollments** table used `min-w-[1040px]`, which forced a wide minimum width and made the table feel misaligned with the `max-w-7xl` main column.

## Changes

- Replaced the fixed min-width with `w-full table-fixed` and proportional column widths.
- Applied `min-w-0` + `break-words` on **Parent** and **Discount** so long labels wrap instead of expanding the layout.
- Used `whitespace-nowrap` on date and amount cells where a single line is expected.
- Wrapped the table in `min-w-0` so the flex main column can shrink correctly with the rest of the shell.

## Testing

- `npx vitest run tests/components/admin/services/enrollment-list-panel.test.tsx`
- `npm run lint` in `apps/admin_web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de10907e-5f95-497d-8ec4-df41ec6a3b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de10907e-5f95-497d-8ec4-df41ec6a3b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

