### PR TITLE
fix(admin): Family/org draft invoice picker shows entity · primary contact

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -133,10 +133,14 @@ function defaultLineAmount(row: BillingEnrollmentPickerRow): string {
   return row.amountPaid != null && row.amountPaid.trim() !== '' ? row.amountPaid.trim() : '0';
 }
 
-/** Party column: `name · email` when email is non-empty; otherwise party name only. */
+/** Party column: contact rows use `name · email`. Family/org rows use `partyDisplayName` only (entity · primary). */
 function formatEnrollmentPartyCellDisplay(row: BillingEnrollmentPickerRow): string {
   const party = row.partyDisplayName?.trim() ?? '';
   const email = row.partyEmail?.trim() ?? '';
+  const kind = row.billToKind;
+  if (kind === 'family' || kind === 'organization') {
+    return party;
+  }
   if (email === '') {
     return party;
   }

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -6133,10 +6133,15 @@ export interface components {
         BillingEnrollmentPickerRow: {
             /** Format: uuid */
             enrollmentId: string;
-            /** @description Contact, family, or organization display name for bill-to / enrollment party. */
+            /** @description Display label for the bill-to / enrollment party. For `contact` this is the contact name. For `family` or `organization` this is `entity name · primary contact name` (middle dot) when both the entity and primary contact names are known; otherwise the best available single label. */
             partyDisplayName: string;
             /** Format: email */
             partyEmail?: string | null;
+            /**
+             * @description Bill-to kind for this enrollment (matches `billing_bill_to_kind`).
+             * @enum {string}
+             */
+            billToKind?: "contact" | "family" | "organization";
             /** @description Trimmed instance-specific title when set. */
             instanceTitle?: string | null;
             /** @description Parent service template title from the instance's service (for display when `instanceTitle` is empty). */

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -763,11 +763,13 @@ describe('ClientInvoicesPanel', () => {
       billToMergeKey: string;
       invoiceLinked: boolean;
       amountPaid: string | null;
+      billToKind: 'contact' | 'family' | 'organization';
     }>,
   ) => ({
     enrollmentId: overrides.enrollmentId ?? 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
     partyDisplayName: overrides.partyDisplayName ?? 'Pat',
     partyEmail: overrides.partyEmail !== undefined ? overrides.partyEmail : 'pat@example.com',
+    billToKind: overrides.billToKind ?? 'contact',
     instanceTitle: 'Inst',
     serviceTierName: null,
     instanceCohort: null,
@@ -1143,5 +1145,25 @@ describe('ClientInvoicesPanel', () => {
     expect(screen.getByText('No Email Party')).toBeInTheDocument();
     const enrollmentPicker = screen.getByRole('region', { name: 'Enrollment picker' });
     expect(within(enrollmentPicker).queryByRole('columnheader', { name: 'Email' })).not.toBeInTheDocument();
+  });
+
+  it('draft enrollment picker Party column for family bill-to uses composed label without appending email', async () => {
+    billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
+      items: [
+        pickerRow({
+          enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-111111111111',
+          partyDisplayName: 'Smith Family · Jane Primary',
+          partyEmail: 'jane@example.com',
+          billToKind: 'family',
+        }),
+      ],
+      truncated: false,
+    });
+    render(<ClientInvoicesPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Smith Family · Jane Primary')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Smith Family · Jane Primary · jane@example.com/)).not.toBeInTheDocument();
   });
 });

--- a/backend/src/app/api/admin_billing_common.py
+++ b/backend/src/app/api/admin_billing_common.py
@@ -82,3 +82,47 @@ def primary_org_emails(session: Session, org_ids: set[UUID]) -> dict[UUID, str]:
         if email and oid not in out:
             out[oid] = str(email)
     return out
+
+
+def primary_family_contact_names(
+    session: Session, family_ids: set[UUID]
+) -> dict[UUID, str]:
+    """Map family id -> primary contact display name (first + last) when non-empty."""
+    if not family_ids:
+        return {}
+    stmt = (
+        select(FamilyMember.family_id, Contact.first_name, Contact.last_name)
+        .join(Contact, FamilyMember.contact_id == Contact.id)
+        .where(FamilyMember.family_id.in_(family_ids))
+        .where(FamilyMember.is_primary_contact.is_(True))
+    )
+    out: dict[UUID, str] = {}
+    for fid, fn, ln in session.execute(stmt).all():
+        if fid in out:
+            continue
+        display = " ".join(x for x in (fn, ln) if x).strip()
+        if display:
+            out[fid] = display
+    return out
+
+
+def primary_org_contact_names(session: Session, org_ids: set[UUID]) -> dict[UUID, str]:
+    """Map organization id -> primary contact display name (first + last) when non-empty."""
+    if not org_ids:
+        return {}
+    stmt = (
+        select(
+            OrganizationMember.organization_id, Contact.first_name, Contact.last_name
+        )
+        .join(Contact, OrganizationMember.contact_id == Contact.id)
+        .where(OrganizationMember.organization_id.in_(org_ids))
+        .where(OrganizationMember.is_primary_contact.is_(True))
+    )
+    out: dict[UUID, str] = {}
+    for oid, fn, ln in session.execute(stmt).all():
+        if oid in out:
+            continue
+        display = " ".join(x for x in (fn, ln) if x).strip()
+        if display:
+            out[oid] = display
+    return out

--- a/backend/src/app/api/admin_billing_enrollment_queries.py
+++ b/backend/src/app/api/admin_billing_enrollment_queries.py
@@ -17,7 +17,9 @@ from app.api.admin_billing_common import (
     _session_with_audit,
     contact_display_name,
     enrollment_bill_to_merge_key,
+    primary_family_contact_names,
     primary_family_emails,
+    primary_org_contact_names,
     primary_org_emails,
 )
 from app.api.admin_request import parse_limit, query_param
@@ -43,7 +45,13 @@ def _decimal_to_string(value: Decimal | None) -> str | None:
     return format(value, "f")
 
 
-def _party_display_name(enrollment: Enrollment) -> str:
+def _compose_party_display_name(
+    enrollment: Enrollment,
+    *,
+    family_primary_contact_name: str | None,
+    org_primary_contact_name: str | None,
+) -> str:
+    """Party label for picker rows: contact name; family/org use entity · primary contact name."""
     bk = enrollment.bill_to_kind or BillingBillToKind.CONTACT
     if bk == BillingBillToKind.CONTACT:
         c = enrollment.bill_to_contact or enrollment.contact
@@ -51,10 +59,26 @@ def _party_display_name(enrollment: Enrollment) -> str:
         return name if name else "—"
     if bk == BillingBillToKind.FAMILY:
         fam = enrollment.bill_to_family or enrollment.family
-        return fam.family_name if fam and fam.family_name else "—"
+        entity = (fam.family_name or "").strip() if fam else ""
+        pc = (family_primary_contact_name or "").strip()
+        if entity and pc:
+            return f"{entity} \u00b7 {pc}"
+        if entity:
+            return entity
+        if pc:
+            return pc
+        return "—"
     if bk == BillingBillToKind.ORGANIZATION:
         org = enrollment.bill_to_organization or enrollment.organization
-        return org.name if org and org.name else "—"
+        entity = (org.name or "").strip() if org else ""
+        pc = (org_primary_contact_name or "").strip()
+        if entity and pc:
+            return f"{entity} \u00b7 {pc}"
+        if entity:
+            return entity
+        if pc:
+            return pc
+        return "—"
     return "—"
 
 
@@ -299,6 +323,8 @@ def list_recent_enrollments_for_invoicing(
         fam_ids, org_ids = _collect_family_org_ids(page_rows)
         fam_emails = primary_family_emails(session, fam_ids)
         org_emails = primary_org_emails(session, org_ids)
+        fam_primary_names = primary_family_contact_names(session, fam_ids)
+        org_primary_names = primary_org_contact_names(session, org_ids)
 
         default_ccy = get_default_currency_code()
         items: list[dict[str, Any]] = []
@@ -319,11 +345,28 @@ def list_recent_enrollments_for_invoicing(
                 tier_name = _trimmed_str_or_none(svc_obj.service_tier)
             currency = (en.currency or default_ccy).upper()[:3]
             email = _party_email(session, en, fam_emails, org_emails)
+            bk = en.bill_to_kind or BillingBillToKind.CONTACT
+            fam_pc: str | None = None
+            org_pc: str | None = None
+            if bk == BillingBillToKind.FAMILY:
+                fid = en.bill_to_family_id or en.family_id
+                if fid:
+                    fam_pc = fam_primary_names.get(fid)
+            elif bk == BillingBillToKind.ORGANIZATION:
+                oid = en.bill_to_organization_id or en.organization_id
+                if oid:
+                    org_pc = org_primary_names.get(oid)
+            party_display = _compose_party_display_name(
+                en,
+                family_primary_contact_name=fam_pc,
+                org_primary_contact_name=org_pc,
+            )
             items.append(
                 {
                     "enrollmentId": str(en.id),
-                    "partyDisplayName": _party_display_name(en),
+                    "partyDisplayName": party_display,
                     "partyEmail": email,
+                    "billToKind": bk.value,
                     "instanceTitle": title,
                     "parentServiceTitle": parent_service_title,
                     "serviceTierName": tier_name,

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -6333,11 +6333,22 @@ components:
           format: uuid
         partyDisplayName:
           type: string
-          description: Contact, family, or organization display name for bill-to / enrollment party.
+          description: >
+            Display label for the bill-to / enrollment party. For `contact` this is the contact
+            name. For `family` or `organization` this is `entity name · primary contact name` (middle
+            dot) when both the entity and primary contact names are known; otherwise the best
+            available single label.
         partyEmail:
           type: string
           format: email
           nullable: true
+        billToKind:
+          type: string
+          enum:
+            - contact
+            - family
+            - organization
+          description: Bill-to kind for this enrollment (matches `billing_bill_to_kind`).
         instanceTitle:
           type: string
           nullable: true

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -479,7 +479,10 @@ def test_list_recent_enrollments_orders_and_filters(
             elif "customer_invoice_lines" in sql:
                 out.scalars.return_value.all.return_value = [en_later.id]
             elif "FamilyMember" in sql or "family_members" in sql:
-                out.all.return_value = [(fam_id, "primary@example.com")]
+                if "first_name" in sql.lower():
+                    out.all.return_value = [(fam_id, "Primary", "Person")]
+                else:
+                    out.all.return_value = [(fam_id, "primary@example.com")]
             elif "organization_members" in sql:
                 out.all.return_value = []
             else:
@@ -513,6 +516,10 @@ def test_list_recent_enrollments_orders_and_filters(
     row0 = body["items"][0]
     assert row0["invoiceLinked"] is True
     assert row0["partyEmail"] == "primary@example.com"
+    assert row0["partyDisplayName"] == "Smith Family · Primary Person"
+    assert row0["billToKind"] == "family"
+    assert body["items"][1]["partyDisplayName"] == "Smith Family · Primary Person"
+    assert body["items"][1]["billToKind"] == "family"
 
 
 def test_create_invoice_draft_currency_empty_string_derives(
@@ -1019,10 +1026,12 @@ def test_list_recent_enrollments_org_bill_to_primary_email(
     en.ticket_tier = None
     en.contact = None
     en.family = None
-    en.organization = MagicMock(name="Acme Corp")
+    org_obj = MagicMock()
+    org_obj.name = "Acme Corp"
+    en.organization = org_obj
     en.bill_to_contact = None
     en.bill_to_family = None
-    en.bill_to_organization = MagicMock(name="Acme Corp")
+    en.bill_to_organization = org_obj
 
     @contextmanager
     def _fake_session(_u: str, _r: str | None) -> Any:
@@ -1036,7 +1045,10 @@ def test_list_recent_enrollments_org_bill_to_primary_email(
             elif "customer_invoice_lines" in sql:
                 out.scalars.return_value.all.return_value = []
             elif "organization_members" in sql:
-                out.all.return_value = [(oid, "org.primary@example.com")]
+                if "first_name" in sql.lower():
+                    out.all.return_value = [(oid, "Jane", "Doe")]
+                else:
+                    out.all.return_value = [(oid, "org.primary@example.com")]
             elif "FamilyMember" in sql or "family_members" in sql:
                 out.all.return_value = []
             else:
@@ -1063,6 +1075,8 @@ def test_list_recent_enrollments_org_bill_to_primary_email(
     assert r["statusCode"] == 200
     body = json.loads(r["body"])
     assert body["items"][0]["partyEmail"] == "org.primary@example.com"
+    assert body["items"][0]["partyDisplayName"] == "Acme Corp · Jane Doe"
+    assert body["items"][0]["billToKind"] == "organization"
 
 
 def test_list_recent_enrollments_parent_service_title_and_service_tier_fallback(
@@ -1153,6 +1167,7 @@ def test_list_recent_enrollments_parent_service_title_and_service_tier_fallback(
     assert row["parentServiceTitle"] == "Parent Course"
     assert row["serviceTierName"] == "Standard"
     assert row["instanceCohort"] == "Cohort A"
+    assert row["billToKind"] == "contact"
 
 
 def test_confirm_payment_creates_receipt_for_pending_inbound(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Creates draft invoice enrollment picker rows now show a meaningful Party label for family and organization bill-to enrollments: **`entity name · primary contact name`** (middle dot), using the primary family/org member’s first and last name from the database.

## Changes

- **Backend:** `GET /v1/admin/billing/enrollments/recent-for-invoicing` builds `partyDisplayName` with `primary_family_contact_names` / `primary_org_contact_names` (alongside existing primary-email lookups). Each item includes **`billToKind`** (`contact` | `family` | `organization`).
- **Admin Web:** The Party column still shows **`name · email`** for contact bill-to. For family/org it shows **`partyDisplayName` only** so we do not append email after an already composed label.
- **OpenAPI:** `BillingEnrollmentPickerRow` documents `billToKind` and updates `partyDisplayName` description; admin API types regenerated.

## Tests

- `pytest tests/test_admin_billing.py` (full module)
- `npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx`
- `npm run lint` (admin_web)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e88aaa6-a3a0-4653-af6d-cfc02ffd95d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e88aaa6-a3a0-4653-af6d-cfc02ffd95d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

