### PR TITLE
Bulk expense import from combined PDF (OpenRouter)

### DIFF
--- a/apps/admin_web/src/components/admin/finance/bulk-expense-pdf-import-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/bulk-expense-pdf-import-panel.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+
+import { StatusBanner } from '@/components/status-banner';
+import { Button } from '@/components/ui/button';
+import { AdminEditorCard } from '@/components/ui/admin-editor-card';
+import { FileUploadButton } from '@/components/ui/file-upload-button';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+import type { Vendor } from '@/types/vendors';
+
+interface BulkExpensePdfImportPanelProps {
+  vendorOptions: Vendor[];
+  isLoadingVendors: boolean;
+  isBusy: boolean;
+  error: string;
+  onImport: (payload: { file: File; defaultVendorId: string }) => Promise<void>;
+}
+
+export function BulkExpensePdfImportPanel({
+  vendorOptions,
+  isLoadingVendors,
+  isBusy,
+  error,
+  onImport,
+}: BulkExpensePdfImportPanelProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [defaultVendorId, setDefaultVendorId] = useState('');
+  const [formKey, setFormKey] = useState(0);
+
+  const vendorRequired = defaultVendorId.trim().length === 0;
+  const submitDisabled = isBusy || vendorRequired || !file;
+
+  async function handleSubmit() {
+    if (!file || vendorRequired) {
+      return;
+    }
+    await onImport({ file, defaultVendorId: defaultVendorId.trim() });
+    setFile(null);
+    setDefaultVendorId('');
+    setFormKey((value) => value + 1);
+  }
+
+  return (
+    <AdminEditorCard
+      key={formKey}
+      title='Import from combined PDF'
+      description='Upload one PDF that lists several expenses. OpenRouter extracts rows the same way as queued invoice parsing; each row becomes an expense that shares this PDF attachment. When a row has no matching vendor name, the default vendor below is used.'
+      actions={
+        <Button
+          type='submit'
+          form='bulk-expense-pdf-import'
+          disabled={submitDisabled}
+        >
+          {isBusy ? 'Working...' : 'Parse PDF and create expenses'}
+        </Button>
+      }
+    >
+      {error ? (
+        <StatusBanner variant='error' title='Bulk import'>
+          {error}
+        </StatusBanner>
+      ) : null}
+      <form
+        id='bulk-expense-pdf-import'
+        className='space-y-3'
+        onSubmit={(event) => {
+          event.preventDefault();
+          void handleSubmit();
+        }}
+      >
+        <div>
+          <Label htmlFor='bulk-expense-pdf-default-vendor'>
+            Default vendor
+            <span aria-hidden='true' className='ml-0.5 text-red-600'>
+              *
+            </span>
+          </Label>
+          <Select
+            id='bulk-expense-pdf-default-vendor'
+            value={defaultVendorId}
+            onChange={(event) => setDefaultVendorId(event.target.value)}
+            required
+            aria-required
+            disabled={isBusy}
+          >
+            <option value=''>
+              {isLoadingVendors ? 'Loading vendors...' : 'Select default vendor'}
+            </option>
+            {vendorOptions.map((vendor) => (
+              <option key={vendor.id} value={vendor.id}>
+                {vendor.name}
+                {vendor.active ? '' : ' (Inactive)'}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div>
+          <Label htmlFor='bulk-expense-pdf-file'>Combined PDF (max 15MB)</Label>
+          <FileUploadButton
+            id='bulk-expense-pdf-file'
+            accept='application/pdf'
+            disabled={isBusy}
+            selectedFileName={file?.name ?? null}
+            emptyLabel='No file selected'
+            buttonLabel='Choose PDF'
+            onChange={(event) => {
+              const picked = event.target.files?.[0] ?? null;
+              setFile(picked);
+            }}
+          />
+        </div>
+      </form>
+    </AdminEditorCard>
+  );
+}

--- a/apps/admin_web/src/components/admin/finance/finance-page.tsx
+++ b/apps/admin_web/src/components/admin/finance/finance-page.tsx
@@ -11,6 +11,7 @@ import { listAllAdminExpenses } from '@/lib/expenses-api';
 import type { Expense } from '@/types/expenses';
 
 import { ExpensesEditorPanel } from './expenses-editor-panel';
+import { BulkExpensePdfImportPanel } from './bulk-expense-pdf-import-panel';
 import { ExpensesListPanel } from './expenses-list-panel';
 import {
   DEFAULT_FINANCE_VIEW,
@@ -127,6 +128,13 @@ export function FinancePage() {
         onUpdate={expenses.updateExpenseEntry}
         onAmend={expenses.amendExpenseEntry}
         onStartCreate={expenses.clearSelectedExpense}
+      />
+      <BulkExpensePdfImportPanel
+        vendorOptions={vendors.vendors}
+        isLoadingVendors={vendors.isLoading}
+        isBusy={expenses.isBulkImporting || expenses.isUploadingFiles}
+        error={expenses.bulkImportError}
+        onImport={expenses.bulkImportFromPdf}
       />
       <ExpensesListPanel
         expenses={expenses.items}

--- a/apps/admin_web/src/hooks/use-expenses.ts
+++ b/apps/admin_web/src/hooks/use-expenses.ts
@@ -8,6 +8,7 @@ import {
   cancelAdminExpense,
   createAdminExpense,
   deleteAdminDraftExpense,
+  importAdminExpensesFromBulkPdf,
   listAdminExpenses,
   markAdminExpensePaid,
   reparseAdminExpense,
@@ -41,6 +42,8 @@ export function useExpenses() {
   const [isDeletingDraftId, setIsDeletingDraftId] = useState<string | null>(null);
   const [isMarkingPaidId, setIsMarkingPaidId] = useState<string | null>(null);
   const [isReparsingId, setIsReparsingId] = useState<string | null>(null);
+  const [isBulkImporting, setIsBulkImporting] = useState(false);
+  const [bulkImportError, setBulkImportError] = useState('');
   const [mutationError, setMutationError] = useState('');
 
   const fetchExpenses = useCallback(
@@ -311,6 +314,34 @@ export function useExpenses() {
     [list]
   );
 
+  const bulkImportFromPdf = useCallback(
+    async ({ file, defaultVendorId }: { file: File; defaultVendorId: string }) => {
+      setIsBulkImporting(true);
+      setBulkImportError('');
+      let uploadedAssetIds: string[] = [];
+      try {
+        uploadedAssetIds = await uploadExpenseFiles([file]);
+        const attachmentAssetId = uploadedAssetIds[0];
+        if (!attachmentAssetId) {
+          throw new Error('Upload did not return an asset id.');
+        }
+        await importAdminExpensesFromBulkPdf({
+          attachmentAssetId,
+          defaultVendorId,
+        });
+        await list.refetch();
+        setSelectedExpenseId(null);
+      } catch (error) {
+        await cleanupUploadedAssets(uploadedAssetIds);
+        setBulkImportError(toErrorMessage(error, 'Failed to import expenses from PDF.'));
+        throw error;
+      } finally {
+        setIsBulkImporting(false);
+      }
+    },
+    [cleanupUploadedAssets, list, uploadExpenseFiles]
+  );
+
   return {
     ...list,
     selectedExpenseId,
@@ -321,6 +352,8 @@ export function useExpenses() {
     isDeletingDraftId,
     isMarkingPaidId,
     isReparsingId,
+    isBulkImporting,
+    bulkImportError,
     mutationError,
     selectExpense,
     clearSelectedExpense,
@@ -332,5 +365,6 @@ export function useExpenses() {
     deleteDraftExpenseEntry,
     markPaidExpenseEntry,
     reparseExpenseEntry,
+    bulkImportFromPdf,
   };
 }

--- a/apps/admin_web/src/lib/expenses-api.ts
+++ b/apps/admin_web/src/lib/expenses-api.ts
@@ -21,9 +21,13 @@ type ApiExpenseListResponse = ApiSchemas['ExpenseListResponse'];
 type ApiCreateExpenseRequest = ApiSchemas['CreateExpenseRequest'];
 type ApiUpdateExpenseRequest = ApiSchemas['UpdateExpenseRequest'];
 type ApiCancelExpenseRequest = ApiSchemas['CancelExpenseRequest'];
+type ApiBulkImportExpensesFromPdfResponse = ApiSchemas['BulkImportExpensesFromPdfResponse'];
 
 type ApiExpensePayload = ApiExpenseResponse | ApiExpense | ApiDataWrapper<ApiExpenseResponse | ApiExpense>;
 type ApiExpenseListPayload = ApiExpenseListResponse | ApiDataWrapper<ApiExpenseListResponse>;
+type ApiBulkImportPayload =
+  | ApiBulkImportExpensesFromPdfResponse
+  | ApiDataWrapper<ApiBulkImportExpensesFromPdfResponse>;
 
 function isApiExpenseLineItem(value: unknown): value is ApiExpenseLineItem {
   return isRecord(value);
@@ -272,6 +276,28 @@ export async function reparseAdminExpense(expenseId: string): Promise<void> {
     method: 'POST',
     expectedSuccessStatuses: [202],
   });
+}
+
+export async function importAdminExpensesFromBulkPdf(input: {
+  attachmentAssetId: string;
+  defaultVendorId: string;
+}): Promise<{ expenses: Expense[]; createdCount: number }> {
+  const payload = await adminApiRequest<ApiBulkImportPayload>({
+    endpointPath: '/v1/admin/expenses/import-from-bulk-pdf',
+    method: 'POST',
+    body: {
+      attachment_asset_id: input.attachmentAssetId.trim(),
+      default_vendor_id: input.defaultVendorId.trim(),
+    },
+    expectedSuccessStatuses: [201],
+  });
+  const root = unwrapPayload(payload);
+  const expenses = Array.isArray(root.expenses)
+    ? root.expenses.filter((entry): entry is ApiExpense => isApiExpense(entry)).map((entry) => parseExpense(entry))
+    : [];
+  const createdCount =
+    typeof root.created_count === 'number' ? root.created_count : expenses.length;
+  return { expenses, createdCount };
 }
 
 export async function deleteAdminDraftExpense(expenseId: string): Promise<void> {

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4666,6 +4666,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/expenses/import-from-bulk-pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import multiple expenses from one combined PDF
+         * @description Upload a PDF as an admin asset, then call this endpoint with its asset id. OpenRouter extracts one JSON object per distinct invoice or charge row; each row becomes a separate expense that references the same attachment asset. Parsed vendor names are matched to active vendors when possible; otherwise `default_vendor_id` is used. Synchronous parse is subject to API Gateway time limits; very large PDFs may fail with a validation error.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["BulkImportExpensesFromPdfRequest"];
+                };
+            };
+            responses: {
+                /** @description Expenses created from parsed rows. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BulkImportExpensesFromPdfResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/expenses/{id}": {
         parameters: {
             query?: never;
@@ -6319,6 +6365,24 @@ export interface components {
             notes?: string | null;
             attachment_asset_ids: string[];
             parse_requested?: boolean;
+        };
+        BulkImportExpensesFromPdfRequest: {
+            /**
+             * Format: uuid
+             * @description Uploaded PDF asset id (same presign flow as single expense attachments).
+             */
+            attachment_asset_id: string;
+            /**
+             * Format: uuid
+             * @description Vendor applied when a parsed row has no resolvable vendor_name match.
+             */
+            default_vendor_id: string;
+            /** @description Defaults to `submitted`. Draft may be used when operators want to review rows before submission. */
+            status?: components["schemas"]["ExpenseStatus"];
+        };
+        BulkImportExpensesFromPdfResponse: {
+            expenses: components["schemas"]["Expense"][];
+            created_count: number;
         };
         UpdateExpenseRequest: {
             status?: components["schemas"]["ExpenseStatus"];

--- a/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
@@ -28,6 +28,8 @@ const {
     isDeletingDraftId: null as string | null,
     isMarkingPaidId: null as string | null,
     isReparsingId: null as string | null,
+    isBulkImporting: false,
+    bulkImportError: '',
     mutationError: '',
     selectExpense: vi.fn(),
     clearSelectedExpense: vi.fn(),
@@ -39,6 +41,7 @@ const {
     deleteDraftExpenseEntry: vi.fn(),
     markPaidExpenseEntry: vi.fn(),
     reparseExpenseEntry: vi.fn(),
+    bulkImportFromPdf: vi.fn(),
   };
   const vendorsState = {
     vendors: [],
@@ -144,13 +147,15 @@ describe('FinancePage', () => {
     });
   });
 
-  it('renders expense editor before submitted expenses list', () => {
+  it('renders expense editor before bulk PDF import and submitted expenses list', () => {
     render(<FinancePage />);
 
     const editorHeading = screen.getByRole('heading', { name: 'Expense Details' });
+    const bulkHeading = screen.getByRole('heading', { name: 'Import from combined PDF' });
     const listHeading = screen.getByRole('heading', { name: 'Submitted Expenses' });
 
-    expect(editorHeading.compareDocumentPosition(listHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(editorHeading.compareDocumentPosition(bulkHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(bulkHeading.compareDocumentPosition(listHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('uses expense hook state', () => {

--- a/apps/admin_web/tests/hooks/use-expenses.test.ts
+++ b/apps/admin_web/tests/hooks/use-expenses.test.ts
@@ -8,6 +8,7 @@ const {
   mockCancelAdminExpense,
   mockMarkAdminExpensePaid,
   mockReparseAdminExpense,
+  mockImportAdminExpensesFromBulkPdf,
   mockCreateAdminAsset,
   mockDeleteAdminAsset,
   mockUploadFileToPresignedUrl,
@@ -36,6 +37,7 @@ const {
     mockCancelAdminExpense: vi.fn(),
     mockMarkAdminExpensePaid: vi.fn(),
     mockReparseAdminExpense: vi.fn(),
+    mockImportAdminExpensesFromBulkPdf: vi.fn(),
     mockCreateAdminAsset: vi.fn(),
     mockDeleteAdminAsset: vi.fn(),
     mockUploadFileToPresignedUrl: vi.fn(),
@@ -56,6 +58,7 @@ vi.mock('@/lib/expenses-api', () => ({
   cancelAdminExpense: mockCancelAdminExpense,
   markAdminExpensePaid: mockMarkAdminExpensePaid,
   reparseAdminExpense: mockReparseAdminExpense,
+  importAdminExpensesFromBulkPdf: mockImportAdminExpensesFromBulkPdf,
 }));
 
 vi.mock('@/lib/assets-api', () => ({
@@ -590,5 +593,38 @@ describe('useExpenses', () => {
     });
 
     expect(result.current.mutationError).toBe('');
+  });
+
+  it('bulk imports from a PDF asset and refetches expenses', async () => {
+    mockCreateAdminAsset.mockResolvedValue({
+      asset: { id: 'asset-bulk-1' },
+      upload: {
+        uploadUrl: 'https://example.com/up',
+        uploadMethod: 'PUT',
+        uploadHeaders: {} as Record<string, string>,
+      },
+    });
+    mockUploadFileToPresignedUrl.mockResolvedValue(undefined);
+    mockImportAdminExpensesFromBulkPdf.mockResolvedValue({
+      expenses: [],
+      createdCount: 2,
+    });
+
+    const file = new File([new Uint8Array([1])], 'combined.pdf', { type: 'application/pdf' });
+    const { result } = renderHook(() => useExpenses());
+
+    await act(async () => {
+      await result.current.bulkImportFromPdf({
+        file,
+        defaultVendorId: 'vendor-1',
+      });
+    });
+
+    expect(mockImportAdminExpensesFromBulkPdf).toHaveBeenCalledWith({
+      attachmentAssetId: 'asset-bulk-1',
+      defaultVendorId: 'vendor-1',
+    });
+    expect(mockRefetch).toHaveBeenCalled();
+    expect(result.current.bulkImportError).toBe('');
   });
 });

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1666,6 +1666,7 @@ export class ApiStack extends cdk.Stack {
     const adminFunction = createPythonFunction("EvolvesproutsAdminFunction", {
       handler: "lambda/admin/handler.lambda_handler",
       extraCopyPaths: ["src/app/assets/invoice"],
+      timeout: cdk.Duration.seconds(29),
       environment: {
         TURNSTILE_SECRET_KEY: turnstileSecretKey.valueAsString,
         DATABASE_SECRET_ARN: database.adminUserSecret.secretArn,
@@ -1802,6 +1803,20 @@ export class ApiStack extends cdk.Stack {
         ),
         encryptionKey: secretsEncryptionKey,
       }
+    );
+    openrouterApiSecret.grantRead(adminFunction);
+    adminFunction.addEnvironment(
+      "OPENROUTER_API_KEY_SECRET_ARN",
+      openrouterApiSecret.secretArn
+    );
+    adminFunction.addEnvironment(
+      "OPENROUTER_CHAT_COMPLETIONS_URL",
+      openrouterChatCompletionsUrl.valueAsString
+    );
+    adminFunction.addEnvironment("OPENROUTER_MODEL", openrouterModel.valueAsString);
+    adminFunction.addEnvironment(
+      "OPENROUTER_MAX_FILE_BYTES",
+      openrouterMaxFileBytes.valueAsString
     );
 
     const sqsEncryptionKey = new kms.Key(this, "SqsEncryptionKey", {

--- a/backend/src/app/api/admin_expenses.py
+++ b/backend/src/app/api/admin_expenses.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, date
+from decimal import Decimal
 from typing import Any
 from collections.abc import Mapping
 from uuid import UUID
@@ -13,10 +14,12 @@ from app.api.admin_expenses_common import (
     _STATUS_TERMINAL,
     apply_common_fields,
     ensure_expense_ready_to_mark_paid,
+    optional_field,
     parse_create_payload,
     parse_optional_parse_status,
     parse_optional_status,
     parse_optional_string,
+    parse_optional_uuid,
     parse_update_payload,
     required_string,
     resolve_vendor,
@@ -35,11 +38,18 @@ from app.api.admin_request import (
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
-from app.db.models import ExpenseParseStatus, ExpenseStatus
-from app.db.repositories import ExpenseRepository
+from app.db.models import Expense, ExpenseParseStatus, ExpenseStatus
+from app.db.repositories import (
+    AssetRepository,
+    ExpenseRepository,
+    OrganizationRepository,
+)
 from app.exceptions import NotFoundError, ValidationError
 from app.services.asset_expense_tagging import sync_expense_attachment_tags_for_assets
 from app.services.expense_events import enqueue_expense_parse
+from app.services.openrouter_expense_parser import (
+    parse_bulk_expense_invoices_from_assets,
+)
 from app.utils import json_response
 from app.utils.logging import get_logger
 
@@ -69,6 +79,11 @@ def handle_admin_expenses_request(
         if method == "POST":
             return _create_expense(event, actor_sub=identity.user_sub)
         return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 3 and parts[2] == "import-from-bulk-pdf":
+        if method != "POST":
+            return json_response(405, {"error": "Method not allowed"}, event=event)
+        return _import_expenses_from_bulk_pdf(event, actor_sub=identity.user_sub)
 
     expense_id = parse_uuid(parts[2])
     if len(parts) == 3:
@@ -461,11 +476,195 @@ def _amend_expense(
         expense_repo.update(amendment)
         session.commit()
 
-        if payload["parse_requested"]:
-            enqueue_expense_parse(amendment.id)
         refreshed = expense_repo.get_with_attachments(amendment.id)
         if refreshed is None:
             raise NotFoundError("Expense", str(amendment.id))
         return json_response(
             201, {"expense": serialize_expense(refreshed)}, event=event
         )
+
+
+def _import_expenses_from_bulk_pdf(
+    event: Mapping[str, Any], *, actor_sub: str
+) -> dict[str, Any]:
+    """Parse a combined PDF with OpenRouter and create one expense per extracted row."""
+    logger.info("Bulk importing expenses from PDF", extra={"actor": actor_sub})
+    body = parse_body(event)
+    attachment_id = parse_optional_uuid(
+        optional_field(body, "attachment_asset_id", "attachmentAssetId"),
+        field="attachment_asset_id",
+    )
+    if attachment_id is None:
+        raise ValidationError(
+            "attachment_asset_id is required", field="attachment_asset_id"
+        )
+    default_vendor_id = parse_optional_uuid(
+        optional_field(body, "default_vendor_id", "defaultVendorId"),
+        field="default_vendor_id",
+    )
+    if default_vendor_id is None:
+        raise ValidationError(
+            "default_vendor_id is required", field="default_vendor_id"
+        )
+    status = (
+        parse_optional_status(optional_field(body, "status")) or ExpenseStatus.SUBMITTED
+    )
+
+    req_id = request_id(event)
+    now = datetime.now(UTC)
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
+        resolve_vendor(session, default_vendor_id)
+        assets = AssetRepository(session).list_by_ids([attachment_id])
+        if not assets:
+            raise NotFoundError("Asset", str(attachment_id))
+        asset_ent = assets[0]
+        content_type = (asset_ent.content_type or "").strip().lower()
+        file_name = (asset_ent.file_name or "").strip().lower()
+        if "pdf" not in content_type and not file_name.endswith(".pdf"):
+            raise ValidationError(
+                "attachment_asset_id must reference a PDF document",
+                field="attachment_asset_id",
+            )
+        parser_asset: dict[str, Any] = {
+            "id": str(asset_ent.id),
+            "s3_key": asset_ent.s3_key,
+            "file_name": asset_ent.file_name,
+            "content_type": asset_ent.content_type,
+        }
+
+    try:
+        normalized_rows = parse_bulk_expense_invoices_from_assets(
+            [parser_asset], timeout=25
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise ValidationError(str(exc), field="attachment_asset_id") from exc
+
+    created_payload: list[dict[str, Any]] = []
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
+        expense_repo = ExpenseRepository(session)
+        org_repo = OrganizationRepository(session)
+        resolve_vendor(session, default_vendor_id)
+        asset_ids = resolve_asset_ids(session, [attachment_id])
+
+        for parsed in normalized_rows:
+            vendor_id = _resolve_bulk_row_vendor_id(
+                org_repo, parsed, default_vendor_id=default_vendor_id
+            )
+            expense = expense_repo.create_expense(
+                created_by=actor_sub,
+                status=status,
+                parse_status=ExpenseParseStatus.SUCCEEDED,
+                vendor_id=vendor_id,
+                invoice_number=None,
+                invoice_date=None,
+                due_date=None,
+                currency=None,
+                subtotal=None,
+                tax=None,
+                total=None,
+                line_items=None,
+                notes=None,
+            )
+            _apply_openrouter_normalized_to_expense(expense, parsed)
+            expense.updated_by = actor_sub
+            if status == ExpenseStatus.SUBMITTED:
+                expense.submitted_at = now
+            expense_repo.replace_attachments(expense, asset_ids)
+            expense_repo.update(expense)
+            refreshed = expense_repo.get_with_attachments(expense.id)
+            if refreshed is None:
+                raise NotFoundError("Expense", str(expense.id))
+            created_payload.append(serialize_expense(refreshed))
+
+        session.commit()
+
+    return json_response(
+        201,
+        {"expenses": created_payload, "created_count": len(created_payload)},
+        event=event,
+    )
+
+
+def _resolve_bulk_row_vendor_id(
+    org_repo: OrganizationRepository,
+    parsed: Mapping[str, Any],
+    *,
+    default_vendor_id: UUID,
+) -> UUID:
+    parsed_vendor_only = _bulk_pick_text(parsed.get("vendor_name"), fallback=None)
+    if parsed_vendor_only:
+        matched = org_repo.try_resolve_active_vendor_by_parsed_name(parsed_vendor_only)
+        if matched is not None:
+            return matched.id
+    return default_vendor_id
+
+
+def _apply_openrouter_normalized_to_expense(
+    expense: Expense, parsed: Mapping[str, Any]
+) -> None:
+    expense.invoice_number = _bulk_pick_text(
+        parsed.get("invoice_number"), fallback=expense.invoice_number
+    )
+    expense.invoice_date = _bulk_pick_date(
+        parsed.get("invoice_date"), fallback=expense.invoice_date
+    )
+    expense.due_date = _bulk_pick_date(
+        parsed.get("due_date"), fallback=expense.due_date
+    )
+    expense.currency = _bulk_pick_currency(
+        parsed.get("currency"), fallback=expense.currency
+    )
+    expense.subtotal = _bulk_pick_decimal(
+        parsed.get("subtotal"), fallback=expense.subtotal
+    )
+    expense.tax = _bulk_pick_decimal(parsed.get("tax"), fallback=expense.tax)
+    expense.total = _bulk_pick_decimal(parsed.get("total"), fallback=expense.total)
+    line_items = parsed.get("line_items")
+    if isinstance(line_items, list):
+        expense.line_items = line_items
+    expense.parse_confidence = _bulk_pick_decimal(
+        parsed.get("confidence"), fallback=expense.parse_confidence
+    )
+    expense.parser_raw = (
+        parsed.get("raw") if isinstance(parsed.get("raw"), dict) else {"raw": parsed}
+    )
+
+
+def _bulk_pick_text(value: Any, *, fallback: str | None) -> str | None:
+    if value is None:
+        return fallback
+    normalized = str(value).strip()
+    return normalized or fallback
+
+
+def _bulk_pick_date(value: Any, *, fallback: date | None) -> date | None:
+    if value is None:
+        return fallback
+    normalized = str(value).strip()
+    if not normalized:
+        return fallback
+    try:
+        return date.fromisoformat(normalized)
+    except ValueError:
+        return fallback
+
+
+def _bulk_pick_currency(value: Any, *, fallback: str | None) -> str | None:
+    if value is None:
+        return fallback
+    normalized = str(value).strip().upper()
+    if len(normalized) != 3:
+        return fallback
+    return normalized
+
+
+def _bulk_pick_decimal(value: Any, *, fallback: Decimal | None) -> Decimal | None:
+    if value is None:
+        return fallback
+    try:
+        return Decimal(str(value)).quantize(Decimal("0.01"))
+    except Exception:
+        return fallback

--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -27,30 +27,89 @@ def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, 
         raise ValueError("At least one asset is required for parsing")
 
     logger.info("Starting invoice parse", extra={"asset_count": len(assets)})
+    content: list[dict[str, Any]] = [{"type": "text", "text": _schema_prompt()}]
+    for asset in assets:
+        content.append(_build_attachment_content(asset))
+
+    has_pdf = any(
+        _normalize_content_type(asset) == "application/pdf" for asset in assets
+    )
+    body = _openrouter_chat_completion(
+        system_prompt="You extract invoice data and return strict JSON only.",
+        user_content_blocks=content,
+        has_pdf_attachment=has_pdf,
+        timeout=30,
+    )
+    parsed = _parse_completion_body(body)
+    logger.info("Invoice parse completed successfully")
+    return _normalize_result(parsed)
+
+
+_MAX_BULK_INVOICES = 100
+
+
+def parse_bulk_expense_invoices_from_assets(
+    assets: Sequence[Mapping[str, Any]],
+    *,
+    timeout: int = 25,
+) -> list[dict[str, Any]]:
+    """Parse many invoice rows from one combined PDF (or images) via OpenRouter.
+
+    Returns a list of normalized invoice dicts (same shape as ``parse_invoice_from_assets``).
+    """
+    if not assets:
+        raise ValueError("At least one asset is required for parsing")
+
+    logger.info("Starting bulk invoice parse", extra={"asset_count": len(assets)})
+    content: list[dict[str, Any]] = [{"type": "text", "text": _bulk_schema_prompt()}]
+    for asset in assets:
+        content.append(_build_attachment_content(asset))
+
+    has_pdf = any(
+        _normalize_content_type(asset) == "application/pdf" for asset in assets
+    )
+    body = _openrouter_chat_completion(
+        system_prompt=(
+            "You extract structured invoice rows from financial documents and "
+            "return strict JSON only."
+        ),
+        user_content_blocks=content,
+        has_pdf_attachment=has_pdf,
+        timeout=timeout,
+    )
+    raw_invoices = _parse_bulk_invoices_payload(body)
+    if not raw_invoices:
+        raise RuntimeError("Parser returned no invoice rows")
+    if len(raw_invoices) > _MAX_BULK_INVOICES:
+        raise RuntimeError(
+            f"Parser returned too many invoices (max {_MAX_BULK_INVOICES})"
+        )
+    normalized = [_normalize_result(entry) for entry in raw_invoices]
+    logger.info(
+        "Bulk invoice parse completed successfully",
+        extra={"invoice_count": len(normalized)},
+    )
+    return normalized
+
+
+def _openrouter_chat_completion(
+    *,
+    system_prompt: str,
+    user_content_blocks: list[dict[str, Any]],
+    has_pdf_attachment: bool,
+    timeout: int,
+) -> str:
+    """POST to OpenRouter and return the raw HTTP response body string."""
     endpoint_url = _require_env("OPENROUTER_CHAT_COMPLETIONS_URL")
     model = _require_env("OPENROUTER_MODEL")
     api_key = _get_api_key()
-
-    content: list[dict[str, Any]] = [{"type": "text", "text": _schema_prompt()}]
-    has_pdf_attachment = False
-    for asset in assets:
-        attachment_content = _build_attachment_content(asset)
-        content.append(attachment_content)
-        if (
-            attachment_content.get("type") == "file"
-            and _normalize_content_type(asset) == "application/pdf"
-        ):
-            has_pdf_attachment = True
 
     payload: dict[str, Any] = {
         "model": model,
         "temperature": 0,
         "messages": [
-            {
-                "role": "system",
-                "content": "You extract invoice data and return strict JSON only.",
-            },
-            {"role": "user", "content": content},
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content_blocks},
         ],
     }
     if has_pdf_attachment:
@@ -69,7 +128,7 @@ def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, 
             "Content-Type": "application/json",
         },
         body=json.dumps(payload),
-        timeout=30,
+        timeout=timeout,
     )
 
     status_code = int(response.get("status", 0) or 0)
@@ -86,9 +145,7 @@ def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, 
         raise RuntimeError(
             f"OpenRouter request failed with status {status_code}{detail}"
         )
-    parsed = _parse_completion_body(body)
-    logger.info("Invoice parse completed successfully")
-    return _normalize_result(parsed)
+    return body
 
 
 def _build_attachment_content(asset: Mapping[str, Any]) -> dict[str, Any]:
@@ -183,6 +240,61 @@ def _parse_completion_body(body: str) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise RuntimeError("Parser response payload is not an object")
     return parsed
+
+
+def _parse_bulk_invoices_payload(body: str) -> list[dict[str, Any]]:
+    """Parse OpenRouter envelope and return raw invoice objects for bulk import."""
+    payload = json.loads(body)
+    if not isinstance(payload, dict):
+        raise RuntimeError("OpenRouter response must be a JSON object")
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise RuntimeError("OpenRouter response choices are missing")
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        raise RuntimeError("OpenRouter response choice has invalid shape")
+    message = first_choice.get("message")
+    if not isinstance(message, dict):
+        raise RuntimeError("OpenRouter response message is missing")
+    content = message.get("content")
+    if isinstance(content, list):
+        text_parts = [
+            str(item.get("text"))
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "text"
+        ]
+        raw_text = "\n".join(part for part in text_parts if part)
+    else:
+        raw_text = str(content or "")
+    cleaned = (
+        raw_text.strip()
+        .removeprefix("```json")
+        .removeprefix("```")
+        .removesuffix("```")
+        .strip()
+    )
+    parsed = json.loads(cleaned)
+    raw_list: list[Any]
+    if isinstance(parsed, list):
+        raw_list = parsed
+    elif isinstance(parsed, dict):
+        inner = parsed.get("invoices")
+        if inner is None:
+            inner = parsed.get("records")
+        if not isinstance(inner, list):
+            raise RuntimeError(
+                "Bulk parser response must be an array or an object with "
+                '"invoices" or "records" array'
+            )
+        raw_list = inner
+    else:
+        raise RuntimeError("Bulk parser response payload has invalid shape")
+
+    invoices: list[dict[str, Any]] = []
+    for entry in raw_list:
+        if isinstance(entry, dict):
+            invoices.append(entry)
+    return invoices
 
 
 def _normalize_result(parsed: dict[str, Any]) -> dict[str, Any]:
@@ -572,4 +684,24 @@ def _schema_prompt() -> str:
         "If the invoice shows only the $ symbol for money (not HK$, S$, etc.), set "
         "currency to USD. "
         "Input may be plain text pasted in an email body rather than a PDF or image."
+    )
+
+
+def _bulk_schema_prompt() -> str:
+    return (
+        "This document may contain many separate charges or invoices in one file "
+        "(for example a consolidated PDF, card statement, or vendor statement). "
+        "Extract each distinct expense or invoice as its own row. "
+        'Return strict JSON only with shape: {"invoices":[{"vendor_name":"string|null",'
+        '"invoice_number":"string|null","invoice_date":"YYYY-MM-DD|null",'
+        '"due_date":"YYYY-MM-DD|null","currency":"string|null",'
+        '"subtotal":"number|null","tax":"number|null","total":"number|null",'
+        '"line_items":[{"description":"string|null","quantity":"number|null",'
+        '"unit_price":"number|null","amount":"number|null"}],'
+        '"confidence":"number|null"}]}. '
+        "Use null for unknown values. No markdown. No prose. "
+        "For subtotal, tax, and total prefer JSON numbers; if you use strings, use "
+        "plain digits only (no currency symbols or thousands separators) when possible. "
+        "If a row shows only the $ symbol for money (not HK$, S$, etc.), set currency to USD. "
+        "Include every billable row you can identify; skip blank pages and headers only."
     )

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -49,6 +49,7 @@ info:
     - `PATCH /v1/admin/organizations/{id}/members/{memberId}`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
     - `GET|POST /v1/admin/expenses`
+    - `POST /v1/admin/expenses/import-from-bulk-pdf`
     - `GET|PATCH|DELETE /v1/admin/expenses/{id}`
     - `POST /v1/admin/expenses/{id}/cancel`
     - `POST /v1/admin/expenses/{id}/mark-paid`
@@ -3473,6 +3474,38 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
 
+  /v1/admin/expenses/import-from-bulk-pdf:
+    post:
+      summary: Import multiple expenses from one combined PDF
+      description: >
+        Upload a PDF as an admin asset, then call this endpoint with its asset id.
+        OpenRouter extracts one JSON object per distinct invoice or charge row; each
+        row becomes a separate expense that references the same attachment asset.
+        Parsed vendor names are matched to active vendors when possible; otherwise
+        `default_vendor_id` is used. Synchronous parse is subject to API Gateway
+        time limits; very large PDFs may fail with a validation error.
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BulkImportExpensesFromPdfRequest"
+      responses:
+        "201":
+          description: Expenses created from parsed rows.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BulkImportExpensesFromPdfResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /v1/admin/expenses/{id}:
     parameters:
       - $ref: "#/components/parameters/ExpenseId"
@@ -6692,6 +6725,39 @@ components:
             format: uuid
         parse_requested:
           type: boolean
+    BulkImportExpensesFromPdfRequest:
+      type: object
+      required:
+        - attachment_asset_id
+        - default_vendor_id
+      properties:
+        attachment_asset_id:
+          type: string
+          format: uuid
+          description: Uploaded PDF asset id (same presign flow as single expense attachments).
+        default_vendor_id:
+          type: string
+          format: uuid
+          description: >
+            Vendor applied when a parsed row has no resolvable vendor_name match.
+        status:
+          $ref: "#/components/schemas/ExpenseStatus"
+          description: >
+            Defaults to `submitted`. Draft may be used when operators want to review
+            rows before submission.
+    BulkImportExpensesFromPdfResponse:
+      type: object
+      required:
+        - expenses
+        - created_count
+      properties:
+        expenses:
+          type: array
+          items:
+            $ref: "#/components/schemas/Expense"
+        created_count:
+          type: integer
+          minimum: 1
     UpdateExpenseRequest:
       type: object
       properties:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -110,7 +110,10 @@ their primary responsibilities.
   case-insensitive unique index; `PUT` accepts `discount_value` `0` only when the
   effective discount type after the update is `referral`, otherwise `discount_value`
   must be greater than `0`),
-  `/v1/admin/expenses/*`,
+  `/v1/admin/expenses/*` (including `POST /v1/admin/expenses/import-from-bulk-pdf`, which
+  reads a single uploaded PDF asset from S3, calls OpenRouter via `AwsApiProxyFunction`
+  with the same PDF plugin stack as `ExpenseParserFunction`, and creates one submitted
+  expense per parsed row sharing that attachment),
   `/v1/admin/billing/*` (customer AR: `GET /v1/admin/billing/payments` optional `invoice_id` filters to payments with an allocation to that invoice; `GET /v1/admin/billing/payments/{id}` includes `allocationInvoices` and `orphanPaymentDeletable`; `DELETE /v1/admin/billing/payments/{id}` removes eligible orphan inbound payments (pending or free/zero, enrollment unlinked or cancelled, no allocations/receipt/refund children); payments, invoices list/detail, draft invoices via
   `POST /v1/admin/billing/invoices` with `draftKind` `enrollment_merge` or `customized_manual`,
   `GET /v1/admin/billing/enrollments/recent-for-invoicing` (draft invoice enrollment picker: non-cancelled rows with `enrolled_at` within the last 730 rolling days), `DELETE /v1/admin/billing/invoices/{id}` (draft-only permanent delete; blocked when allocations exist), `GET /v1/admin/billing/invoices/{id}/pdf`

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -452,3 +452,79 @@ def test_parse_invoice_surfaces_openrouter_error_body(monkeypatch: Any) -> None:
 
     assert "404" in str(exc_info.value)
     assert "No endpoints found" in str(exc_info.value)
+
+
+def test_parse_bulk_expense_invoices_normalizes_each_row(monkeypatch: Any) -> None:
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        assert kwargs["timeout"] == 25
+        payload = json.loads(kwargs["body"])
+        assert payload["plugins"][0]["id"] == "file-parser"
+        return {
+            "status": 200,
+            "body": json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps(
+                                    {
+                                        "invoices": [
+                                            {
+                                                "vendor_name": "Shop A",
+                                                "invoice_number": "1",
+                                                "invoice_date": "2026-01-02",
+                                                "due_date": None,
+                                                "currency": "HKD",
+                                                "subtotal": 10,
+                                                "tax": 0,
+                                                "total": 10,
+                                                "line_items": [],
+                                                "confidence": 0.9,
+                                            },
+                                            {
+                                                "vendor_name": "Shop B",
+                                                "invoice_number": "2",
+                                                "invoice_date": "2026-01-03",
+                                                "due_date": None,
+                                                "currency": "HKD",
+                                                "subtotal": 20,
+                                                "tax": 0,
+                                                "total": 20,
+                                                "line_items": [],
+                                                "confidence": 0.8,
+                                            },
+                                        ]
+                                    }
+                                )
+                            }
+                        }
+                    ]
+                }
+            ),
+        }
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    rows = parser.parse_bulk_expense_invoices_from_assets(
+        [
+            {
+                "id": "asset-b",
+                "s3_key": "k",
+                "file_name": "bulk.pdf",
+                "content_type": "application/pdf",
+            }
+        ],
+        timeout=25,
+    )
+    assert len(rows) == 2
+    assert rows[0]["invoice_number"] == "1"
+    assert rows[0]["total"] == 10.0
+    assert rows[1]["vendor_name"] == "Shop B"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Finance → Expenses** workflow for a single **combined PDF** that contains many expense rows (no per-invoice PDFs). The backend uses the **same OpenRouter stack** as async expense parsing (PDF plugin, `http_invoke` via `AwsApiProxyFunction`, Secrets Manager API key). Each parsed row becomes a **separate expense** with **parse_status succeeded** and the **same attachment asset** on every row.

## Backend

- New route: `POST /v1/admin/expenses/import-from-bulk-pdf` with `attachment_asset_id`, required `default_vendor_id`, optional `status` (defaults to submitted).
- `openrouter_expense_parser.parse_bulk_expense_invoices_from_assets` returns a list of normalized invoice dicts; prompt asks for `{"invoices":[...]}` (or `records`).
- **EvolvesproutsAdminFunction** now has OpenRouter env vars and read access to the OpenRouter secret; Lambda timeout set to **29s** to stay within typical API Gateway limits for synchronous parsing.

## Admin web

- New **Import from combined PDF** `AdminEditorCard` between **Expense Details** and **Submitted Expenses**: PDF picker, default vendor select, primary action to upload then import.

## Docs / contract

- `docs/api/admin.yaml` and generated admin API types.
- `docs/architecture/lambdas.md` notes the new admin behavior.

## Tests

- OpenRouter bulk parse unit test; `useExpenses` and finance page tests updated.

## Risks / limits

- Synchronous OpenRouter calls are bounded by **API Gateway (~29s)** and `http_invoke` timeout **25s**; very large PDFs may fail with a validation error.
- Parser output capped at **100** rows server-side.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5619c4b-6892-45dd-bba0-f0e747f32a45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5619c4b-6892-45dd-bba0-f0e747f32a45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

