### PR TITLE
Fix family member role derivation from contact type

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -453,7 +453,8 @@ export function FamiliesPanel({
                     </Button>
                   </AdminTableToolbar>
                   <p className='text-xs text-slate-600'>
-                    Role for each member follows the contact type set on the contact record.
+                    Role is stored on each membership and matches the contact type when the member
+                    is added or when the contact type is changed on the contact record.
                   </p>
                   <AdminDataTable tableClassName='min-w-[520px]'>
                     <AdminDataTableHead>

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -6598,6 +6598,10 @@ export interface components {
              */
             referral_contact_id?: string | null;
         };
+        /**
+         * @description Persisted membership fields. `role` matches the contact's `contact_type` when the
+         *     membership is created and is refreshed when `contact_type` is updated on the contact.
+         */
         AdminFamilyMember: {
             /** Format: uuid */
             id: string;

--- a/backend/src/app/api/admin_contacts_helpers.py
+++ b/backend/src/app/api/admin_contacts_helpers.py
@@ -24,7 +24,7 @@ from app.db.models import (
     OrganizationMember,
     RelationshipType,
 )
-from app.db.models.enums import FamilyRole
+from app.db.models.family import family_membership_role_from_contact_type
 from app.db.models.organization import organization_membership_role_from_contact_type
 from app.exceptions import ValidationError
 from app.utils.logging import get_logger
@@ -127,11 +127,14 @@ def sync_memberships_from_body(
             )
         ).scalar_one()
         if not has_row:
+            subject = session.get(Contact, contact_id)
+            if subject is None:
+                raise ValidationError("contact_id not found", field="family_ids")
             session.add(
                 FamilyMember(
                     family_id=want_fam,
                     contact_id=contact_id,
-                    role=FamilyRole.PARENT,
+                    role=family_membership_role_from_contact_type(subject.contact_type),
                     is_primary_contact=False,
                 )
             )
@@ -222,6 +225,25 @@ def parse_referral_contact_id_from_metadata(contact: Contact) -> UUID | None:
         if raw_meta is not None and str(raw_meta).strip() != ""
         else None
     )
+
+
+def refresh_family_member_roles_for_contact(
+    session: Session, *, contact_id: UUID
+) -> None:
+    """Recompute stored family membership roles when a contact's type changes."""
+    members = list(
+        session.execute(
+            select(FamilyMember).where(FamilyMember.contact_id == contact_id)
+        )
+        .scalars()
+        .all()
+    )
+    contact = session.get(Contact, contact_id)
+    if contact is None:
+        return
+    next_role = family_membership_role_from_contact_type(contact.contact_type)
+    for m in members:
+        m.role = next_role
 
 
 def refresh_organization_member_roles_for_contact(

--- a/backend/src/app/api/admin_contacts_mutations.py
+++ b/backend/src/app/api/admin_contacts_mutations.py
@@ -18,6 +18,7 @@ from app.api.admin_contacts_helpers import (
     parse_contact_type,
     parse_optional_date,
     parse_referral_contact_id_from_metadata,
+    refresh_family_member_roles_for_contact,
     refresh_organization_member_roles_for_contact,
     sync_memberships_from_body,
     validate_referrer_contact,
@@ -286,6 +287,7 @@ def update_contact(
             contact.contact_type = parse_contact_type(
                 body.get("contact_type"), field="contact_type"
             )
+            refresh_family_member_roles_for_contact(session, contact_id=contact.id)
             refresh_organization_member_roles_for_contact(
                 session, contact_id=contact.id
             )

--- a/backend/src/app/api/admin_families.py
+++ b/backend/src/app/api/admin_families.py
@@ -34,7 +34,8 @@ from app.api.admin_validators import validate_string_length
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
-from app.db.models import Contact, ContactType, Family, FamilyMember, FamilyRole
+from app.db.models import Contact, Family, FamilyMember
+from app.db.models.family import family_membership_role_from_contact_type
 from app.db.repositories import FamilyRepository
 from app.exceptions import DatabaseError, NotFoundError, ValidationError
 from app.utils import json_response
@@ -109,17 +110,6 @@ def handle_admin_families_request(
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     return json_response(404, {"error": "Not found"}, event=event)
-
-
-def _family_role_from_contact_type(contact_type: ContactType) -> FamilyRole:
-    """Map contact category to stored family membership role."""
-    if contact_type is ContactType.PARENT:
-        return FamilyRole.PARENT
-    if contact_type is ContactType.CHILD:
-        return FamilyRole.CHILD
-    if contact_type is ContactType.HELPER:
-        return FamilyRole.HELPER
-    return FamilyRole.OTHER
 
 
 def _list_families(event: Mapping[str, Any]) -> dict[str, Any]:
@@ -302,7 +292,7 @@ def _add_family_member(
             session, contact_id=contact_id, family_id=family_id
         )
 
-        role = _family_role_from_contact_type(contact.contact_type)
+        role = family_membership_role_from_contact_type(contact.contact_type)
         member = FamilyMember(
             family_id=family_id,
             contact_id=contact_id,

--- a/backend/src/app/db/models/family.py
+++ b/backend/src/app/db/models/family.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import TIMESTAMP
 
 from app.db.base import Base
-from app.db.models.enums import FamilyRole, RelationshipType
+from app.db.models.enums import ContactType, FamilyRole, RelationshipType
 
 if TYPE_CHECKING:
     from app.db.models.contact import Contact
@@ -27,6 +27,19 @@ if TYPE_CHECKING:
 def _enum_values(enum_cls: Iterable[RelationshipType | FamilyRole]) -> list[str]:
     """Return enum labels stored in PostgreSQL."""
     return [member.value for member in enum_cls]
+
+
+def family_membership_role_from_contact_type(
+    contact_type: ContactType,
+) -> FamilyRole:
+    """Map contact category to stored family membership role."""
+    if contact_type is ContactType.PARENT:
+        return FamilyRole.PARENT
+    if contact_type is ContactType.CHILD:
+        return FamilyRole.CHILD
+    if contact_type is ContactType.HELPER:
+        return FamilyRole.HELPER
+    return FamilyRole.OTHER
 
 
 class Family(Base):

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -7364,6 +7364,9 @@ components:
             (omit or null to clear only when source is not referral).
     AdminFamilyMember:
       type: object
+      description: |
+        Persisted membership fields. `role` matches the contact's `contact_type` when the
+        membership is created and is refreshed when `contact_type` is updated on the contact.
       required:
         - id
         - contact_id

--- a/tests/test_family_membership_role_from_contact_type.py
+++ b/tests/test_family_membership_role_from_contact_type.py
@@ -1,0 +1,29 @@
+"""Unit tests for family membership role derivation from contact type."""
+
+from __future__ import annotations
+
+from app.db.models.enums import ContactType, FamilyRole
+from app.db.models.family import family_membership_role_from_contact_type
+
+
+def test_family_role_from_contact_type_mapping() -> None:
+    assert (
+        family_membership_role_from_contact_type(ContactType.PARENT)
+        == FamilyRole.PARENT
+    )
+    assert (
+        family_membership_role_from_contact_type(ContactType.CHILD)
+        == FamilyRole.CHILD
+    )
+    assert (
+        family_membership_role_from_contact_type(ContactType.HELPER)
+        == FamilyRole.HELPER
+    )
+    assert (
+        family_membership_role_from_contact_type(ContactType.PROFESSIONAL)
+        == FamilyRole.OTHER
+    )
+    assert (
+        family_membership_role_from_contact_type(ContactType.OTHER)
+        == FamilyRole.OTHER
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Family membership `role` was wrong when a contact was linked to a family through the contact record (`family_ids` / `sync_memberships_from_body`): new rows always used `parent`. Stored roles also stayed stale if `contact_type` was changed later.

## Changes

- Add `family_membership_role_from_contact_type` on `Family` model module (same pattern as organisation membership mapping).
- Use it when creating `FamilyMember` rows from contact-driven membership sync.
- Call `refresh_family_member_roles_for_contact` when `contact_type` is updated on a contact (parallel to existing org role refresh).
- Reuse the shared mapper from `admin_families` when adding a member via the family API.
- Document behaviour in OpenAPI (`AdminFamilyMember`) and align the admin families panel helper copy.

## Tests

- `tests/test_family_membership_role_from_contact_type.py` for the mapping matrix.
- Full `pytest tests/` passed locally.

Existing rows with incorrect roles self-correct the next time an admin saves a `contact_type` change on that contact; alternatively remove and re-add the family member.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56c7aa4a-6376-4d5c-9f99-153698230414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56c7aa4a-6376-4d5c-9f99-153698230414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

