### PR TITLE
Extend draft invoice enrollment picker to one year (365 days)

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1078,9 +1078,9 @@ export function ClientInvoicesPanel() {
               onSubmit={(e) => void handleCreateDraft(e)}
             >
               <p className='text-sm text-slate-600'>
-                Shown: enrollments from the last 90 days (by enrolled date), excluding cancelled. Rows
-                already on a draft or issued invoice cannot be selected. Selected rows must share bill-to and
-                currency on the server.
+                Shown: enrollments from the last year (365 rolling days by enrolled date), excluding cancelled.
+                Rows already on a draft or issued invoice cannot be selected. Selected rows must share bill-to
+                and currency on the server.
               </p>
               <div className='flex flex-wrap items-end gap-3'>
                 <div className='min-w-[220px] flex-1'>

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4140,7 +4140,7 @@ export interface paths {
         };
         /**
          * List recent enrollments for draft invoice picker
-         * @description Returns non-cancelled enrollments with `enrolled_at` within the last 90 days, ordered by `enrolled_at` descending (cursor pagination). At most `limit` rows per response (default and maximum 500). Pass `next_cursor` from the prior response as `cursor`. Optional `q` filters server-side by enrollment UUID substring, instance title, cohort, contact email/name, bill-to contact, family name, organization name, or ticket tier name. Includes `invoiceLinked` when the enrollment already appears on a draft or issued customer invoice line (void invoices do not block).
+         * @description Returns non-cancelled enrollments with `enrolled_at` within the last 365 days, ordered by `enrolled_at` descending (cursor pagination). At most `limit` rows per response (default and maximum 500). Pass `next_cursor` from the prior response as `cursor`. Optional `q` filters server-side by enrollment UUID substring, instance title, cohort, contact email/name, bill-to contact, family name, organization name, or ticket tier name. Includes `invoiceLinked` when the enrollment already appears on a draft or issued customer invoice line (void invoices do not block).
          */
         get: {
             parameters: {

--- a/backend/src/app/api/admin_billing_enrollment_queries.py
+++ b/backend/src/app/api/admin_billing_enrollment_queries.py
@@ -220,12 +220,12 @@ def _encode_enrolled_at_cursor(enrolled_at: datetime, row_id: UUID) -> str:
 def list_recent_enrollments_for_invoicing(
     event: Mapping[str, Any], *, user_sub: str, request_id: str | None
 ) -> dict[str, Any]:
-    """Non-cancelled enrollments from the last 90 days (`enrolled_at`), capped and paginated.
+    """Non-cancelled enrollments from the last 365 days (`enrolled_at`), capped and paginated.
 
     Tenant note: this deployment is single-tenant Aurora; there is no tenant_id column on
     enrollments. Authorization is enforced at API Gateway (admin group).
     """
-    cutoff = datetime.now(UTC) - timedelta(days=90)
+    cutoff = datetime.now(UTC) - timedelta(days=365)
     limit = parse_limit(event, default=_PICKER_MAX_LIMIT, max_limit=_PICKER_MAX_LIMIT)
     cursor_ts, cursor_id = _parse_enrolled_at_cursor(query_param(event, "cursor"))
     q_raw = (query_param(event, "q") or "").strip()

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -2980,7 +2980,7 @@ paths:
     get:
       summary: List recent enrollments for draft invoice picker
       description: >
-        Returns non-cancelled enrollments with `enrolled_at` within the last 90 days,
+        Returns non-cancelled enrollments with `enrolled_at` within the last 365 days,
         ordered by `enrolled_at` descending (cursor pagination). At most `limit` rows per response
         (default and maximum 500). Pass `next_cursor` from the prior response as `cursor`.
         Optional `q` filters server-side by enrollment UUID substring, instance title, cohort,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Create draft invoice** enrollment picker previously loaded only enrollments with `enrolled_at` in the **last 90 days**. It now uses a **365-day rolling window** (one calendar year of lookback) so older enrollments within that range appear.

## Changes

- **Backend** (`list_recent_enrollments_for_invoicing`): `timedelta(days=90)` → `timedelta(days=365)`; docstring updated.
- **OpenAPI** (`docs/api/admin.yaml`): endpoint description updated; admin web types regenerated.
- **Admin UI** (`client-invoices-panel.tsx`): helper text under the picker updated to match.

## Validation

- `pytest tests/test_admin_billing.py -k list_recent -q`
- `pre-commit run ruff-format --files backend/src/app/api/admin_billing_enrollment_queries.py`
- `npm run generate:admin-api-types` and `npm run check:admin-api-types`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54230ed8-6994-409c-867b-9cbe9a5a5b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54230ed8-6994-409c-867b-9cbe9a5a5b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

