### PR TITLE
fix(gitleaks): suppress ApiCustomDomainName false positive in security workflow

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,5 +10,5 @@ regexes = [
   '''\b4-ways-patience\b''',
   '''\bmay-2026-the-missing-piece\b''',
   '''\bthe-missing-piece-2026-05-16\b''',
-  '''"ApiCustomDomainName"\s*:\s*"[^"]*"''',
+  '''ApiCustomDomainName"?\s*:\s*"[^"]*"''',
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The scheduled `Security Scanning` workflow has been failing on the **Secret Scanning** (Gitleaks) job — see [run 25661149403](https://github.com/lcacchiani/evolvesprouts/actions/runs/25661149403). The single finding is a false positive against `backend/infrastructure/params/production.json` for the `generic-api-key` rule.

The captured "secret" is `api2.evolvesprouts.com` — a public DNS hostname for the API Gateway custom domain — introduced historically by commit `fa779a29` ("Change API custom domain from api.evolvesprouts.com to api2.evolvesprouts.com"). It is configuration, not a credential. HEAD already has `"ApiCustomDomainName": ""`. No real secret was exposed; no rotation is required.

`.gitleaks.toml` already attempted to allowlist this exact JSON key, but the regex was effectively a no-op:

- The default `generic-api-key` rule's regex anchors the captured match on a letter (`[a-z]`), so Gitleaks' `match` text begins at `ApiCustomDomain…` **without** the leading `"`.
- The previous allowlist regex required a leading `"`, so it never matched the captured text and the historical commit kept tripping CI.

## Change

`.gitleaks.toml` — drop the leading quote anchor and make the quote optional with a non-capturing `"?`:

```diff
-  '''"ApiCustomDomainName"\s*:\s*"[^"]*"''',
+  '''ApiCustomDomainName"?\s*:\s*"[^"]*"''',
```

This is the minimum-surface fix. The allowlist remains tightly scoped to the `ApiCustomDomainName` key — it does not weaken detection elsewhere in `params/production.json` or in the rest of the repo.

## Testing

Verified locally with the same Gitleaks version and flags as the workflow (`gitleaks 8.24.3`, `gitleaks detect --redact -v --exit-code=2 --report-format=sarif`):

- **Before fix**: `leaks found: 1` (matches the CI failure on run 25661149403).
- **After fix**: `3212 commits scanned … no leaks found`, exit 0 over full git history.

[gitleaks_after_fix.log](https://cursor.com/agents/bc-d8f7ca7b-6a65-48ed-892f-d1ab9b6fdc6e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgitleaks_after_fix.log)

`bash scripts/validate-cursorrules.sh` still passes (`.cursorrules compliance checks passed.`).

## Out of scope

- The unrelated workflow warning that `gitleaks/gitleaks-action@v2` runs on Node.js 20 (forced Node 24 migration on June 2, 2026). Not blocking; can be addressed separately when an updated action tag is available.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8f7ca7b-6a65-48ed-892f-d1ab9b6fdc6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8f7ca7b-6a65-48ed-892f-d1ab9b6fdc6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

