### PR TITLE
Allow zero price for training service instances

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5606,6 +5606,7 @@ export interface components {
             session_slots?: components["schemas"]["SessionSlot"][];
             training_details?: {
                 training_format?: components["schemas"]["TrainingFormat"];
+                /** @description Required for training_course instances. Decimal amount as a string; zero is allowed (free offerings). */
                 price?: string;
                 currency?: string;
                 pricing_unit?: components["schemas"]["TrainingPricingUnit"];

--- a/backend/src/app/api/admin_services_payload_utils.py
+++ b/backend/src/app/api/admin_services_payload_utils.py
@@ -193,7 +193,7 @@ def parse_instance_type_details(
                 TrainingFormat,
                 "training_format",
             ),
-            "price": parse_required_decimal(
+            "price": parse_required_non_negative_decimal(
                 source.get("price") if "price" in source else body.get("price"),
                 "price",
             ),

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -5141,6 +5141,8 @@ components:
               $ref: "#/components/schemas/TrainingFormat"
             price:
               type: string
+              description: >
+                Required for training_course instances. Decimal amount as a string; zero is allowed (free offerings).
             currency:
               type: string
             pricing_unit:

--- a/tests/test_admin_services_instance_metadata.py
+++ b/tests/test_admin_services_instance_metadata.py
@@ -187,6 +187,38 @@ def test_parse_create_instance_payload_accepts_tag_ids() -> None:
     assert parsed["tag_ids"] == [t2, t1]
 
 
+def test_parse_create_training_instance_accepts_zero_price() -> None:
+    service = _minimal_training_service()
+    body = {
+        "slug": "free-run",
+        "training_details": {
+            "training_format": "group",
+            "price": "0",
+            "currency": "HKD",
+            "pricing_unit": "per_person",
+        },
+    }
+    parsed = parse_create_instance_payload(body, service)
+    assert parsed["type_details"]["price"] == Decimal("0")
+
+
+def test_parse_create_training_instance_rejects_negative_price() -> None:
+    service = _minimal_training_service()
+    body = {
+        "slug": "bad-price",
+        "training_details": {
+            "training_format": "group",
+            "price": "-1.00",
+            "currency": "HKD",
+            "pricing_unit": "per_person",
+        },
+    }
+    with pytest.raises(ValidationError) as exc:
+        parse_create_instance_payload(body, service)
+    assert exc.value.field == "price"
+    assert "must be >= 0" in exc.value.message
+
+
 def test_training_instance_round_trip_cohort_tags_in_memory() -> None:
     """ORM-only check: fields map and serializer ordering matches tag name (case-insensitive)."""
     from app.api.admin_services_serializers import serialize_instance


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Training course **instance** prices were validated with `parse_required_decimal`, which requires values strictly greater than zero. That blocked free (HKD 0) training offerings.

## Changes

- Parse `training_details.price` on instance create/update with `parse_required_non_negative_decimal` so **zero is allowed**; negative amounts remain rejected.
- Document `CreateInstanceRequest.training_details.price` in `docs/api/admin.yaml` and regenerate `apps/admin_web/src/types/generated/admin-api.generated.ts`.
- Add pytest coverage for zero and negative training instance prices.

## Notes

- **Event** instance ticket tiers already used optional decimal parsing without a strict positivity check; **service** catalog `default_price` fields already used optional decimals.
- Non-training flows (for example discount codes) still use strict positive decimals where required.

## Verification

- `pytest tests/test_admin_services_instance_metadata.py`
- `npm run generate:admin-api-types && npm run check:admin-api-types` (admin web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ac8c8db-08c5-4666-b8ff-9df1e26aba65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ac8c8db-08c5-4666-b8ff-9df1e26aba65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

