### PR TITLE
Admin web: expense status filter on Tax fiscal year table

### DIFF
--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -21,7 +21,7 @@ import {
   type TaxFiscalYearRow,
 } from '@/lib/tax-fiscal-year-report';
 import { formatMoneyLineWithFxToDefault, loadFxMultipliersToAdminDefault } from '@/lib/vendor-spend';
-import type { Expense } from '@/types/expenses';
+import { EXPENSE_STATUSES, type Expense, type ExpenseStatus } from '@/types/expenses';
 
 /** Earliest Hong Kong FY start year offered in the selector (April Y → March Y+1). */
 const MIN_FISCAL_YEAR_START = 2024;
@@ -37,9 +37,11 @@ function isTaxDisplayedAsDash(tax: string | undefined): boolean {
 
 export function TaxFiscalYearPanel() {
   const fySelectId = useId();
+  const expenseStatusSelectId = useId();
   const [fyStartYear, setFyStartYear] = useState(
     () => Math.max(MIN_FISCAL_YEAR_START, defaultFiscalYearStartYear()),
   );
+  const [expenseStatusFilter, setExpenseStatusFilter] = useState<ExpenseStatus>('paid');
   const [loadError, setLoadError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [expensesPayload, setExpensesPayload] = useState<Expense[] | null>(null);
@@ -82,8 +84,8 @@ export function TaxFiscalYearPanel() {
     if (!expensesPayload || !issuedInvoicesPayload) {
       return [];
     }
-    return buildTaxFiscalYearRows(expensesPayload, issuedInvoicesPayload, fyStartYear);
-  }, [expensesPayload, issuedInvoicesPayload, fyStartYear]);
+    return buildTaxFiscalYearRows(expensesPayload, issuedInvoicesPayload, fyStartYear, expenseStatusFilter);
+  }, [expensesPayload, issuedInvoicesPayload, fyStartYear, expenseStatusFilter]);
 
   const rowsNeedForeignFx = useMemo(() => {
     const defaultCurrency = getAdminDefaultCurrencyCode();
@@ -139,11 +141,11 @@ export function TaxFiscalYearPanel() {
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
     anchor.href = url;
-    anchor.download = `tax-fiscal-year-${fyStartYear}-${fyStartYear + 1}.csv`;
+    anchor.download = `tax-fiscal-year-${fyStartYear}-${fyStartYear + 1}-${expenseStatusFilter}.csv`;
     anchor.rel = 'noopener';
     anchor.click();
     URL.revokeObjectURL(url);
-  }, [rows, fyStartYear]);
+  }, [rows, fyStartYear, expenseStatusFilter]);
 
   const tableError = [loadError, fxError].filter(Boolean).join(' ');
 
@@ -170,6 +172,21 @@ export function TaxFiscalYearPanel() {
               {fyYearOptions.map((y) => (
                 <option key={y} value={y}>
                   {y} - {y + 1}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className='min-w-[180px]'>
+            <Label htmlFor={expenseStatusSelectId}>Expense status</Label>
+            <Select
+              id={expenseStatusSelectId}
+              value={expenseStatusFilter}
+              onChange={(event) => setExpenseStatusFilter(event.target.value as ExpenseStatus)}
+              disabled={isLoading || Boolean(tableError)}
+            >
+              {EXPENSE_STATUSES.map((entry) => (
+                <option key={entry} value={entry}>
+                  {formatEnumLabel(entry)}
                 </option>
               ))}
             </Select>

--- a/apps/admin_web/src/lib/tax-fiscal-year-report.ts
+++ b/apps/admin_web/src/lib/tax-fiscal-year-report.ts
@@ -7,7 +7,7 @@ import {
   parseIsoDateOnly,
   todayHongKongDateString,
 } from '@/lib/fiscal-year';
-import type { Expense } from '@/types/expenses';
+import type { Expense, ExpenseStatus } from '@/types/expenses';
 
 export interface TaxFiscalYearRow {
   kind: 'expense' | 'revenue';
@@ -34,20 +34,17 @@ function expenseClassificationDate(expense: Expense): {
   return { date: paid, needsInvoiceDateWarning: true };
 }
 
-function expenseIncludedStatuses(expense: Expense): boolean {
-  return expense.status !== 'voided';
-}
-
 export function buildTaxFiscalYearRows(
   expenses: Expense[],
   issuedInvoices: CustomerInvoiceSummary[],
   fyStartYear: number,
+  expenseStatusFilter: ExpenseStatus,
 ): TaxFiscalYearRow[] {
   const { start, end } = getFiscalYearRangeInclusive(fyStartYear);
 
   const expenseRows: TaxFiscalYearRow[] = [];
   for (const expense of expenses) {
-    if (!expenseIncludedStatuses(expense)) {
+    if (expense.status !== expenseStatusFilter) {
       continue;
     }
     const { date, needsInvoiceDateWarning } = expenseClassificationDate(expense);

--- a/apps/admin_web/tests/lib/tax-fiscal-year-report.test.ts
+++ b/apps/admin_web/tests/lib/tax-fiscal-year-report.test.ts
@@ -43,23 +43,26 @@ describe('tax-fiscal-year-report', () => {
     expect(defaultFiscalYearStartYear(new Date('2026-03-20T12:00:00.000Z'))).toBe(2025);
   });
 
-  it('excludes voided expenses', () => {
-    const rows = buildTaxFiscalYearRows(
-      [
-        expenseStub({
-          id: 'x',
-          status: 'voided',
-          invoiceDate: '2025-06-01',
-          total: '50',
-        }),
-      ],
-      [],
-      2025,
-    );
-    expect(rows).toHaveLength(0);
+  it('filters expenses by selected status', () => {
+    const voided = expenseStub({
+      id: 'v',
+      status: 'voided',
+      invoiceDate: '2025-06-01',
+      total: '50',
+    });
+    const paid = expenseStub({
+      id: 'p',
+      status: 'paid',
+      invoiceDate: '2025-06-01',
+      total: '100',
+    });
+    expect(buildTaxFiscalYearRows([voided, paid], [], 2025, 'paid')).toHaveLength(1);
+    expect(buildTaxFiscalYearRows([voided, paid], [], 2025, 'paid')[0]?.referenceId).toBe('p');
+    expect(buildTaxFiscalYearRows([voided, paid], [], 2025, 'voided')).toHaveLength(1);
+    expect(buildTaxFiscalYearRows([voided, paid], [], 2025, 'voided')[0]?.referenceId).toBe('v');
   });
 
-  it('includes non-void expenses in range and revenue by issued date', () => {
+  it('includes expenses matching the status filter in range and revenue by issued date', () => {
     const rows = buildTaxFiscalYearRows(
       [
         expenseStub({
@@ -85,6 +88,7 @@ describe('tax-fiscal-year-report', () => {
         } satisfies CustomerInvoiceSummary,
       ],
       2025,
+      'draft',
     );
     expect(rows.map((r) => r.kind)).toEqual(['expense', 'revenue']);
     expect(rows[0]?.kind).toBe('expense');
@@ -105,6 +109,7 @@ describe('tax-fiscal-year-report', () => {
       ],
       [],
       2025,
+      'paid',
     );
     expect(rows).toHaveLength(1);
     expect(rows[0]?.needsInvoiceDateWarning).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **Expense status** dropdown to the Finance → Tax view toolbar, placed between **Fiscal year** and **Download CSV**. Options are the full `ExpenseStatus` set (draft, submitted, paid, voided, amended) using the same labels as elsewhere in admin. The default selection is **Paid**.

Expense rows in the table and in the CSV export are limited to the selected status. Issued invoice (revenue) rows are unchanged. The downloaded CSV filename includes the selected status segment for easier filing.

## Tests

- `cd apps/admin_web && npx vitest run tests/lib/tax-fiscal-year-report.test.ts`
- `cd apps/admin_web && npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0222352-3ea8-426f-8e3d-7cc65313476b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0222352-3ea8-426f-8e3d-7cc65313476b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

