### PR TITLE
Admin web: void before delete on customer invoice operations

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1576,6 +1576,19 @@ export function ClientInvoicesPanel() {
                           )}
                         </Button>
                       ) : null}
+                      {inv.status !== 'void' ? (
+                        <Button
+                          type='button'
+                          size='sm'
+                          variant='danger'
+                          disabled={editorBusy || deleteDraftDialogOpen || voidDialogOpen || !id}
+                          onClick={() => openVoidInvoiceDialog(id)}
+                          aria-label='Void invoice'
+                          title='Void invoice'
+                        >
+                          <VoidExpenseIcon className='h-4 w-4' aria-hidden />
+                        </Button>
+                      ) : null}
                       {inv.status === 'draft' ? (
                         <Button
                           type='button'
@@ -1595,19 +1608,6 @@ export function ClientInvoicesPanel() {
                           ) : (
                             <DeleteIcon className='h-4 w-4' aria-hidden />
                           )}
-                        </Button>
-                      ) : null}
-                      {inv.status !== 'void' ? (
-                        <Button
-                          type='button'
-                          size='sm'
-                          variant='danger'
-                          disabled={editorBusy || deleteDraftDialogOpen || voidDialogOpen || !id}
-                          onClick={() => openVoidInvoiceDialog(id)}
-                          aria-label='Void invoice'
-                          title='Void invoice'
-                        >
-                          <VoidExpenseIcon className='h-4 w-4' aria-hidden />
                         </Button>
                       ) : null}
                     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In **Finance → Customer invoices**, the Operations column for draft rows now shows **Void invoice** before **Delete draft invoice**, so the reversible void action appears ahead of permanent draft deletion.

## Testing

- `npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx`
- `npm run lint` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7defb220-9394-4c2c-af23-27ab15cf2787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7defb220-9394-4c2c-af23-27ab15cf2787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

