### PR TITLE
Admin web: order Submitted Expenses by invoice issue date (newest first)

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4598,7 +4598,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List expenses */
+        /**
+         * List expenses
+         * @description Returns expenses ordered by invoice issue date (`invoice_date`) descending; rows without an invoice date appear after dated rows. Pagination uses stable key order (`invoice_date`, `id`).
+         */
         get: {
             parameters: {
                 query?: {

--- a/backend/src/app/db/repositories/expense.py
+++ b/backend/src/app/db/repositories/expense.py
@@ -7,7 +7,7 @@ from datetime import date
 from decimal import Decimal
 from uuid import UUID
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, literal, or_, select
 from sqlalchemy.orm import Session, aliased, selectinload
 
 from app.db.models import Expense, ExpenseAttachment, ExpenseParseStatus, ExpenseStatus
@@ -20,6 +20,10 @@ from app.services.asset_expense_tagging import sync_expense_attachment_tags_for_
 def _escape_like_pattern(pattern: str) -> str:
     """Escape LIKE pattern special characters."""
     return pattern.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+# Keyset pagination for newest invoice date first; NULL dates sort after all real dates.
+_INVOICE_DATE_SORT_SENTINEL = date(1, 1, 1)
 
 
 class ExpenseRepository(BaseRepository[Expense]):
@@ -37,8 +41,15 @@ class ExpenseRepository(BaseRepository[Expense]):
         status: ExpenseStatus | None = None,
         parse_status: ExpenseParseStatus | None = None,
     ) -> Sequence[Expense]:
-        """List expenses with optional filters and cursor pagination."""
+        """List expenses with optional filters and cursor pagination.
+
+        Results are ordered by invoice issue date (``invoice_date``) descending,
+        with undated rows last, then by id descending for a stable keyset.
+        """
         vendor_org = aliased(Organization)
+        invoice_sort_key = func.coalesce(
+            Expense.invoice_date, literal(_INVOICE_DATE_SORT_SENTINEL)
+        )
         statement = (
             select(Expense)
             .outerjoin(vendor_org, Expense.vendor_id == vendor_org.id)
@@ -46,16 +57,25 @@ class ExpenseRepository(BaseRepository[Expense]):
                 selectinload(Expense.attachments).selectinload(ExpenseAttachment.asset),
                 selectinload(Expense.vendor),
             )
-            .order_by(Expense.created_at.desc(), Expense.id.desc())
+            .order_by(invoice_sort_key.desc(), Expense.id.desc())
         )
         if cursor is not None:
-            cursor_created_at = (
-                select(Expense.created_at).where(Expense.id == cursor).scalar_subquery()
+            cursor_invoice_sort_key = (
+                select(
+                    func.coalesce(
+                        Expense.invoice_date, literal(_INVOICE_DATE_SORT_SENTINEL)
+                    )
+                )
+                .where(Expense.id == cursor)
+                .scalar_subquery()
             )
             statement = statement.where(
                 or_(
-                    Expense.created_at < cursor_created_at,
-                    and_(Expense.created_at == cursor_created_at, Expense.id < cursor),
+                    invoice_sort_key < cursor_invoice_sort_key,
+                    and_(
+                        invoice_sort_key == cursor_invoice_sort_key,
+                        Expense.id < cursor,
+                    ),
                 )
             )
         if status is not None:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -3399,6 +3399,10 @@ paths:
   /v1/admin/expenses:
     get:
       summary: List expenses
+      description: >-
+        Returns expenses ordered by invoice issue date (`invoice_date`) descending;
+        rows without an invoice date appear after dated rows. Pagination uses stable
+        key order (`invoice_date`, `id`).
       security:
         - AdminBearerAuth: []
       parameters:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -223,7 +223,7 @@ their primary responsibilities.
   CRM contact/family/organization management with soft-archive, locations, tags,
   and family/organization membership rows,
   sales pipeline lead management (list/detail/create/update/notes/export/analytics),
-  vendor management, expense invoice ingestion/listing/amendment/void/pay/draft-delete flows
+  vendor management, expense invoice ingestion and listing (newest `invoice_date` first, undated last), amendment/void/pay/draft-delete flows
   (mark-paid requires vendor, invoice date, currency, and total), and admin-user
   listing for lead assignment and instructor-group listing for service instances
   (service list items may include nullable `training_details` for training courses


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Submitted Expenses** table loads `/v1/admin/expenses`, which previously sorted rows by `created_at` descending. That put newer submissions ahead even when their invoice **issue date** (`invoice_date`) was older.

## Changes

- **`ExpenseRepository.list_expenses`**: Order by `invoice_date` descending (newest issue date first), with a stable keyset on `(sort key, id)`. Missing invoice dates are treated as a minimal sentinel so undated rows appear **after** all dated rows, consistent with “newest issued first” for real invoices.
- **Docs**: Describe list ordering in `docs/api/admin.yaml` and note behavior in `docs/architecture/lambdas.md`.
- **Generated types**: Ran `npm run generate:admin-api-types` so `check:admin-api-types` stays aligned with the updated OpenAPI spec.

No admin web UI changes are required; the table already displays `invoiceDate` in the Issued column.

## Validation

- `cd apps/admin_web && npm run lint`
- `pytest tests/` (997 passed)
- `bash scripts/validate-cursorrules.sh`
- `ruff check` / `ruff-format` on touched Python file
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8275abdd-b251-4e23-a6df-8426e1f4f3f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8275abdd-b251-4e23-a6df-8426e1f4f3f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

