### PR TITLE
Invoice numbers: INV-YYYY-NNNNNN without currency suffix

### DIFF
--- a/backend/src/app/api/admin_billing_invoices.py
+++ b/backend/src/app/api/admin_billing_invoices.py
@@ -123,7 +123,7 @@ def _issue_invoice(
         _resolve_bill_to_party_from_invoice_fks(session, inv=inv)
         inv.bill_to_snapshot = _build_bill_to_snapshot(session, inv)
 
-        num, seq = next_invoice_number(session, currency=inv.currency)
+        num, seq = next_invoice_number(session)
         inv.invoice_number = num
         inv.invoice_sequence = seq
         inv.status = BillingInvoiceStatus.ISSUED

--- a/backend/src/app/services/customer_billing.py
+++ b/backend/src/app/services/customer_billing.py
@@ -60,11 +60,11 @@ def store_pdf_in_assets_bucket(*, s3_key: str, body: bytes, content_type: str) -
     )
 
 
-def next_invoice_number(session: Session, *, currency: str) -> tuple[str, int]:
-    """Atomically allocate next invoice number (counter per currency scope + year)."""
+def next_invoice_number(session: Session) -> tuple[str, int]:
+    """Atomically allocate next invoice number (one counter per calendar year, UTC)."""
     now = datetime.now(UTC)
     year = now.year
-    scope_key = f"inv-{currency.upper()}"
+    scope_key = _SCOPE_DEFAULT
     session.execute(
         text(
             """
@@ -84,7 +84,7 @@ def next_invoice_number(session: Session, *, currency: str) -> tuple[str, int]:
     ).scalar_one()
     row.last_number += 1
     seq = row.last_number
-    inv_num = f"INV-{year}-{seq:06d}-{currency.upper()}"
+    inv_num = f"INV-{year}-{seq:06d}"
     session.flush()
     return inv_num, seq
 

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -638,7 +638,8 @@ Migration `0055_customer_billing_ar` introduces:
   **`payment_unapplied_amount`** sums allocations **matching the parent payment's currency** only
   (one currency per payment; multi-currency allocation is not supported).
 - `customer_receipts`: one row per succeeded inbound payment (`customer_payment_id` unique).
-- `document_counters`: serialized invoice/receipt numbering per scope and year.
+- `document_counters`: serialized numbering per scope and year; **invoices** use one
+  global sequence per year (`INV-YYYY-NNNNNN`), while **receipts** keep a per-currency scope.
 - Audit: same `audit_trigger_func()` as `0054_add_audit_log` on all five billing tables.
 - Migration `0057_invoice_dates_snapshot` adds nullable `invoice_date` and `due_date`
   on `customer_invoices`. Drafts persist `invoice_date` at creation (defaulting to today in

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -131,7 +131,7 @@ def test_payment_unapplied_amount_subtracts_allocations() -> None:
     assert customer_billing.payment_unapplied_amount(session, pid) == Decimal("65")
 
 
-def test_next_invoice_number_increments_per_currency_year(
+def test_next_invoice_number_increments_per_year(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _CounterRow:
@@ -148,11 +148,11 @@ def test_next_invoice_number_increments_per_currency_year(
 
     session = MagicMock()
     session.execute.side_effect = _exec
-    num, seq = customer_billing.next_invoice_number(session, currency="hkd")
+    num, seq = customer_billing.next_invoice_number(session)
     assert seq == 1
     assert row.last_number == 1
     assert num.startswith("INV-")
-    assert num.endswith("-HKD")
+    assert num.count("-") == 2
     assert n_calls["n"] == 2
 
 
@@ -2345,7 +2345,7 @@ def test_issue_preserves_draft_invoice_date_and_derives_due_date(
     monkeypatch.setattr(
         admin_billing_invoices_mod,
         "next_invoice_number",
-        lambda _session, currency: ("INV-TEST-1", 1),
+        lambda _session: ("INV-TEST-1", 1),
     )
     monkeypatch.setattr(admin_billing_invoices_mod, "refresh_invoice_pdf", lambda *_a, **_k: None)
     monkeypatch.setattr(
@@ -2430,7 +2430,7 @@ def test_issue_legacy_draft_without_invoice_date_uses_snapshot(
     monkeypatch.setattr(
         admin_billing_invoices_mod,
         "next_invoice_number",
-        lambda _session, currency: ("INV-TEST-2", 2),
+        lambda _session: ("INV-TEST-2", 2),
     )
     monkeypatch.setattr(admin_billing_invoices_mod, "refresh_invoice_pdf", lambda *_a, **_k: None)
     monkeypatch.setattr(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issued customer invoices now get numbers in the form **`INV-{year}-{6-digit-sequence}`** (for example `INV-2026-000042`) with no trailing currency code.

## Implementation

- `next_invoice_number` allocates from a **single per-calendar-year counter** (UTC) using `document_counters` scope `default` for `document_type=invoice`, so numbers stay unique across currencies under the existing unique index on `invoice_number`.
- Receipt numbering is unchanged (still per currency).

## Docs / tests

- Architecture database notes updated for `document_counters` behavior.
- Billing unit tests updated for the new signature and format.

## Deploy note

Existing per-currency counter rows (`inv-HKD`, etc.) are left in place but unused; new issues start a fresh sequence for the new format in each year.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ef40ac9-53e3-4c70-b071-be6beefa77a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ef40ac9-53e3-4c70-b071-be6beefa77a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

