### PR TITLE
Align contacts table min-width with families

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -943,7 +943,7 @@ export function ContactsPanel({
           </AdminTableToolbar>
         }
       >
-        <AdminDataTable tableClassName='min-w-[960px]'>
+        <AdminDataTable tableClassName='min-w-[720px]'>
           <AdminDataTableHead>
             <tr>
               <AdminDataTableHeadCell>Name</AdminDataTableHeadCell>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The contacts listing `AdminDataTable` used `min-w-[960px]` while the families listing used `min-w-[720px]`, which made the contacts table appear wider in the same layout. This change sets the contacts table minimum width to `min-w-[720px]` to match families.

**Testing:** `cd apps/admin_web && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e0d8a1c-be02-49df-adac-4efafb2109dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e0d8a1c-be02-49df-adac-4efafb2109dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

