### PR TITLE
Encode PublicWwwConfigSecret with Fn::ToJsonString to escape multi-li…

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -216,6 +216,14 @@ export class ApiStack extends cdk.Stack {
     cdk.Tags.of(this).add("Organization", "Evolve Sprouts");
     cdk.Tags.of(this).add("Project", "Backend");
 
+    // Required for `cdk.Fn.toJsonString(...)` used by PublicWwwConfigSecret.
+    // Without this transform, CFN would substitute parameter values verbatim
+    // into the SecretString via Fn::Join — multi-line values (for example
+    // PUBLIC_WWW_BUSINESS_ADDRESS containing "\r\n") would produce invalid
+    // JSON, the Lambda's json.loads() would fail, and PUBLIC_WWW_* lookups
+    // would silently fall back to defaults.
+    this.addTransform("AWS::LanguageExtensions");
+
     const resourcePrefix = "evolvesprouts";
     const name = (suffix: string) => `${resourcePrefix}-${suffix}`;
     /** production | staging — gates SES/Mailchimp/SNS in app code; override via CDK_DEPLOYMENT_STAGE for non-prod stacks. */
@@ -1810,6 +1818,40 @@ export class ApiStack extends cdk.Stack {
     // 4 KB AWS limit. Lambdas read the secret via the existing Secrets
     // Manager VPC interface endpoint and a 5-minute in-process cache, so the
     // cold-start overhead is bounded and there is no new VPC infrastructure.
+    //
+    // The SecretString is built with `Fn::ToJsonString` (enabled by the
+    // AWS::LanguageExtensions transform on this stack). This is required:
+    // CDK's `secretObjectValue` and naked `cdk.Fn.toJsonString` on a plain
+    // object both fall back to `Fn::Join` and substitute CFN parameter
+    // values verbatim — multi-line values (for example
+    // `PUBLIC_WWW_BUSINESS_ADDRESS` containing literal CRLF) would then
+    // produce invalid JSON and break every consumer. Wrapping the payload
+    // in `cdk.Lazy.any({...})` keeps the whole object an unresolved token,
+    // which CDK then emits as a real `Fn::ToJsonString` intrinsic that
+    // properly escapes embedded newlines, quotes, and backslashes at
+    // deploy time.
+    const publicWwwConfigPayload = cdk.Fn.toJsonString(
+      cdk.Lazy.any({
+        produce: () => ({
+          BASE_URL: `https://${publicWwwDomainName.valueAsString}`,
+          STAGING_SITE_ORIGIN: `https://${publicWwwStagingDomainName.valueAsString}`,
+          INSTAGRAM_URL: publicWwwInstagramUrl.valueAsString,
+          LINKEDIN_URL: publicWwwLinkedinUrl.valueAsString,
+          WHATSAPP_URL: publicWwwWhatsappUrl.valueAsString,
+          BUSINESS_PHONE_NUMBER: publicWwwBusinessPhoneNumber.valueAsString,
+          BILLING_EMAIL: publicWwwBillingEmail.valueAsString,
+          BUSINESS_NAME: publicWwwBusinessName.valueAsString,
+          BUSINESS_LEGAL_NAME: publicWwwBusinessLegalName.valueAsString,
+          BUSINESS_ADDRESS: publicWwwBusinessAddress.valueAsString,
+          BUSINESS_REGISTRATION: publicWwwBusinessRegistration.valueAsString,
+          BANK_NAME: publicWwwBankName.valueAsString,
+          BANK_ACCOUNT_HOLDER: publicWwwBankAccountHolder.valueAsString,
+          BANK_ACCOUNT_NUMBER: publicWwwBankAccountNumber.valueAsString,
+          FPS_MERCHANT_NAME: publicWwwFpsMerchantName.valueAsString,
+          FPS_MOBILE_NUMBER: publicWwwFpsMobileNumber.valueAsString,
+        }),
+      })
+    );
     const publicWwwConfigSecret = new secretsmanager.Secret(
       this,
       "PublicWwwConfigSecret",
@@ -1822,56 +1864,9 @@ export class ApiStack extends cdk.Stack {
           "are packed here to keep the admin Lambda environment-variable " +
           "string under AWS's 4 KB limit.",
         encryptionKey: secretsEncryptionKey,
-        secretObjectValue: {
-          BASE_URL: cdk.SecretValue.unsafePlainText(
-            `https://${publicWwwDomainName.valueAsString}`
-          ),
-          STAGING_SITE_ORIGIN: cdk.SecretValue.unsafePlainText(
-            `https://${publicWwwStagingDomainName.valueAsString}`
-          ),
-          INSTAGRAM_URL: cdk.SecretValue.unsafePlainText(
-            publicWwwInstagramUrl.valueAsString
-          ),
-          LINKEDIN_URL: cdk.SecretValue.unsafePlainText(
-            publicWwwLinkedinUrl.valueAsString
-          ),
-          WHATSAPP_URL: cdk.SecretValue.unsafePlainText(
-            publicWwwWhatsappUrl.valueAsString
-          ),
-          BUSINESS_PHONE_NUMBER: cdk.SecretValue.unsafePlainText(
-            publicWwwBusinessPhoneNumber.valueAsString
-          ),
-          BILLING_EMAIL: cdk.SecretValue.unsafePlainText(
-            publicWwwBillingEmail.valueAsString
-          ),
-          BUSINESS_NAME: cdk.SecretValue.unsafePlainText(
-            publicWwwBusinessName.valueAsString
-          ),
-          BUSINESS_LEGAL_NAME: cdk.SecretValue.unsafePlainText(
-            publicWwwBusinessLegalName.valueAsString
-          ),
-          BUSINESS_ADDRESS: cdk.SecretValue.unsafePlainText(
-            publicWwwBusinessAddress.valueAsString
-          ),
-          BUSINESS_REGISTRATION: cdk.SecretValue.unsafePlainText(
-            publicWwwBusinessRegistration.valueAsString
-          ),
-          BANK_NAME: cdk.SecretValue.unsafePlainText(
-            publicWwwBankName.valueAsString
-          ),
-          BANK_ACCOUNT_HOLDER: cdk.SecretValue.unsafePlainText(
-            publicWwwBankAccountHolder.valueAsString
-          ),
-          BANK_ACCOUNT_NUMBER: cdk.SecretValue.unsafePlainText(
-            publicWwwBankAccountNumber.valueAsString
-          ),
-          FPS_MERCHANT_NAME: cdk.SecretValue.unsafePlainText(
-            publicWwwFpsMerchantName.valueAsString
-          ),
-          FPS_MOBILE_NUMBER: cdk.SecretValue.unsafePlainText(
-            publicWwwFpsMobileNumber.valueAsString
-          ),
-        },
+        secretStringValue: cdk.SecretValue.unsafePlainText(
+          publicWwwConfigPayload
+        ),
       }
     );
     publicWwwConfigSecret.grantRead(adminFunction);

--- a/backend/infrastructure/package.json
+++ b/backend/infrastructure/package.json
@@ -9,7 +9,7 @@
     "cdk": "cdk",
     "synth": "cdk synth",
     "deploy": "cdk deploy",
-    "test:infra": "ts-node --prefer-ts-exts scripts/assert-existing-db.ts && ts-node --prefer-ts-exts test/public-www-stack.test.ts && ts-node --prefer-ts-exts test/api-stack.test.ts && ts-node --prefer-ts-exts test/admin-env-size.test.ts",
+    "test:infra": "ts-node --prefer-ts-exts scripts/assert-existing-db.ts && ts-node --prefer-ts-exts test/public-www-stack.test.ts && ts-node --prefer-ts-exts test/api-stack.test.ts && ts-node --prefer-ts-exts test/admin-env-size.test.ts && ts-node --prefer-ts-exts test/public-www-config-secret.test.ts",
     "test:admin-web-stack": "ts-node --prefer-ts-exts test/admin-web-stack.test.ts",
     "postinstall": "node scripts/patch-bundled-aws-cdk-lib-deps.js"
   },

--- a/backend/infrastructure/test/public-www-config-secret.test.ts
+++ b/backend/infrastructure/test/public-www-config-secret.test.ts
@@ -1,0 +1,71 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+
+import { ApiStack } from "../lib/api-stack";
+
+/**
+ * Guards the JSON encoding of the PublicWwwConfig secret.
+ *
+ * `secretObjectValue` and naked `cdk.Fn.toJsonString` on a plain JS object
+ * both fall back to `Fn::Join`, which substitutes CFN parameter values
+ * verbatim with no JSON escaping. That breaks any value containing
+ * newlines (`PUBLIC_WWW_BUSINESS_ADDRESS`), double quotes, or backslashes:
+ * the resulting SecretString is invalid JSON, `json.loads` in
+ * `app.config.public_www` fails, and every PUBLIC_WWW_* lookup silently
+ * falls back to defaults — the symptom that broke the AR invoice PDF when
+ * this stack was first deployed.
+ *
+ * The fix is to wrap the payload in `cdk.Lazy.any({...})` so CDK emits a
+ * real `Fn::ToJsonString` intrinsic (enabled by the `AWS::LanguageExtensions`
+ * transform on the stack), which CloudFormation evaluates server-side
+ * with proper JSON escaping for embedded newlines / quotes / backslashes.
+ *
+ * This test asserts both invariants so a regression cannot reach
+ * production unnoticed.
+ */
+function synth(): Template {
+  const app = new cdk.App();
+  const stack = new ApiStack(app, "TestApi", {
+    env: { account: "111111111111", region: "ap-southeast-1" },
+  });
+  return Template.fromStack(stack);
+}
+
+const template = synth();
+const stackJson = template.toJSON() as Record<string, unknown>;
+const transform = stackJson.Transform;
+const transforms = Array.isArray(transform) ? transform : [transform];
+if (!transforms.includes("AWS::LanguageExtensions")) {
+  throw new Error(
+    `ApiStack must declare the AWS::LanguageExtensions transform so ` +
+      `Fn::ToJsonString resolves at deploy time; got ${JSON.stringify(transform)}`,
+  );
+}
+
+const secrets = template.findResources("AWS::SecretsManager::Secret", {
+  Properties: { Name: "evolvesprouts-public-www-config" },
+});
+const entries = Object.entries(secrets);
+if (entries.length !== 1) {
+  throw new Error(
+    `Expected exactly 1 evolvesprouts-public-www-config secret; found ${entries.length}`,
+  );
+}
+const [, resource] = entries[0];
+const secretString = (
+  resource.Properties as { SecretString?: unknown }
+).SecretString;
+const looksLikeFnToJsonString =
+  secretString !== null &&
+  typeof secretString === "object" &&
+  Object.prototype.hasOwnProperty.call(secretString, "Fn::ToJsonString");
+if (!looksLikeFnToJsonString) {
+  throw new Error(
+    "PublicWwwConfigSecret must use Fn::ToJsonString so multi-line / " +
+      "quote-bearing CFN parameter values produce valid JSON. " +
+      `Got: ${JSON.stringify(secretString)}`,
+  );
+}
+console.log(
+  "PublicWwwConfigSecret JSON-encoding assertions passed (Fn::ToJsonString + transform).",
+);


### PR DESCRIPTION
…ne values

The previous implementation used `secretObjectValue` (which CDK serialises as `Fn::Join`). At deploy time CloudFormation would substitute CFN parameter values verbatim into the SecretString with no JSON escaping. Any value containing newlines, double quotes, or backslashes — most importantly `PUBLIC_WWW_BUSINESS_ADDRESS`, which ships as a CRLF-separated postal address — produced an invalid JSON SecretString. `json.loads` in `app.config.public_www` then raised `JSONDecodeError`, the helper logged-and-fell-back-to-defaults, and every PUBLIC_WWW_* lookup quietly returned an empty string. The visible symptom was AR invoice PDFs rendering with no business name, bank info, or FPS QR after the original deploy fix shipped.

Switch the SecretString to a real `Fn::ToJsonString` intrinsic, which CloudFormation evaluates server-side with proper JSON escaping for embedded newlines / quotes / backslashes:

- Add the `AWS::LanguageExtensions` template transform on `ApiStack` so `Fn::ToJsonString` is available in this stack.
- Wrap the payload in `cdk.Lazy.any({...})` before calling `cdk.Fn.toJsonString(...)`. This is required because `Fn.toJsonString` only emits the intrinsic when its input is itself an unresolved token; given a plain JS object with token-valued fields, it falls back to synth-time `JSON.stringify` and the inner CFN tokens then collapse into another `Fn::Join`.
- Add `backend/infrastructure/test/public-www-config-secret.test.ts` as a regression guard that asserts both invariants (transform on the stack + `Fn::ToJsonString` on the SecretString). Wired into `npm run test:infra`.

After re-deploying with this change, warm Lambda instances pick up the corrected SecretString within five minutes (cache TTL); cold starts immediately read the new JSON. No GitHub var changes required.