### PR TITLE
Admin web: format submitted expense totals like tax money lines

### DIFF
--- a/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { KeyboardEvent } from 'react';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { OpenAdminAssetInNewTabButton } from '@/components/admin/shared/open-admin-asset-in-new-tab-button';
 import { DeleteIcon, MarkPaidIcon, RotateIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
@@ -14,9 +14,12 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { toErrorMessage } from '@/hooks/hook-errors';
 import { useOpenAdminAssetInNewTab } from '@/hooks/use-open-admin-asset-in-new-tab';
+import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { primaryExpenseAttachmentAssetId } from '@/lib/expense-attachments';
 import { formatDateOnly, formatEnumLabel } from '@/lib/format';
+import { formatMoneyLineWithFxToDefault, loadFxMultipliersToAdminDefault } from '@/lib/vendor-spend';
 import {
   EXPENSE_PARSE_STATUSES,
   EXPENSE_STATUSES,
@@ -98,6 +101,45 @@ export function ExpensesListPanel({
   const [voidExpenseId, setVoidExpenseId] = useState<string | null>(null);
   const [voidReason, setVoidReason] = useState('');
   const [voidError, setVoidError] = useState('');
+  const [fxMultipliers, setFxMultipliers] = useState<Map<string, number> | null>(null);
+  const [fxError, setFxError] = useState('');
+
+  const expensesNeedForeignFx = useMemo(() => {
+    const defaultCurrency = getAdminDefaultCurrencyCode();
+    return expenses.some(
+      (expense) => (expense.currency?.trim().toUpperCase() || defaultCurrency) !== defaultCurrency,
+    );
+  }, [expenses]);
+
+  useEffect(() => {
+    if (!expensesNeedForeignFx) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      setFxMultipliers(null);
+      try {
+        const codes = expenses
+          .map((expense) => expense.currency?.trim().toUpperCase())
+          .filter((code): code is string => Boolean(code));
+        const map = await loadFxMultipliersToAdminDefault(codes);
+        if (!cancelled) {
+          setFxMultipliers(map);
+          setFxError('');
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setFxError(toErrorMessage(err, 'Could not load FX rates for currency conversion.'));
+          setFxMultipliers(new Map());
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [expenses, expensesNeedForeignFx]);
+
+  const tableError = [error, expensesNeedForeignFx ? fxError : ''].filter(Boolean).join(' ');
 
   const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, expenseId: string) => {
     if (event.target !== event.currentTarget) {
@@ -172,7 +214,7 @@ export function ExpensesListPanel({
         isLoading={isLoading}
         isLoadingMore={isLoadingMore}
         hasMore={hasMore}
-        error={error}
+        error={tableError}
         loadingLabel='Loading submitted expenses...'
         onLoadMore={onLoadMore}
         toolbar={
@@ -255,18 +297,15 @@ export function ExpensesListPanel({
                     </p>
                   </td>
                   <td className='px-4 py-3'>
-                    {!expense.total ? (
-                      '—'
-                    ) : expense.currency ? (
-                      <span className='tabular-nums'>
-                        {expense.total} {expense.currency}
-                      </span>
-                    ) : (
-                      <div>
-                        <span className='tabular-nums'>{expense.total}</span>
-                        <p className='mt-0.5 text-xs text-slate-500'>No currency code</p>
-                      </div>
-                    )}
+                    <span className='tabular-nums'>
+                      {fxMultipliers === null && expensesNeedForeignFx
+                        ? '…'
+                        : formatMoneyLineWithFxToDefault(
+                            expense.total?.trim() ?? '',
+                            expense.currency ?? undefined,
+                            expensesNeedForeignFx ? (fxMultipliers ?? new Map()) : new Map(),
+                          )}
+                    </span>
                   </td>
                   <td className='px-4 py-3'>{formatEnumLabel(expense.status)}</td>
                   <td className='px-4 py-3'>{formatDateOnly(expense.invoiceDate)}</td>

--- a/apps/admin_web/tests/components/admin/finance/expenses-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/expenses-list-panel.test.tsx
@@ -14,8 +14,28 @@ vi.mock('@/lib/assets-api', async (importOriginal) => {
   };
 });
 
+vi.mock('@/lib/currency-converter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/currency-converter')>();
+  return {
+    ...actual,
+    getCurrencyConversionMultiplier: vi.fn(async (fromCurrency: string, toCurrency: string) => {
+      const from = fromCurrency.trim().toUpperCase();
+      const to = toCurrency.trim().toUpperCase();
+      if (!from || !to || from === to) {
+        return 1;
+      }
+      if (from === 'USD' && to === 'HKD') {
+        return 7.8;
+      }
+      return 1;
+    }),
+  };
+});
+
 import { ExpensesListPanel } from '@/components/admin/finance/expenses-list-panel';
+import { clearCurrencyConversionRateCacheForTests } from '@/lib/currency-converter';
 import { formatDateOnly } from '@/lib/format';
+import { formatMoneyLineWithFxToDefault } from '@/lib/vendor-spend';
 
 import type { Expense } from '@/types/expenses';
 
@@ -91,6 +111,7 @@ describe('ExpensesListPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetUserAssetDownloadUrl.mockReset();
+    clearCurrencyConversionRateCacheForTests();
   });
 
   it('renders core columns without Invoice or Parse headers', () => {
@@ -146,7 +167,7 @@ describe('ExpensesListPanel', () => {
     expect(screen.getByRole('button', { name: 'No invoice document available' })).toBeDisabled();
   });
 
-  it('shows invoice date without time in Issued column and labels missing currency', () => {
+  it('shows invoice date without time in Issued column and formats total like tax amounts when currency is missing', () => {
     render(
       <ExpensesListPanel
         {...listProps}
@@ -163,8 +184,35 @@ describe('ExpensesListPanel', () => {
     );
 
     expect(screen.getByText(formatDateOnly('2026-02-15T14:30:00Z'))).toBeInTheDocument();
-    expect(screen.getByText('30.00')).toBeInTheDocument();
-    expect(screen.getByText('No currency code')).toBeInTheDocument();
+    expect(
+      screen.getByText(formatMoneyLineWithFxToDefault('30.00', undefined, new Map())),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No currency code')).not.toBeInTheDocument();
+  });
+
+  it('formats total with FX line for non-default currency (same helper as tax fiscal year table)', async () => {
+    const multipliers = new Map([['USD', 7.8]]);
+    const expected = formatMoneyLineWithFxToDefault('100.00', 'USD', multipliers);
+
+    render(
+      <ExpensesListPanel
+        {...listProps}
+        expenses={[{ ...baseExpense, currency: 'USD', total: '100.00' }]}
+        {...makeRowActions()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeInTheDocument();
+    });
+  });
+
+  it('formats HKD total with locale currency styling', () => {
+    render(<ExpensesListPanel {...listProps} {...makeRowActions()} />);
+
+    expect(
+      screen.getByText(formatMoneyLineWithFxToDefault('10.00', 'HKD', new Map())),
+    ).toBeInTheDocument();
   });
 
   it('calls onSelectExpense when a row is clicked', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Submitted Expenses** table **Total** column now uses the same money formatting as the **Tax** fiscal year report (amount/tax columns): `formatMoneyLineWithFxToDefault` from `vendor-spend`, which delegates HKD vs other currencies to `formatAmountInCurrency` and adds the admin-default conversion suffix when the row currency is not the default.

## Behavior

- **HKD (or default currency) rows:** locale currency string (e.g. `HK$10.00`).
- **Foreign currency rows:** `converted (original)` once Frankfurter rates load; **…** while rates load (same pattern as the Tax table).
- **Missing currency:** treated like the Tax report—amount is formatted using the admin default currency code (no separate “No currency code” line).
- **FX load failures:** error message is merged into the list card error area (only while the list includes foreign-currency rows).

## Tests

- `cd apps/admin_web && npx vitest run tests/components/admin/finance/expenses-list-panel.test.tsx`
- `cd apps/admin_web && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91dcb019-72f4-4066-af12-0a3f603de3cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91dcb019-72f4-4066-af12-0a3f603de3cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

