### PR TITLE
Reduce AR invoice PDF font sizes by 2pt

### DIFF
--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -31,7 +31,7 @@ from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v7"
+INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v8"
 RECEIPT_PDF_TEMPLATE_VERSION = "billing-receipt-v1"
 _SCOPE_DEFAULT = "default"
 _DOC_INVOICE = "invoice"

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -362,8 +362,8 @@ def render_invoice_pdf(
         "InvTitle",
         parent=styles["Heading1"],
         fontName="Helvetica-Bold",
-        fontSize=18,
-        leading=22,
+        fontSize=16,
+        leading=20,
         textColor=_INV_TITLE,
         alignment=TA_RIGHT,
         spaceAfter=0,
@@ -372,32 +372,32 @@ def render_invoice_pdf(
         "InvLabelHeading",
         parent=styles["Normal"],
         fontName="Helvetica-Bold",
-        fontSize=12,
-        leading=18,
+        fontSize=10,
+        leading=16,
         textColor=_INV_LABEL_TEXT,
     )
     body_text_style = ParagraphStyle(
         "InvBodyText",
         parent=styles["Normal"],
         fontName="Helvetica",
-        fontSize=12,
-        leading=18,
+        fontSize=10,
+        leading=16,
         textColor=_INV_BODY_TEXT,
     )
     header_label_style = ParagraphStyle(
         "InvHeaderLabel",
         parent=styles["Normal"],
         fontName="Helvetica-Bold",
-        fontSize=12,
-        leading=14,
+        fontSize=10,
+        leading=12,
         textColor=_INV_HEADER_TEXT,
     )
     totals_label_style = ParagraphStyle(
         "InvTotalsLabel",
         parent=styles["Normal"],
         fontName="Helvetica-Bold",
-        fontSize=12,
-        leading=14,
+        fontSize=10,
+        leading=12,
         textColor=_INV_LABEL_TEXT,
         alignment=TA_RIGHT,
     )
@@ -405,8 +405,8 @@ def render_invoice_pdf(
         "InvTotalsValue",
         parent=styles["Normal"],
         fontName="Helvetica",
-        fontSize=12,
-        leading=14,
+        fontSize=10,
+        leading=12,
         textColor=_INV_BODY_TEXT,
         alignment=TA_RIGHT,
     )
@@ -414,8 +414,8 @@ def render_invoice_pdf(
         "InvTotalsTotal",
         parent=styles["Normal"],
         fontName="Helvetica-Bold",
-        fontSize=13.5,
-        leading=16,
+        fontSize=11.5,
+        leading=14,
         textColor=_INV_BODY_TEXT,
         alignment=TA_RIGHT,
     )
@@ -505,9 +505,9 @@ def render_invoice_pdf(
 
     body_lines_count = (1 if business_name else 0) + len(address_lines)
     from_lines = min(6, max(2, body_lines_count))
-    header_row_pt = max(150, 22 + (from_lines * 18) + 22)
+    header_row_pt = max(150, 22 + (from_lines * 16) + 22)
     if not show_due_date:
-        header_row_pt = max(132, header_row_pt - 18)
+        header_row_pt = max(132, header_row_pt - 16)
 
     from_cell = Table(
         [
@@ -925,7 +925,7 @@ def render_invoice_pdf(
         if not footer_text:
             return
         canvas_obj.saveState()
-        canvas_obj.setFont("Helvetica", 9)
+        canvas_obj.setFont("Helvetica", 7)
         canvas_obj.setFillColor(_INV_FOOTER_TEXT)
         y_footer = 14 * mm
         canvas_obj.drawCentredString(A4[0] / 2, y_footer, footer_text)

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -98,7 +98,7 @@ drops the old polymorphic tables, renames `crm_notes` → `notes`, and adds null
 
 ## AR invoice PDFs (FPS QR)
 
-**Decision:** Customer AR invoice PDFs (`billing-invoice-v7`) embed an FPS QR code server-side when the invoice total is positive, the invoice currency is HKD, and `PUBLIC_WWW_FPS_MERCHANT_NAME` plus `PUBLIC_WWW_FPS_MOBILE_NUMBER` are set on the admin Lambda (same semantics as the public booking modal / confirmation email, using the EMVCo payload rules from `apps/public_www/public/scripts/fps-generator.js`). Non-HKD invoices, missing FPS env configuration, or non-positive totals skip the QR and use bank-only or FPS-only copy as appropriate. Zero or negative totals omit the due date and the entire payment-instructions block.
+**Decision:** Customer AR invoice PDFs (`billing-invoice-v8`) embed an FPS QR code server-side when the invoice total is positive, the invoice currency is HKD, and `PUBLIC_WWW_FPS_MERCHANT_NAME` plus `PUBLIC_WWW_FPS_MOBILE_NUMBER` are set on the admin Lambda (same semantics as the public booking modal / confirmation email, using the EMVCo payload rules from `apps/public_www/public/scripts/fps-generator.js`). Non-HKD invoices, missing FPS env configuration, or non-positive totals skip the QR and use bank-only or FPS-only copy as appropriate. Zero or negative totals omit the due date and the entire payment-instructions block.
 
 **Why:** Keeps payment instructions consistent with the FPS path customers already see while avoiding misleading due dates or bank/FPS prompts on zero-amount documents.
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -207,7 +207,7 @@ their primary responsibilities.
   `ADMIN_GROUP`, `AWS_PROXY_FUNCTION_ARN` (sales recap recipient resolution via Cognito group),
   `SALES_RECAP_DISPLAY_TIMEZONE` (optional IANA id for recap **Submitted at**; CDK `SalesRecapDisplayTimezone` parameter, empty = app default),
   `MAILCHIMP_*` welcome journey vars (see `aws-messaging.md`)
-- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v7`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
+- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v8`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
 - **Invoice currency display:** `HKD` amounts render with the `HK$` prefix in AR invoice PDFs.
 - **AR invoice footer (Option B):** when both legal/trading and registration are set, the centered footer is `{legal_name} | Proudly registered in Hong Kong | BR: {reg}` with `legal_name` = `PUBLIC_WWW_BUSINESS_LEGAL_NAME` or `PUBLIC_WWW_BUSINESS_NAME`, and with fallbacks: legal only → legal; registration only → `BR: {reg}`; both empty → no footer. The **"Proudly registered in Hong Kong"** fragment is fixed product copy (see `.cursorrules` exception).
 - **Snapshot dates:** on issue, `customer_invoices.invoice_date` and `customer_invoices.due_date` are persisted (see `docs/architecture/database-schema.md`); the PDF uses these when present; draft previews compute dates in **UTC** when columns are null.

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -523,7 +523,7 @@ def test_v6_wide_hkd_amount_fits(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_invoice_pdf_versions_distinct() -> None:
-    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v7"
+    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v8"
     assert customer_billing.RECEIPT_PDF_TEMPLATE_VERSION == "billing-receipt-v1"
     assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION != (
         customer_billing.RECEIPT_PDF_TEMPLATE_VERSION


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Customer AR invoice PDFs (`backend/src/app/services/customer_invoice_pdf.py`) now use text that is **2pt smaller** across title, body, table header, totals, and footer canvas copy. `leading` values were reduced by 2pt in step so line spacing stays consistent with the smaller type.

The From/Bill To header row height calculation was updated to use the new body line height (16pt leading instead of 18pt).

`INVOICE_PDF_TEMPLATE_VERSION` is bumped to `billing-invoice-v8` so newly issued invoices record the layout change. `docs/architecture/lambdas.md` and `docs/architecture/decisions.md` reference the new version string.

## Testing

- `pytest tests/test_customer_invoice_pdf.py -q`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
- `ruff check` on touched Python files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ff0e59a-4b1a-411c-b690-da11e150a731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ff0e59a-4b1a-411c-b690-da11e150a731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

