### PR TITLE
Admin: draft invoice enrollment picker hides invoiced rows

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1146,9 +1146,9 @@ export function ClientInvoicesPanel() {
               onSubmit={(e) => void handleCreateDraft(e)}
             >
               <p className='text-sm text-slate-600'>
-                Shown: enrollments from the last two years (730 rolling days by enrolled date), excluding cancelled.
-                Rows already on a draft or issued invoice cannot be selected. Selected rows must share bill-to
-                and currency on the server.
+                Shown: enrollments from the last two years (730 rolling days by enrolled date), excluding cancelled
+                and any row already on a draft or issued invoice. Selected rows must share bill-to and currency on
+                the server.
               </p>
               <AdminTableToolbar marginBottom='none'>
                 <div className='min-w-[220px] flex-1'>
@@ -1218,27 +1218,30 @@ export function ClientInvoicesPanel() {
                       </AdminDataTableHeadCell>
                       <AdminDataTableHeadCell className='text-right'>Price</AdminDataTableHeadCell>
                       <AdminDataTableHeadCell>Enrolled</AdminDataTableHeadCell>
-                      <AdminDataTableHeadCell>Invoice</AdminDataTableHeadCell>
                     </tr>
                   </AdminDataTableHead>
                   <AdminDataTableBody>
                     {enrollmentPickerLoading ? (
                       <tr>
-                        <AdminDataTableCell colSpan={7} className='py-6 text-sm text-slate-600'>
+                        <AdminDataTableCell colSpan={6} className='py-6 text-sm text-slate-600'>
                           Loading enrollments…
                         </AdminDataTableCell>
                       </tr>
                     ) : enrollmentPickerRows.length === 0 ? (
                       <tr>
-                        <AdminDataTableCell colSpan={7} className='py-6 text-sm text-slate-600'>
+                        <AdminDataTableCell colSpan={6} className='py-6 text-sm text-slate-600'>
                           No enrollments match this filter.
                         </AdminDataTableCell>
                       </tr>
+                    ) : selectableFilteredRows.length === 0 ? (
+                      <tr>
+                        <AdminDataTableCell colSpan={6} className='py-6 text-sm text-slate-600'>
+                          All matching enrollments are already on a draft or issued invoice.
+                        </AdminDataTableCell>
+                      </tr>
                     ) : (
-                      enrollmentPickerRows.map((row) => {
-                        const blocked = row.invoiceLinked;
+                      selectableFilteredRows.map((row) => {
                         const checked = selectedEnrollmentIds.has(row.enrollmentId);
-                        const blockedNoteId = `billing-enrollment-blocked-note-${row.enrollmentId}`;
                         const amountPaidTrimmed = row.amountPaid?.trim() ?? '';
                         const currencyCode =
                           (row.currency ?? defaultCurrency).trim().toUpperCase() || defaultCurrency;
@@ -1255,17 +1258,13 @@ export function ClientInvoicesPanel() {
                           formatEnrollmentPickerInstanceServiceDisplay(row);
                         const partyCellDisplay = formatBillingEnrollmentPartyCell(row);
                         return (
-                          <tr
-                            key={row.enrollmentId}
-                            className={blocked ? 'bg-slate-50 text-slate-500' : undefined}
-                          >
+                          <tr key={row.enrollmentId}>
                             <AdminDataTableCell className='align-top'>
                               <input
                                 type='checkbox'
                                 aria-label={`Select enrollment ${row.enrollmentId}`}
-                                aria-describedby={blocked ? blockedNoteId : undefined}
                                 checked={checked}
-                                disabled={editorBusy || blocked}
+                                disabled={editorBusy}
                                 onChange={(event) => {
                                   const nextChecked = event.target.checked;
                                   setSelectedEnrollmentIds((prev) => {
@@ -1279,11 +1278,6 @@ export function ClientInvoicesPanel() {
                                   });
                                 }}
                               />
-                              {blocked ? (
-                                <span id={blockedNoteId} className='sr-only'>
-                                  Already on a draft or issued invoice.
-                                </span>
-                              ) : null}
                             </AdminDataTableCell>
                             <AdminDataTableCell className='min-w-0 max-w-[22rem] break-words align-top text-sm'>
                               {partyCellDisplay !== '' ? partyCellDisplay : '—'}
@@ -1299,9 +1293,6 @@ export function ClientInvoicesPanel() {
                             </AdminDataTableCell>
                             <AdminDataTableCell className='align-top whitespace-nowrap text-sm'>
                               {row.enrolledAt ? row.enrolledAt.slice(0, 10) : '—'}
-                            </AdminDataTableCell>
-                            <AdminDataTableCell className='align-top text-sm'>
-                              {blocked ? 'On draft/issued invoice' : '—'}
                             </AdminDataTableCell>
                           </tr>
                         );

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -1248,7 +1248,21 @@ describe('ClientInvoicesPanel', () => {
     }
   });
 
-  it('blocks checkbox when invoiceLinked', async () => {
+  it('shows message when every enrollment returned is invoice-linked', async () => {
+    billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
+      items: [pickerRow({ enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-111111111111', invoiceLinked: true })],
+      truncated: false,
+    });
+    render(<ClientInvoicesPanel />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/All matching enrollments are already on a draft or issued invoice/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it('hides invoice-linked enrollments from draft picker table', async () => {
     const blockedId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
     billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
       items: [
@@ -1260,11 +1274,12 @@ describe('ClientInvoicesPanel', () => {
     render(<ClientInvoicesPanel />);
 
     await waitFor(() =>
-      expect(screen.getByRole('checkbox', { name: new RegExp(blockedId, 'i') })).toBeDisabled(),
+      expect(screen.getByRole('checkbox', { name: /Select enrollment cccccccc/i })).toBeInTheDocument(),
     );
+    expect(screen.queryByRole('checkbox', { name: new RegExp(blockedId, 'i') })).not.toBeInTheDocument();
   });
 
-  it('select all visible only affects selectable rows when one row is invoice-linked', async () => {
+  it('select all visible selects every shown row when server also returns invoice-linked enrollments', async () => {
     billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
       items: [
         pickerRow({ enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-111111111111', invoiceLinked: true }),
@@ -1281,7 +1296,8 @@ describe('ClientInvoicesPanel', () => {
 
     await waitFor(() => {
       const rowChecks = screen.getAllByRole('checkbox', { name: /^Select enrollment /i });
-      expect(rowChecks.filter((el) => (el as HTMLInputElement).checked)).toHaveLength(2);
+      expect(rowChecks).toHaveLength(2);
+      expect(rowChecks.every((el) => (el as HTMLInputElement).checked)).toBe(true);
     });
   });
 
@@ -1309,6 +1325,7 @@ describe('ClientInvoicesPanel', () => {
     expect(screen.getByText('No Email Party')).toBeInTheDocument();
     const enrollmentPicker = screen.getByRole('region', { name: 'Enrollment picker' });
     expect(within(enrollmentPicker).queryByRole('columnheader', { name: 'Email' })).not.toBeInTheDocument();
+    expect(within(enrollmentPicker).queryByRole('columnheader', { name: 'Invoice' })).not.toBeInTheDocument();
   });
 
   it('draft enrollment picker Party column for family bill-to uses composed label without appending email', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the **Create draft invoice** enrollment-based picker in Finance:

- Removes the **Invoice** column (it only distinguished linked vs not).
- The table lists **only** enrollments with `invoiceLinked === false` (not on a draft or issued invoice).
- If the server returns matches but all are already invoiced, shows: *All matching enrollments are already on a draft or issued invoice.*
- Help text under the form reflects that linked rows are excluded from the list rather than shown as disabled.

`handleCreateDraft` still validates linked rows defensively if the list changes between loads.

## Tests

- `npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx`
- `npm run lint` (admin_web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ea618a8-9146-40d6-bdfc-be6282bec386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ea618a8-9146-40d6-bdfc-be6282bec386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

