### PR TITLE
Fix enrollment-merge customer invoice bill-to and refresh enrollment picker after draft delete

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -741,6 +741,7 @@ export function ClientInvoicesPanel() {
       }
       await loadPayments();
       await loadInvoicesFirstPage();
+      await loadEnrollmentPicker(undefined, enrollmentFilter.trim());
     } catch (caught) {
       setDeleteDraftError(toErrorMessage(caught, 'Delete failed.', { honorBackendMessage: true }));
     } finally {

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -516,6 +516,9 @@ describe('ClientInvoicesPanel', () => {
       within(invoiceTable).getByRole('button', { name: /delete draft invoice/i }),
     );
 
+    const enrollmentFetchCountBefore =
+      billingMocks.listRecentEnrollmentsForInvoicing.mock.calls.length;
+
     await userEvent.click(within(invoiceTable).getByRole('button', { name: /delete draft invoice/i }));
 
     await waitFor(() => {
@@ -526,6 +529,12 @@ describe('ClientInvoicesPanel', () => {
 
     await waitFor(() => {
       expect(billingMocks.deleteDraftCustomerInvoice).toHaveBeenCalledWith(invId);
+    });
+
+    await waitFor(() => {
+      expect(billingMocks.listRecentEnrollmentsForInvoicing.mock.calls.length).toBeGreaterThan(
+        enrollmentFetchCountBefore,
+      );
     });
   });
 

--- a/backend/src/app/api/admin_billing_common.py
+++ b/backend/src/app/api/admin_billing_common.py
@@ -34,6 +34,40 @@ def contact_display_name(c: Contact | None) -> str | None:
     return " ".join(x for x in [c.first_name, c.last_name] if x).strip() or None
 
 
+def _uuid_fk_or_none(value: object | None) -> UUID | None:
+    """Return ``value`` only when it is a concrete UUID (avoids MagicMock truthiness in tests)."""
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        return value
+    return None
+
+
+def effective_enrollment_bill_to_fks(
+    enrollment: Enrollment,
+) -> tuple[BillingBillToKind, UUID | None, UUID | None, UUID | None]:
+    """Resolved bill-to kind and mutually exclusive FK ids for invoicing (picker merge + draft rows).
+
+    Uses ``effective_enrollment_bill_to_kind`` so legacy family/org enrollments that only set
+    ``family_id`` / ``organization_id`` align with customer invoice bill-to constraints.
+    """
+    bk = effective_enrollment_bill_to_kind(enrollment)
+    if bk == BillingBillToKind.CONTACT:
+        cid = _uuid_fk_or_none(enrollment.bill_to_contact_id)
+        if cid is None:
+            cid = _uuid_fk_or_none(enrollment.contact_id)
+        return (bk, cid, None, None)
+    if bk == BillingBillToKind.FAMILY:
+        fid = _uuid_fk_or_none(enrollment.bill_to_family_id)
+        if fid is None:
+            fid = _uuid_fk_or_none(enrollment.family_id)
+        return (bk, None, fid, None)
+    oid = _uuid_fk_or_none(enrollment.bill_to_organization_id)
+    if oid is None:
+        oid = _uuid_fk_or_none(enrollment.organization_id)
+    return (bk, None, None, oid)
+
+
 def family_or_organization_bill_to_display_label(
     *,
     entity_name: str | None,
@@ -57,14 +91,12 @@ def family_or_organization_bill_to_display_label(
 
 def enrollment_bill_to_merge_key(enrollment: Enrollment) -> str:
     """Stable string key for comparing bill-to identity across enrollments."""
-    bk = enrollment.bill_to_kind or BillingBillToKind.CONTACT
+    bk, cid, fid, oid = effective_enrollment_bill_to_fks(enrollment)
     parts = (
         bk.value,
-        str(enrollment.bill_to_contact_id) if enrollment.bill_to_contact_id else "",
-        str(enrollment.bill_to_family_id) if enrollment.bill_to_family_id else "",
-        str(enrollment.bill_to_organization_id)
-        if enrollment.bill_to_organization_id
-        else "",
+        str(cid) if cid else "",
+        str(fid) if fid else "",
+        str(oid) if oid else "",
     )
     return "|".join(parts)
 

--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.api.admin_billing_common import (
     contact_display_name,
+    effective_enrollment_bill_to_fks,
     family_or_organization_bill_to_display_label,
 )
 from app.db.models import Contact, Enrollment, Family, Organization
@@ -37,13 +38,7 @@ def _decimal_field(raw: Any, *, field: str) -> Decimal:
 
 
 def _enrollment_merge_key(en: Enrollment) -> tuple[Any, ...]:
-    bk = en.bill_to_kind or BillingBillToKind.CONTACT
-    return (
-        bk,
-        en.bill_to_contact_id,
-        en.bill_to_family_id,
-        en.bill_to_organization_id,
-    )
+    return effective_enrollment_bill_to_fks(en)
 
 
 def _resolve_bill_to_party_from_invoice_fks(

--- a/backend/src/app/api/admin_billing_invoice_drafts.py
+++ b/backend/src/app/api/admin_billing_invoice_drafts.py
@@ -10,7 +10,10 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
-from app.api.admin_billing_common import _session_with_audit
+from app.api.admin_billing_common import (
+    _session_with_audit,
+    effective_enrollment_bill_to_fks,
+)
 from app.api.admin_billing_invoice_draft_helpers import (
     _decimal_field,
     _enrollment_merge_key,
@@ -333,7 +336,9 @@ def _create_invoice_draft(
             )
 
         first = enrollments[0]
-        bill_kind = first.bill_to_kind or BillingBillToKind.CONTACT
+        bill_kind, bill_cid, bill_fid, bill_oid = effective_enrollment_bill_to_fks(
+            first
+        )
         inv = CustomerInvoice(
             status=BillingInvoiceStatus.DRAFT,
             currency=currency,
@@ -341,9 +346,9 @@ def _create_invoice_draft(
             tax_total=Decimal("0"),
             total=Decimal("0"),
             bill_to_kind=bill_kind,
-            bill_to_contact_id=first.bill_to_contact_id or first.contact_id,
-            bill_to_family_id=first.bill_to_family_id,
-            bill_to_organization_id=first.bill_to_organization_id,
+            bill_to_contact_id=bill_cid,
+            bill_to_family_id=bill_fid,
+            bill_to_organization_id=bill_oid,
         )
         _resolve_bill_to_party_for_draft(session, inv=inv, first=first)
 

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -20,6 +20,10 @@ from app.api import admin_billing_invoice_drafts as admin_billing_invoice_drafts
 from app.api import admin_billing_invoice_queries as admin_billing_invoice_queries_mod
 from app.api import admin_billing_invoices as admin_billing_invoices_mod
 from app.api import admin_billing_payments as admin_billing_payments_mod
+from app.api.admin_billing_common import (
+    effective_enrollment_bill_to_fks,
+    enrollment_bill_to_merge_key,
+)
 from app.db.models import Enrollment
 from app.db.models.customer_invoice import CustomerInvoice
 from app.db.models.enums import (
@@ -607,6 +611,40 @@ def test_list_recent_enrollments_infers_family_when_bill_to_kind_null(
     body = json.loads(r["body"])
     assert body["items"][0]["billToKind"] == "family"
     assert body["items"][0]["partyDisplayName"] == "Ng Household · Pat Ng"
+
+
+def test_effective_enrollment_bill_to_fks_family_falls_back_to_family_id() -> None:
+    """Family-scoped enrollments may set ``family_id`` without ``bill_to_family_id``."""
+    iid = uuid4()
+    fam_id = uuid4()
+    contact_id = uuid4()
+    en = Enrollment(
+        instance_id=iid,
+        contact_id=contact_id,
+        family_id=fam_id,
+        organization_id=None,
+        ticket_tier_id=None,
+        discount_code_id=None,
+        bill_to_kind=BillingBillToKind.FAMILY,
+        bill_to_contact_id=None,
+        bill_to_family_id=None,
+        bill_to_organization_id=None,
+        status=EnrollmentStatus.CONFIRMED,
+        amount_paid=Decimal("10"),
+        currency="HKD",
+        enrolled_at=datetime(2026, 3, 1, tzinfo=UTC),
+        cancelled_at=None,
+        notes=None,
+        created_by="test",
+    )
+    bk, cid, fid, oid = effective_enrollment_bill_to_fks(en)
+    assert bk == BillingBillToKind.FAMILY
+    assert cid is None
+    assert fid == fam_id
+    assert oid is None
+    key = enrollment_bill_to_merge_key(en)
+    assert key.startswith("family||")
+    assert str(fam_id) in key
 
 
 def test_create_invoice_draft_currency_empty_string_derives(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Customer invoice bill-to (enrollment merge):** Draft invoices now copy bill-to from `effective_enrollment_bill_to_fks`, which uses `effective_enrollment_bill_to_kind` and falls back to structural `family_id` / `organization_id` when bill-to FK columns are unset. Family and organization drafts no longer populate `bill_to_contact_id` with the enrolled contact; only the appropriate family or organization FK is set, so `_resolve_bill_to_party_from_invoice_fks` loads the family/org row and **primary contact** for display name and email (unchanged resolver logic, correct inputs).
- **Merge key alignment:** `enrollment_bill_to_merge_key` and the draft merge guard use the same effective FK tuple, so the admin enrollment picker and merge validation stay consistent for legacy family/org rows.
- **Admin UI:** After a successful draft invoice delete, the panel calls `loadEnrollmentPicker` again so the “Create draft invoice” enrollment table refreshes (`invoiceLinked` clears, selection prunes blocked rows).
- **Tests:** New Python unit test for family bill-to fallback; Vitest asserts enrollment list refetch after delete.

## Risk / notes

- `enrollment_bill_to_merge_key` strings change for enrollments that previously keyed only on `bill_to_*` columns while the effective party was inferred from `family_id` / `organization_id`. That aligns server behavior with the picker and merge rules.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ee425b5-daea-40bd-942d-b0562d5172b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ee425b5-daea-40bd-942d-b0562d5172b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

