### PR TITLE
fix(admin_web): exclude family-linked contacts from enrollment contact picker

### DIFF
--- a/apps/admin_web/src/hooks/use-enrollment-parent-pickers.ts
+++ b/apps/admin_web/src/hooks/use-enrollment-parent-pickers.ts
@@ -90,7 +90,10 @@ export function useEnrollmentParentPickers(canCreate: boolean) {
         } while (cursor);
 
         contactRows.sort((a, b) => collator.compare(formatContactSortKey(a), formatContactSortKey(b)));
-        setContacts(contactRows);
+        const enrollmentEligibleContacts = contactRows.filter(
+          (c) => (c.family_ids?.length ?? 0) === 0
+        );
+        setContacts(enrollmentEligibleContacts);
       } catch (err) {
         if (signal.aborted) {
           return;

--- a/apps/admin_web/tests/hooks/use-enrollment-parent-pickers.test.tsx
+++ b/apps/admin_web/tests/hooks/use-enrollment-parent-pickers.test.tsx
@@ -1,0 +1,85 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useEnrollmentParentPickers } from '@/hooks/use-enrollment-parent-pickers';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type AdminContact = components['schemas']['AdminContact'];
+
+vi.mock('@/lib/entity-api', () => ({
+  listAdminContacts: vi.fn(),
+  listEntityFamilyPicker: vi.fn(),
+  listEntityOrganizationPicker: vi.fn(),
+  listEntityPartnerOrganizationPicker: vi.fn(),
+}));
+
+function makeContact(overrides: Partial<AdminContact> & Pick<AdminContact, 'id' | 'first_name'>): AdminContact {
+  return {
+    email: null,
+    instagram_handle: null,
+    last_name: null,
+    phone_region: null,
+    phone_national_number: null,
+    date_of_birth: null,
+    location_id: null,
+    location_summary: null,
+    family_location_summary: null,
+    organization_location_summary: null,
+    source_detail: null,
+    referral_contact_id: null,
+    archived_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    contact_type: 'parent',
+    relationship_type: 'client',
+    source: 'manual',
+    mailchimp_status: 'pending',
+    active: true,
+    tag_ids: [],
+    tags: [],
+    family_ids: [],
+    organization_ids: [],
+    standalone_note_count: 0,
+    ...overrides,
+  };
+}
+
+describe('useEnrollmentParentPickers', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('excludes contacts that belong to at least one family from contactOptions', async () => {
+    const entityApi = await import('@/lib/entity-api');
+    vi.mocked(entityApi.listEntityFamilyPicker).mockResolvedValue([]);
+    vi.mocked(entityApi.listEntityOrganizationPicker).mockResolvedValue([]);
+    vi.mocked(entityApi.listEntityPartnerOrganizationPicker).mockResolvedValue([]);
+    vi.mocked(entityApi.listAdminContacts).mockResolvedValue({
+      items: [
+        makeContact({
+          id: 'contact-in-family',
+          first_name: 'InFamily',
+          family_ids: ['family-1'],
+        }),
+        makeContact({
+          id: 'contact-standalone',
+          first_name: 'Standalone',
+          family_ids: [],
+        }),
+      ],
+      nextCursor: null,
+      totalCount: 2,
+    });
+
+    const { result } = renderHook(() => useEnrollmentParentPickers(true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.contactOptions).toEqual([
+      { id: 'contact-standalone', label: expect.stringContaining('Standalone') },
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Services enrollment inline editor loads contacts for the **Contact** field via `useEnrollmentParentPickers`. Contacts that already belong to one or more families (`family_ids` non-empty) are no longer listed there, so operators pick the **Family** (or organization) party instead of a household member as a standalone contact.

## Implementation

- After paging and sorting admin contacts, filter to `(family_ids?.length ?? 0) === 0` before building `contactOptions`.
- Existing `ensureOption` in `enrollment-list-panel.tsx` still appends the selected contact id if it is missing from the list (e.g. rare legacy rows), so edit mode remains safe.

## Tests

- Added `tests/hooks/use-enrollment-parent-pickers.test.tsx` asserting a family-linked contact is omitted while a standalone contact remains.

## Docs / API

- No OpenAPI or backend changes; `AdminContact.family_ids` was already part of the contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6e37586-3e66-470c-8fd7-fceb5d0a55e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6e37586-3e66-470c-8fd7-fceb5d0a55e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

