### PR TITLE
Persist draft invoice date and derive due date on issue

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -68,9 +68,12 @@ import {
   INSTANCE_TABLE_TIER_COHORT_HEADER,
   formatBillingEnrollmentPartyCell,
   formatDate,
+  formatDateOnly,
   formatEnumLabel,
   formatEnrollmentPickerInstanceServiceDisplay,
   formatTierCohortDisplay,
+  formatYmdAsLocalDate,
+  localTodayYmd,
 } from '@/lib/format';
 import { formatAmountInCurrency } from '@/lib/vendor-spend';
 
@@ -205,10 +208,15 @@ export function ClientInvoicesPanel() {
   const [enrollmentFilter, setEnrollmentFilter] = useState('');
   const [selectedEnrollmentIds, setSelectedEnrollmentIds] = useState<Set<string>>(() => new Set());
   const [lineOverrideByEnrollmentId, setLineOverrideByEnrollmentId] = useState<Record<string, string>>({});
+  const draftInvoiceDateMin = '2000-01-01';
+  const draftInvoiceDateMax = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 365);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }, []);
   const draftInvoiceDateId = useId();
-  const [draftInvoiceDate, setDraftInvoiceDate] = useState<string>(
-    () => new Date().toLocaleDateString('en-CA'), // YYYY-MM-DD in browser local TZ
-  );
+  const [draftInvoiceDate, setDraftInvoiceDate] = useState<string>(() => localTodayYmd());
 
   const [allocateInvoiceId, setAllocateInvoiceId] = useState('');
   const [allocateLineId, setAllocateLineId] = useState('');
@@ -937,7 +945,7 @@ export function ClientInvoicesPanel() {
       setAllocateInvoiceId('');
       setAllocateLineId('');
       setActionMessage(`Draft invoice created: ${result.invoiceId}`);
-      setDraftInvoiceDate(new Date().toLocaleDateString('en-CA'));
+      setDraftInvoiceDate(localTodayYmd());
       await loadPayments();
       await loadInvoicesFirstPage();
       await loadEnrollmentPicker(undefined, enrollmentFilter.trim());
@@ -1126,8 +1134,18 @@ export function ClientInvoicesPanel() {
                     className='mt-1 w-full'
                     value={draftInvoiceDate}
                     onChange={(e) => setDraftInvoiceDate(e.target.value)}
+                    onBlur={(e) => {
+                      if (e.target.value === '') {
+                        setDraftInvoiceDate(localTodayYmd());
+                      }
+                    }}
+                    min={draftInvoiceDateMin}
+                    max={draftInvoiceDateMax}
                     disabled={editorBusy}
                   />
+                  <p className='mt-1 text-xs text-slate-600'>
+                    Shown on the issued PDF and in the Invoice date column. Defaults to today.
+                  </p>
                 </div>
               </div>
               <AdminTableToolbar marginBottom='none'>
@@ -1381,7 +1399,7 @@ export function ClientInvoicesPanel() {
 
       <PaginatedTableCard
         title='Customer invoices'
-        description='Cursor-paginated invoices (newest first). Use Operations to preview, issue, void, or permanently delete **draft** rows. Select an issued row to pre-fill allocation; when the selection is issued, use Email recipients and Send email below.'
+        description='Cursor-paginated invoices, ordered by record creation time (most recent first); the displayed Invoice date may differ from creation order when drafts are backdated. Use Operations to preview, issue, void, or permanently delete **draft** rows. Select an issued row to pre-fill allocation; when the selection is issued, use Email recipients and Send email below.'
         isLoading={invoiceListLoading}
         isLoadingMore={invoiceListLoadingMore}
         hasMore={Boolean(invoiceListCursor)}
@@ -1502,7 +1520,11 @@ export function ClientInvoicesPanel() {
                   </AdminDataTableCell>
                   <AdminDataTableCell>{totalDisplay}</AdminDataTableCell>
                   <AdminDataTableCell>{inv.lineCount ?? 0}</AdminDataTableCell>
-                  <AdminDataTableCell>{formatDate(inv.invoiceDate ?? inv.createdAt ?? null)}</AdminDataTableCell>
+                  <AdminDataTableCell>
+                    {inv.invoiceDate
+                      ? formatYmdAsLocalDate(inv.invoiceDate)
+                      : formatDateOnly(inv.createdAt ?? null)}
+                  </AdminDataTableCell>
                   <AdminDataTableCell
                     className='text-right'
                     onClick={(event) => {

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -205,6 +205,10 @@ export function ClientInvoicesPanel() {
   const [enrollmentFilter, setEnrollmentFilter] = useState('');
   const [selectedEnrollmentIds, setSelectedEnrollmentIds] = useState<Set<string>>(() => new Set());
   const [lineOverrideByEnrollmentId, setLineOverrideByEnrollmentId] = useState<Record<string, string>>({});
+  const draftInvoiceDateId = useId();
+  const [draftInvoiceDate, setDraftInvoiceDate] = useState<string>(
+    () => new Date().toLocaleDateString('en-CA'), // YYYY-MM-DD in browser local TZ
+  );
 
   const [allocateInvoiceId, setAllocateInvoiceId] = useState('');
   const [allocateLineId, setAllocateLineId] = useState('');
@@ -925,11 +929,15 @@ export function ClientInvoicesPanel() {
       if (Object.keys(overrides).length > 0) {
         body.lineTotalsByEnrollmentId = overrides;
       }
+      if (draftInvoiceDate.trim() !== '') {
+        body.invoiceDate = draftInvoiceDate.trim();
+      }
       const result = await createDraftInvoice(body);
       setSelectedInvoiceId(result.invoiceId);
       setAllocateInvoiceId('');
       setAllocateLineId('');
       setActionMessage(`Draft invoice created: ${result.invoiceId}`);
+      setDraftInvoiceDate(new Date().toLocaleDateString('en-CA'));
       await loadPayments();
       await loadInvoicesFirstPage();
       await loadEnrollmentPicker(undefined, enrollmentFilter.trim());
@@ -1109,6 +1117,19 @@ export function ClientInvoicesPanel() {
                 Rows already on a draft or issued invoice cannot be selected. Selected rows must share bill-to
                 and currency on the server.
               </p>
+              <div className='flex flex-wrap gap-4'>
+                <div className='min-w-[180px]'>
+                  <Label htmlFor={draftInvoiceDateId}>Invoice date</Label>
+                  <Input
+                    id={draftInvoiceDateId}
+                    type='date'
+                    className='mt-1 w-full'
+                    value={draftInvoiceDate}
+                    onChange={(e) => setDraftInvoiceDate(e.target.value)}
+                    disabled={editorBusy}
+                  />
+                </div>
+              </div>
               <AdminTableToolbar marginBottom='none'>
                 <div className='min-w-[220px] flex-1'>
                   <Label htmlFor={draftFilterId}>Filter enrollments</Label>
@@ -1446,7 +1467,7 @@ export function ClientInvoicesPanel() {
               <AdminDataTableHeadCell>Bill to</AdminDataTableHeadCell>
               <AdminDataTableHeadCell>Total</AdminDataTableHeadCell>
               <AdminDataTableHeadCell>Lines</AdminDataTableHeadCell>
-              <AdminDataTableHeadCell>Created</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Invoice date</AdminDataTableHeadCell>
               <AdminDataTableOperationsHeadCell />
             </tr>
           </AdminDataTableHead>
@@ -1481,7 +1502,7 @@ export function ClientInvoicesPanel() {
                   </AdminDataTableCell>
                   <AdminDataTableCell>{totalDisplay}</AdminDataTableCell>
                   <AdminDataTableCell>{inv.lineCount ?? 0}</AdminDataTableCell>
-                  <AdminDataTableCell>{formatDate(inv.createdAt ?? null)}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatDate(inv.invoiceDate ?? inv.createdAt ?? null)}</AdminDataTableCell>
                   <AdminDataTableCell
                     className='text-right'
                     onClick={(event) => {

--- a/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
+++ b/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
@@ -92,6 +92,7 @@ export function CustomizedDraftInvoiceCard({
   const customizedBillKindId = useId();
   const customizedBillEntitySelectId = useId();
   const customizedCurrencyId = useId();
+  const customizedInvoiceDateId = useId();
 
   const {
     contactOptions,
@@ -112,6 +113,9 @@ export function CustomizedDraftInvoiceCard({
   const [customizedLines, setCustomizedLines] = useState<CustomizedLineDraftRow[]>(() => [
     makeCustomizedLineRow(1),
   ]);
+  const [customizedInvoiceDate, setCustomizedInvoiceDate] = useState<string>(
+    () => new Date().toLocaleDateString('en-CA'),
+  );
 
   useEffect(() => {
     setCustomizedBillEntityId('');
@@ -265,10 +269,12 @@ export function CustomizedDraftInvoiceCard({
         billTo,
         currency: customizedCurrency.trim().toUpperCase(),
         lines,
+        invoiceDate: customizedInvoiceDate.trim() || undefined,
       });
       await onCreated(result.invoiceId);
       customizedLineIdSeq.current += 1;
       setCustomizedLines([makeCustomizedLineRow(customizedLineIdSeq.current)]);
+      setCustomizedInvoiceDate(new Date().toLocaleDateString('en-CA'));
     } catch (caught) {
       onDraftError?.(
         toErrorMessage(caught, 'Create draft failed.', { honorBackendMessage: true }),
@@ -345,6 +351,17 @@ export function CustomizedDraftInvoiceCard({
                 </option>
               ))}
             </Select>
+          </div>
+          <div className='min-w-[180px]'>
+            <Label htmlFor={customizedInvoiceDateId}>Invoice date</Label>
+            <Input
+              id={customizedInvoiceDateId}
+              type='date'
+              className='mt-1 w-full'
+              value={customizedInvoiceDate}
+              onChange={(e) => setCustomizedInvoiceDate(e.target.value)}
+              disabled={editorBusy}
+            />
           </div>
         </div>
         <AdminCollapsibleSection

--- a/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
+++ b/apps/admin_web/src/components/admin/finance/customized-draft-invoice-card.tsx
@@ -20,6 +20,7 @@ import { Select } from '@/components/ui/select';
 import { useEnrollmentParentPickers } from '@/hooks/use-enrollment-parent-pickers';
 import { toErrorMessage } from '@/hooks/hook-errors';
 import { createDraftInvoice } from '@/lib/billing-api';
+import { localTodayYmd } from '@/lib/format';
 
 export const CUSTOMIZED_DRAFT_INVOICE_FORM_ID = 'client-billing-customized-draft-form';
 const CUSTOMIZED_FORM_ID = CUSTOMIZED_DRAFT_INVOICE_FORM_ID;
@@ -105,6 +106,14 @@ export function CustomizedDraftInvoiceCard({
 
   const customizedLineIdSeq = useRef(1);
 
+  const draftInvoiceDateMin = '2000-01-01';
+  const draftInvoiceDateMax = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 365);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }, []);
+
   const [customizedBillKind, setCustomizedBillKind] = useState<CustomizedBillKind>('contact');
   const [customizedBillEntityId, setCustomizedBillEntityId] = useState('');
   const [customizedCurrency, setCustomizedCurrency] = useState(() =>
@@ -113,9 +122,7 @@ export function CustomizedDraftInvoiceCard({
   const [customizedLines, setCustomizedLines] = useState<CustomizedLineDraftRow[]>(() => [
     makeCustomizedLineRow(1),
   ]);
-  const [customizedInvoiceDate, setCustomizedInvoiceDate] = useState<string>(
-    () => new Date().toLocaleDateString('en-CA'),
-  );
+  const [customizedInvoiceDate, setCustomizedInvoiceDate] = useState<string>(() => localTodayYmd());
 
   useEffect(() => {
     setCustomizedBillEntityId('');
@@ -274,7 +281,7 @@ export function CustomizedDraftInvoiceCard({
       await onCreated(result.invoiceId);
       customizedLineIdSeq.current += 1;
       setCustomizedLines([makeCustomizedLineRow(customizedLineIdSeq.current)]);
-      setCustomizedInvoiceDate(new Date().toLocaleDateString('en-CA'));
+      setCustomizedInvoiceDate(localTodayYmd());
     } catch (caught) {
       onDraftError?.(
         toErrorMessage(caught, 'Create draft failed.', { honorBackendMessage: true }),
@@ -360,8 +367,18 @@ export function CustomizedDraftInvoiceCard({
               className='mt-1 w-full'
               value={customizedInvoiceDate}
               onChange={(e) => setCustomizedInvoiceDate(e.target.value)}
+              onBlur={(e) => {
+                if (e.target.value === '') {
+                  setCustomizedInvoiceDate(localTodayYmd());
+                }
+              }}
+              min={draftInvoiceDateMin}
+              max={draftInvoiceDateMax}
               disabled={editorBusy}
             />
+            <p className='mt-1 text-xs text-slate-600'>
+              Shown on the issued PDF and in the Invoice date column. Defaults to today.
+            </p>
           </div>
         </div>
         <AdminCollapsibleSection

--- a/apps/admin_web/src/lib/format.ts
+++ b/apps/admin_web/src/lib/format.ts
@@ -764,6 +764,27 @@ export function formatDateOnly(value: string | null): string {
   return LOCAL_DATE_FORMATTER.format(parsedDate);
 }
 
+export function localTodayYmd(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Format a `YYYY-MM-DD` calendar date without TZ shifting. */
+export function formatYmdAsLocalDate(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim());
+  if (!m) {
+    return value;
+  }
+  const year = Number.parseInt(m[1], 10);
+  const month = Number.parseInt(m[2], 10) - 1;
+  const day = Number.parseInt(m[3], 10);
+  return LOCAL_DATE_FORMATTER.format(new Date(year, month, day));
+}
+
 export function formatDateForInput(value: Date): string {
   return value.toISOString().slice(0, 10);
 }

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -6151,6 +6151,10 @@ export interface components {
             billToEmail?: string | null;
             /** Format: date-time */
             issuedAt?: string | null;
+            /** Format: date */
+            invoiceDate?: string | null;
+            /** Format: date */
+            dueDate?: string | null;
             /** Format: date-time */
             voidedAt?: string | null;
             issuedPdfSha256?: string | null;
@@ -6221,6 +6225,11 @@ export interface components {
             lineTotalsByEnrollmentId?: {
                 [key: string]: string;
             };
+            /**
+             * Format: date
+             * @description Optional ISO date (YYYY-MM-DD). When omitted, defaults to today in INVOICE_DISPLAY_TIMEZONE (or UTC if unset).
+             */
+            invoiceDate?: string | null;
         };
         /** @description Bill-to party for a customized draft. Supply exactly one of contactId, familyId, or organizationId matching `kind`. */
         InvoiceBillToInput: {
@@ -6266,6 +6275,11 @@ export interface components {
             billTo: components["schemas"]["InvoiceBillToInput"];
             currency: string;
             lines: components["schemas"]["CustomizedInvoiceLineInput"][];
+            /**
+             * Format: date
+             * @description Optional ISO date (YYYY-MM-DD). When omitted, defaults to today in INVOICE_DISPLAY_TIMEZONE (or UTC if unset).
+             */
+            invoiceDate?: string | null;
         };
         CreatePaymentAllocationRequest: {
             /** Format: uuid */

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
 }));
 
 import { ClientInvoicesPanel } from '@/components/admin/finance/client-invoices-panel';
+import { formatDate } from '@/lib/format';
 
 function firstCustomerInvoiceDataRow(invoiceTable: HTMLElement): HTMLElement {
   const rows = within(invoiceTable).getAllByRole('row');
@@ -116,6 +117,51 @@ describe('ClientInvoicesPanel', () => {
       const sel = document.getElementById('billing-allocate-invoice') as HTMLSelectElement;
       expect(sel.value).toBe(invId);
     });
+  });
+
+  it('invoice list shows Invoice date column and prefers invoiceDate over createdAt', async () => {
+    billingMocks.listCustomerInvoices.mockResolvedValue({
+      items: [
+        {
+          id: 'inv-a',
+          status: 'draft',
+          invoiceNumber: null,
+          currency: 'HKD',
+          total: '10',
+          lineCount: 1,
+          billToDisplayName: 'Pat',
+          createdAt: '2020-01-01T00:00:00+00:00',
+          invoiceDate: '2025-05-15',
+        },
+        {
+          id: 'inv-b',
+          status: 'draft',
+          invoiceNumber: null,
+          currency: 'HKD',
+          total: '5',
+          lineCount: 1,
+          billToDisplayName: 'Sam',
+          createdAt: '2024-06-01T12:00:00+00:00',
+          invoiceDate: null,
+        },
+      ],
+      next_cursor: null,
+    });
+
+    render(<ClientInvoicesPanel />);
+
+    await waitFor(() => {
+      expect(billingMocks.listCustomerInvoices).toHaveBeenCalled();
+    });
+
+    const invoiceRegion = screen.getByRole('region', { name: /customer invoices list/i });
+    const invoiceTable = within(invoiceRegion).getByRole('table');
+    expect(within(invoiceTable).getByRole('columnheader', { name: 'Invoice date' })).toBeInTheDocument();
+    const dataRows = within(invoiceTable).getAllByRole('row').slice(1);
+    const row1cells = within(dataRows[0]).getAllByRole('cell');
+    const row2cells = within(dataRows[1]).getAllByRole('cell');
+    expect(row1cells[5]).toHaveTextContent(formatDate('2025-05-15'));
+    expect(row2cells[5]).toHaveTextContent(formatDate('2024-06-01T12:00:00+00:00'));
   });
 
   it('passes status filter to listCustomerInvoices', async () => {
@@ -965,6 +1011,7 @@ describe('ClientInvoicesPanel', () => {
     expect(arg.currency).toBeUndefined();
     expect(arg.enrollmentIds).toEqual([id1, id2]);
     expect(arg.lineTotalsByEnrollmentId).toBeUndefined();
+    expect(arg.invoiceDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
   it('create draft allows zero-dollar enrollments with recorded amount 0', async () => {
@@ -1000,6 +1047,7 @@ describe('ClientInvoicesPanel', () => {
     expect(arg.draftKind).toBe('enrollment_merge');
     expect(arg.enrollmentIds).toEqual([id1]);
     expect(arg.lineTotalsByEnrollmentId).toBeUndefined();
+    expect(arg.invoiceDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
   it('create draft is disabled when line total override is not a valid number', async () => {
@@ -1065,6 +1113,7 @@ describe('ClientInvoicesPanel', () => {
     expect(arg.draftKind).toBe('enrollment_merge');
     expect(arg.currency).toBeUndefined();
     expect(arg.lineTotalsByEnrollmentId).toEqual({ [id1]: '99' });
+    expect(arg.invoiceDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     cleanup();
     billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
       items: [
@@ -1131,6 +1180,7 @@ describe('ClientInvoicesPanel', () => {
       billTo: { kind: 'contact', contactId: 'cccccccc-cccc-cccc-cccc-cccccccccccc' },
       currency: 'HKD',
       lines: [{ description: 'Consulting hours', quantity: '1', unitAmount: '150' }],
+      invoiceDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
     });
   });
 

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -45,7 +45,7 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
 }));
 
 import { ClientInvoicesPanel } from '@/components/admin/finance/client-invoices-panel';
-import { formatDate } from '@/lib/format';
+import { formatDateOnly, formatYmdAsLocalDate } from '@/lib/format';
 
 function firstCustomerInvoiceDataRow(invoiceTable: HTMLElement): HTMLElement {
   const rows = within(invoiceTable).getAllByRole('row');
@@ -160,8 +160,8 @@ describe('ClientInvoicesPanel', () => {
     const dataRows = within(invoiceTable).getAllByRole('row').slice(1);
     const row1cells = within(dataRows[0]).getAllByRole('cell');
     const row2cells = within(dataRows[1]).getAllByRole('cell');
-    expect(row1cells[5]).toHaveTextContent(formatDate('2025-05-15'));
-    expect(row2cells[5]).toHaveTextContent(formatDate('2024-06-01T12:00:00+00:00'));
+    expect(row1cells[5]).toHaveTextContent(formatYmdAsLocalDate('2025-05-15'));
+    expect(row2cells[5]).toHaveTextContent(formatDateOnly('2024-06-01T12:00:00+00:00'));
   });
 
   it('passes status filter to listCustomerInvoices', async () => {

--- a/apps/admin_web/tests/components/admin/finance/customized-draft-invoice-card.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/customized-draft-invoice-card.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
 import { CustomizedDraftInvoiceCard } from '@/components/admin/finance/customized-draft-invoice-card';
 
 describe('CustomizedDraftInvoiceCard', () => {
+  // localTodayYmd() uses getFullYear/getMonth/getDate (browser-local TZ); jsdom matches Vitest host TZ.
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(new Date('2025-06-01T12:00:00Z'));

--- a/apps/admin_web/tests/components/admin/finance/customized-draft-invoice-card.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/customized-draft-invoice-card.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const billingMocks = vi.hoisted(() => ({
   createDraftInvoice: vi.fn(),
@@ -28,6 +28,15 @@ vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
 import { CustomizedDraftInvoiceCard } from '@/components/admin/finance/customized-draft-invoice-card';
 
 describe('CustomizedDraftInvoiceCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2025-06-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('submits customized draft with draftKind and billTo', async () => {
     billingMocks.createDraftInvoice.mockResolvedValue({ invoiceId: 'inv-x', status: 'draft' });
     const onCreated = vi.fn();
@@ -66,6 +75,7 @@ describe('CustomizedDraftInvoiceCard', () => {
       billTo: { kind: 'contact', contactId: 'cccccccc-cccc-cccc-cccc-cccccccccccc' },
       currency: 'HKD',
       lines: [{ description: 'Line A', quantity: '1', unitAmount: '25' }],
+      invoiceDate: '2025-06-01',
     });
     expect(onCreated).toHaveBeenCalledWith('inv-x');
   });
@@ -108,6 +118,51 @@ describe('CustomizedDraftInvoiceCard', () => {
       draftKind: 'customized_manual',
       billTo: { kind: 'organization', organizationId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
       lines: [{ description: 'Partner fee', quantity: '1', unitAmount: '99' }],
+      invoiceDate: '2025-06-01',
     });
+  });
+
+  it('sends chosen invoiceDate after user changes the date input', async () => {
+    billingMocks.createDraftInvoice.mockResolvedValue({ invoiceId: 'inv-d', status: 'draft' });
+    const onCreated = vi.fn();
+
+    render(
+      <CustomizedDraftInvoiceCard
+        defaultCurrency='HKD'
+        currencyOptions={[{ value: 'HKD', label: 'HKD' }]}
+        editorBusy={false}
+        loadParents
+        onCreated={onCreated}
+      />,
+    );
+
+    const form = document.getElementById('client-billing-customized-draft-form');
+    expect(form).toBeTruthy();
+
+    const dateInput = within(form as HTMLElement).getByLabelText(/^Invoice date$/i) as HTMLInputElement;
+    fireEvent.change(dateInput, { target: { value: '2025-07-04' } });
+
+    const desc = within(form as HTMLElement).getByLabelText(/^Description/i);
+    await userEvent.type(desc, 'Line A');
+
+    const unit = within(form as HTMLElement).getByLabelText(/^Unit price/i);
+    await userEvent.clear(unit);
+    await userEvent.type(unit, '25');
+
+    await userEvent.selectOptions(
+      screen.getByLabelText(/^Contact$/i),
+      'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    );
+
+    fireEvent.submit(form as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(billingMocks.createDraftInvoice).toHaveBeenCalled();
+    });
+    expect(billingMocks.createDraftInvoice.mock.calls[0][0]).toMatchObject({
+      draftKind: 'customized_manual',
+      invoiceDate: '2025-07-04',
+    });
+    expect(onCreated).toHaveBeenCalledWith('inv-d');
   });
 });

--- a/apps/admin_web/tests/lib/format.test.ts
+++ b/apps/admin_web/tests/lib/format.test.ts
@@ -17,6 +17,7 @@ import {
   formatInstanceTableTierCohort,
   formatInstanceTableTitle,
   formatTierCohortDisplay,
+  formatYmdAsLocalDate,
   ENROLLMENT_PICKER_INSTANCE_SERVICE_HEADER,
   formatEnrollmentPickerInstanceServiceDisplay,
   INSTANCE_TABLE_TIER_COHORT_HEADER,
@@ -31,6 +32,7 @@ import {
   getFirstSessionSlotStartTimeMs,
   getContentLanguageOptions,
   getCurrencyOptions,
+  localTodayYmd,
   matchAdminSelectableContentLanguage,
   buildSessionSlotsUtcPayload,
   mapSessionSlotsFromApiToForm,
@@ -849,6 +851,22 @@ describe('format helpers', () => {
     }).format(parsed);
     expect(formatDateOnly(iso)).toBe(expected);
     expect(formatDateOnly(null)).toBe('—');
+  });
+
+  it('formats YMD API dates without shifting the calendar day', () => {
+    const expected = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }).format(new Date(2025, 4, 15));
+    expect(formatYmdAsLocalDate('2025-05-15')).toBe(expected);
+    expect(formatYmdAsLocalDate(null)).toBe('—');
+    expect(formatYmdAsLocalDate('not-ymd')).toBe('not-ymd');
+  });
+
+  it('localTodayYmd returns a YYYY-MM-DD string for the local calendar day', () => {
+    const ymd = localTodayYmd();
+    expect(ymd).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
   it('maps API ISO instants to datetime-local strings and back for the API', () => {

--- a/backend/src/app/api/admin_billing_export.py
+++ b/backend/src/app/api/admin_billing_export.py
@@ -229,6 +229,8 @@ def _export_csv(
                     inv.invoice_number or "",
                     "",
                     "",
+                    # TODO: CSV invoice rows still emit record `created_at`; aligning this column
+                    # with admin UI `invoice_date` is a product/export-schema decision (separate change).
                     inv.created_at.isoformat(),
                 ]
             )

--- a/backend/src/app/api/admin_billing_invoice_drafts.py
+++ b/backend/src/app/api/admin_billing_invoice_drafts.py
@@ -49,10 +49,11 @@ def _resolve_draft_invoice_date(body: Mapping[str, Any]) -> date:
             raise ValidationError(str(exc), field="invoiceDate") from exc
     else:
         parsed = None
-    chosen = parsed if parsed is not None else today_in_invoice_display_tz_or_utc()
+    today = today_in_invoice_display_tz_or_utc()
+    chosen = parsed if parsed is not None else today
     if chosen < _INVOICE_DATE_MIN:
         raise ValidationError("invoiceDate is too far in the past", field="invoiceDate")
-    if chosen > date.today() + timedelta(days=365):
+    if chosen > today + timedelta(days=365):
         raise ValidationError(
             "invoiceDate is too far in the future", field="invoiceDate"
         )
@@ -89,6 +90,8 @@ def _create_customized_invoice_draft(
             field="lines",
         )
 
+    inv_date = _resolve_draft_invoice_date(body)
+
     with _session_with_audit(user_sub, request_id) as session:
         if bill_kind == BillingBillToKind.CONTACT:
             if bill_cid is None:
@@ -108,7 +111,6 @@ def _create_customized_invoice_draft(
             if session.get(Organization, bill_oid) is None:
                 raise ValidationError("Organization not found", field="billTo")
 
-        inv_date = _resolve_draft_invoice_date(body)
         inv = CustomerInvoice(
             status=BillingInvoiceStatus.DRAFT,
             currency=currency,

--- a/backend/src/app/api/admin_billing_invoice_drafts.py
+++ b/backend/src/app/api/admin_billing_invoice_drafts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date, timedelta
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import Any
 from collections.abc import Mapping
@@ -24,15 +25,38 @@ from app.api.admin_billing_invoice_draft_helpers import (
 )
 from app.config import get_default_currency_code
 from app.api.admin_request import parse_body
+from app.api.admin_expenses_common import parse_optional_date
 from app.db.audit import AuditService
 from app.db.models import Contact, Enrollment, Family, Organization
 from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
 from app.db.models.enums import BillingBillToKind, BillingInvoiceStatus
 from app.exceptions import ValidationError
+from app.services.customer_invoice_pdf import today_in_invoice_display_tz_or_utc
 from app.utils import json_response
 
 _CUSTOMIZED_DRAFT_MAX_LINES = 50
 _DESC_MAX_LEN = 500
+
+_INVOICE_DATE_MIN = date(2000, 1, 1)
+
+
+def _resolve_draft_invoice_date(body: Mapping[str, Any]) -> date:
+    raw = _first_present(body, "invoiceDate", "invoice_date")
+    if raw is not None:
+        try:
+            parsed = parse_optional_date(raw)
+        except ValidationError as exc:
+            raise ValidationError(str(exc), field="invoiceDate") from exc
+    else:
+        parsed = None
+    chosen = parsed if parsed is not None else today_in_invoice_display_tz_or_utc()
+    if chosen < _INVOICE_DATE_MIN:
+        raise ValidationError("invoiceDate is too far in the past", field="invoiceDate")
+    if chosen > date.today() + timedelta(days=365):
+        raise ValidationError(
+            "invoiceDate is too far in the future", field="invoiceDate"
+        )
+    return chosen
 
 
 def _create_customized_invoice_draft(
@@ -84,6 +108,7 @@ def _create_customized_invoice_draft(
             if session.get(Organization, bill_oid) is None:
                 raise ValidationError("Organization not found", field="billTo")
 
+        inv_date = _resolve_draft_invoice_date(body)
         inv = CustomerInvoice(
             status=BillingInvoiceStatus.DRAFT,
             currency=currency,
@@ -94,6 +119,7 @@ def _create_customized_invoice_draft(
             bill_to_contact_id=bill_cid,
             bill_to_family_id=bill_fid,
             bill_to_organization_id=bill_oid,
+            invoice_date=inv_date,
         )
         _resolve_bill_to_party_from_invoice_fks(session, inv=inv)
 
@@ -209,6 +235,7 @@ def _create_customized_invoice_draft(
                 "bill_to_family_id": str(bill_fid) if bill_fid else None,
                 "bill_to_organization_id": str(bill_oid) if bill_oid else None,
                 "total": str(inv.total),
+                "invoice_date": inv_date.isoformat(),
             },
         )
 
@@ -288,6 +315,8 @@ def _create_invoice_draft(
                     field="lineTotalsByEnrollmentId",
                 ) from None
 
+    inv_date = _resolve_draft_invoice_date(body)
+
     with _session_with_audit(user_sub, request_id) as session:
         rows = list(
             session.execute(
@@ -349,6 +378,7 @@ def _create_invoice_draft(
             bill_to_contact_id=bill_cid,
             bill_to_family_id=bill_fid,
             bill_to_organization_id=bill_oid,
+            invoice_date=inv_date,
         )
         _resolve_bill_to_party_for_draft(session, inv=inv, first=first)
 
@@ -390,7 +420,10 @@ def _create_invoice_draft(
             table_name="customer_invoices",
             record_id=inv.id,
             action="DRAFT_CREATED",
-            new_values={"enrollment_ids": [str(x) for x in eids]},
+            new_values={
+                "enrollment_ids": [str(x) for x in eids],
+                "invoice_date": inv_date.isoformat(),
+            },
         )
 
         return json_response(

--- a/backend/src/app/api/admin_billing_invoice_serializers.py
+++ b/backend/src/app/api/admin_billing_invoice_serializers.py
@@ -54,6 +54,8 @@ def serialize_invoice_summary(
         "billToDisplayName": inv.bill_to_display_name,
         "billToEmail": inv.bill_to_email,
         "issuedAt": inv.issued_at.isoformat() if inv.issued_at else None,
+        "invoiceDate": inv.invoice_date.isoformat() if inv.invoice_date else None,
+        "dueDate": inv.due_date.isoformat() if inv.due_date else None,
         "voidedAt": inv.voided_at.isoformat() if inv.voided_at else None,
         "issuedPdfSha256": inv.issued_pdf_sha256,
         "lineCount": line_count,

--- a/backend/src/app/api/admin_billing_invoices.py
+++ b/backend/src/app/api/admin_billing_invoices.py
@@ -23,7 +23,10 @@ from app.services.customer_billing import (
     refresh_invoice_pdf,
     send_invoice_email,
 )
-from app.services.customer_invoice_pdf import compute_invoice_snapshot_dates
+from app.services.customer_invoice_pdf import (
+    add_payment_terms,
+    compute_invoice_snapshot_dates,
+)
 from app.utils import json_response
 
 
@@ -120,7 +123,12 @@ def _issue_invoice(
         inv.invoice_sequence = seq
         inv.status = BillingInvoiceStatus.ISSUED
         inv.issued_at = datetime.now(UTC)
-        inv.invoice_date, inv.due_date = compute_invoice_snapshot_dates(inv.issued_at)
+        if inv.invoice_date is None:
+            inv.invoice_date, inv.due_date = compute_invoice_snapshot_dates(
+                inv.issued_at
+            )
+        else:
+            inv.due_date = add_payment_terms(inv.invoice_date)
         session.flush()
         refresh_invoice_pdf(session, inv)
 

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -33,7 +33,7 @@ import re
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_RIGHT
@@ -232,12 +232,12 @@ def compute_invoice_snapshot_dates(issued_at: datetime) -> tuple[date, date]:
 def today_in_invoice_display_tz_or_utc() -> date:
     """Calendar-today in INVOICE_DISPLAY_TIMEZONE; fall back to UTC if env var unset/invalid."""
     tz_name = os.getenv("INVOICE_DISPLAY_TIMEZONE", "").strip()
-    if tz_name:
-        try:
-            return datetime.now(UTC).astimezone(ZoneInfo(tz_name)).date()
-        except Exception:
-            pass
-    return datetime.now(UTC).date()
+    if not tz_name:
+        return datetime.now(UTC).date()
+    try:
+        return datetime.now(UTC).astimezone(ZoneInfo(tz_name)).date()
+    except (ZoneInfoNotFoundError, OSError, ValueError, TypeError):
+        return datetime.now(UTC).date()
 
 
 def calendar_date_in_tz(dt: datetime | None, tz: ZoneInfo) -> date:

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -198,6 +198,11 @@ def payment_terms_days_or_raise() -> int:
     return val
 
 
+def add_payment_terms(inv_date: date) -> date:
+    """Return ``inv_date + INVOICE_PAYMENT_TERMS_DAYS`` using the same env helper."""
+    return inv_date + timedelta(days=payment_terms_days_or_raise())
+
+
 def invoice_display_timezone_or_raise() -> ZoneInfo:
     """Timezone for issued invoice date math; required for issuance (non-preview)."""
     tz_name = os.getenv("INVOICE_DISPLAY_TIMEZONE", "").strip()
@@ -219,10 +224,20 @@ def invoice_display_timezone_preview() -> ZoneInfo:
 def compute_invoice_snapshot_dates(issued_at: datetime) -> tuple[date, date]:
     """Compute persisted invoice_date and due_date at issue time from ``issued_at``."""
     tz = invoice_display_timezone_or_raise()
-    terms_days = payment_terms_days_or_raise()
     inv_date = calendar_date_in_tz(issued_at, tz)
-    due_date = inv_date + timedelta(days=terms_days)
+    due_date = add_payment_terms(inv_date)
     return inv_date, due_date
+
+
+def today_in_invoice_display_tz_or_utc() -> date:
+    """Calendar-today in INVOICE_DISPLAY_TIMEZONE; fall back to UTC if env var unset/invalid."""
+    tz_name = os.getenv("INVOICE_DISPLAY_TIMEZONE", "").strip()
+    if tz_name:
+        try:
+            return datetime.now(UTC).astimezone(ZoneInfo(tz_name)).date()
+        except Exception:
+            pass
+    return datetime.now(UTC).date()
 
 
 def calendar_date_in_tz(dt: datetime | None, tz: ZoneInfo) -> date:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -6325,6 +6325,14 @@ components:
           type: string
           format: date-time
           nullable: true
+        invoiceDate:
+          type: string
+          format: date
+          nullable: true
+        dueDate:
+          type: string
+          format: date
+          nullable: true
         voidedAt:
           type: string
           format: date-time
@@ -6483,6 +6491,11 @@ components:
           additionalProperties:
             type: string
             description: Decimal amount as string
+        invoiceDate:
+          type: string
+          format: date
+          nullable: true
+          description: Optional ISO date (YYYY-MM-DD). When omitted, defaults to today in INVOICE_DISPLAY_TIMEZONE (or UTC if unset).
     InvoiceBillToInput:
       type: object
       required:
@@ -6566,6 +6579,11 @@ components:
             $ref: "#/components/schemas/CustomizedInvoiceLineInput"
           minItems: 1
           maxItems: 50
+        invoiceDate:
+          type: string
+          format: date
+          nullable: true
+          description: Optional ISO date (YYYY-MM-DD). When omitted, defaults to today in INVOICE_DISPLAY_TIMEZONE (or UTC if unset).
     CreatePaymentAllocationRequest:
       type: object
       required:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -621,9 +621,11 @@ Migration `0055_customer_billing_ar` introduces:
 - `document_counters`: serialized invoice/receipt numbering per scope and year.
 - Audit: same `audit_trigger_func()` as `0054_add_audit_log` on all five billing tables.
 - Migration `0057_invoice_dates_snapshot` adds nullable `invoice_date` and `due_date`
-  on `customer_invoices` (calendar snapshots computed at issuance in
-  `INVOICE_DISPLAY_TIMEZONE`; drafts leave both null). PDF rendering prefers these
-  columns when set.
+  on `customer_invoices`. Drafts persist `invoice_date` at creation (defaulting to today in
+  `INVOICE_DISPLAY_TIMEZONE` when that env var is set, else UTC); `due_date` remains unset until
+  issuance and is then derived as `invoice_date` + `INVOICE_PAYMENT_TERMS_DAYS`. At issue time,
+  if `invoice_date` was not set on the draft (legacy rows), both dates are computed from `issued_at`
+  in `INVOICE_DISPLAY_TIMEZONE` as before. PDF rendering prefers these columns when set.
 
 **Migration `0058_inv_line_null_enrollment`:** `customer_invoice_lines.enrollment_id` is nullable so customized (non-enrollment) invoice lines can omit the enrollment foreign key.
 

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
@@ -24,7 +25,7 @@ from app.api.admin_billing_common import (
     effective_enrollment_bill_to_fks,
     enrollment_bill_to_merge_key,
 )
-from app.db.models import Enrollment
+from app.db.models import Contact, Enrollment
 from app.db.models.customer_invoice import CustomerInvoice
 from app.db.models.enums import (
     BillingBillToKind,
@@ -1507,6 +1508,8 @@ def test_list_invoices_returns_items_and_cursor(
         voided_at = None
         void_reason = None
         issued_pdf_sha256 = None
+        invoice_date = None
+        due_date = None
         created_at = created
         updated_at = created
 
@@ -1582,6 +1585,8 @@ def test_get_invoice_returns_detail_with_lines(
         bill_to_snapshot = {"kind": "contact"}
         issued_pdf_sha256 = None
         email_sent_at = None
+        invoice_date = None
+        due_date = None
         created_at = ts
         updated_at = ts
         lines = [_Line()]
@@ -1976,6 +1981,399 @@ def test_email_invoice_rejects_invalid_email(
         admin_billing.handle_admin_billing_request(
             ev, "POST", f"/v1/admin/billing/invoices/{inv_id}/email"
         )
+
+
+def test_create_invoice_draft_accepts_invoice_date(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eid = uuid4()
+    saved: dict[str, Any] = {}
+
+    fake_en = MagicMock()
+    fake_en.id = eid
+    fake_en.currency = "USD"
+    fake_en.amount_paid = Decimal("10")
+    fake_en.instance = MagicMock(title="Inst")
+    fake_en.contact = MagicMock(
+        email="u@example.com", first_name="U", last_name="Ser"
+    )
+    fake_en.bill_to_kind = BillingBillToKind.CONTACT
+    fake_en.bill_to_contact_id = None
+    fake_en.bill_to_family_id = None
+    fake_en.bill_to_organization_id = None
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _exec(_stmt: Any, *a: Any, **k: Any) -> MagicMock:
+            out = MagicMock()
+            out.unique.return_value.scalars.return_value.all.return_value = [fake_en]
+            return out
+
+        def _add(obj: Any) -> None:
+            if isinstance(obj, CustomerInvoice):
+                saved["inv"] = obj
+
+        s.execute.side_effect = _exec
+        s.add.side_effect = _add
+        s.get.return_value = None
+        s.flush = MagicMock()
+        yield s
+
+    monkeypatch.setattr(admin_billing_invoice_drafts_mod, "_session_with_audit", _fake_session)
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "_resolve_bill_to_party_for_draft",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "AuditService",
+        lambda *_a, **_k: MagicMock(log_custom=lambda **_kw: None),
+    )
+
+    body = {
+        "draftKind": "enrollment_merge",
+        "enrollmentIds": [str(eid)],
+        "invoiceDate": "2024-12-31",
+    }
+    ev = api_gateway_event(
+        method="POST",
+        path="/v1/admin/billing/invoices",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(ev, "POST", "/v1/admin/billing/invoices")
+    assert r["statusCode"] == 201
+    assert saved["inv"].invoice_date == date(2024, 12, 31)
+
+
+def test_create_invoice_draft_defaults_invoice_date_to_today(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eid = uuid4()
+    saved: dict[str, Any] = {}
+
+    fake_en = MagicMock()
+    fake_en.id = eid
+    fake_en.currency = "USD"
+    fake_en.amount_paid = Decimal("10")
+    fake_en.instance = MagicMock(title="Inst")
+    fake_en.contact = MagicMock(
+        email="u@example.com", first_name="U", last_name="Ser"
+    )
+    fake_en.bill_to_kind = BillingBillToKind.CONTACT
+    fake_en.bill_to_contact_id = None
+    fake_en.bill_to_family_id = None
+    fake_en.bill_to_organization_id = None
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _exec(_stmt: Any, *a: Any, **k: Any) -> MagicMock:
+            out = MagicMock()
+            out.unique.return_value.scalars.return_value.all.return_value = [fake_en]
+            return out
+
+        def _add(obj: Any) -> None:
+            if isinstance(obj, CustomerInvoice):
+                saved["inv"] = obj
+
+        s.execute.side_effect = _exec
+        s.add.side_effect = _add
+        s.get.return_value = None
+        s.flush = MagicMock()
+        yield s
+
+    monkeypatch.setattr(admin_billing_invoice_drafts_mod, "_session_with_audit", _fake_session)
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "_resolve_bill_to_party_for_draft",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "AuditService",
+        lambda *_a, **_k: MagicMock(log_custom=lambda **_kw: None),
+    )
+
+    body = {"draftKind": "enrollment_merge", "enrollmentIds": [str(eid)]}
+    ev = api_gateway_event(
+        method="POST",
+        path="/v1/admin/billing/invoices",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(ev, "POST", "/v1/admin/billing/invoices")
+    assert r["statusCode"] == 201
+    assert saved["inv"].invoice_date is not None
+    assert saved["inv"].invoice_date == datetime.now(UTC).date()
+
+
+def test_create_customized_invoice_draft_accepts_invoice_date(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cid = uuid4()
+    saved: dict[str, Any] = {}
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is Contact and pk == cid:
+                return MagicMock()
+            return None
+
+        def _add(obj: Any) -> None:
+            if isinstance(obj, CustomerInvoice):
+                saved["inv"] = obj
+
+        s.get.side_effect = _get
+        s.add.side_effect = _add
+        s.flush = MagicMock()
+        yield s
+
+    monkeypatch.setattr(admin_billing_invoice_drafts_mod, "_session_with_audit", _fake_session)
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "_resolve_bill_to_party_from_invoice_fks",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "AuditService",
+        lambda *_a, **_k: MagicMock(log_custom=lambda **_kw: None),
+    )
+
+    body = {
+        "draftKind": "customized_manual",
+        "billTo": {"kind": "contact", "contactId": str(cid)},
+        "currency": "HKD",
+        "lines": [{"description": "A", "quantity": "1", "unitAmount": "10"}],
+        "invoiceDate": "2024-06-15",
+    }
+    ev = api_gateway_event(
+        method="POST",
+        path="/v1/admin/billing/invoices",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(ev, "POST", "/v1/admin/billing/invoices")
+    assert r["statusCode"] == 201
+    assert saved["inv"].invoice_date == date(2024, 6, 15)
+
+
+def test_create_invoice_draft_rejects_invalid_invoice_date(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eid = uuid4()
+    fake_en = MagicMock()
+    fake_en.id = eid
+    fake_en.currency = "HKD"
+    fake_en.instance = None
+    fake_en.contact = None
+    fake_en.bill_to_kind = None
+    fake_en.bill_to_contact_id = None
+    fake_en.bill_to_family_id = None
+    fake_en.bill_to_organization_id = None
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _exec(_stmt: Any, *a: Any, **k: Any) -> MagicMock:
+            out = MagicMock()
+            out.unique.return_value.scalars.return_value.all.return_value = [fake_en]
+            return out
+
+        s.execute.side_effect = _exec
+        yield s
+
+    monkeypatch.setattr(admin_billing_invoice_drafts_mod, "_session_with_audit", _fake_session)
+
+    body = {
+        "draftKind": "enrollment_merge",
+        "enrollmentIds": [str(eid)],
+        "invoiceDate": "not-a-date",
+    }
+    ev = api_gateway_event(
+        method="POST",
+        path="/v1/admin/billing/invoices",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(ValidationError) as excinfo:
+        admin_billing.handle_admin_billing_request(ev, "POST", "/v1/admin/billing/invoices")
+    assert getattr(excinfo.value, "field", None) == "invoiceDate"
+
+
+def test_issue_preserves_draft_invoice_date_and_derives_due_date(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INVOICE_PAYMENT_TERMS_DAYS", "7")
+    inv_id = uuid4()
+    bill_cid = uuid4()
+    inv = SimpleNamespace(
+        id=inv_id,
+        status=BillingInvoiceStatus.DRAFT,
+        currency="HKD",
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact_id=bill_cid,
+        bill_to_family_id=None,
+        bill_to_organization_id=None,
+        bill_to_display_name="Pat",
+        bill_to_email="p@example.com",
+        bill_to_snapshot=None,
+        invoice_date=date(2024, 3, 10),
+        due_date=None,
+        invoice_number=None,
+        invoice_sequence=None,
+        issued_at=None,
+        issued_pdf_sha256="abc",
+    )
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is CustomerInvoice and pk == inv_id:
+                return inv
+            if model is Contact and pk == bill_cid:
+                return SimpleNamespace(
+                    id=bill_cid,
+                    first_name="P",
+                    last_name="N",
+                    email="p@example.com",
+                )
+            return None
+
+        s.get.side_effect = _get
+        s.flush = MagicMock()
+        yield s
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+    monkeypatch.setattr(
+        admin_billing_invoices_mod,
+        "next_invoice_number",
+        lambda _session, currency: ("INV-TEST-1", 1),
+    )
+    monkeypatch.setattr(admin_billing_invoices_mod, "refresh_invoice_pdf", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        admin_billing_invoices_mod,
+        "AuditService",
+        lambda *_a, **_k: MagicMock(log_custom=lambda **_kw: None),
+    )
+
+    ev = api_gateway_event(
+        method="POST",
+        path=f"/v1/admin/billing/invoices/{inv_id}/issue",
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "POST", f"/v1/admin/billing/invoices/{inv_id}/issue"
+    )
+    assert r["statusCode"] == 200
+    assert inv.invoice_date == date(2024, 3, 10)
+    assert inv.due_date == date(2024, 3, 17)
+
+
+def test_issue_legacy_draft_without_invoice_date_uses_snapshot(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INVOICE_DISPLAY_TIMEZONE", "UTC")
+    monkeypatch.setenv("INVOICE_PAYMENT_TERMS_DAYS", "7")
+    fixed_issue = datetime(2026, 6, 15, 14, 0, 0, tzinfo=UTC)
+
+    class _DateTimeShim:
+        UTC = UTC
+
+        @staticmethod
+        def now(tz: Any = None) -> datetime:
+            return fixed_issue
+
+    monkeypatch.setattr(admin_billing_invoices_mod, "datetime", _DateTimeShim)
+
+    inv_id = uuid4()
+    bill_cid = uuid4()
+    inv = SimpleNamespace(
+        id=inv_id,
+        status=BillingInvoiceStatus.DRAFT,
+        currency="HKD",
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact_id=bill_cid,
+        bill_to_family_id=None,
+        bill_to_organization_id=None,
+        bill_to_display_name="Pat",
+        bill_to_email="p@example.com",
+        bill_to_snapshot=None,
+        invoice_date=None,
+        due_date=None,
+        invoice_number=None,
+        invoice_sequence=None,
+        issued_at=None,
+        issued_pdf_sha256="abc",
+    )
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is CustomerInvoice and pk == inv_id:
+                return inv
+            if model is Contact and pk == bill_cid:
+                return SimpleNamespace(
+                    id=bill_cid,
+                    first_name="P",
+                    last_name="N",
+                    email="p@example.com",
+                )
+            return None
+
+        s.get.side_effect = _get
+        s.flush = MagicMock()
+        yield s
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+    monkeypatch.setattr(
+        admin_billing_invoices_mod,
+        "next_invoice_number",
+        lambda _session, currency: ("INV-TEST-2", 2),
+    )
+    monkeypatch.setattr(admin_billing_invoices_mod, "refresh_invoice_pdf", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        admin_billing_invoices_mod,
+        "AuditService",
+        lambda *_a, **_k: MagicMock(log_custom=lambda **_kw: None),
+    )
+
+    ev = api_gateway_event(
+        method="POST",
+        path=f"/v1/admin/billing/invoices/{inv_id}/issue",
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "POST", f"/v1/admin/billing/invoices/{inv_id}/issue"
+    )
+    assert r["statusCode"] == 200
+    assert inv.invoice_date == date(2026, 6, 15)
+    assert inv.due_date == date(2026, 6, 22)
 
 
 def test_create_payment_returns_400_on_invalid_amount(

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from contextlib import contextmanager
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 from types import SimpleNamespace
@@ -2049,6 +2049,82 @@ def test_create_invoice_draft_accepts_invoice_date(
     r = admin_billing.handle_admin_billing_request(ev, "POST", "/v1/admin/billing/invoices")
     assert r["statusCode"] == 201
     assert saved["inv"].invoice_date == date(2024, 12, 31)
+
+
+def test_create_invoice_draft_accepts_invoice_date_at_upper_bound_in_display_tz(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INVOICE_DISPLAY_TIMEZONE", "Asia/Hong_Kong")
+    fixed_today = date(2026, 6, 15)
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "today_in_invoice_display_tz_or_utc",
+        lambda: fixed_today,
+    )
+    eid = uuid4()
+    saved: dict[str, Any] = {}
+
+    fake_en = MagicMock()
+    fake_en.id = eid
+    fake_en.currency = "USD"
+    fake_en.amount_paid = Decimal("10")
+    fake_en.instance = MagicMock(title="Inst")
+    fake_en.contact = MagicMock(
+        email="u@example.com", first_name="U", last_name="Ser"
+    )
+    fake_en.bill_to_kind = BillingBillToKind.CONTACT
+    fake_en.bill_to_contact_id = None
+    fake_en.bill_to_family_id = None
+    fake_en.bill_to_organization_id = None
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _exec(_stmt: Any, *a: Any, **k: Any) -> MagicMock:
+            out = MagicMock()
+            out.unique.return_value.scalars.return_value.all.return_value = [fake_en]
+            return out
+
+        def _add(obj: Any) -> None:
+            if isinstance(obj, CustomerInvoice):
+                saved["inv"] = obj
+
+        s.execute.side_effect = _exec
+        s.add.side_effect = _add
+        s.get.return_value = None
+        s.flush = MagicMock()
+        yield s
+
+    monkeypatch.setattr(admin_billing_invoice_drafts_mod, "_session_with_audit", _fake_session)
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "_resolve_bill_to_party_for_draft",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        admin_billing_invoice_drafts_mod,
+        "AuditService",
+        lambda *_a, **_k: MagicMock(log_custom=lambda **_kw: None),
+    )
+
+    upper = (fixed_today + timedelta(days=365)).isoformat()
+    body = {
+        "draftKind": "enrollment_merge",
+        "enrollmentIds": [str(eid)],
+        "invoiceDate": upper,
+    }
+    ev = api_gateway_event(
+        method="POST",
+        path="/v1/admin/billing/invoices",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(ev, "POST", "/v1/admin/billing/invoices")
+    assert r["statusCode"] == 201
+    assert saved["inv"].invoice_date == fixed_today + timedelta(days=365)
 
 
 def test_create_invoice_draft_defaults_invoice_date_to_today(

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -866,6 +866,27 @@ def test_preview_uses_utc_without_display_tz(monkeypatch: pytest.MonkeyPatch) ->
     assert pdf.startswith(b"%PDF")
 
 
+def test_rendered_pdf_includes_explicit_invoice_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    _base_invoice_env(monkeypatch)
+    inv = SimpleNamespace(
+        invoice_number="N-2025",
+        currency="HKD",
+        subtotal=Decimal("1"),
+        tax_total=Decimal("0"),
+        total=Decimal("1"),
+        bill_to_display_name="Client",
+        bill_to_email=None,
+        issued_at=datetime(2026, 1, 10, tzinfo=UTC),
+        invoice_date=date(2025, 5, 15),
+        due_date=date(2025, 5, 22),
+        status=BillingInvoiceStatus.ISSUED,
+    )
+    pdf = render_invoice_pdf(invoice=inv, lines=[_inv_line()], preview=False)
+    text = _pdf_text(pdf)
+    assert "2025-05-15" in text
+    assert "2025-05-22" in text
+
+
 def test_issued_requires_display_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("INVOICE_DISPLAY_TIMEZONE", raising=False)
     monkeypatch.setenv("INVOICE_PAYMENT_TERMS_DAYS", "7")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements optional `invoiceDate` on admin draft invoice creation, persists `invoice_date` on drafts, preserves it at issue with `due_date` from payment terms, and exposes `invoiceDate`/`dueDate` on invoice summaries. Follow-up remediation: date-only list rendering, sort-key copy, native min/max, aligned server upper bound, form microcopy and blur behavior, shared `localTodayYmd`, PDF integration test, and CSV export TODO.

## Follow-up fixes (this update)

- **Invoice date column**: `formatYmdAsLocalDate` + `formatDateOnly` for legacy `createdAt` fallback (no clock, no YMD UTC parse shift).
- **PaginatedTableCard**: Description clarifies ordering by record creation time vs displayed invoice date.
- **Date inputs**: `min`/`max`, helper paragraph, `onBlur` empty → `localTodayYmd()`; shared helpers in `@/lib/format`.
- **Server**: `_resolve_draft_invoice_date` uses `today = today_in_invoice_display_tz_or_utc()` for upper bound; customized draft resolves `inv_date` before `_session_with_audit`.
- **CSV**: TODO on `admin_billing_export` invoice rows still using `created_at`.
- **Tests**: Upper-bound test with `INVOICE_DISPLAY_TIMEZONE` + patched today helper; PDF text asserts `2025-05-15` / due date; Vitest uses `formatYmdAsLocalDate` / `formatDateOnly`.

## Validation

- `ruff check backend/ tests/ --config=backend/pyproject.toml`
- `pre-commit run ruff-format --files` (touched Python)
- `pytest tests/test_admin_billing.py tests/test_customer_invoice_pdf.py -x`
- `cd apps/admin_web && npm run lint && npx vitest run` (targeted + format tests)
- `bash scripts/validate-cursorrules.sh`

## Not in this PR

- **Fix 10 (optional)**: Relocating `parse_optional_date` out of `admin_expenses_common` deferred.
- **CSV column semantics**: No export schema change without product sign-off (TODO only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c060a747-1c55-4f3b-b9db-1cd893ed31ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c060a747-1c55-4f3b-b9db-1cd893ed31ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

