### PR TITLE
Invoice PDF: place FPS QR beside bank details

### DIFF
--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -31,7 +31,7 @@ from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v10"
+INVOICE_PDF_TEMPLATE_VERSION = "billing-invoice-v11"
 RECEIPT_PDF_TEMPLATE_VERSION = "billing-receipt-v1"
 _SCOPE_DEFAULT = "default"
 _DOC_INVOICE = "invoice"

--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -12,7 +12,9 @@ Environment:
 - ``PUBLIC_WWW_BUSINESS_LEGAL_NAME``: optional legal entity name for footer.
 - ``PUBLIC_WWW_BUSINESS_REGISTRATION``: BR / registration number for footer.
 - ``PUBLIC_WWW_FPS_MERCHANT_NAME`` / ``PUBLIC_WWW_FPS_MOBILE_NUMBER``: optional FPS QR on
-  invoices when ``total > 0`` and currency is HKD (align with public-site FPS config).
+  invoices when ``total > 0`` and currency is HKD (same EMVCo payload as the public booking
+  flow). When bank details are present, the QR sits to the right of those lines in the payment
+  section.
 
 The Evolve Sprouts wordmark is embedded from ``app/assets/invoice/evolvesprouts-invoice-logo.png``
 (raster export of the public-site SVG) so Lambda bundles match brand artwork without SVG
@@ -157,7 +159,7 @@ def _invoice_logo_flowable() -> Image | Paragraph:
 
 
 def _fps_logo_image() -> Image | None:
-    """FPS brand mark for payment band (~25 mm × 12 mm max, right-aligned under totals)."""
+    """FPS brand mark (~25 mm × 12 mm max) beside the FPS QR in the payment section."""
     if not _INV_FPS_LOGO_PATH.is_file():
         return None
     img = Image(
@@ -873,6 +875,16 @@ def render_invoice_pdf(
                 )
                 fps_cell_flow = fps_cell_inner
 
+            bank_line_htmls: list[str] = []
+            if has_bank_block:
+                for bl in (
+                    f"Bank: {_esc(bank_name)}" if bank_name else "",
+                    f"Account Number: {_esc(bank_number)}" if bank_number else "",
+                    f"Account Name: {_esc(bank_holder)}" if bank_holder else "",
+                ):
+                    if bl:
+                        bank_line_htmls.append(bl)
+
             pay_rows: list[list] = []
             pay_style_cmds: list[tuple] = [
                 ("VALIGN", (0, 0), (-1, -1), "TOP"),
@@ -886,19 +898,39 @@ def render_invoice_pdf(
             pay_style_cmds.append(("SPAN", (0, r), (1, r)))
             r += 1
 
-            if has_bank_block:
+            if has_bank_block and fps_stack_rows:
+                bank_inner_rows: list[list] = [[Spacer(1, 12)]]
+                for i, bl in enumerate(bank_line_htmls):
+                    if i > 0:
+                        bank_inner_rows.append([Spacer(1, 1)])
+                    bank_inner_rows.append([Paragraph(bl, bank_detail_line_style)])
+                bank_left = Table(bank_inner_rows, colWidths=[pay_left_w])
+                bank_left.setStyle(
+                    TableStyle(
+                        [
+                            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                            ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                            ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+                            ("TOPPADDING", (0, 0), (-1, -1), 0),
+                            ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
+                            ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                        ]
+                    )
+                )
+                pay_rows.append([bank_left, fps_cell_flow])
+                pay_style_cmds.extend(
+                    [
+                        ("VALIGN", (0, r), (1, r), "TOP"),
+                        ("ALIGN", (1, r), (1, r), "RIGHT"),
+                    ]
+                )
+                r += 1
+            elif has_bank_block:
                 pay_rows.append([Spacer(1, 12), ""])
                 pay_style_cmds.append(("SPAN", (0, r), (1, r)))
                 r += 1
-                bank_lines = [
-                    f"Bank: {_esc(bank_name)}" if bank_name else "",
-                    f"Account Number: {_esc(bank_number)}" if bank_number else "",
-                    f"Account Name: {_esc(bank_holder)}" if bank_holder else "",
-                ]
                 first_bank = True
-                for bl in bank_lines:
-                    if not bl:
-                        continue
+                for bl in bank_line_htmls:
                     if not first_bank:
                         pay_rows.append([Spacer(1, 1), ""])
                         pay_style_cmds.append(("SPAN", (0, r), (1, r)))
@@ -907,10 +939,10 @@ def render_invoice_pdf(
                     pay_style_cmds.append(("SPAN", (0, r), (1, r)))
                     r += 1
                     first_bank = False
-
-            if fps_stack_rows:
+            elif fps_stack_rows:
                 pay_rows.append([Paragraph("", body_text_style), fps_cell_flow])
                 pay_style_cmds.append(("ALIGN", (1, r), (1, r), "RIGHT"))
+                r += 1
 
             pay_table = Table(
                 pay_rows,

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -98,7 +98,7 @@ drops the old polymorphic tables, renames `crm_notes` → `notes`, and adds null
 
 ## AR invoice PDFs (FPS QR)
 
-**Decision:** Customer AR invoice PDFs (`billing-invoice-v10`) embed an FPS QR code server-side when the invoice total is positive, the invoice currency is HKD, and `PUBLIC_WWW_FPS_MERCHANT_NAME` plus `PUBLIC_WWW_FPS_MOBILE_NUMBER` are set on the admin Lambda (same semantics as the public booking modal / confirmation email, using the EMVCo payload rules from `apps/public_www/public/scripts/fps-generator.js`). Non-HKD invoices, missing FPS env configuration, or non-positive totals skip the QR and use bank-only or FPS-only copy as appropriate. Zero or negative totals omit the due date and the entire payment-instructions block.
+**Decision:** Customer AR invoice PDFs (`billing-invoice-v11`) embed an FPS QR code server-side when the invoice total is positive, the invoice currency is HKD, and `PUBLIC_WWW_FPS_MERCHANT_NAME` plus `PUBLIC_WWW_FPS_MOBILE_NUMBER` are set on the admin Lambda (same semantics as the public booking modal / confirmation email, using the EMVCo payload rules from `apps/public_www/public/scripts/fps-generator.js`). When bank transfer details are also configured, the QR is laid out to the right of the bank lines in the payment section. Non-HKD invoices, missing FPS env configuration, or non-positive totals skip the QR and use bank-only or FPS-only copy as appropriate. Zero or negative totals omit the due date and the entire payment-instructions block.
 
 **Why:** Keeps payment instructions consistent with the FPS path customers already see while avoiding misleading due dates or bank/FPS prompts on zero-amount documents.
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -207,7 +207,7 @@ their primary responsibilities.
   `ADMIN_GROUP`, `AWS_PROXY_FUNCTION_ARN` (sales recap recipient resolution via Cognito group),
   `SALES_RECAP_DISPLAY_TIMEZONE` (optional IANA id for recap **Submitted at**; CDK `SalesRecapDisplayTimezone` parameter, empty = app default),
   `MAILCHIMP_*` welcome journey vars (see `aws-messaging.md`)
-- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v10`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
+- **AR PDF template versions (DB `pdf_template_version` column, shared by invoices and receipts):** issued customer invoices set `INVOICE_PDF_TEMPLATE_VERSION` = `billing-invoice-v11`; receipts set `RECEIPT_PDF_TEMPLATE_VERSION` = `billing-receipt-v1`.
 - **Invoice currency display:** `HKD` amounts render with the `HK$` prefix in AR invoice PDFs.
 - **AR invoice footer (Option B):** when both legal/trading and registration are set, the centered footer is `{legal_name} | Proudly registered in Hong Kong | BR: {reg}` with `legal_name` = `PUBLIC_WWW_BUSINESS_LEGAL_NAME` or `PUBLIC_WWW_BUSINESS_NAME`, and with fallbacks: legal only → legal; registration only → `BR: {reg}`; both empty → no footer. The **"Proudly registered in Hong Kong"** fragment is fixed product copy (see `.cursorrules` exception).
 - **Snapshot dates:** on issue, `customer_invoices.invoice_date` and `customer_invoices.due_date` are persisted (see `docs/architecture/database-schema.md`); the PDF uses these when present; draft previews compute dates in **UTC** when columns are null.

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -523,7 +523,7 @@ def test_v6_wide_hkd_amount_fits(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_invoice_pdf_versions_distinct() -> None:
-    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v10"
+    assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION == "billing-invoice-v11"
     assert customer_billing.RECEIPT_PDF_TEMPLATE_VERSION == "billing-receipt-v1"
     assert customer_billing.INVOICE_PDF_TEMPLATE_VERSION != (
         customer_billing.RECEIPT_PDF_TEMPLATE_VERSION


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Customer AR invoice PDFs already embed an FPS QR using the same EMVCo payload and PNG generation as the booking confirmation path (`build_fps_payload` + `render_fps_qr_png`). This change adjusts the layout when **both** bank transfer lines and FPS are configured: the FPS logo and QR now sit in the **right column of the same payment row** as the bank details, instead of appearing only below full-width bank lines.

## Changes

- `customer_invoice_pdf.py`: build a left nested table (spacer + bank paragraphs) and pair it with the existing FPS cell in one two-column row when both blocks apply; bank-only and FPS-only branches unchanged.
- `INVOICE_PDF_TEMPLATE_VERSION` → `billing-invoice-v11` so issued invoices refresh their stored template marker on next PDF refresh.
- Architecture docs and the invoice PDF version test updated accordingly.

## Testing

- `pytest tests/test_customer_invoice_pdf.py`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`

## Assumption

The request wording “band details” is interpreted as **bank** transfer details in the payment section. If the intent was instead the header “Bill to” block, say so and we can revisit placement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b075c7c-84b8-4c9d-8ee9-2a3ec086307c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b075c7c-84b8-4c9d-8ee9-2a3ec086307c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

