### PR TITLE
Remove user email column from admin audit logs table

### DIFF
--- a/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
+++ b/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
@@ -168,13 +168,6 @@ export function AuditLogsPanel({ auditableTables }: AuditLogsPanelProps) {
 
   const timestampHeader = useMemo(() => `Timestamp (${formatGmtOffset()})`, []);
 
-  const getUserEmail = useCallback((row: AuditLog) => {
-    if (row.user_email) {
-      return row.user_email;
-    }
-    return '—';
-  }, []);
-
   return (
     <div className='space-y-6'>
       <PaginatedTableCard
@@ -298,9 +291,6 @@ export function AuditLogsPanel({ auditableTables }: AuditLogsPanelProps) {
                 <th className='px-4 py-3' scope='col'>
                   Action
                 </th>
-                <th className='px-4 py-3' scope='col'>
-                  User email
-                </th>
                 <th className='hidden px-4 py-3 md:table-cell' scope='col'>
                   Changed fields
                 </th>
@@ -314,9 +304,6 @@ export function AuditLogsPanel({ auditableTables }: AuditLogsPanelProps) {
                   <td className='px-4 py-3 font-medium text-slate-900'>{item.table_name}</td>
                   <td className='px-4 py-3'>
                     <ActionBadge action={item.action} />
-                  </td>
-                  <td className='px-4 py-3 font-mono text-xs text-slate-600'>
-                    {getUserEmail(item)}
                   </td>
                   <td className='hidden px-4 py-3 text-slate-500 md:table-cell'>
                     {item.changed_fields?.length ? item.changed_fields.join(', ') : '—'}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **User email** column from the Audit logs data table in admin web. Email remains available via the existing filter (toolbar) and the audit log detail dialog.

## Changes

- `audit-logs-panel.tsx`: drop table header/cell and `getUserEmail` helper.

## Validation

- `npx vitest run tests/components/admin/audit/audit-logs-page.test.tsx`
- `npm run lint` (admin web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7743c94f-2c9c-49a5-9b9b-27b00796a63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7743c94f-2c9c-49a5-9b9b-27b00796a63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

