### PR TITLE
Standardize admin CRM party labels (contact · email, entity · primary)

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
@@ -8,6 +8,7 @@ import { OrganizationsPanel } from '@/components/admin/contacts/organizations-pa
 import { AdminPageErrorBanner } from '@/components/admin/admin-page-error-banner';
 import { AdminTabStrip } from '@/components/ui/admin-tab-strip';
 import { listEntityTags, type EntityTagRef } from '@/lib/entity-api';
+import { formatAdminContactPickerLabel } from '@/lib/format';
 import { listAllLocations, listGeographicAreas } from '@/lib/services-api';
 import { toErrorMessage } from '@/hooks/hook-errors';
 import { useAdminEntityContacts } from '@/hooks/use-admin-entity-contacts';
@@ -91,11 +92,10 @@ export function ContactsPage() {
   }, []);
 
   const contactOptions = useMemo(() => {
-    return contacts.contacts.map((c) => {
-      const name = [c.first_name, c.last_name].filter(Boolean).join(' ').trim();
-      const label = name ? `${name}${c.email ? ` · ${c.email}` : ''}` : c.email || c.id;
-      return { id: c.id, label };
-    });
+    return contacts.contacts.map((c) => ({
+      id: c.id,
+      label: formatAdminContactPickerLabel(c),
+    }));
   }, [contacts.contacts]);
 
   const contactsForMembership = useMemo(

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -38,7 +38,11 @@ import {
   searchEntityContactsForPicker,
   type EntityTagRef,
 } from '@/lib/entity-api';
-import { formatEntityVenueLocationLabel, formatEnumLabel } from '@/lib/format';
+import {
+  formatAdminContactPickerLabel,
+  formatEntityVenueLocationLabel,
+  formatEnumLabel,
+} from '@/lib/format';
 import { contactPhoneRequestFields } from '@/lib/phone-request';
 import type { EntityListFilters } from '@/types/entity-list';
 import {
@@ -63,11 +67,6 @@ const CONTACT_TYPES: ApiSchemas['EntityContactType'][] = [
   'professional',
   'other',
 ];
-
-function formatContactPickerLabel(c: ApiSchemas['AdminContact']): string {
-  const name = [c.first_name, c.last_name].filter(Boolean).join(' ').trim();
-  return name ? `${name}${c.email ? ` · ${c.email}` : ''}` : c.email || c.id;
-}
 
 const SOURCES: ApiSchemas['EntityContactSource'][] = [
   'free_guide',
@@ -372,7 +371,7 @@ export function ContactsPanel({
         if (cancelled || !c) {
           return;
         }
-        setReferralPinnedLabel(formatContactPickerLabel(c));
+        setReferralPinnedLabel(formatAdminContactPickerLabel(c));
       } catch {
         if (!cancelled) {
           setReferralPinnedLabel('');

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -29,7 +29,7 @@ import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import type { EntityTagRef } from '@/lib/entity-api';
 import { contactEligibleForEntityMembership } from '@/lib/entity-contact-eligibility';
-import { formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel, formatFamilyOrOrganizationPartyLabel } from '@/lib/format';
 import type { EntityListFilters } from '@/types/entity-list';
 import {
   FAMILY_RELATIONSHIP_TYPES,
@@ -572,13 +572,7 @@ export function FamiliesPanel({
                 onClick={() => selectRow(row.id)}
               >
                 <AdminDataTableCell>
-                  {row.family_name}
-                  {primaryLabel ? (
-                    <>
-                      <span aria-hidden> · </span>
-                      {primaryLabel}
-                    </>
-                  ) : null}
+                  {formatFamilyOrOrganizationPartyLabel(row.family_name, primaryLabel) || '—'}
                 </AdminDataTableCell>
                 <AdminDataTableCell>{row.members.length}</AdminDataTableCell>
                 <AdminDataTableCell>{row.active ? 'Active' : 'Archived'}</AdminDataTableCell>

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -29,7 +29,7 @@ import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { contactEligibleForEntityMembership } from '@/lib/entity-contact-eligibility';
 import type { EntityTagRef } from '@/lib/entity-api';
-import { formatEnumLabel } from '@/lib/format';
+import { formatEnumLabel, formatFamilyOrOrganizationPartyLabel } from '@/lib/format';
 import type { EntityListFilters } from '@/types/entity-list';
 import {
   ORGANIZATION_RELATIONSHIP_TYPES,
@@ -626,13 +626,7 @@ export function OrganizationsPanel({
                 onClick={() => selectRow(row.id)}
               >
                 <AdminDataTableCell>
-                  {row.name}
-                  {primaryLabel ? (
-                    <>
-                      <span aria-hidden> · </span>
-                      {primaryLabel}
-                    </>
-                  ) : null}
+                  {formatFamilyOrOrganizationPartyLabel(row.name, primaryLabel) || '—'}
                 </AdminDataTableCell>
                 <AdminDataTableCell>{formatEnumLabel(row.organization_type)}</AdminDataTableCell>
                 <AdminDataTableCell>{row.members.length}</AdminDataTableCell>

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -129,6 +129,10 @@ function parseAmountInput(raw: string): number | null {
   return Number.isNaN(n) ? null : n;
 }
 
+function defaultLineAmount(row: BillingEnrollmentPickerRow): string {
+  return row.amountPaid != null && row.amountPaid.trim() !== '' ? row.amountPaid.trim() : '0';
+}
+
 function lineAmountsDiffer(input: string, row: BillingEnrollmentPickerRow): boolean {
   const trimmed = input.trim();
   const baseline = defaultLineAmount(row);

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -66,6 +66,7 @@ import {
   getCurrencyOptions,
   ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER,
   INSTANCE_TABLE_TIER_COHORT_HEADER,
+  formatBillingEnrollmentPartyCell,
   formatDate,
   formatEnumLabel,
   formatEnrollmentPickerInstanceServiceDisplay,
@@ -126,27 +127,6 @@ function parseAmountInput(raw: string): number | null {
   }
   const n = Number.parseFloat(t);
   return Number.isNaN(n) ? null : n;
-}
-
-function defaultLineAmount(row: BillingEnrollmentPickerRow): string {
-  return row.amountPaid != null && row.amountPaid.trim() !== '' ? row.amountPaid.trim() : '0';
-}
-
-/** Party column: contact rows use `name · email`. Family/org rows use `partyDisplayName` only (entity · primary). */
-function formatEnrollmentPartyCellDisplay(row: BillingEnrollmentPickerRow): string {
-  const party = row.partyDisplayName?.trim() ?? '';
-  const email = row.partyEmail?.trim() ?? '';
-  const kind = row.billToKind;
-  if (kind === 'family' || kind === 'organization') {
-    return party;
-  }
-  if (email === '') {
-    return party;
-  }
-  if (party === '') {
-    return email;
-  }
-  return `${party} \u00b7 ${email}`;
 }
 
 function lineAmountsDiffer(input: string, row: BillingEnrollmentPickerRow): boolean {
@@ -1227,7 +1207,7 @@ export function ClientInvoicesPanel() {
                         );
                         const instanceServiceDisplay =
                           formatEnrollmentPickerInstanceServiceDisplay(row);
-                        const partyCellDisplay = formatEnrollmentPartyCellDisplay(row);
+                        const partyCellDisplay = formatBillingEnrollmentPartyCell(row);
                         return (
                           <tr
                             key={row.enrollmentId}

--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -28,6 +28,7 @@ import {
   formatIsoForDatetimeLocalInput,
   getCurrencyOptions,
   parseDatetimeLocalToIsoUtc,
+  resolveEnrollmentListPartyLabel,
 } from '@/lib/format';
 import { isAbortRequestError, listEnrollmentDiscountOptions } from '@/lib/services-api';
 import { formatAmountInCurrency } from '@/lib/vendor-spend';
@@ -184,22 +185,13 @@ export function EnrollmentListPanel({
   );
 
   const formatEnrollmentParentCell = useCallback(
-    (enrollment: Enrollment) => {
-      const fromApi = enrollment.partyDisplayName?.trim();
-      if (fromApi) {
-        return fromApi;
-      }
-      if (enrollment.contactId) {
-        return labelByContactId.get(enrollment.contactId) ?? enrollment.contactId;
-      }
-      if (enrollment.familyId) {
-        return labelByFamilyId.get(enrollment.familyId) ?? enrollment.familyId;
-      }
-      if (enrollment.organizationId) {
-        return labelByOrganizationId.get(enrollment.organizationId) ?? enrollment.organizationId;
-      }
-      return '-';
-    },
+    (enrollment: Enrollment) =>
+      resolveEnrollmentListPartyLabel(
+        enrollment,
+        labelByContactId,
+        labelByFamilyId,
+        labelByOrganizationId
+      ),
     [labelByContactId, labelByFamilyId, labelByOrganizationId]
   );
 

--- a/apps/admin_web/src/hooks/use-enrollment-parent-pickers.ts
+++ b/apps/admin_web/src/hooks/use-enrollment-parent-pickers.ts
@@ -9,6 +9,7 @@ import {
   listEntityOrganizationPicker,
   listEntityPartnerOrganizationPicker,
 } from '@/lib/entity-api';
+import { formatAdminContactFullName, formatAdminContactPickerLabel } from '@/lib/format';
 import { DEFAULT_CONTACT_LIST_FILTERS } from '@/types/entity-list';
 
 import type { components } from '@/types/generated/admin-api.generated';
@@ -21,13 +22,8 @@ export interface EnrollmentParentPickerOption {
 }
 
 function formatContactSortKey(contact: AdminContact): string {
-  const name = [contact.first_name, contact.last_name].filter(Boolean).join(' ').trim();
+  const name = formatAdminContactFullName(contact);
   return (name || contact.email || contact.id).toLowerCase();
-}
-
-function formatContactOptionLabel(contact: AdminContact): string {
-  const name = [contact.first_name, contact.last_name].filter(Boolean).join(' ').trim();
-  return name ? `${name}${contact.email ? ` · ${contact.email}` : ''}` : contact.email || contact.id;
 }
 
 export function useEnrollmentParentPickers(canCreate: boolean) {
@@ -118,7 +114,7 @@ export function useEnrollmentParentPickers(canCreate: boolean) {
   }, [canCreate]);
 
   const contactOptions = useMemo<EnrollmentParentPickerOption[]>(
-    () => contacts.map((c) => ({ id: c.id, label: formatContactOptionLabel(c) })),
+    () => contacts.map((c) => ({ id: c.id, label: formatAdminContactPickerLabel(c) })),
     [contacts]
   );
 

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -15,6 +15,112 @@ import adminSelectableCurrency from '@shared-config/admin-selectable-currency-co
 const SERVICE_TITLE_TIER_SEP = '\u00b7';
 const DISPLAY_PART_SEP = ` ${SERVICE_TITLE_TIER_SEP} `;
 
+/**
+ * CRM contact line: `display name · email` when both exist; otherwise name, email, or id fallback.
+ * Matches billing enrollment picker party labels for contact bill-to.
+ */
+export function formatContactNameEmailLabel(
+  displayName: string,
+  email: string | null | undefined,
+  idFallback: string,
+): string {
+  const name = displayName.trim();
+  const em = (email ?? '').trim();
+  if (name) {
+    return em ? `${name}${DISPLAY_PART_SEP}${em}` : name;
+  }
+  if (em) {
+    return em;
+  }
+  return idFallback;
+}
+
+/** Admin CRM contact: first + last name trimmed, or empty string. */
+export function formatAdminContactFullName(contact: {
+  first_name?: string | null;
+  last_name?: string | null;
+}): string {
+  return [contact.first_name, contact.last_name].filter(Boolean).join(' ').trim();
+}
+
+/**
+ * Select options and pickers: `name · email` when name is set; otherwise email or id.
+ */
+export function formatAdminContactPickerLabel(contact: {
+  first_name?: string | null;
+  last_name?: string | null;
+  email?: string | null;
+  id: string;
+}): string {
+  return formatContactNameEmailLabel(formatAdminContactFullName(contact), contact.email, contact.id);
+}
+
+/**
+ * Family or organization party line: `entity · primary contact` when both exist (billing/enrollment convention).
+ */
+export function formatFamilyOrOrganizationPartyLabel(
+  entityName: string | null | undefined,
+  primaryContactName: string | null | undefined,
+): string {
+  const entity = entityName?.trim() ?? '';
+  const primary = primaryContactName?.trim() ?? '';
+  if (entity && primary) {
+    return `${entity}${DISPLAY_PART_SEP}${primary}`;
+  }
+  if (entity) {
+    return entity;
+  }
+  if (primary) {
+    return primary;
+  }
+  return '';
+}
+
+/** Billing draft invoice enrollment picker — Party column (contact uses name · email; family/org use API label). */
+export function formatBillingEnrollmentPartyCell(row: {
+  billToKind: string;
+  partyDisplayName?: string | null;
+  partyEmail?: string | null;
+}): string {
+  const party = row.partyDisplayName?.trim() ?? '';
+  const email = row.partyEmail?.trim() ?? '';
+  if (row.billToKind === 'family' || row.billToKind === 'organization') {
+    return party;
+  }
+  return formatContactNameEmailLabel(party, email, party || email || '');
+}
+
+/** Service enrollment list — Party cell: API label, else picker-derived labels by structural parent id. */
+export function resolveEnrollmentListPartyLabel(
+  enrollment: {
+    partyDisplayName?: string | null;
+    contactId?: string | null;
+    familyId?: string | null;
+    organizationId?: string | null;
+  },
+  labelByContactId: Map<string, string>,
+  labelByFamilyId: Map<string, string>,
+  labelByOrganizationId: Map<string, string>,
+): string {
+  const fromApi = enrollment.partyDisplayName?.trim();
+  if (fromApi) {
+    return fromApi;
+  }
+  const cid = enrollment.contactId?.trim();
+  if (cid) {
+    return labelByContactId.get(cid) ?? cid;
+  }
+  const fid = enrollment.familyId?.trim();
+  if (fid) {
+    return labelByFamilyId.get(fid) ?? fid;
+  }
+  const oid = enrollment.organizationId?.trim();
+  if (oid) {
+    return labelByOrganizationId.get(oid) ?? oid;
+  }
+  return '—';
+}
+
 /** Service list label: title, space, interpunct, space, tier when tier is set. */
 export function formatServiceTitleWithTier(title: string, serviceTier: string | null): string {
   const tier = serviceTier?.trim();

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5676,7 +5676,7 @@ export interface components {
             /** Format: date-time */
             cancelled_at?: string | null;
             notes?: string | null;
-            /** @description Display label for the enrollment party. For contact bill-to this is the contact name. For family or organization this is `entity name · primary contact name` (middle dot) when both the entity and primary contact names are known; otherwise the best available single label. Matches the billing enrollment picker `partyDisplayName` convention. */
+            /** @description Display label for the enrollment party. For contact enrollment this is `contact name · email` (middle dot) when both name and email are known; otherwise the best available single label. For family or organization enrollment this is `entity name · primary contact name` (middle dot) when both the entity and primary contact names are known; otherwise the best available single label. Matches the billing enrollment picker `partyDisplayName` convention. */
             party_display_name?: string;
             created_by?: string;
             /** Format: date-time */
@@ -6182,7 +6182,7 @@ export interface components {
         BillingEnrollmentPickerRow: {
             /** Format: uuid */
             enrollmentId: string;
-            /** @description Display label for the bill-to / enrollment party. For `contact` this is the contact name. For `family` or `organization` this is `entity name · primary contact name` (middle dot) when both the entity and primary contact names are known; otherwise the best available single label. */
+            /** @description Display label for the bill-to / enrollment party. For `contact` the admin UI combines this with `partyEmail` as `name · email` when both are known. For `family` or `organization` this is `entity name · primary contact name` (middle dot) when both the entity and primary contact names are known; otherwise the best available single label. */
             partyDisplayName: string;
             /** Format: email */
             partyEmail?: string | null;
@@ -6442,6 +6442,7 @@ export interface components {
         EntityPickerListItem: {
             /** Format: uuid */
             id: string;
+            /** @description Single-line display label. For CRM contact picker items this matches admin contact pickers (`name · email` when both known). For family and organisation picker items this is `entity name · primary contact name` when both are known; otherwise the best available label. */
             label: string;
         };
         EntityPickerListResponse: {

--- a/apps/admin_web/src/types/services.ts
+++ b/apps/admin_web/src/types/services.ts
@@ -344,7 +344,7 @@ export interface Enrollment {
   createdBy: string;
   createdAt: string | null;
   updatedAt: string | null;
-  /** Server-computed party label (family/org · primary contact when applicable). */
+  /** Server-computed party label (contact `name · email`, family/org `entity · primary` when applicable). */
   partyDisplayName?: string | null;
   /** Present when the admin enrollment list includes instance scheduled-start metadata. */
   scheduledStartAt?: string | null;

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatContactNameEmailLabel,
+  formatAdminContactFullName,
+  formatAdminContactPickerLabel,
+  formatFamilyOrOrganizationPartyLabel,
+  formatBillingEnrollmentPartyCell,
+  resolveEnrollmentListPartyLabel,
   compareInstancesByFirstSlotStartsDesc,
   formatAssetContentLanguageLabel,
   formatDate,
@@ -957,5 +963,98 @@ describe('format helpers', () => {
       },
     ]);
     expect(partial.ok).toBe(false);
+  });
+});
+
+describe('CRM party display labels', () => {
+  it('formats contact name and email with interpunct when both are set', () => {
+    expect(formatContactNameEmailLabel('Sam Sample', 'sam@example.com', 'id-1')).toBe(
+      'Sam Sample · sam@example.com',
+    );
+    expect(formatContactNameEmailLabel('Sam', '', 'id-1')).toBe('Sam');
+    expect(formatContactNameEmailLabel('', 'sam@example.com', 'id-1')).toBe('sam@example.com');
+    expect(formatContactNameEmailLabel('', '', 'id-1')).toBe('id-1');
+  });
+
+  it('formats admin contact pickers', () => {
+    expect(
+      formatAdminContactPickerLabel({
+        first_name: 'Sam',
+        last_name: 'Sample',
+        email: 'sam@example.com',
+        id: 'c-1',
+      }),
+    ).toBe('Sam Sample · sam@example.com');
+    expect(
+      formatAdminContactPickerLabel({
+        first_name: null,
+        last_name: null,
+        email: 'sole@example.com',
+        id: 'c-2',
+      }),
+    ).toBe('sole@example.com');
+  });
+
+  it('joins first and last for formatAdminContactFullName', () => {
+    expect(formatAdminContactFullName({ first_name: 'A', last_name: 'B' })).toBe('A B');
+    expect(formatAdminContactFullName({ first_name: '', last_name: '' })).toBe('');
+  });
+
+  it('formats family or organisation entity · primary lines', () => {
+    expect(formatFamilyOrOrganizationPartyLabel('Smith Family', 'Jane Primary')).toBe(
+      'Smith Family · Jane Primary',
+    );
+    expect(formatFamilyOrOrganizationPartyLabel('Acme', '')).toBe('Acme');
+    expect(formatFamilyOrOrganizationPartyLabel('', 'Pat')).toBe('Pat');
+    expect(formatFamilyOrOrganizationPartyLabel('', '')).toBe('');
+  });
+
+  it('matches billing enrollment picker party column rules', () => {
+    expect(
+      formatBillingEnrollmentPartyCell({
+        billToKind: 'contact',
+        partyDisplayName: 'Sam Sample',
+        partyEmail: 'sam@example.com',
+      }),
+    ).toBe('Sam Sample · sam@example.com');
+    expect(
+      formatBillingEnrollmentPartyCell({
+        billToKind: 'family',
+        partyDisplayName: 'Smith Family · Jane',
+        partyEmail: 'jane@example.com',
+      }),
+    ).toBe('Smith Family · Jane');
+  });
+
+  it('resolves enrollment list party from API or picker maps', () => {
+    const maps = {
+      labelByContactId: new Map([['c1', 'A · a@x.com']]),
+      labelByFamilyId: new Map([['f1', 'Fam · Primary']]),
+      labelByOrganizationId: new Map([['o1', 'Org · Primary']]),
+    };
+    expect(
+      resolveEnrollmentListPartyLabel(
+        { partyDisplayName: 'From API', contactId: 'c1' },
+        maps.labelByContactId,
+        maps.labelByFamilyId,
+        maps.labelByOrganizationId,
+      ),
+    ).toBe('From API');
+    expect(
+      resolveEnrollmentListPartyLabel(
+        { contactId: 'c1' },
+        maps.labelByContactId,
+        maps.labelByFamilyId,
+        maps.labelByOrganizationId,
+      ),
+    ).toBe('A · a@x.com');
+    expect(
+      resolveEnrollmentListPartyLabel(
+        {},
+        maps.labelByContactId,
+        maps.labelByFamilyId,
+        maps.labelByOrganizationId,
+      ),
+    ).toBe('—');
   });
 });

--- a/backend/src/app/api/admin_billing_common.py
+++ b/backend/src/app/api/admin_billing_common.py
@@ -111,14 +111,19 @@ def compose_enrollment_party_display_name(
     family_primary_contact_name: str | None,
     org_primary_contact_name: str | None,
 ) -> str:
-    """Party label: contact name; family/org use ``entity · primary contact`` when both known."""
+    """Party label: contact ``name · email`` when both known; family/org use ``entity · primary contact``."""
     bk = effective_enrollment_bill_to_kind(enrollment)
     enrolled_nm = contact_display_name(enrollment.contact)
     if bk == BillingBillToKind.CONTACT:
         c = enrollment.bill_to_contact or enrollment.contact
-        name = contact_display_name(c)
+        name = (contact_display_name(c) or "").strip()
+        email = (c.email or "").strip() if c else ""
+        if name and email:
+            return f"{name} \u00b7 {email}"
         if name:
             return name
+        if email:
+            return email
         fid = enrollment.bill_to_family_id or enrollment.family_id
         if fid is not None:
             fam = enrollment.bill_to_family or enrollment.family

--- a/backend/src/app/api/admin_families_picker.py
+++ b/backend/src/app/api/admin_families_picker.py
@@ -8,6 +8,10 @@ from collections.abc import Mapping
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.api.admin_billing_common import (
+    family_or_organization_bill_to_display_label,
+    primary_family_contact_names,
+)
 from app.api.admin_entities_helpers import parse_limit
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.engine import get_engine
@@ -58,5 +62,16 @@ def _list_family_picker(event: Mapping[str, Any]) -> dict[str, Any]:
             .limit(limit)
         )
         rows = session.execute(statement).all()
-        items = [{"id": str(r[0]), "label": r[1]} for r in rows]
+        fam_ids = {r[0] for r in rows}
+        primary_by_id = primary_family_contact_names(session, fam_ids)
+        items: list[dict[str, str]] = []
+        for fam_id, family_name in rows:
+            entity = (family_name or "").strip()
+            pc = (primary_by_id.get(fam_id) or "").strip()
+            label = family_or_organization_bill_to_display_label(
+                entity_name=entity or None,
+                primary_display_name=pc or None,
+            )
+            display = label if label else entity or str(fam_id)
+            items.append({"id": str(fam_id), "label": display})
         return json_response(200, {"items": items}, event=event)

--- a/backend/src/app/api/admin_organizations_picker.py
+++ b/backend/src/app/api/admin_organizations_picker.py
@@ -8,6 +8,10 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.api.admin_billing_common import (
+    family_or_organization_bill_to_display_label,
+    primary_org_contact_names,
+)
 from app.api.admin_entities_helpers import parse_limit, parse_relationship_type
 from app.api.admin_request import query_param
 from app.api.assets.assets_common import extract_identity, split_route_parts
@@ -72,5 +76,16 @@ def _list_organization_picker(event: Mapping[str, Any]) -> dict[str, Any]:
             Organization.name.asc(), Organization.id.asc()
         ).limit(limit)
         rows = session.execute(statement).all()
-        items = [{"id": str(r[0]), "label": r[1]} for r in rows]
+        org_ids = {r[0] for r in rows}
+        primary_by_id = primary_org_contact_names(session, org_ids)
+        items: list[dict[str, str]] = []
+        for org_id, org_name in rows:
+            entity = (org_name or "").strip()
+            pc = (primary_by_id.get(org_id) or "").strip()
+            label = family_or_organization_bill_to_display_label(
+                entity_name=entity or None,
+                primary_display_name=pc or None,
+            )
+            display = label if label else entity or str(org_id)
+            items.append({"id": str(org_id), "label": display})
         return json_response(200, {"items": items}, event=event)

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -5261,10 +5261,12 @@ components:
         party_display_name:
           type: string
           description: >
-            Display label for the enrollment party. For contact bill-to this is the contact name.
-            For family or organization this is `entity name · primary contact name` (middle dot) when
-            both the entity and primary contact names are known; otherwise the best available single
-            label. Matches the billing enrollment picker `partyDisplayName` convention.
+            Display label for the enrollment party. For contact enrollment this is
+            `contact name · email` (middle dot) when both name and email are known; otherwise the best
+            available single label. For family or organization enrollment this is
+            `entity name · primary contact name` (middle dot) when both the entity and primary contact
+            names are known; otherwise the best available single label. Matches the billing enrollment
+            picker `partyDisplayName` convention.
         created_by:
           type: string
         created_at:
@@ -6399,10 +6401,10 @@ components:
         partyDisplayName:
           type: string
           description: >
-            Display label for the bill-to / enrollment party. For `contact` this is the contact
-            name. For `family` or `organization` this is `entity name · primary contact name` (middle
-            dot) when both the entity and primary contact names are known; otherwise the best
-            available single label.
+            Display label for the bill-to / enrollment party. For `contact` the admin UI combines
+            this with `partyEmail` as `name · email` when both are known. For `family` or `organization`
+            this is `entity name · primary contact name` (middle dot) when both the entity and primary
+            contact names are known; otherwise the best available single label.
         partyEmail:
           type: string
           format: email
@@ -6992,6 +6994,10 @@ components:
           format: uuid
         label:
           type: string
+          description: >
+            Single-line display label. For CRM contact picker items this matches admin contact pickers
+            (`name · email` when both known). For family and organisation picker items this is
+            `entity name · primary contact name` when both are known; otherwise the best available label.
     EntityPickerListResponse:
       type: object
       required:

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -1997,3 +1997,33 @@ def test_family_or_organization_bill_to_display_label() -> None:
         entity_name="  ",
         primary_display_name="  ",
     ) is None
+
+
+def test_compose_enrollment_party_display_name_contact_includes_email_when_known() -> None:
+    from types import SimpleNamespace
+
+    from app.api.admin_billing_common import compose_enrollment_party_display_name
+    from app.db.models.enums import BillingBillToKind
+
+    contact = SimpleNamespace(first_name="Sam", last_name="Sample", email="sam@example.com")
+    enrollment = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact=None,
+        contact=contact,
+        bill_to_family_id=None,
+        family_id=None,
+        bill_to_organization_id=None,
+        organization_id=None,
+        bill_to_family=None,
+        family=None,
+        bill_to_organization=None,
+        organization=None,
+    )
+    assert (
+        compose_enrollment_party_display_name(
+            enrollment,
+            family_primary_contact_name=None,
+            org_primary_contact_name=None,
+        )
+        == "Sam Sample \u00b7 sam@example.com"
+    )

--- a/tests/test_admin_families_picker.py
+++ b/tests/test_admin_families_picker.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.api import admin_families_picker
+from app.api.assets.assets_common import RequestIdentity
+
+
+def _admin_identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_sub="admin-sub",
+        groups={"admin"},
+        organization_ids=set(),
+    )
+
+
+@pytest.fixture
+def picker_session(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    session = MagicMock()
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> MagicMock:
+            return session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    monkeypatch.setattr(admin_families_picker, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_families_picker, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        admin_families_picker,
+        "extract_identity",
+        lambda _event: _admin_identity(),
+    )
+    return session
+
+
+def _make_execute_result(rows: list[tuple[Any, ...]]) -> MagicMock:
+    m = MagicMock()
+    m.all.return_value = rows
+    return m
+
+
+def test_picker_label_includes_primary_contact_name(
+    api_gateway_event: Any,
+    picker_session: MagicMock,
+) -> None:
+    fam_id = uuid4()
+    picker_session.execute.side_effect = [
+        _make_execute_result([(fam_id, "Smith Family")]),
+        _make_execute_result([(fam_id, "Jane", "Primary")]),
+    ]
+
+    path = "/v1/admin/families/picker"
+    response = admin_families_picker.handle_admin_families_picker_request(
+        api_gateway_event(method="GET", path=path),
+        "GET",
+        path,
+    )
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["items"] == [{"id": str(fam_id), "label": "Smith Family \u00b7 Jane Primary"}]

--- a/tests/test_admin_organizations_picker.py
+++ b/tests/test_admin_organizations_picker.py
@@ -44,12 +44,21 @@ def picker_session(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     return session
 
 
+def _make_org_list_result(rows: list[tuple[Any, ...]]) -> MagicMock:
+    m = MagicMock()
+    m.all.return_value = rows
+    return m
+
+
 def test_picker_default_excludes_vendors_and_partners(
     api_gateway_event: Any,
     picker_session: MagicMock,
 ) -> None:
     org_id = uuid4()
-    picker_session.execute.return_value.all.return_value = [(org_id, "Alpha Org")]
+    picker_session.execute.side_effect = [
+        _make_org_list_result([(org_id, "Alpha Org")]),
+        _make_org_list_result([]),
+    ]
 
     path = "/v1/admin/organizations/picker"
     response = admin_organizations_picker.handle_admin_organizations_picker_request(
@@ -69,7 +78,10 @@ def test_picker_relationship_type_partner_calls_parser(
     picker_session: MagicMock,
 ) -> None:
     org_id = uuid4()
-    picker_session.execute.return_value.all.return_value = [(org_id, "Partner Org")]
+    picker_session.execute.side_effect = [
+        _make_org_list_result([(org_id, "Partner Org")]),
+        _make_org_list_result([]),
+    ]
     captured: list[Any] = []
 
     def _capture(value: Any, *, field: str, allowed: Any = None) -> RelationshipType:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Centralizes the middle-dot display patterns in `apps/admin_web/src/lib/format.ts` (`formatContactNameEmailLabel`, `formatAdminContactPickerLabel`, `formatFamilyOrOrganizationPartyLabel`, `formatBillingEnrollmentPartyCell`, `resolveEnrollmentListPartyLabel`) with Vitest coverage.
- Refactors the enrollment parent pickers hook, services enrollment list, contacts pages, finance draft-invoice enrollment picker, and families/organisations CRM tables to use the shared helpers instead of ad hoc string templates.
- **Backend:** `party_display_name` for contact enrollments now uses `name · email` when both are present (aligned with the billing UI). Family and organisation picker endpoints now return `entity · primary contact` using the same `family_or_organization_bill_to_display_label` helper as billing.
- Updates OpenAPI descriptions for `Enrollment`, `EntityPickerListItem`, and `BillingEnrollmentPickerRow`; regenerates `admin-api.generated.ts`.

## Tests
- `npx vitest run tests/lib/format.test.ts`
- `pytest tests/test_admin_families_picker.py tests/test_admin_organizations_picker.py` (+ targeted billing compose test)
- `npm run lint` (admin web), `ruff check` on touched Python modules
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53750d4a-7677-4b71-ab46-c8c24a572f4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53750d4a-7677-4b71-ab46-c8c24a572f4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

