### PR TITLE
fix(admin): refetch families and orgs after contact mutations

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-page.tsx
@@ -46,6 +46,8 @@ export function ContactsPage() {
   const adminUsers = useAdminUsers();
   const families = useAdminEntityFamilies();
   const organizations = useAdminEntityOrganizations();
+  const { refetch: refetchFamilies } = families;
+  const { refetch: refetchOrganizations } = organizations;
 
   const patchStandaloneNoteCountRef = useRef(contacts.patchContactStandaloneNoteCount);
   useLayoutEffect(() => {
@@ -54,6 +56,10 @@ export function ContactsPage() {
   const stablePatchStandaloneNoteCount = useCallback((contactId: string, count: number) => {
     patchStandaloneNoteCountRef.current(contactId, count);
   }, []);
+
+  const refreshFamilyOrgLists = useCallback(async () => {
+    await Promise.all([refetchFamilies(), refetchOrganizations()]);
+  }, [refetchFamilies, refetchOrganizations]);
 
   const refreshLocations = useCallback(async () => {
     const locList = await listAllLocations();
@@ -136,6 +142,7 @@ export function ContactsPage() {
           geographicAreas={geographicAreas}
           areasLoading={pickerLoading}
           refreshLocations={refreshLocations}
+          refreshFamilyOrgLists={refreshFamilyOrgLists}
         />
       ) : activeView === 'families' ? (
         <FamiliesPanel

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -145,6 +145,8 @@ export interface ContactsPanelProps {
   geographicAreas: GeographicAreaSummary[];
   areasLoading: boolean;
   refreshLocations: () => Promise<void> | void;
+  /** Refetch family and organisation lists (membership can change when a contact is saved). */
+  refreshFamilyOrgLists?: () => void | Promise<void>;
 }
 
 export function ContactsPanel({
@@ -156,6 +158,7 @@ export function ContactsPanel({
   geographicAreas,
   areasLoading,
   refreshLocations,
+  refreshFamilyOrgLists,
 }: ContactsPanelProps) {
   const {
     contacts: rows,
@@ -455,6 +458,7 @@ export function ContactsPanel({
           referral_contact_id:
             source === 'referral' ? referralContactId.trim() : null,
         });
+        await refreshFamilyOrgLists?.();
         await resetCreateForm();
         return;
       }
@@ -484,6 +488,7 @@ export function ContactsPanel({
         body.location_id = loc;
       }
       await updateContact(selected.id, body);
+      await refreshFamilyOrgLists?.();
     } catch {
       // Retry with form state preserved.
     }
@@ -518,6 +523,7 @@ export function ContactsPanel({
     setDeleteActionError('');
     try {
       await deleteContact(row.id);
+      await refreshFamilyOrgLists?.();
       if (selectedId === row.id) {
         await resetCreateForm();
       }
@@ -1003,7 +1009,9 @@ export function ContactsPanel({
                         className='h-8 min-w-8 px-0'
                         onClick={(e) => {
                           e.stopPropagation();
-                          void updateContact(row.id, { active: !row.active });
+                          void updateContact(row.id, { active: !row.active }).then(() =>
+                            refreshFamilyOrgLists?.()
+                          );
                         }}
                         disabled={isSaving}
                         aria-label={row.active ? 'Archive contact' : 'Restore contact'}

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -86,6 +86,7 @@ describe('ContactsPanel', () => {
     const user = userEvent.setup();
     const createContact = vi.fn().mockResolvedValue(null);
     const contacts = buildContactsHook({ createContact });
+    const refreshFamilyOrgLists = vi.fn().mockResolvedValue(undefined);
 
     render(
       <ContactsPanel
@@ -97,6 +98,7 @@ describe('ContactsPanel', () => {
         geographicAreas={[]}
         areasLoading={false}
         refreshLocations={noopRefresh}
+        refreshFamilyOrgLists={refreshFamilyOrgLists}
       />
     );
 
@@ -110,6 +112,9 @@ describe('ContactsPanel', () => {
         contact_type: 'parent',
       })
     );
+    await waitFor(() => {
+      expect(refreshFamilyOrgLists).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('loads the next page when Load more is available', async () => {
@@ -269,6 +274,7 @@ describe('ContactsPanel', () => {
   it('calls deleteContact when Delete is confirmed', async () => {
     const user = userEvent.setup();
     const deleteContact = vi.fn().mockResolvedValue(undefined);
+    const refreshFamilyOrgLists = vi.fn().mockResolvedValue(undefined);
     const row: components['schemas']['AdminContact'] = {
       id: '11111111-1111-1111-1111-111111111111',
       first_name: 'Ann',
@@ -306,12 +312,16 @@ describe('ContactsPanel', () => {
         geographicAreas={[]}
         areasLoading={false}
         refreshLocations={noopRefresh}
+        refreshFamilyOrgLists={refreshFamilyOrgLists}
       />
     );
 
     await user.click(screen.getByRole('button', { name: 'Delete contact' }));
 
     expect(deleteContact).toHaveBeenCalledWith(row.id);
+    await waitFor(() => {
+      expect(refreshFamilyOrgLists).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('shows list error from the hook in the table card', async () => {
@@ -471,6 +481,7 @@ describe('ContactsPanel', () => {
   it('sends location_id null on update after Clear', async () => {
     const user = userEvent.setup();
     const updateContact = vi.fn().mockResolvedValue(null);
+    const refreshFamilyOrgLists = vi.fn().mockResolvedValue(undefined);
     const row: components['schemas']['AdminContact'] = {
       id: '22222222-2222-2222-2222-222222222222',
       first_name: 'Bob',
@@ -524,6 +535,7 @@ describe('ContactsPanel', () => {
         geographicAreas={[hkArea]}
         areasLoading={false}
         refreshLocations={noopRefresh}
+        refreshFamilyOrgLists={refreshFamilyOrgLists}
       />
     );
 
@@ -539,5 +551,8 @@ describe('ContactsPanel', () => {
       })
     );
     expect(updateLocationPartial).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(refreshFamilyOrgLists).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After saving a contact from the **Contacts** tab (create, update, delete, or archive/restore), the **Families** and **Organisations** paginated lists are refetched so membership columns stay accurate without switching tabs to force a reload.

## Changes

- `ContactsPage`: `refreshFamilyOrgLists` runs `families.refetch()` and `organizations.refetch()` in parallel.
- `ContactsPanel`: optional `refreshFamilyOrgLists` callback invoked after successful `createContact`, `updateContact` (editor submit and row archive/restore), and `deleteContact`.
- Tests extended to assert the callback runs on create, update, and delete.

## Testing

- `npx vitest run tests/components/admin/contacts/contacts-panel.test.tsx tests/components/admin/contacts/contacts-page.test.tsx`
- `npm run lint` (admin_web)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a433648e-6a27-4e4e-9843-bc04cb8f819e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a433648e-6a27-4e4e-9843-bc04cb8f819e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

