### PR TITLE
Add admin delete for orphan inbound customer payments

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -14,7 +14,13 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { CheckIcon, MarkPaidIcon, ViewIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
+import {
+  CheckIcon,
+  DeleteIcon,
+  MarkPaidIcon,
+  ViewIcon,
+  VoidExpenseIcon,
+} from '@/components/icons/action-icons';
 import {
   CUSTOMIZED_DRAFT_INVOICE_FORM_ID,
   CustomizedDraftInvoiceCard,
@@ -24,6 +30,7 @@ import {
   createCustomerRefund,
   createDraftInvoice,
   createPaymentAllocation,
+  deleteCustomerPayment,
   emailInvoice,
   exportBillingCsv,
   getCustomerInvoice,
@@ -195,6 +202,10 @@ export function ClientInvoicesPanel() {
   const [confirmPaymentId, setConfirmPaymentId] = useState<string | null>(null);
   const [confirmPaymentExternalRef, setConfirmPaymentExternalRef] = useState('');
   const [confirmPaymentError, setConfirmPaymentError] = useState('');
+
+  const [deletePaymentDialogOpen, setDeletePaymentDialogOpen] = useState(false);
+  const [deletePaymentId, setDeletePaymentId] = useState<string | null>(null);
+  const [deletePaymentError, setDeletePaymentError] = useState('');
 
   const [enrollmentPickerRows, setEnrollmentPickerRows] = useState<BillingEnrollmentPickerRow[]>([]);
   const [enrollmentPickerTruncated, setEnrollmentPickerTruncated] = useState(false);
@@ -796,6 +807,41 @@ export function ClientInvoicesPanel() {
       }
     } catch (caught) {
       setConfirmPaymentError(caught instanceof Error ? caught.message : 'Confirm failed.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const openDeletePaymentDialog = (paymentId: string) => {
+    setDeletePaymentId(paymentId);
+    setDeletePaymentError('');
+    setDeletePaymentDialogOpen(true);
+  };
+
+  const closeDeletePaymentDialog = () => {
+    setDeletePaymentDialogOpen(false);
+    setDeletePaymentId(null);
+    setDeletePaymentError('');
+  };
+
+  const submitDeletePayment = async () => {
+    const id = deletePaymentId?.trim();
+    if (!id) {
+      return;
+    }
+    setDeletePaymentError('');
+    setBusy('delete-payment');
+    try {
+      await deleteCustomerPayment(id);
+      setActionMessage(`Payment deleted: ${id}`);
+      closeDeletePaymentDialog();
+      await loadPayments();
+      if (selectedId === id) {
+        setSelectedId(null);
+        setDetail(null);
+      }
+    } catch (caught) {
+      setDeletePaymentError(caught instanceof Error ? caught.message : 'Delete failed.');
     } finally {
       setBusy(null);
     }
@@ -1728,7 +1774,7 @@ export function ClientInvoicesPanel() {
 
       <PaginatedTableCard
         title='Customer payments'
-        description='Recent customer payments and refunds. Select a row for allocation and refund source. Pending inbound: confirm from Operations.'
+        description='Recent customer payments and refunds. Select a row for allocation and refund source. Pending inbound: confirm from Operations. Deletable orphan rows: delete from Operations (see server rules).'
         isLoading={listLoading}
         isLoadingMore={false}
         hasMore={false}
@@ -1788,27 +1834,42 @@ export function ClientInvoicesPanel() {
                       event.stopPropagation();
                     }}
                   >
-                    {p.status === 'pending' && p.direction === 'inbound' ? (
-                      <Button
-                        type='button'
-                        size='sm'
-                        variant='secondary'
-                        disabled={confirmPaymentDialogOpen || busyAction === 'confirm'}
-                        onClick={() => openConfirmPaymentDialog(id)}
-                        aria-label='Confirm pending payment'
-                        title='Confirm pending payment'
-                        aria-busy={busyAction === 'confirm' && confirmPaymentId === id}
-                      >
-                        {busyAction === 'confirm' && confirmPaymentId === id ? (
-                          <span
-                            className='inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-slate-600 border-t-transparent'
-                            aria-hidden
-                          />
-                        ) : (
-                          <MarkPaidIcon className='h-4 w-4' aria-hidden />
-                        )}
-                      </Button>
-                    ) : null}
+                    <div className='flex flex-wrap justify-end gap-1'>
+                      {p.status === 'pending' && p.direction === 'inbound' ? (
+                        <Button
+                          type='button'
+                          size='sm'
+                          variant='secondary'
+                          disabled={editorBusy || deletePaymentDialogOpen || busyAction === 'confirm'}
+                          onClick={() => openConfirmPaymentDialog(id)}
+                          aria-label='Confirm pending payment'
+                          title='Confirm pending payment'
+                          aria-busy={busyAction === 'confirm' && confirmPaymentId === id}
+                        >
+                          {busyAction === 'confirm' && confirmPaymentId === id ? (
+                            <span
+                              className='inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-slate-600 border-t-transparent'
+                              aria-hidden
+                            />
+                          ) : (
+                            <MarkPaidIcon className='h-4 w-4' aria-hidden />
+                          )}
+                        </Button>
+                      ) : null}
+                      {p.orphanPaymentDeletable ? (
+                        <Button
+                          type='button'
+                          size='sm'
+                          variant='danger'
+                          disabled={editorBusy || deletePaymentDialogOpen || !id}
+                          onClick={() => openDeletePaymentDialog(id)}
+                          aria-label='Delete customer payment'
+                          title='Delete customer payment'
+                        >
+                          <DeleteIcon className='h-4 w-4' aria-hidden />
+                        </Button>
+                      ) : null}
+                    </div>
                   </td>
                 </tr>
               );
@@ -1866,6 +1927,20 @@ export function ClientInvoicesPanel() {
           />
           {confirmPaymentError ? <AdminInlineError>{confirmPaymentError}</AdminInlineError> : null}
         </div>
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={deletePaymentDialogOpen}
+        title='Delete customer payment'
+        description='Permanently removes this payment row. Allowed only when the server marks the row as deletable (pending or free payment, no active enrollment link, and no allocations or receipt).'
+        confirmLabel='Delete payment'
+        cancelLabel='Cancel'
+        variant='danger'
+        confirmDisabled={busyAction === 'delete-payment'}
+        onCancel={closeDeletePaymentDialog}
+        onConfirm={() => void submitDeletePayment()}
+      >
+        {deletePaymentError ? <AdminInlineError>{deletePaymentError}</AdminInlineError> : null}
       </ConfirmDialog>
     </div>
   );

--- a/apps/admin_web/src/lib/billing-api.ts
+++ b/apps/admin_web/src/lib/billing-api.ts
@@ -159,6 +159,13 @@ export async function confirmCustomerPayment(
   return root.payment;
 }
 
+export async function deleteCustomerPayment(id: string): Promise<void> {
+  await adminApiRequest<unknown>({
+    endpointPath: `/v1/admin/billing/payments/${id}`,
+    method: 'DELETE',
+  });
+}
+
 export async function createCustomerRefund(
   body: ApiSchemas['CreateCustomerRefundRequest'],
 ): Promise<CustomerPaymentSummary> {

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4006,7 +4006,33 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete orphan inbound customer payment
+         * @description Removes an inbound payment row only when it is safe cleanup: the payment must be pending **or** free ($0 method or zero amount), not linked to an active enrollment (enrollment id null, enrollment cancelled, or enrollment row missing), and must have no invoice allocations, no customer receipt row, and no refund rows pointing at it.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Payment deleted. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -6024,6 +6050,8 @@ export interface components {
             enrollmentId?: string | null;
             /** Format: uuid */
             contactId?: string | null;
+            /** @description True when DELETE /v1/admin/billing/payments/{id} is allowed for this row (pending or free/zero inbound; enrollment unlinked or cancelled; no allocations, receipt, or refund children). */
+            orphanPaymentDeletable: boolean;
             /** Format: date-time */
             succeededAt?: string | null;
             /** Format: date-time */

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -12,6 +12,7 @@ const billingMocks = vi.hoisted(() => ({
   voidInvoice: vi.fn(),
   emailInvoice: vi.fn(),
   confirmCustomerPayment: vi.fn(),
+  deleteCustomerPayment: vi.fn(),
   createDraftInvoice: vi.fn(),
   createPaymentAllocation: vi.fn(),
   createCustomerRefund: vi.fn(),
@@ -403,6 +404,7 @@ describe('ClientInvoicesPanel', () => {
         amount: '10',
         currency: 'HKD',
         createdAt: '2026-01-01T00:00:00+00:00',
+        orphanPaymentDeletable: false,
       },
     ]);
     billingMocks.getCustomerPayment.mockResolvedValue({
@@ -414,6 +416,7 @@ describe('ClientInvoicesPanel', () => {
       currency: 'HKD',
       unappliedAmount: '10',
       createdAt: '2026-01-01T00:00:00+00:00',
+      orphanPaymentDeletable: false,
     });
     billingMocks.confirmCustomerPayment.mockResolvedValue({
       id: payId,
@@ -423,6 +426,7 @@ describe('ClientInvoicesPanel', () => {
       amount: '10',
       currency: 'HKD',
       createdAt: '2026-01-01T00:00:00+00:00',
+      orphanPaymentDeletable: false,
     });
 
     render(<ClientInvoicesPanel />);
@@ -445,6 +449,42 @@ describe('ClientInvoicesPanel', () => {
       expect(billingMocks.confirmCustomerPayment).toHaveBeenCalledWith(payId, {
         externalReference: 'REF-99',
       });
+    });
+  });
+
+  it('delete payment dialog calls deleteCustomerPayment when server marks row deletable', async () => {
+    const payId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    billingMocks.listCustomerPayments.mockResolvedValue([
+      {
+        id: payId,
+        direction: 'inbound',
+        status: 'pending',
+        method: 'bank_transfer',
+        amount: '10',
+        currency: 'HKD',
+        createdAt: '2026-01-01T00:00:00+00:00',
+        orphanPaymentDeletable: true,
+      },
+    ]);
+    billingMocks.deleteCustomerPayment.mockResolvedValue(undefined);
+
+    render(<ClientInvoicesPanel />);
+
+    const paymentTable = screen.getAllByRole('table').at(-1) as HTMLElement;
+    await waitFor(() =>
+      within(paymentTable).getByRole('button', { name: /delete customer payment/i }),
+    );
+
+    await userEvent.click(within(paymentTable).getByRole('button', { name: /delete customer payment/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /delete customer payment/i })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /^delete payment$/i }));
+
+    await waitFor(() => {
+      expect(billingMocks.deleteCustomerPayment).toHaveBeenCalledWith(payId);
     });
   });
 

--- a/backend/src/app/api/admin_billing.py
+++ b/backend/src/app/api/admin_billing.py
@@ -26,6 +26,7 @@ from app.api.admin_billing_payments import (
     CustomerReceipt,
     _confirm_payment,
     _create_payment,
+    _delete_payment,
     _get_payment,
     _list_payments,
     _unapplied,
@@ -76,6 +77,10 @@ def handle_admin_billing_request(
         pid = parse_uuid(parts[3])
         if method == "GET":
             return _get_payment(event, pid, user_sub=identity.user_sub, request_id=req)
+        if method == "DELETE":
+            return _delete_payment(
+                event, pid, user_sub=identity.user_sub, request_id=req
+            )
 
     if sub == "payments" and len(parts) == 5 and parts[4] == "unapplied":
         pid = parse_uuid(parts[3])

--- a/backend/src/app/api/admin_billing_payments.py
+++ b/backend/src/app/api/admin_billing_payments.py
@@ -8,7 +8,7 @@ from typing import Any
 from collections.abc import Mapping
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 
 from app.api.admin_billing_common import DEFAULT_BILLING_LIST_LIMIT, _session_with_audit
@@ -18,7 +18,12 @@ from app.db.engine import get_engine
 from app.db.models.customer_invoice import CustomerInvoice
 from app.db.models.customer_payment import CustomerPayment
 from app.db.models.customer_receipt import CustomerReceipt
-from app.db.models.enums import BillingPaymentDirection, BillingPaymentStatus
+from app.db.models.enrollment import Enrollment
+from app.db.models.enums import (
+    BillingPaymentDirection,
+    BillingPaymentStatus,
+    EnrollmentStatus,
+)
 from app.db.models.payment_allocation import PaymentAllocation
 from app.exceptions import NotFoundError, ValidationError
 from app.services.customer_billing import (
@@ -74,7 +79,9 @@ def _payment_allocation_invoice_refs(
     return out
 
 
-def _serialize_payment(p: CustomerPayment) -> dict[str, Any]:
+def _serialize_payment(
+    p: CustomerPayment, *, orphan_payment_deletable: bool
+) -> dict[str, Any]:
     return {
         "id": str(p.id),
         "direction": p.direction.value,
@@ -91,7 +98,160 @@ def _serialize_payment(p: CustomerPayment) -> dict[str, Any]:
         "contactId": str(p.contact_id) if p.contact_id else None,
         "succeededAt": p.succeeded_at.isoformat() if p.succeeded_at else None,
         "createdAt": p.created_at.isoformat(),
+        "orphanPaymentDeletable": orphan_payment_deletable,
     }
+
+
+def _pending_or_free_payment(p: CustomerPayment) -> bool:
+    if p.status == BillingPaymentStatus.PENDING:
+        return True
+    if p.method.strip().lower() == "free":
+        return True
+    if p.amount == Decimal("0"):
+        return True
+    return False
+
+
+def _enrollment_unlinked_or_cancelled(
+    enrollment_id: UUID | None,
+    enrollment_status_by_id: dict[UUID, EnrollmentStatus],
+) -> bool:
+    if enrollment_id is None:
+        return True
+    status = enrollment_status_by_id.get(enrollment_id)
+    if status is None:
+        return True
+    return status == EnrollmentStatus.CANCELLED
+
+
+def _batch_orphan_payment_deletable(
+    session: Session, rows: list[CustomerPayment]
+) -> dict[UUID, bool]:
+    """Server-side eligibility for DELETE (matches single-payment validation)."""
+    if not rows:
+        return {}
+    pay_ids = [p.id for p in rows]
+    allocation_pay_ids = {
+        row[0]
+        for row in session.execute(
+            select(PaymentAllocation.payment_id).where(
+                PaymentAllocation.payment_id.in_(pay_ids)
+            )
+        ).all()
+    }
+    receipt_pay_ids = {
+        row[0]
+        for row in session.execute(
+            select(CustomerReceipt.customer_payment_id).where(
+                CustomerReceipt.customer_payment_id.in_(pay_ids)
+            )
+        ).all()
+    }
+    refund_parent_ids: set[UUID] = set()
+    for (orig_id,) in session.execute(
+        select(CustomerPayment.original_payment_id).where(
+            CustomerPayment.original_payment_id.in_(pay_ids),
+            CustomerPayment.direction == BillingPaymentDirection.REFUND,
+        )
+    ).all():
+        if orig_id is not None:
+            refund_parent_ids.add(orig_id)
+    enrollment_ids = [p.enrollment_id for p in rows if p.enrollment_id is not None]
+    enrollment_status_by_id: dict[UUID, EnrollmentStatus] = {}
+    if enrollment_ids:
+        for eid, st in session.execute(
+            select(Enrollment.id, Enrollment.status).where(
+                Enrollment.id.in_(enrollment_ids)
+            )
+        ):
+            enrollment_status_by_id[eid] = st
+
+    out: dict[UUID, bool] = {}
+    for p in rows:
+        ok = (
+            p.direction == BillingPaymentDirection.INBOUND
+            and _pending_or_free_payment(p)
+            and _enrollment_unlinked_or_cancelled(
+                p.enrollment_id, enrollment_status_by_id
+            )
+            and p.id not in allocation_pay_ids
+            and p.id not in receipt_pay_ids
+            and p.id not in refund_parent_ids
+        )
+        out[p.id] = ok
+    return out
+
+
+def _validate_orphan_delete(session: Session, p: CustomerPayment) -> None:
+    if p.direction != BillingPaymentDirection.INBOUND:
+        raise ValidationError("Only inbound payments can be deleted", field="paymentId")
+    if not _pending_or_free_payment(p):
+        raise ValidationError(
+            "Only pending inbound or free ($0) payments can be deleted",
+            field="paymentId",
+        )
+    if p.enrollment_id is not None:
+        en = session.get(Enrollment, p.enrollment_id)
+        if en is not None and en.status != EnrollmentStatus.CANCELLED:
+            raise ValidationError(
+                "Payment is still linked to an enrollment that is not cancelled",
+                field="enrollmentId",
+            )
+    has_alloc = session.execute(
+        select(
+            exists().where(PaymentAllocation.payment_id == p.id),
+        )
+    ).scalar_one()
+    if has_alloc:
+        raise ValidationError(
+            "Payment has invoice allocations and cannot be deleted",
+            field="paymentId",
+        )
+    has_rcpt = session.execute(
+        select(exists().where(CustomerReceipt.customer_payment_id == p.id))
+    ).scalar_one()
+    if has_rcpt:
+        raise ValidationError(
+            "Payment has a receipt row and cannot be deleted", field="paymentId"
+        )
+    has_refund = session.execute(
+        select(
+            exists().where(
+                CustomerPayment.original_payment_id == p.id,
+                CustomerPayment.direction == BillingPaymentDirection.REFUND,
+            )
+        )
+    ).scalar_one()
+    if has_refund:
+        raise ValidationError(
+            "Payment has linked refund rows and cannot be deleted",
+            field="paymentId",
+        )
+
+
+def _delete_payment(
+    event: Mapping[str, Any],
+    payment_id: UUID,
+    *,
+    user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    with _session_with_audit(user_sub, request_id) as session:
+        p = session.get(CustomerPayment, payment_id)
+        if p is None:
+            raise NotFoundError("CustomerPayment", str(payment_id))
+        _validate_orphan_delete(session, p)
+        old_values = p.to_audit_dict()
+        audit = AuditService(session, user_id=user_sub, request_id=request_id)
+        audit.log_custom(
+            table_name="customer_payments",
+            record_id=payment_id,
+            action="ORPHAN_INBOUND_PAYMENT_DELETED",
+            old_values=old_values,
+        )
+        session.delete(p)
+        session.flush()
+    return json_response(204, {}, event=event)
 
 
 def _list_payments(
@@ -123,9 +283,17 @@ def _list_payments(
             )
         stmt = stmt.limit(DEFAULT_BILLING_LIST_LIMIT)
         rows = list(session.execute(stmt).scalars().all())
+        deletable_by_id = _batch_orphan_payment_deletable(session, rows)
         return json_response(
             200,
-            {"items": [_serialize_payment(p) for p in rows]},
+            {
+                "items": [
+                    _serialize_payment(
+                        p, orphan_payment_deletable=deletable_by_id.get(p.id, False)
+                    )
+                    for p in rows
+                ]
+            },
             event=event,
         )
 
@@ -143,10 +311,11 @@ def _get_payment(
             raise NotFoundError("CustomerPayment", str(payment_id))
         unapplied = str(payment_unapplied_amount(session, payment_id))
         allocation_invoices = _payment_allocation_invoice_refs(session, payment_id)
+        deletable = _batch_orphan_payment_deletable(session, [p]).get(p.id, False)
         return json_response(
             200,
             {
-                **_serialize_payment(p),
+                **_serialize_payment(p, orphan_payment_deletable=deletable),
                 "unappliedAmount": unapplied,
                 "allocationInvoices": allocation_invoices,
             },
@@ -235,7 +404,7 @@ def _create_payment(
             action="REFUND_CREATED",
             new_values={"original_payment_id": str(orig_id), "amount": str(amount)},
         )
-        payload = _serialize_payment(refund)
+        payload = _serialize_payment(refund, orphan_payment_deletable=False)
     return json_response(201, {"payment": payload}, event=event)
 
 
@@ -270,7 +439,8 @@ def _confirm_payment(
         if existing_receipt is None:
             rcpt = create_receipt_for_succeeded_inbound_payment(session, payment=p)
             receipt_id_for_upload = rcpt.id
-        out = _serialize_payment(p)
+        deletable = _batch_orphan_payment_deletable(session, [p]).get(p.id, False)
+        out = _serialize_payment(p, orphan_payment_deletable=deletable)
     if receipt_id_for_upload is not None:
         try:
             with Session(get_engine()) as upload_session:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -2882,6 +2882,31 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete orphan inbound customer payment
+      description: >
+        Removes an inbound payment row only when it is safe cleanup: the payment must be
+        pending **or** free ($0 method or zero amount), not linked to an active enrollment
+        (enrollment id null, enrollment cancelled, or enrollment row missing), and must have
+        no invoice allocations, no customer receipt row, and no refund rows pointing at it.
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: Payment deleted.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /v1/admin/billing/payments/{id}/unapplied:
     get:
@@ -6086,6 +6111,8 @@ components:
           nullable: true
     CustomerPaymentSummary:
       type: object
+      required:
+        - orphanPaymentDeletable
       properties:
         id:
           type: string
@@ -6122,6 +6149,12 @@ components:
           type: string
           format: uuid
           nullable: true
+        orphanPaymentDeletable:
+          type: boolean
+          description: >
+            True when DELETE /v1/admin/billing/payments/{id} is allowed for this row
+            (pending or free/zero inbound; enrollment unlinked or cancelled; no allocations,
+            receipt, or refund children).
         succeededAt:
           type: string
           format: date-time

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -110,7 +110,7 @@ their primary responsibilities.
   effective discount type after the update is `referral`, otherwise `discount_value`
   must be greater than `0`),
   `/v1/admin/expenses/*`,
-  `/v1/admin/billing/*` (customer AR: `GET /v1/admin/billing/payments` optional `invoice_id` filters to payments with an allocation to that invoice; `GET /v1/admin/billing/payments/{id}` includes `allocationInvoices`; payments, invoices list/detail, draft invoices via
+  `/v1/admin/billing/*` (customer AR: `GET /v1/admin/billing/payments` optional `invoice_id` filters to payments with an allocation to that invoice; `GET /v1/admin/billing/payments/{id}` includes `allocationInvoices` and `orphanPaymentDeletable`; `DELETE /v1/admin/billing/payments/{id}` removes eligible orphan inbound payments (pending or free/zero, enrollment unlinked or cancelled, no allocations/receipt/refund children); payments, invoices list/detail, draft invoices via
   `POST /v1/admin/billing/invoices` with `draftKind` `enrollment_merge` or `customized_manual`,
   `GET /v1/admin/billing/enrollments/recent-for-invoicing`, `GET /v1/admin/billing/invoices/{id}/pdf`
   (returns a CloudFront-signed URL; each response includes a unique cache-bust query on the

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -29,7 +29,7 @@ from app.db.models.enums import (
     BillingPaymentStatus,
     EnrollmentStatus,
 )
-from app.exceptions import ValidationError
+from app.exceptions import NotFoundError, ValidationError
 from app.services import customer_billing
 
 
@@ -78,6 +78,11 @@ def test_handle_admin_billing_get_payment_and_unapplied_no_name_error(
     _patch_billing_sessions(monkeypatch, _fake_session)
     monkeypatch.setattr(
         admin_billing_payments_mod,
+        "_batch_orphan_payment_deletable",
+        lambda _session, rows: {r.id: False for r in rows},
+    )
+    monkeypatch.setattr(
+        admin_billing_payments_mod,
         "payment_unapplied_amount",
         lambda _s, _pid: Decimal("3"),
     )
@@ -93,6 +98,7 @@ def test_handle_admin_billing_get_payment_and_unapplied_no_name_error(
     assert r1["statusCode"] == 200
     body1 = json.loads(r1["body"])
     assert body1["unappliedAmount"] == "3"
+    assert body1["orphanPaymentDeletable"] is False
 
     ev2 = api_gateway_event(
         method="GET",
@@ -1196,6 +1202,11 @@ def test_confirm_payment_creates_receipt_for_pending_inbound(
     _patch_billing_sessions(monkeypatch, _fake_session)
     monkeypatch.setattr(
         admin_billing_payments_mod,
+        "_batch_orphan_payment_deletable",
+        lambda _session, rows: {r.id: False for r in rows},
+    )
+    monkeypatch.setattr(
+        admin_billing_payments_mod,
         "create_receipt_for_succeeded_inbound_payment",
         _create_rcpt,
     )
@@ -1216,6 +1227,82 @@ def test_confirm_payment_creates_receipt_for_pending_inbound(
     )
     assert r["statusCode"] == 200
     assert created["n"] == 1
+
+
+def test_delete_orphan_payment_succeeds(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pid = uuid4()
+    pay = MagicMock()
+    pay.id = pid
+    pay.to_audit_dict.return_value = {"id": str(pid)}
+    holder: dict[str, Any] = {}
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+        holder["s"] = s
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is admin_billing_payments_mod.CustomerPayment and pk == pid:
+                return pay
+            return None
+
+        s.get.side_effect = _get
+        yield s
+
+    class _FakeAudit:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def log_custom(self, **_kw: Any) -> None:
+            return None
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+    monkeypatch.setattr(
+        admin_billing_payments_mod, "_validate_orphan_delete", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(admin_billing_payments_mod, "AuditService", _FakeAudit)
+
+    ev = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/billing/payments/{pid}",
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "DELETE", f"/v1/admin/billing/payments/{pid}"
+    )
+    assert r["statusCode"] == 204
+    assert json.loads(r["body"]) == {}
+    holder["s"].delete.assert_called_once_with(pay)
+
+
+def test_delete_orphan_payment_not_found_raises(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pid = uuid4()
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+        s.get.return_value = None
+        yield s
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+
+    ev = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/billing/payments/{pid}",
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(NotFoundError):
+        admin_billing.handle_admin_billing_request(
+            ev, "DELETE", f"/v1/admin/billing/payments/{pid}"
+        )
 
 
 def test_refund_create_rejects_currency_mismatch_with_original(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Backend:** `DELETE /v1/admin/billing/payments/{id}` deletes an inbound payment only when it is **pending** or **free** (method `free` or amount `0`), the enrollment link is **gone**, **missing**, or **cancelled**, and there are **no** payment allocations, customer receipt rows, or refund children. Deletes are audit-logged as `ORPHAN_INBOUND_PAYMENT_DELETED`.
- **API contract:** `CustomerPaymentSummary` now includes required **`orphanPaymentDeletable`** so the Finance UI can show the delete action only when the server will accept `DELETE`.
- **Admin web:** Customer payments table **Operations** column shows a **delete** icon (with `ConfirmDialog`) when `orphanPaymentDeletable` is true; `deleteCustomerPayment` calls the new endpoint.
- **Docs:** OpenAPI (`docs/api/admin.yaml`), regenerated admin API types, and `docs/architecture/lambdas.md` updated.

## Tests

- `pytest tests/test_admin_billing.py -q`
- `cd apps/admin_web && npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx`
- `cd apps/admin_web && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-926a267a-4431-4ef5-a3dc-240b7476a125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-926a267a-4431-4ef5-a3dc-240b7476a125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

