### PR TITLE
admin_web: shared useListMutate hook for list mutations

### DIFF
--- a/apps/admin_web/src/hooks/use-admin-entity-contacts.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-contacts.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   createAdminContact,
@@ -11,6 +11,7 @@ import {
 import { DEFAULT_CONTACT_LIST_FILTERS, type EntityListFilters } from '@/types/entity-list';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -48,21 +49,7 @@ export function useAdminEntityContacts() {
     limit: 50,
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult,>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await refetchContacts();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [refetchContacts]
-  );
+  const { isSaving, mutate } = useListMutate(refetchContacts);
 
   const createContact = useCallback(
     async (payload: ApiSchemas['CreateAdminContactRequest']) =>

--- a/apps/admin_web/src/hooks/use-admin-entity-families.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-families.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   addAdminFamilyMember,
@@ -17,6 +17,7 @@ import {
 } from '@/types/entity-list';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -41,21 +42,7 @@ export function useAdminEntityFamilies() {
     limit: 50,
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult,>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await list.refetch();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [list]
-  );
+  const { isSaving, mutate } = useListMutate(list.refetch);
 
   const createFamily = useCallback(
     async (payload: ApiSchemas['CreateAdminFamilyRequest']) =>

--- a/apps/admin_web/src/hooks/use-admin-entity-organizations.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-organizations.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   addAdminOrganizationMember,
@@ -18,6 +18,7 @@ import {
 import { ORGANIZATION_RELATIONSHIP_TYPES } from '@/types/entity-relationship';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -42,21 +43,7 @@ export function useAdminEntityOrganizations() {
     limit: 50,
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult,>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await list.refetch();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [list]
-  );
+  const { isSaving, mutate } = useListMutate(list.refetch);
 
   const createOrganization = useCallback(
     async (payload: ApiSchemas['CreateAdminOrganizationRequest']) =>

--- a/apps/admin_web/src/hooks/use-discount-codes.ts
+++ b/apps/admin_web/src/hooks/use-discount-codes.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   createDiscountCode,
@@ -13,7 +13,7 @@ import type { DiscountCode, DiscountCodeFilters } from '@/types/services';
 
 import type { components } from '@/types/generated/admin-api.generated';
 
-import { toErrorMessage } from './hook-errors';
+import { useListMutate, type ListMutateOptions } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -35,38 +35,9 @@ export function useDiscountCodes() {
   });
 
   const { refetch } = list;
-  const [isSaving, setIsSaving] = useState(false);
+  const { isSaving, mutate } = useListMutate(refetch);
 
-  type MutateOptions = {
-    /** When true, skip toggling `isSaving` (caller manages a longer-lived saving state). */
-    suppressSaving?: boolean;
-    /** When true, skip the post-mutation list refetch (caller will refetch once). */
-    suppressRefetch?: boolean;
-  };
-
-  const mutate = useCallback(
-    async <TResult>(
-      work: () => Promise<TResult>,
-      options: MutateOptions = {},
-    ): Promise<TResult> => {
-      const { suppressSaving = false, suppressRefetch = false } = options;
-      if (!suppressSaving) {
-        setIsSaving(true);
-      }
-      try {
-        const result = await work();
-        if (!suppressRefetch) {
-          await refetch();
-        }
-        return result;
-      } finally {
-        if (!suppressSaving) {
-          setIsSaving(false);
-        }
-      }
-    },
-    [refetch],
-  );
+  type MutateOptions = ListMutateOptions;
 
   const createCode = useCallback(
     async (

--- a/apps/admin_web/src/hooks/use-list-mutate.ts
+++ b/apps/admin_web/src/hooks/use-list-mutate.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+export interface ListMutateOptions {
+  /** When true, skip toggling `isSaving` (caller manages a longer-lived saving state). */
+  suppressSaving?: boolean;
+  /** When true, skip the post-mutation list refetch (caller will refetch once). */
+  suppressRefetch?: boolean;
+}
+
+export interface UseListMutateOptions {
+  /** Invoked after a successful mutation and after `refetch` when refetch was not suppressed. */
+  onAfterSuccess?: () => void | Promise<void>;
+}
+
+export interface UseListMutateReturn {
+  isSaving: boolean;
+  mutate: <TResult>(work: () => Promise<TResult>, options?: ListMutateOptions) => Promise<TResult>;
+}
+
+/**
+ * Wraps list mutations: optional saving flag, post-mutation refetch, optional success hook.
+ * Used by admin entity and finance list hooks that share the same refetch-after-mutate pattern.
+ */
+export function useListMutate(
+  refetch: () => Promise<void>,
+  hookOptions: UseListMutateOptions = {}
+): UseListMutateReturn {
+  const { onAfterSuccess } = hookOptions;
+  const [isSaving, setIsSaving] = useState(false);
+
+  const mutate = useCallback(
+    async <TResult>(work: () => Promise<TResult>, options: ListMutateOptions = {}): Promise<TResult> => {
+      const { suppressSaving = false, suppressRefetch = false } = options;
+      if (!suppressSaving) {
+        setIsSaving(true);
+      }
+      try {
+        const result = await work();
+        if (!suppressRefetch) {
+          await refetch();
+        }
+        await onAfterSuccess?.();
+        return result;
+      } finally {
+        if (!suppressSaving) {
+          setIsSaving(false);
+        }
+      }
+    },
+    [refetch, onAfterSuccess]
+  );
+
+  return { isSaving, mutate };
+}

--- a/apps/admin_web/src/hooks/use-partners.ts
+++ b/apps/admin_web/src/hooks/use-partners.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   addPartnerMember,
@@ -14,6 +14,7 @@ import {
 import { DEFAULT_PARTNER_FILTERS, type PartnerFilters } from '@/types/partners';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -40,21 +41,7 @@ export function usePartners() {
     limit: 50,
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult,>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await list.refetch();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [list]
-  );
+  const { isSaving, mutate } = useListMutate(list.refetch);
 
   const createPartner = useCallback(
     async (payload: ApiSchemas['CreateAdminOrganizationRequest']) =>

--- a/apps/admin_web/src/hooks/use-vendors.ts
+++ b/apps/admin_web/src/hooks/use-vendors.ts
@@ -1,12 +1,13 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import { createAdminVendor, listAdminVendors, updateAdminVendor } from '@/lib/vendors-api';
 import { DEFAULT_VENDOR_FILTERS } from '@/types/vendors';
 import type { Vendor, VendorFilters } from '@/types/vendors';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -24,21 +25,7 @@ export function useVendors() {
     debounceKeys: ['query'],
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await list.refetch();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [list]
-  );
+  const { isSaving, mutate } = useListMutate(list.refetch);
 
   const createVendor = useCallback(
     async (payload: ApiSchemas['CreateAdminOrganizationRequest']) =>

--- a/apps/admin_web/src/hooks/use-venues.ts
+++ b/apps/admin_web/src/hooks/use-venues.ts
@@ -16,6 +16,7 @@ import type { GeographicAreaSummary, LocationSummary, VenueFilters } from '@/typ
 import type { components } from '@/types/generated/admin-api.generated';
 
 import { toErrorMessage } from './hook-errors';
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -75,22 +76,7 @@ export function useVenues(options: { onMutationSuccess?: () => void | Promise<vo
   });
 
   const { refetch } = list;
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await refetch();
-        await onMutationSuccess?.();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [refetch, onMutationSuccess]
-  );
+  const { isSaving, mutate } = useListMutate(refetch, { onAfterSuccess: onMutationSuccess });
 
   const createVenue = useCallback(
     async (payload: ApiSchemas['CreateLocationRequest']) => mutate(async () => createLocation(payload)),

--- a/apps/admin_web/tests/hooks/use-list-mutate.test.ts
+++ b/apps/admin_web/tests/hooks/use-list-mutate.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useListMutate } from '@/hooks/use-list-mutate';
+
+describe('useListMutate', () => {
+  it('refetches after successful work and clears isSaving', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const work = vi.fn().mockResolvedValue('ok');
+
+    const { result } = renderHook(() => useListMutate(refetch));
+
+    await act(async () => {
+      await result.current.mutate(work);
+    });
+
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it('skips refetch when suppressRefetch is true', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useListMutate(refetch));
+
+    await act(async () => {
+      await result.current.mutate(async () => 1, { suppressRefetch: true });
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it('skips saving flag when suppressSaving is true', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useListMutate(refetch));
+
+    await act(async () => {
+      await result.current.mutate(async () => 1, { suppressSaving: true });
+    });
+
+    expect(result.current.isSaving).toBe(false);
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('runs onAfterSuccess after refetch', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const onAfterSuccess = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useListMutate(refetch, { onAfterSuccess }));
+
+    await act(async () => {
+      await result.current.mutate(async () => undefined);
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(onAfterSuccess).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces `useListMutate` to centralize the repeated pattern: toggle saving state, run async work, refetch the paginated list, optional `suppressSaving` / `suppressRefetch`, and optional `onAfterSuccess` (used by venues).

## Hooks updated

- `use-admin-entity-families`, `use-admin-entity-organizations`, `use-admin-entity-contacts`
- `use-vendors`, `use-partners`, `use-venues`, `use-discount-codes`

## Tests

- New `tests/hooks/use-list-mutate.test.ts`
- Existing hook tests (`use-vendors`, `use-discount-codes`, `use-expenses`) still pass locally with targeted vitest runs; full `npm run lint` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d908cac-34b3-48c1-a11d-5cf8bc6f6f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d908cac-34b3-48c1-a11d-5cf8bc6f6f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

