### PR TITLE
refactor(admin_web): standardize AdminDataTable cell primitives

### DIFF
--- a/apps/admin_web/src/components/admin/assets/asset-grants-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-grants-panel.tsx
@@ -12,7 +12,9 @@ import { StatusBanner } from '@/components/status-banner';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -183,28 +185,30 @@ export function AssetGrantsPanel({
             <AdminDataTable tableClassName='min-w-[680px]'>
               <AdminDataTableHead>
                 <tr>
-                  <th className='px-4 py-3 font-semibold'>Type</th>
-                  <th className='px-4 py-3 font-semibold'>Grantee</th>
-                  <th className='px-4 py-3 font-semibold'>Granted by</th>
-                  <th className='px-4 py-3 font-semibold'>Created</th>
+                  <AdminDataTableHeadCell>Type</AdminDataTableHeadCell>
+                  <AdminDataTableHeadCell>Grantee</AdminDataTableHeadCell>
+                  <AdminDataTableHeadCell>Granted by</AdminDataTableHeadCell>
+                  <AdminDataTableHeadCell>Created</AdminDataTableHeadCell>
                   <AdminDataTableOperationsHeadCell />
                 </tr>
               </AdminDataTableHead>
               <AdminDataTableBody>
                 {isLoadingGrants ? null : grants.length === 0 ? (
                   <tr>
-                    <td className='px-4 py-8 text-slate-600' colSpan={5}>
+                    <AdminDataTableCell colSpan={5} className='py-8 text-slate-600'>
                       No grants configured for this asset.
-                    </td>
+                    </AdminDataTableCell>
                   </tr>
                 ) : (
                   grants.map((grant) => (
                     <tr key={grant.id}>
-                      <td className='px-4 py-3 text-slate-700'>{formatEnumLabel(grant.grantType)}</td>
-                      <td className='px-4 py-3 text-slate-700'>{grant.granteeId || '—'}</td>
-                      <td className='px-4 py-3 text-slate-700'>{grant.grantedBy || '—'}</td>
-                      <td className='px-4 py-3 text-slate-700'>{formatDate(grant.createdAt)}</td>
-                      <td className='px-4 py-3 text-right'>
+                      <AdminDataTableCell className='text-slate-700'>
+                        {formatEnumLabel(grant.grantType)}
+                      </AdminDataTableCell>
+                      <AdminDataTableCell className='text-slate-700'>{grant.granteeId || '—'}</AdminDataTableCell>
+                      <AdminDataTableCell className='text-slate-700'>{grant.grantedBy || '—'}</AdminDataTableCell>
+                      <AdminDataTableCell className='text-slate-700'>{formatDate(grant.createdAt)}</AdminDataTableCell>
+                      <AdminDataTableCell className='text-right'>
                         <Button
                           type='button'
                           size='sm'
@@ -224,7 +228,7 @@ export function AssetGrantsPanel({
                             <DeleteIcon className='h-4 w-4' />
                           )}
                         </Button>
-                      </td>
+                      </AdminDataTableCell>
                     </tr>
                   ))
                 )}

--- a/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/assets/asset-list-panel.tsx
@@ -17,7 +17,9 @@ import { useOpenAdminAssetInNewTab } from '@/hooks/use-open-admin-asset-in-new-t
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
@@ -175,21 +177,21 @@ export function AssetListPanel({
         <AdminDataTable tableClassName='min-w-[920px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Title</th>
-              <th className='px-4 py-3 font-semibold'>Tags</th>
-              <th className='px-4 py-3 font-semibold'>Language</th>
-              <th className='px-4 py-3 font-semibold'>Visibility</th>
-              <th className='px-4 py-3 font-semibold'>File</th>
-              <th className='px-4 py-3 font-semibold'>Updated</th>
+              <AdminDataTableHeadCell>Title</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Tags</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Language</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Visibility</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>File</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Updated</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
             {isLoadingAssets ? null : assets.length === 0 ? (
               <tr>
-                <td className='px-4 py-8 text-slate-600' colSpan={7}>
+                <AdminDataTableCell colSpan={7} className='py-8 text-slate-600'>
                   No assets found for the current filters.
-                </td>
+                </AdminDataTableCell>
               </tr>
             ) : (
               assets.map((asset) => {
@@ -212,11 +214,11 @@ export function AssetListPanel({
                     role='row'
                     aria-selected={isSelected}
                   >
-                    <td className='px-4 py-3'>
+                    <AdminDataTableCell>
                       <p className='font-medium text-slate-900'>{asset.title}</p>
                       <p className='mt-0.5 text-xs text-slate-500'>{asset.id}</p>
-                    </td>
-                    <td className='px-4 py-3 text-slate-700'>
+                    </AdminDataTableCell>
+                    <AdminDataTableCell className='text-slate-700'>
                       {sortedTags.length === 0 ? (
                         '—'
                       ) : (
@@ -238,14 +240,16 @@ export function AssetListPanel({
                           })}
                         </div>
                       )}
-                    </td>
-                    <td className='px-4 py-3 text-slate-700'>
+                    </AdminDataTableCell>
+                    <AdminDataTableCell className='text-slate-700'>
                       {formatAssetContentLanguageLabel(asset.contentLanguage)}
-                    </td>
-                    <td className='px-4 py-3 text-slate-700'>{formatEnumLabel(asset.visibility)}</td>
-                    <td className='px-4 py-3 text-slate-700'>{asset.fileName || '—'}</td>
-                    <td className='px-4 py-3 text-slate-700'>{formatDate(asset.updatedAt)}</td>
-                    <td className='px-4 py-3 text-right'>
+                    </AdminDataTableCell>
+                    <AdminDataTableCell className='text-slate-700'>
+                      {formatEnumLabel(asset.visibility)}
+                    </AdminDataTableCell>
+                    <AdminDataTableCell className='text-slate-700'>{asset.fileName || '—'}</AdminDataTableCell>
+                    <AdminDataTableCell className='text-slate-700'>{formatDate(asset.updatedAt)}</AdminDataTableCell>
+                    <AdminDataTableCell className='text-right'>
                       <div className='flex justify-end gap-1'>
                         <OpenAdminAssetInNewTabButton
                           assetId={asset.id}
@@ -275,7 +279,7 @@ export function AssetListPanel({
                           <DeleteIcon className='h-4 w-4' />
                         </Button>
                       </div>
-                    </td>
+                    </AdminDataTableCell>
                   </tr>
                 );
               })

--- a/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
+++ b/apps/admin_web/src/components/admin/audit/audit-logs-panel.tsx
@@ -8,7 +8,9 @@ import { ViewIcon } from '@/components/icons/action-icons';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
@@ -282,33 +284,27 @@ export function AuditLogsPanel({ auditableTables }: AuditLogsPanelProps) {
           <AdminDataTable>
             <AdminDataTableHead>
               <tr>
-                <th className='px-4 py-3' scope='col'>
-                  {timestampHeader}
-                </th>
-                <th className='px-4 py-3' scope='col'>
-                  Table
-                </th>
-                <th className='px-4 py-3' scope='col'>
-                  Action
-                </th>
-                <th className='hidden px-4 py-3 md:table-cell' scope='col'>
+                <AdminDataTableHeadCell scope='col'>{timestampHeader}</AdminDataTableHeadCell>
+                <AdminDataTableHeadCell scope='col'>Table</AdminDataTableHeadCell>
+                <AdminDataTableHeadCell scope='col'>Action</AdminDataTableHeadCell>
+                <AdminDataTableHeadCell scope='col' className='hidden md:table-cell'>
                   Changed fields
-                </th>
+                </AdminDataTableHeadCell>
                 <AdminDataTableOperationsHeadCell scope='col' />
               </tr>
             </AdminDataTableHead>
             <AdminDataTableBody>
               {items.map((item) => (
                 <tr key={item.id} className='hover:bg-slate-50'>
-                  <td className='px-4 py-3 text-slate-600'>{formatDate(item.timestamp)}</td>
-                  <td className='px-4 py-3 font-medium text-slate-900'>{item.table_name}</td>
-                  <td className='px-4 py-3'>
+                  <AdminDataTableCell className='text-slate-600'>{formatDate(item.timestamp)}</AdminDataTableCell>
+                  <AdminDataTableCell className='font-medium text-slate-900'>{item.table_name}</AdminDataTableCell>
+                  <AdminDataTableCell>
                     <ActionBadge action={item.action} />
-                  </td>
-                  <td className='hidden px-4 py-3 text-slate-500 md:table-cell'>
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='hidden text-slate-500 md:table-cell'>
                     {item.changed_fields?.length ? item.changed_fields.join(', ') : '—'}
-                  </td>
-                  <td className='px-4 py-3 text-right'>
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='text-right'>
                     <Button
                       type='button'
                       size='sm'
@@ -318,7 +314,7 @@ export function AuditLogsPanel({ auditableTables }: AuditLogsPanelProps) {
                     >
                       <ViewIcon className='h-4 w-4' />
                     </Button>
-                  </td>
+                  </AdminDataTableCell>
                 </tr>
               ))}
             </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
+++ b/apps/admin_web/src/components/admin/calendar/calendar-manual-blocks-page.tsx
@@ -7,7 +7,9 @@ import { Button } from '@/components/ui/button';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -295,18 +297,18 @@ export function CalendarManualBlocksPage() {
         <AdminDataTable tableClassName='min-w-[640px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Date</th>
-              <th className='px-4 py-3 font-semibold'>AM/PM</th>
-              <th className='px-4 py-3 font-semibold'>Note</th>
+              <AdminDataTableHeadCell>Date</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>AM/PM</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Note</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
             {rows.length === 0 && !isLoading ? (
               <tr>
-                <td className='px-4 py-6 text-slate-600' colSpan={4}>
+                <AdminDataTableCell colSpan={4} className='py-6 text-slate-600'>
                   No manual blocks in this range.
-                </td>
+                </AdminDataTableCell>
               </tr>
             ) : null}
             {rows.map((row) => (
@@ -324,10 +326,10 @@ export function CalendarManualBlocksPage() {
                   }
                 }}
               >
-                <td className='px-4 py-3 font-medium text-slate-900'>{row.block_date}</td>
-                <td className='px-4 py-3 uppercase'>{row.period}</td>
-                <td className='px-4 py-3 text-slate-700'>{row.note?.trim() || '—'}</td>
-                <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
+                <AdminDataTableCell className='font-medium text-slate-900'>{row.block_date}</AdminDataTableCell>
+                <AdminDataTableCell className='uppercase'>{row.period}</AdminDataTableCell>
+                <AdminDataTableCell className='text-slate-700'>{row.note?.trim() || '—'}</AdminDataTableCell>
+                <AdminDataTableCell className='text-right' onClick={(event) => event.stopPropagation()}>
                   <Button
                     type='button'
                     size='sm'
@@ -340,7 +342,7 @@ export function CalendarManualBlocksPage() {
                   >
                     <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                   </Button>
-                </td>
+                </AdminDataTableCell>
               </tr>
             ))}
           </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -17,7 +17,9 @@ import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-secti
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -939,9 +941,9 @@ export function ContactsPanel({
         <AdminDataTable tableClassName='min-w-[960px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Name</th>
-              <th className='px-4 py-3 font-semibold'>Email</th>
-              <th className='px-4 py-3 font-semibold'>Type</th>
+              <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Email</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Type</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -957,7 +959,7 @@ export function ContactsPanel({
                   }`}
                   onClick={() => selectRow(row)}
                 >
-                  <td className='px-4 py-3'>
+                  <AdminDataTableCell>
                     {name}
                     {membershipSuffix ? (
                       <>
@@ -970,10 +972,10 @@ export function ContactsPanel({
                         ) : null}
                       </>
                     ) : null}
-                  </td>
-                  <td className='px-4 py-3'>{row.email ?? '—'}</td>
-                  <td className='px-4 py-3'>{formatEnumLabel(row.contact_type)}</td>
-                  <td className='px-4 py-3 text-right'>
+                  </AdminDataTableCell>
+                  <AdminDataTableCell>{row.email ?? '—'}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatEnumLabel(row.contact_type)}</AdminDataTableCell>
+                  <AdminDataTableCell className='text-right'>
                     <div className='flex flex-wrap justify-end gap-2'>
                       <Button
                         type='button'
@@ -1029,7 +1031,7 @@ export function ContactsPanel({
                         <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                       </Button>
                     </div>
-                  </td>
+                  </AdminDataTableCell>
                 </tr>
               );
             })}

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -15,7 +15,9 @@ import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-secti
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -456,18 +458,18 @@ export function FamiliesPanel({
                   <AdminDataTable tableClassName='min-w-[520px]'>
                     <AdminDataTableHead>
                       <tr>
-                        <th className='px-3 py-2 font-semibold'>Contact</th>
-                        <th className='px-3 py-2 font-semibold'>Role</th>
-                        <th className='px-3 py-2 font-semibold'>Primary contact</th>
-                        <AdminDataTableOperationsHeadCell className='px-3 py-2' />
+                        <AdminDataTableHeadCell>Contact</AdminDataTableHeadCell>
+                        <AdminDataTableHeadCell>Role</AdminDataTableHeadCell>
+                        <AdminDataTableHeadCell>Primary contact</AdminDataTableHeadCell>
+                        <AdminDataTableOperationsHeadCell />
                       </tr>
                     </AdminDataTableHead>
                     <AdminDataTableBody>
                       {selected.members.map((m) => (
                         <tr key={m.id}>
-                          <td className='px-3 py-2'>{m.contact_label || m.contact_id}</td>
-                          <td className='px-3 py-2'>{formatEnumLabel(m.role)}</td>
-                          <td className='px-3 py-2'>
+                          <AdminDataTableCell>{m.contact_label || m.contact_id}</AdminDataTableCell>
+                          <AdminDataTableCell>{formatEnumLabel(m.role)}</AdminDataTableCell>
+                          <AdminDataTableCell>
                             <input
                               type='checkbox'
                               className='h-4 w-4 rounded border-slate-300'
@@ -478,8 +480,8 @@ export function FamiliesPanel({
                               }}
                               aria-label={`Primary contact for ${m.contact_label || m.contact_id}`}
                             />
-                          </td>
-                          <td className='px-3 py-2 text-right'>
+                          </AdminDataTableCell>
+                          <AdminDataTableCell className='text-right'>
                             <Button
                               type='button'
                               size='sm'
@@ -497,7 +499,7 @@ export function FamiliesPanel({
                             >
                               <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                             </Button>
-                          </td>
+                          </AdminDataTableCell>
                         </tr>
                       ))}
                     </AdminDataTableBody>
@@ -552,9 +554,9 @@ export function FamiliesPanel({
         <AdminDataTable tableClassName='min-w-[720px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Name</th>
-              <th className='px-4 py-3 font-semibold'>Members</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
+              <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Members</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -569,7 +571,7 @@ export function FamiliesPanel({
                 }`}
                 onClick={() => selectRow(row.id)}
               >
-                <td className='px-4 py-3'>
+                <AdminDataTableCell>
                   {row.family_name}
                   {primaryLabel ? (
                     <>
@@ -577,10 +579,10 @@ export function FamiliesPanel({
                       {primaryLabel}
                     </>
                   ) : null}
-                </td>
-                <td className='px-4 py-3'>{row.members.length}</td>
-                <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
-                <td className='px-4 py-3 text-right'>
+                </AdminDataTableCell>
+                <AdminDataTableCell>{row.members.length}</AdminDataTableCell>
+                <AdminDataTableCell>{row.active ? 'Active' : 'Archived'}</AdminDataTableCell>
+                <AdminDataTableCell className='text-right'>
                   <div className='flex flex-wrap justify-end gap-2'>
                     <Button
                       type='button'
@@ -597,7 +599,7 @@ export function FamiliesPanel({
                       <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                     </Button>
                   </div>
-                </td>
+                </AdminDataTableCell>
               </tr>
               );
             })}

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -15,7 +15,9 @@ import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-secti
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -509,18 +511,18 @@ export function OrganizationsPanel({
                   <AdminDataTable tableClassName='min-w-[520px]'>
                     <AdminDataTableHead>
                       <tr>
-                        <th className='px-3 py-2 font-semibold'>Contact</th>
-                        <th className='px-3 py-2 font-semibold'>Role</th>
-                        <th className='px-3 py-2 font-semibold'>Primary contact</th>
-                        <AdminDataTableOperationsHeadCell className='px-3 py-2' />
+                        <AdminDataTableHeadCell>Contact</AdminDataTableHeadCell>
+                        <AdminDataTableHeadCell>Role</AdminDataTableHeadCell>
+                        <AdminDataTableHeadCell>Primary contact</AdminDataTableHeadCell>
+                        <AdminDataTableOperationsHeadCell />
                       </tr>
                     </AdminDataTableHead>
                     <AdminDataTableBody>
                       {selected.members.map((m) => (
                         <tr key={m.id}>
-                          <td className='px-3 py-2'>{m.contact_label || m.contact_id}</td>
-                          <td className='px-3 py-2'>{formatEnumLabel(m.role)}</td>
-                          <td className='px-3 py-2'>
+                          <AdminDataTableCell>{m.contact_label || m.contact_id}</AdminDataTableCell>
+                          <AdminDataTableCell>{formatEnumLabel(m.role)}</AdminDataTableCell>
+                          <AdminDataTableCell>
                             <input
                               type='checkbox'
                               className='h-4 w-4 rounded border-slate-300'
@@ -531,8 +533,8 @@ export function OrganizationsPanel({
                               }}
                               aria-label={`Primary contact for ${m.contact_label || m.contact_id}`}
                             />
-                          </td>
-                          <td className='px-3 py-2 text-right'>
+                          </AdminDataTableCell>
+                          <AdminDataTableCell className='text-right'>
                             <Button
                               type='button'
                               size='sm'
@@ -550,7 +552,7 @@ export function OrganizationsPanel({
                             >
                               <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                             </Button>
-                          </td>
+                          </AdminDataTableCell>
                         </tr>
                       ))}
                     </AdminDataTableBody>
@@ -605,10 +607,10 @@ export function OrganizationsPanel({
         <AdminDataTable tableClassName='min-w-[800px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Name</th>
-              <th className='px-4 py-3 font-semibold'>Type</th>
-              <th className='px-4 py-3 font-semibold'>Members</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
+              <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Type</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Members</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -623,7 +625,7 @@ export function OrganizationsPanel({
                 }`}
                 onClick={() => selectRow(row.id)}
               >
-                <td className='px-4 py-3'>
+                <AdminDataTableCell>
                   {row.name}
                   {primaryLabel ? (
                     <>
@@ -631,11 +633,11 @@ export function OrganizationsPanel({
                       {primaryLabel}
                     </>
                   ) : null}
-                </td>
-                <td className='px-4 py-3'>{formatEnumLabel(row.organization_type)}</td>
-                <td className='px-4 py-3'>{row.members.length}</td>
-                <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
-                <td className='px-4 py-3 text-right'>
+                </AdminDataTableCell>
+                <AdminDataTableCell>{formatEnumLabel(row.organization_type)}</AdminDataTableCell>
+                <AdminDataTableCell>{row.members.length}</AdminDataTableCell>
+                <AdminDataTableCell>{row.active ? 'Active' : 'Archived'}</AdminDataTableCell>
+                <AdminDataTableCell className='text-right'>
                   <div className='flex flex-wrap justify-end gap-2'>
                     <Button
                       type='button'
@@ -652,7 +654,7 @@ export function OrganizationsPanel({
                       <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                     </Button>
                   </div>
-                </td>
+                </AdminDataTableCell>
               </tr>
               );
             })}

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -8,7 +8,9 @@ import { Button } from '@/components/ui/button';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -1150,7 +1152,7 @@ export function ClientInvoicesPanel() {
                 <AdminDataTable>
                   <AdminDataTableHead>
                     <tr>
-                      <th className='px-3 py-2'>
+                      <AdminDataTableHeadCell>
                         <input
                           type='checkbox'
                           aria-label='Select all visible enrollments'
@@ -1182,27 +1184,29 @@ export function ClientInvoicesPanel() {
                             selectableFilteredRows.length === 0
                           }
                         />
-                      </th>
-                      <th className='px-3 py-2'>Party</th>
-                      <th className='px-3 py-2'>{ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER}</th>
-                      <th className='max-w-[14rem] px-3 py-2'>{INSTANCE_TABLE_TIER_COHORT_HEADER}</th>
-                      <th className='px-3 py-2 text-right'>Price</th>
-                      <th className='px-3 py-2'>Enrolled</th>
-                      <th className='px-3 py-2'>Invoice</th>
+                      </AdminDataTableHeadCell>
+                      <AdminDataTableHeadCell>Party</AdminDataTableHeadCell>
+                      <AdminDataTableHeadCell>{ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER}</AdminDataTableHeadCell>
+                      <AdminDataTableHeadCell className='max-w-[14rem]'>
+                        {INSTANCE_TABLE_TIER_COHORT_HEADER}
+                      </AdminDataTableHeadCell>
+                      <AdminDataTableHeadCell className='text-right'>Price</AdminDataTableHeadCell>
+                      <AdminDataTableHeadCell>Enrolled</AdminDataTableHeadCell>
+                      <AdminDataTableHeadCell>Invoice</AdminDataTableHeadCell>
                     </tr>
                   </AdminDataTableHead>
                   <AdminDataTableBody>
                     {enrollmentPickerLoading ? (
                       <tr>
-                        <td colSpan={7} className='px-3 py-6 text-sm text-slate-600'>
+                        <AdminDataTableCell colSpan={7} className='py-6 text-sm text-slate-600'>
                           Loading enrollments…
-                        </td>
+                        </AdminDataTableCell>
                       </tr>
                     ) : enrollmentPickerRows.length === 0 ? (
                       <tr>
-                        <td colSpan={7} className='px-3 py-6 text-sm text-slate-600'>
+                        <AdminDataTableCell colSpan={7} className='py-6 text-sm text-slate-600'>
                           No enrollments match this filter.
-                        </td>
+                        </AdminDataTableCell>
                       </tr>
                     ) : (
                       enrollmentPickerRows.map((row) => {
@@ -1229,7 +1233,7 @@ export function ClientInvoicesPanel() {
                             key={row.enrollmentId}
                             className={blocked ? 'bg-slate-50 text-slate-500' : undefined}
                           >
-                            <td className='px-3 py-2 align-top'>
+                            <AdminDataTableCell className='align-top'>
                               <input
                                 type='checkbox'
                                 aria-label={`Select enrollment ${row.enrollmentId}`}
@@ -1254,25 +1258,25 @@ export function ClientInvoicesPanel() {
                                   Already on a draft or issued invoice.
                                 </span>
                               ) : null}
-                            </td>
-                            <td className='min-w-0 max-w-[22rem] break-words px-3 py-2 align-top text-sm'>
+                            </AdminDataTableCell>
+                            <AdminDataTableCell className='min-w-0 max-w-[22rem] break-words align-top text-sm'>
                               {partyCellDisplay !== '' ? partyCellDisplay : '—'}
-                            </td>
-                            <td className='px-3 py-2 align-top text-sm'>
+                            </AdminDataTableCell>
+                            <AdminDataTableCell className='align-top text-sm'>
                               {instanceServiceDisplay !== '' ? instanceServiceDisplay : '—'}
-                            </td>
-                            <td className='max-w-[14rem] min-w-0 break-words px-3 py-2 align-top text-sm'>
+                            </AdminDataTableCell>
+                            <AdminDataTableCell className='max-w-[14rem] min-w-0 break-words align-top text-sm'>
                               {tierCohortDisplay !== '' ? tierCohortDisplay : '—'}
-                            </td>
-                            <td className='px-3 py-2 align-top text-right text-sm tabular-nums'>
+                            </AdminDataTableCell>
+                            <AdminDataTableCell className='align-top text-right text-sm tabular-nums'>
                               {priceLabel}
-                            </td>
-                            <td className='px-3 py-2 align-top whitespace-nowrap text-sm'>
+                            </AdminDataTableCell>
+                            <AdminDataTableCell className='align-top whitespace-nowrap text-sm'>
                               {row.enrolledAt ? row.enrolledAt.slice(0, 10) : '—'}
-                            </td>
-                            <td className='px-3 py-2 align-top text-sm'>
+                            </AdminDataTableCell>
+                            <AdminDataTableCell className='align-top text-sm'>
                               {blocked ? 'On draft/issued invoice' : '—'}
-                            </td>
+                            </AdminDataTableCell>
                           </tr>
                         );
                       })
@@ -1452,13 +1456,13 @@ export function ClientInvoicesPanel() {
         <AdminDataTable tableClassName='min-w-[900px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-3 py-2'>Status</th>
-              <th className='px-3 py-2'>Number</th>
-              <th className='px-3 py-2'>Bill to</th>
-              <th className='px-3 py-2'>Total</th>
-              <th className='px-3 py-2'>Lines</th>
-              <th className='px-3 py-2'>Created</th>
-              <AdminDataTableOperationsHeadCell className='px-3 py-2 font-normal' />
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Number</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Bill to</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Total</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Lines</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Created</AdminDataTableHeadCell>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
@@ -1485,18 +1489,16 @@ export function ClientInvoicesPanel() {
                     }
                   }}
                 >
-                  <td className='px-3 py-2'>
-                    {formatEnumLabel(inv.status ?? '') || '—'}
-                  </td>
-                  <td className='px-3 py-2'>{inv.invoiceNumber ?? '—'}</td>
-                  <td className='px-3 py-2 text-slate-700'>
+                  <AdminDataTableCell>{formatEnumLabel(inv.status ?? '') || '—'}</AdminDataTableCell>
+                  <AdminDataTableCell>{inv.invoiceNumber ?? '—'}</AdminDataTableCell>
+                  <AdminDataTableCell className='text-slate-700'>
                     {inv.billToDisplayName ?? inv.billToEmail ?? '—'}
-                  </td>
-                  <td className='px-3 py-2'>{totalDisplay}</td>
-                  <td className='px-3 py-2'>{inv.lineCount ?? 0}</td>
-                  <td className='px-3 py-2'>{formatDate(inv.createdAt ?? null)}</td>
-                  <td
-                    className='px-3 py-2 text-right'
+                  </AdminDataTableCell>
+                  <AdminDataTableCell>{totalDisplay}</AdminDataTableCell>
+                  <AdminDataTableCell>{inv.lineCount ?? 0}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatDate(inv.createdAt ?? null)}</AdminDataTableCell>
+                  <AdminDataTableCell
+                    className='text-right'
                     onClick={(event) => {
                       event.stopPropagation();
                     }}
@@ -1577,7 +1579,7 @@ export function ClientInvoicesPanel() {
                         </Button>
                       ) : null}
                     </div>
-                  </td>
+                  </AdminDataTableCell>
                 </tr>
               );
             })}
@@ -1861,12 +1863,12 @@ export function ClientInvoicesPanel() {
         <AdminDataTable tableClassName='min-w-[640px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-3 py-2'>Direction</th>
-              <th className='px-3 py-2'>Status</th>
-              <th className='px-3 py-2'>Method</th>
-              <th className='px-3 py-2'>Amount</th>
-              <th className='px-3 py-2'>Created</th>
-              <AdminDataTableOperationsHeadCell className='px-3 py-2 font-normal' />
+              <AdminDataTableHeadCell>Direction</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Method</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Amount</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Created</AdminDataTableHeadCell>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
@@ -1893,13 +1895,13 @@ export function ClientInvoicesPanel() {
                     }
                   }}
                 >
-                  <td className='px-3 py-2'>{formatEnumLabel(p.direction ?? '')}</td>
-                  <td className='px-3 py-2'>{formatEnumLabel(p.status ?? '')}</td>
-                  <td className='px-3 py-2'>{formatPaymentMethodLabel(p.method)}</td>
-                  <td className='px-3 py-2'>{amountDisplay}</td>
-                  <td className='px-3 py-2'>{formatDate(p.createdAt ?? null)}</td>
-                  <td
-                    className='px-3 py-2 text-right'
+                  <AdminDataTableCell>{formatEnumLabel(p.direction ?? '')}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatEnumLabel(p.status ?? '')}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatPaymentMethodLabel(p.method)}</AdminDataTableCell>
+                  <AdminDataTableCell>{amountDisplay}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatDate(p.createdAt ?? null)}</AdminDataTableCell>
+                  <AdminDataTableCell
+                    className='text-right'
                     onClick={(event) => {
                       event.stopPropagation();
                     }}
@@ -1940,7 +1942,7 @@ export function ClientInvoicesPanel() {
                         </Button>
                       ) : null}
                     </div>
-                  </td>
+                  </AdminDataTableCell>
                 </tr>
               );
             })}

--- a/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
+++ b/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
@@ -8,7 +8,9 @@ import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-secti
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
@@ -355,19 +357,19 @@ export function CustomizedDraftInvoiceCard({
               <AdminDataTable tableClassName='min-w-[52rem]'>
                 <AdminDataTableHead sticky>
                   <tr>
-                    <th className='min-w-[12rem] px-3 py-2'>Description</th>
-                    <th className='w-[5.5rem] px-3 py-2 text-right'>Quantity</th>
-                    <th className='w-[6.5rem] px-3 py-2 text-right'>Unit price</th>
-                    <th className='w-[6rem] px-3 py-2 text-right'>Discount</th>
-                    <th className='w-[5.5rem] px-3 py-2 text-right'>Tax rate</th>
-                    <th className='w-[6.5rem] px-3 py-2 text-right'>Tax amount</th>
-                    <AdminDataTableOperationsHeadCell className='px-3 py-2 font-normal' />
+                    <AdminDataTableHeadCell className='min-w-[12rem]'>Description</AdminDataTableHeadCell>
+                    <AdminDataTableHeadCell className='w-[5.5rem] text-right'>Quantity</AdminDataTableHeadCell>
+                    <AdminDataTableHeadCell className='w-[6.5rem] text-right'>Unit price</AdminDataTableHeadCell>
+                    <AdminDataTableHeadCell className='w-[6rem] text-right'>Discount</AdminDataTableHeadCell>
+                    <AdminDataTableHeadCell className='w-[5.5rem] text-right'>Tax rate</AdminDataTableHeadCell>
+                    <AdminDataTableHeadCell className='w-[6.5rem] text-right'>Tax amount</AdminDataTableHeadCell>
+                    <AdminDataTableOperationsHeadCell />
                   </tr>
                 </AdminDataTableHead>
                 <AdminDataTableBody>
                   {customizedLines.map((ln) => (
                     <tr key={ln.id}>
-                      <td className='align-top px-3 py-2'>
+                      <AdminDataTableCell className='align-top'>
                         <Input
                           id={`${CUSTOMIZED_FORM_ID}-desc-${ln.id}`}
                           className='w-full min-w-0'
@@ -382,8 +384,8 @@ export function CustomizedDraftInvoiceCard({
                             )
                           }
                         />
-                      </td>
-                      <td className='align-top px-3 py-2'>
+                      </AdminDataTableCell>
+                      <AdminDataTableCell className='align-top'>
                         <Input
                           id={`${CUSTOMIZED_FORM_ID}-qty-${ln.id}`}
                           className='w-full min-w-0 font-mono tabular-nums'
@@ -399,8 +401,8 @@ export function CustomizedDraftInvoiceCard({
                             )
                           }
                         />
-                      </td>
-                      <td className='align-top px-3 py-2'>
+                      </AdminDataTableCell>
+                      <AdminDataTableCell className='align-top'>
                         <Input
                           id={`${CUSTOMIZED_FORM_ID}-unit-${ln.id}`}
                           className='w-full min-w-0 font-mono tabular-nums'
@@ -416,8 +418,8 @@ export function CustomizedDraftInvoiceCard({
                             )
                           }
                         />
-                      </td>
-                      <td className='align-top px-3 py-2'>
+                      </AdminDataTableCell>
+                      <AdminDataTableCell className='align-top'>
                         <Input
                           id={`${CUSTOMIZED_FORM_ID}-disc-${ln.id}`}
                           className='w-full min-w-0 font-mono tabular-nums'
@@ -434,8 +436,8 @@ export function CustomizedDraftInvoiceCard({
                           }
                           placeholder='0'
                         />
-                      </td>
-                      <td className='align-top px-3 py-2'>
+                      </AdminDataTableCell>
+                      <AdminDataTableCell className='align-top'>
                         <Input
                           id={`${CUSTOMIZED_FORM_ID}-tr-${ln.id}`}
                           className='w-full min-w-0 font-mono tabular-nums'
@@ -452,8 +454,8 @@ export function CustomizedDraftInvoiceCard({
                           }
                           placeholder='—'
                         />
-                      </td>
-                      <td className='align-top px-3 py-2'>
+                      </AdminDataTableCell>
+                      <AdminDataTableCell className='align-top'>
                         <Input
                           id={`${CUSTOMIZED_FORM_ID}-ta-${ln.id}`}
                           className='w-full min-w-0 font-mono tabular-nums'
@@ -470,8 +472,8 @@ export function CustomizedDraftInvoiceCard({
                           }
                           placeholder='—'
                         />
-                      </td>
-                      <td className='align-top px-3 py-2 text-right'>
+                      </AdminDataTableCell>
+                      <AdminDataTableCell className='align-top text-right'>
                         <div className='flex flex-wrap justify-end gap-1'>
                           <Button
                             type='button'
@@ -488,7 +490,7 @@ export function CustomizedDraftInvoiceCard({
                             <DeleteIcon className='h-4 w-4' />
                           </Button>
                         </div>
-                      </td>
+                      </AdminDataTableCell>
                     </tr>
                   ))}
                 </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/expenses-list-panel.tsx
@@ -9,7 +9,9 @@ import { Button } from '@/components/ui/button';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -256,10 +258,10 @@ export function ExpensesListPanel({
         <AdminDataTable tableClassName='min-w-[780px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Vendor</th>
-              <th className='px-4 py-3 font-semibold'>Total</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 font-semibold'>Issued</th>
+              <AdminDataTableHeadCell>Vendor</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Total</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Issued</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -279,13 +281,13 @@ export function ExpensesListPanel({
                   role='row'
                   aria-selected={isSelected}
                 >
-                  <td className='px-4 py-3'>
+                  <AdminDataTableCell>
                     <p className='font-medium text-slate-900'>{expense.vendorName ?? '—'}</p>
                     <p className='mt-0.5 text-xs text-slate-500'>
                       {expense.invoiceNumber ?? expense.id.slice(0, 8)}
                     </p>
-                  </td>
-                  <td className='px-4 py-3'>
+                  </AdminDataTableCell>
+                  <AdminDataTableCell>
                     <span className='tabular-nums'>
                       {fxMultipliers === null && expensesNeedForeignFx
                         ? '…'
@@ -295,10 +297,10 @@ export function ExpensesListPanel({
                             expensesNeedForeignFx ? (fxMultipliers ?? new Map()) : new Map(),
                           )}
                     </span>
-                  </td>
-                  <td className='px-4 py-3'>{formatEnumLabel(expense.status)}</td>
-                  <td className='px-4 py-3'>{formatDateOnly(expense.invoiceDate)}</td>
-                  <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
+                  </AdminDataTableCell>
+                  <AdminDataTableCell>{formatEnumLabel(expense.status)}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatDateOnly(expense.invoiceDate)}</AdminDataTableCell>
+                  <AdminDataTableCell className='text-right' onClick={(event) => event.stopPropagation()}>
                     <div className='flex flex-wrap justify-end gap-1'>
                       <OpenAdminAssetInNewTabButton
                         assetId={documentAssetId ?? ''}
@@ -411,7 +413,7 @@ export function ExpensesListPanel({
                         </Button>
                       ) : null}
                     </div>
-                  </td>
+                  </AdminDataTableCell>
                 </tr>
               );
             })}

--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -4,7 +4,13 @@ import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 
 import { WarningTriangleIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableCell,
+  AdminDataTableHead,
+  AdminDataTableHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
@@ -177,26 +183,26 @@ export function TaxFiscalYearPanel() {
       <AdminDataTable tableClassName='min-w-[920px]'>
         <AdminDataTableHead>
           <tr>
-            <th className='px-4 py-3 font-semibold'>Type</th>
-            <th className='px-4 py-3 font-semibold'>Date</th>
-            <th className='px-4 py-3 font-semibold'>Description</th>
-            <th className='px-4 py-3 font-semibold'>Amount</th>
-            <th className='px-4 py-3 font-semibold'>Tax</th>
-            <th className='px-4 py-3 font-semibold'>Expense status</th>
+            <AdminDataTableHeadCell>Type</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Date</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Description</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Amount</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Tax</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Expense status</AdminDataTableHeadCell>
           </tr>
         </AdminDataTableHead>
         <AdminDataTableBody>
           {!isLoading && !tableError && rows.length === 0 ? (
             <tr>
-              <td className='px-4 py-6 text-slate-600' colSpan={6}>
+              <AdminDataTableCell colSpan={6} className='py-6 text-slate-600'>
                 No expense or revenue rows in this fiscal year.
-              </td>
+              </AdminDataTableCell>
             </tr>
           ) : null}
           {rows.map((row) => (
             <tr key={`${row.kind}:${row.referenceId}`}>
-              <td className='px-4 py-3'>{row.kind === 'revenue' ? 'Revenue' : 'Expense'}</td>
-              <td className='px-4 py-3'>
+              <AdminDataTableCell>{row.kind === 'revenue' ? 'Revenue' : 'Expense'}</AdminDataTableCell>
+              <AdminDataTableCell>
                 <div className='flex flex-wrap items-center gap-2'>
                   <span>{formatDateOnly(row.classificationDate)}</span>
                   {row.needsInvoiceDateWarning ? (
@@ -209,18 +215,18 @@ export function TaxFiscalYearPanel() {
                     </span>
                   ) : null}
                 </div>
-              </td>
-              <td className='px-4 py-3'>
+              </AdminDataTableCell>
+              <AdminDataTableCell>
                 <p className='font-medium text-slate-900'>{row.description}</p>
-              </td>
-              <td className='px-4 py-3'>
+              </AdminDataTableCell>
+              <AdminDataTableCell>
                 <span className='tabular-nums'>
                   {fxMultipliers === null && rowsNeedForeignFx
                     ? '…'
                     : formatMoneyLineWithFxToDefault(row.amount, row.currency, fxMultipliers ?? new Map())}
                 </span>
-              </td>
-              <td className='px-4 py-3'>
+              </AdminDataTableCell>
+              <AdminDataTableCell>
                 <span className='tabular-nums'>
                   {isTaxDisplayedAsDash(row.tax)
                     ? '—'
@@ -228,10 +234,10 @@ export function TaxFiscalYearPanel() {
                       ? '…'
                       : formatMoneyLineWithFxToDefault(row.tax, row.currency, fxMultipliers ?? new Map())}
                 </span>
-              </td>
-              <td className='px-4 py-3'>
+              </AdminDataTableCell>
+              <AdminDataTableCell>
                 {row.kind === 'expense' && row.expenseStatus ? formatEnumLabel(row.expenseStatus) : '—'}
-              </td>
+              </AdminDataTableCell>
             </tr>
           ))}
         </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/finance/vendors-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/vendors-panel.tsx
@@ -7,7 +7,9 @@ import { Button } from '@/components/ui/button';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -198,9 +200,9 @@ export function VendorsPanel({
         <AdminDataTable tableClassName='min-w-[760px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Name</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 font-semibold text-right'>Total Spend</th>
+              <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell className='text-right'>Total Spend</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -219,16 +221,16 @@ export function VendorsPanel({
                   setActive(vendor.active);
                 }}
               >
-                <td className='px-4 py-3'>{vendor.name}</td>
-                <td className='px-4 py-3'>{vendor.active ? 'Active' : 'Inactive'}</td>
-                <td className='px-4 py-3 text-right tabular-nums'>
+                <AdminDataTableCell>{vendor.name}</AdminDataTableCell>
+                <AdminDataTableCell>{vendor.active ? 'Active' : 'Inactive'}</AdminDataTableCell>
+                <AdminDataTableCell className='text-right tabular-nums'>
                   {isVendorSpendLoading ? (
                     '…'
                   ) : (
                     formatAmountInDefaultCurrency(vendorSpendByVendorId.get(vendor.id) ?? 0)
                   )}
-                </td>
-                <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
+                </AdminDataTableCell>
+                <AdminDataTableCell className='text-right' onClick={(event) => event.stopPropagation()}>
                   <Button
                     type='button'
                     size='sm'
@@ -249,7 +251,7 @@ export function VendorsPanel({
                       <VendorInactiveIcon className='h-4 w-4 shrink-0' aria-hidden />
                     )}
                   </Button>
-                </td>
+                </AdminDataTableCell>
               </tr>
             ))}
           </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/sales/assignee-leaderboard.tsx
+++ b/apps/admin_web/src/components/admin/sales/assignee-leaderboard.tsx
@@ -1,6 +1,13 @@
 import type { AdminUser } from '@/types/leads';
 
 import { Card } from '@/components/ui/card';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableCell,
+  AdminDataTableHead,
+  AdminDataTableHeadCell,
+} from '@/components/ui/admin-data-table';
 
 export interface AssigneeLeaderboardProps {
   users: AdminUser[];
@@ -23,35 +30,39 @@ function resolveUserLabel(sub: string | null, users: AdminUser[]): string {
 export function AssigneeLeaderboard({ users, values }: AssigneeLeaderboardProps) {
   return (
     <Card title='Team Performance'>
-      <div className='overflow-x-auto rounded-md border border-slate-200'>
-        <table className='w-full min-w-[520px] divide-y divide-slate-200 text-left'>
-          <thead className='bg-slate-100 text-xs uppercase tracking-[0.08em] text-slate-700'>
+      <div className='overflow-x-auto'>
+        <AdminDataTable tableClassName='min-w-[520px]'>
+          <AdminDataTableHead>
             <tr>
-              <th className='px-3 py-2 font-semibold'>Assignee</th>
-              <th className='px-3 py-2 font-semibold'>Total</th>
-              <th className='px-3 py-2 font-semibold'>Converted</th>
-              <th className='px-3 py-2 font-semibold'>Conversion rate</th>
+              <AdminDataTableHeadCell>Assignee</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Total</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Converted</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Conversion rate</AdminDataTableHeadCell>
             </tr>
-          </thead>
-          <tbody className='divide-y divide-slate-200 bg-white text-sm'>
+          </AdminDataTableHead>
+          <AdminDataTableBody>
             {values.length === 0 ? (
               <tr>
-                <td className='px-3 py-6 text-slate-600' colSpan={4}>
+                <AdminDataTableCell colSpan={4} className='py-6 text-slate-600'>
                   No assignee performance data.
-                </td>
+                </AdminDataTableCell>
               </tr>
             ) : (
               values.map((entry) => (
                 <tr key={entry.assignedTo ?? 'unassigned'}>
-                  <td className='px-3 py-2 text-slate-900'>{resolveUserLabel(entry.assignedTo, users)}</td>
-                  <td className='px-3 py-2 text-slate-700'>{entry.total}</td>
-                  <td className='px-3 py-2 text-slate-700'>{entry.converted}</td>
-                  <td className='px-3 py-2 text-slate-700'>{(entry.conversionRate * 100).toFixed(1)}%</td>
+                  <AdminDataTableCell className='text-slate-900'>
+                    {resolveUserLabel(entry.assignedTo, users)}
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='text-slate-700'>{entry.total}</AdminDataTableCell>
+                  <AdminDataTableCell className='text-slate-700'>{entry.converted}</AdminDataTableCell>
+                  <AdminDataTableCell className='text-slate-700'>
+                    {(entry.conversionRate * 100).toFixed(1)}%
+                  </AdminDataTableCell>
                 </tr>
               ))
             )}
-          </tbody>
-        </table>
+          </AdminDataTableBody>
+        </AdminDataTable>
       </div>
     </Card>
   );

--- a/apps/admin_web/src/components/admin/sales/leads-table-row.tsx
+++ b/apps/admin_web/src/components/admin/sales/leads-table-row.tsx
@@ -3,6 +3,7 @@
 import type { AdminUser, LeadSummary } from '@/types/leads';
 
 import { ArrowRightIcon } from '@/components/icons/action-icons';
+import { AdminDataTableCell } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
 import { formatDate, formatEnumLabel } from '@/lib/format';
 
@@ -39,37 +40,37 @@ export function LeadsTableRow({
       className={`cursor-pointer ${isSelected ? 'bg-slate-100' : 'hover:bg-slate-50'}`}
       onClick={() => onSelect(lead.id)}
     >
-      <td className='px-3 py-2' onClick={(event) => event.stopPropagation()}>
+      <AdminDataTableCell onClick={(event) => event.stopPropagation()}>
         <input
           type='checkbox'
           checked={isChecked}
           onChange={(event) => onCheck(lead.id, event.target.checked)}
         />
-      </td>
-      <td className='px-3 py-2 text-sm font-medium text-slate-900'>
+      </AdminDataTableCell>
+      <AdminDataTableCell className='text-sm font-medium text-slate-900'>
         {[lead.contact.firstName, lead.contact.lastName].filter(Boolean).join(' ') || 'Unnamed lead'}
-      </td>
-      <td className='px-3 py-2 text-sm text-slate-700'>{lead.contact.email ?? '—'}</td>
-      <td className='px-3 py-2 text-sm text-slate-700'>
+      </AdminDataTableCell>
+      <AdminDataTableCell className='text-sm text-slate-700'>{lead.contact.email ?? '—'}</AdminDataTableCell>
+      <AdminDataTableCell className='text-sm text-slate-700'>
         {lead.contact.source ? formatEnumLabel(lead.contact.source) : '—'}
-      </td>
-      <td className='px-3 py-2 text-sm'>
+      </AdminDataTableCell>
+      <AdminDataTableCell className='text-sm'>
         <span
           className={`inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ${getStageBadgeClass(lead.funnelStage)}`}
         >
           {formatEnumLabel(lead.funnelStage)}
         </span>
-      </td>
-      <td className='px-3 py-2 text-sm text-slate-700'>
+      </AdminDataTableCell>
+      <AdminDataTableCell className='text-sm text-slate-700'>
         {resolveAssigneeLabel(lead.assignedTo, users)}
-      </td>
-      <td className='px-3 py-2 text-sm text-slate-700'>{formatDate(lead.createdAt)}</td>
-      <td className='px-3 py-2 text-sm text-slate-700'>
+      </AdminDataTableCell>
+      <AdminDataTableCell className='text-sm text-slate-700'>{formatDate(lead.createdAt)}</AdminDataTableCell>
+      <AdminDataTableCell className='text-sm text-slate-700'>
         <span className={lead.daysInStage > 7 ? 'font-semibold text-amber-700' : ''}>
           {lead.daysInStage}
         </span>
-      </td>
-      <td className='px-3 py-2 text-right' onClick={(event) => event.stopPropagation()}>
+      </AdminDataTableCell>
+      <AdminDataTableCell className='text-right' onClick={(event) => event.stopPropagation()}>
         <Button
           type='button'
           size='sm'
@@ -80,7 +81,7 @@ export function LeadsTableRow({
         >
           <ArrowRightIcon className='h-4 w-4' />
         </Button>
-      </td>
+      </AdminDataTableCell>
     </tr>
   );
 }

--- a/apps/admin_web/src/components/admin/sales/leads-table.tsx
+++ b/apps/admin_web/src/components/admin/sales/leads-table.tsx
@@ -7,7 +7,9 @@ import type { AdminUser, FunnelStage, LeadListFilters, LeadSummary } from '@/typ
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
@@ -96,7 +98,7 @@ export function LeadsTable({
       <AdminDataTable tableClassName='min-w-[1080px]'>
         <AdminDataTableHead sticky>
           <tr>
-            <th className='px-3 py-3'>
+            <AdminDataTableHeadCell>
               <input
                 type='checkbox'
                 checked={leads.length > 0 && selectedIds.length === leads.length}
@@ -104,29 +106,29 @@ export function LeadsTable({
                   setSelectedIds(event.target.checked ? leads.map((lead) => lead.id) : [])
                 }
               />
-            </th>
-            <th className='px-3 py-3 font-semibold'>Name</th>
-            <th className='px-3 py-3 font-semibold'>Email</th>
-            <th className='px-3 py-3 font-semibold'>Source</th>
-            <th className='px-3 py-3 font-semibold'>Stage</th>
-            <th className='px-3 py-3 font-semibold'>Assigned</th>
-            <th className='px-3 py-3 font-semibold'>Created</th>
-            <th className='px-3 py-3 font-semibold'>Days in stage</th>
-            <AdminDataTableOperationsHeadCell className='px-3 py-3' />
+            </AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Email</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Source</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Stage</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Assigned</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Created</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Days in stage</AdminDataTableHeadCell>
+            <AdminDataTableOperationsHeadCell />
           </tr>
         </AdminDataTableHead>
         <AdminDataTableBody>
           {isLoading ? (
             <tr>
-              <td colSpan={9} className='px-3 py-8 text-sm text-slate-600'>
+              <AdminDataTableCell colSpan={9} className='py-8 text-sm text-slate-600'>
                 Loading leads...
-              </td>
+              </AdminDataTableCell>
             </tr>
           ) : leads.length === 0 ? (
             <tr>
-              <td colSpan={9} className='px-3 py-8 text-sm text-slate-600'>
+              <AdminDataTableCell colSpan={9} className='py-8 text-sm text-slate-600'>
                 No leads found for these filters.
-              </td>
+              </AdminDataTableCell>
             </tr>
           ) : (
             leads.map((lead) => (

--- a/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/discount-codes-panel.tsx
@@ -6,7 +6,9 @@ import { Button } from '@/components/ui/button';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -569,12 +571,12 @@ export function DiscountCodesPanel({
         <AdminDataTable tableClassName='min-w-[880px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Code</th>
-              <th className='px-4 py-3 font-semibold'>Valid from</th>
-              <th className='px-4 py-3 font-semibold'>Valid until</th>
-              <th className='px-4 py-3 font-semibold'>Value</th>
-              <th className='px-4 py-3 font-semibold'>Uses</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
+              <AdminDataTableHeadCell>Code</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Valid from</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Valid until</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Value</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Uses</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -587,15 +589,15 @@ export function DiscountCodesPanel({
                 }`}
                 onClick={() => applyCodeSelection(row)}
               >
-                <td className='px-4 py-3'>{row.code}</td>
-                <td className='px-4 py-3'>{formatDate(row.validFrom)}</td>
-                <td className='px-4 py-3'>{formatDate(row.validUntil)}</td>
-                <td className='px-4 py-3'>{formatDiscountRowValue(row)}</td>
-                <td className='px-4 py-3'>
+                <AdminDataTableCell>{row.code}</AdminDataTableCell>
+                <AdminDataTableCell>{formatDate(row.validFrom)}</AdminDataTableCell>
+                <AdminDataTableCell>{formatDate(row.validUntil)}</AdminDataTableCell>
+                <AdminDataTableCell>{formatDiscountRowValue(row)}</AdminDataTableCell>
+                <AdminDataTableCell>
                   {row.currentUses}/{row.maxUses ?? '∞'}
-                </td>
-                <td className='px-4 py-3'>{row.active ? 'Enabled' : 'Disabled'}</td>
-                <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
+                </AdminDataTableCell>
+                <AdminDataTableCell>{row.active ? 'Enabled' : 'Disabled'}</AdminDataTableCell>
+                <AdminDataTableCell className='text-right' onClick={(event) => event.stopPropagation()}>
                   <div className='flex justify-end gap-1'>
                     <Button
                       type='button'
@@ -636,7 +638,7 @@ export function DiscountCodesPanel({
                       <DeleteIcon className='h-4 w-4' />
                     </Button>
                   </div>
-                </td>
+                </AdminDataTableCell>
               </tr>
             ))}
           </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -5,7 +5,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -539,54 +541,46 @@ export function EnrollmentListPanel({
           <AdminDataTable tableClassName='w-full table-fixed'>
             <AdminDataTableHead>
               <tr>
-                <th
+                <AdminDataTableHeadCell
                   className={
-                    showScheduledStartColumn
-                      ? 'w-[22%] min-w-0 px-4 py-3 font-semibold'
-                      : 'w-[28%] min-w-0 px-4 py-3 font-semibold'
+                    showScheduledStartColumn ? 'w-[22%] min-w-0' : 'w-[28%] min-w-0'
                   }
                 >
                   Party
-                </th>
+                </AdminDataTableHeadCell>
                 {showScheduledStartColumn ? (
-                  <th className='w-[10%] whitespace-nowrap px-4 py-3 font-semibold'>Scheduled start</th>
+                  <AdminDataTableHeadCell className='w-[10%] whitespace-nowrap'>
+                    Scheduled start
+                  </AdminDataTableHeadCell>
                 ) : null}
-                <th
+                <AdminDataTableHeadCell
                   className={
-                    showScheduledStartColumn
-                      ? 'w-[9%] min-w-0 px-4 py-3 font-semibold'
-                      : 'w-[10%] min-w-0 px-4 py-3 font-semibold'
+                    showScheduledStartColumn ? 'w-[9%] min-w-0' : 'w-[10%] min-w-0'
                   }
                 >
                   Status
-                </th>
-                <th
+                </AdminDataTableHeadCell>
+                <AdminDataTableHeadCell
                   className={
-                    showScheduledStartColumn
-                      ? 'w-[10%] whitespace-nowrap px-4 py-3 font-semibold'
-                      : 'w-[11%] whitespace-nowrap px-4 py-3 font-semibold'
+                    showScheduledStartColumn ? 'w-[10%] whitespace-nowrap' : 'w-[11%] whitespace-nowrap'
                   }
                 >
                   Amount
-                </th>
-                <th
+                </AdminDataTableHeadCell>
+                <AdminDataTableHeadCell
                   className={
-                    showScheduledStartColumn
-                      ? 'w-[17%] min-w-0 px-4 py-3 font-semibold'
-                      : 'w-[20%] min-w-0 px-4 py-3 font-semibold'
+                    showScheduledStartColumn ? 'w-[17%] min-w-0' : 'w-[20%] min-w-0'
                   }
                 >
                   Discount
-                </th>
-                <th
+                </AdminDataTableHeadCell>
+                <AdminDataTableHeadCell
                   className={
-                    showScheduledStartColumn
-                      ? 'w-[12%] whitespace-nowrap px-4 py-3 font-semibold'
-                      : 'w-[14%] whitespace-nowrap px-4 py-3 font-semibold'
+                    showScheduledStartColumn ? 'w-[12%] whitespace-nowrap' : 'w-[14%] whitespace-nowrap'
                   }
                 >
                   Enrolled at
-                </th>
+                </AdminDataTableHeadCell>
                 <AdminDataTableOperationsHeadCell className='w-[4.5rem] whitespace-nowrap' />
               </tr>
             </AdminDataTableHead>
@@ -608,28 +602,30 @@ export function EnrollmentListPanel({
                     }`}
                     onClick={() => applyEnrollmentSelection(enrollment)}
                   >
-                    <td className='min-w-0 break-words px-4 py-3'>
+                    <AdminDataTableCell className='min-w-0 break-words'>
                       {formatEnrollmentParentCell(enrollment)}
-                    </td>
+                    </AdminDataTableCell>
                     {showScheduledStartColumn ? (
-                      <td className='whitespace-nowrap px-4 py-3'>
+                      <AdminDataTableCell className='whitespace-nowrap'>
                         {enrollment.scheduledStartAt?.trim()
                           ? formatDate(enrollment.scheduledStartAt)
                           : '—'}
-                      </td>
+                      </AdminDataTableCell>
                     ) : null}
-                    <td className='min-w-0 break-words px-4 py-3'>
+                    <AdminDataTableCell className='min-w-0 break-words'>
                       {formatEnumLabel(enrollment.status)}
-                    </td>
-                    <td className='whitespace-nowrap px-4 py-3'>{amountDisplay}</td>
-                    <td className='min-w-0 break-words px-4 py-3'>
+                    </AdminDataTableCell>
+                    <AdminDataTableCell className='whitespace-nowrap'>{amountDisplay}</AdminDataTableCell>
+                    <AdminDataTableCell className='min-w-0 break-words'>
                       {enrollment.discountCodeId
                         ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
                             enrollment.discountCodeId)
                         : '-'}
-                    </td>
-                    <td className='whitespace-nowrap px-4 py-3'>{formatDate(enrollment.enrolledAt)}</td>
-                    <td className='px-4 py-3 text-right'>
+                    </AdminDataTableCell>
+                    <AdminDataTableCell className='whitespace-nowrap'>
+                      {formatDate(enrollment.enrolledAt)}
+                    </AdminDataTableCell>
+                    <AdminDataTableCell className='text-right'>
                       <Button
                         type='button'
                         size='sm'
@@ -644,7 +640,7 @@ export function EnrollmentListPanel({
                       >
                         <DeleteIcon className='h-4 w-4' />
                       </Button>
-                    </td>
+                    </AdminDataTableCell>
                   </tr>
                 );
               })}

--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -6,7 +6,9 @@ import { useMemo } from 'react';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { Button } from '@/components/ui/button';
@@ -205,30 +207,30 @@ export function InstanceListPanel({
             <AdminDataTableHead>
               <tr>
                 {showServiceColumn ? (
-                  <th className='w-[22%] min-w-0 px-4 py-3 font-semibold'>Title</th>
+                  <AdminDataTableHeadCell className='w-[22%] min-w-0'>Title</AdminDataTableHeadCell>
                 ) : null}
                 {showServiceColumn ? (
-                  <th className='w-[17%] min-w-0 px-4 py-3 font-semibold'>
+                  <AdminDataTableHeadCell className='w-[17%] min-w-0'>
                     {INSTANCE_TABLE_TIER_COHORT_HEADER}
-                  </th>
+                  </AdminDataTableHeadCell>
                 ) : null}
                 {showServiceColumn ? (
-                  <th className='w-[17%] min-w-0 px-4 py-3 font-semibold'>Locations</th>
+                  <AdminDataTableHeadCell className='w-[17%] min-w-0'>Locations</AdminDataTableHeadCell>
                 ) : null}
                 {showServiceColumn ? (
-                  <th className='w-[13%] whitespace-nowrap px-4 py-3 align-middle font-semibold'>
+                  <AdminDataTableHeadCell className='w-[13%] whitespace-nowrap align-middle'>
                     First slot
-                  </th>
+                  </AdminDataTableHeadCell>
                 ) : null}
-                <th
+                <AdminDataTableHeadCell
                   className={
                     showServiceColumn
-                      ? 'w-[18%] whitespace-nowrap px-4 py-3 font-semibold'
-                      : 'min-w-0 whitespace-nowrap px-4 py-3 font-semibold'
+                      ? 'w-[18%] whitespace-nowrap'
+                      : 'min-w-0 whitespace-nowrap'
                   }
                 >
                   Capacity
-                </th>
+                </AdminDataTableHeadCell>
                 <AdminDataTableOperationsHeadCell className='w-[7rem] whitespace-nowrap' />
               </tr>
             </AdminDataTableHead>
@@ -250,33 +252,33 @@ export function InstanceListPanel({
                     aria-selected={selectedInstanceId === instance.id}
                   >
                     {showServiceColumn ? (
-                      <td className='min-w-0 break-words px-4 py-3'>
+                      <AdminDataTableCell className='min-w-0 break-words'>
                         <span className='inline-flex flex-wrap items-center gap-2'>
                           <span>
                             {instanceTableTitle.trim() !== '' ? instanceTableTitle : '\u00a0'}
                           </span>
                         </span>
-                      </td>
+                      </AdminDataTableCell>
                     ) : null}
                     {showServiceColumn ? (
-                      <td className='min-w-0 break-words px-4 py-3 text-sm'>
+                      <AdminDataTableCell className='min-w-0 break-words text-sm'>
                         {tierCohortDisplay !== '' ? tierCohortDisplay : '-'}
-                      </td>
+                      </AdminDataTableCell>
                     ) : null}
                     {showServiceColumn ? (
-                      <td className='min-w-0 break-words px-4 py-3 text-sm'>
+                      <AdminDataTableCell className='min-w-0 break-words text-sm'>
                         {formatInstanceSlotLocationSummary(instance, locationById)}
-                      </td>
+                      </AdminDataTableCell>
                     ) : null}
                     {showServiceColumn ? (
-                      <td className='whitespace-nowrap px-4 py-3 align-middle text-sm'>
+                      <AdminDataTableCell className='whitespace-nowrap align-middle text-sm'>
                         {firstSlot ? formatSessionSlotStartsAtDisplay(firstSlot.startsAt) : '-'}
-                      </td>
+                      </AdminDataTableCell>
                     ) : null}
-                    <td className='whitespace-nowrap px-4 py-3'>
+                    <AdminDataTableCell className='whitespace-nowrap'>
                       {formatInstanceTableCapacity(instance)}
-                    </td>
-                    <td className='whitespace-nowrap px-4 py-3 text-right'>
+                    </AdminDataTableCell>
+                    <AdminDataTableCell className='whitespace-nowrap text-right'>
                       <div className='flex justify-end gap-2'>
                         <CopyFeedbackIconButton
                           copied={duplicateDraftFeedbackId === instance.id}
@@ -301,7 +303,7 @@ export function InstanceListPanel({
                           <DeleteIcon className='h-4 w-4' />
                         </Button>
                       </div>
-                    </td>
+                    </AdminDataTableCell>
                   </tr>
                 );
               })}

--- a/apps/admin_web/src/components/admin/services/partners-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/partners-panel.tsx
@@ -16,7 +16,9 @@ import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-secti
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -466,9 +468,9 @@ export function PartnersPanel({
         <AdminDataTable tableClassName='min-w-[800px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Name</th>
-              <th className='px-4 py-3 font-semibold'>Type</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
+              <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Type</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -481,10 +483,10 @@ export function PartnersPanel({
                 }`}
                 onClick={() => selectRow(row.id)}
               >
-                <td className='px-4 py-3'>{row.name}</td>
-                <td className='px-4 py-3'>{formatEnumLabel(row.organization_type)}</td>
-                <td className='px-4 py-3'>{row.active ? 'Active' : 'Archived'}</td>
-                <td className='px-4 py-3 text-right'>
+                <AdminDataTableCell>{row.name}</AdminDataTableCell>
+                <AdminDataTableCell>{formatEnumLabel(row.organization_type)}</AdminDataTableCell>
+                <AdminDataTableCell>{row.active ? 'Active' : 'Archived'}</AdminDataTableCell>
+                <AdminDataTableCell className='text-right'>
                   <div className='flex flex-wrap justify-end gap-2'>
                     <Button
                       type='button'
@@ -501,7 +503,7 @@ export function PartnersPanel({
                       <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                     </Button>
                   </div>
-                </td>
+                </AdminDataTableCell>
               </tr>
             ))}
           </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/services/service-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/service-list-panel.tsx
@@ -5,7 +5,9 @@ import type { KeyboardEvent, MouseEvent } from 'react';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { Input } from '@/components/ui/input';
@@ -154,12 +156,12 @@ export function ServiceListPanel({
         <AdminDataTable tableClassName='min-w-[800px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Title</th>
-              <th className='px-4 py-3 font-semibold'>Tier</th>
-              <th className='px-4 py-3 font-semibold'>Type</th>
-              <th className='px-4 py-3 font-semibold'>Price</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
-              <th className='px-4 py-3 font-semibold'>Delivery</th>
+              <AdminDataTableHeadCell>Title</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Tier</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Type</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Price</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Delivery</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -176,13 +178,13 @@ export function ServiceListPanel({
                 role='row'
                 aria-selected={selectedServiceId === service.id}
               >
-                <td className='px-4 py-3'>{service.title}</td>
-                <td className='px-4 py-3'>{service.serviceTier?.trim() ? service.serviceTier : '—'}</td>
-                <td className='px-4 py-3'>{formatEnumLabel(service.serviceType)}</td>
-                <td className='px-4 py-3'>{formatServiceListPriceLabel(service)}</td>
-                <td className='px-4 py-3'>{formatEnumLabel(service.status)}</td>
-                <td className='px-4 py-3'>{formatEnumLabel(service.deliveryMode)}</td>
-                <td className='px-4 py-3 text-right'>
+                <AdminDataTableCell>{service.title}</AdminDataTableCell>
+                <AdminDataTableCell>{service.serviceTier?.trim() ? service.serviceTier : '—'}</AdminDataTableCell>
+                <AdminDataTableCell>{formatEnumLabel(service.serviceType)}</AdminDataTableCell>
+                <AdminDataTableCell>{formatServiceListPriceLabel(service)}</AdminDataTableCell>
+                <AdminDataTableCell>{formatEnumLabel(service.status)}</AdminDataTableCell>
+                <AdminDataTableCell>{formatEnumLabel(service.deliveryMode)}</AdminDataTableCell>
+                <AdminDataTableCell className='text-right'>
                   <div className='flex justify-end gap-2'>
                     <CopyFeedbackIconButton
                       copied={duplicateDraftFeedbackId === service.id}
@@ -215,7 +217,7 @@ export function ServiceListPanel({
                       <DeleteIcon className='h-4 w-4' />
                     </Button>
                   </div>
-                </td>
+                </AdminDataTableCell>
               </tr>
             ))}
           </AdminDataTableBody>

--- a/apps/admin_web/src/components/admin/services/venues-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/venues-panel.tsx
@@ -6,7 +6,9 @@ import { Button } from '@/components/ui/button';
 import {
   AdminDataTable,
   AdminDataTableBody,
+  AdminDataTableCell,
   AdminDataTableHead,
+  AdminDataTableHeadCell,
   AdminDataTableOperationsHeadCell,
 } from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
@@ -398,9 +400,9 @@ export function VenuesPanel({
         <AdminDataTable tableClassName='min-w-[520px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Name</th>
-              <th className='px-4 py-3 font-semibold'>Address</th>
-              <th className='px-4 py-3 font-semibold'>Area</th>
+              <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Address</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Area</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -415,10 +417,10 @@ export function VenuesPanel({
                   }`}
                   onClick={() => applyVenueSelection(row)}
                 >
-                  <td className='px-4 py-3'>{row.name?.trim() || '—'}</td>
-                  <td className='px-4 py-3'>{row.address?.trim() || '—'}</td>
-                  <td className='px-4 py-3'>{area?.name ?? row.areaId}</td>
-                  <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
+                  <AdminDataTableCell>{row.name?.trim() || '—'}</AdminDataTableCell>
+                  <AdminDataTableCell>{row.address?.trim() || '—'}</AdminDataTableCell>
+                  <AdminDataTableCell>{area?.name ?? row.areaId}</AdminDataTableCell>
+                  <AdminDataTableCell className='text-right' onClick={(event) => event.stopPropagation()}>
                     <Button
                       type='button'
                       size='sm'
@@ -430,7 +432,7 @@ export function VenuesPanel({
                     >
                       <DeleteIcon className='h-4 w-4' />
                     </Button>
-                  </td>
+                  </AdminDataTableCell>
                 </tr>
               );
             })}

--- a/apps/admin_web/src/components/admin/tags/tags-page.tsx
+++ b/apps/admin_web/src/components/admin/tags/tags-page.tsx
@@ -5,7 +5,14 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ArchiveIcon, DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
-import { AdminDataTable, AdminDataTableBody, AdminDataTableHead, AdminDataTableOperationsHeadCell } from '@/components/ui/admin-data-table';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableCell,
+  AdminDataTableHead,
+  AdminDataTableHeadCell,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
 import { AdminEditorCard } from '@/components/ui/admin-editor-card';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
@@ -347,10 +354,10 @@ export function TagsPage() {
         <AdminDataTable tableClassName='min-w-[720px]'>
           <AdminDataTableHead>
             <tr>
-              <th className='px-4 py-3 font-semibold'>Name</th>
-              <th className='px-4 py-3 font-semibold'>Color</th>
-              <th className='px-4 py-3 font-semibold'>Uses</th>
-              <th className='px-4 py-3 font-semibold'>Status</th>
+              <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Color</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Uses</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -370,18 +377,18 @@ export function TagsPage() {
                   }
                 }}
               >
-                <td className='px-4 py-3 font-medium text-slate-900'>
+                <AdminDataTableCell className='font-medium text-slate-900'>
                   {row.name}
                   {row.is_system ? (
                     <span className='ml-2 text-xs font-normal text-slate-500'>(system)</span>
                   ) : null}
-                </td>
-                <td className='px-4 py-3 font-mono text-sm text-slate-700'>{row.color ?? '—'}</td>
-                <td className='px-4 py-3'>{row.usage_count}</td>
-                <td className='px-4 py-3 text-sm text-slate-700'>
+                </AdminDataTableCell>
+                <AdminDataTableCell className='font-mono text-sm text-slate-700'>{row.color ?? '—'}</AdminDataTableCell>
+                <AdminDataTableCell>{row.usage_count}</AdminDataTableCell>
+                <AdminDataTableCell className='text-sm text-slate-700'>
                   {row.archived_at ? 'Archived' : 'Active'}
-                </td>
-                <td className='px-4 py-3 text-right' onClick={(event) => event.stopPropagation()}>
+                </AdminDataTableCell>
+                <AdminDataTableCell className='text-right' onClick={(event) => event.stopPropagation()}>
                   <div className='flex justify-end gap-1'>
                     {row.archived_at && !row.is_system ? (
                       <Button
@@ -438,7 +445,7 @@ export function TagsPage() {
                       <DeleteIcon className='h-4 w-4 shrink-0' aria-hidden />
                     </Button>
                   </div>
-                </td>
+                </AdminDataTableCell>
               </tr>
             ))}
           </AdminDataTableBody>

--- a/apps/admin_web/src/components/ui/admin-data-table.tsx
+++ b/apps/admin_web/src/components/ui/admin-data-table.tsx
@@ -1,9 +1,16 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+
+/**
+ * Admin listing tables use a single cell padding and header weight everywhere.
+ * Prefer `AdminDataTableHeadCell` / `AdminDataTableCell` over ad-hoc `px-*` / `py-*` on `th`/`td`.
+ */
+const adminDataTableHeadCellBase = 'px-4 py-3 text-left font-semibold';
+const adminDataTableBodyCellBase = 'px-4 py-3';
 
 export interface AdminDataTableProps {
   children: ReactNode;
@@ -24,14 +31,16 @@ export function AdminDataTable({ children, tableClassName }: AdminDataTableProps
 export interface AdminDataTableHeadProps {
   children: ReactNode;
   sticky?: boolean;
+  className?: string;
 }
 
-export function AdminDataTableHead({ children, sticky }: AdminDataTableHeadProps) {
+export function AdminDataTableHead({ children, sticky, className }: AdminDataTableHeadProps) {
   return (
     <thead
       className={clsx(
         'bg-slate-100 text-xs uppercase tracking-[0.08em] text-slate-700',
-        sticky && 'sticky top-0 z-10'
+        sticky && 'sticky top-0 z-10',
+        className
       )}
     >
       {children}
@@ -41,6 +50,30 @@ export function AdminDataTableHead({ children, sticky }: AdminDataTableHeadProps
 
 export function AdminDataTableBody({ children }: { children: ReactNode }) {
   return <tbody className='divide-y divide-slate-200 bg-white text-sm'>{children}</tbody>;
+}
+
+export type AdminDataTableHeadCellProps = Omit<ComponentPropsWithoutRef<'th'>, 'className'> & {
+  className?: string;
+};
+
+export function AdminDataTableHeadCell({ children, className, ...rest }: AdminDataTableHeadCellProps) {
+  return (
+    <th {...rest} className={twMerge(adminDataTableHeadCellBase, className)}>
+      {children}
+    </th>
+  );
+}
+
+export type AdminDataTableCellProps = Omit<ComponentPropsWithoutRef<'td'>, 'className'> & {
+  className?: string;
+};
+
+export function AdminDataTableCell({ children, className, ...rest }: AdminDataTableCellProps) {
+  return (
+    <td {...rest} className={twMerge(adminDataTableBodyCellBase, className)}>
+      {children}
+    </td>
+  );
 }
 
 export interface AdminDataTableOperationsHeadCellProps {
@@ -56,7 +89,7 @@ export function AdminDataTableOperationsHeadCell({
   scope = 'col',
 }: AdminDataTableOperationsHeadCellProps) {
   return (
-    <th scope={scope} className={twMerge('px-4 py-3 text-right font-semibold', className)}>
+    <th scope={scope} className={twMerge(adminDataTableHeadCellBase, 'text-right', className)}>
       {children}
     </th>
   );

--- a/apps/admin_web/tests/components/ui/admin-data-table-cells.test.tsx
+++ b/apps/admin_web/tests/components/ui/admin-data-table-cells.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  AdminDataTableCell,
+  AdminDataTableHeadCell,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
+
+describe('AdminDataTableHeadCell', () => {
+  it('applies standard padding and font-semibold', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <AdminDataTableHeadCell>Label</AdminDataTableHeadCell>
+          </tr>
+        </thead>
+      </table>
+    );
+    const cell = screen.getByRole('columnheader', { name: 'Label' });
+    expect(cell.className).toContain('px-4');
+    expect(cell.className).toContain('py-3');
+    expect(cell.className).toContain('font-semibold');
+  });
+
+  it('merges text-right over default text-left', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <AdminDataTableHeadCell className='text-right'>Amount</AdminDataTableHeadCell>
+          </tr>
+        </thead>
+      </table>
+    );
+    const cell = screen.getByRole('columnheader', { name: 'Amount' });
+    expect(cell.className).toContain('text-right');
+    expect(cell.className).not.toContain('text-left');
+  });
+});
+
+describe('AdminDataTableCell', () => {
+  it('applies standard padding', () => {
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <AdminDataTableCell>Value</AdminDataTableCell>
+          </tr>
+        </tbody>
+      </table>
+    );
+    const cell = screen.getByRole('cell', { name: 'Value' });
+    expect(cell.className).toContain('px-4');
+    expect(cell.className).toContain('py-3');
+  });
+});
+
+describe('AdminDataTableOperationsHeadCell', () => {
+  it('keeps font-semibold when className does not override weight', () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <AdminDataTableOperationsHeadCell className='w-[7rem] whitespace-nowrap' />
+          </tr>
+        </thead>
+      </table>
+    );
+    const cell = screen.getByRole('columnheader', { name: 'Operations' });
+    expect(cell.className).toContain('font-semibold');
+    expect(cell.className).toContain('text-right');
+    expect(cell.className).toContain('px-4');
+    expect(cell.className).toContain('py-3');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces `AdminDataTableHeadCell` and `AdminDataTableCell` as the single source of truth for admin listing table padding (`px-4 py-3`) and header typography (`font-semibold`). `AdminDataTableOperationsHeadCell` composes the same header base with `text-right`.

`AdminDataTableHead` accepts an optional `className` for rare layout tweaks (e.g. sticky stacking).

## Migration

All screens that use `AdminDataTable` now render header/body cells through these primitives, including:

- Finance (client invoices enrollment picker + invoice/payment tables, customized draft lines, expenses, tax fiscal year, vendors)
- Services (venues, services, partners, instances, enrollments, discount codes)
- Contacts (contacts, organisations, families — main and nested member tables)
- Tags, calendar manual blocks, assets, audit logs
- Sales (leads table + row, assignee leaderboard aligned to the same bordered table shell)

## Testing

- `cd apps/admin_web && npx vitest run tests/components/ui/admin-data-table-cells.test.tsx tests/components/ui/admin-data-table-operations-head-cell.test.tsx`
- `cd apps/admin_web && npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30cb67b0-35bd-48ad-8635-5b234a99d07f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30cb67b0-35bd-48ad-8635-5b234a99d07f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

