### PR TITLE
admin_web: refactors (useListMutate, toolbars, errors, FX, conflicts)

### DIFF
--- a/apps/admin_web/package-lock.json
+++ b/apps/admin_web/package-lock.json
@@ -14,7 +14,8 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "recharts": "^3.8.1"
+        "recharts": "^3.8.1",
+        "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.5",
@@ -11641,6 +11642,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.2.4",

--- a/apps/admin_web/package.json
+++ b/apps/admin_web/package.json
@@ -20,7 +20,8 @@
     "qrcode": "^1.5.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.5",

--- a/apps/admin_web/src/components/admin/admin-page-error-banner.tsx
+++ b/apps/admin_web/src/components/admin/admin-page-error-banner.tsx
@@ -4,11 +4,11 @@ import { StatusBanner } from '@/components/status-banner';
 
 export interface AdminPageErrorBannerProps {
   title: string;
-  message: string;
+  message?: string | null;
 }
 
 export function AdminPageErrorBanner({ title, message }: AdminPageErrorBannerProps) {
-  if (!message.trim()) {
+  if (!message?.trim()) {
     return null;
   }
   return (

--- a/apps/admin_web/src/components/admin/admin-page-error-banner.tsx
+++ b/apps/admin_web/src/components/admin/admin-page-error-banner.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { StatusBanner } from '@/components/status-banner';
+
+export interface AdminPageErrorBannerProps {
+  title: string;
+  message: string;
+}
+
+export function AdminPageErrorBanner({ title, message }: AdminPageErrorBannerProps) {
+  if (!message.trim()) {
+    return null;
+  }
+  return (
+    <StatusBanner variant='error' title={title}>
+      {message}
+    </StatusBanner>
+  );
+}

--- a/apps/admin_web/src/components/admin/assets/asset-grants-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-grants-panel.tsx
@@ -9,7 +9,12 @@ import { ACCESS_GRANT_TYPES } from '@/types/assets';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { StatusBanner } from '@/components/status-banner';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -182,7 +187,7 @@ export function AssetGrantsPanel({
                   <th className='px-4 py-3 font-semibold'>Grantee</th>
                   <th className='px-4 py-3 font-semibold'>Granted by</th>
                   <th className='px-4 py-3 font-semibold'>Created</th>
-                  <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+                  <AdminDataTableOperationsHeadCell />
                 </tr>
               </AdminDataTableHead>
               <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
@@ -125,7 +125,7 @@ export function AssetListPanel({
         onLoadMore={onLoadMore}
         toolbar={
           <div className='mb-3 space-y-2'>
-            <AdminTableToolbar noMargin>
+            <AdminTableToolbar marginBottom='none'>
               <div className='min-w-[200px] flex-1'>
                 <Label htmlFor='assets-search'>Search</Label>
                 <Input

--- a/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
@@ -14,13 +14,19 @@ import { OpenAdminAssetInNewTabButton } from '@/components/admin/shared/open-adm
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useOpenAdminAssetInNewTab } from '@/hooks/use-open-admin-asset-in-new-tab';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import {
   formatAssetContentLanguageLabel,
@@ -119,7 +125,7 @@ export function AssetListPanel({
         onLoadMore={onLoadMore}
         toolbar={
           <div className='mb-3 space-y-2'>
-            <div className='flex flex-wrap items-end gap-3'>
+            <AdminTableToolbar noMargin>
               <div className='min-w-[200px] flex-1'>
                 <Label htmlFor='assets-search'>Search</Label>
                 <Input
@@ -161,7 +167,7 @@ export function AssetListPanel({
                   ))}
                 </Select>
               </div>
-            </div>
+            </AdminTableToolbar>
             {viewAssetError ? <AdminInlineError>{viewAssetError}</AdminInlineError> : null}
           </div>
         }
@@ -175,7 +181,7 @@ export function AssetListPanel({
               <th className='px-4 py-3 font-semibold'>Visibility</th>
               <th className='px-4 py-3 font-semibold'>File</th>
               <th className='px-4 py-3 font-semibold'>Updated</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
+++ b/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
@@ -5,7 +5,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AuditLogDetailDialog } from '@/components/admin/audit/audit-log-detail-dialog';
 import { ActionBadge } from '@/components/admin/audit/audit-log-badges';
 import { ViewIcon } from '@/components/icons/action-icons';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -299,9 +304,7 @@ export function AuditLogsPanel({ auditableTables }: AuditLogsPanelProps) {
                 <th className='hidden px-4 py-3 md:table-cell' scope='col'>
                   Changed fields
                 </th>
-                <th className='px-4 py-3 text-right' scope='col'>
-                  Operations
-                </th>
+                <AdminDataTableOperationsHeadCell scope='col' className='px-4 py-3 font-normal' />
               </tr>
             </AdminDataTableHead>
             <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
+++ b/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
@@ -304,7 +304,7 @@ export function AuditLogsPanel({ auditableTables }: AuditLogsPanelProps) {
                 <th className='hidden px-4 py-3 md:table-cell' scope='col'>
                   Changed fields
                 </th>
-                <AdminDataTableOperationsHeadCell scope='col' className='px-4 py-3 font-normal' />
+                <AdminDataTableOperationsHeadCell scope='col' />
               </tr>
             </AdminDataTableHead>
             <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
+++ b/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
@@ -20,6 +20,7 @@ import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { toErrorMessage } from '@/hooks/hook-errors';
 import {
   CONSULTATION_BOOKING_BLOCK_PURPOSE,
   createCalendarManualBlock,
@@ -85,7 +86,7 @@ export function CalendarManualBlocksPage() {
       });
       setRows(items);
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Failed to load blocks.';
+      const message = toErrorMessage(caught, 'Failed to load blocks.');
       setError(message);
     } finally {
       setIsLoading(false);
@@ -159,7 +160,7 @@ export function CalendarManualBlocksPage() {
       );
       await loadRows();
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Save failed.';
+      const message = toErrorMessage(caught, 'Save failed.');
       setSaveError(message);
     } finally {
       setIsSaving(false);
@@ -185,7 +186,7 @@ export function CalendarManualBlocksPage() {
       }
       await loadRows();
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Delete failed.';
+      const message = toErrorMessage(caught, 'Delete failed.');
       setError(message);
     } finally {
       setDeleteBusyId(null);

--- a/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
+++ b/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
@@ -86,7 +86,7 @@ export function CalendarManualBlocksPage() {
       });
       setRows(items);
     } catch (caught) {
-      const message = toErrorMessage(caught, 'Failed to load blocks.');
+      const message = toErrorMessage(caught, 'Failed to load blocks.', { honorBackendMessage: true });
       setError(message);
     } finally {
       setIsLoading(false);
@@ -160,7 +160,7 @@ export function CalendarManualBlocksPage() {
       );
       await loadRows();
     } catch (caught) {
-      const message = toErrorMessage(caught, 'Save failed.');
+      const message = toErrorMessage(caught, 'Save failed.', { honorBackendMessage: true });
       setSaveError(message);
     } finally {
       setIsSaving(false);
@@ -186,7 +186,7 @@ export function CalendarManualBlocksPage() {
       }
       await loadRows();
     } catch (caught) {
-      const message = toErrorMessage(caught, 'Delete failed.');
+      const message = toErrorMessage(caught, 'Delete failed.', { honorBackendMessage: true });
       setError(message);
     } finally {
       setDeleteBusyId(null);

--- a/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
+++ b/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
@@ -4,12 +4,18 @@ import type { FormEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { DeleteIcon } from '@/components/icons/action-icons';
@@ -260,7 +266,7 @@ export function CalendarManualBlocksPage() {
         loadingLabel='Loading blocks…'
         onLoadMore={() => {}}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div>
               <Label htmlFor='calendar-list-from'>From</Label>
               <Input
@@ -282,7 +288,7 @@ export function CalendarManualBlocksPage() {
             <Button type='button' variant='secondary' onClick={() => void loadRows()}>
               Refresh
             </Button>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[640px]'>
@@ -291,7 +297,7 @@ export function CalendarManualBlocksPage() {
               <th className='px-4 py-3 font-semibold'>Date</th>
               <th className='px-4 py-3 font-semibold'>AM/PM</th>
               <th className='px-4 py-3 font-semibold'>Note</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { ContactsPanel } from '@/components/admin/contacts/contacts-panel';
 import { FamiliesPanel } from '@/components/admin/contacts/families-panel';
 import { OrganizationsPanel } from '@/components/admin/contacts/organizations-panel';
-import { StatusBanner } from '@/components/status-banner';
+import { AdminPageErrorBanner } from '@/components/admin/admin-page-error-banner';
 import { AdminTabStrip } from '@/components/ui/admin-tab-strip';
 import { listEntityTags, type EntityTagRef } from '@/lib/entity-api';
 import { listAllLocations, listGeographicAreas } from '@/lib/services-api';
@@ -117,11 +117,7 @@ export function ContactsPage() {
 
   return (
     <div className='space-y-4'>
-      {hasAnyError ? (
-        <StatusBanner variant='error' title='Contacts'>
-          {hasAnyError}
-        </StatusBanner>
-      ) : null}
+      <AdminPageErrorBanner title='Contacts' message={hasAnyError} />
 
       <AdminTabStrip
         items={TAB_ITEMS}

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -14,12 +14,18 @@ import { ArchiveIcon, DeleteIcon, NoteIcon, RestoreIcon } from '@/components/ico
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PhoneField } from '@/components/ui/phone-field';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -881,7 +887,7 @@ export function ContactsPanel({
         loadingLabel='Loading contacts...'
         onLoadMore={loadMore}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div className='min-w-[200px] flex-1'>
               <Label htmlFor='crm-contacts-search'>Search</Label>
               <Input
@@ -927,7 +933,7 @@ export function ContactsPanel({
                 <option value='false'>Archived</option>
               </Select>
             </div>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[960px]'>
@@ -936,7 +942,7 @@ export function ContactsPanel({
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Email</th>
               <th className='px-4 py-3 font-semibold'>Type</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -12,12 +12,18 @@ import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { formatEnumLabel } from '@/lib/format';
 import type { EntityTagRef } from '@/lib/entity-api';
@@ -429,7 +435,7 @@ export function FamiliesPanel({
             <div className='lg:col-span-4'>
               <AdminCollapsibleSection id='crm-family-members' title='Members'>
                 <div className='space-y-3 pt-1'>
-                  <div className='flex flex-wrap items-end gap-3'>
+                  <AdminTableToolbar noMargin>
                     <div className='min-w-[200px] flex-1'>
                       <Label htmlFor='crm-family-member-contact'>Contact</Label>
                       <Select
@@ -452,7 +458,7 @@ export function FamiliesPanel({
                     >
                       Add member
                     </Button>
-                  </div>
+                  </AdminTableToolbar>
                   <p className='text-xs text-slate-600'>
                     Role for each member follows the contact type set on the contact record.
                   </p>
@@ -462,7 +468,7 @@ export function FamiliesPanel({
                         <th className='px-3 py-2 font-semibold'>Contact</th>
                         <th className='px-3 py-2 font-semibold'>Role</th>
                         <th className='px-3 py-2 font-semibold'>Primary contact</th>
-                        <th className='px-3 py-2 font-semibold text-right'>Operations</th>
+                        <AdminDataTableOperationsHeadCell className='px-3 py-2' />
                       </tr>
                     </AdminDataTableHead>
                     <AdminDataTableBody>
@@ -521,7 +527,7 @@ export function FamiliesPanel({
         loadingLabel='Loading families...'
         onLoadMore={loadMore}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div className='min-w-[200px] flex-1'>
               <Label htmlFor='crm-families-search'>Search</Label>
               <Input
@@ -549,7 +555,7 @@ export function FamiliesPanel({
                 <option value='false'>Archived</option>
               </Select>
             </div>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[720px]'>
@@ -558,7 +564,7 @@ export function FamiliesPanel({
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Members</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -426,7 +426,7 @@ export function FamiliesPanel({
             <div className='lg:col-span-4'>
               <AdminCollapsibleSection id='crm-family-members' title='Members'>
                 <div className='space-y-3 pt-1'>
-                  <AdminTableToolbar noMargin>
+                  <AdminTableToolbar marginBottom='none'>
                     <div className='min-w-[200px] flex-1'>
                       <Label htmlFor='crm-family-member-contact'>Contact</Label>
                       <Select

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -25,8 +25,9 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
-import { formatEnumLabel } from '@/lib/format';
 import type { EntityTagRef } from '@/lib/entity-api';
+import { contactEligibleForEntityMembership } from '@/lib/entity-contact-eligibility';
+import { formatEnumLabel } from '@/lib/format';
 import type { EntityListFilters } from '@/types/entity-list';
 import {
   FAMILY_RELATIONSHIP_TYPES,
@@ -36,16 +37,6 @@ import type { GeographicAreaSummary, LocationSummary } from '@/types/services';
 import type { components } from '@/types/generated/admin-api.generated';
 
 type ApiSchemas = components['schemas'];
-
-function contactEligibleForFamilyMember(
-  contact: { id: string; family_ids: string[]; organization_ids: string[] },
-  selectedFamilyId: string | null
-): boolean {
-  if (contact.family_ids.length === 0) {
-    return true;
-  }
-  return Boolean(selectedFamilyId && contact.family_ids.includes(selectedFamilyId));
-}
 
 export interface FamiliesPanelProps {
   families: ReturnType<typeof useAdminEntityFamilies>;
@@ -179,7 +170,7 @@ export function FamiliesPanel({
       if (!row) {
         return true;
       }
-      return contactEligibleForFamilyMember(row, selectedId);
+      return contactEligibleForEntityMembership(row, selectedId, 'family');
     });
   }, [contactOptions, contactsForMembership, selectedId]);
 

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -479,7 +479,7 @@ export function OrganizationsPanel({
             <div className='lg:col-span-4'>
               <AdminCollapsibleSection id='crm-org-members' title='Members'>
                 <div className='space-y-3 pt-1'>
-                  <AdminTableToolbar noMargin>
+                  <AdminTableToolbar marginBottom='none'>
                     <div className='min-w-[200px] flex-1'>
                       <Label htmlFor='crm-org-member-contact'>Contact</Label>
                       <Select

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -12,12 +12,18 @@ import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { formatEnumLabel } from '@/lib/format';
 import type { EntityTagRef } from '@/lib/entity-api';
@@ -482,7 +488,7 @@ export function OrganizationsPanel({
             <div className='lg:col-span-4'>
               <AdminCollapsibleSection id='crm-org-members' title='Members'>
                 <div className='space-y-3 pt-1'>
-                  <div className='flex flex-wrap items-end gap-3'>
+                  <AdminTableToolbar noMargin>
                     <div className='min-w-[200px] flex-1'>
                       <Label htmlFor='crm-org-member-contact'>Contact</Label>
                       <Select
@@ -505,7 +511,7 @@ export function OrganizationsPanel({
                     >
                       Add member
                     </Button>
-                  </div>
+                  </AdminTableToolbar>
                   <p className='text-xs text-slate-600'>
                     Role for each member follows the contact type set on the contact record.
                   </p>
@@ -515,7 +521,7 @@ export function OrganizationsPanel({
                         <th className='px-3 py-2 font-semibold'>Contact</th>
                         <th className='px-3 py-2 font-semibold'>Role</th>
                         <th className='px-3 py-2 font-semibold'>Primary contact</th>
-                        <th className='px-3 py-2 font-semibold text-right'>Operations</th>
+                        <AdminDataTableOperationsHeadCell className='px-3 py-2' />
                       </tr>
                     </AdminDataTableHead>
                     <AdminDataTableBody>
@@ -574,7 +580,7 @@ export function OrganizationsPanel({
         loadingLabel='Loading organisations...'
         onLoadMore={loadMore}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div className='min-w-[200px] flex-1'>
               <Label htmlFor='crm-orgs-search'>Search</Label>
               <Input
@@ -602,7 +608,7 @@ export function OrganizationsPanel({
                 <option value='false'>Archived</option>
               </Select>
             </div>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[800px]'>
@@ -612,7 +618,7 @@ export function OrganizationsPanel({
               <th className='px-4 py-3 font-semibold'>Type</th>
               <th className='px-4 py-3 font-semibold'>Members</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -25,8 +25,9 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
-import { formatEnumLabel } from '@/lib/format';
+import { contactEligibleForEntityMembership } from '@/lib/entity-contact-eligibility';
 import type { EntityTagRef } from '@/lib/entity-api';
+import { formatEnumLabel } from '@/lib/format';
 import type { EntityListFilters } from '@/types/entity-list';
 import {
   ORGANIZATION_RELATIONSHIP_TYPES,
@@ -44,16 +45,6 @@ const ORG_TYPES: ApiSchemas['EntityOrganizationType'][] = [
   'ngo',
   'other',
 ];
-
-function contactEligibleForOrgMember(
-  contact: { id: string; family_ids: string[]; organization_ids: string[] },
-  selectedOrgId: string | null
-): boolean {
-  if (contact.organization_ids.length === 0) {
-    return true;
-  }
-  return Boolean(selectedOrgId && contact.organization_ids.includes(selectedOrgId));
-}
 
 export interface OrganizationsPanelProps {
   organizations: ReturnType<typeof useAdminEntityOrganizations>;
@@ -192,7 +183,7 @@ export function OrganizationsPanel({
       if (!row) {
         return true;
       }
-      return contactEligibleForOrgMember(row, selectedId);
+      return contactEligibleForEntityMembership(row, selectedId, 'organization');
     });
   }, [contactOptions, contactsForMembership, selectedId]);
 

--- a/apps/admin_web/src/components/admin/finance/client-invoices-format-helpers.ts
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-format-helpers.ts
@@ -1,0 +1,16 @@
+import { formatEnumLabel } from '@/lib/format';
+
+export function formatTruncatedId(id: string | null | undefined): string {
+  if (!id) {
+    return '—';
+  }
+  if (id.length <= 12) {
+    return id;
+  }
+  return `${id.slice(0, 8)}…`;
+}
+
+/** Customer payments Method column: snake_case label with FPS acronym spelled out. */
+export function formatPaymentMethodLabel(raw: string | null | undefined): string {
+  return formatEnumLabel(raw ?? '').replace(/\bFps\b/g, 'FPS');
+}

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -5,13 +5,19 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { StatusBanner } from '@/components/status-banner';
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -1126,7 +1132,7 @@ export function ClientInvoicesPanel() {
                 Rows already on a draft or issued invoice cannot be selected. Selected rows must share bill-to
                 and currency on the server.
               </p>
-              <div className='flex flex-wrap items-end gap-3'>
+              <AdminTableToolbar noMargin>
                 <div className='min-w-[220px] flex-1'>
                   <Label htmlFor={draftFilterId}>Filter enrollments</Label>
                   <Input
@@ -1138,7 +1144,7 @@ export function ClientInvoicesPanel() {
                     disabled={editorBusy}
                   />
                 </div>
-              </div>
+              </AdminTableToolbar>
               {enrollmentPickerTruncated ? (
                 <p className='text-sm text-amber-800' role='status'>
                   Enrollment list may be incomplete (server capped additional pages). Narrow your filter or
@@ -1462,7 +1468,7 @@ export function ClientInvoicesPanel() {
               <th className='px-3 py-2'>Total</th>
               <th className='px-3 py-2'>Lines</th>
               <th className='px-3 py-2'>Created</th>
-              <th className='px-3 py-2 text-right'>Operations</th>
+              <AdminDataTableOperationsHeadCell className='px-3 py-2 font-normal' />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
@@ -1870,7 +1876,7 @@ export function ClientInvoicesPanel() {
               <th className='px-3 py-2'>Method</th>
               <th className='px-3 py-2'>Amount</th>
               <th className='px-3 py-2'>Created</th>
-              <th className='px-3 py-2 text-right'>Operations</th>
+              <AdminDataTableOperationsHeadCell className='px-3 py-2 font-normal' />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -260,7 +260,7 @@ export function ClientInvoicesPanel() {
       if (caught instanceof Error && caught.name === 'AbortError') {
         return;
       }
-      const message = toErrorMessage(caught, 'Failed to load payments.');
+      const message = toErrorMessage(caught, 'Failed to load payments.', { honorBackendMessage: true });
       setListError(message);
     } finally {
       setListLoading(false);
@@ -310,7 +310,7 @@ export function ClientInvoicesPanel() {
           return;
         }
         const message =
-          toErrorMessage(caught, 'Failed to load enrollments for invoicing.');
+          toErrorMessage(caught, 'Failed to load enrollments for invoicing.', { honorBackendMessage: true });
         setEnrollmentPickerError(message);
         setEnrollmentPickerRows([]);
         setEnrollmentPickerTruncated(false);
@@ -389,7 +389,7 @@ export function ClientInvoicesPanel() {
       if (caught instanceof Error && caught.name === 'AbortError') {
         return;
       }
-      const message = toErrorMessage(caught, 'Failed to load invoices.');
+      const message = toErrorMessage(caught, 'Failed to load invoices.', { honorBackendMessage: true });
       setInvoiceListError(message);
       setInvoices([]);
     } finally {
@@ -419,7 +419,7 @@ export function ClientInvoicesPanel() {
       setInvoices((prev) => [...prev, ...items]);
       setInvoiceListCursor(next_cursor);
     } catch (caught) {
-      const message = toErrorMessage(caught, 'Failed to load more invoices.');
+      const message = toErrorMessage(caught, 'Failed to load more invoices.', { honorBackendMessage: true });
       setInvoiceListError(message);
     } finally {
       setInvoiceListLoadingMore(false);
@@ -515,7 +515,7 @@ export function ClientInvoicesPanel() {
           setAllocateInvoiceLines([]);
           setAllocateLineId('');
           setAllocateInvoiceLinesError(
-            toErrorMessage(caught, 'Failed to load invoice lines.'),
+            toErrorMessage(caught, 'Failed to load invoice lines.', { honorBackendMessage: true }),
           );
         }
       } finally {
@@ -574,7 +574,7 @@ export function ClientInvoicesPanel() {
         if (caught instanceof Error && caught.name === 'AbortError') {
           return;
         }
-        const message = toErrorMessage(caught, 'Failed to load payment.');
+        const message = toErrorMessage(caught, 'Failed to load payment.', { honorBackendMessage: true });
         setDetailError(message);
         setDetail(null);
       } finally {
@@ -669,7 +669,7 @@ export function ClientInvoicesPanel() {
           setRefundPaymentsForInvoice([]);
           setRefundPaymentSelectId('');
           setRefundPaymentsError(
-            toErrorMessage(caught, 'Failed to load payments for invoice.'),
+            toErrorMessage(caught, 'Failed to load payments for invoice.', { honorBackendMessage: true }),
           );
         }
       } finally {
@@ -717,7 +717,7 @@ export function ClientInvoicesPanel() {
       await loadPayments();
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setVoidError(toErrorMessage(caught, 'Void failed.'));
+      setVoidError(toErrorMessage(caught, 'Void failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -756,7 +756,7 @@ export function ClientInvoicesPanel() {
       await loadPayments();
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setDeleteDraftError(toErrorMessage(caught, 'Delete failed.'));
+      setDeleteDraftError(toErrorMessage(caught, 'Delete failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -779,7 +779,7 @@ export function ClientInvoicesPanel() {
       setActionMessage(out.sent ? 'Email send accepted.' : 'Email was not confirmed sent.');
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setIssuedInvoiceEmailError(toErrorMessage(caught, 'Email failed.'));
+      setIssuedInvoiceEmailError(toErrorMessage(caught, 'Email failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -797,7 +797,7 @@ export function ClientInvoicesPanel() {
       );
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setActionError(toErrorMessage(caught, 'Issue failed.'));
+      setActionError(toErrorMessage(caught, 'Issue failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -810,7 +810,7 @@ export function ClientInvoicesPanel() {
       const { downloadUrl } = await getCustomerInvoicePdfDownload(invoiceId);
       window.open(downloadUrl, '_blank', 'noopener,noreferrer');
     } catch (caught) {
-      setActionError(toErrorMessage(caught, 'Could not open invoice preview.'));
+      setActionError(toErrorMessage(caught, 'Could not open invoice preview.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -850,7 +850,7 @@ export function ClientInvoicesPanel() {
         await loadDetail(confirmPaymentId, ac.signal);
       }
     } catch (caught) {
-      setConfirmPaymentError(toErrorMessage(caught, 'Confirm failed.'));
+      setConfirmPaymentError(toErrorMessage(caught, 'Confirm failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -885,7 +885,7 @@ export function ClientInvoicesPanel() {
         setDetail(null);
       }
     } catch (caught) {
-      setDeletePaymentError(toErrorMessage(caught, 'Delete failed.'));
+      setDeletePaymentError(toErrorMessage(caught, 'Delete failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -947,7 +947,7 @@ export function ClientInvoicesPanel() {
       await loadInvoicesFirstPage();
       await loadEnrollmentPicker(undefined, enrollmentFilter.trim());
     } catch (caught) {
-      setActionError(toErrorMessage(caught, 'Create draft failed.'));
+      setActionError(toErrorMessage(caught, 'Create draft failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -991,7 +991,7 @@ export function ClientInvoicesPanel() {
       await loadDetail(selectedId, ac.signal);
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setActionError(toErrorMessage(caught, 'Allocation failed.'));
+      setActionError(toErrorMessage(caught, 'Allocation failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -1025,7 +1025,7 @@ export function ClientInvoicesPanel() {
       await loadPayments();
       setRefundInvoicePaymentsRefresh((n) => n + 1);
     } catch (caught) {
-      setActionError(toErrorMessage(caught, 'Refund failed.'));
+      setActionError(toErrorMessage(caught, 'Refund failed.', { honorBackendMessage: true }));
     } finally {
       setBusy(null);
     }
@@ -1045,7 +1045,7 @@ export function ClientInvoicesPanel() {
       URL.revokeObjectURL(url);
       setActionMessage('Export downloaded (v2 CSV).');
     } catch (caught) {
-      setActionError(toErrorMessage(caught, 'Export failed.'));
+      setActionError(toErrorMessage(caught, 'Export failed.', { honorBackendMessage: true }));
     } finally {
       setExportBusy(false);
     }
@@ -1122,7 +1122,7 @@ export function ClientInvoicesPanel() {
                 Rows already on a draft or issued invoice cannot be selected. Selected rows must share bill-to
                 and currency on the server.
               </p>
-              <AdminTableToolbar noMargin>
+              <AdminTableToolbar marginBottom='none'>
                 <div className='min-w-[220px] flex-1'>
                   <Label htmlFor={draftFilterId}>Filter enrollments</Label>
                   <Input

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -27,6 +27,10 @@ import {
   ViewIcon,
   VoidExpenseIcon,
 } from '@/components/icons/action-icons';
+import {
+  formatPaymentMethodLabel,
+  formatTruncatedId,
+} from '@/components/admin/finance/client-invoices-format-helpers';
 import { toErrorMessage } from '@/hooks/hook-errors';
 import {
   CUSTOMIZED_DRAFT_INVOICE_FORM_ID,
@@ -70,21 +74,6 @@ import { formatAmountInCurrency } from '@/lib/vendor-spend';
 const DRAFT_FORM_ID = 'client-billing-draft-invoice-form';
 const ALLOCATE_FORM_ID = 'client-billing-allocate-form';
 const REFUND_FORM_ID = 'client-billing-refund-form';
-
-function formatTruncatedId(id: string | null | undefined): string {
-  if (!id) {
-    return '—';
-  }
-  if (id.length <= 12) {
-    return id;
-  }
-  return `${id.slice(0, 8)}…`;
-}
-
-/** Customer payments Method column: snake_case label with FPS acronym spelled out. */
-function formatPaymentMethodLabel(raw: string | null | undefined): string {
-  return formatEnumLabel(raw ?? '').replace(/\bFps\b/g, 'FPS');
-}
 
 type CustomerInvoiceLineRow = NonNullable<CustomerInvoiceDetail['lines']>[number];
 

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -27,6 +27,7 @@ import {
   ViewIcon,
   VoidExpenseIcon,
 } from '@/components/icons/action-icons';
+import { toErrorMessage } from '@/hooks/hook-errors';
 import {
   CUSTOMIZED_DRAFT_INVOICE_FORM_ID,
   CustomizedDraftInvoiceCard,
@@ -270,7 +271,7 @@ export function ClientInvoicesPanel() {
       if (caught instanceof Error && caught.name === 'AbortError') {
         return;
       }
-      const message = caught instanceof Error ? caught.message : 'Failed to load payments.';
+      const message = toErrorMessage(caught, 'Failed to load payments.');
       setListError(message);
     } finally {
       setListLoading(false);
@@ -320,7 +321,7 @@ export function ClientInvoicesPanel() {
           return;
         }
         const message =
-          caught instanceof Error ? caught.message : 'Failed to load enrollments for invoicing.';
+          toErrorMessage(caught, 'Failed to load enrollments for invoicing.');
         setEnrollmentPickerError(message);
         setEnrollmentPickerRows([]);
         setEnrollmentPickerTruncated(false);
@@ -399,7 +400,7 @@ export function ClientInvoicesPanel() {
       if (caught instanceof Error && caught.name === 'AbortError') {
         return;
       }
-      const message = caught instanceof Error ? caught.message : 'Failed to load invoices.';
+      const message = toErrorMessage(caught, 'Failed to load invoices.');
       setInvoiceListError(message);
       setInvoices([]);
     } finally {
@@ -429,7 +430,7 @@ export function ClientInvoicesPanel() {
       setInvoices((prev) => [...prev, ...items]);
       setInvoiceListCursor(next_cursor);
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Failed to load more invoices.';
+      const message = toErrorMessage(caught, 'Failed to load more invoices.');
       setInvoiceListError(message);
     } finally {
       setInvoiceListLoadingMore(false);
@@ -525,7 +526,7 @@ export function ClientInvoicesPanel() {
           setAllocateInvoiceLines([]);
           setAllocateLineId('');
           setAllocateInvoiceLinesError(
-            caught instanceof Error ? caught.message : 'Failed to load invoice lines.',
+            toErrorMessage(caught, 'Failed to load invoice lines.'),
           );
         }
       } finally {
@@ -584,7 +585,7 @@ export function ClientInvoicesPanel() {
         if (caught instanceof Error && caught.name === 'AbortError') {
           return;
         }
-        const message = caught instanceof Error ? caught.message : 'Failed to load payment.';
+        const message = toErrorMessage(caught, 'Failed to load payment.');
         setDetailError(message);
         setDetail(null);
       } finally {
@@ -679,7 +680,7 @@ export function ClientInvoicesPanel() {
           setRefundPaymentsForInvoice([]);
           setRefundPaymentSelectId('');
           setRefundPaymentsError(
-            caught instanceof Error ? caught.message : 'Failed to load payments for invoice.',
+            toErrorMessage(caught, 'Failed to load payments for invoice.'),
           );
         }
       } finally {
@@ -727,7 +728,7 @@ export function ClientInvoicesPanel() {
       await loadPayments();
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setVoidError(caught instanceof Error ? caught.message : 'Void failed.');
+      setVoidError(toErrorMessage(caught, 'Void failed.'));
     } finally {
       setBusy(null);
     }
@@ -766,7 +767,7 @@ export function ClientInvoicesPanel() {
       await loadPayments();
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setDeleteDraftError(caught instanceof Error ? caught.message : 'Delete failed.');
+      setDeleteDraftError(toErrorMessage(caught, 'Delete failed.'));
     } finally {
       setBusy(null);
     }
@@ -789,7 +790,7 @@ export function ClientInvoicesPanel() {
       setActionMessage(out.sent ? 'Email send accepted.' : 'Email was not confirmed sent.');
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setIssuedInvoiceEmailError(caught instanceof Error ? caught.message : 'Email failed.');
+      setIssuedInvoiceEmailError(toErrorMessage(caught, 'Email failed.'));
     } finally {
       setBusy(null);
     }
@@ -807,7 +808,7 @@ export function ClientInvoicesPanel() {
       );
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setActionError(caught instanceof Error ? caught.message : 'Issue failed.');
+      setActionError(toErrorMessage(caught, 'Issue failed.'));
     } finally {
       setBusy(null);
     }
@@ -820,7 +821,7 @@ export function ClientInvoicesPanel() {
       const { downloadUrl } = await getCustomerInvoicePdfDownload(invoiceId);
       window.open(downloadUrl, '_blank', 'noopener,noreferrer');
     } catch (caught) {
-      setActionError(caught instanceof Error ? caught.message : 'Could not open invoice preview.');
+      setActionError(toErrorMessage(caught, 'Could not open invoice preview.'));
     } finally {
       setBusy(null);
     }
@@ -860,7 +861,7 @@ export function ClientInvoicesPanel() {
         await loadDetail(confirmPaymentId, ac.signal);
       }
     } catch (caught) {
-      setConfirmPaymentError(caught instanceof Error ? caught.message : 'Confirm failed.');
+      setConfirmPaymentError(toErrorMessage(caught, 'Confirm failed.'));
     } finally {
       setBusy(null);
     }
@@ -895,7 +896,7 @@ export function ClientInvoicesPanel() {
         setDetail(null);
       }
     } catch (caught) {
-      setDeletePaymentError(caught instanceof Error ? caught.message : 'Delete failed.');
+      setDeletePaymentError(toErrorMessage(caught, 'Delete failed.'));
     } finally {
       setBusy(null);
     }
@@ -957,7 +958,7 @@ export function ClientInvoicesPanel() {
       await loadInvoicesFirstPage();
       await loadEnrollmentPicker(undefined, enrollmentFilter.trim());
     } catch (caught) {
-      setActionError(caught instanceof Error ? caught.message : 'Create draft failed.');
+      setActionError(toErrorMessage(caught, 'Create draft failed.'));
     } finally {
       setBusy(null);
     }
@@ -1001,7 +1002,7 @@ export function ClientInvoicesPanel() {
       await loadDetail(selectedId, ac.signal);
       await loadInvoicesFirstPage();
     } catch (caught) {
-      setActionError(caught instanceof Error ? caught.message : 'Allocation failed.');
+      setActionError(toErrorMessage(caught, 'Allocation failed.'));
     } finally {
       setBusy(null);
     }
@@ -1035,7 +1036,7 @@ export function ClientInvoicesPanel() {
       await loadPayments();
       setRefundInvoicePaymentsRefresh((n) => n + 1);
     } catch (caught) {
-      setActionError(caught instanceof Error ? caught.message : 'Refund failed.');
+      setActionError(toErrorMessage(caught, 'Refund failed.'));
     } finally {
       setBusy(null);
     }
@@ -1055,7 +1056,7 @@ export function ClientInvoicesPanel() {
       URL.revokeObjectURL(url);
       setActionMessage('Export downloaded (v2 CSV).');
     } catch (caught) {
-      setActionError(caught instanceof Error ? caught.message : 'Export failed.');
+      setActionError(toErrorMessage(caught, 'Export failed.'));
     } finally {
       setExportBusy(false);
     }

--- a/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
+++ b/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
@@ -16,6 +16,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { useEnrollmentParentPickers } from '@/hooks/use-enrollment-parent-pickers';
+import { toErrorMessage } from '@/hooks/hook-errors';
 import { createDraftInvoice } from '@/lib/billing-api';
 
 export const CUSTOMIZED_DRAFT_INVOICE_FORM_ID = 'client-billing-customized-draft-form';
@@ -268,7 +269,7 @@ export function CustomizedDraftInvoiceCard({
       setCustomizedLines([makeCustomizedLineRow(customizedLineIdSeq.current)]);
     } catch (caught) {
       onDraftError?.(
-        caught instanceof Error ? caught.message : 'Create draft failed.',
+        toErrorMessage(caught, 'Create draft failed.'),
       );
     } finally {
       onRequestBusy?.(false);

--- a/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
+++ b/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
@@ -9,6 +9,7 @@ import {
   AdminDataTable,
   AdminDataTableBody,
   AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -359,7 +360,7 @@ export function CustomizedDraftInvoiceCard({
                     <th className='w-[6rem] px-3 py-2 text-right'>Discount</th>
                     <th className='w-[5.5rem] px-3 py-2 text-right'>Tax rate</th>
                     <th className='w-[6.5rem] px-3 py-2 text-right'>Tax amount</th>
-                    <th className='px-3 py-2 text-right'>Operations</th>
+                    <AdminDataTableOperationsHeadCell className='px-3 py-2 font-normal' />
                   </tr>
                 </AdminDataTableHead>
                 <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
+++ b/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
@@ -269,7 +269,7 @@ export function CustomizedDraftInvoiceCard({
       setCustomizedLines([makeCustomizedLineRow(customizedLineIdSeq.current)]);
     } catch (caught) {
       onDraftError?.(
-        toErrorMessage(caught, 'Create draft failed.'),
+        toErrorMessage(caught, 'Create draft failed.', { honorBackendMessage: true }),
       );
     } finally {
       onRequestBusy?.(false);

--- a/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
@@ -128,7 +128,7 @@ export function ExpensesListPanel({
     expensesNeedForeignFx,
   );
 
-  const tableError = [error, expensesNeedForeignFx ? fxError : ''].filter(Boolean).join(' ');
+  const tableError = [error, expensesNeedForeignFx ? fxError : ''].filter(Boolean).join(' • ');
 
   const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, expenseId: string) => {
     if (event.target !== event.currentTarget) {
@@ -167,7 +167,7 @@ export function ExpensesListPanel({
       await onVoidExpense(voidExpenseId, voidReason.trim());
       closeVoidDialog();
     } catch (caught) {
-      setVoidError(toErrorMessage(caught, 'Could not void this expense.'));
+      setVoidError(toErrorMessage(caught, 'Could not void this expense.', { honorBackendMessage: true }));
     }
   };
 
@@ -192,7 +192,7 @@ export function ExpensesListPanel({
       await onDeleteDraft(deleteDraftExpenseId);
       closeDeleteDraftDialog();
     } catch (caught) {
-      setDeleteDraftError(toErrorMessage(caught, 'Could not delete this expense.'));
+      setDeleteDraftError(toErrorMessage(caught, 'Could not delete this expense.', { honorBackendMessage: true }));
     }
   };
 
@@ -208,7 +208,7 @@ export function ExpensesListPanel({
         onLoadMore={onLoadMore}
         toolbar={
           <div className='mb-3 space-y-2'>
-            <AdminTableToolbar noMargin>
+            <AdminTableToolbar marginBottom='none'>
               <div className='min-w-[200px] flex-1'>
                 <Label htmlFor='expenses-query'>Search</Label>
                 <Input

--- a/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { KeyboardEvent } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { OpenAdminAssetInNewTabButton } from '@/components/admin/shared/open-admin-asset-in-new-tab-button';
 import { DeleteIcon, MarkPaidIcon, RotateIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
@@ -21,11 +21,12 @@ import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { toErrorMessage } from '@/hooks/hook-errors';
+import { useFxMultipliersForCurrencies } from '@/hooks/use-fx-multipliers-for-currencies';
 import { useOpenAdminAssetInNewTab } from '@/hooks/use-open-admin-asset-in-new-tab';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { primaryExpenseAttachmentAssetId } from '@/lib/expense-attachments';
 import { formatDateOnly, formatEnumLabel } from '@/lib/format';
-import { formatMoneyLineWithFxToDefault, loadFxMultipliersToAdminDefault } from '@/lib/vendor-spend';
+import { formatMoneyLineWithFxToDefault } from '@/lib/vendor-spend';
 import {
   EXPENSE_PARSE_STATUSES,
   EXPENSE_STATUSES,
@@ -107,8 +108,6 @@ export function ExpensesListPanel({
   const [voidExpenseId, setVoidExpenseId] = useState<string | null>(null);
   const [voidReason, setVoidReason] = useState('');
   const [voidError, setVoidError] = useState('');
-  const [fxMultipliers, setFxMultipliers] = useState<Map<string, number> | null>(null);
-  const [fxError, setFxError] = useState('');
 
   const expensesNeedForeignFx = useMemo(() => {
     const defaultCurrency = getAdminDefaultCurrencyCode();
@@ -117,33 +116,17 @@ export function ExpensesListPanel({
     );
   }, [expenses]);
 
-  useEffect(() => {
-    if (!expensesNeedForeignFx) {
-      return;
-    }
-    let cancelled = false;
-    void (async () => {
-      setFxMultipliers(null);
-      try {
-        const codes = expenses
-          .map((expense) => expense.currency?.trim().toUpperCase())
-          .filter((code): code is string => Boolean(code));
-        const map = await loadFxMultipliersToAdminDefault(codes);
-        if (!cancelled) {
-          setFxMultipliers(map);
-          setFxError('');
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setFxError(toErrorMessage(err, 'Could not load FX rates for currency conversion.'));
-          setFxMultipliers(new Map());
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [expenses, expensesNeedForeignFx]);
+  const expenseFxCurrencyCodes = useMemo(
+    () =>
+      expenses
+        .map((expense) => expense.currency?.trim().toUpperCase())
+        .filter((code): code is string => Boolean(code)),
+    [expenses],
+  );
+  const { fxMultipliers, fxError } = useFxMultipliersForCurrencies(
+    expenseFxCurrencyCodes,
+    expensesNeedForeignFx,
+  );
 
   const tableError = [error, expensesNeedForeignFx ? fxError : ''].filter(Boolean).join(' ');
 

--- a/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
@@ -184,7 +184,7 @@ export function ExpensesListPanel({
       await onVoidExpense(voidExpenseId, voidReason.trim());
       closeVoidDialog();
     } catch (caught) {
-      setVoidError(caught instanceof Error ? caught.message : 'Could not void this expense.');
+      setVoidError(toErrorMessage(caught, 'Could not void this expense.'));
     }
   };
 
@@ -209,7 +209,7 @@ export function ExpensesListPanel({
       await onDeleteDraft(deleteDraftExpenseId);
       closeDeleteDraftDialog();
     } catch (caught) {
-      setDeleteDraftError(caught instanceof Error ? caught.message : 'Could not delete this expense.');
+      setDeleteDraftError(toErrorMessage(caught, 'Could not delete this expense.'));
     }
   };
 

--- a/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
@@ -6,12 +6,18 @@ import { useEffect, useMemo, useState } from 'react';
 import { OpenAdminAssetInNewTabButton } from '@/components/admin/shared/open-admin-asset-in-new-tab-button';
 import { DeleteIcon, MarkPaidIcon, RotateIcon, VoidExpenseIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { toErrorMessage } from '@/hooks/hook-errors';
@@ -219,7 +225,7 @@ export function ExpensesListPanel({
         onLoadMore={onLoadMore}
         toolbar={
           <div className='mb-3 space-y-2'>
-            <div className='flex flex-wrap items-end gap-3'>
+            <AdminTableToolbar noMargin>
               <div className='min-w-[200px] flex-1'>
                 <Label htmlFor='expenses-query'>Search</Label>
                 <Input
@@ -259,7 +265,7 @@ export function ExpensesListPanel({
                   ))}
                 </Select>
               </div>
-            </div>
+            </AdminTableToolbar>
             {documentOpenError ? <AdminInlineError>{documentOpenError}</AdminInlineError> : null}
           </div>
         }
@@ -271,7 +277,7 @@ export function ExpensesListPanel({
               <th className='px-4 py-3 font-semibold'>Total</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Issued</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -119,7 +119,7 @@ export function TaxFiscalYearPanel() {
     URL.revokeObjectURL(url);
   }, [rows, fyStartYear, expenseStatusFilter]);
 
-  const tableError = [loadError, fxError].filter(Boolean).join(' ');
+  const tableError = [loadError, fxError].filter(Boolean).join(' • ');
 
   return (
     <PaginatedTableCard

--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { toErrorMessage } from '@/hooks/hook-errors';
+import { useFxMultipliersForCurrencies } from '@/hooks/use-fx-multipliers-for-currencies';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { listAllCustomerInvoices, type CustomerInvoiceSummary } from '@/lib/billing-api';
 import { listAllAdminExpenses } from '@/lib/expenses-api';
@@ -21,7 +22,7 @@ import {
   taxFiscalYearRowsToCsv,
   type TaxFiscalYearRow,
 } from '@/lib/tax-fiscal-year-report';
-import { formatMoneyLineWithFxToDefault, loadFxMultipliersToAdminDefault } from '@/lib/vendor-spend';
+import { formatMoneyLineWithFxToDefault } from '@/lib/vendor-spend';
 import { EXPENSE_STATUSES, type Expense, type ExpenseStatus } from '@/types/expenses';
 
 /** Earliest Hong Kong FY start year offered in the selector (April Y → March Y+1). */
@@ -47,8 +48,6 @@ export function TaxFiscalYearPanel() {
   const [isLoading, setIsLoading] = useState(true);
   const [expensesPayload, setExpensesPayload] = useState<Expense[] | null>(null);
   const [issuedInvoicesPayload, setIssuedInvoicesPayload] = useState<CustomerInvoiceSummary[] | null>(null);
-  const [fxMultipliers, setFxMultipliers] = useState<Map<string, number> | null>(null);
-  const [fxError, setFxError] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -93,40 +92,12 @@ export function TaxFiscalYearPanel() {
     return rows.some((row) => (row.currency?.trim().toUpperCase() || defaultCurrency) !== defaultCurrency);
   }, [rows]);
 
-  useEffect(() => {
-    if (!expensesPayload || !issuedInvoicesPayload) {
-      return;
-    }
-    let cancelled = false;
-    const defaultCurrency = getAdminDefaultCurrencyCode();
-    const needsFx = rows.some(
-      (row) => (row.currency?.trim().toUpperCase() || defaultCurrency) !== defaultCurrency,
-    );
-    if (!needsFx) {
-      setFxMultipliers(new Map());
-      setFxError('');
-      return;
-    }
-    setFxMultipliers(null);
-    void (async () => {
-      try {
-        const codes = rows.map((row) => row.currency?.trim().toUpperCase()).filter(Boolean);
-        const map = await loadFxMultipliersToAdminDefault(codes);
-        if (!cancelled) {
-          setFxMultipliers(map);
-          setFxError('');
-        }
-      } catch (error) {
-        if (!cancelled) {
-          setFxError(toErrorMessage(error, 'Could not load FX rates for currency conversion.'));
-          setFxMultipliers(new Map());
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [rows, expensesPayload, issuedInvoicesPayload]);
+  const taxFxCurrencyCodes = useMemo(
+    () => rows.map((row) => row.currency?.trim().toUpperCase()).filter((c): c is string => Boolean(c)),
+    [rows]
+  );
+  const taxFxEnabled = rowsNeedForeignFx && Boolean(expensesPayload && issuedInvoicesPayload);
+  const { fxMultipliers, fxError } = useFxMultipliersForCurrencies(taxFxCurrencyCodes, taxFxEnabled);
 
   const fyMeta = useMemo(() => getFiscalYearRangeInclusive(fyStartYear), [fyStartYear]);
 

--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { WarningTriangleIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
@@ -160,7 +161,7 @@ export function TaxFiscalYearPanel() {
       loadingLabel='Loading expenses and invoices…'
       onLoadMore={() => {}}
       toolbar={
-        <div className='mb-3 flex flex-wrap items-end gap-3'>
+        <AdminTableToolbar>
           <div className='min-w-[220px]'>
             <Label htmlFor={fySelectId}>Fiscal year</Label>
             <Select
@@ -199,7 +200,7 @@ export function TaxFiscalYearPanel() {
           >
             Download CSV
           </Button>
-        </div>
+        </AdminTableToolbar>
       }
     >
       <AdminDataTable tableClassName='min-w-[920px]'>

--- a/apps/admin_web/src/components/admin/finance/vendors-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/vendors-panel.tsx
@@ -4,11 +4,17 @@ import { useMemo, useState } from 'react';
 
 import { VendorInactiveIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { formatAmountInDefaultCurrency } from '@/lib/vendor-spend';
 
@@ -163,7 +169,7 @@ export function VendorsPanel({
                 {vendorSpendError}
               </p>
             ) : null}
-            <div className='flex flex-wrap items-end gap-3'>
+            <AdminTableToolbar noMargin>
               <div className='min-w-[200px] flex-1'>
                 <Label htmlFor='vendors-search'>Search</Label>
                 <Input
@@ -185,7 +191,7 @@ export function VendorsPanel({
                   <option value='false'>Inactive</option>
                 </Select>
               </div>
-            </div>
+            </AdminTableToolbar>
           </div>
         }
       >
@@ -195,7 +201,7 @@ export function VendorsPanel({
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold text-right'>Total Spend</th>
-              <th className='px-4 py-3 font-semibold text-right'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/finance/vendors-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/vendors-panel.tsx
@@ -169,7 +169,7 @@ export function VendorsPanel({
                 {vendorSpendError}
               </p>
             ) : null}
-            <AdminTableToolbar noMargin>
+            <AdminTableToolbar marginBottom='none'>
               <div className='min-w-[200px] flex-1'>
                 <Label htmlFor='vendors-search'>Search</Label>
                 <Input

--- a/apps/admin_web/src/components/admin/sales/leads-table.tsx
+++ b/apps/admin_web/src/components/admin/sales/leads-table.tsx
@@ -4,9 +4,13 @@ import { useMemo, useState } from 'react';
 
 import type { AdminUser, FunnelStage, LeadListFilters, LeadSummary } from '@/types/leads';
 
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
-
 import { LeadsBulkActions } from './leads-bulk-actions';
 import { LeadsFilterBar } from './leads-filter-bar';
 import { LeadsTableRow } from './leads-table-row';
@@ -108,7 +112,7 @@ export function LeadsTable({
             <th className='px-3 py-3 font-semibold'>Assigned</th>
             <th className='px-3 py-3 font-semibold'>Created</th>
             <th className='px-3 py-3 font-semibold'>Days in stage</th>
-            <th className='px-3 py-3 text-right font-semibold'>Operations</th>
+            <AdminDataTableOperationsHeadCell className='px-3 py-3' />
           </tr>
         </AdminDataTableHead>
         <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/sales/leads-table.tsx
+++ b/apps/admin_web/src/components/admin/sales/leads-table.tsx
@@ -20,7 +20,7 @@ export interface LeadsTableProps {
   filters: LeadListFilters;
   users: AdminUser[];
   selectedLeadId: string | null;
-  totalCount: number;
+  totalCount: number | null;
   isLoading: boolean;
   isLoadingMore: boolean;
   error: string;
@@ -67,7 +67,7 @@ export function LeadsTable({
   return (
     <PaginatedTableCard
       title='Leads'
-      description={`${totalCount.toLocaleString()} total`}
+      description={`${totalCount == null ? '—' : totalCount.toLocaleString()} total`}
       isLoading={isLoading}
       isLoadingMore={isLoadingMore}
       hasMore={hasMore}

--- a/apps/admin_web/src/components/admin/sales/sales-page.tsx
+++ b/apps/admin_web/src/components/admin/sales/sales-page.tsx
@@ -6,7 +6,7 @@ import { LeadDetailPanel } from './lead-detail-panel';
 import { LeadsTable } from './leads-table';
 import { SalesHeader } from './sales-header';
 
-import { StatusBanner } from '@/components/status-banner';
+import { AdminPageErrorBanner } from '@/components/admin/admin-page-error-banner';
 import { AdminTabStrip } from '@/components/ui/admin-tab-strip';
 import { type SalesView, useSalesPage } from '@/hooks/use-sales-page';
 
@@ -26,11 +26,7 @@ export function SalesPage() {
 
   return (
     <div className='space-y-4'>
-      {hasAnyError ? (
-        <StatusBanner variant='error' title='Sales'>
-          {hasAnyError}
-        </StatusBanner>
-      ) : null}
+      <AdminPageErrorBanner title='Sales' message={hasAnyError} />
 
       <AdminTabStrip
         aria-label='Sales views'

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -22,8 +22,9 @@ import { CopyFeedbackIconButton } from '@/components/ui/copy-feedback-icon-butto
 import { ReferralLinkQrDialog } from '@/components/admin/services/referral-link-qr-dialog';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
+import { toErrorMessage } from '@/hooks/hook-errors';
 import { useServiceInstanceOptions } from '@/hooks/use-service-instance-options';
-import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
+import { conflictFieldUserMessage } from '@/lib/admin-api-conflict-messages';
 import { tryCopyTextToClipboard } from '@/lib/clipboard';
 import { listInstances } from '@/lib/services-api';
 import {
@@ -280,9 +281,7 @@ export function DiscountCodesPanel({
       instance_id: instanceUuid,
     };
     const isDuplicateCodeError = (err: unknown) =>
-      err instanceof AdminApiError &&
-      err.statusCode === 409 &&
-      readAdminApiErrorField(err) === 'code';
+      conflictFieldUserMessage(err, { code: 'duplicate' }) !== null;
 
     try {
       if (editorMode === 'create') {
@@ -351,9 +350,7 @@ export function DiscountCodesPanel({
         instance_id: instanceUuid,
       });
     } catch (err) {
-      if (err instanceof AdminApiError) {
-        setSaveError(err.message);
-      }
+      setSaveError(toErrorMessage(err, 'Save failed.'));
     }
   };
 

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -3,12 +3,18 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { DeleteIcon, QrLinkIcon } from '@/components/icons/action-icons';
@@ -593,7 +599,7 @@ export function DiscountCodesPanel({
         loadingLabel='Loading discount codes...'
         onLoadMore={onLoadMore}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div className='min-w-[200px] flex-1'>
               <Label htmlFor='discount-filter-search'>Search</Label>
               <Input
@@ -630,7 +636,7 @@ export function DiscountCodesPanel({
                 <option value='instance'>Instance-scoped</option>
               </Select>
             </div>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[1040px]'>
@@ -643,7 +649,7 @@ export function DiscountCodesPanel({
               <th className='px-4 py-3 font-semibold'>Value</th>
               <th className='px-4 py-3 font-semibold'>Uses</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -24,7 +24,7 @@ import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import { toErrorMessage } from '@/hooks/hook-errors';
 import { useServiceInstanceOptions } from '@/hooks/use-service-instance-options';
-import { conflictFieldUserMessage } from '@/lib/admin-api-conflict-messages';
+import { isAdminApiConflictOnField } from '@/lib/admin-api-conflict-messages';
 import { tryCopyTextToClipboard } from '@/lib/clipboard';
 import { listInstances } from '@/lib/services-api';
 import {
@@ -280,8 +280,7 @@ export function DiscountCodesPanel({
       service_id: serviceUuid,
       instance_id: instanceUuid,
     };
-    const isDuplicateCodeError = (err: unknown) =>
-      conflictFieldUserMessage(err, { code: 'duplicate' }) !== null;
+    const isDuplicateCodeError = (err: unknown) => isAdminApiConflictOnField(err, 'code');
 
     try {
       if (editorMode === 'create') {

--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -2,7 +2,12 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -582,9 +587,7 @@ export function EnrollmentListPanel({
                 >
                   Enrolled at
                 </th>
-                <th className='w-[4.5rem] whitespace-nowrap px-4 py-3 text-right font-semibold'>
-                  Operations
-                </th>
+                <AdminDataTableOperationsHeadCell className='w-[4.5rem] whitespace-nowrap' />
               </tr>
             </AdminDataTableHead>
             <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -52,8 +52,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
-import { isAdminApiConflictOnField } from '@/lib/admin-api-conflict-messages';
-import { AdminApiError } from '@/lib/api-admin-client';
+import { conflictFieldUserMessage } from '@/lib/admin-api-conflict-messages';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { buildSessionSlotsUtcPayload, mapSessionSlotsFromApiToForm } from '@/lib/format';
 import { filterLocationsForInstance } from '@/lib/instance-location-options';
@@ -646,8 +645,9 @@ export function InstanceDetailPanel({
       await onCreate(selectedServiceId, payload);
       setSlugConflictError('');
     } catch (err) {
-      if (isAdminApiConflictOnField(err, 'slug')) {
-        setSlugConflictError(err instanceof AdminApiError ? err.message || 'This slug is already in use.' : 'This slug is already in use.');
+      const slugMsg = conflictFieldUserMessage(err, { slug: 'This slug is already in use.' });
+      if (slugMsg) {
+        setSlugConflictError(slugMsg);
         return;
       }
       throw err;
@@ -666,8 +666,9 @@ export function InstanceDetailPanel({
       await onUpdate(selectedServiceId, instance.id, payload);
       setSlugConflictError('');
     } catch (err) {
-      if (isAdminApiConflictOnField(err, 'slug')) {
-        setSlugConflictError(err instanceof AdminApiError ? err.message || 'This slug is already in use.' : 'This slug is already in use.');
+      const slugMsg = conflictFieldUserMessage(err, { slug: 'This slug is already in use.' });
+      if (slugMsg) {
+        setSlugConflictError(slugMsg);
         return;
       }
       throw err;

--- a/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-detail-panel.tsx
@@ -52,7 +52,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useInstructorUsers } from '@/hooks/use-instructor-users';
-import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
+import { isAdminApiConflictOnField } from '@/lib/admin-api-conflict-messages';
+import { AdminApiError } from '@/lib/api-admin-client';
 import { getAdminDefaultCurrencyCode } from '@/lib/config';
 import { buildSessionSlotsUtcPayload, mapSessionSlotsFromApiToForm } from '@/lib/format';
 import { filterLocationsForInstance } from '@/lib/instance-location-options';
@@ -645,8 +646,8 @@ export function InstanceDetailPanel({
       await onCreate(selectedServiceId, payload);
       setSlugConflictError('');
     } catch (err) {
-      if (err instanceof AdminApiError && err.statusCode === 409 && readAdminApiErrorField(err) === 'slug') {
-        setSlugConflictError(err.message || 'This slug is already in use.');
+      if (isAdminApiConflictOnField(err, 'slug')) {
+        setSlugConflictError(err instanceof AdminApiError ? err.message || 'This slug is already in use.' : 'This slug is already in use.');
         return;
       }
       throw err;
@@ -665,8 +666,8 @@ export function InstanceDetailPanel({
       await onUpdate(selectedServiceId, instance.id, payload);
       setSlugConflictError('');
     } catch (err) {
-      if (err instanceof AdminApiError && err.statusCode === 409 && readAdminApiErrorField(err) === 'slug') {
-        setSlugConflictError(err.message || 'This slug is already in use.');
+      if (isAdminApiConflictOnField(err, 'slug')) {
+        setSlugConflictError(err instanceof AdminApiError ? err.message || 'This slug is already in use.' : 'This slug is already in use.');
         return;
       }
       throw err;

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -3,7 +3,12 @@
 import type { KeyboardEvent, MouseEvent } from 'react';
 import { useMemo } from 'react';
 
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { DeleteIcon, DuplicateIcon } from '@/components/icons/action-icons';
@@ -224,9 +229,7 @@ export function InstanceListPanel({
                 >
                   Capacity
                 </th>
-                <th className='w-[7rem] whitespace-nowrap px-4 py-3 text-right font-semibold'>
-                  Operations
-                </th>
+                <AdminDataTableOperationsHeadCell className='w-[7rem] whitespace-nowrap' />
               </tr>
             </AdminDataTableHead>
             <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/services/partners-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/partners-panel.tsx
@@ -13,12 +13,18 @@ import { DeleteIcon } from '@/components/icons/action-icons';
 import { StatusBanner } from '@/components/status-banner';
 import { Button } from '@/components/ui/button';
 import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { type EntityTagRef } from '@/lib/entity-api';
 import { formatEnumLabel } from '@/lib/format';
@@ -426,7 +432,7 @@ export function PartnersPanel({
         loadingLabel='Loading partners...'
         onLoadMore={loadMore}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div className='min-w-[200px] flex-1'>
               <Label htmlFor='svc-partners-search'>Search</Label>
               <Input
@@ -454,7 +460,7 @@ export function PartnersPanel({
                 <option value='false'>Archived</option>
               </Select>
             </div>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[800px]'>
@@ -463,7 +469,7 @@ export function PartnersPanel({
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Type</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-detail-panel.tsx
@@ -15,7 +15,7 @@ import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { formatEnumLabel, formatLocationLabel } from '@/lib/format';
 import { INSTANCE_SLUG_PATTERN } from '@/lib/slug-utils';
 import { SERVICE_KEY_PATTERN } from '@/lib/service-key-utils';
-import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
+import { isAdminApiConflictOnField } from '@/lib/admin-api-conflict-messages';
 import { getServiceDiscountCodeUsageSummary } from '@/lib/services-api';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -346,11 +346,7 @@ export function ServiceDetailPanel({
     caught: unknown,
     pair: { serviceKey: string | null; tierNormalized: string | null },
   ): boolean {
-    if (!(caught instanceof AdminApiError) || caught.statusCode !== 409) {
-      return false;
-    }
-    const field = readAdminApiErrorField(caught);
-    if (field !== 'service_key_tier') {
+    if (!isAdminApiConflictOnField(caught, 'service_key_tier')) {
       return false;
     }
     const tierNorm = pair.tierNormalized ?? '';

--- a/apps/admin_web/src/components/admin/services/service-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-list-panel.tsx
@@ -2,7 +2,12 @@
 
 import type { KeyboardEvent, MouseEvent } from 'react';
 
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
@@ -10,6 +15,7 @@ import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { CopyFeedbackIconButton } from '@/components/ui/copy-feedback-icon-button';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { DeleteIcon, DuplicateIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
@@ -100,7 +106,7 @@ export function ServiceListPanel({
         loadingLabel='Loading services...'
         onLoadMore={onLoadMore}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div className='min-w-[200px] flex-1'>
               <Label htmlFor='services-filter-search'>Search</Label>
               <Input
@@ -142,7 +148,7 @@ export function ServiceListPanel({
                 ))}
               </Select>
             </div>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[800px]'>
@@ -154,7 +160,7 @@ export function ServiceListPanel({
               <th className='px-4 py-3 font-semibold'>Price</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
               <th className='px-4 py-3 font-semibold'>Delivery</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 
-import { StatusBanner } from '@/components/status-banner';
+import { AdminPageErrorBanner } from '@/components/admin/admin-page-error-banner';
 
 import { useServicesPage, type ServicesView } from '@/hooks/use-services-page';
 import {
@@ -161,11 +161,7 @@ export function ServicesPage() {
 
   return (
     <div className='space-y-4'>
-      {hasAnyError ? (
-        <StatusBanner variant='error' title='Services'>
-          {hasAnyError}
-        </StatusBanner>
-      ) : null}
+      <AdminPageErrorBanner title='Services' message={hasAnyError} />
 
       <ServicesHeader activeView={state.activeView} onSetView={handleSetActiveView} />
 

--- a/apps/admin_web/src/components/admin/services/venues-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/venues-panel.tsx
@@ -3,13 +3,19 @@
 import { useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableHead,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { AdminInlineError } from '@/components/ui/admin-inline-error';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
@@ -361,7 +367,7 @@ export function VenuesPanel({
         loadingLabel='Loading venues...'
         onLoadMore={onLoadMore}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div className='min-w-[160px]'>
               <Label htmlFor='venues-filter-area'>Area</Label>
               <Select
@@ -386,7 +392,7 @@ export function VenuesPanel({
                 placeholder='Name or address'
               />
             </div>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[520px]'>
@@ -395,7 +401,7 @@ export function VenuesPanel({
               <th className='px-4 py-3 font-semibold'>Name</th>
               <th className='px-4 py-3 font-semibold'>Address</th>
               <th className='px-4 py-3 font-semibold'>Area</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -4,12 +4,13 @@ import type { FormEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import { AdminDataTable, AdminDataTableBody, AdminDataTableHead, AdminDataTableOperationsHeadCell } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { ArchiveIcon, DeleteIcon } from '@/components/icons/action-icons';
@@ -315,7 +316,7 @@ export function TagsPage() {
         loadingLabel='Loading tags…'
         onLoadMore={() => {}}
         toolbar={
-          <div className='mb-3 flex flex-wrap items-end gap-3'>
+          <AdminTableToolbar>
             <div className='min-w-[200px] flex-1'>
               <Label htmlFor='tags-list-search'>Search</Label>
               <Input
@@ -338,7 +339,7 @@ export function TagsPage() {
                 <option value='archived'>Archived</option>
               </Select>
             </div>
-          </div>
+          </AdminTableToolbar>
         }
       >
         <AdminDataTable tableClassName='min-w-[720px]'>
@@ -348,7 +349,7 @@ export function TagsPage() {
               <th className='px-4 py-3 font-semibold'>Color</th>
               <th className='px-4 py-3 font-semibold'>Uses</th>
               <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 text-right font-semibold'>Operations</th>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -3,6 +3,7 @@
 import type { FormEvent } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { ArchiveIcon, DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import { AdminDataTable, AdminDataTableBody, AdminDataTableHead, AdminDataTableOperationsHeadCell } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -13,8 +14,8 @@ import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { ArchiveIcon, DeleteIcon } from '@/components/icons/action-icons';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { toErrorMessage } from '@/hooks/hook-errors';
 import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
 import {
   createAdminTag,
@@ -69,7 +70,7 @@ export function TagsPage() {
       const rows = await listAdminTags({ filter: listFilter });
       setTags(rows);
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Failed to load tags.';
+      const message = toErrorMessage(caught, 'Failed to load tags.');
       setError(message);
     } finally {
       setIsLoading(false);
@@ -113,7 +114,7 @@ export function TagsPage() {
         applyRowSelection(updated);
       }
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Restore failed.';
+      const message = toErrorMessage(caught, 'Restore failed.');
       setError(message);
     } finally {
       setRestoreBusyId(null);
@@ -142,7 +143,7 @@ export function TagsPage() {
         applyRowSelection(updated);
       }
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Archive failed.';
+      const message = toErrorMessage(caught, 'Archive failed.');
       setError(message);
     } finally {
       setArchiveBusyId(null);
@@ -182,7 +183,7 @@ export function TagsPage() {
         setSaveError('A tag with this name already exists.');
         return;
       }
-      const message = caught instanceof Error ? caught.message : 'Save failed.';
+      const message = toErrorMessage(caught, 'Save failed.');
       setSaveError(message);
     } finally {
       setIsSaving(false);
@@ -214,7 +215,7 @@ export function TagsPage() {
       }
       await loadTags();
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Delete failed.';
+      const message = toErrorMessage(caught, 'Delete failed.');
       setError(message);
     } finally {
       setDeleteBusyId(null);

--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -16,7 +16,7 @@ import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { toErrorMessage } from '@/hooks/hook-errors';
-import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
+import { conflictFieldUserMessage } from '@/lib/admin-api-conflict-messages';
 import {
   createAdminTag,
   deleteOrArchiveAdminTag,
@@ -179,8 +179,9 @@ export function TagsPage() {
       await updateAdminTag(selectedTagId, body);
       await loadTags();
     } catch (caught) {
-      if (caught instanceof AdminApiError && readAdminApiErrorField(caught) === 'name') {
-        setSaveError('A tag with this name already exists.');
+      const conflict = conflictFieldUserMessage(caught, { name: 'A tag with this name already exists.' });
+      if (conflict) {
+        setSaveError(conflict);
         return;
       }
       const message = toErrorMessage(caught, 'Save failed.');

--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -70,7 +70,7 @@ export function TagsPage() {
       const rows = await listAdminTags({ filter: listFilter });
       setTags(rows);
     } catch (caught) {
-      const message = toErrorMessage(caught, 'Failed to load tags.');
+      const message = toErrorMessage(caught, 'Failed to load tags.', { honorBackendMessage: true });
       setError(message);
     } finally {
       setIsLoading(false);
@@ -114,7 +114,7 @@ export function TagsPage() {
         applyRowSelection(updated);
       }
     } catch (caught) {
-      const message = toErrorMessage(caught, 'Restore failed.');
+      const message = toErrorMessage(caught, 'Restore failed.', { honorBackendMessage: true });
       setError(message);
     } finally {
       setRestoreBusyId(null);
@@ -143,7 +143,7 @@ export function TagsPage() {
         applyRowSelection(updated);
       }
     } catch (caught) {
-      const message = toErrorMessage(caught, 'Archive failed.');
+      const message = toErrorMessage(caught, 'Archive failed.', { honorBackendMessage: true });
       setError(message);
     } finally {
       setArchiveBusyId(null);
@@ -184,7 +184,7 @@ export function TagsPage() {
         setSaveError(conflict);
         return;
       }
-      const message = toErrorMessage(caught, 'Save failed.');
+      const message = toErrorMessage(caught, 'Save failed.', { honorBackendMessage: true });
       setSaveError(message);
     } finally {
       setIsSaving(false);
@@ -216,7 +216,7 @@ export function TagsPage() {
       }
       await loadTags();
     } catch (caught) {
-      const message = toErrorMessage(caught, 'Delete failed.');
+      const message = toErrorMessage(caught, 'Delete failed.', { honorBackendMessage: true });
       setError(message);
     } finally {
       setDeleteBusyId(null);

--- a/apps/admin_web/src/components/ui/admin-data-table.tsx
+++ b/apps/admin_web/src/components/ui/admin-data-table.tsx
@@ -41,3 +41,22 @@ export function AdminDataTableHead({ children, sticky }: AdminDataTableHeadProps
 export function AdminDataTableBody({ children }: { children: ReactNode }) {
   return <tbody className='divide-y divide-slate-200 bg-white text-sm'>{children}</tbody>;
 }
+
+export interface AdminDataTableOperationsHeadCellProps {
+  children?: ReactNode;
+  className?: string;
+  scope?: 'col' | 'row';
+}
+
+/** Standard right-aligned operations column header for admin listing tables. */
+export function AdminDataTableOperationsHeadCell({
+  children = 'Operations',
+  className,
+  scope = 'col',
+}: AdminDataTableOperationsHeadCellProps) {
+  return (
+    <th scope={scope} className={clsx('px-4 py-3 text-right font-semibold', className)}>
+      {children}
+    </th>
+  );
+}

--- a/apps/admin_web/src/components/ui/admin-data-table.tsx
+++ b/apps/admin_web/src/components/ui/admin-data-table.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 
 import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export interface AdminDataTableProps {
   children: ReactNode;
@@ -55,7 +56,7 @@ export function AdminDataTableOperationsHeadCell({
   scope = 'col',
 }: AdminDataTableOperationsHeadCellProps) {
   return (
-    <th scope={scope} className={clsx('px-4 py-3 text-right font-semibold', className)}>
+    <th scope={scope} className={twMerge('px-4 py-3 text-right font-semibold', className)}>
       {children}
     </th>
   );

--- a/apps/admin_web/src/components/ui/admin-table-toolbar.tsx
+++ b/apps/admin_web/src/components/ui/admin-table-toolbar.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { clsx } from 'clsx';
+
+export interface AdminTableToolbarProps {
+  children: ReactNode;
+  /** Omit default bottom margin (for example nested editor toolbars). */
+  noMargin?: boolean;
+  className?: string;
+}
+
+export function AdminTableToolbar({ children, noMargin, className }: AdminTableToolbarProps) {
+  return (
+    <div className={clsx('flex flex-wrap items-end gap-3', !noMargin && 'mb-3', className)}>{children}</div>
+  );
+}

--- a/apps/admin_web/src/components/ui/admin-table-toolbar.tsx
+++ b/apps/admin_web/src/components/ui/admin-table-toolbar.tsx
@@ -2,17 +2,25 @@
 
 import type { ReactNode } from 'react';
 
-import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export interface AdminTableToolbarProps {
   children: ReactNode;
-  /** Omit default bottom margin (for example nested editor toolbars). */
-  noMargin?: boolean;
+  /** Bottom margin under the toolbar row; `none` for nested editor toolbars. */
+  marginBottom?: 'default' | 'none';
   className?: string;
 }
 
-export function AdminTableToolbar({ children, noMargin, className }: AdminTableToolbarProps) {
+export function AdminTableToolbar({
+  children,
+  marginBottom = 'default',
+  className,
+}: AdminTableToolbarProps) {
   return (
-    <div className={clsx('flex flex-wrap items-end gap-3', !noMargin && 'mb-3', className)}>{children}</div>
+    <div
+      className={twMerge('flex flex-wrap items-end gap-3', marginBottom === 'default' && 'mb-3', className)}
+    >
+      {children}
+    </div>
   );
 }

--- a/apps/admin_web/src/hooks/hook-errors.ts
+++ b/apps/admin_web/src/hooks/hook-errors.ts
@@ -1,5 +1,14 @@
 import { AdminApiError } from '@/lib/api-admin-client';
 
+export type ToErrorMessageOptions = {
+  /**
+   * When true, prefer the backend `AdminApiError.message` (trimmed) for all status codes,
+   * falling back to `fallback` only when the message is empty. Use for user actions where
+   * 404/403 payloads (for example "Tag not found") are more helpful than generic deployment copy.
+   */
+  honorBackendMessage?: boolean;
+};
+
 /**
  * User-facing geocode errors: keep 404 copy specific to geocoding (not the generic
  * deployment message from {@link toErrorMessage}).
@@ -11,8 +20,19 @@ export function formatGeocodeErrorMessage(error: unknown, fallbackNon404: string
   return toErrorMessage(error, fallbackNon404);
 }
 
-export function toErrorMessage(error: unknown, fallback: string): string {
+export function toErrorMessage(
+  error: unknown,
+  fallback: string,
+  options?: ToErrorMessageOptions
+): string {
   if (error instanceof AdminApiError) {
+    if (options?.honorBackendMessage) {
+      const trimmed = error.message?.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+      return fallback;
+    }
     if (error.statusCode === 404) {
       return 'The requested resource is not available in this deployment yet.';
     }

--- a/apps/admin_web/src/hooks/use-admin-entity-contacts.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-contacts.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   createAdminContact,
@@ -11,6 +11,7 @@ import {
 import { DEFAULT_CONTACT_LIST_FILTERS, type EntityListFilters } from '@/types/entity-list';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -48,21 +49,7 @@ export function useAdminEntityContacts() {
     limit: 50,
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult,>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await refetchContacts();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [refetchContacts]
-  );
+  const { isSaving, mutate } = useListMutate(refetchContacts);
 
   const createContact = useCallback(
     async (payload: ApiSchemas['CreateAdminContactRequest']) =>

--- a/apps/admin_web/src/hooks/use-admin-entity-families.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-families.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   addAdminFamilyMember,
@@ -17,6 +17,7 @@ import {
 } from '@/types/entity-list';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -41,21 +42,7 @@ export function useAdminEntityFamilies() {
     limit: 50,
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult,>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await list.refetch();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [list]
-  );
+  const { isSaving, mutate } = useListMutate(list.refetch);
 
   const createFamily = useCallback(
     async (payload: ApiSchemas['CreateAdminFamilyRequest']) =>

--- a/apps/admin_web/src/hooks/use-admin-entity-organizations.ts
+++ b/apps/admin_web/src/hooks/use-admin-entity-organizations.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   addAdminOrganizationMember,
@@ -18,6 +18,7 @@ import {
 import { ORGANIZATION_RELATIONSHIP_TYPES } from '@/types/entity-relationship';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -42,21 +43,7 @@ export function useAdminEntityOrganizations() {
     limit: 50,
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult,>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await list.refetch();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [list]
-  );
+  const { isSaving, mutate } = useListMutate(list.refetch);
 
   const createOrganization = useCallback(
     async (payload: ApiSchemas['CreateAdminOrganizationRequest']) =>

--- a/apps/admin_web/src/hooks/use-discount-codes.ts
+++ b/apps/admin_web/src/hooks/use-discount-codes.ts
@@ -37,12 +37,10 @@ export function useDiscountCodes() {
   const { refetch } = list;
   const { isSaving, mutate } = useListMutate(refetch);
 
-  type MutateOptions = ListMutateOptions;
-
   const createCode = useCallback(
     async (
       payload: ApiSchemas['CreateDiscountCodeRequest'],
-      options: MutateOptions = {},
+      options: ListMutateOptions = {},
     ) => mutate(async () => createDiscountCode(payload), options),
     [mutate],
   );

--- a/apps/admin_web/src/hooks/use-discount-codes.ts
+++ b/apps/admin_web/src/hooks/use-discount-codes.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   createDiscountCode,
@@ -13,7 +13,7 @@ import type { DiscountCode, DiscountCodeFilters } from '@/types/services';
 
 import type { components } from '@/types/generated/admin-api.generated';
 
-import { toErrorMessage } from './hook-errors';
+import { useListMutate, type ListMutateOptions } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -35,38 +35,9 @@ export function useDiscountCodes() {
   });
 
   const { refetch } = list;
-  const [isSaving, setIsSaving] = useState(false);
+  const { isSaving, mutate } = useListMutate(refetch);
 
-  type MutateOptions = {
-    /** When true, skip toggling `isSaving` (caller manages a longer-lived saving state). */
-    suppressSaving?: boolean;
-    /** When true, skip the post-mutation list refetch (caller will refetch once). */
-    suppressRefetch?: boolean;
-  };
-
-  const mutate = useCallback(
-    async <TResult>(
-      work: () => Promise<TResult>,
-      options: MutateOptions = {},
-    ): Promise<TResult> => {
-      const { suppressSaving = false, suppressRefetch = false } = options;
-      if (!suppressSaving) {
-        setIsSaving(true);
-      }
-      try {
-        const result = await work();
-        if (!suppressRefetch) {
-          await refetch();
-        }
-        return result;
-      } finally {
-        if (!suppressSaving) {
-          setIsSaving(false);
-        }
-      }
-    },
-    [refetch],
-  );
+  type MutateOptions = ListMutateOptions;
 
   const createCode = useCallback(
     async (

--- a/apps/admin_web/src/hooks/use-fx-multipliers-for-currencies.ts
+++ b/apps/admin_web/src/hooks/use-fx-multipliers-for-currencies.ts
@@ -7,6 +7,11 @@ import { loadFxMultipliersToAdminDefault } from '@/lib/vendor-spend';
 import { toErrorMessage } from './hook-errors';
 
 export interface UseFxMultipliersForCurrenciesResult {
+  /**
+   * FX multipliers map, or `null` while loading (only when `enabled` is true and codes are non-empty).
+   * When `enabled` is false, this is always `null`. When enabled with an empty deduped code list,
+   * this is an empty `Map` (nothing to convert).
+   */
   fxMultipliers: Map<string, number> | null;
   fxError: string;
 }
@@ -29,20 +34,20 @@ export function useFxMultipliersForCurrencies(
   }, [currencyCodes]);
 
   useEffect(() => {
+    /* Sync reset paths must run in the effect body (not microtasks) so cleanup cancellation
+     * applies consistently when `enabled` or codes change — see PR 1585 remediation P2. */
+    /* eslint-disable react-hooks/set-state-in-effect -- intentional synchronous reset */
     if (!enabled) {
-      queueMicrotask(() => {
-        setFxMultipliers(null);
-        setFxError('');
-      });
+      setFxMultipliers(null);
+      setFxError('');
       return;
     }
     if (codesKey.length === 0) {
-      queueMicrotask(() => {
-        setFxMultipliers(new Map());
-        setFxError('');
-      });
+      setFxMultipliers(new Map());
+      setFxError('');
       return;
     }
+    /* eslint-enable react-hooks/set-state-in-effect */
     const codes = codesKey.split(',').filter(Boolean);
     let cancelled = false;
     void (async () => {

--- a/apps/admin_web/src/hooks/use-fx-multipliers-for-currencies.ts
+++ b/apps/admin_web/src/hooks/use-fx-multipliers-for-currencies.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { loadFxMultipliersToAdminDefault } from '@/lib/vendor-spend';
+
+import { toErrorMessage } from './hook-errors';
+
+export interface UseFxMultipliersForCurrenciesResult {
+  fxMultipliers: Map<string, number> | null;
+  fxError: string;
+}
+
+/**
+ * Loads Frankfurter-based FX multipliers into the admin default currency for the given codes.
+ */
+export function useFxMultipliersForCurrencies(
+  currencyCodes: string[],
+  enabled: boolean,
+  errorMessage = 'Could not load FX rates for currency conversion.'
+): UseFxMultipliersForCurrenciesResult {
+  const [fxMultipliers, setFxMultipliers] = useState<Map<string, number> | null>(null);
+  const [fxError, setFxError] = useState('');
+
+  const codesKey = useMemo(() => {
+    const unique = [...new Set(currencyCodes.map((c) => c.trim().toUpperCase()).filter(Boolean))];
+    unique.sort();
+    return unique.join(',');
+  }, [currencyCodes]);
+
+  useEffect(() => {
+    if (!enabled) {
+      queueMicrotask(() => {
+        setFxMultipliers(null);
+        setFxError('');
+      });
+      return;
+    }
+    if (codesKey.length === 0) {
+      queueMicrotask(() => {
+        setFxMultipliers(new Map());
+        setFxError('');
+      });
+      return;
+    }
+    const codes = codesKey.split(',').filter(Boolean);
+    let cancelled = false;
+    void (async () => {
+      if (!cancelled) {
+        setFxMultipliers(null);
+      }
+      try {
+        const map = await loadFxMultipliersToAdminDefault(codes);
+        if (!cancelled) {
+          setFxMultipliers(map);
+          setFxError('');
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setFxError(toErrorMessage(err, errorMessage));
+          setFxMultipliers(new Map());
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, codesKey, errorMessage]);
+
+  return { fxMultipliers, fxError };
+}

--- a/apps/admin_web/src/hooks/use-list-mutate.ts
+++ b/apps/admin_web/src/hooks/use-list-mutate.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+export interface ListMutateOptions {
+  /** When true, skip toggling `isSaving` (caller manages a longer-lived saving state). */
+  suppressSaving?: boolean;
+  /** When true, skip the post-mutation list refetch (caller will refetch once). */
+  suppressRefetch?: boolean;
+}
+
+export interface UseListMutateOptions {
+  /** Invoked after a successful mutation and after `refetch` when refetch was not suppressed. */
+  onAfterSuccess?: () => void | Promise<void>;
+}
+
+export interface UseListMutateReturn {
+  isSaving: boolean;
+  mutate: <TResult>(work: () => Promise<TResult>, options?: ListMutateOptions) => Promise<TResult>;
+}
+
+/**
+ * Wraps list mutations: optional saving flag, post-mutation refetch, optional success hook.
+ * Used by admin entity and finance list hooks that share the same refetch-after-mutate pattern.
+ */
+export function useListMutate(
+  refetch: () => Promise<void>,
+  hookOptions: UseListMutateOptions = {}
+): UseListMutateReturn {
+  const { onAfterSuccess } = hookOptions;
+  const [isSaving, setIsSaving] = useState(false);
+
+  const mutate = useCallback(
+    async <TResult>(work: () => Promise<TResult>, options: ListMutateOptions = {}): Promise<TResult> => {
+      const { suppressSaving = false, suppressRefetch = false } = options;
+      if (!suppressSaving) {
+        setIsSaving(true);
+      }
+      try {
+        const result = await work();
+        if (!suppressRefetch) {
+          await refetch();
+        }
+        await onAfterSuccess?.();
+        return result;
+      } finally {
+        if (!suppressSaving) {
+          setIsSaving(false);
+        }
+      }
+    },
+    [refetch, onAfterSuccess]
+  );
+
+  return { isSaving, mutate };
+}

--- a/apps/admin_web/src/hooks/use-paginated-list.ts
+++ b/apps/admin_web/src/hooks/use-paginated-list.ts
@@ -10,7 +10,8 @@ import { useDebouncedCallback } from './use-debounced-callback';
 export interface PaginatedResponse<TItem> {
   items: TItem[];
   nextCursor: string | null;
-  totalCount: number;
+  /** When omitted, list hooks treat totals as unknown and surface `0`. */
+  totalCount?: number;
 }
 
 export interface UsePaginatedListOptions<TItem, TFilters extends object> {
@@ -82,7 +83,7 @@ export function usePaginatedList<TItem, TFilters extends object>({
         }
         setItems(response.items);
         setNextCursor(response.nextCursor);
-        setTotalCount(response.totalCount);
+        setTotalCount(response.totalCount ?? 0);
       } catch (err) {
         if (latestRequestIdRef.current !== requestId) {
           return;
@@ -111,7 +112,7 @@ export function usePaginatedList<TItem, TFilters extends object>({
       });
       setItems((current) => [...current, ...response.items]);
       setNextCursor(response.nextCursor);
-      setTotalCount(response.totalCount);
+      setTotalCount(response.totalCount ?? 0);
     } catch (err) {
       setError(toErrorMessage(err, `${errorPrefix} more.`));
     } finally {

--- a/apps/admin_web/src/hooks/use-paginated-list.ts
+++ b/apps/admin_web/src/hooks/use-paginated-list.ts
@@ -10,7 +10,7 @@ import { useDebouncedCallback } from './use-debounced-callback';
 export interface PaginatedResponse<TItem> {
   items: TItem[];
   nextCursor: string | null;
-  /** When omitted, list hooks treat totals as unknown and surface `0`. */
+  /** When omitted, {@link usePaginatedList} exposes `totalCount: null` (unknown total). */
   totalCount?: number;
 }
 
@@ -36,7 +36,8 @@ export interface UsePaginatedListReturn<TItem, TFilters extends object> {
   refetch: (nextFilters?: Partial<TFilters>) => Promise<void>;
   loadMore: () => Promise<void>;
   hasMore: boolean;
-  totalCount: number;
+  /** `null` when the list API omitted `totalCount` (unknown). */
+  totalCount: number | null;
 }
 
 export function usePaginatedList<TItem, TFilters extends object>({
@@ -55,7 +56,7 @@ export function usePaginatedList<TItem, TFilters extends object>({
 
   const [items, setItems] = useState<TItem[]>([]);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState(0);
+  const [totalCount, setTotalCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(fetchOnMount);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState('');
@@ -83,7 +84,7 @@ export function usePaginatedList<TItem, TFilters extends object>({
         }
         setItems(response.items);
         setNextCursor(response.nextCursor);
-        setTotalCount(response.totalCount ?? 0);
+        setTotalCount(response.totalCount === undefined ? null : response.totalCount);
       } catch (err) {
         if (latestRequestIdRef.current !== requestId) {
           return;
@@ -112,7 +113,7 @@ export function usePaginatedList<TItem, TFilters extends object>({
       });
       setItems((current) => [...current, ...response.items]);
       setNextCursor(response.nextCursor);
-      setTotalCount(response.totalCount ?? 0);
+      setTotalCount(response.totalCount === undefined ? null : response.totalCount);
     } catch (err) {
       setError(toErrorMessage(err, `${errorPrefix} more.`));
     } finally {

--- a/apps/admin_web/src/hooks/use-partners.ts
+++ b/apps/admin_web/src/hooks/use-partners.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   addPartnerMember,
@@ -14,6 +14,7 @@ import {
 import { DEFAULT_PARTNER_FILTERS, type PartnerFilters } from '@/types/partners';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -40,21 +41,7 @@ export function usePartners() {
     limit: 50,
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult,>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await list.refetch();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [list]
-  );
+  const { isSaving, mutate } = useListMutate(list.refetch);
 
   const createPartner = useCallback(
     async (payload: ApiSchemas['CreateAdminOrganizationRequest']) =>

--- a/apps/admin_web/src/hooks/use-vendors.ts
+++ b/apps/admin_web/src/hooks/use-vendors.ts
@@ -1,12 +1,13 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import { createAdminVendor, listAdminVendors, updateAdminVendor } from '@/lib/vendors-api';
 import { DEFAULT_VENDOR_FILTERS } from '@/types/vendors';
 import type { Vendor, VendorFilters } from '@/types/vendors';
 import type { components } from '@/types/generated/admin-api.generated';
 
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -24,21 +25,7 @@ export function useVendors() {
     debounceKeys: ['query'],
   });
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await list.refetch();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [list]
-  );
+  const { isSaving, mutate } = useListMutate(list.refetch);
 
   const createVendor = useCallback(
     async (payload: ApiSchemas['CreateAdminOrganizationRequest']) =>

--- a/apps/admin_web/src/hooks/use-venues.ts
+++ b/apps/admin_web/src/hooks/use-venues.ts
@@ -16,6 +16,7 @@ import type { GeographicAreaSummary, LocationSummary, VenueFilters } from '@/typ
 import type { components } from '@/types/generated/admin-api.generated';
 
 import { toErrorMessage } from './hook-errors';
+import { useListMutate } from './use-list-mutate';
 import { usePaginatedList } from './use-paginated-list';
 
 type ApiSchemas = components['schemas'];
@@ -75,22 +76,7 @@ export function useVenues(options: { onMutationSuccess?: () => void | Promise<vo
   });
 
   const { refetch } = list;
-  const [isSaving, setIsSaving] = useState(false);
-
-  const mutate = useCallback(
-    async <TResult>(work: () => Promise<TResult>): Promise<TResult> => {
-      setIsSaving(true);
-      try {
-        const result = await work();
-        await refetch();
-        await onMutationSuccess?.();
-        return result;
-      } finally {
-        setIsSaving(false);
-      }
-    },
-    [refetch, onMutationSuccess]
-  );
+  const { isSaving, mutate } = useListMutate(refetch, { onAfterSuccess: onMutationSuccess });
 
   const createVenue = useCallback(
     async (payload: ApiSchemas['CreateLocationRequest']) => mutate(async () => createLocation(payload)),

--- a/apps/admin_web/src/lib/admin-api-conflict-messages.ts
+++ b/apps/admin_web/src/lib/admin-api-conflict-messages.ts
@@ -1,0 +1,25 @@
+import { AdminApiError, readAdminApiErrorField } from '@/lib/api-admin-client';
+
+/**
+ * Maps a 409 conflict on a specific API field to a user-facing editor message.
+ */
+export function conflictFieldUserMessage(
+  err: unknown,
+  fieldMessages: Partial<Record<string, string>>
+): string | null {
+  if (!(err instanceof AdminApiError) || err.statusCode !== 409) {
+    return null;
+  }
+  const field = readAdminApiErrorField(err);
+  if (!field) {
+    return null;
+  }
+  return fieldMessages[field] ?? null;
+}
+
+export function isAdminApiConflictOnField(err: unknown, field: string): boolean {
+  if (!(err instanceof AdminApiError) || err.statusCode !== 409) {
+    return false;
+  }
+  return readAdminApiErrorField(err) === field;
+}

--- a/apps/admin_web/src/lib/entity-contact-eligibility.ts
+++ b/apps/admin_web/src/lib/entity-contact-eligibility.ts
@@ -1,0 +1,17 @@
+/** Whether a contact may be added to the selected family or organisation membership list. */
+export function contactEligibleForEntityMembership(
+  contact: { id: string; family_ids: string[]; organization_ids: string[] },
+  selectedEntityId: string | null,
+  mode: 'family' | 'organization'
+): boolean {
+  if (mode === 'family') {
+    if (contact.family_ids.length === 0) {
+      return true;
+    }
+    return Boolean(selectedEntityId && contact.family_ids.includes(selectedEntityId));
+  }
+  if (contact.organization_ids.length === 0) {
+    return true;
+  }
+  return Boolean(selectedEntityId && contact.organization_ids.includes(selectedEntityId));
+}

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-format-helpers.test.ts
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-format-helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatPaymentMethodLabel,
+  formatTruncatedId,
+} from '@/components/admin/finance/client-invoices-format-helpers';
+
+describe('client-invoices-format-helpers', () => {
+  describe('formatTruncatedId', () => {
+    it('maps nullish and empty to em dash', () => {
+      expect(formatTruncatedId(null)).toBe('—');
+      expect(formatTruncatedId(undefined)).toBe('—');
+      expect(formatTruncatedId('')).toBe('—');
+    });
+
+    it('returns short ids unchanged up to length 12', () => {
+      expect(formatTruncatedId('abc')).toBe('abc');
+      expect(formatTruncatedId('123456789012')).toBe('123456789012');
+    });
+
+    it('truncates ids longer than 12 characters', () => {
+      expect(formatTruncatedId('1234567890123')).toBe('12345678…');
+    });
+  });
+
+  describe('formatPaymentMethodLabel', () => {
+    it('replaces Fps with FPS at word boundaries', () => {
+      expect(formatPaymentMethodLabel('fps_transfer')).toContain('FPS');
+      expect(formatPaymentMethodLabel('prefix_fps_suffix')).toContain('FPS');
+      expect(formatPaymentMethodLabel('fps')).toContain('FPS');
+    });
+
+    it('leaves non-Fps strings unchanged aside from enum formatting', () => {
+      expect(formatPaymentMethodLabel('bank_transfer')).toBe('Bank Transfer');
+    });
+  });
+});

--- a/apps/admin_web/tests/components/ui/admin-data-table-operations-head-cell.test.tsx
+++ b/apps/admin_web/tests/components/ui/admin-data-table-operations-head-cell.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { AdminDataTableOperationsHeadCell } from '@/components/ui/admin-data-table';
+
+describe('AdminDataTableOperationsHeadCell', () => {
+  it('lets font-normal override the default font-semibold via tailwind-merge', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <AdminDataTableOperationsHeadCell className='font-normal' />
+          </tr>
+        </thead>
+      </table>
+    );
+    const header = screen.getByRole('columnheader', { name: 'Operations' });
+    expect(header.className).toContain('font-normal');
+    expect(header.className).not.toContain('font-semibold');
+  });
+});

--- a/apps/admin_web/tests/hooks/hook-errors.test.ts
+++ b/apps/admin_web/tests/hooks/hook-errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { AdminApiError } from '@/lib/api-admin-client';
+
+import { toErrorMessage } from '@/hooks/hook-errors';
+
+describe('toErrorMessage', () => {
+  it('uses generic 404 copy by default', () => {
+    const err = new AdminApiError({
+      statusCode: 404,
+      payload: null,
+      message: 'Tag not found',
+    });
+    expect(toErrorMessage(err, 'fallback')).toBe(
+      'The requested resource is not available in this deployment yet.'
+    );
+  });
+
+  it('honors backend message for 404 when honorBackendMessage is true', () => {
+    const err = new AdminApiError({
+      statusCode: 404,
+      payload: null,
+      message: 'Tag not found',
+    });
+    expect(toErrorMessage(err, 'fallback', { honorBackendMessage: true })).toBe('Tag not found');
+  });
+
+  it('honors backend message for 403 when honorBackendMessage is true', () => {
+    const err = new AdminApiError({
+      statusCode: 403,
+      payload: null,
+      message: 'Custom forbidden',
+    });
+    expect(toErrorMessage(err, 'fallback', { honorBackendMessage: true })).toBe('Custom forbidden');
+  });
+
+  it('uses fallback when honorBackendMessage is true but message is empty', () => {
+    const err = new AdminApiError({
+      statusCode: 404,
+      payload: null,
+      message: '   ',
+    });
+    expect(toErrorMessage(err, 'fallback', { honorBackendMessage: true })).toBe('fallback');
+  });
+});

--- a/apps/admin_web/tests/hooks/use-fx-multipliers-for-currencies.test.ts
+++ b/apps/admin_web/tests/hooks/use-fx-multipliers-for-currencies.test.ts
@@ -1,0 +1,44 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockLoad = vi.fn();
+
+vi.mock('@/lib/vendor-spend', () => ({
+  loadFxMultipliersToAdminDefault: (...args: unknown[]) => mockLoad(...args),
+}));
+
+import { useFxMultipliersForCurrencies } from '@/hooks/use-fx-multipliers-for-currencies';
+
+describe('useFxMultipliersForCurrencies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not load when disabled', () => {
+    const { result } = renderHook(() => useFxMultipliersForCurrencies(['USD'], false));
+    expect(result.current.fxMultipliers).toBeNull();
+    expect(result.current.fxError).toBe('');
+    expect(mockLoad).not.toHaveBeenCalled();
+  });
+
+  it('uses an empty map when enabled with no currency codes', () => {
+    const { result } = renderHook(() => useFxMultipliersForCurrencies([], true));
+    expect(result.current.fxMultipliers).toEqual(new Map());
+    expect(mockLoad).not.toHaveBeenCalled();
+  });
+
+  it('loads multipliers when enabled with codes', async () => {
+    const map = new Map([['USD', 1.1]]);
+    mockLoad.mockResolvedValue(map);
+    const { result } = renderHook(() => useFxMultipliersForCurrencies(['usd'], true));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockLoad).toHaveBeenCalledWith(['USD']);
+    expect(result.current.fxMultipliers).toEqual(map);
+    expect(result.current.fxError).toBe('');
+  });
+});

--- a/apps/admin_web/tests/hooks/use-list-mutate.test.ts
+++ b/apps/admin_web/tests/hooks/use-list-mutate.test.ts
@@ -54,4 +54,35 @@ describe('useListMutate', () => {
     expect(refetch).toHaveBeenCalledTimes(1);
     expect(onAfterSuccess).toHaveBeenCalledTimes(1);
   });
+
+  it('does not refetch or run onAfterSuccess when work rejects, clears isSaving, and propagates rejection', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const onAfterSuccess = vi.fn().mockResolvedValue(undefined);
+    const boom = new Error('mutate failed');
+    const work = vi.fn().mockRejectedValue(boom);
+
+    const { result } = renderHook(() => useListMutate(refetch, { onAfterSuccess }));
+
+    await act(async () => {
+      await expect(result.current.mutate(work)).rejects.toThrow('mutate failed');
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+    expect(onAfterSuccess).not.toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it('keeps isSaving false on rejection when suppressSaving is true', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const work = vi.fn().mockRejectedValue(new Error('no'));
+
+    const { result } = renderHook(() => useListMutate(refetch));
+
+    await act(async () => {
+      await expect(result.current.mutate(work, { suppressSaving: true })).rejects.toThrow('no');
+    });
+
+    expect(result.current.isSaving).toBe(false);
+    expect(refetch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/admin_web/tests/hooks/use-list-mutate.test.ts
+++ b/apps/admin_web/tests/hooks/use-list-mutate.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useListMutate } from '@/hooks/use-list-mutate';
+
+describe('useListMutate', () => {
+  it('refetches after successful work and clears isSaving', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const work = vi.fn().mockResolvedValue('ok');
+
+    const { result } = renderHook(() => useListMutate(refetch));
+
+    await act(async () => {
+      await result.current.mutate(work);
+    });
+
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it('skips refetch when suppressRefetch is true', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useListMutate(refetch));
+
+    await act(async () => {
+      await result.current.mutate(async () => 1, { suppressRefetch: true });
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it('skips saving flag when suppressSaving is true', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useListMutate(refetch));
+
+    await act(async () => {
+      await result.current.mutate(async () => 1, { suppressSaving: true });
+    });
+
+    expect(result.current.isSaving).toBe(false);
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('runs onAfterSuccess after refetch', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    const onAfterSuccess = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useListMutate(refetch, { onAfterSuccess }));
+
+    await act(async () => {
+      await result.current.mutate(async () => undefined);
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(onAfterSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/admin_web/tests/lib/admin-api-conflict-messages.test.ts
+++ b/apps/admin_web/tests/lib/admin-api-conflict-messages.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { AdminApiError } from '@/lib/api-admin-client';
+import { conflictFieldUserMessage, isAdminApiConflictOnField } from '@/lib/admin-api-conflict-messages';
+
+describe('admin-api-conflict-messages', () => {
+  it('maps 409 field messages', () => {
+    const err = new AdminApiError({
+      statusCode: 409,
+      payload: { field: 'name' },
+      message: 'duplicate',
+    });
+    expect(conflictFieldUserMessage(err, { name: 'Taken' })).toBe('Taken');
+    expect(conflictFieldUserMessage(err, { code: 'bad' })).toBeNull();
+  });
+
+  it('detects conflict field', () => {
+    const err = new AdminApiError({
+      statusCode: 409,
+      payload: { field: 'slug' },
+      message: 'dup',
+    });
+    expect(isAdminApiConflictOnField(err, 'slug')).toBe(true);
+    expect(isAdminApiConflictOnField(err, 'name')).toBe(false);
+  });
+});

--- a/apps/admin_web/tests/lib/entity-contact-eligibility.test.ts
+++ b/apps/admin_web/tests/lib/entity-contact-eligibility.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { contactEligibleForEntityMembership } from '@/lib/entity-contact-eligibility';
+
+describe('contactEligibleForEntityMembership', () => {
+  const base = { id: 'c1', family_ids: [] as string[], organization_ids: [] as string[] };
+
+  it('allows any contact with no family memberships for family mode', () => {
+    expect(contactEligibleForEntityMembership(base, null, 'family')).toBe(true);
+  });
+
+  it('requires selected family when contact already has families', () => {
+    const contact = { ...base, family_ids: ['f1'] };
+    expect(contactEligibleForEntityMembership(contact, null, 'family')).toBe(false);
+    expect(contactEligibleForEntityMembership(contact, 'f1', 'family')).toBe(true);
+  });
+
+  it('requires selected organisation when contact already has organisations', () => {
+    const contact = { ...base, organization_ids: ['o1'] };
+    expect(contactEligibleForEntityMembership(contact, null, 'organization')).toBe(false);
+    expect(contactEligibleForEntityMembership(contact, 'o1', 'organization')).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Single PR bundling the planned admin web refactors, **one logical change per commit** (see git log on `cursor/admin-web-refactor-batch-6f8e`).

## Commits (high level)

1. **`useListMutate`** – shared refetch-after-mutate pattern for list hooks; tests added.
2. **`AdminTableToolbar` + `AdminDataTableOperationsHeadCell`** – consistent filter rows and Operations column headers across tables.
3. **`toErrorMessage`** – billing, tags, calendar, customized draft card, expense void/delete paths.
4. **FX loading** – `useFxMultipliersForCurrencies` for expenses + tax panels; **`entity-contact-eligibility`** + families/org picker wiring; **`PaginatedResponse.totalCount` optionality** for cursor-style APIs.
5. **Client invoices** – `client-invoices-format-helpers` module for small format helpers.
6. **`AdminPageErrorBanner`** – Sales, Services, Contacts hub pages.
7. **409 conflict helpers** – `conflictFieldUserMessage` / `isAdminApiConflictOnField` + tags, discount codes, service/instance detail.

## Remediation follow-up (commit `fix(admin_web): remediate PR 1585 pitfalls…`)

Addresses the **Pitfalls and remediation backlog** attached to the review:

- **P1** — `toErrorMessage(..., { honorBackendMessage: true })` for tags, calendar, billing flows, expenses void/delete, customized draft, so 404/403 keep meaningful backend copy.
- **P2** — FX hook: removed `queueMicrotask`; synchronous resets with a scoped `eslint-disable` + comment (lint rule vs. cancellation safety).
- **P3** — `tailwind-merge` / `twMerge` on `AdminDataTableOperationsHeadCell` and `AdminTableToolbar`; audit Operations header aligned with other tables; vitest for `font-normal` override.
- **P4** — `usePaginatedList.totalCount` is `number | null` when the API omits totals; `LeadsTable` displays `—` when unknown.
- **P5–P6** — Discount duplicate check uses `isAdminApiConflictOnField`; instance slug handling uses `conflictFieldUserMessage`.
- **P7** — `useListMutate` rejection + `suppressSaving` rejection tests.
- **P8** — Tests for `client-invoices-format-helpers`.
- **P9** — `AdminPageErrorBanner` accepts `message?: string | null`.
- **P10** — Removed `MutateOptions` alias in `use-discount-codes`.
- **P11** — `AdminTableToolbar` uses `marginBottom: 'default' | 'none'` instead of `noMargin`.
- **P12** — JSDoc on `UseFxMultipliersForCurrenciesResult` for `fxMultipliers` contract.
- **P14** — Expenses / tax combined errors use ` • ` separator.

**P13** (optional git history split) — not done here.

## Validation

- `npm run lint` (admin web)
- `npx vitest run` – **506 tests**, all passing
- `bash scripts/validate-cursorrules.sh`

## Note

An earlier standalone branch/PR existed for `useListMutate` only; this PR supersedes that work on a single integrated branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d908cac-34b3-48c1-a11d-5cf8bc6f6f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d908cac-34b3-48c1-a11d-5cf8bc6f6f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

