### PR TITLE
Drop venue label from family bill-to location snapshot

### DIFF
--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -198,18 +198,27 @@ def _append_unique_invoice_location_line(parts: list[str], line: str | None) -> 
 
 
 def _bill_to_location_snapshot_text(
-    session: Session, location_id: UUID | None
+    session: Session,
+    location_id: UUID | None,
+    *,
+    include_venue_name: bool = True,
 ) -> str | None:
-    """Return newline-separated venue, address, district, and country for invoice PDF."""
+    """Return newline-separated venue, address, district, and country for invoice PDF.
+
+    ``include_venue_name=False`` drops ``Location.name`` from the snapshot. Used by the
+    family bill-to branch because family-affiliated locations are typically labelled with
+    the household/family name, which duplicates and clutters the postal block.
+    """
     if location_id is None:
         return None
     loc = session.get(Location, location_id)
     if loc is None:
         return None
     parts: list[str] = []
-    name = (loc.name or "").strip()
-    if name:
-        parts.append(name)
+    if include_venue_name:
+        name = (loc.name or "").strip()
+        if name:
+            parts.append(name)
     parts.extend(split_address_lines(loc.address or ""))
     area_id = getattr(loc, "area_id", None)
     if area_id is not None:
@@ -264,7 +273,9 @@ def _resolve_bill_to_party_from_invoice_fks(
         loc_id = getattr(fam, "location_id", None)
         if loc_id is None and primary is not None:
             loc_id = getattr(primary, "location_id", None)
-        inv.bill_to_location_text = _bill_to_location_snapshot_text(session, loc_id)
+        inv.bill_to_location_text = _bill_to_location_snapshot_text(
+            session, loc_id, include_venue_name=False
+        )
         return
     if (
         inv.bill_to_kind == BillingBillToKind.ORGANIZATION

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -2826,7 +2826,11 @@ def test_resolve_bill_to_party_from_invoice_fks_contact_includes_location_text()
 
 
 def test_resolve_bill_to_party_from_invoice_fks_family_primary_location_fallback() -> None:
-    """When family has no location, use primary contact's linked location."""
+    """When family has no location, use primary contact's linked location.
+
+    The family bill-to snapshot intentionally drops ``Location.name`` (venue label) so
+    family-affiliated locations don't duplicate the household name in the Bill To block.
+    """
     from app.api.admin_billing_invoice_draft_helpers import (
         _resolve_bill_to_party_from_invoice_fks,
     )
@@ -2866,11 +2870,15 @@ def test_resolve_bill_to_party_from_invoice_fks_family_primary_location_fallback
         bill_to_location_text=None,
     )
     _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
-    assert inv.bill_to_location_text == "Home Base\n99 Road"
+    assert inv.bill_to_location_text == "99 Road"
 
 
 def test_resolve_bill_to_party_from_invoice_fks_family_prefers_family_location() -> None:
-    """Family-level location wins over primary contact location."""
+    """Family-level location wins over primary contact location.
+
+    The family branch drops ``Location.name`` from the snapshot so the assertion uses a
+    distinctive ``address`` to verify which Location was chosen.
+    """
     from app.api.admin_billing_invoice_draft_helpers import (
         _resolve_bill_to_party_from_invoice_fks,
     )
@@ -2886,8 +2894,8 @@ def test_resolve_bill_to_party_from_invoice_fks_family_prefers_family_location()
         email="pat@example.com",
         location_id=primary_lid,
     )
-    fam_loc = SimpleNamespace(name="Family Venue", address=None)
-    primary_loc = SimpleNamespace(name="Wrong", address="X")
+    fam_loc = SimpleNamespace(name="Family Venue", address="2 Family Road")
+    primary_loc = SimpleNamespace(name="Wrong", address="99 Other Road")
 
     session = MagicMock()
 
@@ -2914,7 +2922,51 @@ def test_resolve_bill_to_party_from_invoice_fks_family_prefers_family_location()
         bill_to_location_text=None,
     )
     _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
-    assert inv.bill_to_location_text == "Family Venue"
+    assert inv.bill_to_location_text == "2 Family Road"
+
+
+def test_resolve_bill_to_party_from_invoice_fks_family_excludes_venue_name() -> None:
+    """Family bill-to drops the venue label even when address is empty."""
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Family, Location
+
+    fid = uuid4()
+    lid = uuid4()
+    fam = SimpleNamespace(family_name="Ng Family", location_id=lid)
+    primary = SimpleNamespace(
+        first_name="Pat",
+        last_name="Ng",
+        email="pat@example.com",
+        location_id=None,
+    )
+    loc = SimpleNamespace(name="Ng Family Home", address=None)
+
+    session = MagicMock()
+
+    def _get(model: Any, pk: Any) -> Any:
+        if model is Family and pk == fid:
+            return fam
+        if model is Location and pk == lid:
+            return loc
+        return None
+
+    session.get.side_effect = _get
+
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = primary
+    session.execute.return_value = exec_result
+
+    inv = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.FAMILY,
+        bill_to_family_id=fid,
+        bill_to_display_name=None,
+        bill_to_email=None,
+        bill_to_location_text=None,
+    )
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
+    assert inv.bill_to_location_text is None
 
 
 def test_bill_to_location_snapshot_text_includes_geo_district_and_country() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

For family-billed AR invoices, the rendered Bill To block was visually three lines:

```
Bill To:
<primary contact name>      ← bill_to_display_name
<Location.name>             ← venue label, often a family-style label like "The Smiths"
<address lines>             ← Location.address split lines
```

`Location.name` is the venue display label (free text). For family-affiliated locations users tend to label it with a household/family name, which then duplicates the family identity and clutters the postal block.

This change drops `Location.name` from the family-branch snapshot. Contact and organization snapshots are unchanged because business venues legitimately have distinct, non-redundant labels (e.g. "Harbour Studio · 1 Pier · Central").

## What changed

- `_bill_to_location_snapshot_text` in `backend/src/app/api/admin_billing_invoice_draft_helpers.py` gains `include_venue_name: bool = True`.
- The FAMILY branch of `_resolve_bill_to_party_from_invoice_fks` calls it with `include_venue_name=False`. CONTACT and ORGANIZATION branches keep the default (`True`).
- Updated two FAMILY snapshot tests to assert the new behavior; added a regression test covering the venue-only edge case (returns `None` when `Location.address` is empty).

Already-issued invoices have `bill_to_location_text` persisted in the DB and are unaffected.

## Testing

- ✅ `pytest tests/test_admin_billing.py tests/test_customer_invoice_pdf.py -x -q` (102 passed)
- ✅ `pytest tests/ -x -q` (1028 passed, 17 skipped)
- ✅ `ruff check backend/ tests/ --config=backend/pyproject.toml`
- ✅ `pre-commit run ruff-format --all-files`
- ✅ `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52c7ee5e-d60a-40f5-b682-2861dfa34b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52c7ee5e-d60a-40f5-b682-2861dfa34b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

