### PR TITLE
fix(bulk-expense-import): tolerate alias/unknown wrapper keys in pars…

### DIFF
--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -336,25 +336,98 @@ def _parse_completion_body(body: str) -> dict[str, Any]:
     return parsed
 
 
+# Top-level keys the bulk parser will accept as "the invoices array" without
+# any further inspection. Order does not matter for correctness, but ``invoices``
+# and ``records`` are checked first because the prompt asks for those two.
+_BULK_LIST_KEY_ALIASES = (
+    "invoices",
+    "records",
+    "data",
+    "results",
+    "rows",
+    "items",
+    "expenses",
+    "transactions",
+    "charges",
+    "entries",
+)
+
+# Keys that, if present on a dict, strongly suggest the dict is an invoice row.
+# Used to disambiguate when the model wraps the rows under an unexpected key,
+# and to wrap a single top-level invoice object as a one-row import.
+_INVOICE_ROW_HINT_KEYS = (
+    "vendor_name",
+    "invoice_number",
+    "invoice_date",
+    "due_date",
+    "currency",
+    "subtotal",
+    "tax",
+    "total",
+    "amount",
+    "line_items",
+)
+
+
+def _looks_like_invoice_dict(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return any(key in value for key in _INVOICE_ROW_HINT_KEYS)
+
+
+def _coerce_bulk_invoice_list(parsed: Any) -> list[Any]:
+    """Best-effort coercion of a parsed JSON value into a list of invoice rows.
+
+    Handles common shape variations the model emits in practice: the requested
+    ``{"invoices":[...]}`` shape, alias keys (``data``, ``results``, ...), an
+    unknown key whose value is the only list-of-dicts in the object, multiple
+    candidate lists (the most invoice-like one wins), and a single invoice
+    object at the top level (wrapped as a one-row list).
+    """
+    if isinstance(parsed, list):
+        return parsed
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Bulk parser response payload has invalid shape")
+
+    for key in _BULK_LIST_KEY_ALIASES:
+        candidate = parsed.get(key)
+        if isinstance(candidate, list):
+            return candidate
+
+    list_candidates: list[list[Any]] = [
+        value
+        for value in parsed.values()
+        if isinstance(value, list) and any(isinstance(item, dict) for item in value)
+    ]
+    if len(list_candidates) == 1:
+        return list_candidates[0]
+    if len(list_candidates) > 1:
+        scored = sorted(
+            (
+                (sum(1 for item in lst if _looks_like_invoice_dict(item)), idx, lst)
+                for idx, lst in enumerate(list_candidates)
+            ),
+            key=lambda triple: (-triple[0], triple[1]),
+        )
+        best_score, _idx, best_list = scored[0]
+        if best_score > 0:
+            return best_list
+
+    if _looks_like_invoice_dict(parsed):
+        return [parsed]
+
+    keys_preview = ", ".join(sorted(parsed.keys())[:10]) or "<empty object>"
+    raise RuntimeError(
+        "Bulk parser response must be an array or an object with an array of "
+        f"invoice rows; got top-level keys: {keys_preview}"
+    )
+
+
 def _parse_bulk_invoices_payload(body: str) -> list[dict[str, Any]]:
     """Parse OpenRouter envelope and return raw invoice objects for bulk import."""
     cleaned = _extract_message_text(body)
     parsed = _loads_with_repair(cleaned, expecting="bulk invoices")
-    raw_list: list[Any]
-    if isinstance(parsed, list):
-        raw_list = parsed
-    elif isinstance(parsed, dict):
-        inner = parsed.get("invoices")
-        if inner is None:
-            inner = parsed.get("records")
-        if not isinstance(inner, list):
-            raise RuntimeError(
-                "Bulk parser response must be an array or an object with "
-                '"invoices" or "records" array'
-            )
-        raw_list = inner
-    else:
-        raise RuntimeError("Bulk parser response payload has invalid shape")
+    raw_list = _coerce_bulk_invoice_list(parsed)
 
     invoices: list[dict[str, Any]] = []
     for entry in raw_list:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -513,7 +513,12 @@ their primary responsibilities.
   the parser logs a redacted ±80-char snippet around the failure offset and
   retries once with a JSON-repair chat completion (no PDF re-attached, capped at
   60s). A second failure marks the job `failed` with a snippet-bearing message
-  instead of a bare `JSONDecodeError`.
+  instead of a bare `JSONDecodeError`. Once the response parses, the bulk parser
+  tolerates several wrapper shapes — alias keys (`invoices`, `records`, `data`,
+  `results`, `rows`, `items`, `expenses`, `transactions`, `charges`, `entries`),
+  any single unknown list-of-dicts value, or a top-level dict that itself looks
+  like one invoice (wrapped to a one-row import). When none match, the job
+  `failed` message reports the actual top-level keys for diagnosis.
 - Timeout / budget: **600s** Lambda timeout with **720s** SQS visibility; OpenRouter bulk
   calls cap at **240s** plus an optional **60s** JSON-repair retry, so DB writes
   stay inside the Lambda window

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -106,7 +106,9 @@ def test_parse_invoice_sends_images_as_image_url(monkeypatch: Any) -> None:
     assert payload["response_format"] == {"type": "json_object"}
 
 
-def test_parse_invoice_sends_pdfs_as_file_with_explicit_plugin(monkeypatch: Any) -> None:
+def test_parse_invoice_sends_pdfs_as_file_with_explicit_plugin(
+    monkeypatch: Any,
+) -> None:
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
 
@@ -340,7 +342,12 @@ def test_normalize_result_total_from_line_items_when_total_missing() -> None:
             "tax": None,
             "total": None,
             "line_items": [
-                {"description": "A", "quantity": 1, "unit_price": 10, "amount": "10.00"},
+                {
+                    "description": "A",
+                    "quantity": 1,
+                    "unit_price": 10,
+                    "amount": "10.00",
+                },
                 {"description": "B", "quantity": 1, "unit_price": 5, "amount": "$5.00"},
             ],
             "confidence": None,
@@ -545,7 +552,9 @@ def _bulk_chat_completion_body(content_text: str) -> str:
     )
 
 
-def test_parse_bulk_expense_invoices_sets_json_response_format(monkeypatch: Any) -> None:
+def test_parse_bulk_expense_invoices_sets_json_response_format(
+    monkeypatch: Any,
+) -> None:
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
 
@@ -681,6 +690,97 @@ def test_parse_bulk_expense_invoices_repairs_invalid_json(monkeypatch: Any) -> N
     assert len(rows) == 1
     assert rows[0]["invoice_number"] == "1"
     assert rows[0]["total"] == 5.0
+
+
+def test_coerce_bulk_invoice_list_passes_through_top_level_array() -> None:
+    rows = [{"vendor_name": "A"}, {"vendor_name": "B"}]
+    assert parser._coerce_bulk_invoice_list(rows) is rows
+
+
+def test_coerce_bulk_invoice_list_accepts_alias_keys() -> None:
+    rows = [{"vendor_name": "A"}]
+    for key in ("invoices", "records", "data", "results", "rows", "expenses"):
+        assert parser._coerce_bulk_invoice_list({key: rows}) == rows
+
+
+def test_coerce_bulk_invoice_list_uses_single_unknown_list_of_dicts() -> None:
+    rows = [{"vendor_name": "Acme", "total": 10}]
+    out = parser._coerce_bulk_invoice_list({"meta": {"page_count": 1}, "things": rows})
+    assert out == rows
+
+
+def test_coerce_bulk_invoice_list_picks_most_invoice_like_when_multiple() -> None:
+    invoice_like = [{"vendor_name": "Acme", "total": 1}]
+    decoy = [{"some_other": "value"}]
+    out = parser._coerce_bulk_invoice_list({"noise": decoy, "best_match": invoice_like})
+    assert out == invoice_like
+
+
+def test_coerce_bulk_invoice_list_wraps_single_top_level_invoice() -> None:
+    single = {"vendor_name": "Acme", "total": 10, "currency": "USD"}
+    out = parser._coerce_bulk_invoice_list(single)
+    assert out == [single]
+
+
+def test_coerce_bulk_invoice_list_raises_with_keys_preview_on_unknown_shape() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        parser._coerce_bulk_invoice_list({"alpha": "x", "beta": 2, "gamma": [1, 2, 3]})
+    msg = str(exc_info.value)
+    assert "alpha" in msg
+    assert "beta" in msg
+    assert "gamma" in msg
+
+
+def test_parse_bulk_expense_invoices_accepts_data_alias(monkeypatch: Any) -> None:
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    payload_text = json.dumps(
+        {
+            "data": [
+                {
+                    "vendor_name": "Shop X",
+                    "invoice_number": "9",
+                    "invoice_date": "2026-03-04",
+                    "due_date": None,
+                    "currency": "USD",
+                    "subtotal": 8,
+                    "tax": 0,
+                    "total": 8,
+                    "line_items": [],
+                    "confidence": 0.9,
+                }
+            ]
+        }
+    )
+
+    def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": 200,
+            "body": _bulk_chat_completion_body(payload_text),
+        }
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    rows = parser.parse_bulk_expense_invoices_from_assets(
+        [
+            {
+                "id": "asset-data",
+                "s3_key": "k",
+                "file_name": "bulk.pdf",
+                "content_type": "application/pdf",
+            }
+        ],
+        timeout=25,
+    )
+    assert len(rows) == 1
+    assert rows[0]["vendor_name"] == "Shop X"
+    assert rows[0]["total"] == 8.0
 
 
 def test_parse_bulk_expense_invoices_raises_with_snippet_when_repair_fails(


### PR DESCRIPTION
…er response

Follow-up to the JSON-mode + repair fix. Even with valid JSON, the model sometimes wraps the invoice array under a key other than `invoices` / `records`, surfacing as:

    Status: Failed
    Message: RuntimeError('Bulk parser response must be an array or an object
                          with "invoices" or "records" array')

Replaces the strict two-key check in `_parse_bulk_invoices_payload` with a new `_coerce_bulk_invoice_list(parsed)` helper that:

1. Returns the value as-is if it's already a list (unchanged).
2. Walks an extended alias list (`invoices`, `records`, `data`, `results`, `rows`, `items`, `expenses`, `transactions`, `charges`, `entries`) and returns the first list value.
3. Falls back to scanning all top-level values for lists-of-dicts. With one candidate, takes it. With multiple, scores each list by how many of its items contain invoice-like keys (`vendor_name`, `invoice_number`, `total`, `amount`, `subtotal`, `currency`, `due_date`, `tax`, `line_items`, `invoice_date`) and picks the highest positive score.
4. Last resort: when the top-level dict itself looks like a single invoice, wraps it as a one-row list so a one-row "bulk" import still succeeds.
5. Raises `RuntimeError` with the actual top-level keys preview ("got top-level keys: a, b, c") so future deviations are diagnosable from the persisted job message alone, no log fishing required.

Tests in `tests/test_openrouter_expense_parser.py` cover `_coerce_bulk_invoice_list` directly (alias keys, single unknown list, multi-list scoring, single-invoice wrapping, keys-preview failure) and add an end-to-end test asserting the bulk parser accepts a `{"data":[...]}` model response.

Docs: extends the JSON-robustness paragraph in `docs/architecture/lambdas.md` to describe the alias / fallback / wrap behaviour and the keys-preview error.

No DB schema or API contract change.