### PR TITLE
Contact-only enrollment: promote once to family or organization

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -116,6 +116,13 @@ export function EnrollmentListPanel({
   );
   const isEditMode = Boolean(selectedEnrollment);
 
+  /** Structural party is contact-only; API allows a single conversion to family or organization. */
+  const canPromoteContactEnrollment = Boolean(
+    selectedEnrollment?.contactId?.trim() &&
+      !selectedEnrollment?.familyId?.trim() &&
+      !selectedEnrollment?.organizationId?.trim()
+  );
+
   const contactSelectOptions = useMemo(
     () => ensureOption(contactOptions, selectedEnrollment?.contactId ?? null, 'Contact'),
     [contactOptions, selectedEnrollment?.contactId]
@@ -230,6 +237,13 @@ export function EnrollmentListPanel({
     const prev = selectedEnrollment?.discountCodeId?.trim() || null;
     if (nextDiscount !== prev) {
       base.discount_code_id = nextDiscount;
+    }
+    const nextFamily = familyId.trim();
+    const nextOrg = organizationId.trim();
+    if (canPromoteContactEnrollment && nextFamily) {
+      base.promote_to_family_id = nextFamily;
+    } else if (canPromoteContactEnrollment && nextOrg) {
+      base.promote_to_organization_id = nextOrg;
     }
     return base;
   };
@@ -362,9 +376,15 @@ export function EnrollmentListPanel({
               value={familyId || EMPTY_PARENT_VALUE}
               onChange={(event) => {
                 const next = event.target.value;
-                setFamilyId(next === EMPTY_PARENT_VALUE ? '' : next);
+                const resolved = next === EMPTY_PARENT_VALUE ? '' : next;
+                setFamilyId(resolved);
+                if (resolved.trim()) {
+                  setOrganizationId('');
+                }
               }}
-              disabled={isEditMode || parentPickersLoading}
+              disabled={
+                parentPickersLoading || (isEditMode && !canPromoteContactEnrollment)
+              }
               aria-busy={parentPickersLoading}
             >
               <option value={EMPTY_PARENT_VALUE}>None</option>
@@ -382,9 +402,15 @@ export function EnrollmentListPanel({
               value={organizationId || EMPTY_PARENT_VALUE}
               onChange={(event) => {
                 const next = event.target.value;
-                setOrganizationId(next === EMPTY_PARENT_VALUE ? '' : next);
+                const resolved = next === EMPTY_PARENT_VALUE ? '' : next;
+                setOrganizationId(resolved);
+                if (resolved.trim()) {
+                  setFamilyId('');
+                }
               }}
-              disabled={isEditMode || parentPickersLoading}
+              disabled={
+                parentPickersLoading || (isEditMode && !canPromoteContactEnrollment)
+              }
               aria-busy={parentPickersLoading}
             >
               <option value={EMPTY_PARENT_VALUE}>None</option>
@@ -412,8 +438,19 @@ export function EnrollmentListPanel({
           </p>
         ) : null}
         <p className='text-xs text-slate-500'>
-          Contact, family, and organization are chosen when creating an enrollment and cannot be changed
-          afterward. Enrolled at can be edited when updating an enrollment.
+          {canPromoteContactEnrollment ? (
+            <>
+              This enrollment is contact-only. You may convert it once to family or organization using the
+              Family or Organization field (not both). Contact cannot be changed here. Enrolled at can be
+              edited when updating.
+            </>
+          ) : (
+            <>
+              Contact, family, and organization are chosen when creating an enrollment and cannot be changed
+              afterward (except converting a contact-only enrollment once). Enrolled at can be edited when
+              updating an enrollment.
+            </>
+          )}
         </p>
         {canCreate && discountOptionsError ? (
           <p className='text-xs text-red-600' role='alert'>

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5678,6 +5678,16 @@ export interface components {
             notes?: string | null;
         };
         UpdateEnrollmentRequest: {
+            /**
+             * Format: uuid
+             * @description One-time conversion from a contact-only enrollment (contact_id set, family and organization null) to a family enrollment. Mutually exclusive with promote_to_organization_id. Clears contact_id, sets family_id, and aligns bill-to fields to the family.
+             */
+            promote_to_family_id?: string;
+            /**
+             * Format: uuid
+             * @description One-time conversion from a contact-only enrollment to an organization enrollment. Mutually exclusive with promote_to_family_id. Clears contact_id, sets organization_id, and aligns bill-to fields to the organization.
+             */
+            promote_to_organization_id?: string;
             status?: components["schemas"]["EnrollmentStatus"];
             /**
              * Format: date-time

--- a/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
@@ -45,7 +45,7 @@ const ENROLLMENT_FIXTURE: Enrollment = {
 };
 
 describe('EnrollmentListPanel', () => {
-  it('uses the same copy for create/edit and locks parent pickers in edit mode', () => {
+  it('locks contact in edit mode; allows family and org for contact-only conversion', () => {
     render(
       <EnrollmentListPanel
         enrollments={[ENROLLMENT_FIXTURE]}
@@ -76,9 +76,43 @@ describe('EnrollmentListPanel', () => {
 
     expect(screen.getByText('Add or update an enrollment using the same fields below.')).toBeInTheDocument();
     expect(screen.getByLabelText('Contact')).toBeDisabled();
+    expect(screen.getByLabelText('Family')).toBeEnabled();
+    expect(screen.getByLabelText('Organization')).toBeEnabled();
+    expect(screen.getByLabelText('Enrolled at')).toBeEnabled();
+  });
+
+  it('locks family and organization pickers when enrollment is not contact-only', () => {
+    const familyEnrollment: Enrollment = {
+      ...ENROLLMENT_FIXTURE,
+      id: 'enrollment-2',
+      contactId: null,
+      familyId: 'family-1',
+      organizationId: null,
+    };
+    render(
+      <EnrollmentListPanel
+        enrollments={[familyEnrollment]}
+        serviceId='service-1'
+        instanceId='instance-1'
+        canCreate={true}
+        isLoading={false}
+        isLoadingMore={false}
+        hasMore={false}
+        error=''
+        isMutating={false}
+        onLoadMore={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    const table = screen.getByRole('table');
+    fireEvent.click(within(table).getByText('Smith family').closest('tr') as HTMLTableRowElement);
+
+    expect(screen.getByLabelText('Contact')).toBeDisabled();
     expect(screen.getByLabelText('Family')).toBeDisabled();
     expect(screen.getByLabelText('Organization')).toBeDisabled();
-    expect(screen.getByLabelText('Enrolled at')).toBeEnabled();
   });
 
   it('disables enrolled at while adding a new enrollment', () => {

--- a/backend/src/app/api/admin_enrollments.py
+++ b/backend/src/app/api/admin_enrollments.py
@@ -23,11 +23,13 @@ from app.api.admin_services_common import (
     serialize_enrollment,
 )
 from app.api.assets.assets_common import extract_identity, split_route_parts
+from app.api.instance_capacity_status import bulk_reconcile_instance_capacity_status
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.models import Enrollment
-from app.db.models.enums import EnrollmentStatus
-from app.api.instance_capacity_status import bulk_reconcile_instance_capacity_status
+from app.db.models.enums import BillingBillToKind, EnrollmentStatus
+from app.db.models.family import Family
+from app.db.models.organization import Organization
 from app.db.repositories import (
     DiscountCodeRepository,
     EnrollmentRepository,
@@ -219,6 +221,47 @@ def _update_enrollment(
             session, enrollment, instance_id
         ):
             raise NotFoundError("Enrollment", str(enrollment_id))
+
+        if "promote_to_family_id" in payload or "promote_to_organization_id" in payload:
+            if (
+                enrollment.contact_id is None
+                or enrollment.family_id is not None
+                or enrollment.organization_id is not None
+            ):
+                raise ValidationError(
+                    "Promoting to family or organization is only allowed for contact-only "
+                    "enrollments",
+                    field="body",
+                )
+            if "promote_to_family_id" in payload:
+                fid = payload["promote_to_family_id"]
+                fam = session.get(Family, fid)
+                if fam is None:
+                    raise ValidationError(
+                        "Family not found", field="promote_to_family_id"
+                    )
+                enrollment.contact_id = None
+                enrollment.family_id = fid
+                enrollment.organization_id = None
+                enrollment.bill_to_kind = BillingBillToKind.FAMILY
+                enrollment.bill_to_family_id = fid
+                enrollment.bill_to_contact_id = None
+                enrollment.bill_to_organization_id = None
+            else:
+                oid = payload["promote_to_organization_id"]
+                org = session.get(Organization, oid)
+                if org is None:
+                    raise ValidationError(
+                        "Organization not found",
+                        field="promote_to_organization_id",
+                    )
+                enrollment.contact_id = None
+                enrollment.family_id = None
+                enrollment.organization_id = oid
+                enrollment.bill_to_kind = BillingBillToKind.ORGANIZATION
+                enrollment.bill_to_organization_id = oid
+                enrollment.bill_to_contact_id = None
+                enrollment.bill_to_family_id = None
 
         if "status" in payload:
             enrollment.status = payload["status"]

--- a/backend/src/app/api/admin_services_payloads.py
+++ b/backend/src/app/api/admin_services_payloads.py
@@ -568,6 +568,33 @@ def parse_update_enrollment_payload(body: Mapping[str, Any]) -> dict[str, Any]:
             payload["discount_code_id"] = parse_optional_uuid(
                 raw_dc, "discount_code_id"
             )
+    promote_family = has_field(body, "promote_to_family_id")
+    promote_org = has_field(body, "promote_to_organization_id")
+    if promote_family and promote_org:
+        raise ValidationError(
+            "Send only one of promote_to_family_id or promote_to_organization_id",
+            field="body",
+        )
+    if promote_family:
+        fid = parse_optional_uuid(
+            body.get("promote_to_family_id"), "promote_to_family_id"
+        )
+        if fid is None:
+            raise ValidationError(
+                "promote_to_family_id must be a UUID",
+                field="promote_to_family_id",
+            )
+        payload["promote_to_family_id"] = fid
+    if promote_org:
+        oid = parse_optional_uuid(
+            body.get("promote_to_organization_id"), "promote_to_organization_id"
+        )
+        if oid is None:
+            raise ValidationError(
+                "promote_to_organization_id must be a UUID",
+                field="promote_to_organization_id",
+            )
+        payload["promote_to_organization_id"] = oid
     if not payload:
         raise ValidationError("At least one updatable field is required", field="body")
     return payload

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -5291,6 +5291,21 @@ components:
       type: object
       minProperties: 1
       properties:
+        promote_to_family_id:
+          type: string
+          format: uuid
+          description: >
+            One-time conversion from a contact-only enrollment (contact_id set, family and
+            organization null) to a family enrollment. Mutually exclusive with
+            promote_to_organization_id. Clears contact_id, sets family_id, and aligns bill-to
+            fields to the family.
+        promote_to_organization_id:
+          type: string
+          format: uuid
+          description: >
+            One-time conversion from a contact-only enrollment to an organization enrollment.
+            Mutually exclusive with promote_to_family_id. Clears contact_id, sets
+            organization_id, and aligns bill-to fields to the organization.
         status:
           $ref: "#/components/schemas/EnrollmentStatus"
         enrolled_at:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -258,7 +258,8 @@ their primary responsibilities.
   Other booking systems attach the enrollment directly to the resolved instance when capacity allows
   (or return **409** when the instance is full with waitlist disabled). Admin enrollment APIs validate
   discount code scope to `services.id` / `service_instances.id` as scoped on the code row; `PATCH`
-  enrollments may update `enrolled_at` (ISO instant; omit to leave unchanged).
+  enrollments may update `enrolled_at` (ISO instant; omit to leave unchanged). Contact-only enrollments
+  may be converted once via `promote_to_family_id` or `promote_to_organization_id` (mutually exclusive).
   Then sends
   booking confirmation (SES), optional Mailchimp subscribe, and a plain-text **sales recap**
   with extended booking context when provided, and signed upload/download URL generation in

--- a/tests/test_admin_enrollments_api.py
+++ b/tests/test_admin_enrollments_api.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
 from app.api import admin_enrollments
 from app.api.admin_services_payloads import parse_update_enrollment_payload
-from app.db.models.enums import EnrollmentStatus
+from app.db.models.enums import BillingBillToKind, EnrollmentStatus
 from app.exceptions import ValidationError
 
 
@@ -327,6 +327,139 @@ def test_parse_update_enrollment_payload_rejects_cleared_enrolled_at() -> None:
 def test_parse_update_enrollment_payload_rejects_empty_enrolled_at() -> None:
     with pytest.raises(ValidationError, match="enrolled_at"):
         parse_update_enrollment_payload({"enrolled_at": ""})
+
+
+def test_parse_update_enrollment_payload_accepts_promote_to_family_id() -> None:
+    fid = uuid4()
+    parsed = parse_update_enrollment_payload({"promote_to_family_id": str(fid)})
+    assert parsed["promote_to_family_id"] == fid
+
+
+def test_parse_update_enrollment_payload_accepts_promote_to_organization_id() -> None:
+    oid = uuid4()
+    parsed = parse_update_enrollment_payload({"promote_to_organization_id": str(oid)})
+    assert parsed["promote_to_organization_id"] == oid
+
+
+def test_parse_update_enrollment_payload_rejects_both_promote_fields() -> None:
+    with pytest.raises(ValidationError, match="promote"):
+        parse_update_enrollment_payload(
+            {
+                "promote_to_family_id": str(uuid4()),
+                "promote_to_organization_id": str(uuid4()),
+            }
+        )
+
+
+def test_promote_contact_enrollment_to_family_updates_row(monkeypatch: Any, api_gateway_event: Any) -> None:
+    target_instance_id = uuid4()
+    enrollment_id = uuid4()
+    contact_uuid = uuid4()
+    family_id = uuid4()
+
+    class _MutableEnrollment:
+        instance_id = target_instance_id
+        contact_id: UUID | None = contact_uuid
+        family_id: UUID | None = None
+        organization_id: UUID | None = None
+        bill_to_kind = None
+        bill_to_contact_id: UUID | None = contact_uuid
+        bill_to_family_id = None
+        bill_to_organization_id = None
+        discount_code_id = None
+        status = EnrollmentStatus.REGISTERED
+        cancelled_at = None
+        amount_paid = None
+        currency = None
+        notes = None
+
+    held: dict[str, Any] = {"row": _MutableEnrollment()}
+
+    class _FakeEnrollmentRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id(self, eid: Any) -> Any:
+            if eid == enrollment_id:
+                return held["row"]
+            return None
+
+        def update(self, enrollment: Any) -> Any:
+            return enrollment
+
+    class _FakeDiscountRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+        def get(self, model: Any, eid: Any) -> Any:
+            name = getattr(model, "__name__", "")
+            if name == "Family" and eid == family_id:
+                return object()
+            return None
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            self._session = _FakeSession()
+
+        def __enter__(self) -> _FakeSession:
+            return self._session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    monkeypatch.setattr(admin_enrollments, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_enrollments, "get_engine", lambda: object())
+    monkeypatch.setattr(admin_enrollments, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        admin_enrollments,
+        "parse_body",
+        lambda _e: json.loads(_e["body"]),
+    )
+    monkeypatch.setattr(admin_enrollments, "EnrollmentRepository", _FakeEnrollmentRepo)
+    monkeypatch.setattr(admin_enrollments, "DiscountCodeRepository", _FakeDiscountRepo)
+
+    class _FakeSvcRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id(self, _iid: Any) -> None:
+            return None
+
+    monkeypatch.setattr(admin_enrollments, "ServiceInstanceRepository", _FakeSvcRepo)
+    monkeypatch.setattr(
+        admin_enrollments,
+        "bulk_reconcile_instance_capacity_status",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
+        "serialize_enrollment",
+        lambda e: {"id": str(enrollment_id), "family_id": str(e.family_id)},
+    )
+    _patch_enrollment_discount_scope_ok(monkeypatch)
+
+    resp = admin_enrollments._update_enrollment(
+        api_gateway_event(
+            method="PATCH",
+            path="/v1/admin/services/x/instances/y/enrollments/z",
+            body=json.dumps({"promote_to_family_id": str(family_id), "status": "registered"}),
+        ),
+        instance_id=target_instance_id,
+        enrollment_id=enrollment_id,
+        actor_sub="test-admin-sub-12345",
+    )
+    assert resp["statusCode"] == 200
+    row = held["row"]
+    assert row.contact_id is None
+    assert row.family_id == family_id
+    assert row.organization_id is None
+    assert row.bill_to_kind == BillingBillToKind.FAMILY
+    assert row.bill_to_family_id == family_id
+    assert row.bill_to_contact_id is None
 
 
 def test_delete_enrollment_decrements_discount_usage(monkeypatch: Any, api_gateway_event: Any) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change lets admins correct a **contact-only** enrollment by converting it **once** to a **family** or **organization** enrollment, which matches the common workflow where the enrollee was captured as a contact but should be billed or listed under a household or org.

## Behavior

- **API (`PATCH` enrollment):** Optional `promote_to_family_id` or `promote_to_organization_id` (mutually exclusive). Allowed only when the row is contact-only (`contact_id` set, `family_id` and `organization_id` null). Clears `contact_id`, sets the chosen structural FK, and aligns `bill_to_*` / `bill_to_kind` with the new party.
- **Admin UI:** For contact-only enrollments, **Family** and **Organization** pickers are enabled in edit mode so staff can choose the conversion target (selecting one clears the other). Contact remains read-only in edit mode.

## Validation

- Python: `pytest tests/test_admin_enrollments_api.py`
- Admin web: `npx vitest run tests/components/admin/services/enrollment-list-panel.test.tsx`
- Types: `npm run generate:admin-api-types` and `npm run check:admin-api-types`
- `bash scripts/validate-cursorrules.sh`

## Documentation

- `docs/api/admin.yaml` — `UpdateEnrollmentRequest`
- `docs/architecture/lambdas.md` — enrollment PATCH note
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15f70ae3-e0aa-4e6a-9fd1-a2f2a1033773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15f70ae3-e0aa-4e6a-9fd1-a2f2a1033773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

