### PR TITLE
Add delete (draft-only) for customer invoices in admin Finance

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -31,6 +31,7 @@ import {
   createDraftInvoice,
   createPaymentAllocation,
   deleteCustomerPayment,
+  deleteDraftCustomerInvoice,
   emailInvoice,
   exportBillingCsv,
   getCustomerInvoice,
@@ -201,6 +202,10 @@ export function ClientInvoicesPanel() {
   const [voidInvoiceTargetId, setVoidInvoiceTargetId] = useState<string | null>(null);
   const [voidReason, setVoidReason] = useState('');
   const [voidError, setVoidError] = useState('');
+
+  const [deleteDraftDialogOpen, setDeleteDraftDialogOpen] = useState(false);
+  const [deleteDraftInvoiceId, setDeleteDraftInvoiceId] = useState<string | null>(null);
+  const [deleteDraftError, setDeleteDraftError] = useState('');
 
   const [confirmPaymentDialogOpen, setConfirmPaymentDialogOpen] = useState(false);
   const [confirmPaymentId, setConfirmPaymentId] = useState<string | null>(null);
@@ -717,6 +722,45 @@ export function ClientInvoicesPanel() {
       await loadInvoicesFirstPage();
     } catch (caught) {
       setVoidError(caught instanceof Error ? caught.message : 'Void failed.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const openDeleteDraftInvoiceDialog = (invoiceId: string) => {
+    setDeleteDraftInvoiceId(invoiceId);
+    setDeleteDraftError('');
+    setDeleteDraftDialogOpen(true);
+  };
+
+  const closeDeleteDraftInvoiceDialog = () => {
+    setDeleteDraftDialogOpen(false);
+    setDeleteDraftInvoiceId(null);
+    setDeleteDraftError('');
+  };
+
+  const confirmDeleteDraftInvoice = async () => {
+    const id = deleteDraftInvoiceId?.trim();
+    if (!id) {
+      return;
+    }
+    setDeleteDraftError('');
+    setBusy('delete-draft');
+    try {
+      await deleteDraftCustomerInvoice(id);
+      setActionMessage(`Draft invoice deleted: ${id}`);
+      closeDeleteDraftInvoiceDialog();
+      if (selectedInvoiceId === id) {
+        setSelectedInvoiceId(null);
+      }
+      if (allocateInvoiceId === id) {
+        setAllocateInvoiceId('');
+        setAllocateLineId('');
+      }
+      await loadPayments();
+      await loadInvoicesFirstPage();
+    } catch (caught) {
+      setDeleteDraftError(caught instanceof Error ? caught.message : 'Delete failed.');
     } finally {
       setBusy(null);
     }
@@ -1331,7 +1375,7 @@ export function ClientInvoicesPanel() {
 
       <PaginatedTableCard
         title='Customer invoices'
-        description='Cursor-paginated invoices (newest first). Use Operations to issue or void. Select an issued row to pre-fill allocation; when the selection is issued, use Email recipients and Send email below.'
+        description='Cursor-paginated invoices (newest first). Use Operations to preview, issue, void, or permanently delete **draft** rows. Select an issued row to pre-fill allocation; when the selection is issued, use Email recipients and Send email below.'
         isLoading={invoiceListLoading}
         isLoadingMore={invoiceListLoadingMore}
         hasMore={Boolean(invoiceListCursor)}
@@ -1466,7 +1510,7 @@ export function ClientInvoicesPanel() {
                         type='button'
                         size='sm'
                         variant='outline'
-                        disabled={editorBusy || !id}
+                        disabled={editorBusy || deleteDraftDialogOpen || voidDialogOpen || !id}
                         onClick={() => void handleOpenInvoicePdfPreview(id)}
                         aria-label='Preview invoice PDF'
                         title='Preview invoice PDF'
@@ -1486,7 +1530,7 @@ export function ClientInvoicesPanel() {
                           type='button'
                           size='sm'
                           variant='secondary'
-                          disabled={editorBusy || !id}
+                          disabled={editorBusy || deleteDraftDialogOpen || voidDialogOpen || !id}
                           onClick={() => void handleIssueRow(id)}
                           aria-label='Issue invoice'
                           title='Issue invoice'
@@ -1502,12 +1546,33 @@ export function ClientInvoicesPanel() {
                           )}
                         </Button>
                       ) : null}
+                      {inv.status === 'draft' ? (
+                        <Button
+                          type='button'
+                          size='sm'
+                          variant='danger'
+                          disabled={editorBusy || deleteDraftDialogOpen || voidDialogOpen || !id}
+                          onClick={() => openDeleteDraftInvoiceDialog(id)}
+                          aria-label='Delete draft invoice'
+                          title='Delete draft invoice'
+                          aria-busy={busyAction === 'delete-draft'}
+                        >
+                          {busyAction === 'delete-draft' ? (
+                            <span
+                              className='inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-slate-600 border-t-transparent'
+                              aria-hidden
+                            />
+                          ) : (
+                            <DeleteIcon className='h-4 w-4' aria-hidden />
+                          )}
+                        </Button>
+                      ) : null}
                       {inv.status !== 'void' ? (
                         <Button
                           type='button'
                           size='sm'
                           variant='danger'
-                          disabled={editorBusy || !id}
+                          disabled={editorBusy || deleteDraftDialogOpen || voidDialogOpen || !id}
                           onClick={() => openVoidInvoiceDialog(id)}
                           aria-label='Void invoice'
                           title='Void invoice'
@@ -1894,7 +1959,7 @@ export function ClientInvoicesPanel() {
         confirmLabel='Void invoice'
         cancelLabel='Cancel'
         variant='danger'
-        confirmDisabled={busyAction === 'void'}
+        confirmDisabled={busyAction === 'void' || deleteDraftDialogOpen}
         onCancel={closeVoidInvoiceDialog}
         onConfirm={() => void confirmVoidInvoice()}
       >
@@ -1912,6 +1977,20 @@ export function ClientInvoicesPanel() {
           />
           {voidError ? <AdminInlineError>{voidError}</AdminInlineError> : null}
         </div>
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={deleteDraftDialogOpen}
+        title='Delete draft invoice'
+        description='This permanently removes the draft invoice and its lines. Issued or void invoices cannot be deleted here.'
+        confirmLabel='Delete draft'
+        cancelLabel='Cancel'
+        variant='danger'
+        confirmDisabled={busyAction === 'delete-draft'}
+        onCancel={closeDeleteDraftInvoiceDialog}
+        onConfirm={() => void confirmDeleteDraftInvoice()}
+      >
+        {deleteDraftError ? <AdminInlineError>{deleteDraftError}</AdminInlineError> : null}
       </ConfirmDialog>
 
       <ConfirmDialog

--- a/apps/admin_web/src/lib/billing-api.ts
+++ b/apps/admin_web/src/lib/billing-api.ts
@@ -294,6 +294,13 @@ export async function issueInvoice(invoiceId: string): Promise<{
   };
 }
 
+export async function deleteDraftCustomerInvoice(invoiceId: string): Promise<void> {
+  await adminApiRequest<unknown>({
+    endpointPath: `/v1/admin/billing/invoices/${invoiceId}`,
+    method: 'DELETE',
+  });
+}
+
 export async function voidInvoice(invoiceId: string, reason: string): Promise<{ invoiceId: string; status: string }> {
   const payload = await adminApiRequest<{
     invoiceId?: string;

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4305,7 +4305,39 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete draft customer invoice
+         * @description Permanently deletes the invoice and its line rows. Allowed only when the invoice status is `draft`. Returns 400 if the invoice is issued or void, or when any `payment_allocations` row references the invoice.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Invoice deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uuid */
+                            invoiceId: string;
+                            deleted: boolean;
+                        };
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -10,6 +10,7 @@ const billingMocks = vi.hoisted(() => ({
   getCustomerPayment: vi.fn(),
   issueInvoice: vi.fn(),
   voidInvoice: vi.fn(),
+  deleteDraftCustomerInvoice: vi.fn(),
   emailInvoice: vi.fn(),
   confirmCustomerPayment: vi.fn(),
   deleteCustomerPayment: vi.fn(),
@@ -485,6 +486,46 @@ describe('ClientInvoicesPanel', () => {
 
     await waitFor(() => {
       expect(billingMocks.deleteCustomerPayment).toHaveBeenCalledWith(payId);
+    });
+  });
+
+  it('delete draft invoice dialog calls deleteDraftCustomerInvoice for draft rows', async () => {
+    const invId = 'aaaaaaaa-bbbb-cccc-dddd-ffffffffffff';
+    billingMocks.listCustomerInvoices.mockResolvedValue({
+      items: [
+        {
+          id: invId,
+          status: 'draft',
+          invoiceNumber: null,
+          currency: 'HKD',
+          total: '50',
+          lineCount: 1,
+          billToDisplayName: 'Pat',
+          createdAt: '2026-01-01T00:00:00+00:00',
+        },
+      ],
+      next_cursor: null,
+    });
+    billingMocks.deleteDraftCustomerInvoice.mockResolvedValue(undefined);
+
+    render(<ClientInvoicesPanel />);
+
+    const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
+    const invoiceTable = within(invoiceRegion).getByRole('table');
+    await waitFor(() =>
+      within(invoiceTable).getByRole('button', { name: /delete draft invoice/i }),
+    );
+
+    await userEvent.click(within(invoiceTable).getByRole('button', { name: /delete draft invoice/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /delete draft invoice/i })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /^delete draft$/i }));
+
+    await waitFor(() => {
+      expect(billingMocks.deleteDraftCustomerInvoice).toHaveBeenCalledWith(invId);
     });
   });
 

--- a/backend/src/app/api/admin_billing.py
+++ b/backend/src/app/api/admin_billing.py
@@ -17,6 +17,7 @@ from app.api.admin_billing_enrollment_queries import (
 )
 from app.api.admin_billing_invoice_drafts import _create_invoice_draft
 from app.api.admin_billing_invoices import (
+    _delete_draft_invoice,
     _email_invoice,
     _issue_invoice,
     _void_invoice,
@@ -116,6 +117,10 @@ def handle_admin_billing_request(
         inv_id = parse_uuid(parts[3])
         if method == "GET":
             return get_invoice(
+                event, inv_id, user_sub=identity.user_sub, request_id=req
+            )
+        if method == "DELETE":
+            return _delete_draft_invoice(
                 event, inv_id, user_sub=identity.user_sub, request_id=req
             )
 

--- a/backend/src/app/api/admin_billing_invoices.py
+++ b/backend/src/app/api/admin_billing_invoices.py
@@ -1,4 +1,4 @@
-"""Admin billing: customer invoice mutations (issue, void, email)."""
+"""Admin billing: customer invoice mutations (issue, void, email, delete draft)."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.api.admin_billing_common import _session_with_audit
@@ -15,6 +16,7 @@ from app.db.audit import AuditService
 from app.db.models import Contact, Family, Organization
 from app.db.models.customer_invoice import CustomerInvoice
 from app.db.models.enums import BillingBillToKind, BillingInvoiceStatus
+from app.db.models.payment_allocation import PaymentAllocation
 from app.exceptions import NotFoundError, ValidationError
 from app.services.customer_billing import (
     next_invoice_number,
@@ -167,6 +169,48 @@ def _void_invoice(
         )
         return json_response(
             200, {"invoiceId": str(inv.id), "status": "void"}, event=event
+        )
+
+
+def _delete_draft_invoice(
+    event: Mapping[str, Any],
+    invoice_id: UUID,
+    *,
+    user_sub: str,
+    request_id: str | None,
+) -> dict[str, Any]:
+    """Permanently remove a draft invoice and its lines (no issued number)."""
+    with _session_with_audit(user_sub, request_id) as session:
+        inv = session.get(CustomerInvoice, invoice_id)
+        if inv is None:
+            raise NotFoundError("CustomerInvoice", str(invoice_id))
+        if inv.status != BillingInvoiceStatus.DRAFT:
+            raise ValidationError(
+                "Only draft invoices can be deleted", field="invoiceId"
+            )
+        alloc_count = session.execute(
+            select(func.count())
+            .select_from(PaymentAllocation)
+            .where(PaymentAllocation.invoice_id == invoice_id)
+        ).scalar_one()
+        if int(alloc_count or 0) > 0:
+            raise ValidationError(
+                "Cannot delete invoice with payment allocations",
+                field="invoiceId",
+            )
+        audit = AuditService(session, user_id=user_sub, request_id=request_id)
+        audit.log_custom(
+            table_name="customer_invoices",
+            record_id=inv.id,
+            action="DELETE_DRAFT",
+            old_values={"status": inv.status.value},
+        )
+        session.delete(inv)
+        session.flush()
+        return json_response(
+            200,
+            {"invoiceId": str(invoice_id), "deleted": True},
+            event=event,
         )
 
 

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -62,7 +62,7 @@ info:
     - `POST /v1/admin/billing/payments/{id}/confirm`
     - `GET /v1/admin/billing/enrollments/recent-for-invoicing`
     - `GET|POST /v1/admin/billing/invoices` (GET optional `status`, `currency`, `cursor`, `limit`; POST is either enrollment-based draft (`draftKind: enrollment_merge`, `enrollmentIds`, `currency` optional when derivable) or customized draft (`draftKind: customized_manual`, `billTo`, `currency`, `lines`); see request schemas)
-    - `GET /v1/admin/billing/invoices/{id}`
+    - `GET|DELETE /v1/admin/billing/invoices/{id}` (`DELETE` removes **draft** invoices only)
     - `GET /v1/admin/billing/invoices/{id}/pdf`
     - `POST /v1/admin/billing/invoices/{id}/issue`
     - `POST /v1/admin/billing/invoices/{id}/void`
@@ -3161,6 +3161,43 @@ paths:
                 properties:
                   invoice:
                     $ref: "#/components/schemas/CustomerInvoiceDetail"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete draft customer invoice
+      description: >
+        Permanently deletes the invoice and its line rows. Allowed only when the invoice
+        status is `draft`. Returns 400 if the invoice is issued or void, or when any
+        `payment_allocations` row references the invoice.
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Invoice deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - invoiceId
+                  - deleted
+                properties:
+                  invoiceId:
+                    type: string
+                    format: uuid
+                  deleted:
+                    type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":

--- a/docs/architecture/audit-logging.md
+++ b/docs/architecture/audit-logging.md
@@ -164,7 +164,8 @@ The following tables have audit triggers:
 - `customer_receipts`
 
 Application-level `AuditService` entries supplement invoice draft/issue flows where noted in code
-(for example `DRAFT_CREATED` and `DRAFT_CREATED_CUSTOMIZED` on `customer_invoices` when creating enrollment-based or customized drafts).
+(for example `DRAFT_CREATED` and `DRAFT_CREATED_CUSTOMIZED` on `customer_invoices` when creating enrollment-based or customized drafts,
+and `DELETE_DRAFT` before a draft invoice row is removed).
 
 **Public reservations:** Trigger-written `audit_log` rows for enrollments and related tables
 use `user_id = NULL` (no Cognito actor); correlate using `request_id` from API Gateway. Optional

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -112,7 +112,7 @@ their primary responsibilities.
   `/v1/admin/expenses/*`,
   `/v1/admin/billing/*` (customer AR: `GET /v1/admin/billing/payments` optional `invoice_id` filters to payments with an allocation to that invoice; `GET /v1/admin/billing/payments/{id}` includes `allocationInvoices` and `orphanPaymentDeletable`; `DELETE /v1/admin/billing/payments/{id}` removes eligible orphan inbound payments (pending or free/zero, enrollment unlinked or cancelled, no allocations/receipt/refund children); payments, invoices list/detail, draft invoices via
   `POST /v1/admin/billing/invoices` with `draftKind` `enrollment_merge` or `customized_manual`,
-  `GET /v1/admin/billing/enrollments/recent-for-invoicing`, `GET /v1/admin/billing/invoices/{id}/pdf`
+  `GET /v1/admin/billing/enrollments/recent-for-invoicing`, `DELETE /v1/admin/billing/invoices/{id}` (draft-only permanent delete; blocked when allocations exist), `GET /v1/admin/billing/invoices/{id}/pdf`
   (returns a CloudFront-signed URL; each response includes a unique cache-bust query on the
   signed resource so draft/void preview PDFs re-uploaded to the same S3 key are not edge-cached
   as an older file),

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -1571,6 +1571,128 @@ def test_get_invoice_returns_detail_with_lines(
     assert body["invoice"]["lines"][0]["id"] == str(line_id)
 
 
+def test_delete_draft_invoice_succeeds(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inv_id = uuid4()
+    inv = MagicMock()
+    inv.id = inv_id
+    inv.status = BillingInvoiceStatus.DRAFT
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is CustomerInvoice and pk == inv_id:
+                return inv
+            return None
+
+        s.get.side_effect = _get
+        ex = MagicMock()
+        ex.scalar_one.return_value = 0
+        s.execute.return_value = ex
+        yield s
+
+    class _FakeAudit:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def log_custom(self, **_kw: Any) -> None:
+            return None
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+    monkeypatch.setattr(admin_billing_invoices_mod, "AuditService", _FakeAudit)
+
+    ev = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/billing/invoices/{inv_id}",
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "DELETE", f"/v1/admin/billing/invoices/{inv_id}"
+    )
+    assert r["statusCode"] == 200
+    body = json.loads(r["body"])
+    assert body["invoiceId"] == str(inv_id)
+    assert body["deleted"] is True
+
+
+def test_delete_draft_invoice_rejects_issued(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inv_id = uuid4()
+    inv = MagicMock()
+    inv.id = inv_id
+    inv.status = BillingInvoiceStatus.ISSUED
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is CustomerInvoice and pk == inv_id:
+                return inv
+            return None
+
+        s.get.side_effect = _get
+        yield s
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+
+    ev = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/billing/invoices/{inv_id}",
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(ValidationError, match="Only draft"):
+        admin_billing.handle_admin_billing_request(
+            ev, "DELETE", f"/v1/admin/billing/invoices/{inv_id}"
+        )
+
+
+def test_delete_draft_invoice_rejects_when_allocations_exist(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inv_id = uuid4()
+    inv = MagicMock()
+    inv.id = inv_id
+    inv.status = BillingInvoiceStatus.DRAFT
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is CustomerInvoice and pk == inv_id:
+                return inv
+            return None
+
+        s.get.side_effect = _get
+        ex = MagicMock()
+        ex.scalar_one.return_value = 1
+        s.execute.return_value = ex
+        yield s
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+
+    ev = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/billing/invoices/{inv_id}",
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(ValidationError, match="allocations"):
+        admin_billing.handle_admin_billing_request(
+            ev, "DELETE", f"/v1/admin/billing/invoices/{inv_id}"
+        )
+
+
 def test_get_invoice_pdf_returns_signed_url(
     api_gateway_event: Any,
     admin_identity: dict[str, str],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a permanent **delete** path for **draft** customer invoices only, wired end-to-end from the admin Finance customer-invoices table through the billing API.

## Backend

- `DELETE /v1/admin/billing/invoices/{id}` routes through the existing admin billing Lambda (`handle_admin_billing_request`).
- Deletes are allowed only when `status` is draft; issued/void return validation errors.
- If any `payment_allocations` row references the invoice, delete is rejected (defensive guard; allocations are not expected on drafts).
- `AuditService.log_custom` records `DELETE_DRAFT` before the row is removed.

## Admin web

- Customer invoices **Operations** column: trash (`DeleteIcon`) for draft rows only, with a danger-styled confirmation dialog (per destructive row actions in the table).
- Clears selection and allocate-invoice picker state when the deleted row was selected.
- `deleteDraftCustomerInvoice()` in `billing-api.ts`; OpenAPI types regenerated.

## Docs and tests

- OpenAPI (`docs/api/admin.yaml`), `docs/architecture/lambdas.md`, and `docs/architecture/audit-logging.md` updated.
- Python tests for success, non-draft rejection, and allocation rejection; Vitest for the dialog flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0338abd3-1ee5-4725-b9be-35026458b41d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0338abd3-1ee5-4725-b9be-35026458b41d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

