### PR TITLE
fix(admin_web): align customer invoice and payment table header typography

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1452,13 +1452,13 @@ export function ClientInvoicesPanel() {
         <AdminDataTable tableClassName='min-w-[900px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-3 py-2'>Status</th>
-              <th className='px-3 py-2'>Number</th>
-              <th className='px-3 py-2'>Bill to</th>
-              <th className='px-3 py-2'>Total</th>
-              <th className='px-3 py-2'>Lines</th>
-              <th className='px-3 py-2'>Created</th>
-              <AdminDataTableOperationsHeadCell className='px-3 py-2 font-normal' />
+              <th className='px-3 py-2 font-semibold'>Status</th>
+              <th className='px-3 py-2 font-semibold'>Number</th>
+              <th className='px-3 py-2 font-semibold'>Bill to</th>
+              <th className='px-3 py-2 font-semibold'>Total</th>
+              <th className='px-3 py-2 font-semibold'>Lines</th>
+              <th className='px-3 py-2 font-semibold'>Created</th>
+              <AdminDataTableOperationsHeadCell className='px-3 py-2' />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
@@ -1861,12 +1861,12 @@ export function ClientInvoicesPanel() {
         <AdminDataTable tableClassName='min-w-[640px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-3 py-2'>Direction</th>
-              <th className='px-3 py-2'>Status</th>
-              <th className='px-3 py-2'>Method</th>
-              <th className='px-3 py-2'>Amount</th>
-              <th className='px-3 py-2'>Created</th>
-              <AdminDataTableOperationsHeadCell className='px-3 py-2 font-normal' />
+              <th className='px-3 py-2 font-semibold'>Direction</th>
+              <th className='px-3 py-2 font-semibold'>Status</th>
+              <th className='px-3 py-2 font-semibold'>Method</th>
+              <th className='px-3 py-2 font-semibold'>Amount</th>
+              <th className='px-3 py-2 font-semibold'>Created</th>
+              <AdminDataTableOperationsHeadCell className='px-3 py-2' />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Customer invoices and customer payments tables in `client-invoices-panel.tsx` passed `font-normal` on `AdminDataTableOperationsHeadCell`, which overrode the shared `font-semibold` default and made the Operations label lighter than neighboring headers (plain `<th>` use the browser’s bold weight).

## Changes

- Drop `font-normal` from both Operations head cells so they use the standard `AdminDataTableOperationsHeadCell` typography like other admin listings.
- Add `font-semibold` to the other header cells in those two rows so the whole header row matches listing tables such as expenses and families (explicit semibold on all columns).

## Testing

- `cd apps/admin_web && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30cb67b0-35bd-48ad-8635-5b234a99d07f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30cb67b0-35bd-48ad-8635-5b234a99d07f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

