### PR TITLE
Admin tax table: sort by date newest first

### DIFF
--- a/apps/admin_web/src/lib/tax-fiscal-year-report.ts
+++ b/apps/admin_web/src/lib/tax-fiscal-year-report.ts
@@ -98,7 +98,7 @@ export function buildTaxFiscalYearRows(
 
   const merged = [...expenseRows, ...revenueRows];
   merged.sort((a, b) => {
-    const d = a.classificationDate.localeCompare(b.classificationDate);
+    const d = b.classificationDate.localeCompare(a.classificationDate);
     if (d !== 0) {
       return d;
     }

--- a/apps/admin_web/tests/lib/tax-fiscal-year-report.test.ts
+++ b/apps/admin_web/tests/lib/tax-fiscal-year-report.test.ts
@@ -43,6 +43,29 @@ describe('tax-fiscal-year-report', () => {
     expect(defaultFiscalYearStartYear(new Date('2026-03-20T12:00:00.000Z'))).toBe(2025);
   });
 
+  it('sorts rows by classification date descending (newest first)', () => {
+    const rows = buildTaxFiscalYearRows(
+      [
+        expenseStub({
+          id: 'early',
+          status: 'paid',
+          invoiceDate: '2025-04-10',
+          total: '1',
+        }),
+        expenseStub({
+          id: 'late',
+          status: 'paid',
+          invoiceDate: '2025-06-20',
+          total: '2',
+        }),
+      ],
+      [],
+      2025,
+      'paid',
+    );
+    expect(rows.map((r) => r.referenceId)).toEqual(['late', 'early']);
+  });
+
   it('filters expenses by selected status', () => {
     const voided = expenseStub({
       id: 'v',
@@ -90,9 +113,9 @@ describe('tax-fiscal-year-report', () => {
       2025,
       'draft',
     );
-    expect(rows.map((r) => r.kind)).toEqual(['expense', 'revenue']);
-    expect(rows[0]?.kind).toBe('expense');
-    expect(rows[1]?.kind).toBe('revenue');
+    expect(rows.map((r) => r.kind)).toEqual(['revenue', 'expense']);
+    expect(rows[0]?.kind).toBe('revenue');
+    expect(rows[1]?.kind).toBe('expense');
   });
 
   it('flags missing invoice date when using paid date', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Finance → Tax fiscal-year table (`buildTaxFiscalYearRows`) sorted rows by `classificationDate` in **ascending** order (oldest first). This change sorts by date **descending** (most recent first), matching the requested UX. The same ordering applies to the **Download CSV** export because it uses the same row builder.

## Testing

- `npx vitest run tests/lib/tax-fiscal-year-report.test.ts`
- `npm run lint` in `apps/admin_web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e04f0116-aa28-4416-ab7c-2394f06d16f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e04f0116-aa28-4416-ab7c-2394f06d16f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

