### PR TITLE
Admin: enrollments table Party column (rename + flexible width)

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -493,15 +493,7 @@ export function EnrollmentListPanel({
           <AdminDataTable tableClassName='w-full table-fixed'>
             <AdminDataTableHead>
               <tr>
-                <th
-                  className={
-                    showScheduledStartColumn
-                      ? 'w-[28%] min-w-0 px-4 py-3 font-semibold'
-                      : 'w-[35%] min-w-0 px-4 py-3 font-semibold'
-                  }
-                >
-                  Parent
-                </th>
+                <th className='min-w-0 px-4 py-3 font-semibold'>Party</th>
                 {showScheduledStartColumn ? (
                   <th className='w-[11%] whitespace-nowrap px-4 py-3 font-semibold'>Scheduled start</th>
                 ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Services enrollments table used percentage widths on the first column (`w-[28%]` / `w-[35%]` depending on whether “Scheduled start” is shown), which fixed that column’s share of the `table-fixed` layout.

## Changes

- Remove those width classes so the first column no longer has an explicit fixed percentage width.
- Rename the column header from **Parent** to **Party**.

## Validation

- `npx vitest run tests/components/admin/services/enrollment-list-panel.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3673a22a-7e5e-4fb3-aba9-17705ce9b17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3673a22a-7e5e-4fb3-aba9-17705ce9b17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

