### PR TITLE
Draft invoice picker: two-year lookback and enrollment date sort

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1144,7 +1144,7 @@ export function ClientInvoicesPanel() {
               onSubmit={(e) => void handleCreateDraft(e)}
             >
               <p className='text-sm text-slate-600'>
-                Shown: enrollments from the last year (365 rolling days by enrolled date), excluding cancelled.
+                Shown: enrollments from the last two years (730 rolling days by enrolled date), excluding cancelled.
                 Rows already on a draft or issued invoice cannot be selected. Selected rows must share bill-to
                 and currency on the server.
               </p>

--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -54,6 +54,7 @@ import {
   listCustomerInvoices,
   listCustomerPayments,
   listRecentEnrollmentsForInvoicing,
+  compareBillingEnrollmentPickerRowsByEnrolledAtDesc,
   voidInvoice,
   type BillingEnrollmentPickerRow,
   type CustomerInvoiceDetail,
@@ -339,6 +340,7 @@ export function ClientInvoicesPanel() {
         out.push(row);
       }
     }
+    out.sort(compareBillingEnrollmentPickerRowsByEnrolledAtDesc);
     return out;
   }, [enrollmentPickerRows, selectedEnrollmentIds]);
 

--- a/apps/admin_web/src/lib/billing-api.ts
+++ b/apps/admin_web/src/lib/billing-api.ts
@@ -184,6 +184,26 @@ export async function createCustomerRefund(
 
 export type BillingEnrollmentPickerRow = ApiSchemas['BillingEnrollmentPickerRow'];
 
+/** Newest `enrolledAt` first; rows without a date sort after dated rows. */
+export function compareBillingEnrollmentPickerRowsByEnrolledAtDesc(
+  a: BillingEnrollmentPickerRow,
+  b: BillingEnrollmentPickerRow,
+): number {
+  const ta = (a.enrolledAt ?? '').trim();
+  const tb = (b.enrolledAt ?? '').trim();
+  if (ta !== '' && tb !== '') {
+    const byTime = tb.localeCompare(ta);
+    if (byTime !== 0) {
+      return byTime;
+    }
+  } else if (ta !== '' && tb === '') {
+    return -1;
+  } else if (ta === '' && tb !== '') {
+    return 1;
+  }
+  return String(b.enrollmentId).localeCompare(String(a.enrollmentId));
+}
+
 export async function listRecentEnrollmentsForInvoicing(
   signal?: AbortSignal,
   params?: { q?: string },
@@ -243,6 +263,7 @@ export async function listRecentEnrollmentsForInvoicing(
     cursor = next;
   }
 
+  merged.sort(compareBillingEnrollmentPickerRowsByEnrolledAtDesc);
   return { items: merged, truncated: truncatedOverall };
 }
 

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4140,7 +4140,7 @@ export interface paths {
         };
         /**
          * List recent enrollments for draft invoice picker
-         * @description Returns non-cancelled enrollments with `enrolled_at` within the last 365 days, ordered by `enrolled_at` descending (cursor pagination). At most `limit` rows per response (default and maximum 500). Pass `next_cursor` from the prior response as `cursor`. Optional `q` filters server-side by enrollment UUID substring, instance title, cohort, contact email/name, bill-to contact, family name, organization name, or ticket tier name. Includes `invoiceLinked` when the enrollment already appears on a draft or issued customer invoice line (void invoices do not block).
+         * @description Returns non-cancelled enrollments with `enrolled_at` within the last 730 days (two 365-day rolling windows by enrolled date), ordered by `enrolled_at` descending (cursor pagination). At most `limit` rows per response (default and maximum 500). Pass `next_cursor` from the prior response as `cursor`. Optional `q` filters server-side by enrollment UUID substring, instance title, cohort, contact email/name, bill-to contact, family name, organization name, or ticket tier name. Includes `invoiceLinked` when the enrollment already appears on a draft or issued customer invoice line (void invoices do not block).
          */
         get: {
             parameters: {

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -36,9 +36,28 @@ const enrollmentPickerMocks = vi.hoisted(() => ({
   })),
 }));
 
-vi.mock('@/lib/billing-api', () => ({
-  ...billingMocks,
-}));
+vi.mock('@/lib/billing-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/billing-api')>();
+  return {
+    ...actual,
+    listCustomerInvoices: billingMocks.listCustomerInvoices,
+    getCustomerInvoice: billingMocks.getCustomerInvoice,
+    getCustomerInvoicePdfDownload: billingMocks.getCustomerInvoicePdfDownload,
+    listCustomerPayments: billingMocks.listCustomerPayments,
+    getCustomerPayment: billingMocks.getCustomerPayment,
+    issueInvoice: billingMocks.issueInvoice,
+    voidInvoice: billingMocks.voidInvoice,
+    deleteDraftCustomerInvoice: billingMocks.deleteDraftCustomerInvoice,
+    emailInvoice: billingMocks.emailInvoice,
+    confirmCustomerPayment: billingMocks.confirmCustomerPayment,
+    deleteCustomerPayment: billingMocks.deleteCustomerPayment,
+    createDraftInvoice: billingMocks.createDraftInvoice,
+    createPaymentAllocation: billingMocks.createPaymentAllocation,
+    createCustomerRefund: billingMocks.createCustomerRefund,
+    exportBillingCsv: billingMocks.exportBillingCsv,
+    listRecentEnrollmentsForInvoicing: billingMocks.listRecentEnrollmentsForInvoicing,
+  };
+});
 
 vi.mock('@/hooks/use-enrollment-parent-pickers', () => ({
   useEnrollmentParentPickers: enrollmentPickerMocks.mockUseEnrollmentParentPickers,

--- a/apps/admin_web/tests/lib/billing-api.test.ts
+++ b/apps/admin_web/tests/lib/billing-api.test.ts
@@ -6,7 +6,35 @@ vi.mock('@/lib/api-admin-client', () => ({
   adminApiRequest: (...args: unknown[]) => mockAdminApiRequest(...args),
 }));
 
-import { listRecentEnrollmentsForInvoicing } from '@/lib/billing-api';
+import {
+  compareBillingEnrollmentPickerRowsByEnrolledAtDesc,
+  listRecentEnrollmentsForInvoicing,
+} from '@/lib/billing-api';
+
+describe('compareBillingEnrollmentPickerRowsByEnrolledAtDesc', () => {
+  const minimalRow = {
+    enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    partyDisplayName: 'Party',
+    invoiceLinked: false,
+    currency: 'HKD',
+    billToMergeKey: 'contact|||',
+  };
+
+  it('orders newest enrolledAt first', () => {
+    const older = {
+      ...minimalRow,
+      enrollmentId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      enrolledAt: '2024-06-01T00:00:00Z',
+    };
+    const newer = {
+      ...minimalRow,
+      enrollmentId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      enrolledAt: '2025-06-01T00:00:00Z',
+    };
+    expect(compareBillingEnrollmentPickerRowsByEnrolledAtDesc(older, newer)).toBeGreaterThan(0);
+    expect(compareBillingEnrollmentPickerRowsByEnrolledAtDesc(newer, older)).toBeLessThan(0);
+  });
+});
 
 describe('listRecentEnrollmentsForInvoicing', () => {
   beforeEach(() => {
@@ -24,12 +52,24 @@ describe('listRecentEnrollmentsForInvoicing', () => {
   it('aggregates multiple pages when truncated', async () => {
     mockAdminApiRequest
       .mockResolvedValueOnce({
-        items: [{ ...minimalRow, enrollmentId: '11111111-1111-1111-1111-111111111111' }],
+        items: [
+          {
+            ...minimalRow,
+            enrollmentId: '11111111-1111-1111-1111-111111111111',
+            enrolledAt: '2025-01-15T00:00:00+00:00',
+          },
+        ],
         truncated: true,
         next_cursor: 'c1',
       })
       .mockResolvedValueOnce({
-        items: [{ ...minimalRow, enrollmentId: '22222222-2222-2222-2222-222222222222' }],
+        items: [
+          {
+            ...minimalRow,
+            enrollmentId: '22222222-2222-2222-2222-222222222222',
+            enrolledAt: '2026-02-01T00:00:00+00:00',
+          },
+        ],
         truncated: false,
         next_cursor: null,
       });
@@ -38,6 +78,10 @@ describe('listRecentEnrollmentsForInvoicing', () => {
     expect(mockAdminApiRequest).toHaveBeenCalledTimes(2);
     expect(out.items).toHaveLength(2);
     expect(out.truncated).toBe(true);
+    expect(out.items.map((r) => r.enrollmentId)).toEqual([
+      '22222222-2222-2222-2222-222222222222',
+      '11111111-1111-1111-1111-111111111111',
+    ]);
   });
 
   it('keeps first page when a later page fails', async () => {

--- a/backend/src/app/api/admin_billing_enrollment_queries.py
+++ b/backend/src/app/api/admin_billing_enrollment_queries.py
@@ -71,6 +71,8 @@ def _party_email(
 
 
 _PICKER_MAX_LIMIT = 500
+# Draft invoice picker: `enrolled_at` must be within this many rolling days (two 365-day windows).
+_DRAFT_INVOICE_ENROLLMENT_LOOKBACK_DAYS = 730
 
 
 def _trimmed_str_or_none(value: object | None) -> str | None:
@@ -116,12 +118,14 @@ def _encode_enrolled_at_cursor(enrolled_at: datetime, row_id: UUID) -> str:
 def list_recent_enrollments_for_invoicing(
     event: Mapping[str, Any], *, user_sub: str, request_id: str | None
 ) -> dict[str, Any]:
-    """Non-cancelled enrollments from the last 365 days (`enrolled_at`), capped and paginated.
+    """Non-cancelled enrollments from the last two years (`enrolled_at`), capped and paginated.
+
+    Uses a 730-day rolling window (two 365-day windows), consistent with the prior one-year window.
 
     Tenant note: this deployment is single-tenant Aurora; there is no tenant_id column on
     enrollments. Authorization is enforced at API Gateway (admin group).
     """
-    cutoff = datetime.now(UTC) - timedelta(days=365)
+    cutoff = datetime.now(UTC) - timedelta(days=_DRAFT_INVOICE_ENROLLMENT_LOOKBACK_DAYS)
     limit = parse_limit(event, default=_PICKER_MAX_LIMIT, max_limit=_PICKER_MAX_LIMIT)
     cursor_ts, cursor_id = _parse_enrolled_at_cursor(query_param(event, "cursor"))
     q_raw = (query_param(event, "q") or "").strip()

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -2980,7 +2980,8 @@ paths:
     get:
       summary: List recent enrollments for draft invoice picker
       description: >
-        Returns non-cancelled enrollments with `enrolled_at` within the last 365 days,
+        Returns non-cancelled enrollments with `enrolled_at` within the last 730 days
+        (two 365-day rolling windows by enrolled date),
         ordered by `enrolled_at` descending (cursor pagination). At most `limit` rows per response
         (default and maximum 500). Pass `next_cursor` from the prior response as `cursor`.
         Optional `q` filters server-side by enrollment UUID substring, instance title, cohort,

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -112,7 +112,7 @@ their primary responsibilities.
   `/v1/admin/expenses/*`,
   `/v1/admin/billing/*` (customer AR: `GET /v1/admin/billing/payments` optional `invoice_id` filters to payments with an allocation to that invoice; `GET /v1/admin/billing/payments/{id}` includes `allocationInvoices` and `orphanPaymentDeletable`; `DELETE /v1/admin/billing/payments/{id}` removes eligible orphan inbound payments (pending or free/zero, enrollment unlinked or cancelled, no allocations/receipt/refund children); payments, invoices list/detail, draft invoices via
   `POST /v1/admin/billing/invoices` with `draftKind` `enrollment_merge` or `customized_manual`,
-  `GET /v1/admin/billing/enrollments/recent-for-invoicing`, `DELETE /v1/admin/billing/invoices/{id}` (draft-only permanent delete; blocked when allocations exist), `GET /v1/admin/billing/invoices/{id}/pdf`
+  `GET /v1/admin/billing/enrollments/recent-for-invoicing` (draft invoice enrollment picker: non-cancelled rows with `enrolled_at` within the last 730 rolling days), `DELETE /v1/admin/billing/invoices/{id}` (draft-only permanent delete; blocked when allocations exist), `GET /v1/admin/billing/invoices/{id}/pdf`
   (returns a CloudFront-signed URL; each response includes a unique cache-bust query on the
   signed resource so draft/void preview PDFs re-uploaded to the same S3 key are not edge-cached
   as an older file),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the **Create draft invoice** enrollment list (`GET /v1/admin/billing/enrollments/recent-for-invoicing`) from a **365-day** to a **730-day** rolling window on `enrolled_at`, so staff see roughly **two years** of enrollments (same convention as before: two 365-day rolling periods).

**Follow-up:** Enrollment picker rows are explicitly **sorted by `enrolledAt` descending** (newest first) after multi-page aggregation, and **selected rows** in the line-total overrides block use the same order.

## Changes

- **Backend:** `list_recent_enrollments_for_invoicing` uses `_DRAFT_INVOICE_ENROLLMENT_LOOKBACK_DAYS = 730`.
- **OpenAPI** (`docs/api/admin.yaml`) and **regenerated** `admin-api.generated.ts` descriptions updated.
- **Admin UI:** helper copy on the draft invoice panel matches the new window; enrollment table / selection overrides sorted by enrollment date.
- **Admin web:** `compareBillingEnrollmentPickerRowsByEnrolledAtDesc` in `billing-api.ts`; `listRecentEnrollmentsForInvoicing` sorts merged pages; `client-invoices-panel` sorts selected enrollment rows.
- **Docs:** `docs/architecture/lambdas.md` billing bullet notes the 730-day lookback.

## Tests

- `pytest tests/test_admin_billing.py -k list_recent_enrollments`
- `npm run lint` (admin web)
- Vitest: `billing-api.test.ts`, `client-invoices-panel.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7403d7d5-ea4c-4285-b839-1bcf03bd942a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7403d7d5-ea4c-4285-b839-1bcf03bd942a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

