### PR TITLE
Invoice PDFs: family bill-to primary name only; enrollment line descriptions

### DIFF
--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -41,6 +41,62 @@ def _enrollment_merge_key(en: Enrollment) -> tuple[Any, ...]:
     return effective_enrollment_bill_to_fks(en)
 
 
+def _trimmed_str_or_none(value: object | None) -> str | None:
+    """Return stripped non-empty string, or None (non-strings ignored)."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    t = value.strip()
+    return t or None
+
+
+def _capitalize_first_letter(value: str) -> str:
+    s = value.strip()
+    if not s:
+        return s
+    return s[0].upper() + s[1:]
+
+
+def _build_enrollment_merge_line_description(enrollment: Enrollment) -> str:
+    """Line text for enrollment-merge invoices: title — tier — cohort (hyphen-separated).
+
+    Title prefers instance title, then parent service title. Tier prefers enrollment ticket
+    tier name, then catalog ``service_tier``. Tier and cohort segments use a leading
+    capital letter only (rest unchanged). Falls back to ``Enrollment`` when no title path exists.
+    """
+    inst = enrollment.instance
+    title_part: str | None = None
+    svc = getattr(inst, "service", None) if inst is not None else None
+    if inst is not None:
+        title_part = _trimmed_str_or_none(inst.title)
+    if title_part is None and svc is not None:
+        title_part = _trimmed_str_or_none(getattr(svc, "title", None))
+
+    tier_raw: str | None = None
+    if enrollment.ticket_tier_id and enrollment.ticket_tier is not None:
+        tier_raw = _trimmed_str_or_none(enrollment.ticket_tier.name)
+    if tier_raw is None and svc is not None:
+        tier_raw = _trimmed_str_or_none(getattr(svc, "service_tier", None))
+
+    cohort_raw: str | None = None
+    if inst is not None:
+        cohort_raw = _trimmed_str_or_none(inst.cohort)
+
+    parts: list[str] = []
+    if title_part:
+        parts.append(title_part)
+    if tier_raw:
+        parts.append(_capitalize_first_letter(tier_raw))
+    if cohort_raw:
+        parts.append(_capitalize_first_letter(cohort_raw))
+
+    if not parts:
+        return "Enrollment"
+    out = " - ".join(parts)
+    return out[:500]
+
+
 def _resolve_bill_to_party_from_invoice_fks(
     session: Session, *, inv: CustomerInvoice
 ) -> None:
@@ -69,12 +125,13 @@ def _resolve_bill_to_party_from_invoice_fks(
             .limit(1)
         )
         primary = session.execute(stmt).scalar_one_or_none()
-        label = family_or_organization_bill_to_display_label(
-            entity_name=fam.family_name,
-            primary_display_name=contact_display_name(primary),
-        )
-        if label:
-            inv.bill_to_display_name = label
+        primary_nm = (contact_display_name(primary) or "").strip()
+        if primary_nm:
+            inv.bill_to_display_name = primary_nm
+        else:
+            fam_nm = (fam.family_name or "").strip()
+            if fam_nm:
+                inv.bill_to_display_name = fam_nm
         if primary and primary.email:
             inv.bill_to_email = primary.email
         return

--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session
 from app.api.admin_billing_common import (
     contact_display_name,
     effective_enrollment_bill_to_fks,
-    family_or_organization_bill_to_display_label,
 )
 from app.db.models import Contact, Enrollment, Family, Organization
 from app.db.models.customer_invoice import CustomerInvoice
@@ -59,7 +58,7 @@ def _capitalize_first_letter(value: str) -> str:
 
 
 def _build_enrollment_merge_line_description(enrollment: Enrollment) -> str:
-    """Line text for enrollment-merge invoices: title — tier — cohort (hyphen-separated).
+    """Line text for enrollment-merge invoices: title, tier, and cohort space-separated.
 
     Title prefers instance title, then parent service title. Tier prefers enrollment ticket
     tier name, then catalog ``service_tier``. Tier and cohort segments use a leading
@@ -93,7 +92,7 @@ def _build_enrollment_merge_line_description(enrollment: Enrollment) -> str:
 
     if not parts:
         return "Enrollment"
-    out = " - ".join(parts)
+    out = " ".join(parts)
     return out[:500]
 
 
@@ -153,12 +152,14 @@ def _resolve_bill_to_party_from_invoice_fks(
             .limit(1)
         )
         primary = session.execute(stmt).scalar_one_or_none()
-        label = family_or_organization_bill_to_display_label(
-            entity_name=org.name,
-            primary_display_name=contact_display_name(primary),
-        )
-        if label:
-            inv.bill_to_display_name = label
+        entity_nm = (org.name or "").strip()
+        primary_nm = (contact_display_name(primary) or "").strip()
+        if entity_nm and primary_nm:
+            inv.bill_to_display_name = f"{entity_nm}\n{primary_nm}"
+        elif entity_nm:
+            inv.bill_to_display_name = entity_nm
+        elif primary_nm:
+            inv.bill_to_display_name = primary_nm
         if primary and primary.email:
             inv.bill_to_email = primary.email
 

--- a/backend/src/app/api/admin_billing_invoice_drafts.py
+++ b/backend/src/app/api/admin_billing_invoice_drafts.py
@@ -16,6 +16,7 @@ from app.api.admin_billing_common import (
     effective_enrollment_bill_to_fks,
 )
 from app.api.admin_billing_invoice_draft_helpers import (
+    _build_enrollment_merge_line_description,
     _decimal_field,
     _enrollment_merge_key,
     _first_present,
@@ -30,6 +31,7 @@ from app.db.audit import AuditService
 from app.db.models import Contact, Enrollment, Family, Organization
 from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
 from app.db.models.enums import BillingBillToKind, BillingInvoiceStatus
+from app.db.models.service_instance import ServiceInstance
 from app.exceptions import ValidationError
 from app.services.customer_invoice_pdf import today_in_invoice_display_tz_or_utc
 from app.utils import json_response
@@ -325,8 +327,9 @@ def _create_invoice_draft(
                 select(Enrollment)
                 .where(Enrollment.id.in_(eids))
                 .options(
-                    joinedload(Enrollment.instance),
+                    joinedload(Enrollment.instance).joinedload(ServiceInstance.service),
                     joinedload(Enrollment.contact),
+                    joinedload(Enrollment.ticket_tier),
                 )
             )
             .unique()
@@ -390,15 +393,11 @@ def _create_invoice_draft(
         subtotal = Decimal("0")
         tax_total = Decimal("0")
         for order, en in enumerate(enrollments):
-            title = ""
-            if en.instance:
-                title = (en.instance.title or "").strip()
             if en.id in line_overrides:
                 line_total = line_overrides[en.id]
             else:
                 line_total = en.amount_paid or Decimal("0")
-            desc = title or "Enrollment"
-            line_desc = desc[:500]
+            line_desc = _build_enrollment_merge_line_description(en)
             line = CustomerInvoiceLine(
                 invoice_id=inv.id,
                 enrollment_id=en.id,

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -531,7 +531,11 @@ def render_invoice_pdf(
 
     bill_body_parts: list[str] = []
     if invoice.bill_to_display_name:
-        bill_body_parts.append(_esc(invoice.bill_to_display_name))
+        name_lines = [
+            ln.strip() for ln in invoice.bill_to_display_name.split("\n") if ln.strip()
+        ]
+        if name_lines:
+            bill_body_parts.append("<br/>".join(_esc(ln) for ln in name_lines))
     if invoice.bill_to_email:
         bill_body_parts.append(_esc(invoice.bill_to_email))
     bill_body_html = "<br/>".join(bill_body_parts) if bill_body_parts else ""

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -2625,7 +2625,7 @@ def test_build_enrollment_merge_line_description_title_tier_cohort() -> None:
     )
     assert (
         _build_enrollment_merge_line_description(en)  # type: ignore[arg-type]
-        == "Parent Service - Premium - Spring 2026"
+        == "Parent Service Premium Spring 2026"
     )
 
 
@@ -2645,8 +2645,46 @@ def test_build_enrollment_merge_line_description_prefers_instance_title_and_tick
     )
     assert (
         _build_enrollment_merge_line_description(en)  # type: ignore[arg-type]
-        == "June Weekend - Early bird"
+        == "June Weekend Early bird"
     )
+
+
+def test_resolve_bill_to_party_from_invoice_fks_organization_two_lines() -> None:
+    """Organization invoices store entity and primary contact on separate lines (PDF breaks)."""
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Organization
+
+    oid = uuid4()
+    org = SimpleNamespace(name="Acme Learning Ltd")
+    primary = SimpleNamespace(
+        first_name="Jordan",
+        last_name="Lee",
+        email="jordan@example.com",
+    )
+    session = MagicMock()
+
+    def _get(model: Any, pk: Any) -> Any:
+        if model is Organization and pk == oid:
+            return org
+        return None
+
+    session.get.side_effect = _get
+
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = primary
+    session.execute.return_value = exec_result
+
+    inv = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.ORGANIZATION,
+        bill_to_organization_id=oid,
+        bill_to_display_name=None,
+        bill_to_email=None,
+    )
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
+    assert inv.bill_to_display_name == "Acme Learning Ltd\nJordan Lee"
+    assert inv.bill_to_email == "jordan@example.com"
 
 
 def test_resolve_bill_to_party_from_invoice_fks_contact_without_email_sets_display_name() -> None:

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -2541,6 +2541,114 @@ def test_compose_enrollment_party_display_name_contact_includes_email_when_known
     )
 
 
+def test_resolve_bill_to_party_from_invoice_fks_family_uses_primary_contact_only() -> None:
+    """Family invoices show primary contact as bill-to display name (no family · name line)."""
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Family
+
+    fid = uuid4()
+    fam = SimpleNamespace(family_name="The Ng Household")
+    primary = SimpleNamespace(
+        first_name="Pat",
+        last_name="Ng",
+        email="pat@example.com",
+    )
+    session = MagicMock()
+
+    def _get(model: Any, pk: Any) -> Any:
+        if model is Family and pk == fid:
+            return fam
+        return None
+
+    session.get.side_effect = _get
+
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = primary
+    session.execute.return_value = exec_result
+
+    inv = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.FAMILY,
+        bill_to_family_id=fid,
+        bill_to_display_name=None,
+        bill_to_email=None,
+    )
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
+    assert inv.bill_to_display_name == "Pat Ng"
+    assert inv.bill_to_email == "pat@example.com"
+
+
+def test_resolve_bill_to_party_from_invoice_fks_family_falls_back_to_family_name() -> None:
+    """When no primary contact name exists, family bill-to still gets a non-empty label."""
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Family
+
+    fid = uuid4()
+    fam = SimpleNamespace(family_name="Orphan Household")
+    session = MagicMock()
+
+    def _get(model: Any, pk: Any) -> Any:
+        if model is Family and pk == fid:
+            return fam
+        return None
+
+    session.get.side_effect = _get
+
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = None
+    session.execute.return_value = exec_result
+
+    inv = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.FAMILY,
+        bill_to_family_id=fid,
+        bill_to_display_name=None,
+        bill_to_email=None,
+    )
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
+    assert inv.bill_to_display_name == "Orphan Household"
+
+
+def test_build_enrollment_merge_line_description_title_tier_cohort() -> None:
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _build_enrollment_merge_line_description,
+    )
+
+    svc = SimpleNamespace(title="Parent Service", service_tier="premium")
+    inst = SimpleNamespace(title=None, cohort="spring 2026", service=svc)
+    en = SimpleNamespace(
+        instance=inst,
+        ticket_tier_id=None,
+        ticket_tier=None,
+    )
+    assert (
+        _build_enrollment_merge_line_description(en)  # type: ignore[arg-type]
+        == "Parent Service - Premium - Spring 2026"
+    )
+
+
+def test_build_enrollment_merge_line_description_prefers_instance_title_and_ticket_tier() -> None:
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _build_enrollment_merge_line_description,
+    )
+
+    tier = SimpleNamespace(name="early bird")
+    svc = SimpleNamespace(title="Event Parent", service_tier="ignored_when_ticket")
+    inst = SimpleNamespace(title="June Weekend", cohort=None, service=svc)
+    tt_id = uuid4()
+    en = SimpleNamespace(
+        instance=inst,
+        ticket_tier_id=tt_id,
+        ticket_tier=tier,
+    )
+    assert (
+        _build_enrollment_merge_line_description(en)  # type: ignore[arg-type]
+        == "June Weekend - Early bird"
+    )
+
+
 def test_resolve_bill_to_party_from_invoice_fks_contact_without_email_sets_display_name() -> None:
     """Contact bill-to must populate display name even when email is absent (list + PDF)."""
     from types import SimpleNamespace


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Family bill-to display name**: Primary contact name only (fallback: family name when no primary name).
- **Organization bill-to display name**: Organization name and primary contact on **separate lines** (stored as a single `bill_to_display_name` with a newline; the invoice PDF joins those lines with `<br/>` in the Bill To block).
- **Enrollment-merge line descriptions**: Instance title (else service title), then optional tier and cohort, joined with **spaces** (no hyphens). Tier and cohort still use first-character capitalization only.

## Files

- `backend/src/app/api/admin_billing_invoice_draft_helpers.py` — org `bill_to_display_name` formatting; space-joined line descriptions.
- `backend/src/app/api/admin_billing_invoice_drafts.py` — (prior commit) eager-loads for merge drafts.
- `backend/src/app/services/customer_invoice_pdf.py` — newline-aware Bill To display name rendering.
- `tests/test_admin_billing.py` — coverage for org two-line resolution and updated description expectations.

## Tests

- `pytest tests/test_admin_billing.py tests/test_customer_invoice_pdf.py`
- `pre-commit run ruff-format --all-files`; `ruff check` on touched files; `bash scripts/validate-cursorrules.sh`

## Docs / API

- No OpenAPI changes; admin JSON still exposes `billToDisplayName` as one string (may contain `\n` for organization invoices).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-304b1191-52c5-4ae3-a2f3-4a8cea532c2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-304b1191-52c5-4ae3-a2f3-4a8cea532c2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

