### PR TITLE
Invoice PDF: tighter spacing for bank details lines

### DIFF
--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -31,7 +31,7 @@ from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v9"
+INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v10"
 RECEIPT_PDF_TEMPLATE_VERSION = "billing-receipt-v1"
 _SCOPE_DEFAULT = "default"
 _DOC_INVOICE = "invoice"

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -384,6 +384,12 @@ def render_invoice_pdf(
         leading=16,
         textColor=_INV_BODY_TEXT,
     )
+    # Tighter than ``body_text_style`` for the Bank / Account Number / Account Name block only.
+    bank_detail_line_style = ParagraphStyle(
+        "InvBankDetailLine",
+        parent=body_text_style,
+        leading=13,
+    )
     header_label_style = ParagraphStyle(
         "InvHeaderLabel",
         parent=styles["Normal"],
@@ -894,10 +900,10 @@ def render_invoice_pdf(
                     if not bl:
                         continue
                     if not first_bank:
-                        pay_rows.append([Spacer(1, 2), ""])
+                        pay_rows.append([Spacer(1, 1), ""])
                         pay_style_cmds.append(("SPAN", (0, r), (1, r)))
                         r += 1
-                    pay_rows.append([Paragraph(bl, body_text_style), ""])
+                    pay_rows.append([Paragraph(bl, bank_detail_line_style), ""])
                     pay_style_cmds.append(("SPAN", (0, r), (1, r)))
                     r += 1
                     first_bank = False

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -98,7 +98,7 @@ drops the old polymorphic tables, renames `crm_notes` → `notes`, and adds null
 
 ## AR invoice PDFs (FPS QR)
 
-**Decision:** Customer AR invoice PDFs (`billing-invoice-v9`) embed an FPS QR code server-side when the invoice total is positive, the invoice currency is HKD, and `PUBLIC_WWW_FPS_MERCHANT_NAME` plus `PUBLIC_WWW_FPS_MOBILE_NUMBER` are set on the admin Lambda (same semantics as the public booking modal / confirmation email, using the EMVCo payload rules from `apps/public_www/public/scripts/fps-generator.js`). Non-HKD invoices, missing FPS env configuration, or non-positive totals skip the QR and use bank-only or FPS-only copy as appropriate. Zero or negative totals omit the due date and the entire payment-instructions block.
+**Decision:** Customer AR invoice PDFs (`billing-invoice-v10`) embed an FPS QR code server-side when the invoice total is positive, the invoice currency is HKD, and `PUBLIC_WWW_FPS_MERCHANT_NAME` plus `PUBLIC_WWW_FPS_MOBILE_NUMBER` are set on the admin Lambda (same semantics as the public booking modal / confirmation email, using the EMVCo payload rules from `apps/public_www/public/scripts/fps-generator.js`). Non-HKD invoices, missing FPS env configuration, or non-positive totals skip the QR and use bank-only or FPS-only copy as appropriate. Zero or negative totals omit the due date and the entire payment-instructions block.
 
 **Why:** Keeps payment instructions consistent with the FPS path customers already see while avoiding misleading due dates or bank/FPS prompts on zero-amount documents.
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -207,7 +207,7 @@ their primary responsibilities.
   `ADMIN_GROUP`, `AWS_PROXY_FUNCTION_ARN` (sales recap recipient resolution via Cognito group),
   `SALES_RECAP_DISPLAY_TIMEZONE` (optional IANA id for recap **Submitted at**; CDK `SalesRecapDisplayTimezone` parameter, empty = app default),
   `MAILCHIMP_*` welcome journey vars (see `aws-messaging.md`)
-- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v9`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
+- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v10`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
 - **Invoice currency display:** `HKD` amounts render with the `HK$` prefix in AR invoice PDFs.
 - **AR invoice footer (Option B):** when both legal/trading and registration are set, the centered footer is `{legal_name} | Proudly registered in Hong Kong | BR: {reg}` with `legal_name` = `PUBLIC_WWW_BUSINESS_LEGAL_NAME` or `PUBLIC_WWW_BUSINESS_NAME`, and with fallbacks: legal only → legal; registration only → `BR: {reg}`; both empty → no footer. The **"Proudly registered in Hong Kong"** fragment is fixed product copy (see `.cursorrules` exception).
 - **Snapshot dates:** on issue, `customer_invoices.invoice_date` and `customer_invoices.due_date` are persisted (see `docs/architecture/database-schema.md`); the PDF uses these when present; draft previews compute dates in **UTC** when columns are null.

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -523,7 +523,7 @@ def test_v6_wide_hkd_amount_fits(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_invoice_pdf_versions_distinct() -> None:
-    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v9"
+    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v10"
     assert customer_billing.RECEIPT_PDF_TEMPLATE_VERSION == "billing-receipt-v1"
     assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION != (
         customer_billing.RECEIPT_PDF_TEMPLATE_VERSION


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces vertical spacing between the **Bank**, **Account Number**, and **Account Name** lines on AR invoice PDFs.

## Changes

- `customer_invoice_pdf.py`: dedicated `bank_detail_line_style` with `leading=13` (vs body `16`) and inter-row `Spacer` reduced from `2` to `1` pt so the extra whitespace between those lines is about half of the previous layout.
- `INVOICE_PDF_TEMPLATE_VERSION` bumped to `billing-invoice-v10` so issued invoices record the new layout artifact.
- Tests and architecture docs updated for the new template version.

## Validation

- `pytest tests/test_customer_invoice_pdf.py`
- `pre-commit run ruff-format` on touched Python files
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fe0338e-b1f8-4ab0-b4f4-eeaa8d8ff8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fe0338e-b1f8-4ab0-b4f4-eeaa8d8ff8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

