### PR TITLE
Admin: icon actions for recent combined-PDF import jobs

### DIFF
--- a/apps/admin_web/src/components/admin/finance/bulk-expense-import-jobs-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/bulk-expense-import-jobs-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { RotateIcon, ViewIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
 import {
   AdminDataTable,
@@ -192,7 +193,7 @@ export function BulkExpenseImportJobsPanel({ onAfterMutation }: BulkExpenseImpor
                 <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
                 <AdminDataTableHeadCell>Created</AdminDataTableHeadCell>
                 <AdminDataTableHeadCell>Message</AdminDataTableHeadCell>
-                <AdminDataTableOperationsHeadCell />
+                <AdminDataTableOperationsHeadCell>Icons</AdminDataTableOperationsHeadCell>
               </tr>
             </AdminDataTableHead>
             <AdminDataTableBody>
@@ -219,15 +220,22 @@ export function BulkExpenseImportJobsPanel({ onAfterMutation }: BulkExpenseImpor
                         type='button'
                         size='sm'
                         variant='outline'
+                        aria-label='View result'
+                        title='View result'
                         onClick={() => void openView(row.id)}
                       >
-                        View result
+                        <ViewIcon className='h-4 w-4' aria-hidden />
                       </Button>
                       <Button
                         type='button'
                         size='sm'
                         variant='outline'
                         disabled={!canRetry(row)}
+                        aria-label={
+                          canRetry(row)
+                            ? 'Retry import with the same PDF and vendor defaults'
+                            : 'Retry unavailable for this job status'
+                        }
                         title={
                           canRetry(row)
                             ? 'Queue a new import using the same PDF and vendor defaults'
@@ -235,7 +243,7 @@ export function BulkExpenseImportJobsPanel({ onAfterMutation }: BulkExpenseImpor
                         }
                         onClick={() => startRetry(row)}
                       >
-                        Retry
+                        <RotateIcon className='h-4 w-4' aria-hidden />
                       </Button>
                     </div>
                   </AdminDataTableCell>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the **Recent combined-PDF imports** table so row actions use the same icon-button pattern as other finance lists (for example submitted expenses), instead of text-only controls.

## Changes

- Operations column header is labeled **Icons** (renders uppercase with the shared table head styles).
- **View result** becomes an eye icon (`ViewIcon`) with `aria-label` and `title` preserved for meaning.
- **Retry** becomes a rotate icon (`RotateIcon`) with matching accessibility attributes and the existing disabled/tooltip behavior.

## Testing

- `cd apps/admin_web && npx vitest run tests/components/admin/finance/finance-page.test.tsx`
- `cd apps/admin_web && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2cd9e41-9784-4827-aafc-c3c093bddb3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2cd9e41-9784-4827-aafc-c3c093bddb3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

