### PR TITLE
Admin: simplify enrollments table layout (remove Scheduled start)

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -535,12 +535,12 @@ export function EnrollmentListPanel({
         <AdminDataTable tableClassName='w-full table-fixed'>
           <AdminDataTableHead>
             <tr>
-              <AdminDataTableHeadCell className='w-[28%] min-w-0'>Party</AdminDataTableHeadCell>
-              <AdminDataTableHeadCell className='w-[10%] min-w-0'>Status</AdminDataTableHeadCell>
-              <AdminDataTableHeadCell className='w-[11%] whitespace-nowrap'>Amount</AdminDataTableHeadCell>
-              <AdminDataTableHeadCell className='w-[20%] min-w-0'>Discount</AdminDataTableHeadCell>
-              <AdminDataTableHeadCell className='w-[14%] whitespace-nowrap'>Enrolled at</AdminDataTableHeadCell>
-              <AdminDataTableOperationsHeadCell className='w-[4.5rem] whitespace-nowrap' />
+              <AdminDataTableHeadCell>Party</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Amount</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Discount</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Enrolled at</AdminDataTableHeadCell>
+              <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
           <AdminDataTableBody>
@@ -561,23 +561,17 @@ export function EnrollmentListPanel({
                   }`}
                   onClick={() => applyEnrollmentSelection(enrollment)}
                 >
-                  <AdminDataTableCell className='min-w-0 break-words'>
-                    {formatEnrollmentParentCell(enrollment)}
-                  </AdminDataTableCell>
-                  <AdminDataTableCell className='min-w-0 break-words'>
-                    {formatEnumLabel(enrollment.status)}
-                  </AdminDataTableCell>
-                  <AdminDataTableCell className='whitespace-nowrap'>{amountDisplay}</AdminDataTableCell>
-                  <AdminDataTableCell className='min-w-0 break-words'>
+                  <AdminDataTableCell>{formatEnrollmentParentCell(enrollment)}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatEnumLabel(enrollment.status)}</AdminDataTableCell>
+                  <AdminDataTableCell>{amountDisplay}</AdminDataTableCell>
+                  <AdminDataTableCell>
                     {enrollment.discountCodeId
                       ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
                           enrollment.discountCodeId)
                       : '-'}
                   </AdminDataTableCell>
-                  <AdminDataTableCell className='whitespace-nowrap'>
-                    {formatDate(enrollment.enrolledAt)}
-                  </AdminDataTableCell>
-                  <AdminDataTableCell className='text-right'>
+                  <AdminDataTableCell>{formatDate(enrollment.enrolledAt)}</AdminDataTableCell>
+                  <AdminDataTableCell>
                     <Button
                       type='button'
                       size='sm'

--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -183,11 +183,6 @@ export function EnrollmentListPanel({
     [discountOptions, selectedEnrollment?.discountCodeId]
   );
 
-  const showScheduledStartColumn = useMemo(
-    () => enrollments.some((row) => Boolean(row.scheduledStartAt?.trim())),
-    [enrollments]
-  );
-
   const formatEnrollmentParentCell = useCallback(
     (enrollment: Enrollment) => {
       const fromApi = enrollment.partyDisplayName?.trim();
@@ -537,116 +532,72 @@ export function EnrollmentListPanel({
         loadingLabel='Loading enrollments...'
         onLoadMore={onLoadMore}
       >
-        <div className='min-w-0'>
-          <AdminDataTable tableClassName='w-full table-fixed'>
-            <AdminDataTableHead>
-              <tr>
-                <AdminDataTableHeadCell
-                  className={
-                    showScheduledStartColumn ? 'w-[22%] min-w-0' : 'w-[28%] min-w-0'
-                  }
+        <AdminDataTable tableClassName='w-full table-fixed'>
+          <AdminDataTableHead>
+            <tr>
+              <AdminDataTableHeadCell className='w-[28%] min-w-0'>Party</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell className='w-[10%] min-w-0'>Status</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell className='w-[11%] whitespace-nowrap'>Amount</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell className='w-[20%] min-w-0'>Discount</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell className='w-[14%] whitespace-nowrap'>Enrolled at</AdminDataTableHeadCell>
+              <AdminDataTableOperationsHeadCell className='w-[4.5rem] whitespace-nowrap' />
+            </tr>
+          </AdminDataTableHead>
+          <AdminDataTableBody>
+            {enrollments.map((enrollment) => {
+              const amountRaw = enrollment.amountPaid?.trim() ?? '';
+              const parsedAmount = Number.parseFloat(amountRaw);
+              const currencyCode =
+                (enrollment.currency ?? defaultCurrencyCode).trim().toUpperCase() || defaultCurrencyCode;
+              const amountDisplay =
+                amountRaw !== '' && Number.isFinite(parsedAmount)
+                  ? formatAmountInCurrency(parsedAmount, currencyCode)
+                  : '—';
+              return (
+                <tr
+                  key={enrollment.id}
+                  className={`cursor-pointer transition ${
+                    selectedEnrollmentId === enrollment.id ? 'bg-slate-100' : 'hover:bg-slate-50'
+                  }`}
+                  onClick={() => applyEnrollmentSelection(enrollment)}
                 >
-                  Party
-                </AdminDataTableHeadCell>
-                {showScheduledStartColumn ? (
-                  <AdminDataTableHeadCell className='w-[10%] whitespace-nowrap'>
-                    Scheduled start
-                  </AdminDataTableHeadCell>
-                ) : null}
-                <AdminDataTableHeadCell
-                  className={
-                    showScheduledStartColumn ? 'w-[9%] min-w-0' : 'w-[10%] min-w-0'
-                  }
-                >
-                  Status
-                </AdminDataTableHeadCell>
-                <AdminDataTableHeadCell
-                  className={
-                    showScheduledStartColumn ? 'w-[10%] whitespace-nowrap' : 'w-[11%] whitespace-nowrap'
-                  }
-                >
-                  Amount
-                </AdminDataTableHeadCell>
-                <AdminDataTableHeadCell
-                  className={
-                    showScheduledStartColumn ? 'w-[17%] min-w-0' : 'w-[20%] min-w-0'
-                  }
-                >
-                  Discount
-                </AdminDataTableHeadCell>
-                <AdminDataTableHeadCell
-                  className={
-                    showScheduledStartColumn ? 'w-[12%] whitespace-nowrap' : 'w-[14%] whitespace-nowrap'
-                  }
-                >
-                  Enrolled at
-                </AdminDataTableHeadCell>
-                <AdminDataTableOperationsHeadCell className='w-[4.5rem] whitespace-nowrap' />
-              </tr>
-            </AdminDataTableHead>
-            <AdminDataTableBody>
-              {enrollments.map((enrollment) => {
-                const amountRaw = enrollment.amountPaid?.trim() ?? '';
-                const parsedAmount = Number.parseFloat(amountRaw);
-                const currencyCode =
-                  (enrollment.currency ?? defaultCurrencyCode).trim().toUpperCase() || defaultCurrencyCode;
-                const amountDisplay =
-                  amountRaw !== '' && Number.isFinite(parsedAmount)
-                    ? formatAmountInCurrency(parsedAmount, currencyCode)
-                    : '—';
-                return (
-                  <tr
-                    key={enrollment.id}
-                    className={`cursor-pointer transition ${
-                      selectedEnrollmentId === enrollment.id ? 'bg-slate-100' : 'hover:bg-slate-50'
-                    }`}
-                    onClick={() => applyEnrollmentSelection(enrollment)}
-                  >
-                    <AdminDataTableCell className='min-w-0 break-words'>
-                      {formatEnrollmentParentCell(enrollment)}
-                    </AdminDataTableCell>
-                    {showScheduledStartColumn ? (
-                      <AdminDataTableCell className='whitespace-nowrap'>
-                        {enrollment.scheduledStartAt?.trim()
-                          ? formatDate(enrollment.scheduledStartAt)
-                          : '—'}
-                      </AdminDataTableCell>
-                    ) : null}
-                    <AdminDataTableCell className='min-w-0 break-words'>
-                      {formatEnumLabel(enrollment.status)}
-                    </AdminDataTableCell>
-                    <AdminDataTableCell className='whitespace-nowrap'>{amountDisplay}</AdminDataTableCell>
-                    <AdminDataTableCell className='min-w-0 break-words'>
-                      {enrollment.discountCodeId
-                        ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
-                            enrollment.discountCodeId)
-                        : '-'}
-                    </AdminDataTableCell>
-                    <AdminDataTableCell className='whitespace-nowrap'>
-                      {formatDate(enrollment.enrolledAt)}
-                    </AdminDataTableCell>
-                    <AdminDataTableCell className='text-right'>
-                      <Button
-                        type='button'
-                        size='sm'
-                        variant='danger'
-                        disabled={isMutating}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          void handleDeleteEnrollment(enrollment);
-                        }}
-                        aria-label='Delete enrollment'
-                        title='Delete enrollment'
-                      >
-                        <DeleteIcon className='h-4 w-4' />
-                      </Button>
-                    </AdminDataTableCell>
-                  </tr>
-                );
-              })}
-            </AdminDataTableBody>
-          </AdminDataTable>
-        </div>
+                  <AdminDataTableCell className='min-w-0 break-words'>
+                    {formatEnrollmentParentCell(enrollment)}
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='min-w-0 break-words'>
+                    {formatEnumLabel(enrollment.status)}
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='whitespace-nowrap'>{amountDisplay}</AdminDataTableCell>
+                  <AdminDataTableCell className='min-w-0 break-words'>
+                    {enrollment.discountCodeId
+                      ? (discountOptions.find((c) => c.id === enrollment.discountCodeId)?.code ??
+                          enrollment.discountCodeId)
+                      : '-'}
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='whitespace-nowrap'>
+                    {formatDate(enrollment.enrolledAt)}
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='text-right'>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='danger'
+                      disabled={isMutating}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void handleDeleteEnrollment(enrollment);
+                      }}
+                      aria-label='Delete enrollment'
+                      title='Delete enrollment'
+                    >
+                      <DeleteIcon className='h-4 w-4' />
+                    </Button>
+                  </AdminDataTableCell>
+                </tr>
+              );
+            })}
+          </AdminDataTableBody>
+        </AdminDataTable>
       </PaginatedTableCard>
       <ConfirmDialog {...confirmDialogProps} />
     </>

--- a/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/enrollment-list-panel.test.tsx
@@ -172,33 +172,6 @@ describe('EnrollmentListPanel', () => {
     );
   });
 
-  it('shows scheduled start column when enrollment rows include scheduled start', () => {
-    const enrollmentWithScheduledStart: Enrollment = {
-      ...ENROLLMENT_FIXTURE,
-      scheduledStartAt: '2026-06-15T01:00:00Z',
-    };
-    render(
-      <EnrollmentListPanel
-        enrollments={[enrollmentWithScheduledStart]}
-        serviceId='service-1'
-        instanceId='instance-1'
-        canCreate={true}
-        isLoading={false}
-        isLoadingMore={false}
-        hasMore={false}
-        error=''
-        isMutating={false}
-        onLoadMore={vi.fn()}
-        onCreate={vi.fn()}
-        onUpdate={vi.fn()}
-        onDelete={vi.fn()}
-      />
-    );
-
-    expect(screen.getByRole('columnheader', { name: 'Scheduled start' })).toBeInTheDocument();
-    expect(screen.queryByRole('columnheader', { name: 'Booking slug' })).not.toBeInTheDocument();
-  });
-
   it('uses selectable currency options in the enrollment editor', () => {
     render(
       <EnrollmentListPanel


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Scheduled start** column from the Services → Enrollments table and drops the conditional header/cell width logic.

Also removes the `min-w-0` wrapper around the enrollments table.

Per-cell and per-header custom Tailwind classes are removed so the table uses only the shared `AdminDataTable*` defaults (operations header remains right-aligned via `AdminDataTableOperationsHeadCell`). `AdminDataTable` still uses `tableClassName='w-full table-fixed'`.

## Validation

- `npx vitest run tests/components/admin/services/enrollment-list-panel.test.tsx`
- `npm run lint` in `apps/admin_web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a4e1195-356f-4f22-a04b-684c5ab923a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a4e1195-356f-4f22-a04b-684c5ab923a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

