### PR TITLE
Admin web: editable enrollment enrolled at

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -15,7 +15,13 @@ import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useEnrollmentParentPickers } from '@/hooks/use-enrollment-parent-pickers';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
-import { formatDate, formatEnumLabel, getCurrencyOptions } from '@/lib/format';
+import {
+  formatDate,
+  formatEnumLabel,
+  formatIsoForDatetimeLocalInput,
+  getCurrencyOptions,
+  parseDatetimeLocalToIsoUtc,
+} from '@/lib/format';
 import { isAbortRequestError, listEnrollmentDiscountOptions } from '@/lib/services-api';
 import { formatAmountInCurrency } from '@/lib/vendor-spend';
 
@@ -101,6 +107,8 @@ export function EnrollmentListPanel({
   const [discountOptionsLoading, setDiscountOptionsLoading] = useState(false);
   const [discountOptionsError, setDiscountOptionsError] = useState('');
   const [notes, setNotes] = useState('');
+  const [enrolledAtLocal, setEnrolledAtLocal] = useState('');
+  const [enrolledAtError, setEnrolledAtError] = useState('');
 
   const selectedEnrollment = useMemo(
     () => enrollments.find((entry) => entry.id === selectedEnrollmentId) ?? null,
@@ -192,6 +200,8 @@ export function EnrollmentListPanel({
     setCurrency('HKD');
     setDiscountCodeId('');
     setNotes('');
+    setEnrolledAtLocal('');
+    setEnrolledAtError('');
   };
 
   const buildCreatePayload = (): ApiSchemas['CreateEnrollmentRequest'] => ({
@@ -206,12 +216,16 @@ export function EnrollmentListPanel({
   });
 
   const buildUpdatePayload = (): ApiSchemas['UpdateEnrollmentRequest'] => {
+    const enrolledIso = parseDatetimeLocalToIsoUtc(enrolledAtLocal);
     const base: ApiSchemas['UpdateEnrollmentRequest'] = {
       status,
       amount_paid: amountPaid.trim() || null,
       currency: currency.trim() || null,
       notes: notes.trim() || null,
     };
+    if (enrolledIso) {
+      base.enrolled_at = enrolledIso;
+    }
     const nextDiscount = discountCodeId.trim() || null;
     const prev = selectedEnrollment?.discountCodeId?.trim() || null;
     if (nextDiscount !== prev) {
@@ -230,6 +244,12 @@ export function EnrollmentListPanel({
       if (!selectedEnrollment) {
         return;
       }
+      const enrolledIso = parseDatetimeLocalToIsoUtc(enrolledAtLocal);
+      if (!enrolledIso) {
+        setEnrolledAtError('Choose a valid enrolled date and time.');
+        return;
+      }
+      setEnrolledAtError('');
       await onUpdate(selectedEnrollment.id, buildUpdatePayload());
     } catch {
       // Keep inline form state visible to let users retry.
@@ -246,6 +266,8 @@ export function EnrollmentListPanel({
     setCurrency(enrollment.currency ?? 'HKD');
     setDiscountCodeId(enrollment.discountCodeId ?? '');
     setNotes(enrollment.notes ?? '');
+    setEnrolledAtLocal(formatIsoForDatetimeLocalInput(enrollment.enrolledAt));
+    setEnrolledAtError('');
   };
 
   const handleDeleteEnrollment = async (enrollment: Enrollment) => {
@@ -312,7 +334,7 @@ export function EnrollmentListPanel({
             {parentPickersError}
           </p>
         ) : null}
-        <div className='grid grid-cols-1 gap-3 sm:grid-cols-3'>
+        <div className='grid grid-cols-1 gap-3 sm:grid-cols-4'>
           <div>
             <Label htmlFor='enrollment-contact'>Contact</Label>
             <Select
@@ -373,10 +395,25 @@ export function EnrollmentListPanel({
               ))}
             </Select>
           </div>
+          <div>
+            <Label htmlFor='enrollment-enrolled-at'>Enrolled at</Label>
+            <Input
+              id='enrollment-enrolled-at'
+              type='datetime-local'
+              value={isEditMode ? enrolledAtLocal : ''}
+              onChange={(event) => setEnrolledAtLocal(event.target.value)}
+              disabled={!isEditMode || !canCreate || isMutating}
+            />
+          </div>
         </div>
+        {enrolledAtError ? (
+          <p className='text-xs text-red-600' role='alert'>
+            {enrolledAtError}
+          </p>
+        ) : null}
         <p className='text-xs text-slate-500'>
           Contact, family, and organization are chosen when creating an enrollment and cannot be changed
-          afterward.
+          afterward. Enrolled at can be edited when updating an enrollment.
         </p>
         {canCreate && discountOptionsError ? (
           <p className='text-xs text-red-600' role='alert'>

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5679,6 +5679,11 @@ export interface components {
         };
         UpdateEnrollmentRequest: {
             status?: components["schemas"]["EnrollmentStatus"];
+            /**
+             * Format: date-time
+             * @description ISO 8601 instant for when the enrollment was recorded. Omit to leave unchanged. Null or empty strings are rejected (the enrollment row requires a timestamp).
+             */
+            enrolled_at?: string;
             amount_paid?: string | null;
             currency?: string | null;
             /**

--- a/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { EnrollmentListPanel } from '@/components/admin/services/enrollment-list-panel';
+import { parseDatetimeLocalToIsoUtc } from '@/lib/format';
 import type { Enrollment } from '@/types/services';
 
 vi.mock('@/lib/services-api', () => ({
@@ -77,6 +78,64 @@ describe('EnrollmentListPanel', () => {
     expect(screen.getByLabelText('Contact')).toBeDisabled();
     expect(screen.getByLabelText('Family')).toBeDisabled();
     expect(screen.getByLabelText('Organization')).toBeDisabled();
+    expect(screen.getByLabelText('Enrolled at')).toBeEnabled();
+  });
+
+  it('disables enrolled at while adding a new enrollment', () => {
+    render(
+      <EnrollmentListPanel
+        enrollments={[ENROLLMENT_FIXTURE]}
+        serviceId='service-1'
+        instanceId='instance-1'
+        canCreate={true}
+        isLoading={false}
+        isLoadingMore={false}
+        hasMore={false}
+        error=''
+        isMutating={false}
+        onLoadMore={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Enrolled at')).toBeDisabled();
+  });
+
+  it('includes enrolled_at in the update payload after changing datetime-local', () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    render(
+      <EnrollmentListPanel
+        enrollments={[ENROLLMENT_FIXTURE]}
+        serviceId='service-1'
+        instanceId='instance-1'
+        canCreate={true}
+        isLoading={false}
+        isLoadingMore={false}
+        hasMore={false}
+        error=''
+        isMutating={false}
+        onLoadMore={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={onUpdate}
+        onDelete={vi.fn()}
+      />
+    );
+
+    const table = screen.getByRole('table');
+    fireEvent.click(within(table).getByText('Jane Doe').closest('tr') as HTMLTableRowElement);
+
+    const enrolledInput = screen.getByLabelText('Enrolled at');
+    fireEvent.change(enrolledInput, { target: { value: '2026-06-15T14:30' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Update enrollment' }));
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      'enrollment-1',
+      expect.objectContaining({
+        enrolled_at: parseDatetimeLocalToIsoUtc('2026-06-15T14:30'),
+      }),
+    );
   });
 
   it('shows scheduled start column when enrollment rows include scheduled start', () => {

--- a/backend/src/app/api/admin_enrollments.py
+++ b/backend/src/app/api/admin_enrollments.py
@@ -226,6 +226,8 @@ def _update_enrollment(
                 enrollment.cancelled_at = datetime.now(UTC)
             else:
                 enrollment.cancelled_at = None
+        if "enrolled_at" in payload:
+            enrollment.enrolled_at = payload["enrolled_at"]
         if "amount_paid" in payload:
             enrollment.amount_paid = payload["amount_paid"]
         if "currency" in payload:

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -540,6 +540,16 @@ def parse_update_enrollment_payload(body: Mapping[str, Any]) -> dict[str, Any]:
         payload["status"] = parse_required_enum(
             body.get("status"), EnrollmentStatus, "status"
         )
+    if has_field(body, "enrolled_at"):
+        parsed_enrolled_at = parse_optional_datetime(
+            body.get("enrolled_at"), "enrolled_at"
+        )
+        if parsed_enrolled_at is None:
+            raise ValidationError(
+                "enrolled_at cannot be cleared; omit the field to leave unchanged",
+                field="enrolled_at",
+            )
+        payload["enrolled_at"] = parsed_enrolled_at
     if has_field(body, "amount_paid"):
         payload["amount_paid"] = parse_optional_decimal(
             body.get("amount_paid"), "amount_paid"

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -5293,6 +5293,12 @@ components:
       properties:
         status:
           $ref: "#/components/schemas/EnrollmentStatus"
+        enrolled_at:
+          type: string
+          format: date-time
+          description: >
+            ISO 8601 instant for when the enrollment was recorded. Omit to leave unchanged.
+            Null or empty strings are rejected (the enrollment row requires a timestamp).
         amount_paid:
           type: string
           nullable: true

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -257,7 +257,8 @@ their primary responsibilities.
   on `(purpose_service_id, starts_at)` uniqueness, then attach enrollment and payment rows.
   Other booking systems attach the enrollment directly to the resolved instance when capacity allows
   (or return **409** when the instance is full with waitlist disabled). Admin enrollment APIs validate
-  discount code scope to `services.id` / `service_instances.id` as scoped on the code row.
+  discount code scope to `services.id` / `service_instances.id` as scoped on the code row; `PATCH`
+  enrollments may update `enrolled_at` (ISO instant; omit to leave unchanged).
   Then sends
   booking confirmation (SES), optional Mailchimp subscribe, and a plain-text **sales recap**
   with extended booking context when provided, and signed upload/download URL generation in

--- a/tests/test_admin_enrollments_api.py
+++ b/tests/test_admin_enrollments_api.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 
 from app.api import admin_enrollments
+from app.api.admin_services_payloads import parse_update_enrollment_payload
 from app.db.models.enums import EnrollmentStatus
 from app.exceptions import ValidationError
 
@@ -309,6 +310,23 @@ def test_update_enrollment_discount_swaps_usage_counts(monkeypatch: Any, api_gat
     assert resp["statusCode"] == 200
     assert decrement_calls == [old_dc]
     assert increment_calls == [new_dc]
+
+
+def test_parse_update_enrollment_payload_accepts_enrolled_at() -> None:
+    parsed = parse_update_enrollment_payload({"enrolled_at": "2026-05-01T08:30:00+00:00"})
+    assert parsed["enrolled_at"].year == 2026
+    assert parsed["enrolled_at"].month == 5
+    assert parsed["enrolled_at"].day == 1
+
+
+def test_parse_update_enrollment_payload_rejects_cleared_enrolled_at() -> None:
+    with pytest.raises(ValidationError, match="enrolled_at"):
+        parse_update_enrollment_payload({"enrolled_at": None})
+
+
+def test_parse_update_enrollment_payload_rejects_empty_enrolled_at() -> None:
+    with pytest.raises(ValidationError, match="enrolled_at"):
+        parse_update_enrollment_payload({"enrolled_at": ""})
 
 
 def test_delete_enrollment_decrements_discount_usage(monkeypatch: Any, api_gateway_event: Any) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Administrators can adjust **Enrolled at** when updating an instance enrollment from **Services**. The control sits on the same row as Contact, Family, and Organization (fourth column).

## Backend / API

- `PATCH /v1/admin/services/{id}/instances/{instanceId}/enrollments/{enrollmentId}` accepts optional `enrolled_at` (ISO 8601). Omit to leave unchanged; `null` or empty values return **400** because the column is not nullable.
- OpenAPI (`docs/api/admin.yaml`) and generated admin web types updated accordingly.

## Admin web

- Enrollment inline editor uses `datetime-local` for enrolled at in edit mode; the field stays disabled while adding a new enrollment.
- Update payload includes `enrolled_at` derived via existing `formatIsoForDatetimeLocalInput` / `parseDatetimeLocalToIsoUtc` helpers.

## Docs / tests

- `docs/architecture/lambdas.md`: note that admin enrollment PATCH may update `enrolled_at`.
- Python tests for payload parsing; Vitest coverage for the editor behavior.

## Validation

- `pytest tests/test_admin_enrollments_api.py`
- `npx vitest run tests/components/admin/services/enrollment-list-panel.test.tsx`
- `npm run lint` (admin web)
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78fc501f-4fd3-44ef-9e42-1165b64290c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fc501f-4fd3-44ef-9e42-1165b64290c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

