### PR TITLE
Align enrollment operations column with instance list

### DIFF
--- a/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/enrollment-list-panel.tsx
@@ -571,21 +571,23 @@ export function EnrollmentListPanel({
                       : '-'}
                   </AdminDataTableCell>
                   <AdminDataTableCell>{formatDate(enrollment.enrolledAt)}</AdminDataTableCell>
-                  <AdminDataTableCell>
-                    <Button
-                      type='button'
-                      size='sm'
-                      variant='danger'
-                      disabled={isMutating}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        void handleDeleteEnrollment(enrollment);
-                      }}
-                      aria-label='Delete enrollment'
-                      title='Delete enrollment'
-                    >
-                      <DeleteIcon className='h-4 w-4' />
-                    </Button>
+                  <AdminDataTableCell className='whitespace-nowrap text-right'>
+                    <div className='flex justify-end gap-2'>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='danger'
+                        disabled={isMutating}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          void handleDeleteEnrollment(enrollment);
+                        }}
+                        aria-label='Delete enrollment'
+                        title='Delete enrollment'
+                      >
+                        <DeleteIcon className='h-4 w-4' />
+                      </Button>
+                    </div>
                   </AdminDataTableCell>
                 </tr>
               );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The enrollments table **Operations** body cell now matches the instances table: `whitespace-nowrap text-right` on the cell and a `flex justify-end gap-2` wrapper so icon actions align with the right-aligned **Operations** header and other admin listing tables.

## Testing

- `npx vitest run tests/components/admin/services/enrollment-list-panel.test.tsx`
- `npm run lint` (admin web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7697db94-e478-4074-9911-ee6d525c19eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7697db94-e478-4074-9911-ee6d525c19eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

