### PR TITLE
Enrollment-merge invoice lines: service title + instance title when distinct

### DIFF
--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -63,17 +63,26 @@ def _capitalize_first_letter(value: str) -> str:
 def _build_enrollment_merge_line_description(enrollment: Enrollment) -> str:
     """Line text for enrollment-merge invoices: title, tier, and cohort space-separated.
 
-    Title prefers instance title, then parent service title. Tier prefers enrollment ticket
-    tier name, then catalog ``service_tier``. Tier and cohort segments use a leading
-    capital letter only (rest unchanged). Falls back to ``Enrollment`` when no title path exists.
+    Title uses ``{service title}: {instance title}`` when both are present and differ;
+    otherwise a single title (instance, or service, whichever applies). Tier prefers
+    enrollment ticket tier name, then catalog ``service_tier``. Tier and cohort segments
+    use a leading capital letter only (rest unchanged). Falls back to ``Enrollment`` when
+    no title path exists.
     """
     inst = enrollment.instance
-    title_part: str | None = None
     svc = getattr(inst, "service", None) if inst is not None else None
-    if inst is not None:
-        title_part = _trimmed_str_or_none(inst.title)
-    if title_part is None and svc is not None:
-        title_part = _trimmed_str_or_none(getattr(svc, "title", None))
+    instance_title = _trimmed_str_or_none(inst.title) if inst is not None else None
+    service_title = (
+        _trimmed_str_or_none(getattr(svc, "title", None)) if svc is not None else None
+    )
+
+    title_part: str | None = None
+    if instance_title and service_title and instance_title != service_title:
+        title_part = f"{service_title}: {instance_title}"
+    elif instance_title:
+        title_part = instance_title
+    elif service_title:
+        title_part = service_title
 
     tier_raw: str | None = None
     if enrollment.ticket_tier_id and enrollment.ticket_tier is not None:

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -2645,7 +2645,43 @@ def test_build_enrollment_merge_line_description_prefers_instance_title_and_tick
     )
     assert (
         _build_enrollment_merge_line_description(en)  # type: ignore[arg-type]
-        == "June Weekend Early bird"
+        == "Event Parent: June Weekend Early bird"
+    )
+
+
+def test_build_enrollment_merge_line_description_same_instance_and_service_title() -> None:
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _build_enrollment_merge_line_description,
+    )
+
+    svc = SimpleNamespace(title="Holiday Workshop", service_tier="standard")
+    inst = SimpleNamespace(title="Holiday Workshop", cohort="week 1", service=svc)
+    en = SimpleNamespace(
+        instance=inst,
+        ticket_tier_id=None,
+        ticket_tier=None,
+    )
+    assert (
+        _build_enrollment_merge_line_description(en)  # type: ignore[arg-type]
+        == "Holiday Workshop Standard Week 1"
+    )
+
+
+def test_build_enrollment_merge_line_description_instance_title_without_service_title() -> None:
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _build_enrollment_merge_line_description,
+    )
+
+    svc = SimpleNamespace(title=None, service_tier="solo")
+    inst = SimpleNamespace(title="Drop-in Session", cohort=None, service=svc)
+    en = SimpleNamespace(
+        instance=inst,
+        ticket_tier_id=None,
+        ticket_tier=None,
+    )
+    assert (
+        _build_enrollment_merge_line_description(en)  # type: ignore[arg-type]
+        == "Drop-in Session Solo"
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `_build_enrollment_merge_line_description` so enrollment-merge draft invoice lines combine titles when appropriate:

- If both **service** and **instance** titles are present and **not equal**, the description title segment is `{service title}: {instance title}` (colon + space, matching the stated example format).
- If they are **identical**, or only one side is set, a **single** title is used (no duplication).
- Tier and cohort suffix behavior is unchanged.

## Tests

- Adjusted the existing ticket-tier case to expect the combined title.
- Added coverage for identical service/instance titles and for an instance title when the service title is absent.

## Notes

Existing issued invoices are unchanged; only **new** enrollment-merge drafts get the new text. Customized manual drafts still use admin-supplied descriptions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16f146f1-a019-45b5-b31b-4749792c8691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16f146f1-a019-45b5-b31b-4749792c8691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

