### PR TITLE
fix(admin_web): remove status column from instances table

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -61,7 +61,7 @@ export interface InstanceListPanelProps {
     value: string;
     onChange: (value: string) => void;
   };
-  /** When true, add cross-service columns (title, tier · cohort, locations, first slot) before status. */
+  /** When true, add cross-service columns (title, tier · cohort, locations, first slot) before capacity. */
   showServiceColumn?: boolean;
   /** Resolve location ids for the locations column (optional; ids shown when unknown). */
   locationOptions?: LocationSummary[];
@@ -153,7 +153,7 @@ export function InstanceListPanel({
                     id='instances-filter-search'
                     value={searchFilter.value}
                     onChange={(event) => searchFilter.onChange(event.target.value)}
-                    placeholder='Cohort, service, status'
+                    placeholder='Title, cohort, service, locations'
                   />
                 </div>
               ) : null}
@@ -218,17 +218,8 @@ export function InstanceListPanel({
                 <th
                   className={
                     showServiceColumn
-                      ? 'w-[10%] px-4 py-3 font-semibold'
-                      : 'w-[35%] px-4 py-3 font-semibold'
-                  }
-                >
-                  Status
-                </th>
-                <th
-                  className={
-                    showServiceColumn
-                      ? 'w-[10%] whitespace-nowrap px-4 py-3 font-semibold'
-                      : 'w-[35%] whitespace-nowrap px-4 py-3 font-semibold'
+                      ? 'w-[18%] whitespace-nowrap px-4 py-3 font-semibold'
+                      : 'min-w-0 whitespace-nowrap px-4 py-3 font-semibold'
                   }
                 >
                   Capacity
@@ -279,7 +270,6 @@ export function InstanceListPanel({
                         {firstSlot ? formatSessionSlotStartsAtDisplay(firstSlot.startsAt) : '-'}
                       </td>
                     ) : null}
-                    <td className='break-words px-4 py-3'>{formatEnumLabel(instance.status)}</td>
                     <td className='whitespace-nowrap px-4 py-3'>
                       {formatInstanceTableCapacity(instance)}
                     </td>

--- a/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/table-value-formatting.test.tsx
@@ -224,7 +224,7 @@ describe('services tables value formatting', () => {
     expect(screen.getByRole('button', { name: /cannot delete service while it has instances/i })).toBeDisabled();
   });
 
-  it('formats enum values in instance and discount tables', () => {
+  it('formats values in instance and discount tables', () => {
     render(
       <>
         <InstanceListPanel
@@ -268,7 +268,6 @@ describe('services tables value formatting', () => {
     const instanceTable = tables[0] as HTMLElement;
     expect(within(instanceTable).getByText('Custom instance title')).toBeInTheDocument();
     expect(within(instanceTable).getByText('spring-2024')).toBeInTheDocument();
-    expect(within(instanceTable).getByText('In Progress')).toBeInTheDocument();
     expect(within(instanceTable).getByText('Unlimited')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('SAVE10')).toBeInTheDocument();
     expect(within(tables[1] as HTMLElement).getByText('10%')).toBeInTheDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Status** column from the Services **Instances** list (`InstanceListPanel`). Instance status remains editable in the inline **Instance** editor and is still included in the client-side search filter on the Instances view.

## Changes

- Drop Status header and cell from the instances data table; give **Capacity** a slightly wider column when cross-service columns are shown.
- Update the search field placeholder to match searchable fields (status values remain searchable via `instance.status` in the filter logic in `services-page.tsx`).
- Adjust `table-value-formatting` test expectations (instance table no longer shows formatted status).

## Testing

- `npx vitest run` on affected services tests
- `npm run lint` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7a398fb-3cd6-4d4f-a194-fbba90b19d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7a398fb-3cd6-4d4f-a194-fbba90b19d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

