### PR TITLE
fix: Harden async bulk expense import (safety, jobs list, worker retries)

### DIFF
--- a/apps/admin_web/src/components/admin/finance/bulk-expense-import-jobs-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/bulk-expense-import-jobs-panel.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableCell,
+  AdminDataTableHead,
+  AdminDataTableHeadCell,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
+import { AdminInlineError } from '@/components/ui/admin-inline-error';
+import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { toErrorMessage } from '@/hooks/hook-errors';
+import {
+  getAdminBulkExpenseImportJob,
+  listAdminBulkExpenseImportJobs,
+  queueAdminBulkExpenseImportJob,
+  type BulkImportJobSummary,
+} from '@/lib/expenses-api';
+import { formatEnumLabel } from '@/lib/format';
+
+const PAGE_LIMIT = 25;
+
+function formatWhen(iso: string): string {
+  const trimmed = iso.trim();
+  if (!trimmed) {
+    return '—';
+  }
+  const parsed = Date.parse(trimmed);
+  if (!Number.isFinite(parsed)) {
+    return trimmed;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(parsed));
+}
+
+interface BulkExpenseImportJobsPanelProps {
+  onAfterMutation?: () => void;
+}
+
+export function BulkExpenseImportJobsPanel({ onAfterMutation }: BulkExpenseImportJobsPanelProps) {
+  const [items, setItems] = useState<BulkImportJobSummary[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loadError, setLoadError] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [detailTitle, setDetailTitle] = useState('');
+  const [detailBody, setDetailBody] = useState('');
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [retryTarget, setRetryTarget] = useState<BulkImportJobSummary | null>(null);
+  const [retryBusy, setRetryBusy] = useState(false);
+  const [retryError, setRetryError] = useState('');
+
+  const loadFirstPage = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError('');
+    try {
+      const page = await listAdminBulkExpenseImportJobs({ limit: PAGE_LIMIT });
+      setItems(page.items);
+      setNextCursor(page.nextCursor);
+      setTotalCount(page.totalCount);
+    } catch (error) {
+      setLoadError(toErrorMessage(error, 'Failed to load bulk import jobs.'));
+      setItems([]);
+      setNextCursor(null);
+      setTotalCount(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadFirstPage();
+  }, [loadFirstPage]);
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || isLoadingMore) {
+      return;
+    }
+    setIsLoadingMore(true);
+    setLoadError('');
+    try {
+      const page = await listAdminBulkExpenseImportJobs({
+        cursor: nextCursor,
+        limit: PAGE_LIMIT,
+      });
+      setItems((prev) => [...prev, ...page.items]);
+      setNextCursor(page.nextCursor);
+      setTotalCount(page.totalCount);
+    } catch (error) {
+      setLoadError(toErrorMessage(error, 'Failed to load more jobs.'));
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [isLoadingMore, nextCursor]);
+
+  const openView = useCallback(async (jobId: string) => {
+    setDetailOpen(true);
+    setDetailTitle('Bulk import job');
+    setDetailBody('');
+    setDetailLoading(true);
+    try {
+      const { bulkImportJob } = await getAdminBulkExpenseImportJob(jobId);
+      const lines = [
+        `Status: ${formatEnumLabel(bulkImportJob.status)}`,
+        `Created count: ${bulkImportJob.createdCount ?? '—'}`,
+      ];
+      if (bulkImportJob.errorMessage?.trim()) {
+        lines.push(`Message: ${bulkImportJob.errorMessage.trim()}`);
+      }
+      if (bulkImportJob.expenses?.length) {
+        lines.push(`Expenses returned: ${bulkImportJob.expenses.length}`);
+      }
+      setDetailBody(lines.join('\n'));
+    } catch (error) {
+      setDetailBody(toErrorMessage(error, 'Could not load job details.'));
+    } finally {
+      setDetailLoading(false);
+    }
+  }, []);
+
+  const closeDetail = useCallback(() => {
+    setDetailOpen(false);
+    setDetailTitle('');
+    setDetailBody('');
+    setDetailLoading(false);
+  }, []);
+
+  const startRetry = useCallback((row: BulkImportJobSummary) => {
+    setRetryError('');
+    setRetryTarget(row);
+  }, []);
+
+  const closeRetry = useCallback(() => {
+    if (retryBusy) {
+      return;
+    }
+    setRetryTarget(null);
+    setRetryError('');
+  }, [retryBusy]);
+
+  const confirmRetry = useCallback(async () => {
+    if (!retryTarget) {
+      return;
+    }
+    setRetryBusy(true);
+    setRetryError('');
+    try {
+      await queueAdminBulkExpenseImportJob({
+        attachmentAssetId: retryTarget.attachmentAssetId,
+        defaultVendorId: retryTarget.defaultVendorId,
+        status: retryTarget.expenseStatus,
+      });
+      setRetryTarget(null);
+      await loadFirstPage();
+      onAfterMutation?.();
+    } catch (error) {
+      setRetryError(toErrorMessage(error, 'Retry failed.'));
+    } finally {
+      setRetryBusy(false);
+    }
+  }, [loadFirstPage, onAfterMutation, retryTarget]);
+
+  const canRetry = (row: BulkImportJobSummary) =>
+    row.status === 'failed' || row.status === 'succeeded_with_errors';
+
+  return (
+    <>
+      <PaginatedTableCard
+        title='Recent combined-PDF imports'
+        description={`${totalCount} job${totalCount === 1 ? '' : 's'} for your account (newest first).`}
+        isLoading={isLoading}
+        isLoadingMore={isLoadingMore}
+        hasMore={Boolean(nextCursor)}
+        error={loadError}
+        loadingLabel='Loading jobs…'
+        onLoadMore={loadMore}
+      >
+        <div className='overflow-x-auto'>
+          <AdminDataTable tableClassName='min-w-[720px]'>
+            <AdminDataTableHead>
+              <tr>
+                <AdminDataTableHeadCell>Started</AdminDataTableHeadCell>
+                <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
+                <AdminDataTableHeadCell>Created</AdminDataTableHeadCell>
+                <AdminDataTableHeadCell>Message</AdminDataTableHeadCell>
+                <AdminDataTableOperationsHeadCell />
+              </tr>
+            </AdminDataTableHead>
+            <AdminDataTableBody>
+              {!isLoading && items.length === 0 ? (
+                <tr>
+                  <AdminDataTableCell colSpan={5}>No bulk import jobs yet.</AdminDataTableCell>
+                </tr>
+              ) : null}
+              {items.map((row) => (
+                <tr key={row.id}>
+                  <AdminDataTableCell className='whitespace-nowrap'>
+                    {formatWhen(row.createdAt)}
+                  </AdminDataTableCell>
+                  <AdminDataTableCell>{formatEnumLabel(row.status)}</AdminDataTableCell>
+                  <AdminDataTableCell className='tabular-nums'>
+                    {row.createdCount ?? '—'}
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='max-w-[280px] truncate text-slate-600'>
+                    {row.errorMessage?.trim() || '—'}
+                  </AdminDataTableCell>
+                  <AdminDataTableCell className='text-right'>
+                    <div className='flex flex-wrap justify-end gap-1'>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='outline'
+                        onClick={() => void openView(row.id)}
+                      >
+                        View result
+                      </Button>
+                      <Button
+                        type='button'
+                        size='sm'
+                        variant='outline'
+                        disabled={!canRetry(row)}
+                        title={
+                          canRetry(row)
+                            ? 'Queue a new import using the same PDF and vendor defaults'
+                            : 'Retry is only available for failed or partially failed jobs'
+                        }
+                        onClick={() => startRetry(row)}
+                      >
+                        Retry
+                      </Button>
+                    </div>
+                  </AdminDataTableCell>
+                </tr>
+              ))}
+            </AdminDataTableBody>
+          </AdminDataTable>
+        </div>
+      </PaginatedTableCard>
+
+      <ConfirmDialog
+        open={detailOpen}
+        title={detailTitle}
+        description={detailLoading ? 'Loading job details…' : 'Current job snapshot.'}
+        cancelLabel='Close'
+        hideConfirm
+        dialogRole='dialog'
+        onConfirm={closeDetail}
+        onCancel={closeDetail}
+      >
+        {detailLoading ? null : (
+          <pre className='mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded border border-slate-200 bg-slate-50 p-3 text-xs text-slate-800'>
+            {detailBody}
+          </pre>
+        )}
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={retryTarget !== null}
+        title='Retry bulk import?'
+        description='This queues a new background job using the same PDF attachment and default vendor. It does not remove expenses created by earlier attempts.'
+        confirmLabel={retryBusy ? 'Queuing…' : 'Queue retry'}
+        confirmDisabled={retryBusy}
+        cancelLabel='Cancel'
+        variant='default'
+        onConfirm={() => void confirmRetry()}
+        onCancel={closeRetry}
+        dialogRole='dialog'
+      >
+        {retryError ? <AdminInlineError className='mt-2'>{retryError}</AdminInlineError> : null}
+      </ConfirmDialog>
+    </>
+  );
+}

--- a/apps/admin_web/src/components/admin/finance/bulk-expense-pdf-import-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/bulk-expense-pdf-import-panel.tsx
@@ -46,7 +46,7 @@ export function BulkExpensePdfImportPanel({
     <AdminEditorCard
       key={formKey}
       title='Import from combined PDF'
-      description='Upload one PDF that lists several expenses. OpenRouter extracts rows the same way as queued invoice parsing; each row becomes an expense that shares this PDF attachment. When a row has no matching vendor name, the default vendor below is used.'
+      description='Upload one PDF that lists several expenses. OpenRouter extracts rows the same way as queued invoice parsing; each row becomes an expense that shares this PDF attachment. When a row has no matching vendor name, the default vendor below is used. Processing runs in the background and may take a few minutes for large PDFs.'
       actions={
         <Button
           type='submit'

--- a/apps/admin_web/src/components/admin/finance/bulk-expense-pdf-import-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/bulk-expense-pdf-import-panel.tsx
@@ -16,6 +16,7 @@ interface BulkExpensePdfImportPanelProps {
   isBusy: boolean;
   error: string;
   onImport: (payload: { file: File; defaultVendorId: string }) => Promise<void>;
+  onCancelBusy?: () => void;
 }
 
 export function BulkExpensePdfImportPanel({
@@ -24,6 +25,7 @@ export function BulkExpensePdfImportPanel({
   isBusy,
   error,
   onImport,
+  onCancelBusy,
 }: BulkExpensePdfImportPanelProps) {
   const [file, setFile] = useState<File | null>(null);
   const [defaultVendorId, setDefaultVendorId] = useState('');
@@ -48,13 +50,20 @@ export function BulkExpensePdfImportPanel({
       title='Import from combined PDF'
       description='Upload one PDF that lists several expenses. OpenRouter extracts rows the same way as queued invoice parsing; each row becomes an expense that shares this PDF attachment. When a row has no matching vendor name, the default vendor below is used. Processing runs in the background and may take a few minutes for large PDFs.'
       actions={
-        <Button
-          type='submit'
-          form='bulk-expense-pdf-import'
-          disabled={submitDisabled}
-        >
-          {isBusy ? 'Working...' : 'Parse PDF and create expenses'}
-        </Button>
+        <div className='flex flex-wrap items-center gap-2'>
+          {isBusy && onCancelBusy ? (
+            <Button type='button' variant='outline' onClick={() => onCancelBusy()}>
+              Cancel
+            </Button>
+          ) : null}
+          <Button
+            type='submit'
+            form='bulk-expense-pdf-import'
+            disabled={submitDisabled}
+          >
+            {isBusy ? 'Working...' : 'Parse PDF and create expenses'}
+          </Button>
+        </div>
       }
     >
       {error ? (

--- a/apps/admin_web/src/components/admin/finance/finance-page.tsx
+++ b/apps/admin_web/src/components/admin/finance/finance-page.tsx
@@ -11,6 +11,7 @@ import { listAllAdminExpenses } from '@/lib/expenses-api';
 import type { Expense } from '@/types/expenses';
 
 import { ExpensesEditorPanel } from './expenses-editor-panel';
+import { BulkExpenseImportJobsPanel } from './bulk-expense-import-jobs-panel';
 import { BulkExpensePdfImportPanel } from './bulk-expense-pdf-import-panel';
 import { ExpensesListPanel } from './expenses-list-panel';
 import {
@@ -135,7 +136,9 @@ export function FinancePage() {
         isBusy={expenses.isBulkImporting || expenses.isUploadingFiles}
         error={expenses.bulkImportError}
         onImport={expenses.bulkImportFromPdf}
+        onCancelBusy={expenses.cancelBulkImport}
       />
+      <BulkExpenseImportJobsPanel onAfterMutation={() => void expenses.list.refetch()} />
       <ExpensesListPanel
         expenses={expenses.items}
         selectedExpenseId={expenses.selectedExpenseId}

--- a/apps/admin_web/src/hooks/use-expenses.ts
+++ b/apps/admin_web/src/hooks/use-expenses.ts
@@ -8,9 +8,10 @@ import {
   cancelAdminExpense,
   createAdminExpense,
   deleteAdminDraftExpense,
-  importAdminExpensesFromBulkPdf,
   listAdminExpenses,
   markAdminExpensePaid,
+  pollAdminBulkExpenseImportJob,
+  queueAdminBulkExpenseImportJob,
   reparseAdminExpense,
   updateAdminExpense,
 } from '@/lib/expenses-api';
@@ -325,10 +326,11 @@ export function useExpenses() {
         if (!attachmentAssetId) {
           throw new Error('Upload did not return an asset id.');
         }
-        await importAdminExpensesFromBulkPdf({
+        const { jobId } = await queueAdminBulkExpenseImportJob({
           attachmentAssetId,
           defaultVendorId,
         });
+        await pollAdminBulkExpenseImportJob(jobId);
         await list.refetch();
         setSelectedExpenseId(null);
       } catch (error) {

--- a/apps/admin_web/src/hooks/use-expenses.ts
+++ b/apps/admin_web/src/hooks/use-expenses.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { createAdminAsset, deleteAdminAsset, uploadFileToPresignedUrl } from '@/lib/assets-api';
 import {
@@ -46,6 +46,7 @@ export function useExpenses() {
   const [isBulkImporting, setIsBulkImporting] = useState(false);
   const [bulkImportError, setBulkImportError] = useState('');
   const [mutationError, setMutationError] = useState('');
+  const bulkImportAbortRef = useRef<AbortController | null>(null);
 
   const fetchExpenses = useCallback(
     async ({
@@ -315,11 +316,20 @@ export function useExpenses() {
     [list]
   );
 
+  const cancelBulkImport = useCallback(() => {
+    bulkImportAbortRef.current?.abort();
+  }, []);
+
   const bulkImportFromPdf = useCallback(
     async ({ file, defaultVendorId }: { file: File; defaultVendorId: string }) => {
       setIsBulkImporting(true);
       setBulkImportError('');
       let uploadedAssetIds: string[] = [];
+      let didEnqueue = false;
+      bulkImportAbortRef.current?.abort();
+      const controller = new AbortController();
+      bulkImportAbortRef.current = controller;
+      const signal = controller.signal;
       try {
         uploadedAssetIds = await uploadExpenseFiles([file]);
         const attachmentAssetId = uploadedAssetIds[0];
@@ -330,14 +340,18 @@ export function useExpenses() {
           attachmentAssetId,
           defaultVendorId,
         });
-        await pollAdminBulkExpenseImportJob(jobId);
+        didEnqueue = true;
+        await pollAdminBulkExpenseImportJob(jobId, signal);
         await list.refetch();
         setSelectedExpenseId(null);
       } catch (error) {
-        await cleanupUploadedAssets(uploadedAssetIds);
+        if (!didEnqueue && uploadedAssetIds.length > 0) {
+          await cleanupUploadedAssets(uploadedAssetIds);
+        }
         setBulkImportError(toErrorMessage(error, 'Failed to import expenses from PDF.'));
         throw error;
       } finally {
+        bulkImportAbortRef.current = null;
         setIsBulkImporting(false);
       }
     },
@@ -368,5 +382,6 @@ export function useExpenses() {
     markPaidExpenseEntry,
     reparseExpenseEntry,
     bulkImportFromPdf,
+    cancelBulkImport,
   };
 }

--- a/apps/admin_web/src/lib/expenses-api.ts
+++ b/apps/admin_web/src/lib/expenses-api.ts
@@ -6,6 +6,7 @@ import type {
   Expense,
   ExpenseAttachment,
   ExpenseLineItem,
+  ExpenseStatus,
   ListAdminExpensesInput,
   PaginatedExpenseList,
   UpsertExpenseInput,
@@ -23,6 +24,10 @@ type ApiUpdateExpenseRequest = ApiSchemas['UpdateExpenseRequest'];
 type ApiCancelExpenseRequest = ApiSchemas['CancelExpenseRequest'];
 type ApiBulkImportJobResponse = ApiSchemas['BulkImportJobResponse'];
 type ApiBulkImportJob = ApiSchemas['BulkImportJob'];
+type ApiBulkImportJobSummary = ApiSchemas['BulkImportJobSummary'];
+type ApiBulkImportJobListResponse = ApiSchemas['BulkImportJobListResponse'];
+
+const EXPENSE_LIST_PAGE_LIMIT = 100;
 
 type ApiExpensePayload = ApiExpenseResponse | ApiExpense | ApiDataWrapper<ApiExpenseResponse | ApiExpense>;
 type ApiExpenseListPayload = ApiExpenseListResponse | ApiDataWrapper<ApiExpenseListResponse>;
@@ -160,8 +165,16 @@ function isApiBulkImportJob(value: unknown): value is ApiBulkImportJob {
     value.status === 'pending' ||
     value.status === 'processing' ||
     value.status === 'succeeded' ||
+    value.status === 'succeeded_with_errors' ||
     value.status === 'failed'
   );
+}
+
+function isApiBulkImportJobSummary(value: unknown): value is ApiBulkImportJobSummary {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.status !== 'string') {
+    return false;
+  }
+  return isApiBulkImportJob(value);
 }
 
 function parseBulkImportJobEnvelope(payload: unknown): {
@@ -179,7 +192,7 @@ function parseBulkImportJobEnvelope(payload: unknown): {
     throw new Error('Invalid bulk import job response.');
   }
   const expenses =
-    raw.status === 'succeeded' && Array.isArray(raw.expenses)
+    (raw.status === 'succeeded' || raw.status === 'succeeded_with_errors') && Array.isArray(raw.expenses)
       ? raw.expenses.filter((entry): entry is ApiExpense => isApiExpense(entry)).map((entry) => parseExpense(entry))
       : null;
   return {
@@ -193,7 +206,70 @@ function parseBulkImportJobEnvelope(payload: unknown): {
   };
 }
 
-const EXPENSE_LIST_PAGE_LIMIT = 100;
+export type BulkImportJobSummary = {
+  id: string;
+  status: ApiBulkImportJobSummary['status'];
+  errorMessage: string | null;
+  createdCount: number | null;
+  createdAt: string;
+  updatedAt: string;
+  attachmentAssetId: string;
+  defaultVendorId: string;
+  expenseStatus: ExpenseStatus;
+};
+
+function parseBulkImportJobSummary(raw: ApiBulkImportJobSummary): BulkImportJobSummary {
+  return {
+    id: raw.id,
+    status: raw.status,
+    errorMessage: typeof raw.error_message === 'string' ? raw.error_message : null,
+    createdCount: typeof raw.created_count === 'number' ? raw.created_count : null,
+    createdAt: typeof raw.created_at === 'string' ? raw.created_at : '',
+    updatedAt: typeof raw.updated_at === 'string' ? raw.updated_at : '',
+    attachmentAssetId: typeof raw.attachment_asset_id === 'string' ? raw.attachment_asset_id : '',
+    defaultVendorId: typeof raw.default_vendor_id === 'string' ? raw.default_vendor_id : '',
+    expenseStatus: raw.expense_status as ExpenseStatus,
+  };
+}
+
+export type PaginatedBulkImportJobList = {
+  items: BulkImportJobSummary[];
+  nextCursor: string | null;
+  totalCount: number;
+};
+
+export async function listAdminBulkExpenseImportJobs(input: {
+  cursor?: string | null;
+  limit?: number;
+} = {}): Promise<PaginatedBulkImportJobList> {
+  const params = new URLSearchParams();
+  if (input.cursor?.trim()) {
+    params.set('cursor', input.cursor.trim());
+  }
+  if (typeof input.limit === 'number' && Number.isFinite(input.limit) && input.limit > 0) {
+    params.set('limit', `${Math.min(Math.floor(input.limit), EXPENSE_LIST_PAGE_LIMIT)}`);
+  }
+  const queryString = params.toString();
+  const endpointPath = queryString
+    ? `/v1/admin/expenses/bulk-import-jobs?${queryString}`
+    : '/v1/admin/expenses/bulk-import-jobs';
+  const payload = await adminApiRequest<ApiBulkImportJobListResponse | ApiDataWrapper<ApiBulkImportJobListResponse>>({
+    endpointPath,
+    method: 'GET',
+  });
+  const root = unwrapPayload(payload) as Record<string, unknown>;
+  const rawItems = root.items;
+  const items = Array.isArray(rawItems)
+    ? rawItems
+        .filter((entry): entry is ApiBulkImportJobSummary => isApiBulkImportJobSummary(entry))
+        .map((entry) => parseBulkImportJobSummary(entry))
+    : [];
+  return {
+    items,
+    nextCursor: asNullableString(root.next_cursor ?? null),
+    totalCount: typeof root.total_count === 'number' ? root.total_count : 0,
+  };
+}
 
 export async function listAdminExpenses(
   input: ListAdminExpensesInput = {}
@@ -319,14 +395,19 @@ export async function reparseAdminExpense(expenseId: string): Promise<void> {
 export async function queueAdminBulkExpenseImportJob(input: {
   attachmentAssetId: string;
   defaultVendorId: string;
+  status?: ExpenseStatus;
 }): Promise<{ jobId: string }> {
+  const body: Record<string, string> = {
+    attachment_asset_id: input.attachmentAssetId.trim(),
+    default_vendor_id: input.defaultVendorId.trim(),
+  };
+  if (input.status) {
+    body.status = input.status;
+  }
   const payload = await adminApiRequest<ApiBulkImportJobResponse | ApiDataWrapper<ApiBulkImportJobResponse>>({
     endpointPath: '/v1/admin/expenses/import-from-bulk-pdf',
     method: 'POST',
-    body: {
-      attachment_asset_id: input.attachmentAssetId.trim(),
-      default_vendor_id: input.defaultVendorId.trim(),
-    },
+    body,
     expectedSuccessStatuses: [202],
   });
   const parsed = parseBulkImportJobEnvelope(payload);
@@ -366,7 +447,7 @@ export async function pollAdminBulkExpenseImportJob(
       throw new DOMException('Aborted', 'AbortError');
     }
     const { bulkImportJob } = await getAdminBulkExpenseImportJob(jobId, signal);
-    if (bulkImportJob.status === 'succeeded') {
+    if (bulkImportJob.status === 'succeeded' || bulkImportJob.status === 'succeeded_with_errors') {
       const expenses = bulkImportJob.expenses ?? [];
       const createdCount = bulkImportJob.createdCount ?? expenses.length;
       return { expenses, createdCount };

--- a/apps/admin_web/src/lib/expenses-api.ts
+++ b/apps/admin_web/src/lib/expenses-api.ts
@@ -21,14 +21,11 @@ type ApiExpenseListResponse = ApiSchemas['ExpenseListResponse'];
 type ApiCreateExpenseRequest = ApiSchemas['CreateExpenseRequest'];
 type ApiUpdateExpenseRequest = ApiSchemas['UpdateExpenseRequest'];
 type ApiCancelExpenseRequest = ApiSchemas['CancelExpenseRequest'];
-type ApiBulkImportExpensesFromPdfResponse = ApiSchemas['BulkImportExpensesFromPdfResponse'];
+type ApiBulkImportJobResponse = ApiSchemas['BulkImportJobResponse'];
+type ApiBulkImportJob = ApiSchemas['BulkImportJob'];
 
 type ApiExpensePayload = ApiExpenseResponse | ApiExpense | ApiDataWrapper<ApiExpenseResponse | ApiExpense>;
 type ApiExpenseListPayload = ApiExpenseListResponse | ApiDataWrapper<ApiExpenseListResponse>;
-type ApiBulkImportPayload =
-  | ApiBulkImportExpensesFromPdfResponse
-  | ApiDataWrapper<ApiBulkImportExpensesFromPdfResponse>;
-
 function isApiExpenseLineItem(value: unknown): value is ApiExpenseLineItem {
   return isRecord(value);
 }
@@ -155,6 +152,47 @@ function extractExpense(payload: ApiExpensePayload): Expense | null {
   return null;
 }
 
+function isApiBulkImportJob(value: unknown): value is ApiBulkImportJob {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.status !== 'string') {
+    return false;
+  }
+  return (
+    value.status === 'pending' ||
+    value.status === 'processing' ||
+    value.status === 'succeeded' ||
+    value.status === 'failed'
+  );
+}
+
+function parseBulkImportJobEnvelope(payload: unknown): {
+  bulkImportJob: {
+    id: string;
+    status: ApiBulkImportJob['status'];
+    errorMessage: string | null;
+    createdCount: number | null;
+    expenses: Expense[] | null;
+  };
+} {
+  const root = unwrapPayload(payload) as Record<string, unknown>;
+  const raw = root.bulk_import_job;
+  if (!isRecord(raw) || !isApiBulkImportJob(raw)) {
+    throw new Error('Invalid bulk import job response.');
+  }
+  const expenses =
+    raw.status === 'succeeded' && Array.isArray(raw.expenses)
+      ? raw.expenses.filter((entry): entry is ApiExpense => isApiExpense(entry)).map((entry) => parseExpense(entry))
+      : null;
+  return {
+    bulkImportJob: {
+      id: raw.id,
+      status: raw.status,
+      errorMessage: typeof raw.error_message === 'string' ? raw.error_message : null,
+      createdCount: typeof raw.created_count === 'number' ? raw.created_count : null,
+      expenses,
+    },
+  };
+}
+
 const EXPENSE_LIST_PAGE_LIMIT = 100;
 
 export async function listAdminExpenses(
@@ -278,26 +316,72 @@ export async function reparseAdminExpense(expenseId: string): Promise<void> {
   });
 }
 
-export async function importAdminExpensesFromBulkPdf(input: {
+export async function queueAdminBulkExpenseImportJob(input: {
   attachmentAssetId: string;
   defaultVendorId: string;
-}): Promise<{ expenses: Expense[]; createdCount: number }> {
-  const payload = await adminApiRequest<ApiBulkImportPayload>({
+}): Promise<{ jobId: string }> {
+  const payload = await adminApiRequest<ApiBulkImportJobResponse | ApiDataWrapper<ApiBulkImportJobResponse>>({
     endpointPath: '/v1/admin/expenses/import-from-bulk-pdf',
     method: 'POST',
     body: {
       attachment_asset_id: input.attachmentAssetId.trim(),
       default_vendor_id: input.defaultVendorId.trim(),
     },
-    expectedSuccessStatuses: [201],
+    expectedSuccessStatuses: [202],
   });
-  const root = unwrapPayload(payload);
-  const expenses = Array.isArray(root.expenses)
-    ? root.expenses.filter((entry): entry is ApiExpense => isApiExpense(entry)).map((entry) => parseExpense(entry))
-    : [];
-  const createdCount =
-    typeof root.created_count === 'number' ? root.created_count : expenses.length;
-  return { expenses, createdCount };
+  const parsed = parseBulkImportJobEnvelope(payload);
+  return { jobId: parsed.bulkImportJob.id };
+}
+
+export async function getAdminBulkExpenseImportJob(
+  jobId: string,
+  signal?: AbortSignal,
+): Promise<{
+  bulkImportJob: {
+    id: string;
+    status: ApiBulkImportJob['status'];
+    errorMessage: string | null;
+    createdCount: number | null;
+    expenses: Expense[] | null;
+  };
+}> {
+  const payload = await adminApiRequest<ApiBulkImportJobResponse | ApiDataWrapper<ApiBulkImportJobResponse>>({
+    endpointPath: `/v1/admin/expenses/bulk-import-jobs/${jobId.trim()}`,
+    method: 'GET',
+    expectedSuccessStatuses: [200],
+    signal,
+  });
+  return parseBulkImportJobEnvelope(payload);
+}
+
+export async function pollAdminBulkExpenseImportJob(
+  jobId: string,
+  signal?: AbortSignal,
+): Promise<{ expenses: Expense[]; createdCount: number }> {
+  const maxMs = 5 * 60 * 1000;
+  const started = Date.now();
+  let delayMs = 1500;
+  while (Date.now() - started < maxMs) {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+    const { bulkImportJob } = await getAdminBulkExpenseImportJob(jobId, signal);
+    if (bulkImportJob.status === 'succeeded') {
+      const expenses = bulkImportJob.expenses ?? [];
+      const createdCount = bulkImportJob.createdCount ?? expenses.length;
+      return { expenses, createdCount };
+    }
+    if (bulkImportJob.status === 'failed') {
+      throw new Error(bulkImportJob.errorMessage?.trim() || 'Bulk import failed.');
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
+    delayMs = Math.min(Math.floor(delayMs * 1.25), 8000);
+  }
+  throw new Error(
+    'Bulk import is taking longer than expected; refresh the expenses list to see new rows.',
+  );
 }
 
 export async function deleteAdminDraftExpense(expenseId: string): Promise<void> {

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4676,8 +4676,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Import multiple expenses from one combined PDF
-         * @description Upload a PDF as an admin asset, then call this endpoint with its asset id. OpenRouter extracts one JSON object per distinct invoice or charge row; each row becomes a separate expense that references the same attachment asset. Parsed vendor names are matched to active vendors when possible; otherwise `default_vendor_id` is used. Synchronous parse is subject to API Gateway time limits; very large PDFs may fail with a validation error.
+         * Queue import of multiple expenses from one combined PDF
+         * @description Upload a PDF as an admin asset, then call this endpoint with its asset id. The API enqueues an asynchronous OpenRouter bulk parse (SQS + dedicated Lambda) and returns **202** with a `bulk_import_job` id. Poll `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `status` is `succeeded` (response includes created `expenses`) or `failed` (`error_message` is set). Parsed vendor names are matched to active vendors when possible; otherwise `default_vendor_id` is used.
          */
         post: {
             parameters: {
@@ -4692,13 +4692,13 @@ export interface paths {
                 };
             };
             responses: {
-                /** @description Expenses created from parsed rows. */
-                201: {
+                /** @description Bulk import job accepted for asynchronous processing. */
+                202: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["BulkImportExpensesFromPdfResponse"];
+                        "application/json": components["schemas"]["BulkImportJobResponse"];
                     };
                 };
                 400: components["responses"]["BadRequest"];
@@ -4706,6 +4706,54 @@ export interface paths {
                 404: components["responses"]["NotFound"];
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/expenses/bulk-import-jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Identifier returned from `POST /v1/admin/expenses/import-from-bulk-pdf`. */
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Get bulk PDF import job status
+         * @description Poll this endpoint until `bulk_import_job.status` is `succeeded` or `failed`. Only the admin user who created the job may read it.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Identifier returned from `POST /v1/admin/expenses/import-from-bulk-pdf`. */
+                    job_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current job state (and expenses when succeeded). */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BulkImportJobResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -6366,6 +6414,25 @@ export interface components {
             attachment_asset_ids: string[];
             parse_requested?: boolean;
         };
+        /**
+         * @description Asynchronous bulk PDF import lifecycle.
+         * @enum {string}
+         */
+        BulkImportJobStatus: "pending" | "processing" | "succeeded" | "failed";
+        BulkImportJob: {
+            /** Format: uuid */
+            id: string;
+            status: components["schemas"]["BulkImportJobStatus"];
+            /** @description Populated when `status` is `failed`. */
+            error_message?: string | null;
+            /** @description Number of expenses created when `status` is `succeeded`. */
+            created_count?: number | null;
+            /** @description Full expense payloads when `status` is `succeeded`; otherwise null. */
+            expenses?: components["schemas"]["Expense"][] | null;
+        };
+        BulkImportJobResponse: {
+            bulk_import_job: components["schemas"]["BulkImportJob"];
+        };
         BulkImportExpensesFromPdfRequest: {
             /**
              * Format: uuid
@@ -6379,10 +6446,6 @@ export interface components {
             default_vendor_id: string;
             /** @description Defaults to `submitted`. Draft may be used when operators want to review rows before submission. */
             status?: components["schemas"]["ExpenseStatus"];
-        };
-        BulkImportExpensesFromPdfResponse: {
-            expenses: components["schemas"]["Expense"][];
-            created_count: number;
         };
         UpdateExpenseRequest: {
             status?: components["schemas"]["ExpenseStatus"];

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -4677,7 +4677,7 @@ export interface paths {
         put?: never;
         /**
          * Queue import of multiple expenses from one combined PDF
-         * @description Upload a PDF as an admin asset, then call this endpoint with its asset id. The API enqueues an asynchronous OpenRouter bulk parse (SQS + dedicated Lambda) and returns **202** with a `bulk_import_job` id. Poll `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `status` is `succeeded` (response includes created `expenses`) or `failed` (`error_message` is set). Parsed vendor names are matched to active vendors when possible; otherwise `default_vendor_id` is used.
+         * @description Upload a PDF as an admin asset, then call this endpoint with its asset id. The API enqueues an asynchronous OpenRouter bulk parse (SQS + dedicated Lambda) and returns **202** with a `bulk_import_job` id. Poll `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `status` is `succeeded`, `succeeded_with_errors` (partial row failures; see `error_message`), or `failed` (`error_message` is set). You can also list recent jobs via `GET /v1/admin/expenses/bulk-import-jobs`. Parsed vendor names are matched to active vendors when possible; otherwise `default_vendor_id` is used.
          */
         post: {
             parameters: {
@@ -4712,6 +4712,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/expenses/bulk-import-jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List bulk PDF import jobs for the signed-in admin
+         * @description Returns jobs created by the authenticated admin, newest first. Use this to recover visibility after refresh or when polling times out.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    cursor?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paginated bulk import jobs for the current admin. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BulkImportJobListResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/expenses/bulk-import-jobs/{job_id}": {
         parameters: {
             query?: never;
@@ -4724,7 +4768,7 @@ export interface paths {
         };
         /**
          * Get bulk PDF import job status
-         * @description Poll this endpoint until `bulk_import_job.status` is `succeeded` or `failed`. Only the admin user who created the job may read it.
+         * @description Poll this endpoint until `bulk_import_job.status` is `succeeded`, `succeeded_with_errors`, or `failed`. Only the admin user who created the job may read it.
          */
         get: {
             parameters: {
@@ -6418,17 +6462,38 @@ export interface components {
          * @description Asynchronous bulk PDF import lifecycle.
          * @enum {string}
          */
-        BulkImportJobStatus: "pending" | "processing" | "succeeded" | "failed";
+        BulkImportJobStatus: "pending" | "processing" | "succeeded" | "succeeded_with_errors" | "failed";
         BulkImportJob: {
             /** Format: uuid */
             id: string;
             status: components["schemas"]["BulkImportJobStatus"];
-            /** @description Populated when `status` is `failed`. */
+            /** @description Populated when `status` is `failed`, or carries a short operator-facing summary when `status` is `succeeded_with_errors`. */
             error_message?: string | null;
-            /** @description Number of expenses created when `status` is `succeeded`. */
+            /** @description Number of expenses created when the job finished with successes. */
             created_count?: number | null;
-            /** @description Full expense payloads when `status` is `succeeded`; otherwise null. */
+            /** @description Full expense payloads when `status` is `succeeded` or `succeeded_with_errors` (order matches `created_expense_ids` insertion order); otherwise null. */
             expenses?: components["schemas"]["Expense"][] | null;
+        };
+        BulkImportJobListResponse: {
+            items: components["schemas"]["BulkImportJobSummary"][];
+            next_cursor: string | null;
+            total_count: number;
+        };
+        BulkImportJobSummary: {
+            /** Format: uuid */
+            id: string;
+            status: components["schemas"]["BulkImportJobStatus"];
+            error_message?: string | null;
+            created_count?: number | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** Format: uuid */
+            attachment_asset_id: string;
+            /** Format: uuid */
+            default_vendor_id: string;
+            expense_status: components["schemas"]["ExpenseStatus"];
         };
         BulkImportJobResponse: {
             bulk_import_job: components["schemas"]["BulkImportJob"];
@@ -6444,7 +6509,7 @@ export interface components {
              * @description Vendor applied when a parsed row has no resolvable vendor_name match.
              */
             default_vendor_id: string;
-            /** @description Defaults to `submitted`. Draft may be used when operators want to review rows before submission. */
+            /** @description Optional. Expense status applied to every row created from the PDF; defaults to `submitted` when omitted. */
             status?: components["schemas"]["ExpenseStatus"];
         };
         UpdateExpenseRequest: {

--- a/apps/admin_web/tests/hooks/use-expenses.test.ts
+++ b/apps/admin_web/tests/hooks/use-expenses.test.ts
@@ -8,7 +8,8 @@ const {
   mockCancelAdminExpense,
   mockMarkAdminExpensePaid,
   mockReparseAdminExpense,
-  mockImportAdminExpensesFromBulkPdf,
+  mockQueueAdminBulkExpenseImportJob,
+  mockPollAdminBulkExpenseImportJob,
   mockCreateAdminAsset,
   mockDeleteAdminAsset,
   mockUploadFileToPresignedUrl,
@@ -37,7 +38,8 @@ const {
     mockCancelAdminExpense: vi.fn(),
     mockMarkAdminExpensePaid: vi.fn(),
     mockReparseAdminExpense: vi.fn(),
-    mockImportAdminExpensesFromBulkPdf: vi.fn(),
+    mockQueueAdminBulkExpenseImportJob: vi.fn(),
+    mockPollAdminBulkExpenseImportJob: vi.fn(),
     mockCreateAdminAsset: vi.fn(),
     mockDeleteAdminAsset: vi.fn(),
     mockUploadFileToPresignedUrl: vi.fn(),
@@ -58,7 +60,8 @@ vi.mock('@/lib/expenses-api', () => ({
   cancelAdminExpense: mockCancelAdminExpense,
   markAdminExpensePaid: mockMarkAdminExpensePaid,
   reparseAdminExpense: mockReparseAdminExpense,
-  importAdminExpensesFromBulkPdf: mockImportAdminExpensesFromBulkPdf,
+  queueAdminBulkExpenseImportJob: mockQueueAdminBulkExpenseImportJob,
+  pollAdminBulkExpenseImportJob: mockPollAdminBulkExpenseImportJob,
 }));
 
 vi.mock('@/lib/assets-api', () => ({
@@ -605,7 +608,8 @@ describe('useExpenses', () => {
       },
     });
     mockUploadFileToPresignedUrl.mockResolvedValue(undefined);
-    mockImportAdminExpensesFromBulkPdf.mockResolvedValue({
+    mockQueueAdminBulkExpenseImportJob.mockResolvedValue({ jobId: 'job-1' });
+    mockPollAdminBulkExpenseImportJob.mockResolvedValue({
       expenses: [],
       createdCount: 2,
     });
@@ -620,10 +624,11 @@ describe('useExpenses', () => {
       });
     });
 
-    expect(mockImportAdminExpensesFromBulkPdf).toHaveBeenCalledWith({
+    expect(mockQueueAdminBulkExpenseImportJob).toHaveBeenCalledWith({
       attachmentAssetId: 'asset-bulk-1',
       defaultVendorId: 'vendor-1',
     });
+    expect(mockPollAdminBulkExpenseImportJob).toHaveBeenCalledWith('job-1');
     expect(mockRefetch).toHaveBeenCalled();
     expect(result.current.bulkImportError).toBe('');
   });

--- a/apps/admin_web/tests/hooks/use-expenses.test.ts
+++ b/apps/admin_web/tests/hooks/use-expenses.test.ts
@@ -628,8 +628,38 @@ describe('useExpenses', () => {
       attachmentAssetId: 'asset-bulk-1',
       defaultVendorId: 'vendor-1',
     });
-    expect(mockPollAdminBulkExpenseImportJob).toHaveBeenCalledWith('job-1');
+    expect(mockPollAdminBulkExpenseImportJob).toHaveBeenCalledWith('job-1', expect.any(AbortSignal));
     expect(mockRefetch).toHaveBeenCalled();
     expect(result.current.bulkImportError).toBe('');
+  });
+
+  it('does not delete uploaded assets when polling fails after enqueue', async () => {
+    mockCreateAdminAsset.mockResolvedValue({
+      asset: { id: 'asset-bulk-2' },
+      upload: {
+        uploadUrl: 'https://example.com/up',
+        uploadMethod: 'PUT',
+        uploadHeaders: {} as Record<string, string>,
+      },
+    });
+    mockUploadFileToPresignedUrl.mockResolvedValue(undefined);
+    mockQueueAdminBulkExpenseImportJob.mockResolvedValue({ jobId: 'job-2' });
+    mockPollAdminBulkExpenseImportJob.mockRejectedValue(new Error('poll failed'));
+
+    const file = new File([new Uint8Array([1])], 'combined.pdf', { type: 'application/pdf' });
+    const { result } = renderHook(() => useExpenses());
+
+    await act(async () => {
+      try {
+        await result.current.bulkImportFromPdf({
+          file,
+          defaultVendorId: 'vendor-1',
+        });
+      } catch {
+        // expected
+      }
+    });
+
+    expect(mockDeleteAdminAsset).not.toHaveBeenCalled();
   });
 });

--- a/backend/db/alembic/versions/0065_bulk_import_jobs.py
+++ b/backend/db/alembic/versions/0065_bulk_import_jobs.py
@@ -1,0 +1,102 @@
+"""Add bulk_expense_import_jobs for async combined-PDF imports.
+
+Tracks queued OpenRouter bulk parses that exceed synchronous API limits.
+
+Seed-data assessment (``backend/db/seed/seed_data.sql``):
+1. Compatible: no seed inserts into this table.
+2. NOT NULL columns: job rows are app-created only.
+3. N/A.
+4. No seed rows for operational job queue.
+5. Job status strings are application-defined; no enum overlap with seed.
+6. FKs reference ``assets`` and ``organizations`` (vendors); insert order is
+   job creation after those entities exist.
+
+Result: No seed updates required.
+
+Revision id: ``0065_bulk_import_jobs`` (22 chars, <= 32).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0065_bulk_import_jobs"
+down_revision: Union[str, None] = "0064_invoice_bill_to_location"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    expense_status = postgresql.ENUM(
+        "draft",
+        "submitted",
+        "paid",
+        "voided",
+        "amended",
+        name="expense_status",
+        create_type=False,
+    )
+    op.create_table(
+        "bulk_expense_import_jobs",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("created_by", sa.Text(), nullable=False),
+        sa.Column(
+            "attachment_asset_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "default_vendor_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("expense_status", expense_status, nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_expense_ids", postgresql.JSONB(), nullable=True),
+        sa.Column("created_count", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("timezone('utc', now())"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("timezone('utc', now())"),
+        ),
+    )
+    op.create_index(
+        "ix_bulk_expense_import_jobs_created_by",
+        "bulk_expense_import_jobs",
+        ["created_by"],
+    )
+    op.create_index(
+        "ix_bulk_expense_import_jobs_status",
+        "bulk_expense_import_jobs",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_bulk_expense_import_jobs_status", table_name="bulk_expense_import_jobs"
+    )
+    op.drop_index(
+        "ix_bulk_expense_import_jobs_created_by",
+        table_name="bulk_expense_import_jobs",
+    )
+    op.drop_table("bulk_expense_import_jobs")

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1890,6 +1890,15 @@ export class ApiStack extends cdk.Stack {
       deploymentStage,
     });
     awsProxyFunction.grantInvoke(messaging.mediaRequestProcessor);
+    awsProxyFunction.grantInvoke(messaging.bulkExpenseImportFunction);
+    database.grantAdminUserSecretRead(messaging.bulkExpenseImportFunction);
+    database.grantConnect(messaging.bulkExpenseImportFunction, "evolvesprouts_admin");
+
+    messaging.bulkExpenseImportQueue.grantSendMessages(adminFunction);
+    adminFunction.addEnvironment(
+      "BULK_EXPENSE_IMPORT_QUEUE_URL",
+      messaging.bulkExpenseImportQueue.queueUrl
+    );
 
     adminFunction.addToRolePolicy(
       new iam.PolicyStatement({
@@ -3332,6 +3341,14 @@ export class ApiStack extends cdk.Stack {
     new cdk.CfnOutput(this, "ExpenseParserDLQUrl", {
       value: messaging.expenseParserDLQ.queueUrl,
       description: "SQS dead letter queue URL for failed expense parser jobs",
+    });
+    new cdk.CfnOutput(this, "BulkExpenseImportQueueUrl", {
+      value: messaging.bulkExpenseImportQueue.queueUrl,
+      description: "SQS queue URL for async bulk combined-PDF expense imports",
+    });
+    new cdk.CfnOutput(this, "BulkExpenseImportDLQUrl", {
+      value: messaging.bulkExpenseImportDLQ.queueUrl,
+      description: "SQS dead letter queue URL for failed bulk expense import jobs",
     });
     new cdk.CfnOutput(this, "EventbriteSyncTopicArn", {
       value: eventbriteSync.topic.topicArn,

--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -424,7 +424,7 @@ export class MessagingNestedStack extends cdk.NestedStack {
 
     this.bulkExpenseImportQueue = new sqs.Queue(this, "BulkExpenseImportQueue", {
       queueName: name("bulk-expense-import-queue"),
-      visibilityTimeout: cdk.Duration.seconds(360),
+      visibilityTimeout: cdk.Duration.seconds(720),
       deadLetterQueue: {
         queue: this.bulkExpenseImportDLQ,
         maxReceiveCount: 3,
@@ -435,9 +435,10 @@ export class MessagingNestedStack extends cdk.NestedStack {
 
     this.bulkExpenseImportFunction = createPythonFunction("BulkExpenseImportFunction", {
       handler: "lambda/bulk_expense_import/handler.lambda_handler",
-      timeout: cdk.Duration.seconds(300),
+      timeout: cdk.Duration.seconds(600),
       manageLogGroup: false,
       environment: {
+        BULK_IMPORT_LAMBDA_TIMEOUT_SECONDS: "600",
         DATABASE_SECRET_ARN: props.databaseSecretArn,
         DATABASE_NAME: "evolvesprouts",
         DATABASE_USERNAME: "evolvesprouts_admin",

--- a/backend/infrastructure/lib/messaging-stack.ts
+++ b/backend/infrastructure/lib/messaging-stack.ts
@@ -78,6 +78,10 @@ export class MessagingNestedStack extends cdk.NestedStack {
   public readonly expenseParserDLQ: sqs.Queue;
   public readonly expenseParserFunction: lambda.Function;
 
+  public readonly bulkExpenseImportDLQ: sqs.Queue;
+  public readonly bulkExpenseImportQueue: sqs.Queue;
+  public readonly bulkExpenseImportFunction: lambda.Function;
+
   public constructor(scope: Construct, id: string, props: MessagingNestedStackProps) {
     super(scope, id, props);
 
@@ -400,6 +404,113 @@ export class MessagingNestedStack extends cdk.NestedStack {
       alarmDescription:
         "Expense parser messages failed processing and landed in DLQ",
       metric: this.expenseParserDLQ.metricApproximateNumberOfMessagesVisible({
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      treatMissingData: cdk.aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    // -------------------------------------------------------------------------
+    // Bulk expense import (direct SQS; long-running OpenRouter parse)
+    // -------------------------------------------------------------------------
+
+    this.bulkExpenseImportDLQ = new sqs.Queue(this, "BulkExpenseImportDLQ", {
+      queueName: name("bulk-expense-import-dlq"),
+      retentionPeriod: cdk.Duration.days(14),
+      encryption: sqs.QueueEncryption.KMS,
+      encryptionMasterKey: props.sqsEncryptionKey,
+    });
+
+    this.bulkExpenseImportQueue = new sqs.Queue(this, "BulkExpenseImportQueue", {
+      queueName: name("bulk-expense-import-queue"),
+      visibilityTimeout: cdk.Duration.seconds(360),
+      deadLetterQueue: {
+        queue: this.bulkExpenseImportDLQ,
+        maxReceiveCount: 3,
+      },
+      encryption: sqs.QueueEncryption.KMS,
+      encryptionMasterKey: props.sqsEncryptionKey,
+    });
+
+    this.bulkExpenseImportFunction = createPythonFunction("BulkExpenseImportFunction", {
+      handler: "lambda/bulk_expense_import/handler.lambda_handler",
+      timeout: cdk.Duration.seconds(300),
+      manageLogGroup: false,
+      environment: {
+        DATABASE_SECRET_ARN: props.databaseSecretArn,
+        DATABASE_NAME: "evolvesprouts",
+        DATABASE_USERNAME: "evolvesprouts_admin",
+        DATABASE_PROXY_ENDPOINT: props.databaseProxyEndpoint,
+        DATABASE_IAM_AUTH: "true",
+        ASSETS_BUCKET_NAME: props.assetsBucketName,
+        OPENROUTER_API_KEY_SECRET_ARN: props.openrouterApiSecretArn,
+        OPENROUTER_CHAT_COMPLETIONS_URL: props.openrouterChatCompletionsUrl,
+        OPENROUTER_MODEL: props.openrouterModel,
+        OPENROUTER_MAX_FILE_BYTES: props.openrouterMaxFileBytes,
+        AWS_PROXY_FUNCTION_ARN: props.awsProxyFunctionArn,
+      },
+    });
+
+    this.bulkExpenseImportFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+        resources: [props.databaseSecretArn, props.openrouterApiSecretArn],
+      })
+    );
+    if (props.databaseSecretKmsKeyArn) {
+      this.bulkExpenseImportFunction.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ["kms:Decrypt"],
+          resources: [props.databaseSecretKmsKeyArn],
+        })
+      );
+    }
+    if (props.openrouterApiSecretKmsKeyArn) {
+      this.bulkExpenseImportFunction.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ["kms:Decrypt"],
+          resources: [props.openrouterApiSecretKmsKeyArn],
+        })
+      );
+    }
+    this.bulkExpenseImportFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["rds-db:connect"],
+        resources: [
+          cdk.Fn.join("", [
+            "arn:", cdk.Aws.PARTITION, ":rds-db:", cdk.Aws.REGION, ":", cdk.Aws.ACCOUNT_ID,
+            ":dbuser:", cdk.Fn.select(6, cdk.Fn.split(":", props.databaseProxyArn)),
+            "/evolvesprouts_admin",
+          ]),
+        ],
+      })
+    );
+    this.bulkExpenseImportFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["s3:GetObject", "s3:GetBucketLocation", "s3:ListBucket"],
+        resources: [props.assetsBucketArn, `${props.assetsBucketArn}/*`],
+      })
+    );
+    this.bulkExpenseImportFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["lambda:InvokeFunction"],
+        resources: [props.awsProxyFunctionArn],
+      })
+    );
+
+    this.bulkExpenseImportFunction.addEventSource(
+      new lambdaEventSources.SqsEventSource(this.bulkExpenseImportQueue, {
+        batchSize: 1,
+        reportBatchItemFailures: true,
+      })
+    );
+
+    new cdk.aws_cloudwatch.Alarm(this, "BulkExpenseImportDLQAlarm", {
+      alarmName: name("bulk-expense-import-dlq-alarm"),
+      alarmDescription:
+        "Bulk expense import messages failed processing and landed in DLQ",
+      metric: this.bulkExpenseImportDLQ.metricApproximateNumberOfMessagesVisible({
         period: cdk.Duration.minutes(5),
       }),
       threshold: 1,

--- a/backend/lambda/bulk_expense_import/handler.py
+++ b/backend/lambda/bulk_expense_import/handler.py
@@ -1,0 +1,41 @@
+"""Lambda worker for async bulk PDF expense imports."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID
+
+from app.events.sqs_batch import SqsBatchProcessor
+from app.services.bulk_expense_import_runner import process_bulk_expense_import_job
+from app.utils.logging import configure_logging, get_logger
+
+configure_logging()
+logger = get_logger(__name__)
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Process bulk expense import jobs from SQS (plain JSON body, not SNS)."""
+    batch = SqsBatchProcessor(logger=logger)
+
+    for record in event.get("Records", []):
+        with batch.record(
+            record,
+            failure_message="Failed to process bulk expense import message",
+        ):
+            raw_body = record.get("body")
+            if raw_body is None:
+                batch.skip()
+                continue
+            body = json.loads(str(raw_body))
+            if not isinstance(body, dict):
+                batch.skip()
+                continue
+            job_raw = body.get("job_id")
+            if not job_raw:
+                batch.skip()
+                continue
+            process_bulk_expense_import_job(UUID(str(job_raw)))
+            batch.process()
+
+    return batch.response()

--- a/backend/lambda/bulk_expense_import/handler.py
+++ b/backend/lambda/bulk_expense_import/handler.py
@@ -35,7 +35,13 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             if not job_raw:
                 batch.skip()
                 continue
-            process_bulk_expense_import_job(UUID(str(job_raw)))
-            batch.process()
+            outcome = process_bulk_expense_import_job(UUID(str(job_raw)))
+            if outcome.ack_sqs_message:
+                batch.process()
+            else:
+                batch.retry_record(
+                    record,
+                    reason="Bulk import job still processing; deferring SQS retry",
+                )
 
     return batch.response()

--- a/backend/src/app/api/admin_expenses.py
+++ b/backend/src/app/api/admin_expenses.py
@@ -42,11 +42,13 @@ from app.db.models.bulk_expense_import_job import (
     BulkExpenseImportJob,
     BulkExpenseImportJobStatus,
 )
-from app.db.repositories import AssetRepository, ExpenseRepository
+from app.db.repositories import ExpenseRepository
 from app.db.repositories.bulk_expense_import_job import BulkExpenseImportJobRepository
 from app.exceptions import NotFoundError, ValidationError
 from app.services.asset_expense_tagging import sync_expense_attachment_tags_for_assets
+from app.services.bulk_expense_import_common import assert_pdf_asset
 from app.services.bulk_expense_import_events import enqueue_bulk_expense_import_job
+from app.services.bulk_expense_import_runner import sanitize_bulk_import_error_message
 from app.services.expense_events import enqueue_expense_parse
 from app.utils import json_response
 from app.utils.logging import get_logger
@@ -82,6 +84,11 @@ def handle_admin_expenses_request(
         if method != "POST":
             return json_response(405, {"error": "Method not allowed"}, event=event)
         return _import_expenses_from_bulk_pdf(event, actor_sub=identity.user_sub)
+
+    if len(parts) == 3 and parts[2] == "bulk-import-jobs":
+        if method != "GET":
+            return json_response(405, {"error": "Method not allowed"}, event=event)
+        return _list_bulk_expense_import_jobs(event, actor_sub=identity.user_sub)
 
     if len(parts) == 4 and parts[2] == "bulk-import-jobs":
         if method != "GET":
@@ -490,6 +497,54 @@ def _amend_expense(
         )
 
 
+def _serialize_bulk_import_job_summary(job: BulkExpenseImportJob) -> dict[str, Any]:
+    err = job.error_message
+    return {
+        "id": str(job.id),
+        "status": job.status.value,
+        "error_message": (
+            None if err is None else sanitize_bulk_import_error_message(err)
+        ),
+        "created_count": job.created_count,
+        "created_at": job.created_at.isoformat() if job.created_at else None,
+        "updated_at": job.updated_at.isoformat() if job.updated_at else None,
+        "attachment_asset_id": str(job.attachment_asset_id),
+        "default_vendor_id": str(job.default_vendor_id),
+        "expense_status": job.expense_status.value,
+    }
+
+
+def _list_bulk_expense_import_jobs(
+    event: Mapping[str, Any], *, actor_sub: str
+) -> dict[str, Any]:
+    limit = parse_limit(event, default=_DEFAULT_LIMIT, max_limit=_MAX_LIMIT)
+    cursor = parse_cursor(query_param(event, "cursor"))
+    req_id = request_id(event)
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
+        job_repo = BulkExpenseImportJobRepository(session)
+        rows = job_repo.list_for_actor(
+            actor_sub=actor_sub, limit=limit + 1, cursor_job_id=cursor
+        )
+        has_more = len(rows) > limit
+        page_items = rows[:limit]
+        next_cursor = (
+            encode_cursor(page_items[-1].id) if has_more and page_items else None
+        )
+        total_count = job_repo.count_for_actor(actor_sub=actor_sub)
+        return json_response(
+            200,
+            {
+                "items": [
+                    _serialize_bulk_import_job_summary(row) for row in page_items
+                ],
+                "next_cursor": next_cursor,
+                "total_count": total_count,
+            },
+            event=event,
+        )
+
+
 def _import_expenses_from_bulk_pdf(
     event: Mapping[str, Any], *, actor_sub: str
 ) -> dict[str, Any]:
@@ -521,17 +576,7 @@ def _import_expenses_from_bulk_pdf(
     with Session(get_engine()) as session:
         set_audit_context(session, user_id=actor_sub, request_id=req_id)
         resolve_vendor(session, default_vendor_id)
-        assets = AssetRepository(session).list_by_ids([attachment_id])
-        if not assets:
-            raise NotFoundError("Asset", str(attachment_id))
-        asset_ent = assets[0]
-        content_type = (asset_ent.content_type or "").strip().lower()
-        file_name = (asset_ent.file_name or "").strip().lower()
-        if "pdf" not in content_type and not file_name.endswith(".pdf"):
-            raise ValidationError(
-                "attachment_asset_id must reference a PDF document",
-                field="attachment_asset_id",
-            )
+        assert_pdf_asset(session, attachment_id)
 
         job = BulkExpenseImportJob(
             created_by=actor_sub,
@@ -597,28 +642,30 @@ def _get_bulk_expense_import_job(
             raise NotFoundError("BulkExpenseImportJob", str(job_id))
 
         expenses_payload: list[dict[str, Any]] | None = None
-        if (
-            job.status == BulkExpenseImportJobStatus.SUCCEEDED
-            and job.created_expense_ids
+        if job.created_expense_ids and job.status in (
+            BulkExpenseImportJobStatus.SUCCEEDED,
+            BulkExpenseImportJobStatus.SUCCEEDED_WITH_ERRORS,
         ):
             expense_repo = ExpenseRepository(session)
-            expenses_payload = []
+            ordered_ids: list[UUID] = []
             for raw_id in job.created_expense_ids:
                 try:
-                    eid = UUID(str(raw_id))
+                    ordered_ids.append(UUID(str(raw_id)))
                 except (TypeError, ValueError):
                     continue
-                loaded = expense_repo.get_with_attachments(eid)
-                if loaded is not None:
-                    expenses_payload.append(serialize_expense(loaded))
+            loaded = expense_repo.get_many_with_attachments(ordered_ids)
+            expenses_payload = [serialize_expense(row) for row in loaded]
 
+        err = job.error_message
         return json_response(
             200,
             {
                 "bulk_import_job": {
                     "id": str(job.id),
                     "status": job.status.value,
-                    "error_message": job.error_message,
+                    "error_message": (
+                        None if err is None else sanitize_bulk_import_error_message(err)
+                    ),
                     "created_count": job.created_count,
                     "expenses": expenses_payload,
                 }

--- a/backend/src/app/api/admin_expenses.py
+++ b/backend/src/app/api/admin_expenses.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, date
-from decimal import Decimal
+from datetime import UTC, datetime
 from typing import Any
 from collections.abc import Mapping
 from uuid import UUID
@@ -38,18 +37,17 @@ from app.api.admin_request import (
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
-from app.db.models import Expense, ExpenseParseStatus, ExpenseStatus
-from app.db.repositories import (
-    AssetRepository,
-    ExpenseRepository,
-    OrganizationRepository,
+from app.db.models import ExpenseParseStatus, ExpenseStatus
+from app.db.models.bulk_expense_import_job import (
+    BulkExpenseImportJob,
+    BulkExpenseImportJobStatus,
 )
+from app.db.repositories import AssetRepository, ExpenseRepository
+from app.db.repositories.bulk_expense_import_job import BulkExpenseImportJobRepository
 from app.exceptions import NotFoundError, ValidationError
 from app.services.asset_expense_tagging import sync_expense_attachment_tags_for_assets
+from app.services.bulk_expense_import_events import enqueue_bulk_expense_import_job
 from app.services.expense_events import enqueue_expense_parse
-from app.services.openrouter_expense_parser import (
-    parse_bulk_expense_invoices_from_assets,
-)
 from app.utils import json_response
 from app.utils.logging import get_logger
 
@@ -84,6 +82,14 @@ def handle_admin_expenses_request(
         if method != "POST":
             return json_response(405, {"error": "Method not allowed"}, event=event)
         return _import_expenses_from_bulk_pdf(event, actor_sub=identity.user_sub)
+
+    if len(parts) == 4 and parts[2] == "bulk-import-jobs":
+        if method != "GET":
+            return json_response(405, {"error": "Method not allowed"}, event=event)
+        job_id = parse_uuid(parts[3])
+        return _get_bulk_expense_import_job(
+            event, job_id=job_id, actor_sub=identity.user_sub
+        )
 
     expense_id = parse_uuid(parts[2])
     if len(parts) == 3:
@@ -487,7 +493,7 @@ def _amend_expense(
 def _import_expenses_from_bulk_pdf(
     event: Mapping[str, Any], *, actor_sub: str
 ) -> dict[str, Any]:
-    """Parse a combined PDF with OpenRouter and create one expense per extracted row."""
+    """Queue a combined PDF for async OpenRouter bulk parse (returns job id)."""
     logger.info("Bulk importing expenses from PDF", extra={"actor": actor_sub})
     body = parse_body(event)
     attachment_id = parse_optional_uuid(
@@ -511,7 +517,6 @@ def _import_expenses_from_bulk_pdf(
     )
 
     req_id = request_id(event)
-    now = datetime.now(UTC)
 
     with Session(get_engine()) as session:
         set_audit_context(session, user_id=actor_sub, request_id=req_id)
@@ -527,144 +532,96 @@ def _import_expenses_from_bulk_pdf(
                 "attachment_asset_id must reference a PDF document",
                 field="attachment_asset_id",
             )
-        parser_asset: dict[str, Any] = {
-            "id": str(asset_ent.id),
-            "s3_key": asset_ent.s3_key,
-            "file_name": asset_ent.file_name,
-            "content_type": asset_ent.content_type,
-        }
 
-    try:
-        normalized_rows = parse_bulk_expense_invoices_from_assets(
-            [parser_asset], timeout=25
+        job = BulkExpenseImportJob(
+            created_by=actor_sub,
+            attachment_asset_id=attachment_id,
+            default_vendor_id=default_vendor_id,
+            expense_status=status,
+            status=BulkExpenseImportJobStatus.PENDING,
         )
-    except (RuntimeError, ValueError) as exc:
-        raise ValidationError(str(exc), field="attachment_asset_id") from exc
-
-    created_payload: list[dict[str, Any]] = []
-    with Session(get_engine()) as session:
-        set_audit_context(session, user_id=actor_sub, request_id=req_id)
-        expense_repo = ExpenseRepository(session)
-        org_repo = OrganizationRepository(session)
-        resolve_vendor(session, default_vendor_id)
-        asset_ids = resolve_asset_ids(session, [attachment_id])
-
-        for parsed in normalized_rows:
-            vendor_id = _resolve_bulk_row_vendor_id(
-                org_repo, parsed, default_vendor_id=default_vendor_id
-            )
-            expense = expense_repo.create_expense(
-                created_by=actor_sub,
-                status=status,
-                parse_status=ExpenseParseStatus.SUCCEEDED,
-                vendor_id=vendor_id,
-                invoice_number=None,
-                invoice_date=None,
-                due_date=None,
-                currency=None,
-                subtotal=None,
-                tax=None,
-                total=None,
-                line_items=None,
-                notes=None,
-            )
-            _apply_openrouter_normalized_to_expense(expense, parsed)
-            expense.updated_by = actor_sub
-            if status == ExpenseStatus.SUBMITTED:
-                expense.submitted_at = now
-            expense_repo.replace_attachments(expense, asset_ids)
-            expense_repo.update(expense)
-            refreshed = expense_repo.get_with_attachments(expense.id)
-            if refreshed is None:
-                raise NotFoundError("Expense", str(expense.id))
-            created_payload.append(serialize_expense(refreshed))
-
+        session.add(job)
+        session.flush()
+        job_id = job.id
         session.commit()
 
+    try:
+        enqueue_bulk_expense_import_job(job_id)
+    except ValidationError:
+        with Session(get_engine()) as session:
+            stale = session.get(BulkExpenseImportJob, job_id)
+            if stale is not None:
+                session.delete(stale)
+                session.commit()
+        raise
+    except Exception:
+        logger.exception(
+            "Failed to enqueue bulk expense import job",
+            extra={"job_id": str(job_id)},
+        )
+        with Session(get_engine()) as session:
+            job_repo = BulkExpenseImportJobRepository(session)
+            failed = job_repo.get_by_id(job_id)
+            if failed is not None:
+                job_repo.mark_failed(
+                    failed, "Could not queue bulk import; try again shortly."
+                )
+                session.commit()
+        raise ValidationError(
+            "Bulk import could not be queued; try again shortly.",
+            field="configuration",
+        ) from None
+
     return json_response(
-        201,
-        {"expenses": created_payload, "created_count": len(created_payload)},
+        202,
+        {
+            "bulk_import_job": {
+                "id": str(job_id),
+                "status": BulkExpenseImportJobStatus.PENDING.value,
+                "error_message": None,
+                "created_count": None,
+                "expenses": None,
+            }
+        },
         event=event,
     )
 
 
-def _resolve_bulk_row_vendor_id(
-    org_repo: OrganizationRepository,
-    parsed: Mapping[str, Any],
-    *,
-    default_vendor_id: UUID,
-) -> UUID:
-    parsed_vendor_only = _bulk_pick_text(parsed.get("vendor_name"), fallback=None)
-    if parsed_vendor_only:
-        matched = org_repo.try_resolve_active_vendor_by_parsed_name(parsed_vendor_only)
-        if matched is not None:
-            return matched.id
-    return default_vendor_id
+def _get_bulk_expense_import_job(
+    event: Mapping[str, Any], *, job_id: UUID, actor_sub: str
+) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        job_repo = BulkExpenseImportJobRepository(session)
+        job = job_repo.get_for_actor(job_id, actor_sub=actor_sub)
+        if job is None:
+            raise NotFoundError("BulkExpenseImportJob", str(job_id))
 
+        expenses_payload: list[dict[str, Any]] | None = None
+        if (
+            job.status == BulkExpenseImportJobStatus.SUCCEEDED
+            and job.created_expense_ids
+        ):
+            expense_repo = ExpenseRepository(session)
+            expenses_payload = []
+            for raw_id in job.created_expense_ids:
+                try:
+                    eid = UUID(str(raw_id))
+                except (TypeError, ValueError):
+                    continue
+                loaded = expense_repo.get_with_attachments(eid)
+                if loaded is not None:
+                    expenses_payload.append(serialize_expense(loaded))
 
-def _apply_openrouter_normalized_to_expense(
-    expense: Expense, parsed: Mapping[str, Any]
-) -> None:
-    expense.invoice_number = _bulk_pick_text(
-        parsed.get("invoice_number"), fallback=expense.invoice_number
-    )
-    expense.invoice_date = _bulk_pick_date(
-        parsed.get("invoice_date"), fallback=expense.invoice_date
-    )
-    expense.due_date = _bulk_pick_date(
-        parsed.get("due_date"), fallback=expense.due_date
-    )
-    expense.currency = _bulk_pick_currency(
-        parsed.get("currency"), fallback=expense.currency
-    )
-    expense.subtotal = _bulk_pick_decimal(
-        parsed.get("subtotal"), fallback=expense.subtotal
-    )
-    expense.tax = _bulk_pick_decimal(parsed.get("tax"), fallback=expense.tax)
-    expense.total = _bulk_pick_decimal(parsed.get("total"), fallback=expense.total)
-    line_items = parsed.get("line_items")
-    if isinstance(line_items, list):
-        expense.line_items = line_items
-    expense.parse_confidence = _bulk_pick_decimal(
-        parsed.get("confidence"), fallback=expense.parse_confidence
-    )
-    expense.parser_raw = (
-        parsed.get("raw") if isinstance(parsed.get("raw"), dict) else {"raw": parsed}
-    )
-
-
-def _bulk_pick_text(value: Any, *, fallback: str | None) -> str | None:
-    if value is None:
-        return fallback
-    normalized = str(value).strip()
-    return normalized or fallback
-
-
-def _bulk_pick_date(value: Any, *, fallback: date | None) -> date | None:
-    if value is None:
-        return fallback
-    normalized = str(value).strip()
-    if not normalized:
-        return fallback
-    try:
-        return date.fromisoformat(normalized)
-    except ValueError:
-        return fallback
-
-
-def _bulk_pick_currency(value: Any, *, fallback: str | None) -> str | None:
-    if value is None:
-        return fallback
-    normalized = str(value).strip().upper()
-    if len(normalized) != 3:
-        return fallback
-    return normalized
-
-
-def _bulk_pick_decimal(value: Any, *, fallback: Decimal | None) -> Decimal | None:
-    if value is None:
-        return fallback
-    try:
-        return Decimal(str(value)).quantize(Decimal("0.01"))
-    except Exception:
-        return fallback
+        return json_response(
+            200,
+            {
+                "bulk_import_job": {
+                    "id": str(job.id),
+                    "status": job.status.value,
+                    "error_message": job.error_message,
+                    "created_count": job.created_count,
+                    "expenses": expenses_payload,
+                }
+            },
+            event=event,
+        )

--- a/backend/src/app/db/models/__init__.py
+++ b/backend/src/app/db/models/__init__.py
@@ -3,6 +3,10 @@
 from app.db.models.asset import Asset, AssetAccessGrant, AssetShareLink
 from app.db.models.calendar_manual_block import CalendarManualBlock
 from app.db.models.audit_log import AuditLog
+from app.db.models.bulk_expense_import_job import (
+    BulkExpenseImportJob,
+    BulkExpenseImportJobStatus,
+)
 from app.db.models.contact import Contact
 from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
 from app.db.models.customer_payment import CustomerPayment
@@ -84,6 +88,8 @@ __all__ = [
     "BillingInvoiceStatus",
     "BillingPaymentDirection",
     "BillingPaymentStatus",
+    "BulkExpenseImportJob",
+    "BulkExpenseImportJobStatus",
     "CalendarManualBlock",
     "ConsultationDetails",
     "ConsultationFormat",

--- a/backend/src/app/db/models/bulk_expense_import_job.py
+++ b/backend/src/app/db/models/bulk_expense_import_job.py
@@ -1,0 +1,91 @@
+"""Bulk combined-PDF expense import job tracking."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy import ForeignKey, Integer, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import TIMESTAMP
+
+from app.db.base import Base
+from app.db.models.enums import ExpenseStatus
+
+
+class BulkExpenseImportJobStatus(str, enum.Enum):
+    """Worker lifecycle for a bulk PDF import job."""
+
+    PENDING = "pending"
+    PROCESSING = "processing"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+def _bulk_job_status_values(enum_cls: object) -> list[str]:
+    del enum_cls
+    return [member.value for member in BulkExpenseImportJobStatus]
+
+
+def _expense_status_values(enum_cls: object) -> list[str]:
+    del enum_cls
+    return [member.value for member in ExpenseStatus]
+
+
+class BulkExpenseImportJob(Base):
+    """Queued bulk import from a single combined PDF attachment."""
+
+    __tablename__ = "bulk_expense_import_jobs"
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    created_by: Mapped[str] = mapped_column(Text(), nullable=False)
+    attachment_asset_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("assets.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    default_vendor_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    expense_status: Mapped[ExpenseStatus] = mapped_column(
+        SAEnum(
+            ExpenseStatus,
+            name="expense_status",
+            values_callable=_expense_status_values,
+            create_type=False,
+        ),
+        nullable=False,
+    )
+    status: Mapped[BulkExpenseImportJobStatus] = mapped_column(
+        SAEnum(
+            BulkExpenseImportJobStatus,
+            native_enum=False,
+            length=32,
+            values_callable=_bulk_job_status_values,
+        ),
+        nullable=False,
+    )
+    error_message: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    created_expense_ids: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    created_count: Mapped[int | None] = mapped_column(Integer(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("timezone('utc', now())"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("timezone('utc', now())"),
+    )

--- a/backend/src/app/db/models/bulk_expense_import_job.py
+++ b/backend/src/app/db/models/bulk_expense_import_job.py
@@ -24,6 +24,7 @@ class BulkExpenseImportJobStatus(str, enum.Enum):
     PENDING = "pending"
     PROCESSING = "processing"
     SUCCEEDED = "succeeded"
+    SUCCEEDED_WITH_ERRORS = "succeeded_with_errors"
     FAILED = "failed"
 
 
@@ -77,6 +78,8 @@ class BulkExpenseImportJob(Base):
         nullable=False,
     )
     error_message: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    #: UUID strings in **creation order** (worker insertion order). GET job returns
+    #: ``expenses`` in this same order when the job finished with successes.
     created_expense_ids: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
     created_count: Mapped[int | None] = mapped_column(Integer(), nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/app/db/repositories/__init__.py
+++ b/backend/src/app/db/repositories/__init__.py
@@ -5,6 +5,7 @@ making business logic independent of the persistence layer.
 """
 
 from app.db.repositories.base import BaseRepository
+from app.db.repositories.bulk_expense_import_job import BulkExpenseImportJobRepository
 from app.db.repositories.asset import AssetRepository
 from app.db.repositories.contact import ContactRepository
 from app.db.repositories.note import NoteRepository
@@ -22,6 +23,7 @@ from app.db.repositories.service_instance import ServiceInstanceRepository
 
 __all__ = [
     "BaseRepository",
+    "BulkExpenseImportJobRepository",
     "AssetRepository",
     "ContactRepository",
     "NoteRepository",

--- a/backend/src/app/db/repositories/__init__.py
+++ b/backend/src/app/db/repositories/__init__.py
@@ -5,8 +5,8 @@ making business logic independent of the persistence layer.
 """
 
 from app.db.repositories.base import BaseRepository
-from app.db.repositories.bulk_expense_import_job import BulkExpenseImportJobRepository
 from app.db.repositories.asset import AssetRepository
+from app.db.repositories.bulk_expense_import_job import BulkExpenseImportJobRepository
 from app.db.repositories.contact import ContactRepository
 from app.db.repositories.note import NoteRepository
 from app.db.repositories.discount_code import DiscountCodeRepository
@@ -23,8 +23,8 @@ from app.db.repositories.service_instance import ServiceInstanceRepository
 
 __all__ = [
     "BaseRepository",
-    "BulkExpenseImportJobRepository",
     "AssetRepository",
+    "BulkExpenseImportJobRepository",
     "ContactRepository",
     "NoteRepository",
     "DiscountCodeRepository",

--- a/backend/src/app/db/repositories/bulk_expense_import_job.py
+++ b/backend/src/app/db/repositories/bulk_expense_import_job.py
@@ -1,0 +1,52 @@
+"""Repository for bulk expense import jobs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.bulk_expense_import_job import (
+    BulkExpenseImportJob,
+    BulkExpenseImportJobStatus,
+)
+from app.db.repositories.base import BaseRepository
+
+
+class BulkExpenseImportJobRepository(BaseRepository[BulkExpenseImportJob]):
+    def __init__(self, session: Session):
+        super().__init__(session, BulkExpenseImportJob)
+
+    def get_for_actor(self, job_id: UUID, *, actor_sub: str) -> BulkExpenseImportJob | None:
+        stmt = select(BulkExpenseImportJob).where(
+            BulkExpenseImportJob.id == job_id,
+            BulkExpenseImportJob.created_by == actor_sub,
+        )
+        return self._session.execute(stmt).scalar_one_or_none()
+
+    def mark_processing(self, job: BulkExpenseImportJob) -> None:
+        job.status = BulkExpenseImportJobStatus.PROCESSING
+        job.updated_at = datetime.now(UTC)
+        self.update(job)
+
+    def mark_succeeded(
+        self,
+        job: BulkExpenseImportJob,
+        *,
+        expense_ids: list[UUID],
+        created_count: int,
+    ) -> None:
+        job.status = BulkExpenseImportJobStatus.SUCCEEDED
+        job.created_expense_ids = [str(eid) for eid in expense_ids]
+        job.created_count = created_count
+        job.error_message = None
+        job.updated_at = datetime.now(UTC)
+        self.update(job)
+
+    def mark_failed(self, job: BulkExpenseImportJob, message: str) -> None:
+        job.status = BulkExpenseImportJobStatus.FAILED
+        job.error_message = message[:8000]
+        job.updated_at = datetime.now(UTC)
+        self.update(job)

--- a/backend/src/app/db/repositories/bulk_expense_import_job.py
+++ b/backend/src/app/db/repositories/bulk_expense_import_job.py
@@ -19,7 +19,9 @@ class BulkExpenseImportJobRepository(BaseRepository[BulkExpenseImportJob]):
     def __init__(self, session: Session):
         super().__init__(session, BulkExpenseImportJob)
 
-    def get_for_actor(self, job_id: UUID, *, actor_sub: str) -> BulkExpenseImportJob | None:
+    def get_for_actor(
+        self, job_id: UUID, *, actor_sub: str
+    ) -> BulkExpenseImportJob | None:
         stmt = select(BulkExpenseImportJob).where(
             BulkExpenseImportJob.id == job_id,
             BulkExpenseImportJob.created_by == actor_sub,

--- a/backend/src/app/db/repositories/bulk_expense_import_job.py
+++ b/backend/src/app/db/repositories/bulk_expense_import_job.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session
 
 from app.db.models.bulk_expense_import_job import (
@@ -28,6 +28,45 @@ class BulkExpenseImportJobRepository(BaseRepository[BulkExpenseImportJob]):
         )
         return self._session.execute(stmt).scalar_one_or_none()
 
+    def list_for_actor(
+        self,
+        *,
+        actor_sub: str,
+        limit: int,
+        cursor_job_id: UUID | None = None,
+    ) -> list[BulkExpenseImportJob]:
+        """Newest jobs first (``created_at`` desc, ``id`` desc). Optional keyset cursor."""
+        stmt = (
+            select(BulkExpenseImportJob)
+            .where(BulkExpenseImportJob.created_by == actor_sub)
+            .order_by(
+                BulkExpenseImportJob.created_at.desc(),
+                BulkExpenseImportJob.id.desc(),
+            )
+        )
+        if cursor_job_id is not None:
+            cursor_row = self._session.get(BulkExpenseImportJob, cursor_job_id)
+            if cursor_row is not None and cursor_row.created_by == actor_sub:
+                stmt = stmt.where(
+                    or_(
+                        BulkExpenseImportJob.created_at < cursor_row.created_at,
+                        and_(
+                            BulkExpenseImportJob.created_at == cursor_row.created_at,
+                            BulkExpenseImportJob.id < cursor_row.id,
+                        ),
+                    )
+                )
+        stmt = stmt.limit(limit)
+        return list(self._session.execute(stmt).scalars().all())
+
+    def count_for_actor(self, *, actor_sub: str) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(BulkExpenseImportJob)
+            .where(BulkExpenseImportJob.created_by == actor_sub)
+        )
+        return int(self._session.execute(stmt).scalar_one() or 0)
+
     def mark_processing(self, job: BulkExpenseImportJob) -> None:
         job.status = BulkExpenseImportJobStatus.PROCESSING
         job.updated_at = datetime.now(UTC)
@@ -44,6 +83,21 @@ class BulkExpenseImportJobRepository(BaseRepository[BulkExpenseImportJob]):
         job.created_expense_ids = [str(eid) for eid in expense_ids]
         job.created_count = created_count
         job.error_message = None
+        job.updated_at = datetime.now(UTC)
+        self.update(job)
+
+    def mark_succeeded_with_errors(
+        self,
+        job: BulkExpenseImportJob,
+        *,
+        expense_ids: list[UUID],
+        created_count: int,
+        message: str,
+    ) -> None:
+        job.status = BulkExpenseImportJobStatus.SUCCEEDED_WITH_ERRORS
+        job.created_expense_ids = [str(eid) for eid in expense_ids]
+        job.created_count = created_count
+        job.error_message = message[:8000]
         job.updated_at = datetime.now(UTC)
         self.update(job)
 

--- a/backend/src/app/db/repositories/expense.py
+++ b/backend/src/app/db/repositories/expense.py
@@ -141,6 +141,25 @@ class ExpenseRepository(BaseRepository[Expense]):
         )
         return self._session.execute(statement).scalar_one_or_none()
 
+    def get_many_with_attachments(self, expense_ids: list[UUID]) -> list[Expense]:
+        """Load expenses with the same eager loads as ``get_with_attachments``.
+
+        Returned rows follow the order of ``expense_ids`` (skips unknown ids).
+        """
+        if not expense_ids:
+            return []
+        statement = (
+            select(Expense)
+            .options(
+                selectinload(Expense.attachments).selectinload(ExpenseAttachment.asset),
+                selectinload(Expense.vendor),
+            )
+            .where(Expense.id.in_(expense_ids))
+        )
+        rows = list(self._session.execute(statement).scalars().all())
+        by_id = {row.id: row for row in rows}
+        return [by_id[eid] for eid in expense_ids if eid in by_id]
+
     def count_amendments_targeting(self, expense_id: UUID) -> int:
         """Count expense rows that reference this expense as their amendment parent."""
         stmt = (

--- a/backend/src/app/events/sqs_batch.py
+++ b/backend/src/app/events/sqs_batch.py
@@ -83,6 +83,14 @@ class SqsBatchProcessor:
         )
         self._result.mark_failed(record)
 
+    def retry_record(self, record: Mapping[str, Any], *, reason: str) -> None:
+        """Request an SQS retry for this record without logging an exception."""
+        self._logger.info(
+            reason,
+            extra={"message_id": record_message_id(record) or None},
+        )
+        self._result.mark_failed(record)
+
     @contextmanager
     def record(
         self,

--- a/backend/src/app/services/aws_clients.py
+++ b/backend/src/app/services/aws_clients.py
@@ -49,3 +49,7 @@ def get_cognito_idp_client(region_name: str | None = None) -> Any:
 
 def get_rds_client(region_name: str | None = None) -> Any:
     return get_client("rds", region_name=region_name)
+
+
+def get_sqs_client(region_name: str | None = None) -> Any:
+    return get_client("sqs", region_name=region_name)

--- a/backend/src/app/services/bulk_expense_import_common.py
+++ b/backend/src/app/services/bulk_expense_import_common.py
@@ -1,0 +1,114 @@
+"""Shared helpers for bulk PDF expense import (async worker + API)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from collections.abc import Mapping
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.db.models import Expense
+from app.db.repositories import OrganizationRepository
+
+
+def resolve_bulk_row_vendor_id(
+    org_repo: OrganizationRepository,
+    parsed: Mapping[str, Any],
+    *,
+    default_vendor_id: UUID,
+) -> UUID:
+    parsed_vendor_only = bulk_pick_text(parsed.get("vendor_name"), fallback=None)
+    if parsed_vendor_only:
+        matched = org_repo.try_resolve_active_vendor_by_parsed_name(parsed_vendor_only)
+        if matched is not None:
+            return matched.id
+    return default_vendor_id
+
+
+def apply_openrouter_normalized_to_expense(
+    expense: Expense, parsed: Mapping[str, Any]
+) -> None:
+    expense.invoice_number = bulk_pick_text(
+        parsed.get("invoice_number"), fallback=expense.invoice_number
+    )
+    expense.invoice_date = bulk_pick_date(
+        parsed.get("invoice_date"), fallback=expense.invoice_date
+    )
+    expense.due_date = bulk_pick_date(parsed.get("due_date"), fallback=expense.due_date)
+    expense.currency = bulk_pick_currency(
+        parsed.get("currency"), fallback=expense.currency
+    )
+    expense.subtotal = bulk_pick_decimal(
+        parsed.get("subtotal"), fallback=expense.subtotal
+    )
+    expense.tax = bulk_pick_decimal(parsed.get("tax"), fallback=expense.tax)
+    expense.total = bulk_pick_decimal(parsed.get("total"), fallback=expense.total)
+    line_items = parsed.get("line_items")
+    if isinstance(line_items, list):
+        expense.line_items = line_items
+    expense.parse_confidence = bulk_pick_decimal(
+        parsed.get("confidence"), fallback=expense.parse_confidence
+    )
+    expense.parser_raw = (
+        parsed.get("raw") if isinstance(parsed.get("raw"), dict) else {"raw": parsed}
+    )
+
+
+def bulk_pick_text(value: Any, *, fallback: str | None) -> str | None:
+    if value is None:
+        return fallback
+    normalized = str(value).strip()
+    return normalized or fallback
+
+
+def bulk_pick_date(value: Any, *, fallback: date | None) -> date | None:
+    if value is None:
+        return fallback
+    normalized = str(value).strip()
+    if not normalized:
+        return fallback
+    try:
+        return date.fromisoformat(normalized)
+    except ValueError:
+        return fallback
+
+
+def bulk_pick_currency(value: Any, *, fallback: str | None) -> str | None:
+    if value is None:
+        return fallback
+    normalized = str(value).strip().upper()
+    if len(normalized) != 3:
+        return fallback
+    return normalized
+
+
+def bulk_pick_decimal(value: Any, *, fallback: Decimal | None) -> Decimal | None:
+    if value is None:
+        return fallback
+    try:
+        return Decimal(str(value)).quantize(Decimal("0.01"))
+    except Exception:
+        return fallback
+
+
+def build_parser_asset_dict(session: Session, attachment_id: UUID) -> dict[str, Any]:
+    """Load asset fields required by OpenRouter bulk parser."""
+    from app.db.repositories import AssetRepository
+
+    assets = AssetRepository(session).list_by_ids([attachment_id])
+    if not assets:
+        raise ValueError("attachment_asset_id not found")
+    asset_ent = assets[0]
+    content_type = (asset_ent.content_type or "").strip().lower()
+    file_name = (asset_ent.file_name or "").strip().lower()
+    if "pdf" not in content_type and not file_name.endswith(".pdf"):
+        raise ValueError("attachment_asset_id must reference a PDF document")
+    return {
+        "id": str(asset_ent.id),
+        "s3_key": asset_ent.s3_key,
+        "file_name": asset_ent.file_name,
+        "content_type": asset_ent.content_type,
+    }

--- a/backend/src/app/services/bulk_expense_import_common.py
+++ b/backend/src/app/services/bulk_expense_import_common.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.db.models import Expense
 from app.db.repositories import OrganizationRepository
+from app.exceptions import ValidationError
 
 
 def resolve_bulk_row_vendor_id(
@@ -94,18 +95,35 @@ def bulk_pick_decimal(value: Any, *, fallback: Decimal | None) -> Decimal | None
         return fallback
 
 
-def build_parser_asset_dict(session: Session, attachment_id: UUID) -> dict[str, Any]:
-    """Load asset fields required by OpenRouter bulk parser."""
+def _load_validated_bulk_pdf_asset(session: Session, attachment_id: UUID):
+    """Return the asset row after ensuring it exists and is a PDF."""
     from app.db.repositories import AssetRepository
 
     assets = AssetRepository(session).list_by_ids([attachment_id])
     if not assets:
-        raise ValueError("attachment_asset_id not found")
+        raise ValidationError(
+            "attachment_asset_id not found",
+            field="attachment_asset_id",
+        )
     asset_ent = assets[0]
     content_type = (asset_ent.content_type or "").strip().lower()
     file_name = (asset_ent.file_name or "").strip().lower()
     if "pdf" not in content_type and not file_name.endswith(".pdf"):
-        raise ValueError("attachment_asset_id must reference a PDF document")
+        raise ValidationError(
+            "attachment_asset_id must reference a PDF document",
+            field="attachment_asset_id",
+        )
+    return asset_ent
+
+
+def assert_pdf_asset(session: Session, attachment_id: UUID) -> None:
+    """Ensure ``attachment_id`` references an existing PDF asset (API + worker)."""
+    _load_validated_bulk_pdf_asset(session, attachment_id)
+
+
+def build_parser_asset_dict(session: Session, attachment_id: UUID) -> dict[str, Any]:
+    """Load asset fields required by OpenRouter bulk parser."""
+    asset_ent = _load_validated_bulk_pdf_asset(session, attachment_id)
     return {
         "id": str(asset_ent.id),
         "s3_key": asset_ent.s3_key,

--- a/backend/src/app/services/bulk_expense_import_events.py
+++ b/backend/src/app/services/bulk_expense_import_events.py
@@ -1,0 +1,23 @@
+"""Enqueue bulk expense import jobs to SQS."""
+
+from __future__ import annotations
+
+import json
+import os
+from uuid import UUID
+
+from app.exceptions import ValidationError
+from app.services.aws_clients import get_sqs_client
+
+
+def enqueue_bulk_expense_import_job(job_id: UUID) -> None:
+    """Send a bulk import job id to the configured worker queue."""
+    queue_url = os.getenv("BULK_EXPENSE_IMPORT_QUEUE_URL", "").strip()
+    if not queue_url:
+        raise ValidationError(
+            "Bulk expense import queue is not configured", field="configuration"
+        )
+    get_sqs_client().send_message(
+        QueueUrl=queue_url,
+        MessageBody=json.dumps({"job_id": str(job_id)}),
+    )

--- a/backend/src/app/services/bulk_expense_import_runner.py
+++ b/backend/src/app/services/bulk_expense_import_runner.py
@@ -1,8 +1,16 @@
-"""Execute bulk PDF expense import jobs (SQS worker)."""
+"""Execute bulk PDF expense import jobs (SQS worker).
+
+Time budget: the bulk-import Lambda timeout is configured in CDK (typically **600s**)
+via ``BULK_IMPORT_LAMBDA_TIMEOUT_SECONDS``. OpenRouter bulk parse is capped at
+**240s** so the remainder covers asset validation, per-row expense commits, and
+job status updates without racing the Lambda hard timeout.
+"""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -23,49 +31,105 @@ from app.services.bulk_expense_import_common import (
 from app.services.openrouter_expense_parser import (
     parse_bulk_expense_invoices_from_assets,
 )
-from app.utils.logging import get_logger
+from app.utils.logging import get_logger, mask_pii
 
 logger = get_logger(__name__)
 
-_OPENROUTER_TIMEOUT_SECONDS = 280
+_OPENROUTER_TIMEOUT_SECONDS = 240
 
 
-def process_bulk_expense_import_job(job_id: UUID) -> None:
+def _lambda_timeout_seconds() -> int:
+    raw = os.environ.get("BULK_IMPORT_LAMBDA_TIMEOUT_SECONDS", "600").strip()
+    try:
+        return max(60, int(raw))
+    except ValueError:
+        return 600
+
+
+def _processing_stale_threshold() -> timedelta:
+    """Treat PROCESSING rows older than this as abandoned (worker died)."""
+    sec = _lambda_timeout_seconds() * 2 + 120
+    return timedelta(seconds=sec)
+
+
+def sanitize_bulk_import_error_message(message: str) -> str:
+    """Redact persisted/API-facing bulk-import error text."""
+    trimmed = (message or "").strip()
+    if not trimmed:
+        return "An error occurred."
+    if len(trimmed) > 8000:
+        trimmed = trimmed[:8000]
+    return mask_pii(trimmed, visible_chars=4)
+
+
+@dataclass(frozen=True)
+class BulkImportWorkerOutcome:
+    """Whether the SQS message should be deleted (``True``) or retried (``False``)."""
+
+    ack_sqs_message: bool
+
+
+def process_bulk_expense_import_job(job_id: UUID) -> BulkImportWorkerOutcome:
     """Load job, parse PDF via OpenRouter, create expenses, update job status."""
+    req_id = f"bulk-import-job:{job_id}"
+    stale_after = _processing_stale_threshold()
+
     with Session(get_engine()) as session:
         job_repo = BulkExpenseImportJobRepository(session)
         job = job_repo.get_by_id(job_id)
         if job is None:
             logger.warning("Bulk import job not found", extra={"job_id": str(job_id)})
-            return
-        if job.status == BulkExpenseImportJobStatus.SUCCEEDED:
+            return BulkImportWorkerOutcome(ack_sqs_message=True)
+        if job.status in (
+            BulkExpenseImportJobStatus.SUCCEEDED,
+            BulkExpenseImportJobStatus.SUCCEEDED_WITH_ERRORS,
+        ):
             logger.info(
-                "Bulk import job already succeeded; skipping",
-                extra={"job_id": str(job_id)},
+                "Bulk import job already finished; skipping",
+                extra={"job_id": str(job_id), "status": job.status.value},
             )
-            return
+            return BulkImportWorkerOutcome(ack_sqs_message=True)
         if job.status == BulkExpenseImportJobStatus.FAILED:
             logger.info(
                 "Bulk import job already failed; skipping",
                 extra={"job_id": str(job_id)},
             )
-            return
+            return BulkImportWorkerOutcome(ack_sqs_message=True)
+
+        if job.status == BulkExpenseImportJobStatus.PROCESSING:
+            now = datetime.now(UTC)
+            updated = job.updated_at
+            if updated is not None and (now - updated) < stale_after:
+                logger.info(
+                    "Bulk import job still processing elsewhere; deferring SQS message",
+                    extra={"job_id": str(job_id)},
+                )
+                return BulkImportWorkerOutcome(ack_sqs_message=False)
+            set_audit_context(session, user_id=job.created_by, request_id=req_id)
+            job_repo.mark_failed(
+                job,
+                sanitize_bulk_import_error_message(
+                    "Worker did not finish the previous attempt; please retry the import."
+                ),
+            )
+            session.commit()
+            return BulkImportWorkerOutcome(ack_sqs_message=True)
+
         if job.status != BulkExpenseImportJobStatus.PENDING:
             logger.warning(
                 "Bulk import job in unexpected state",
                 extra={"job_id": str(job_id), "status": job.status.value},
             )
-            return
+            return BulkImportWorkerOutcome(ack_sqs_message=True)
 
         actor_sub = job.created_by
         attachment_id = job.attachment_asset_id
         default_vendor_id = job.default_vendor_id
         expense_status = job.expense_status
 
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
         job_repo.mark_processing(job)
         session.commit()
-
-    req_id = f"bulk-import-job:{job_id}"
 
     try:
         with Session(get_engine()) as session:
@@ -74,43 +138,42 @@ def process_bulk_expense_import_job(job_id: UUID) -> None:
             parser_asset = build_parser_asset_dict(session, attachment_id)
     except ValidationError as exc:
         _fail_job(job_id, str(exc))
-        return
+        return BulkImportWorkerOutcome(ack_sqs_message=True)
     except ValueError as exc:
         _fail_job(job_id, str(exc))
-        return
-    except Exception:
+        return BulkImportWorkerOutcome(ack_sqs_message=True)
+    except Exception as exc:
         logger.exception(
             "Bulk import job validation failed", extra={"job_id": str(job_id)}
         )
-        _fail_job(job_id, "Failed to validate attachment for bulk import.")
-        return
+        _fail_job(job_id, repr(exc))
+        return BulkImportWorkerOutcome(ack_sqs_message=True)
 
     try:
         normalized_rows = parse_bulk_expense_invoices_from_assets(
             [parser_asset], timeout=_OPENROUTER_TIMEOUT_SECONDS
         )
     except (RuntimeError, ValueError) as exc:
-        _fail_job(job_id, str(exc))
-        return
-    except Exception:
+        _fail_job(job_id, repr(exc))
+        return BulkImportWorkerOutcome(ack_sqs_message=True)
+    except Exception as exc:
         logger.exception(
             "Bulk import OpenRouter parse failed", extra={"job_id": str(job_id)}
         )
-        _fail_job(job_id, "OpenRouter bulk parse failed.")
-        return
+        _fail_job(job_id, repr(exc))
+        return BulkImportWorkerOutcome(ack_sqs_message=True)
 
     created_ids: list[UUID] = []
-    try:
-        with Session(get_engine()) as session:
-            set_audit_context(session, user_id=actor_sub, request_id=req_id)
-            expense_repo = ExpenseRepository(session)
-            org_repo = OrganizationRepository(session)
-
-            resolve_vendor(session, default_vendor_id)
-            asset_ids = resolve_asset_ids(session, [attachment_id])
-            now = datetime.now(UTC)
-
-            for parsed in normalized_rows:
+    row_errors: list[str] = []
+    for row_index, parsed in enumerate(normalized_rows):
+        try:
+            with Session(get_engine()) as session:
+                set_audit_context(session, user_id=actor_sub, request_id=req_id)
+                expense_repo = ExpenseRepository(session)
+                org_repo = OrganizationRepository(session)
+                resolve_vendor(session, default_vendor_id)
+                asset_ids = resolve_asset_ids(session, [attachment_id])
+                now = datetime.now(UTC)
                 vendor_id = resolve_bulk_row_vendor_id(
                     org_repo, parsed, default_vendor_id=default_vendor_id
                 )
@@ -135,32 +198,59 @@ def process_bulk_expense_import_job(job_id: UUID) -> None:
                     expense.submitted_at = now
                 expense_repo.replace_attachments(expense, asset_ids)
                 expense_repo.update(expense)
+                session.commit()
                 created_ids.append(expense.id)
+        except Exception as exc:
+            logger.exception(
+                "Bulk import row failed",
+                extra={"job_id": str(job_id), "row_index": row_index},
+            )
+            row_errors.append(
+                f"row {row_index}: {sanitize_bulk_import_error_message(repr(exc))}"
+            )
 
-            session.commit()
-    except Exception:
-        logger.exception(
-            "Bulk import expense creation failed", extra={"job_id": str(job_id)}
-        )
-        _fail_job(job_id, "Failed to create expenses from parsed rows.")
-        return
+    if not created_ids and row_errors:
+        summary = "; ".join(row_errors)[:7900]
+        _fail_job(job_id, summary)
+        return BulkImportWorkerOutcome(ack_sqs_message=True)
 
     with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=req_id)
         job_repo = BulkExpenseImportJobRepository(session)
         refreshed = job_repo.get_by_id(job_id)
         if refreshed is None:
-            return
-        job_repo.mark_succeeded(
-            refreshed, expense_ids=created_ids, created_count=len(created_ids)
-        )
+            return BulkImportWorkerOutcome(ack_sqs_message=True)
+        if row_errors:
+            summary = (
+                f"Imported {len(created_ids)} of {len(normalized_rows)} rows. "
+                + "; ".join(row_errors)
+            )[:8000]
+            job_repo.mark_succeeded_with_errors(
+                refreshed,
+                expense_ids=created_ids,
+                created_count=len(created_ids),
+                message=summary,
+            )
+        else:
+            job_repo.mark_succeeded(
+                refreshed, expense_ids=created_ids, created_count=len(created_ids)
+            )
         session.commit()
+
+    return BulkImportWorkerOutcome(ack_sqs_message=True)
 
 
 def _fail_job(job_id: UUID, message: str) -> None:
+    safe = sanitize_bulk_import_error_message(message)
     with Session(get_engine()) as session:
         job_repo = BulkExpenseImportJobRepository(session)
         job = job_repo.get_by_id(job_id)
         if job is None:
             return
-        job_repo.mark_failed(job, message)
+        set_audit_context(
+            session,
+            user_id=job.created_by,
+            request_id=f"bulk-import-job:{job_id}",
+        )
+        job_repo.mark_failed(job, safe)
         session.commit()

--- a/backend/src/app/services/bulk_expense_import_runner.py
+++ b/backend/src/app/services/bulk_expense_import_runner.py
@@ -1,0 +1,158 @@
+"""Execute bulk PDF expense import jobs (SQS worker)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.api.admin_expenses_common import resolve_asset_ids, resolve_vendor
+from app.db.audit import set_audit_context
+from app.db.engine import get_engine
+from app.db.models import ExpenseParseStatus, ExpenseStatus
+from app.db.models.bulk_expense_import_job import BulkExpenseImportJobStatus
+from app.db.repositories import ExpenseRepository, OrganizationRepository
+from app.db.repositories.bulk_expense_import_job import BulkExpenseImportJobRepository
+from app.exceptions import ValidationError
+from app.services.bulk_expense_import_common import (
+    apply_openrouter_normalized_to_expense,
+    build_parser_asset_dict,
+    resolve_bulk_row_vendor_id,
+)
+from app.services.openrouter_expense_parser import parse_bulk_expense_invoices_from_assets
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_OPENROUTER_TIMEOUT_SECONDS = 280
+
+
+def process_bulk_expense_import_job(job_id: UUID) -> None:
+    """Load job, parse PDF via OpenRouter, create expenses, update job status."""
+    with Session(get_engine()) as session:
+        job_repo = BulkExpenseImportJobRepository(session)
+        job = job_repo.get_by_id(job_id)
+        if job is None:
+            logger.warning("Bulk import job not found", extra={"job_id": str(job_id)})
+            return
+        if job.status == BulkExpenseImportJobStatus.SUCCEEDED:
+            logger.info(
+                "Bulk import job already succeeded; skipping",
+                extra={"job_id": str(job_id)},
+            )
+            return
+        if job.status == BulkExpenseImportJobStatus.FAILED:
+            logger.info(
+                "Bulk import job already failed; skipping",
+                extra={"job_id": str(job_id)},
+            )
+            return
+        if job.status != BulkExpenseImportJobStatus.PENDING:
+            logger.warning(
+                "Bulk import job in unexpected state",
+                extra={"job_id": str(job_id), "status": job.status.value},
+            )
+            return
+
+        actor_sub = job.created_by
+        attachment_id = job.attachment_asset_id
+        default_vendor_id = job.default_vendor_id
+        expense_status = job.expense_status
+
+        job_repo.mark_processing(job)
+        session.commit()
+
+    req_id = f"bulk-import-job:{job_id}"
+
+    try:
+        with Session(get_engine()) as session:
+            set_audit_context(session, user_id=actor_sub, request_id=req_id)
+            resolve_vendor(session, default_vendor_id)
+            parser_asset = build_parser_asset_dict(session, attachment_id)
+    except ValidationError as exc:
+        _fail_job(job_id, str(exc))
+        return
+    except ValueError as exc:
+        _fail_job(job_id, str(exc))
+        return
+    except Exception:
+        logger.exception("Bulk import job validation failed", extra={"job_id": str(job_id)})
+        _fail_job(job_id, "Failed to validate attachment for bulk import.")
+        return
+
+    try:
+        normalized_rows = parse_bulk_expense_invoices_from_assets(
+            [parser_asset], timeout=_OPENROUTER_TIMEOUT_SECONDS
+        )
+    except (RuntimeError, ValueError) as exc:
+        _fail_job(job_id, str(exc))
+        return
+    except Exception:
+        logger.exception("Bulk import OpenRouter parse failed", extra={"job_id": str(job_id)})
+        _fail_job(job_id, "OpenRouter bulk parse failed.")
+        return
+
+    created_ids: list[UUID] = []
+    try:
+        with Session(get_engine()) as session:
+            set_audit_context(session, user_id=actor_sub, request_id=req_id)
+            expense_repo = ExpenseRepository(session)
+            org_repo = OrganizationRepository(session)
+
+            resolve_vendor(session, default_vendor_id)
+            asset_ids = resolve_asset_ids(session, [attachment_id])
+            now = datetime.now(UTC)
+
+            for parsed in normalized_rows:
+                vendor_id = resolve_bulk_row_vendor_id(
+                    org_repo, parsed, default_vendor_id=default_vendor_id
+                )
+                expense = expense_repo.create_expense(
+                    created_by=actor_sub,
+                    status=expense_status,
+                    parse_status=ExpenseParseStatus.SUCCEEDED,
+                    vendor_id=vendor_id,
+                    invoice_number=None,
+                    invoice_date=None,
+                    due_date=None,
+                    currency=None,
+                    subtotal=None,
+                    tax=None,
+                    total=None,
+                    line_items=None,
+                    notes=None,
+                )
+                apply_openrouter_normalized_to_expense(expense, parsed)
+                expense.updated_by = actor_sub
+                if expense_status == ExpenseStatus.SUBMITTED:
+                    expense.submitted_at = now
+                expense_repo.replace_attachments(expense, asset_ids)
+                expense_repo.update(expense)
+                created_ids.append(expense.id)
+
+            session.commit()
+    except Exception:
+        logger.exception("Bulk import expense creation failed", extra={"job_id": str(job_id)})
+        _fail_job(job_id, "Failed to create expenses from parsed rows.")
+        return
+
+    with Session(get_engine()) as session:
+        job_repo = BulkExpenseImportJobRepository(session)
+        refreshed = job_repo.get_by_id(job_id)
+        if refreshed is None:
+            return
+        job_repo.mark_succeeded(
+            refreshed, expense_ids=created_ids, created_count=len(created_ids)
+        )
+        session.commit()
+
+
+def _fail_job(job_id: UUID, message: str) -> None:
+    with Session(get_engine()) as session:
+        job_repo = BulkExpenseImportJobRepository(session)
+        job = job_repo.get_by_id(job_id)
+        if job is None:
+            return
+        job_repo.mark_failed(job, message)
+        session.commit()

--- a/backend/src/app/services/bulk_expense_import_runner.py
+++ b/backend/src/app/services/bulk_expense_import_runner.py
@@ -20,7 +20,9 @@ from app.services.bulk_expense_import_common import (
     build_parser_asset_dict,
     resolve_bulk_row_vendor_id,
 )
-from app.services.openrouter_expense_parser import parse_bulk_expense_invoices_from_assets
+from app.services.openrouter_expense_parser import (
+    parse_bulk_expense_invoices_from_assets,
+)
 from app.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -77,7 +79,9 @@ def process_bulk_expense_import_job(job_id: UUID) -> None:
         _fail_job(job_id, str(exc))
         return
     except Exception:
-        logger.exception("Bulk import job validation failed", extra={"job_id": str(job_id)})
+        logger.exception(
+            "Bulk import job validation failed", extra={"job_id": str(job_id)}
+        )
         _fail_job(job_id, "Failed to validate attachment for bulk import.")
         return
 
@@ -89,7 +93,9 @@ def process_bulk_expense_import_job(job_id: UUID) -> None:
         _fail_job(job_id, str(exc))
         return
     except Exception:
-        logger.exception("Bulk import OpenRouter parse failed", extra={"job_id": str(job_id)})
+        logger.exception(
+            "Bulk import OpenRouter parse failed", extra={"job_id": str(job_id)}
+        )
         _fail_job(job_id, "OpenRouter bulk parse failed.")
         return
 
@@ -133,7 +139,9 @@ def process_bulk_expense_import_job(job_id: UUID) -> None:
 
             session.commit()
     except Exception:
-        logger.exception("Bulk import expense creation failed", extra={"job_id": str(job_id)})
+        logger.exception(
+            "Bulk import expense creation failed", extra={"job_id": str(job_id)}
+        )
         _fail_job(job_id, "Failed to create expenses from parsed rows.")
         return
 

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -49,7 +49,8 @@ info:
     - `PATCH /v1/admin/organizations/{id}/members/{memberId}`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
     - `GET|POST /v1/admin/expenses`
-    - `POST /v1/admin/expenses/import-from-bulk-pdf` (returns **202** with a job id; poll `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `succeeded` or `failed`)
+    - `POST /v1/admin/expenses/import-from-bulk-pdf` (returns **202** with a job id; poll `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `succeeded`, `succeeded_with_errors`, or `failed`)
+    - `GET /v1/admin/expenses/bulk-import-jobs` (creator-scoped list of recent jobs)
     - `GET /v1/admin/expenses/bulk-import-jobs/{job_id}`
     - `GET|PATCH|DELETE /v1/admin/expenses/{id}`
     - `POST /v1/admin/expenses/{id}/cancel`
@@ -3482,8 +3483,10 @@ paths:
         Upload a PDF as an admin asset, then call this endpoint with its asset id.
         The API enqueues an asynchronous OpenRouter bulk parse (SQS + dedicated Lambda)
         and returns **202** with a `bulk_import_job` id. Poll
-        `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `status` is `succeeded`
-        (response includes created `expenses`) or `failed` (`error_message` is set).
+        `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `status` is `succeeded`,
+        `succeeded_with_errors` (partial row failures; see `error_message`), or `failed`
+        (`error_message` is set). You can also list recent jobs via
+        `GET /v1/admin/expenses/bulk-import-jobs`.
         Parsed vendor names are matched to active vendors when possible; otherwise
         `default_vendor_id` is used.
       security:
@@ -3508,6 +3511,37 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/admin/expenses/bulk-import-jobs:
+    get:
+      summary: List bulk PDF import jobs for the signed-in admin
+      description: >
+        Returns jobs created by the authenticated admin, newest first. Use this to
+        recover visibility after refresh or when polling times out.
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Paginated bulk import jobs for the current admin.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BulkImportJobListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /v1/admin/expenses/bulk-import-jobs/{job_id}:
     parameters:
       - name: job_id
@@ -3520,13 +3554,14 @@ paths:
     get:
       summary: Get bulk PDF import job status
       description: >
-        Poll this endpoint until `bulk_import_job.status` is `succeeded` or `failed`.
-        Only the admin user who created the job may read it.
+        Poll this endpoint until `bulk_import_job.status` is `succeeded`,
+        `succeeded_with_errors`, or `failed`. Only the admin user who created the job
+        may read it.
       security:
         - AdminBearerAuth: []
       responses:
         "200":
-          description: Current job state (and expenses when succeeded).
+          description: Current job state (and expenses when the job finished with successes).
           content:
             application/json:
               schema:
@@ -6763,6 +6798,7 @@ components:
         - pending
         - processing
         - succeeded
+        - succeeded_with_errors
         - failed
       description: Asynchronous bulk PDF import lifecycle.
     BulkImportJob:
@@ -6779,18 +6815,76 @@ components:
         error_message:
           type: string
           nullable: true
-          description: Populated when `status` is `failed`.
+          description: >
+            Populated when `status` is `failed`, or carries a short operator-facing
+            summary when `status` is `succeeded_with_errors`.
         created_count:
           type: integer
           nullable: true
           minimum: 0
-          description: Number of expenses created when `status` is `succeeded`.
+          description: Number of expenses created when the job finished with successes.
         expenses:
           type: array
           nullable: true
           items:
             $ref: "#/components/schemas/Expense"
-          description: Full expense payloads when `status` is `succeeded`; otherwise null.
+          description: >
+            Full expense payloads when `status` is `succeeded` or `succeeded_with_errors`
+            (order matches `created_expense_ids` insertion order); otherwise null.
+    BulkImportJobListResponse:
+      type: object
+      required:
+        - items
+        - next_cursor
+        - total_count
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/BulkImportJobSummary"
+        next_cursor:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+          minimum: 0
+    BulkImportJobSummary:
+      type: object
+      required:
+        - id
+        - status
+        - created_at
+        - updated_at
+        - attachment_asset_id
+        - default_vendor_id
+        - expense_status
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: "#/components/schemas/BulkImportJobStatus"
+        error_message:
+          type: string
+          nullable: true
+        created_count:
+          type: integer
+          nullable: true
+          minimum: 0
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        attachment_asset_id:
+          type: string
+          format: uuid
+        default_vendor_id:
+          type: string
+          format: uuid
+        expense_status:
+          $ref: "#/components/schemas/ExpenseStatus"
     BulkImportJobResponse:
       type: object
       required:
@@ -6816,8 +6910,8 @@ components:
         status:
           $ref: "#/components/schemas/ExpenseStatus"
           description: >
-            Defaults to `submitted`. Draft may be used when operators want to review
-            rows before submission.
+            Optional. Expense status applied to every row created from the PDF; defaults
+            to `submitted` when omitted.
 
     UpdateExpenseRequest:
       type: object

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -49,7 +49,8 @@ info:
     - `PATCH /v1/admin/organizations/{id}/members/{memberId}`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
     - `GET|POST /v1/admin/expenses`
-    - `POST /v1/admin/expenses/import-from-bulk-pdf`
+    - `POST /v1/admin/expenses/import-from-bulk-pdf` (returns **202** with a job id; poll `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `succeeded` or `failed`)
+    - `GET /v1/admin/expenses/bulk-import-jobs/{job_id}`
     - `GET|PATCH|DELETE /v1/admin/expenses/{id}`
     - `POST /v1/admin/expenses/{id}/cancel`
     - `POST /v1/admin/expenses/{id}/mark-paid`
@@ -3476,14 +3477,15 @@ paths:
 
   /v1/admin/expenses/import-from-bulk-pdf:
     post:
-      summary: Import multiple expenses from one combined PDF
+      summary: Queue import of multiple expenses from one combined PDF
       description: >
         Upload a PDF as an admin asset, then call this endpoint with its asset id.
-        OpenRouter extracts one JSON object per distinct invoice or charge row; each
-        row becomes a separate expense that references the same attachment asset.
+        The API enqueues an asynchronous OpenRouter bulk parse (SQS + dedicated Lambda)
+        and returns **202** with a `bulk_import_job` id. Poll
+        `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `status` is `succeeded`
+        (response includes created `expenses`) or `failed` (`error_message` is set).
         Parsed vendor names are matched to active vendors when possible; otherwise
-        `default_vendor_id` is used. Synchronous parse is subject to API Gateway
-        time limits; very large PDFs may fail with a validation error.
+        `default_vendor_id` is used.
       security:
         - AdminBearerAuth: []
       requestBody:
@@ -3493,12 +3495,42 @@ paths:
             schema:
               $ref: "#/components/schemas/BulkImportExpensesFromPdfRequest"
       responses:
-        "201":
-          description: Expenses created from parsed rows.
+        "202":
+          description: Bulk import job accepted for asynchronous processing.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BulkImportExpensesFromPdfResponse"
+                $ref: "#/components/schemas/BulkImportJobResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/expenses/bulk-import-jobs/{job_id}:
+    parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+        description: Identifier returned from `POST /v1/admin/expenses/import-from-bulk-pdf`.
+    get:
+      summary: Get bulk PDF import job status
+      description: >
+        Poll this endpoint until `bulk_import_job.status` is `succeeded` or `failed`.
+        Only the admin user who created the job may read it.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Current job state (and expenses when succeeded).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BulkImportJobResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -6725,6 +6757,47 @@ components:
             format: uuid
         parse_requested:
           type: boolean
+    BulkImportJobStatus:
+      type: string
+      enum:
+        - pending
+        - processing
+        - succeeded
+        - failed
+      description: Asynchronous bulk PDF import lifecycle.
+    BulkImportJob:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: "#/components/schemas/BulkImportJobStatus"
+        error_message:
+          type: string
+          nullable: true
+          description: Populated when `status` is `failed`.
+        created_count:
+          type: integer
+          nullable: true
+          minimum: 0
+          description: Number of expenses created when `status` is `succeeded`.
+        expenses:
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/Expense"
+          description: Full expense payloads when `status` is `succeeded`; otherwise null.
+    BulkImportJobResponse:
+      type: object
+      required:
+        - bulk_import_job
+      properties:
+        bulk_import_job:
+          $ref: "#/components/schemas/BulkImportJob"
     BulkImportExpensesFromPdfRequest:
       type: object
       required:
@@ -6745,19 +6818,7 @@ components:
           description: >
             Defaults to `submitted`. Draft may be used when operators want to review
             rows before submission.
-    BulkImportExpensesFromPdfResponse:
-      type: object
-      required:
-        - expenses
-        - created_count
-      properties:
-        expenses:
-          type: array
-          items:
-            $ref: "#/components/schemas/Expense"
-        created_count:
-          type: integer
-          minimum: 1
+
     UpdateExpenseRequest:
       type: object
       properties:

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -695,6 +695,8 @@ These raster files ship with `EvolvesproutsAdminFunction` under `backend/src/app
 | `ExpenseParserTopicArn` | SNS topic ARN | Expense parser events topic (from nested stack `evolvesprouts-Messaging`) |
 | `ExpenseParserQueueUrl` | SQS queue URL | Expense parser processing queue (from nested stack `evolvesprouts-Messaging`) |
 | `ExpenseParserDLQUrl` | SQS DLQ URL | Failed expense parser messages (from nested stack `evolvesprouts-Messaging`) |
+| `BulkExpenseImportQueueUrl` | SQS queue URL | Async bulk combined-PDF import jobs (from nested stack `evolvesprouts-Messaging`) |
+| `BulkExpenseImportDLQUrl` | SQS DLQ URL | Failed bulk expense import messages (from nested stack `evolvesprouts-Messaging`) |
 | `EventbriteSyncTopicArn` | SNS topic ARN | Eventbrite sync events topic (from nested stack `evolvesprouts-EventbriteSync`) |
 | `EventbriteSyncQueueUrl` | SQS queue URL | Eventbrite sync processing queue (from nested stack `evolvesprouts-EventbriteSync`) |
 | `EventbriteSyncDLQUrl` | SQS DLQ URL | Failed Eventbrite sync jobs (SQS redrive; from nested stack `evolvesprouts-EventbriteSync`) |

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -219,12 +219,20 @@ admin API requests while files are parsed by OpenRouter.
 
 Admin `POST /v1/admin/expenses/import-from-bulk-pdf` enqueues work on a **direct**
 SQS queue (no SNS) so OpenRouter can run longer than API Gateway limits while the
-admin UI polls `GET /v1/admin/expenses/bulk-import-jobs/{job_id}`.
+admin UI polls `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` or lists recent
+jobs via `GET /v1/admin/expenses/bulk-import-jobs`.
+
+**Deduplication:** the queue is a standard SQS queue (at-least-once delivery). Each
+message carries a unique `job_id`. The worker uses `bulk_expense_import_jobs.status`
+(and `updated_at` for abandoned `processing` rows) to stay idempotent across
+redeliveries. Retrying the **HTTP** enqueue creates a **new** `job_id` and therefore a
+new import run—clients should not assume SQS deduplicates duplicate POST retries.
 
 ### SQS Queue: `evolvesprouts-bulk-expense-import-queue`
 
 - Receives JSON messages `{ "job_id": "<uuid>" }` from `EvolvesproutsAdminFunction`.
-- 360 second visibility timeout (matches the worker Lambda timeout budget).
+- **720** second visibility timeout (above the **600** second worker Lambda timeout so
+  a single invocation can finish before redelivery).
 - 3 retry attempts before DLQ.
 - KMS encryption using the shared queue key.
 
@@ -240,7 +248,8 @@ admin UI polls `GET /v1/admin/expenses/bulk-import-jobs/{job_id}`.
 - Loads `bulk_expense_import_jobs` rows, validates the PDF asset, calls OpenRouter
   bulk extraction via `AwsApiProxyFunction`, then creates one expense per parsed row.
 - Uses the same OpenRouter + S3 + Secrets wiring as `ExpenseParserFunction`, with a
-  longer Lambda timeout for large combined PDFs.
+  **600** second Lambda timeout (`BULK_IMPORT_LAMBDA_TIMEOUT_SECONDS`) and a shorter
+  OpenRouter client timeout so asset validation and DB writes retain headroom.
 
 ## Inbound invoice email flow
 

--- a/docs/architecture/aws-messaging.md
+++ b/docs/architecture/aws-messaging.md
@@ -215,6 +215,33 @@ admin API requests while files are parsed by OpenRouter.
 - Fetches file bytes from S3 and calls OpenRouter via `AwsApiProxyFunction`.
 - Updates `expenses` parse status and extracted fields.
 
+## Bulk combined-PDF import flow
+
+Admin `POST /v1/admin/expenses/import-from-bulk-pdf` enqueues work on a **direct**
+SQS queue (no SNS) so OpenRouter can run longer than API Gateway limits while the
+admin UI polls `GET /v1/admin/expenses/bulk-import-jobs/{job_id}`.
+
+### SQS Queue: `evolvesprouts-bulk-expense-import-queue`
+
+- Receives JSON messages `{ "job_id": "<uuid>" }` from `EvolvesproutsAdminFunction`.
+- 360 second visibility timeout (matches the worker Lambda timeout budget).
+- 3 retry attempts before DLQ.
+- KMS encryption using the shared queue key.
+
+### Dead Letter Queue: `evolvesprouts-bulk-expense-import-dlq`
+
+- Receives bulk import messages that fail processing 3 times.
+- 14 day retention for investigation.
+- CloudWatch alarm triggers when messages appear.
+
+### Processor Lambda: `BulkExpenseImportFunction`
+
+- Triggered by `evolvesprouts-bulk-expense-import-queue`.
+- Loads `bulk_expense_import_jobs` rows, validates the PDF asset, calls OpenRouter
+  bulk extraction via `AwsApiProxyFunction`, then creates one expense per parsed row.
+- Uses the same OpenRouter + S3 + Secrets wiring as `ExpenseParserFunction`, with a
+  longer Lambda timeout for large combined PDFs.
+
 ## Inbound invoice email flow
 
 Inbound invoice emails use SES receipt rules plus the existing expense parser
@@ -304,6 +331,7 @@ SQS retries or mailbox forwarding duplicates.
 | `backend/infrastructure/lib/api-stack.ts` | CDK infrastructure |
 | `backend/src/app/api/admin.py` | API handler with SNS publish and public calendar feed routing |
 | `backend/lambda/media_processor/handler.py` | SQS media request processor |
+| `backend/lambda/bulk_expense_import/handler.py` | SQS bulk combined-PDF import processor |
 | `backend/lambda/ses_template_manager/handler.py` | CloudFormation custom resource — upsert SES email templates |
 | `backend/lambda/inbound_invoice_email/handler.py` | SQS inbound invoice email processor |
 | `backend/src/app/services/inbound_invoice_ingest.py` | Expense + asset creation from inbound email |
@@ -316,6 +344,7 @@ SQS retries or mailbox forwarding duplicates.
 |----------|-------------|
 | `MEDIA_REQUEST_TOPIC_ARN` | SNS topic ARN for media events (required) |
 | `EXPENSE_PARSE_TOPIC_ARN` | SNS topic ARN for expense parser events (required) |
+| `BULK_EXPENSE_IMPORT_QUEUE_URL` | SQS queue URL for async bulk combined-PDF imports (admin enqueue) |
 | `EVENTBRITE_SYNC_TOPIC_ARN` | SNS topic ARN for Eventbrite sync events (required for Eventbrite DB-sync) |
 | `CONFIRMATION_EMAIL_FROM_ADDRESS` | SES-verified from address for customer-facing templated emails on legacy public routes (`EvolvesproutsAdminFunction`) |
 | `PUBLIC_WWW_BASE_URL` | HTTPS origin of the public website (Contact Us FAQ anchor in contact confirmation templates: `/{locale}/contact-us#contact-us-faq`) |
@@ -376,6 +405,8 @@ SQS retries or mailbox forwarding duplicates.
 | `ExpenseParserTopicArn` | SNS topic ARN for expense parser events |
 | `ExpenseParserQueueUrl` | SQS queue URL for expense parser processing |
 | `ExpenseParserDLQUrl` | Dead letter queue URL for failed expense parser jobs |
+| `BulkExpenseImportQueueUrl` | SQS queue URL for async bulk combined-PDF imports |
+| `BulkExpenseImportDLQUrl` | Dead letter queue URL for failed bulk import jobs |
 | `EventbriteSyncTopicArn` | SNS topic ARN for Eventbrite sync events |
 | `EventbriteSyncQueueUrl` | SQS queue URL for Eventbrite sync processing |
 | `EventbriteSyncDLQUrl` | Dead letter queue URL for failed Eventbrite sync jobs (SQS redrive) |

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -262,6 +262,26 @@ Constraints and indexes:
   `expenses_vendor_idx`
 - `set_updated_at()` trigger updates `updated_at` on write
 
+## Table: bulk_expense_import_jobs
+
+Purpose: Tracks asynchronous combined-PDF bulk imports (OpenRouter extraction + expense creation).
+
+Columns:
+- `id` (UUID, PK, default `gen_random_uuid()`)
+- `created_by` (text, required) — Cognito `sub` of the admin who queued the job
+- `attachment_asset_id` (UUID, FK → `assets.id`, cascade delete)
+- `default_vendor_id` (UUID, FK → `organizations.id`, restrict delete)
+- `expense_status` (enum `expense_status`, required) — `draft` or `submitted` rows created from parsed data
+- `status` (varchar(32), required) — `pending | processing | succeeded | failed`
+- `error_message` (text, optional)
+- `created_expense_ids` (jsonb, optional) — ordered UUID strings for created expenses
+- `created_count` (integer, optional)
+- `created_at` / `updated_at` (timestamptz, default `timezone('utc', now())`)
+
+Indexes:
+- `ix_bulk_expense_import_jobs_created_by` on `created_by`
+- `ix_bulk_expense_import_jobs_status` on `status`
+
 ## Table: expense_attachments
 
 Purpose: Links each expense record to one or more uploaded assets.

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -272,7 +272,7 @@ Columns:
 - `attachment_asset_id` (UUID, FK → `assets.id`, cascade delete)
 - `default_vendor_id` (UUID, FK → `organizations.id`, restrict delete)
 - `expense_status` (enum `expense_status`, required) — `draft` or `submitted` rows created from parsed data
-- `status` (varchar(32), required) — `pending | processing | succeeded | failed`
+- `status` (varchar(32), required) — `pending | processing | succeeded | succeeded_with_errors | failed`
 - `error_message` (text, optional)
 - `created_expense_ids` (jsonb, optional) — ordered UUID strings for created expenses
 - `created_count` (integer, optional)

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -111,9 +111,10 @@ their primary responsibilities.
   effective discount type after the update is `referral`, otherwise `discount_value`
   must be greater than `0`),
   `/v1/admin/expenses/*` (including `POST /v1/admin/expenses/import-from-bulk-pdf`, which
-  reads a single uploaded PDF asset from S3, calls OpenRouter via `AwsApiProxyFunction`
-  with the same PDF plugin stack as `ExpenseParserFunction`, and creates one submitted
-  expense per parsed row sharing that attachment),
+  validates a single uploaded PDF asset, writes a `bulk_expense_import_jobs` row,
+  enqueues `evolvesprouts-bulk-expense-import-queue`, and returns **202** with a job id;
+  `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` polls job status until `BulkExpenseImportFunction`
+  finishes OpenRouter bulk extraction and creates one expense per parsed row sharing that attachment),
   `/v1/admin/billing/*` (customer AR: `GET /v1/admin/billing/payments` optional `invoice_id` filters to payments with an allocation to that invoice; `GET /v1/admin/billing/payments/{id}` includes `allocationInvoices` and `orphanPaymentDeletable`; `DELETE /v1/admin/billing/payments/{id}` removes eligible orphan inbound payments (pending or free/zero, enrollment unlinked or cancelled, no allocations/receipt/refund children); payments, invoices list/detail, draft invoices via
   `POST /v1/admin/billing/invoices` with `draftKind` `enrollment_merge` or `customized_manual`,
   `GET /v1/admin/billing/enrollments/recent-for-invoicing` (draft invoice enrollment picker: non-cancelled rows with `enrolled_at` within the last 730 rolling days), `DELETE /v1/admin/billing/invoices/{id}` (draft-only permanent delete; blocked when allocations exist), `GET /v1/admin/billing/invoices/{id}/pdf`
@@ -481,6 +482,26 @@ their primary responsibilities.
 - VPC: Yes
 - Permissions: S3 read for the assets bucket, Secrets Manager read for OpenRouter key,
   Lambda invoke permission for `AwsApiProxyFunction`
+- Environment:
+  - `DATABASE_SECRET_ARN`, `DATABASE_NAME`, `DATABASE_USERNAME`,
+    `DATABASE_PROXY_ENDPOINT`, `DATABASE_IAM_AUTH`
+  - `ASSETS_BUCKET_NAME`
+  - `OPENROUTER_API_KEY_SECRET_ARN`, `OPENROUTER_CHAT_COMPLETIONS_URL`,
+    `OPENROUTER_MODEL`, `OPENROUTER_MAX_FILE_BYTES`
+  - `AWS_PROXY_FUNCTION_ARN`
+
+### Bulk expense import processor
+- Function: BulkExpenseImportFunction
+- Handler: backend/lambda/bulk_expense_import/handler.py
+- Stack: nested stack `evolvesprouts-Messaging`
+- Trigger: SQS queue (`evolvesprouts-bulk-expense-import-queue`) with plain JSON bodies
+  `{ "job_id": "<uuid>" }` (not SNS-wrapped)
+- Purpose: run long-running OpenRouter **bulk** extraction for combined PDF imports
+  queued by `POST /v1/admin/expenses/import-from-bulk-pdf`, then create expenses and
+  mark the `bulk_expense_import_jobs` row `succeeded` or `failed`
+- DB access: RDS Proxy with IAM auth (`evolvesprouts_admin`)
+- VPC: Yes
+- Permissions: same OpenRouter + S3 + proxy invoke pattern as `ExpenseParserFunction`
 - Environment:
   - `DATABASE_SECRET_ARN`, `DATABASE_NAME`, `DATABASE_USERNAME`,
     `DATABASE_PROXY_ENDPOINT`, `DATABASE_IAM_AUTH`

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -110,11 +110,13 @@ their primary responsibilities.
   case-insensitive unique index; `PUT` accepts `discount_value` `0` only when the
   effective discount type after the update is `referral`, otherwise `discount_value`
   must be greater than `0`),
-  `/v1/admin/expenses/*` (including `POST /v1/admin/expenses/import-from-bulk-pdf`, which
-  validates a single uploaded PDF asset, writes a `bulk_expense_import_jobs` row,
-  enqueues `evolvesprouts-bulk-expense-import-queue`, and returns **202** with a job id;
-  `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` polls job status until `BulkExpenseImportFunction`
-  finishes OpenRouter bulk extraction and creates one expense per parsed row sharing that attachment),
+  `/v1/admin/expenses/*`, including:
+  - `POST /v1/admin/expenses/import-from-bulk-pdf` — validates a single uploaded PDF asset,
+    writes a `bulk_expense_import_jobs` row, enqueues `evolvesprouts-bulk-expense-import-queue`,
+    and returns **202** with a job id.
+  - `GET /v1/admin/expenses/bulk-import-jobs` — creator-scoped list of recent bulk-import jobs.
+  - `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` — polls job status until `BulkExpenseImportFunction`
+    finishes OpenRouter bulk extraction and creates one expense per parsed row (sharing that attachment).
   `/v1/admin/billing/*` (customer AR: `GET /v1/admin/billing/payments` optional `invoice_id` filters to payments with an allocation to that invoice; `GET /v1/admin/billing/payments/{id}` includes `allocationInvoices` and `orphanPaymentDeletable`; `DELETE /v1/admin/billing/payments/{id}` removes eligible orphan inbound payments (pending or free/zero, enrollment unlinked or cancelled, no allocations/receipt/refund children); payments, invoices list/detail, draft invoices via
   `POST /v1/admin/billing/invoices` with `draftKind` `enrollment_merge` or `customized_manual`,
   `GET /v1/admin/billing/enrollments/recent-for-invoicing` (draft invoice enrollment picker: non-cancelled rows with `enrolled_at` within the last 730 rolling days), `DELETE /v1/admin/billing/invoices/{id}` (draft-only permanent delete; blocked when allocations exist), `GET /v1/admin/billing/invoices/{id}/pdf`
@@ -498,11 +500,14 @@ their primary responsibilities.
   `{ "job_id": "<uuid>" }` (not SNS-wrapped)
 - Purpose: run long-running OpenRouter **bulk** extraction for combined PDF imports
   queued by `POST /v1/admin/expenses/import-from-bulk-pdf`, then create expenses and
-  mark the `bulk_expense_import_jobs` row `succeeded` or `failed`
+  mark the `bulk_expense_import_jobs` row `succeeded`, `succeeded_with_errors`, or `failed`
 - DB access: RDS Proxy with IAM auth (`evolvesprouts_admin`)
 - VPC: Yes
 - Permissions: same OpenRouter + S3 + proxy invoke pattern as `ExpenseParserFunction`
+- Timeout / budget: **600s** Lambda timeout with **720s** SQS visibility; OpenRouter bulk
+  calls cap at **240s** so DB writes stay inside the Lambda window
 - Environment:
+  - `BULK_IMPORT_LAMBDA_TIMEOUT_SECONDS` (mirrors Lambda timeout for stale `processing` handling)
   - `DATABASE_SECRET_ARN`, `DATABASE_NAME`, `DATABASE_USERNAME`,
     `DATABASE_PROXY_ENDPOINT`, `DATABASE_IAM_AUTH`
   - `ASSETS_BUCKET_NAME`

--- a/tests/test_bulk_expense_import_events.py
+++ b/tests/test_bulk_expense_import_events.py
@@ -1,0 +1,37 @@
+"""Tests for bulk expense import SQS enqueue."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.exceptions import ValidationError
+from app.services.bulk_expense_import_events import enqueue_bulk_expense_import_job
+
+
+def test_enqueue_bulk_expense_import_requires_queue_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BULK_EXPENSE_IMPORT_QUEUE_URL", raising=False)
+    with pytest.raises(ValidationError, match="queue is not configured"):
+        enqueue_bulk_expense_import_job(uuid4())
+
+
+def test_enqueue_bulk_expense_import_sends_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BULK_EXPENSE_IMPORT_QUEUE_URL", "https://sqs.example.com/123/q")
+    sent: dict = {}
+
+    class _FakeSqs:
+        def send_message(self, **kwargs: object) -> None:
+            sent.update(kwargs)
+
+    monkeypatch.setattr(
+        "app.services.bulk_expense_import_events.get_sqs_client", lambda: _FakeSqs()
+    )
+    job_id = uuid4()
+    enqueue_bulk_expense_import_job(job_id)
+    assert sent.get("QueueUrl") == "https://sqs.example.com/123/q"
+    body = sent.get("MessageBody")
+    assert isinstance(body, str)
+    assert str(job_id) in body

--- a/tests/test_bulk_expense_import_runner.py
+++ b/tests/test_bulk_expense_import_runner.py
@@ -1,0 +1,15 @@
+"""Tests for bulk expense import worker helpers."""
+
+from __future__ import annotations
+
+from app.services.bulk_expense_import_runner import sanitize_bulk_import_error_message
+
+
+def test_sanitize_bulk_import_error_message_non_empty() -> None:
+    out = sanitize_bulk_import_error_message("Something went wrong with vendor@example.com")
+    assert out.endswith("***")
+    assert len(out) <= 8000
+
+
+def test_sanitize_bulk_import_error_message_empty_defaults() -> None:
+    assert sanitize_bulk_import_error_message("") == "An error occurred."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the bulk async import review items: post-enqueue asset cleanup (data safety), stuck `processing` jobs after Lambda death, audit context on all job transitions, partial row success with `succeeded_with_errors`, masked `error_message` for PII, clearer failure text, creator-scoped **GET** `/v1/admin/expenses/bulk-import-jobs`, `ExpenseRepository.get_many_with_attachments` to remove N+1 loads, shared `assert_pdf_asset` validation, longer Lambda (600s) + SQS visibility (720s) with documented OpenRouter cap (240s), SQS dedup/idempotency notes, repository import order, cancellable client polling + Finance jobs table (PaginatedTableCard pattern), optional `status` on import POST for retries, docs/OpenAPI updates, and focused pytest coverage for enqueue + error sanitization.

## Testing

- `pytest tests/test_bulk_expense_import_events.py tests/test_bulk_expense_import_runner.py tests/test_admin_expenses_delete_draft.py`
- `cd apps/admin_web && npm run lint`
- `npm run generate:admin-api-types` / `npm run check:admin-api-types`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c759f7b4-d982-46ac-a882-d1dd0b983996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c759f7b4-d982-46ac-a882-d1dd0b983996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

