### PR TITLE
fix(finance): show readable bulk PDF import error messages

### DIFF
--- a/backend/src/app/services/bulk_expense_import_runner.py
+++ b/backend/src/app/services/bulk_expense_import_runner.py
@@ -9,6 +9,7 @@ job status updates without racing the Lambda hard timeout.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
@@ -31,11 +32,14 @@ from app.services.bulk_expense_import_common import (
 from app.services.openrouter_expense_parser import (
     parse_bulk_expense_invoices_from_assets,
 )
-from app.utils.logging import get_logger, mask_pii
+from app.utils.logging import get_logger, mask_email
 
 logger = get_logger(__name__)
 
 _OPENROUTER_TIMEOUT_SECONDS = 240
+
+# Likely email addresses embedded in free-text error messages (admin API only).
+_EMAIL_IN_TEXT_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 
 
 def _lambda_timeout_seconds() -> int:
@@ -52,14 +56,25 @@ def _processing_stale_threshold() -> timedelta:
     return timedelta(seconds=sec)
 
 
+def _redact_emails_in_bulk_import_message(text: str) -> str:
+    def _sub(match: re.Match[str]) -> str:
+        return mask_email(match.group(0))
+
+    return _EMAIL_IN_TEXT_RE.sub(_sub, text)
+
+
 def sanitize_bulk_import_error_message(message: str) -> str:
-    """Redact persisted/API-facing bulk-import error text."""
+    """Redact persisted/API-facing bulk-import error text.
+
+    Masks embedded email addresses while preserving technical detail (for example
+    ``RuntimeError`` messages) so operators can diagnose parser failures.
+    """
     trimmed = (message or "").strip()
     if not trimmed:
         return "An error occurred."
     if len(trimmed) > 8000:
         trimmed = trimmed[:8000]
-    return mask_pii(trimmed, visible_chars=4)
+    return _redact_emails_in_bulk_import_message(trimmed)
 
 
 @dataclass(frozen=True)

--- a/tests/test_bulk_expense_import_runner.py
+++ b/tests/test_bulk_expense_import_runner.py
@@ -6,9 +6,18 @@ from app.services.bulk_expense_import_runner import sanitize_bulk_import_error_m
 
 
 def test_sanitize_bulk_import_error_message_non_empty() -> None:
-    out = sanitize_bulk_import_error_message("Something went wrong with vendor@example.com")
-    assert out.endswith("***")
+    out = sanitize_bulk_import_error_message(
+        "Something went wrong with vendor@example.com"
+    )
+    assert "Something went wrong with " in out
+    assert "vendor@example.com" not in out
     assert len(out) <= 8000
+
+
+def test_sanitize_bulk_import_error_message_preserves_runtime_detail() -> None:
+    raw = "RuntimeError('Parser returned no invoice rows')"
+    out = sanitize_bulk_import_error_message(raw)
+    assert out == raw
 
 
 def test_sanitize_bulk_import_error_message_empty_defaults() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bulk combined-PDF expense import failures were shown in the admin UI as **`Runt***`** (and similar). That was not a mysterious new exception type: **`sanitize_bulk_import_error_message`** applied **`mask_pii()`** to the **entire** error string, which only keeps the first four characters and appends `***`.

So a message like `RuntimeError('Parser returned no invoice rows')` became **`Runt***`**.

## Changes

- **`sanitize_bulk_import_error_message`** now **redacts embedded email addresses** with **`mask_email()`** via a regex, and **preserves the rest** of the message (still capped at 8000 characters).
- Tests updated to assert email redaction without destroying technical detail, plus a regression test for `RuntimeError(...)` text.

## Notes for operators

After this ships, the same underlying failure should read clearly—for example **`Parser returned no invoice rows`** when the model returns no `invoices` array from the combined PDF. Fixing that behavior is separate (prompt/model/PDF quality); this PR only fixes misleading UI/API error text.

## Validation

- `pytest tests/test_bulk_expense_import_runner.py`
- `pre-commit run ruff-format` on touched files
- `ruff check` on touched files
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-700ccb4c-3695-41a9-a1e3-356524eacef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-700ccb4c-3695-41a9-a1e3-356524eacef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

