### PR TITLE
Enrollment party column: family/org · primary contact

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -183,6 +183,10 @@ export function EnrollmentListPanel({
 
   const formatEnrollmentParentCell = useCallback(
     (enrollment: Enrollment) => {
+      const fromApi = enrollment.partyDisplayName?.trim();
+      if (fromApi) {
+        return fromApi;
+      }
       if (enrollment.contactId) {
         return labelByContactId.get(enrollment.contactId) ?? enrollment.contactId;
       }

--- a/apps/admin_web/src/lib/services-api.ts
+++ b/apps/admin_web/src/lib/services-api.ts
@@ -385,6 +385,7 @@ function parseEnrollment(value: unknown): Enrollment {
     createdBy: asNullableString(item.created_by) ?? '',
     createdAt: asNullableString(item.created_at),
     updatedAt: asNullableString(item.updated_at),
+    partyDisplayName: asNullableString(item.party_display_name),
     scheduledStartAt: asNullableString(item.scheduled_start_at),
   };
 }

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5676,6 +5676,8 @@ export interface components {
             /** Format: date-time */
             cancelled_at?: string | null;
             notes?: string | null;
+            /** @description Display label for the enrollment party. For contact bill-to this is the contact name. For family or organization this is `entity name · primary contact name` (middle dot) when both the entity and primary contact names are known; otherwise the best available single label. Matches the billing enrollment picker `partyDisplayName` convention. */
+            party_display_name?: string;
             created_by?: string;
             /** Format: date-time */
             created_at?: string | null;

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -344,6 +344,8 @@ export interface Enrollment {
   createdBy: string;
   createdAt: string | null;
   updatedAt: string | null;
+  /** Server-computed party label (family/org · primary contact when applicable). */
+  partyDisplayName?: string | null;
   /** Present when the admin enrollment list includes instance scheduled-start metadata. */
   scheduledStartAt?: string | null;
 }

--- a/backend/src/app/api/admin_billing_common.py
+++ b/backend/src/app/api/admin_billing_common.py
@@ -69,6 +69,129 @@ def enrollment_bill_to_merge_key(enrollment: Enrollment) -> str:
     return "|".join(parts)
 
 
+def effective_enrollment_bill_to_kind(enrollment: Enrollment) -> BillingBillToKind:
+    """Resolve bill-to kind when legacy rows omit ``billing_bill_to_kind``.
+
+    Some enrollments only set structural ``family_id`` / ``organization_id`` (or bill-to FKs)
+    without persisting ``bill_to_kind``. Infer family/org for lookups and JSON labels.
+    """
+    raw = enrollment.bill_to_kind
+    if raw is not None:
+        return raw
+    if enrollment.bill_to_family_id is not None:
+        return BillingBillToKind.FAMILY
+    if enrollment.bill_to_organization_id is not None:
+        return BillingBillToKind.ORGANIZATION
+    if enrollment.contact_id is None and enrollment.family_id is not None:
+        return BillingBillToKind.FAMILY
+    if enrollment.contact_id is None and enrollment.organization_id is not None:
+        return BillingBillToKind.ORGANIZATION
+    return BillingBillToKind.CONTACT
+
+
+def collect_enrollment_family_org_ids(
+    rows: list[Enrollment],
+) -> tuple[set[UUID], set[UUID]]:
+    """Collect distinct family and organization ids (bill-to or structural)."""
+    fam: set[UUID] = set()
+    org: set[UUID] = set()
+    for en in rows:
+        fid = en.bill_to_family_id or en.family_id
+        if fid:
+            fam.add(fid)
+        oid = en.bill_to_organization_id or en.organization_id
+        if oid:
+            org.add(oid)
+    return fam, org
+
+
+def compose_enrollment_party_display_name(
+    enrollment: Enrollment,
+    *,
+    family_primary_contact_name: str | None,
+    org_primary_contact_name: str | None,
+) -> str:
+    """Party label: contact name; family/org use ``entity · primary contact`` when both known."""
+    bk = effective_enrollment_bill_to_kind(enrollment)
+    enrolled_nm = contact_display_name(enrollment.contact)
+    if bk == BillingBillToKind.CONTACT:
+        c = enrollment.bill_to_contact or enrollment.contact
+        name = contact_display_name(c)
+        if name:
+            return name
+        fid = enrollment.bill_to_family_id or enrollment.family_id
+        if fid is not None:
+            fam = enrollment.bill_to_family or enrollment.family
+            entity = (fam.family_name or "").strip() if fam else ""
+            pc = (family_primary_contact_name or "").strip()
+            if not pc and enrolled_nm:
+                pc = enrolled_nm.strip()
+            if entity and pc:
+                return f"{entity} \u00b7 {pc}"
+            if entity:
+                return entity
+            if pc:
+                return pc
+        oid = enrollment.bill_to_organization_id or enrollment.organization_id
+        if oid is not None:
+            org = enrollment.bill_to_organization or enrollment.organization
+            entity = (org.name or "").strip() if org else ""
+            pc = (org_primary_contact_name or "").strip()
+            if not pc and enrolled_nm:
+                pc = enrolled_nm.strip()
+            if entity and pc:
+                return f"{entity} \u00b7 {pc}"
+            if entity:
+                return entity
+            if pc:
+                return pc
+        return "—"
+    if bk == BillingBillToKind.FAMILY:
+        fam = enrollment.bill_to_family or enrollment.family
+        entity = (fam.family_name or "").strip() if fam else ""
+        pc = (family_primary_contact_name or "").strip()
+        if not pc and enrolled_nm:
+            pc = enrolled_nm.strip()
+        label = family_or_organization_bill_to_display_label(
+            entity_name=entity or None,
+            primary_display_name=pc or None,
+        )
+        return label if label else "—"
+    if bk == BillingBillToKind.ORGANIZATION:
+        org = enrollment.bill_to_organization or enrollment.organization
+        entity = (org.name or "").strip() if org else ""
+        pc = (org_primary_contact_name or "").strip()
+        if not pc and enrolled_nm:
+            pc = enrolled_nm.strip()
+        label = family_or_organization_bill_to_display_label(
+            entity_name=entity or None,
+            primary_display_name=pc or None,
+        )
+        return label if label else "—"
+    return "—"
+
+
+def batch_enrollment_party_display_names(
+    session: Session, rows: list[Enrollment]
+) -> list[str]:
+    """Compute party labels for many enrollments with batched primary-contact lookups."""
+    fam_ids, org_ids = collect_enrollment_family_org_ids(rows)
+    fam_pc = primary_family_contact_names(session, fam_ids)
+    org_pc = primary_org_contact_names(session, org_ids)
+    labels: list[str] = []
+    for en in rows:
+        fid = en.bill_to_family_id or en.family_id
+        oid = en.bill_to_organization_id or en.organization_id
+        labels.append(
+            compose_enrollment_party_display_name(
+                en,
+                family_primary_contact_name=fam_pc.get(fid) if fid else None,
+                org_primary_contact_name=org_pc.get(oid) if oid else None,
+            )
+        )
+    return labels
+
+
 def primary_family_emails(session: Session, family_ids: set[UUID]) -> dict[UUID, str]:
     """Map family id -> primary contact email when present."""
     if not family_ids:

--- a/backend/src/app/api/admin_billing_enrollment_queries.py
+++ b/backend/src/app/api/admin_billing_enrollment_queries.py
@@ -15,12 +15,11 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.api.admin_billing_common import (
     _session_with_audit,
-    contact_display_name,
+    batch_enrollment_party_display_names,
+    collect_enrollment_family_org_ids,
+    effective_enrollment_bill_to_kind,
     enrollment_bill_to_merge_key,
-    family_or_organization_bill_to_display_label,
-    primary_family_contact_names,
     primary_family_emails,
-    primary_org_contact_names,
     primary_org_emails,
 )
 from app.api.admin_request import parse_limit, query_param
@@ -46,113 +45,13 @@ def _decimal_to_string(value: Decimal | None) -> str | None:
     return format(value, "f")
 
 
-def _effective_bill_to_kind(enrollment: Enrollment) -> BillingBillToKind:
-    """Resolve bill-to kind for picker labels when legacy rows omit ``billing_bill_to_kind``.
-
-    Some enrollments only set structural ``family_id`` / ``organization_id`` (or bill-to FKs)
-    without persisting ``bill_to_kind``. Infer family/org for lookups and ``billToKind`` JSON.
-    """
-    raw = enrollment.bill_to_kind
-    if raw is not None:
-        return raw
-    if enrollment.bill_to_family_id is not None:
-        return BillingBillToKind.FAMILY
-    if enrollment.bill_to_organization_id is not None:
-        return BillingBillToKind.ORGANIZATION
-    if enrollment.contact_id is None and enrollment.family_id is not None:
-        return BillingBillToKind.FAMILY
-    if enrollment.contact_id is None and enrollment.organization_id is not None:
-        return BillingBillToKind.ORGANIZATION
-    return BillingBillToKind.CONTACT
-
-
-def _compose_party_display_name(
-    enrollment: Enrollment,
-    *,
-    family_primary_contact_name: str | None,
-    org_primary_contact_name: str | None,
-) -> str:
-    """Party label for picker rows: contact name; family/org use entity · primary contact name."""
-    bk = _effective_bill_to_kind(enrollment)
-    enrolled_nm = contact_display_name(enrollment.contact)
-    if bk == BillingBillToKind.CONTACT:
-        c = enrollment.bill_to_contact or enrollment.contact
-        name = contact_display_name(c)
-        if name:
-            return name
-        fid = enrollment.bill_to_family_id or enrollment.family_id
-        if fid is not None:
-            fam = enrollment.bill_to_family or enrollment.family
-            entity = (fam.family_name or "").strip() if fam else ""
-            pc = (family_primary_contact_name or "").strip()
-            if not pc and enrolled_nm:
-                pc = enrolled_nm.strip()
-            if entity and pc:
-                return f"{entity} \u00b7 {pc}"
-            if entity:
-                return entity
-            if pc:
-                return pc
-        oid = enrollment.bill_to_organization_id or enrollment.organization_id
-        if oid is not None:
-            org = enrollment.bill_to_organization or enrollment.organization
-            entity = (org.name or "").strip() if org else ""
-            pc = (org_primary_contact_name or "").strip()
-            if not pc and enrolled_nm:
-                pc = enrolled_nm.strip()
-            if entity and pc:
-                return f"{entity} \u00b7 {pc}"
-            if entity:
-                return entity
-            if pc:
-                return pc
-        return "—"
-    if bk == BillingBillToKind.FAMILY:
-        fam = enrollment.bill_to_family or enrollment.family
-        entity = (fam.family_name or "").strip() if fam else ""
-        pc = (family_primary_contact_name or "").strip()
-        if not pc and enrolled_nm:
-            pc = enrolled_nm.strip()
-        label = family_or_organization_bill_to_display_label(
-            entity_name=entity or None,
-            primary_display_name=pc or None,
-        )
-        return label if label else "—"
-    if bk == BillingBillToKind.ORGANIZATION:
-        org = enrollment.bill_to_organization or enrollment.organization
-        entity = (org.name or "").strip() if org else ""
-        pc = (org_primary_contact_name or "").strip()
-        if not pc and enrolled_nm:
-            pc = enrolled_nm.strip()
-        label = family_or_organization_bill_to_display_label(
-            entity_name=entity or None,
-            primary_display_name=pc or None,
-        )
-        return label if label else "—"
-    return "—"
-
-
-def _collect_family_org_ids(rows: list[Enrollment]) -> tuple[set[UUID], set[UUID]]:
-    """Collect distinct family and organization ids referenced by enrollments (bill-to or structural)."""
-    fam: set[UUID] = set()
-    org: set[UUID] = set()
-    for en in rows:
-        fid = en.bill_to_family_id or en.family_id
-        if fid:
-            fam.add(fid)
-        oid = en.bill_to_organization_id or en.organization_id
-        if oid:
-            org.add(oid)
-    return fam, org
-
-
 def _party_email(
     session: Session,
     enrollment: Enrollment,
     family_emails: dict[UUID, str],
     org_emails: dict[UUID, str],
 ) -> str | None:
-    bk = _effective_bill_to_kind(enrollment)
+    bk = effective_enrollment_bill_to_kind(enrollment)
     if bk == BillingBillToKind.CONTACT:
         c = enrollment.bill_to_contact or enrollment.contact
         return c.email if c and c.email else None
@@ -370,15 +269,14 @@ def list_recent_enrollments_for_invoicing(
                 .all()
             )
 
-        fam_ids, org_ids = _collect_family_org_ids(page_rows)
+        fam_ids, org_ids = collect_enrollment_family_org_ids(page_rows)
         fam_emails = primary_family_emails(session, fam_ids)
         org_emails = primary_org_emails(session, org_ids)
-        fam_primary_names = primary_family_contact_names(session, fam_ids)
-        org_primary_names = primary_org_contact_names(session, org_ids)
+        party_labels = batch_enrollment_party_display_names(session, page_rows)
 
         default_ccy = get_default_currency_code()
         items: list[dict[str, Any]] = []
-        for en in page_rows:
+        for idx, en in enumerate(page_rows):
             inst = en.instance
             title = _trimmed_str_or_none(inst.title) if inst else None
             cohort = _trimmed_str_or_none(inst.cohort) if inst else None
@@ -395,16 +293,8 @@ def list_recent_enrollments_for_invoicing(
                 tier_name = _trimmed_str_or_none(svc_obj.service_tier)
             currency = (en.currency or default_ccy).upper()[:3]
             email = _party_email(session, en, fam_emails, org_emails)
-            bk = _effective_bill_to_kind(en)
-            fid = en.bill_to_family_id or en.family_id
-            oid = en.bill_to_organization_id or en.organization_id
-            fam_pc = fam_primary_names.get(fid) if fid else None
-            org_pc = org_primary_names.get(oid) if oid else None
-            party_display = _compose_party_display_name(
-                en,
-                family_primary_contact_name=fam_pc,
-                org_primary_contact_name=org_pc,
-            )
+            bk = effective_enrollment_bill_to_kind(en)
+            party_display = party_labels[idx]
             items.append(
                 {
                     "enrollmentId": str(en.id),

--- a/backend/src/app/api/admin_enrollments.py
+++ b/backend/src/app/api/admin_enrollments.py
@@ -14,6 +14,7 @@ from app.api.discount_enrollment_scope import (
     ensure_discount_code_eligible_for_instance,
     service_id_for_instance,
 )
+from app.api.admin_billing_common import batch_enrollment_party_display_names
 from app.api.admin_services_common import (
     encode_enrollment_cursor,
     parse_create_enrollment_payload,
@@ -125,10 +126,15 @@ def _list_enrollments(event: Mapping[str, Any], *, instance_id: UUID) -> dict[st
         total_count = repository.count_enrollments(
             instance_id=instance_id, status=filters["status"]
         )
+        party_labels = batch_enrollment_party_display_names(session, page_rows)
+        items = [
+            serialize_enrollment(row, party_display_name=party_labels[idx])
+            for idx, row in enumerate(page_rows)
+        ]
         return json_response(
             200,
             {
-                "items": [serialize_enrollment(row) for row in page_rows],
+                "items": items,
                 "next_cursor": next_cursor,
                 "total_count": total_count,
             },
@@ -188,10 +194,15 @@ def _create_enrollment(
             instance_row = instance_repository.get_by_id(created.instance_id)
             if instance_row is not None:
                 bulk_reconcile_instance_capacity_status(session, [instance_row])
+        party_labels = batch_enrollment_party_display_names(session, [created])
         session.commit()
         return json_response(
             201,
-            {"enrollment": serialize_enrollment(created)},
+            {
+                "enrollment": serialize_enrollment(
+                    created, party_display_name=party_labels[0]
+                )
+            },
             event=event,
         )
 
@@ -311,10 +322,15 @@ def _update_enrollment(
             instance_row = instance_repository.get_by_id(updated.instance_id)
             if instance_row is not None:
                 bulk_reconcile_instance_capacity_status(session, [instance_row])
+        party_labels = batch_enrollment_party_display_names(session, [updated])
         session.commit()
         return json_response(
             200,
-            {"enrollment": serialize_enrollment(updated)},
+            {
+                "enrollment": serialize_enrollment(
+                    updated, party_display_name=party_labels[0]
+                )
+            },
             event=event,
         )
 

--- a/backend/src/app/api/admin_services_serializers.py
+++ b/backend/src/app/api/admin_services_serializers.py
@@ -371,6 +371,8 @@ def serialize_event_ticket_tier(tier: EventTicketTier) -> dict[str, Any]:
 
 def serialize_enrollment(
     enrollment: Enrollment,
+    *,
+    party_display_name: str,
 ) -> dict[str, Any]:
     """Serialize enrollment payload."""
     payload: dict[str, Any] = {
@@ -404,6 +406,7 @@ def serialize_enrollment(
         "updated_at": enrollment.updated_at.isoformat()
         if enrollment.updated_at
         else None,
+        "party_display_name": party_display_name,
     }
     return payload
 

--- a/backend/src/app/db/repositories/enrollment.py
+++ b/backend/src/app/db/repositories/enrollment.py
@@ -39,8 +39,11 @@ class EnrollmentRepository(BaseRepository[Enrollment]):
             .where(Enrollment.instance_id == instance_id)
             .options(
                 joinedload(Enrollment.contact),
+                joinedload(Enrollment.bill_to_contact),
                 joinedload(Enrollment.family),
+                joinedload(Enrollment.bill_to_family),
                 joinedload(Enrollment.organization),
+                joinedload(Enrollment.bill_to_organization),
                 joinedload(Enrollment.ticket_tier),
                 joinedload(Enrollment.discount_code),
             )

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -5258,6 +5258,13 @@ components:
         notes:
           type: string
           nullable: true
+        party_display_name:
+          type: string
+          description: >
+            Display label for the enrollment party. For contact bill-to this is the contact name.
+            For family or organization this is `entity name · primary contact name` (middle dot) when
+            both the entity and primary contact names are known; otherwise the best available single
+            label. Matches the billing enrollment picker `partyDisplayName` convention.
         created_by:
           type: string
         created_at:

--- a/tests/test_admin_enrollments_api.py
+++ b/tests/test_admin_enrollments_api.py
@@ -154,6 +154,11 @@ def test_create_enrollment_with_discount_code_calls_validate_and_increment(
     monkeypatch.setattr(admin_enrollments, "set_audit_context", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         admin_enrollments,
+        "batch_enrollment_party_display_names",
+        lambda _session, rows: ["—"] * len(rows),
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
         "parse_body",
         lambda _event: json.loads(_event["body"]),
     )
@@ -199,7 +204,7 @@ def test_create_enrollment_with_discount_code_calls_validate_and_increment(
     monkeypatch.setattr(
         admin_enrollments,
         "serialize_enrollment",
-        lambda e: {"id": "new-1", "discount_code_id": str(e.discount_code_id)},
+        lambda e, **_kwargs: {"id": "new-1", "discount_code_id": str(e.discount_code_id)},
     )
     _patch_enrollment_discount_scope_ok(monkeypatch)
 
@@ -280,6 +285,11 @@ def test_update_enrollment_discount_swaps_usage_counts(monkeypatch: Any, api_gat
     monkeypatch.setattr(admin_enrollments, "set_audit_context", lambda *_a, **_k: None)
     monkeypatch.setattr(
         admin_enrollments,
+        "batch_enrollment_party_display_names",
+        lambda _session, rows: ["—"] * len(rows),
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
         "parse_body",
         lambda _e: json.loads(_e["body"]),
     )
@@ -293,7 +303,7 @@ def test_update_enrollment_discount_swaps_usage_counts(monkeypatch: Any, api_gat
     monkeypatch.setattr(
         admin_enrollments,
         "serialize_enrollment",
-        lambda e: {"id": str(enrollment_id), "discount_code_id": str(e.discount_code_id)},
+        lambda e, **_kwargs: {"id": str(enrollment_id), "discount_code_id": str(e.discount_code_id)},
     )
     _patch_enrollment_discount_scope_ok(monkeypatch)
 
@@ -416,6 +426,11 @@ def test_promote_contact_enrollment_to_family_updates_row(monkeypatch: Any, api_
     monkeypatch.setattr(admin_enrollments, "set_audit_context", lambda *_a, **_k: None)
     monkeypatch.setattr(
         admin_enrollments,
+        "batch_enrollment_party_display_names",
+        lambda _session, rows: ["—"] * len(rows),
+    )
+    monkeypatch.setattr(
+        admin_enrollments,
         "parse_body",
         lambda _e: json.loads(_e["body"]),
     )
@@ -438,7 +453,7 @@ def test_promote_contact_enrollment_to_family_updates_row(monkeypatch: Any, api_
     monkeypatch.setattr(
         admin_enrollments,
         "serialize_enrollment",
-        lambda e: {"id": str(enrollment_id), "family_id": str(e.family_id)},
+        lambda e, **_kwargs: {"id": str(enrollment_id), "family_id": str(e.family_id)},
     )
     _patch_enrollment_discount_scope_ok(monkeypatch)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Services instance **Enrollments** table **Party** column now shows the same label convention as billing: **entity name · primary contact name** (middle dot) for family and organization enrollments when both names are known.

## Changes

- **API:** `Enrollment` responses include `party_display_name`, computed with shared helpers extracted from the billing enrollment picker (`effective_enrollment_bill_to_kind`, `compose_enrollment_party_display_name`, batched primary-contact lookups).
- **Backend:** Enrollment list/create/update serialize this field; list queries eager-load `bill_to_*` relationships so bill-to rows resolve correctly.
- **Admin web:** Parses `party_display_name` as `partyDisplayName` and prefers it in the table cell, with the existing picker maps as fallback.

## Validation

- `pytest tests/test_admin_enrollments_api.py`
- Selected `tests/test_admin_billing.py` enrollment picker tests
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b27d5892-9d3f-4efc-b148-364e5a4f1fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b27d5892-9d3f-4efc-b148-364e5a4f1fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

