### PR TITLE
Customer invoices: family/org Bill To uses primary contact label

### DIFF
--- a/backend/src/app/api/admin_billing_common.py
+++ b/backend/src/app/api/admin_billing_common.py
@@ -34,6 +34,27 @@ def contact_display_name(c: Contact | None) -> str | None:
     return " ".join(x for x in [c.first_name, c.last_name] if x).strip() or None
 
 
+def family_or_organization_bill_to_display_label(
+    *,
+    entity_name: str | None,
+    primary_display_name: str | None,
+) -> str | None:
+    """Bill-to line for family or organization: ``{entity} · {primary}`` when both exist.
+
+    Keeps customer invoices and enrollment invoicing labels aligned when the party
+    is a family or organization and billing names the main (primary) contact.
+    """
+    entity = (entity_name or "").strip()
+    primary = (primary_display_name or "").strip()
+    if entity and primary:
+        return f"{entity} \u00b7 {primary}"
+    if entity:
+        return entity
+    if primary:
+        return primary
+    return None
+
+
 def enrollment_bill_to_merge_key(enrollment: Enrollment) -> str:
     """Stable string key for comparing bill-to identity across enrollments."""
     bk = enrollment.bill_to_kind or BillingBillToKind.CONTACT

--- a/backend/src/app/api/admin_billing_enrollment_queries.py
+++ b/backend/src/app/api/admin_billing_enrollment_queries.py
@@ -17,6 +17,7 @@ from app.api.admin_billing_common import (
     _session_with_audit,
     contact_display_name,
     enrollment_bill_to_merge_key,
+    family_or_organization_bill_to_display_label,
     primary_family_contact_names,
     primary_family_emails,
     primary_org_contact_names,
@@ -112,26 +113,22 @@ def _compose_party_display_name(
         pc = (family_primary_contact_name or "").strip()
         if not pc and enrolled_nm:
             pc = enrolled_nm.strip()
-        if entity and pc:
-            return f"{entity} \u00b7 {pc}"
-        if entity:
-            return entity
-        if pc:
-            return pc
-        return "—"
+        label = family_or_organization_bill_to_display_label(
+            entity_name=entity or None,
+            primary_display_name=pc or None,
+        )
+        return label if label else "—"
     if bk == BillingBillToKind.ORGANIZATION:
         org = enrollment.bill_to_organization or enrollment.organization
         entity = (org.name or "").strip() if org else ""
         pc = (org_primary_contact_name or "").strip()
         if not pc and enrolled_nm:
             pc = enrolled_nm.strip()
-        if entity and pc:
-            return f"{entity} \u00b7 {pc}"
-        if entity:
-            return entity
-        if pc:
-            return pc
-        return "—"
+        label = family_or_organization_bill_to_display_label(
+            entity_name=entity or None,
+            primary_display_name=pc or None,
+        )
+        return label if label else "—"
     return "—"
 
 

--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -10,7 +10,10 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.admin_billing_common import contact_display_name
+from app.api.admin_billing_common import (
+    contact_display_name,
+    family_or_organization_bill_to_display_label,
+)
 from app.db.models import Contact, Enrollment, Family, Organization
 from app.db.models.customer_invoice import CustomerInvoice
 from app.db.models.enums import BillingBillToKind
@@ -59,7 +62,6 @@ def _resolve_bill_to_party_from_invoice_fks(
         fam = session.get(Family, inv.bill_to_family_id)
         if fam is None:
             return
-        inv.bill_to_display_name = fam.family_name
         stmt = (
             select(Contact)
             .join(FamilyMember, FamilyMember.contact_id == Contact.id)
@@ -68,6 +70,12 @@ def _resolve_bill_to_party_from_invoice_fks(
             .limit(1)
         )
         primary = session.execute(stmt).scalar_one_or_none()
+        label = family_or_organization_bill_to_display_label(
+            entity_name=fam.family_name,
+            primary_display_name=contact_display_name(primary),
+        )
+        if label:
+            inv.bill_to_display_name = label
         if primary and primary.email:
             inv.bill_to_email = primary.email
         return
@@ -78,7 +86,6 @@ def _resolve_bill_to_party_from_invoice_fks(
         org = session.get(Organization, inv.bill_to_organization_id)
         if org is None:
             return
-        inv.bill_to_display_name = org.name
         stmt = (
             select(Contact)
             .join(
@@ -90,6 +97,12 @@ def _resolve_bill_to_party_from_invoice_fks(
             .limit(1)
         )
         primary = session.execute(stmt).scalar_one_or_none()
+        label = family_or_organization_bill_to_display_label(
+            entity_name=org.name,
+            primary_display_name=contact_display_name(primary),
+        )
+        if label:
+            inv.bill_to_display_name = label
         if primary and primary.email:
             inv.bill_to_email = primary.email
 

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -1845,3 +1845,33 @@ def test_create_payment_returns_400_on_invalid_amount(
     )
     with pytest.raises(ValidationError, match="amount"):
         admin_billing.handle_admin_billing_request(ev, "POST", "/v1/admin/billing/payments")
+
+
+def test_family_or_organization_bill_to_display_label() -> None:
+    from app.api.admin_billing_common import family_or_organization_bill_to_display_label
+
+    assert (
+        family_or_organization_bill_to_display_label(
+            entity_name="Smith Family",
+            primary_display_name="Jane Doe",
+        )
+        == "Smith Family \u00b7 Jane Doe"
+    )
+    assert (
+        family_or_organization_bill_to_display_label(
+            entity_name="Acme Ltd",
+            primary_display_name=None,
+        )
+        == "Acme Ltd"
+    )
+    assert (
+        family_or_organization_bill_to_display_label(
+            entity_name=None,
+            primary_display_name="Pat Lee",
+        )
+        == "Pat Lee"
+    )
+    assert family_or_organization_bill_to_display_label(
+        entity_name="  ",
+        primary_display_name="  ",
+    ) is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a customer invoice is billed to a **family** or **organization**, the Bill To display name now follows the same pattern as the enrollment invoicing picker: **`{entity} · {primary contact name}`**, using the membership row marked `is_primary_contact`. Email was already taken from that primary contact; this change aligns the visible addressee with the person being billed.

## Changes

- Add `family_or_organization_bill_to_display_label()` in `backend/src/app/api/admin_billing_common.py`.
- Use it in `_resolve_bill_to_party_from_invoice_fks()` (`admin_billing_invoice_draft_helpers.py`) for family and organization bill-to kinds.
- Refactor `_compose_party_display_name()` (`admin_billing_enrollment_queries.py`) to call the shared helper (behavior unchanged for existing tests).
- Add unit tests for the new helper in `tests/test_admin_billing.py`.

## Testing

- `pytest tests/test_admin_billing.py -q`
- `ruff check` on touched files
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83d649b9-88ee-41e8-aa42-8dc0388c5505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83d649b9-88ee-41e8-aa42-8dc0388c5505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

