### PR TITLE
AR invoice PDF: tighter table/totals spacing and payment alignment

### DIFF
--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -31,7 +31,7 @@ from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v8"
+INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v9"
 RECEIPT_PDF_TEMPLATE_VERSION = "billing-receipt-v1"
 _SCOPE_DEFAULT = "default"
 _DOC_INVOICE = "invoice"

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -625,7 +625,7 @@ def render_invoice_pdf(
         )
     )
     story.append(header_band)
-    story.append(Spacer(1, 32))
+    story.append(Spacer(1, 16))
 
     header_row = [
         Paragraph("<b>Description</b>", header_label_style),
@@ -671,8 +671,8 @@ def render_invoice_pdf(
                 ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
                 ("LEFTPADDING", (0, 0), (-1, -1), 5),
                 ("RIGHTPADDING", (0, 0), (-1, -1), 5),
-                ("TOPPADDING", (0, 0), (-1, -1), 10),
-                ("BOTTOMPADDING", (0, 0), (-1, -1), 10),
+                ("TOPPADDING", (0, 0), (-1, -1), 5),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
             ]
             if has_header:
                 hdr = 0
@@ -681,8 +681,8 @@ def render_invoice_pdf(
                         ("BACKGROUND", (0, hdr), (-1, hdr), _INV_HEADER_FILL),
                         ("TEXTCOLOR", (0, hdr), (-1, hdr), _INV_HEADER_TEXT),
                         ("ALIGN", (0, hdr), (-1, hdr), "LEFT"),
-                        ("TOPPADDING", (0, hdr), (-1, hdr), 12),
-                        ("BOTTOMPADDING", (0, hdr), (-1, hdr), 12),
+                        ("TOPPADDING", (0, hdr), (-1, hdr), 6),
+                        ("BOTTOMPADDING", (0, hdr), (-1, hdr), 6),
                         (
                             "LINEBELOW",
                             (0, hdr),
@@ -758,7 +758,7 @@ def render_invoice_pdf(
     )
     last_row = len(inner_totals_rows) - 1
     totals_card_w = 88 * mm
-    totals_card_h = 30 * (last_row + 1) + 28
+    totals_card_h = 30 * (last_row + 1) + 20
     inner_totals = Table(
         inner_totals_rows,
         colWidths=[48 * mm, 40 * mm],
@@ -767,8 +767,8 @@ def render_invoice_pdf(
         ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
         ("LEFTPADDING", (0, 0), (-1, -1), 8),
         ("RIGHTPADDING", (0, 0), (-1, -1), 8),
-        ("TOPPADDING", (0, 0), (-1, -1), 8),
-        ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
         ("LINEABOVE", (1, last_row), (1, last_row), 0.6, _INV_TOTAL_RULE),
     ]
     inner_totals.setStyle(TableStyle(totals_style_cmds))
@@ -803,7 +803,7 @@ def render_invoice_pdf(
             ]
         )
     )
-    story.append(Spacer(1, 18))
+    story.append(Spacer(1, 9))
     story.append(totals_outer)
     story.append(Spacer(1, 36))
 
@@ -831,38 +831,6 @@ def render_invoice_pdf(
             pay_left_w = 102 * mm
             pay_right_w = 88 * mm
 
-            bank_rows: list[list] = [
-                [Paragraph(_esc(pay_intro), body_text_style)],
-            ]
-            if has_bank_block:
-                bank_rows.append([Spacer(1, 12)])
-                bank_lines = [
-                    f"Bank: {_esc(bank_name)}" if bank_name else "",
-                    f"Account Number: {_esc(bank_number)}" if bank_number else "",
-                    f"Account Name: {_esc(bank_holder)}" if bank_holder else "",
-                ]
-                first_bank = True
-                for bl in bank_lines:
-                    if not bl:
-                        continue
-                    if not first_bank:
-                        bank_rows.append([Spacer(1, 2)])
-                    bank_rows.append([Paragraph(bl, body_text_style)])
-                    first_bank = False
-
-            bank_cell = Table(bank_rows, colWidths=[pay_left_w])
-            bank_cell.setStyle(
-                TableStyle(
-                    [
-                        ("VALIGN", (0, 0), (-1, -1), "TOP"),
-                        ("LEFTPADDING", (0, 0), (-1, -1), 0),
-                        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
-                        ("TOPPADDING", (0, 0), (-1, -1), 0),
-                        ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
-                    ]
-                )
-            )
-
             fps_stack_rows: list[list] = []
             if fps_payload is not None:
                 logo_flow = _fps_logo_image()
@@ -879,6 +847,7 @@ def render_invoice_pdf(
                 qr_img.hAlign = "RIGHT"
                 fps_stack_rows.append([qr_img])
 
+            fps_cell_flow: Paragraph | Table = Paragraph("", body_text_style)
             if fps_stack_rows:
                 fps_cell_inner = Table(
                     fps_stack_rows,
@@ -896,25 +865,52 @@ def render_invoice_pdf(
                         ]
                     )
                 )
-                fps_cell = fps_cell_inner
-            else:
-                fps_cell = Paragraph("", body_text_style)
+                fps_cell_flow = fps_cell_inner
+
+            pay_rows: list[list] = []
+            pay_style_cmds: list[tuple] = [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+                ("TOPPADDING", (0, 0), (-1, -1), 0),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
+            ]
+            r = 0
+            pay_rows.append([Paragraph(_esc(pay_intro), body_text_style), ""])
+            pay_style_cmds.append(("SPAN", (0, r), (1, r)))
+            r += 1
+
+            if has_bank_block:
+                pay_rows.append([Spacer(1, 12), ""])
+                pay_style_cmds.append(("SPAN", (0, r), (1, r)))
+                r += 1
+                bank_lines = [
+                    f"Bank: {_esc(bank_name)}" if bank_name else "",
+                    f"Account Number: {_esc(bank_number)}" if bank_number else "",
+                    f"Account Name: {_esc(bank_holder)}" if bank_holder else "",
+                ]
+                first_bank = True
+                for bl in bank_lines:
+                    if not bl:
+                        continue
+                    if not first_bank:
+                        pay_rows.append([Spacer(1, 2), ""])
+                        pay_style_cmds.append(("SPAN", (0, r), (1, r)))
+                        r += 1
+                    pay_rows.append([Paragraph(bl, body_text_style), ""])
+                    pay_style_cmds.append(("SPAN", (0, r), (1, r)))
+                    r += 1
+                    first_bank = False
+
+            if fps_stack_rows:
+                pay_rows.append([Paragraph("", body_text_style), fps_cell_flow])
+                pay_style_cmds.append(("ALIGN", (1, r), (1, r), "RIGHT"))
 
             pay_table = Table(
-                [[bank_cell, fps_cell]],
+                pay_rows,
                 colWidths=[pay_left_w, pay_right_w],
             )
-            pay_table.setStyle(
-                TableStyle(
-                    [
-                        ("VALIGN", (0, 0), (-1, -1), "TOP"),
-                        ("LEFTPADDING", (0, 0), (-1, -1), 0),
-                        ("RIGHTPADDING", (0, 0), (-1, -1), 0),
-                        ("TOPPADDING", (0, 0), (-1, -1), 0),
-                        ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
-                    ]
-                )
-            )
+            pay_table.setStyle(TableStyle(pay_style_cmds))
             story.append(pay_table)
     else:
         story.append(Spacer(1, 36))

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -98,7 +98,7 @@ drops the old polymorphic tables, renames `crm_notes` → `notes`, and adds null
 
 ## AR invoice PDFs (FPS QR)
 
-**Decision:** Customer AR invoice PDFs (`billing-invoice-v8`) embed an FPS QR code server-side when the invoice total is positive, the invoice currency is HKD, and `PUBLIC_WWW_FPS_MERCHANT_NAME` plus `PUBLIC_WWW_FPS_MOBILE_NUMBER` are set on the admin Lambda (same semantics as the public booking modal / confirmation email, using the EMVCo payload rules from `apps/public_www/public/scripts/fps-generator.js`). Non-HKD invoices, missing FPS env configuration, or non-positive totals skip the QR and use bank-only or FPS-only copy as appropriate. Zero or negative totals omit the due date and the entire payment-instructions block.
+**Decision:** Customer AR invoice PDFs (`billing-invoice-v9`) embed an FPS QR code server-side when the invoice total is positive, the invoice currency is HKD, and `PUBLIC_WWW_FPS_MERCHANT_NAME` plus `PUBLIC_WWW_FPS_MOBILE_NUMBER` are set on the admin Lambda (same semantics as the public booking modal / confirmation email, using the EMVCo payload rules from `apps/public_www/public/scripts/fps-generator.js`). Non-HKD invoices, missing FPS env configuration, or non-positive totals skip the QR and use bank-only or FPS-only copy as appropriate. Zero or negative totals omit the due date and the entire payment-instructions block.
 
 **Why:** Keeps payment instructions consistent with the FPS path customers already see while avoiding misleading due dates or bank/FPS prompts on zero-amount documents.
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -207,7 +207,7 @@ their primary responsibilities.
   `ADMIN_GROUP`, `AWS_PROXY_FUNCTION_ARN` (sales recap recipient resolution via Cognito group),
   `SALES_RECAP_DISPLAY_TIMEZONE` (optional IANA id for recap **Submitted at**; CDK `SalesRecapDisplayTimezone` parameter, empty = app default),
   `MAILCHIMP_*` welcome journey vars (see `aws-messaging.md`)
-- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v8`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
+- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v9`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
 - **Invoice currency display:** `HKD` amounts render with the `HK$` prefix in AR invoice PDFs.
 - **AR invoice footer (Option B):** when both legal/trading and registration are set, the centered footer is `{legal_name} | Proudly registered in Hong Kong | BR: {reg}` with `legal_name` = `PUBLIC_WWW_BUSINESS_LEGAL_NAME` or `PUBLIC_WWW_BUSINESS_NAME`, and with fallbacks: legal only → legal; registration only → `BR: {reg}`; both empty → no footer. The **"Proudly registered in Hong Kong"** fragment is fixed product copy (see `.cursorrules` exception).
 - **Snapshot dates:** on issue, `customer_invoices.invoice_date` and `customer_invoices.due_date` are persisted (see `docs/architecture/database-schema.md`); the PDF uses these when present; draft previews compute dates in **UTC** when columns are null.

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -177,8 +177,8 @@ def test_v6_items_header_navy_fill(monkeypatch: pytest.MonkeyPatch) -> None:
 
     page = fitz.open(stream=pdf, filetype="pdf")[0]
     pix, s = _pixmap_pt_coords(page)
-    # Items header navy band sits around y_pt 400-437 in v6.
-    rgb = pix.pixel(int(200 * s), int(420 * s))
+    # Items header navy band (y shifts with header→lines spacing and row padding).
+    rgb = pix.pixel(int(200 * s), int(385 * s))
     assert _rgb_close(rgb, (51, 73, 93))
 
 
@@ -192,8 +192,8 @@ def test_v6_totals_card_width(monkeypatch: pytest.MonkeyPatch) -> None:
     page = fitz.open(stream=pdf, filetype="pdf")[0]
     pix, s = _pixmap_pt_coords(page)
     W = pix.width
-    # Totals card spans y_pt ~493-580 in v6; sample mid-card.
-    y_pt = 530
+    # Totals card (y shifts with lines→totals spacing and totals panel padding).
+    y_pt = 510
     y = int(y_pt * s)
 
     def matches_panel(rgb: tuple[int, int, int]) -> bool:
@@ -226,7 +226,7 @@ def test_v6_totals_card_width(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _totals_card_bounds_on_page(
-    page, *, y_sample_pt: float = 530.0
+    page, *, y_sample_pt: float = 510.0
 ) -> tuple[float, float, float] | None:
     """Return (left_pt, width_pt, bottom_y_pt) if a totals-sized panel is found."""
     from reportlab.lib.units import mm
@@ -523,7 +523,7 @@ def test_v6_wide_hkd_amount_fits(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_invoice_pdf_versions_distinct() -> None:
-    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v8"
+    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v9"
     assert customer_billing.RECEIPT_PDF_TEMPLATE_VERSION == "billing-receipt-v1"
     assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION != (
         customer_billing.RECEIPT_PDF_TEMPLATE_VERSION


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Reduced vertical padding on the line-items table (header and body cells) and halved the vertical spacers before the line-items block and before the totals row.
- Halved top/bottom padding inside the subtotal/total grey rounded panel and slightly reduced the panel height so the inner table still fits.
- Payment instructions and bank details now use `Table` row spans across the full content width (190mm), matching the left edge and wrap width of the Terms & Conditions paragraphs above instead of the previous 102mm-only column.
- Bumped `INVOICE_PDF_TEMPLATE_VERSION` to `billing-invoice-v9` with docs and layout pixel tests updated for the shifted Y positions.

## Testing

- `pytest tests/test_customer_invoice_pdf.py -q`
- `bash scripts/validate-cursorrules.sh`
- `pre-commit run ruff-format --files` on touched Python paths
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afb524cd-8383-411d-840c-25287bc2753a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afb524cd-8383-411d-840c-25287bc2753a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

