### PR TITLE
Fix draft invoice party email duplication and empty Bill to for contacts without email

### DIFF
--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -88,6 +88,13 @@ export function formatBillingEnrollmentPartyCell(row: {
   if (kind === 'family' || kind === 'organization') {
     return party;
   }
+  // Contact (or unknown): list API already returns `name · email` in partyDisplayName when both exist.
+  if (party && email) {
+    const suffix = `${DISPLAY_PART_SEP}${email}`;
+    if (party === email || party.endsWith(suffix)) {
+      return party;
+    }
+  }
   return formatContactNameEmailLabel(party, email, party || email || '');
 }
 

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -76,26 +76,11 @@ export function formatFamilyOrOrganizationPartyLabel(
   return '';
 }
 
-/** Billing draft invoice enrollment picker — Party column (contact uses name · email; family/org use API label). */
+/** Billing draft invoice enrollment picker — Party column: server `partyDisplayName` only. */
 export function formatBillingEnrollmentPartyCell(row: {
-  billToKind?: string | null;
   partyDisplayName?: string | null;
-  partyEmail?: string | null;
 }): string {
-  const party = row.partyDisplayName?.trim() ?? '';
-  const email = row.partyEmail?.trim() ?? '';
-  const kind = (row.billToKind ?? '').trim();
-  if (kind === 'family' || kind === 'organization') {
-    return party;
-  }
-  // Contact (or unknown): list API already returns `name · email` in partyDisplayName when both exist.
-  if (party && email) {
-    const suffix = `${DISPLAY_PART_SEP}${email}`;
-    if (party === email || party.endsWith(suffix)) {
-      return party;
-    }
-  }
-  return formatContactNameEmailLabel(party, email, party || email || '');
+  return row.partyDisplayName?.trim() ?? '';
 }
 
 /** Service enrollment list — Party cell: API label, else picker-derived labels by structural parent id. */

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -1162,12 +1162,12 @@ describe('ClientInvoicesPanel', () => {
     });
   });
 
-  it('draft enrollment picker Party column merges name and email with middle dot', async () => {
+  it('draft enrollment picker Party column shows server partyDisplayName', async () => {
     billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
       items: [
         pickerRow({
           enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-111111111111',
-          partyDisplayName: 'Sam Sample',
+          partyDisplayName: 'Sam Sample \u00b7 sam@example.com',
           partyEmail: 'sam@example.com',
         }),
         pickerRow({

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -1019,6 +1019,13 @@ describe('CRM party display labels', () => {
     ).toBe('Sam Sample · sam@example.com');
     expect(
       formatBillingEnrollmentPartyCell({
+        billToKind: 'contact',
+        partyDisplayName: 'Sam Sample · sam@example.com',
+        partyEmail: 'sam@example.com',
+      }),
+    ).toBe('Sam Sample · sam@example.com');
+    expect(
+      formatBillingEnrollmentPartyCell({
         billToKind: 'family',
         partyDisplayName: 'Smith Family · Jane',
         partyEmail: 'jane@example.com',

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -1012,31 +1012,20 @@ describe('CRM party display labels', () => {
   it('matches billing enrollment picker party column rules', () => {
     expect(
       formatBillingEnrollmentPartyCell({
-        billToKind: 'contact',
         partyDisplayName: 'Sam Sample',
-        partyEmail: 'sam@example.com',
       }),
-    ).toBe('Sam Sample · sam@example.com');
+    ).toBe('Sam Sample');
     expect(
       formatBillingEnrollmentPartyCell({
-        billToKind: 'contact',
         partyDisplayName: 'Sam Sample · sam@example.com',
-        partyEmail: 'sam@example.com',
       }),
     ).toBe('Sam Sample · sam@example.com');
     expect(
       formatBillingEnrollmentPartyCell({
-        billToKind: 'family',
         partyDisplayName: 'Smith Family · Jane',
-        partyEmail: 'jane@example.com',
       }),
     ).toBe('Smith Family · Jane');
-    expect(
-      formatBillingEnrollmentPartyCell({
-        partyDisplayName: 'Sam Sample',
-        partyEmail: 'sam@example.com',
-      }),
-    ).toBe('Sam Sample · sam@example.com');
+    expect(formatBillingEnrollmentPartyCell({ partyDisplayName: '' })).toBe('');
   });
 
   it('resolves enrollment list party from API or picker maps', () => {

--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -54,9 +54,13 @@ def _resolve_bill_to_party_from_invoice_fks(
         cid = inv.bill_to_contact_id
         if cid:
             c = session.get(Contact, cid)
-            if c and c.email:
-                inv.bill_to_email = c.email
-                inv.bill_to_display_name = contact_display_name(c)
+            if c:
+                name = (contact_display_name(c) or "").strip()
+                if name:
+                    inv.bill_to_display_name = name
+                em = (c.email or "").strip()
+                if em:
+                    inv.bill_to_email = em
         return
     if inv.bill_to_kind == BillingBillToKind.FAMILY and inv.bill_to_family_id:
         fam = session.get(Family, inv.bill_to_family_id)

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -2027,3 +2027,33 @@ def test_compose_enrollment_party_display_name_contact_includes_email_when_known
         )
         == "Sam Sample \u00b7 sam@example.com"
     )
+
+
+def test_resolve_bill_to_party_from_invoice_fks_contact_without_email_sets_display_name() -> None:
+    """Contact bill-to must populate display name even when email is absent (list + PDF)."""
+    from types import SimpleNamespace
+
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Contact
+
+    cid = uuid4()
+    contact = SimpleNamespace(email=None, first_name="Pat", last_name="Ng")
+    session = MagicMock()
+
+    def _get(model: Any, pk: Any) -> Any:
+        if model is Contact and pk == cid:
+            return contact
+        return None
+
+    session.get.side_effect = _get
+    inv = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact_id=cid,
+        bill_to_display_name=None,
+        bill_to_email=None,
+    )
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
+    assert inv.bill_to_display_name == "Pat Ng"
+    assert inv.bill_to_email is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Party column (draft invoice enrollment picker):** Use server `partyDisplayName` only (no client-side email merging).

- **Bill to (customer invoice list / PDF):** `_resolve_bill_to_party_from_invoice_fks` sets `bill_to_display_name` from the contact name whenever the row exists; `bill_to_email` only when an email is present. Previously display name was only set when email existed, so the list and PDF stayed empty for name-only contacts.

- **CI:** `client-invoices-panel` integration test expected the old merged Party label; it now uses API-shaped `partyDisplayName` (`name · email`) in the mock.

## Tests

- `pytest tests/test_admin_billing.py::test_resolve_bill_to_party_from_invoice_fks_contact_without_email_sets_display_name`
- `cd apps/admin_web && npm run test`

## Note

Existing draft or issued rows that were saved with null bill-to display fields are unchanged until recreated or updated by a flow that re-resolves bill-to from FKs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e497945-6eaa-4a9b-939b-8c6ec088b826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e497945-6eaa-4a9b-939b-8c6ec088b826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

