### PR TITLE
Relax FPS QR merchant name validation to printable ASCII

### DIFF
--- a/backend/src/app/services/customer_invoice_pdf.py
+++ b/backend/src/app/services/customer_invoice_pdf.py
@@ -60,7 +60,7 @@ from reportlab.platypus import (
 
 from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
 from app.db.models.enums import BillingInvoiceStatus
-from app.services.fps_qr_payload import build_fps_payload
+from app.services.fps_qr_payload import build_fps_payload_detailed
 from app.services.fps_qr_pdf_image import render_fps_qr_png
 from app.utils.logging import get_logger
 
@@ -275,6 +275,7 @@ def _log_fps_qr_skipped(
     fps_mobile: str,
     attempted_fps_build: bool,
     fps_payload: str | None,
+    fps_rejection_code: str | None = None,
 ) -> None:
     """Emit a single structured warning when an FPS QR would not appear but ops might expect it."""
     if fps_payload is not None:
@@ -298,6 +299,8 @@ def _log_fps_qr_skipped(
         extra["reason"] = "fps_payload_build_failed"
         extra["has_fps_merchant"] = True
         extra["has_fps_mobile"] = True
+        if fps_rejection_code:
+            extra["fps_rejection_code"] = fps_rejection_code
         logger.warning("FPS QR skipped", extra=extra)
         return
 
@@ -514,8 +517,9 @@ def render_invoice_pdf(
         and bool(fps_merchant)
         and bool(fps_mobile)
     )
+    fps_rejection_code: str | None = None
     if attempted_fps_build:
-        fps_payload = build_fps_payload(
+        fps_payload, fps_rejection_code = build_fps_payload_detailed(
             fps_merchant,
             fps_mobile,
             invoice.total,
@@ -530,6 +534,7 @@ def render_invoice_pdf(
         fps_mobile=fps_mobile,
         attempted_fps_build=attempted_fps_build,
         fps_payload=fps_payload,
+        fps_rejection_code=fps_rejection_code,
     )
 
     inv_label = (invoice.invoice_number or "").strip()

--- a/backend/src/app/services/fps_qr_payload.py
+++ b/backend/src/app/services/fps_qr_payload.py
@@ -3,8 +3,9 @@
 Mirrors the booking-modal / email path in ``apps/public_www/src/lib/fps-qr-code.ts``:
 dynamic initiation point (12), merchant account 26 with unique id ``hk.com.hkicl`` and
 mobile identifier ``03``, currency HKD, optional transaction amount, country HK,
-merchant name and city, then CRC-16/CCITT-FALSE over the assembled prefix including
-the ``6304`` tag (same algorithm as module 2 in ``public/scripts/fps-generator.js``).
+merchant name (tag 59: printable ASCII, 1–25 characters after trim) and city, then
+CRC-16/CCITT-FALSE over the assembled prefix including the ``6304`` tag (same algorithm
+as module 2 in ``public/scripts/fps-generator.js``).
 """
 
 from __future__ import annotations
@@ -346,35 +347,50 @@ def _payload(tag_id: str, content: str) -> str:
     return f"{tag_id}{_number_to_valid_id(len(content))}{content}"
 
 
-def build_fps_payload(
+_MERCHANT_NAME_PRINTABLE_ASCII = re.compile(r"[\x20-\x7E]{1,25}")
+
+
+def build_fps_payload_detailed(
     merchant_name: str,
     mobile_e164_local: str,
     amount: Decimal | None,
     currency: str = "HKD",
-) -> str | None:
-    """Build FPS EMVCo payload string, or ``None`` when inputs are invalid.
+) -> tuple[str | None, str | None]:
+    """Build FPS EMVCo payload, or return ``(None, rejection_code)``.
 
-    ``mobile_e164_local`` accepts ``85291234567``, ``91234567``, or ``+852-91234567``.
+    Tag 59 merchant name allows printable ASCII (``\\x20``–``\\x7E``), 1–25 chars after
+    strip, matching the public-site FPS generator (no tag-64 encoding declaration).
+
+    ``mobile_e164_local`` accepts ``85291234567``, ``91234567``, or ``+852-91234567``
+    (same alphanumeric/special rules as ``setMerchantAccount`` in JS).
+
     ``amount`` omitted or ``None`` skips tag 54 (matches optional amount in generator).
+
+    On success, ``rejection_code`` is ``None``. On failure, ``payload`` is ``None`` and
+    ``rejection_code`` names the first validation that failed (for structured logs).
     """
     code = currency.strip().upper()
     if code != "HKD":
-        return None
+        return None, "fps_currency_not_hkd"
 
     name = merchant_name.strip()
-    if not name or len(name) > 25 or not _is_alphanumeric_special(name):
-        return None
+    if not name:
+        return None, "fps_merchant_name_empty"
+    if len(name) > 25:
+        return None, "fps_merchant_name_too_long"
+    if not _MERCHANT_NAME_PRINTABLE_ASCII.fullmatch(name):
+        return None, "fps_merchant_name_not_printable_ascii"
 
     mobile_norm = _normalize_mobile_e164_local(mobile_e164_local)
     if not mobile_norm or not re.fullmatch(r"[0-9+-]+", mobile_norm):
-        return None
+        return None, "fps_mobile_invalid"
 
     inner = _payload(_MERCHANT_ACCOUNT_UNIQUE, _FPS_UNIQUE_ID) + _payload(
         _MERCHANT_ACCOUNT_IDENTIFIER_MOBILE,
         mobile_norm,
     )
     if len(inner) > 99:
-        return None
+        return None, "fps_merchant_account_tlv_too_long"
 
     fmt = "01"
     t = _payload(_FORMAT_INDICATOR, fmt)
@@ -387,7 +403,7 @@ def build_fps_payload(
     if amount is not None:
         amt_s = _format_amount_for_tag(amount)
         if amt_s is None:
-            return None
+            return None, "fps_transaction_amount_invalid"
         t += _payload(_TRANSACTION_AMOUNT, amt_s)
 
     t += _payload(_COUNTRY_CODE, "HK")
@@ -397,4 +413,23 @@ def build_fps_payload(
     crc_input = (t + _CYCLIC_REDUNDANCY_CHECK + "04").encode("ascii")
     crc_hex = _crc16_ccitt_false(crc_input)
     t += _payload(_CYCLIC_REDUNDANCY_CHECK, crc_hex)
-    return t
+    return t, None
+
+
+def build_fps_payload(
+    merchant_name: str,
+    mobile_e164_local: str,
+    amount: Decimal | None,
+    currency: str = "HKD",
+) -> str | None:
+    """Build FPS EMVCo payload string, or ``None`` when inputs are invalid.
+
+    See :func:`build_fps_payload_detailed` for validation rules and rejection codes.
+    """
+    payload, _rejection = build_fps_payload_detailed(
+        merchant_name,
+        mobile_e164_local,
+        amount,
+        currency=currency,
+    )
+    return payload

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -19,6 +19,7 @@ from app.services.customer_invoice_pdf import (
     payment_terms_days_or_raise,
     render_invoice_pdf,
 )
+from app.services.fps_qr_payload import build_fps_payload
 
 
 def _pdf_text(pdf: bytes) -> str:
@@ -330,7 +331,7 @@ def test_v7_fps_qr_below_totals_card(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PUBLIC_WWW_BANK_NAME", "389 - Mox Bank Limited")
     monkeypatch.setenv("PUBLIC_WWW_BANK_ACCOUNT_NUMBER", "749 86477821")
     monkeypatch.setenv("PUBLIC_WWW_BANK_ACCOUNT_HOLDER", "IDA DE GREGORIO")
-    monkeypatch.setenv("PUBLIC_WWW_FPS_MERCHANT_NAME", "FPSMerchant")
+    monkeypatch.setenv("PUBLIC_WWW_FPS_MERCHANT_NAME", "Evolve Sprouts")
     monkeypatch.setenv("PUBLIC_WWW_FPS_MOBILE_NUMBER", "91234567")
     inv = SimpleNamespace(
         invoice_number="I-2603-027",
@@ -352,6 +353,15 @@ def test_v7_fps_qr_below_totals_card(monkeypatch: pytest.MonkeyPatch) -> None:
         unit_amount=Decimal("583.33"),
         line_total=Decimal("583.33"),
         currency="HKD",
+    )
+    assert (
+        build_fps_payload(
+            "Evolve Sprouts",
+            "91234567",
+            inv.total,
+            currency="HKD",
+        )
+        is not None
     )
     pdf = render_invoice_pdf(invoice=inv, lines=[line], preview=False)
     totals_pi, left_pt, width_pt, totals_bottom = _find_totals_card_in_pdf(pdf)

--- a/tests/test_fps_qr_payload.py
+++ b/tests/test_fps_qr_payload.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 import pytest
 
-from app.services.fps_qr_payload import build_fps_payload
+from app.services.fps_qr_payload import build_fps_payload, build_fps_payload_detailed
 
 
 def test_mobile_normalization_variants() -> None:
@@ -63,7 +63,61 @@ def test_amount_non_positive_returns_none() -> None:
 
 def test_merchant_name_validation() -> None:
     assert build_fps_payload("", "91234567", Decimal("1"), currency="HKD") is None
-    assert build_fps_payload("Bad space", "91234567", Decimal("1"), currency="HKD") is None
+    assert (
+        build_fps_payload("Bad space", "91234567", Decimal("1"), currency="HKD")
+        is not None
+    )
+
+
+def test_evolve_sprouts_merchant_name_builds_payload() -> None:
+    payload = build_fps_payload(
+        "Evolve Sprouts",
+        "91234567",
+        Decimal("100"),
+        currency="HKD",
+    )
+    assert payload is not None
+    assert "5914Evolve Sprouts" in payload
+
+
+def test_merchant_name_non_ascii_rejected() -> None:
+    assert build_fps_payload("進化", "91234567", Decimal("1"), currency="HKD") is None
+    _p, code = build_fps_payload_detailed(
+        "進化",
+        "91234567",
+        Decimal("1"),
+        currency="HKD",
+    )
+    assert code == "fps_merchant_name_not_printable_ascii"
+
+
+def test_merchant_name_newline_rejected() -> None:
+    assert (
+        build_fps_payload("Evolve\nSprouts", "91234567", Decimal("1"), currency="HKD")
+        is None
+    )
+
+
+def test_merchant_name_over_25_chars_rejected() -> None:
+    name = "A" * 26
+    assert build_fps_payload(name, "91234567", Decimal("1"), currency="HKD") is None
+    _p, code = build_fps_payload_detailed(
+        name,
+        "91234567",
+        Decimal("1"),
+        currency="HKD",
+    )
+    assert code == "fps_merchant_name_too_long"
+
+
+def test_build_fps_payload_detailed_mobile_rejection_code() -> None:
+    _p, code = build_fps_payload_detailed(
+        "Acme",
+        "not-a-mobile",
+        Decimal("1"),
+        currency="HKD",
+    )
+    assert code == "fps_mobile_invalid"
 
 
 def test_fps_payload_crc_matches_js_reference() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Tag 59 (merchant name)** in `build_fps_payload` now allows printable ASCII (`\x20`–`\x7E`), 1–25 characters after trim, via `re.fullmatch(r"[\x20-\x7E]{1,25}", name)`. This aligns with the public-site FPS path and avoids rejecting legitimate names with spaces, `&`, `'`, etc., while still blocking control characters, newlines, and non-ASCII (which would need tag-64 handling the JS generator does not emit).
- **Mobile identifier** validation is unchanged (`_normalize_mobile_e164_local` + `[0-9+-]+` check), still mirroring `setMerchantAccount` in JS.
- **`build_fps_payload_detailed`** returns `(payload, rejection_code)` so invoice PDF rendering can log **`fps_rejection_code`** (e.g. `fps_mobile_invalid`, `fps_merchant_name_too_long`) under the existing `reason: fps_payload_build_failed` umbrella for CloudWatch.
- **Tests:** unit coverage for `Evolve Sprouts` + `Decimal("100")`, CJK/newline/length rejection codes, mobile rejection code; **v7 PDF** integration uses `PUBLIC_WWW_FPS_MERCHANT_NAME=Evolve Sprouts` and asserts `build_fps_payload` succeeds before `render_invoice_pdf`.

## Validation

- `pytest tests/test_fps_qr_payload.py tests/test_customer_invoice_pdf.py::test_v7_fps_qr_below_totals_card`
- `ruff check` on touched files
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22ec6b77-6dc2-4c5b-a58f-f6c707f4f83e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22ec6b77-6dc2-4c5b-a58f-f6c707f4f83e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

