### PR TITLE
Sort admin Finance vendors table by name

### DIFF
--- a/apps/admin_web/src/lib/vendors-api.ts
+++ b/apps/admin_web/src/lib/vendors-api.ts
@@ -30,6 +30,7 @@ export async function listAdminVendors(
 ): Promise<{ items: Vendor[]; nextCursor: string | null; totalCount: number }> {
   const query = new URLSearchParams();
   query.set('relationship_type', 'vendor');
+  query.set('sort', 'name');
   if (params.cursor) {
     query.set('cursor', params.cursor);
   }

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -3557,6 +3557,8 @@ export interface paths {
                     active?: boolean;
                     /** @description When set, only organizations with this CRM relationship type are returned (e.g. `vendor` for Finance). When omitted, vendor and partner rows are both excluded from the list (Contacts default). */
                     relationship_type?: components["schemas"]["EntityRelationshipType"];
+                    /** @description Optional sort order. When `name`, results are ordered case-insensitively by trimmed `name` ascending, then by `id` ascending (stable pagination with the same `cursor` token as the default list). When omitted, rows are ordered by `created_at` descending (newest first), then `id` descending. */
+                    sort?: "name";
                     cursor?: string;
                     limit?: number;
                 };

--- a/apps/admin_web/tests/lib/vendors-api.test.ts
+++ b/apps/admin_web/tests/lib/vendors-api.test.ts
@@ -61,6 +61,7 @@ describe('vendors-api', () => {
     expect(request.method).toBe('GET');
     expect(request.endpointPath).toContain('/v1/admin/organizations?');
     expect(request.endpointPath).toContain('relationship_type=vendor');
+    expect(request.endpointPath).toContain('sort=name');
     expect(request.endpointPath).toContain('query=acme');
     expect(request.endpointPath).toContain('active=true');
     expect(request.endpointPath).toContain('cursor=abc');

--- a/backend/src/app/api/admin_organizations.py
+++ b/backend/src/app/api/admin_organizations.py
@@ -46,7 +46,10 @@ from app.db.models import (
     RelationshipType,
 )
 from app.db.models.organization import organization_membership_role_from_contact_type
-from app.db.repositories import OrganizationRepository
+from app.db.repositories.organization import (
+    OrganizationListOrder,
+    OrganizationRepository,
+)
 from app.exceptions import DatabaseError, NotFoundError, ValidationError
 from app.utils import json_response
 from app.utils.logging import get_logger
@@ -157,6 +160,19 @@ def _apply_organization_partner_key_from_body(
     org.partner_key = partner_key
 
 
+def _parse_organization_list_order(raw: str | None) -> OrganizationListOrder:
+    """Parse optional ``sort`` query for ``GET /v1/admin/organizations``."""
+    if raw is None or str(raw).strip() == "":
+        return "created_desc"
+    normalized = str(raw).strip().lower()
+    if normalized == "name":
+        return "name_asc"
+    raise ValidationError(
+        "sort must be omitted or name",
+        field="sort",
+    )
+
+
 def _parse_relationship_type_filter(
     raw: str | None,
 ) -> Sequence[RelationshipType] | None:
@@ -201,6 +217,7 @@ def _list_organizations(event: Mapping[str, Any]) -> dict[str, Any]:
     relationship_types = _parse_relationship_type_filter(
         query_param(event, "relationship_type")
     )
+    list_order = _parse_organization_list_order(query_param(event, "sort"))
     include_relationships = not (
         relationship_types is not None
         and len(relationship_types) == 1
@@ -216,6 +233,7 @@ def _list_organizations(event: Mapping[str, Any]) -> dict[str, Any]:
             active=active,
             relationship_types=relationship_types,
             include_relationships=include_relationships,
+            list_order=list_order,
         )
         has_more = len(rows) > limit
         page_rows = rows[:limit]

--- a/backend/src/app/db/repositories/organization.py
+++ b/backend/src/app/db/repositories/organization.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
+from typing import Literal
 from uuid import UUID
 
 from sqlalchemy import and_, func, literal, or_, select
@@ -96,6 +97,9 @@ def _is_substantial_vendor_name_for_reverse_match(normalized_vendor_name: str) -
     return True
 
 
+OrganizationListOrder = Literal["created_desc", "name_asc"]
+
+
 class OrganizationRepository(BaseRepository[Organization]):
     """Repository helpers for organization records."""
 
@@ -111,6 +115,7 @@ class OrganizationRepository(BaseRepository[Organization]):
         active: bool | None = None,
         relationship_types: Sequence[RelationshipType] | None = None,
         include_relationships: bool = True,
+        list_order: OrganizationListOrder = "created_desc",
     ) -> list[Organization]:
         """List organizations with optional relationship-type filter.
 
@@ -143,21 +148,37 @@ class OrganizationRepository(BaseRepository[Organization]):
                 noload(Organization.organization_members),
                 noload(Organization.location),
             )
+        name_sort_key = func.lower(func.trim(Organization.name))
         if cursor is not None:
-            cursor_created_at = (
-                select(Organization.created_at)
-                .where(Organization.id == cursor)
-                .scalar_subquery()
-            )
-            statement = statement.where(
-                or_(
-                    Organization.created_at < cursor_created_at,
-                    and_(
-                        Organization.created_at == cursor_created_at,
-                        Organization.id < cursor,
-                    ),
+            if list_order == "name_asc":
+                cursor_name_key = (
+                    select(name_sort_key)
+                    .where(Organization.id == cursor)
+                    .scalar_subquery()
                 )
-            )
+                statement = statement.where(
+                    or_(
+                        name_sort_key > cursor_name_key,
+                        and_(
+                            name_sort_key == cursor_name_key, Organization.id > cursor
+                        ),
+                    )
+                )
+            else:
+                cursor_created_at = (
+                    select(Organization.created_at)
+                    .where(Organization.id == cursor)
+                    .scalar_subquery()
+                )
+                statement = statement.where(
+                    or_(
+                        Organization.created_at < cursor_created_at,
+                        and_(
+                            Organization.created_at == cursor_created_at,
+                            Organization.id < cursor,
+                        ),
+                    )
+                )
         if query:
             escaped = _escape_like_pattern(query.strip())
             pattern = f"%{escaped}%"
@@ -166,10 +187,17 @@ class OrganizationRepository(BaseRepository[Organization]):
             statement = statement.where(Organization.archived_at.is_(None))
         if active is False:
             statement = statement.where(Organization.archived_at.is_not(None))
-        statement = statement.order_by(
-            Organization.created_at.desc(),
-            Organization.id.desc(),
-        ).limit(limit)
+        if list_order == "name_asc":
+            statement = statement.order_by(
+                name_sort_key.asc(),
+                Organization.id.asc(),
+            )
+        else:
+            statement = statement.order_by(
+                Organization.created_at.desc(),
+                Organization.id.desc(),
+            )
+        statement = statement.limit(limit)
         return list(self._session.execute(statement).scalars().unique().all())
 
     def count_organizations(

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -2578,6 +2578,17 @@ paths:
             excluded from the list (Contacts default).
           schema:
             $ref: "#/components/schemas/EntityRelationshipType"
+        - name: sort
+          in: query
+          description: >
+            Optional sort order. When `name`, results are ordered case-insensitively by
+            trimmed `name` ascending, then by `id` ascending (stable pagination with the
+            same `cursor` token as the default list). When omitted, rows are ordered by
+            `created_at` descending (newest first), then `id` descending.
+          schema:
+            type: string
+            enum:
+              - name
         - name: cursor
           in: query
           schema:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -80,7 +80,8 @@ their primary responsibilities.
   partner-only admin pickers), `/v1/admin/organizations/*` (CRM organisations and vendor
   rows share one resource; default list excludes vendors and partners; Services → Partners lists
   partners with `GET /v1/admin/organizations?relationship_type=partner`; Finance lists vendors with
-  `GET /v1/admin/organizations?relationship_type=vendor`; includes `DELETE /v1/admin/organizations/{id}`
+  `GET /v1/admin/organizations?relationship_type=vendor` (optional `sort=name` for case-insensitive
+  alphabetical order by trimmed name); includes `DELETE /v1/admin/organizations/{id}`
   for non-vendor orgs; `POST /v1/admin/organizations/{id}/members` derives each member's role from the
   linked contact's `contact_type`; `PATCH /v1/admin/organizations/{id}/members/{memberId}` updates
   membership fields such as primary contact),

--- a/tests/test_admin_organizations_handler.py
+++ b/tests/test_admin_organizations_handler.py
@@ -53,6 +53,7 @@ def test_list_organizations_default_excludes_vendors_from_repository_filter(
 
     assert captured["list"].get("relationship_types") is None
     assert captured["list"].get("include_relationships") is True
+    assert captured["list"].get("list_order") == "created_desc"
     assert captured["count"].get("relationship_types") is None
 
 
@@ -104,7 +105,55 @@ def test_list_organizations_vendor_query_sets_vendor_filter_and_skips_relationsh
 
     assert captured["list"]["relationship_types"] == (RelationshipType.VENDOR,)
     assert captured["list"]["include_relationships"] is False
+    assert captured["list"].get("list_order") == "created_desc"
     assert captured["count"]["relationship_types"] == (RelationshipType.VENDOR,)
+
+
+def test_list_organizations_sort_name_sets_name_asc_list_order(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def list_organizations(self, **kwargs: Any) -> list[object]:
+            captured["list"] = kwargs
+            return []
+
+        def count_organizations(self, **kwargs: Any) -> int:
+            captured["count"] = kwargs
+            return 0
+
+    class _FakeSessionCtx:
+        def __enter__(self) -> object:
+            return object()
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(admin_organizations, "OrganizationRepository", _FakeRepo)
+    monkeypatch.setattr(admin_organizations, "Session", lambda _engine: _FakeSessionCtx())
+    monkeypatch.setattr(admin_organizations, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        admin_organizations,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    admin_organizations.handle_admin_organizations_request(
+        api_gateway_event(
+            method="GET",
+            path="/v1/admin/organizations",
+            query_params={"relationship_type": "vendor", "sort": "name"},
+        ),
+        "GET",
+        "/v1/admin/organizations",
+    )
+
+    assert captured["list"]["list_order"] == "name_asc"
 
 
 def test_get_organization_returns_partner_row_via_non_vendor_loader(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Finance → Vendors table is backed by the paginated `GET /v1/admin/organizations?relationship_type=vendor` list, which previously ordered rows by `created_at` descending. That order does not match an alphabetical vendor table.

## Changes

- **API:** Optional query parameter `sort=name` on `GET /v1/admin/organizations` orders rows by case-insensitive trimmed `name` ascending, with `id` ascending as a stable tie-break. Cursor pagination uses the same UUID cursor token: the handler still passes the last row’s `id`; the repository resolves the cursor row’s sort key for the continuation predicate.
- **Admin web:** `listAdminVendors` always appends `sort=name` so the vendors table is alphabetical across pages.
- **Docs:** OpenAPI (`docs/api/admin.yaml`) and `docs/architecture/lambdas.md` updated. Regenerated `admin-api.generated.ts`.

## Tests

- Extended `tests/test_admin_organizations_handler.py` for default `list_order`, explicit `sort=name`, and vendor filter behavior.
- Extended `apps/admin_web/tests/lib/vendors-api.test.ts` to assert `sort=name` in the request URL.
- Ran targeted pytest, Vitest (vendors-api + vendors-panel), `ruff check`, `npm run generate:admin-api-types` / `check:admin-api-types`, and `scripts/validate-cursorrules.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f10373a-a4e8-446e-98ba-7b22293743d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f10373a-a4e8-446e-98ba-7b22293743d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

