### PR TITLE
fix(admin_web): enrollment table column widths for layout fit

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -493,15 +493,23 @@ export function EnrollmentListPanel({
           <AdminDataTable tableClassName='w-full table-fixed'>
             <AdminDataTableHead>
               <tr>
-                <th className='min-w-0 px-4 py-3 font-semibold'>Party</th>
+                <th
+                  className={
+                    showScheduledStartColumn
+                      ? 'w-[22%] min-w-0 px-4 py-3 font-semibold'
+                      : 'w-[28%] min-w-0 px-4 py-3 font-semibold'
+                  }
+                >
+                  Party
+                </th>
                 {showScheduledStartColumn ? (
-                  <th className='w-[11%] whitespace-nowrap px-4 py-3 font-semibold'>Scheduled start</th>
+                  <th className='w-[10%] whitespace-nowrap px-4 py-3 font-semibold'>Scheduled start</th>
                 ) : null}
                 <th
                   className={
                     showScheduledStartColumn
-                      ? 'w-[10%] px-4 py-3 font-semibold'
-                      : 'w-[12%] px-4 py-3 font-semibold'
+                      ? 'w-[9%] min-w-0 px-4 py-3 font-semibold'
+                      : 'w-[10%] min-w-0 px-4 py-3 font-semibold'
                   }
                 >
                   Status
@@ -510,13 +518,29 @@ export function EnrollmentListPanel({
                   className={
                     showScheduledStartColumn
                       ? 'w-[10%] whitespace-nowrap px-4 py-3 font-semibold'
-                      : 'w-[12%] whitespace-nowrap px-4 py-3 font-semibold'
+                      : 'w-[11%] whitespace-nowrap px-4 py-3 font-semibold'
                   }
                 >
                   Amount
                 </th>
-                <th className='min-w-0 px-4 py-3 font-semibold'>Discount</th>
-                <th className='w-[14%] whitespace-nowrap px-4 py-3 font-semibold'>Enrolled at</th>
+                <th
+                  className={
+                    showScheduledStartColumn
+                      ? 'w-[17%] min-w-0 px-4 py-3 font-semibold'
+                      : 'w-[20%] min-w-0 px-4 py-3 font-semibold'
+                  }
+                >
+                  Discount
+                </th>
+                <th
+                  className={
+                    showScheduledStartColumn
+                      ? 'w-[12%] whitespace-nowrap px-4 py-3 font-semibold'
+                      : 'w-[14%] whitespace-nowrap px-4 py-3 font-semibold'
+                  }
+                >
+                  Enrolled at
+                </th>
                 <th className='w-[4.5rem] whitespace-nowrap px-4 py-3 text-right font-semibold'>
                   Operations
                 </th>
@@ -550,7 +574,9 @@ export function EnrollmentListPanel({
                           : '—'}
                       </td>
                     ) : null}
-                    <td className='px-4 py-3'>{formatEnumLabel(enrollment.status)}</td>
+                    <td className='min-w-0 break-words px-4 py-3'>
+                      {formatEnumLabel(enrollment.status)}
+                    </td>
                     <td className='whitespace-nowrap px-4 py-3'>{amountDisplay}</td>
                     <td className='min-w-0 break-words px-4 py-3'>
                       {enrollment.discountCodeId


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Enrollments list used `table-fixed` with **Party** and **Discount** headers having only `min-w-0` and no width share. That let the browser treat them like unconstrained columns while several other columns used fixed percentages and `whitespace-nowrap`, which made the grid fight the viewport and encouraged horizontal overflow.

## Changes

- Assign explicit percentage widths to **Party** and **Discount** (with slightly different splits when the optional **Scheduled start** column is visible), aligned with how **InstanceListPanel** allocates **Title** / tier / locations.
- Add `min-w-0` on **Status** headers and `break-words` on status cells so labels can wrap like the instances **Status** column.

## Verification

- `cd apps/admin_web && npm run lint`
- `npx vitest run tests/components/admin/services/enrollment-list-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec393a84-4eee-4c36-bfe9-cb8c998b5af3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec393a84-4eee-4c36-bfe9-cb8c998b5af3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

