### PR TITLE
Admin: record payment UI cleanup and auto payment on enrollment create

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -117,6 +117,21 @@ function formatAllocateLineOptionLabel(
   return base;
 }
 
+function formatRecentEnrollmentPaymentSelectLabel(row: BillingEnrollmentPickerRow): string {
+  const party = formatBillingEnrollmentPartyCell(row).trim();
+  const inst = formatEnrollmentPickerInstanceServiceDisplay(row).trim();
+  if (party !== '' && inst !== '') {
+    return `${party} · ${inst}`;
+  }
+  if (party !== '') {
+    return party;
+  }
+  if (inst !== '') {
+    return inst;
+  }
+  return 'Enrollment';
+}
+
 function currencySelectValue(
   code: string,
   options: readonly { value: string }[],
@@ -267,15 +282,6 @@ export function ClientInvoicesPanel() {
       return '';
     }
     return enrollmentPickerRows.some((r) => r.enrollmentId === tid) ? tid : '';
-  }, [createPaymentEnrollmentId, enrollmentPickerRows]);
-
-  const createPaymentEnrollmentSummary = useMemo(() => {
-    const tid = createPaymentEnrollmentId.trim();
-    if (tid === '') {
-      return '';
-    }
-    const row = enrollmentPickerRows.find((r) => r.enrollmentId === tid);
-    return row?.partyDisplayName?.trim() ?? '';
   }, [createPaymentEnrollmentId, enrollmentPickerRows]);
 
   const lastPaymentSeedIdRef = useRef<string | null>(null);
@@ -1089,7 +1095,7 @@ export function ClientInvoicesPanel() {
     setActionMessage('');
     const eid = createPaymentEnrollmentId.trim();
     if (!eid) {
-      setActionError('Enrollment id is required.');
+      setActionError('Select a recent enrollment.');
       return;
     }
     const amt = createPaymentAmount.trim();
@@ -1716,7 +1722,7 @@ export function ClientInvoicesPanel() {
 
       <AdminEditorCard
         title='Record customer payment'
-        description='Choose a recent enrollment from the picker (same list as draft invoices) or paste its UUID. Currency must match the enrollment billing currency. Use Pending until funds clear, then confirm or record as Succeeded when appropriate.'
+        description='Choose a recent enrollment from the picker (same list as draft invoices). Currency defaults from the enrollment. Use Pending until funds clear, then record as Succeeded when appropriate.'
         actions={
           <Button
             type='submit'
@@ -1753,31 +1759,11 @@ export function ClientInvoicesPanel() {
                 <option value=''>Choose from recent enrollments…</option>
                 {enrollmentPickerRows.map((row) => (
                   <option key={row.enrollmentId} value={row.enrollmentId}>
-                    {formatBillingEnrollmentPartyCell(row)} — {formatTruncatedId(row.enrollmentId)} (
-                    {row.currency})
+                    {formatRecentEnrollmentPaymentSelectLabel(row)}
                   </option>
                 ))}
               </Select>
             </div>
-            <div className='min-w-0'>
-              <Label htmlFor='billing-create-pay-enrollment'>Or paste enrollment UUID</Label>
-              <Input
-                id='billing-create-pay-enrollment'
-                value={createPaymentEnrollmentId}
-                onChange={(e) => {
-                  setCreatePaymentEnrollmentId(e.target.value);
-                }}
-                className='mt-1 w-full min-w-0 font-mono text-sm'
-                disabled={editorBusy}
-                autoComplete='off'
-                placeholder='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-              />
-              {createPaymentEnrollmentSummary ? (
-                <p className='mt-1 text-xs text-slate-600'>{createPaymentEnrollmentSummary}</p>
-              ) : null}
-            </div>
-          </div>
-          <div className='grid gap-3 min-[780px]:grid-cols-2 min-[780px]:items-end'>
             <div className='min-w-0'>
               <Label htmlFor='billing-create-pay-status'>Payment status</Label>
               <Select
@@ -1802,9 +1788,6 @@ export function ClientInvoicesPanel() {
                 className='mt-1 w-full min-w-0 max-w-xs min-[780px]:max-w-none'
                 disabled={editorBusy}
               />
-              <p className='mt-1 text-xs text-slate-600'>
-                Zero amounts are stored as succeeded free payments (method is coerced to free).
-              </p>
             </div>
             <div className='min-w-0'>
               <Label htmlFor='billing-create-pay-currency'>Currency</Label>
@@ -1841,7 +1824,7 @@ export function ClientInvoicesPanel() {
               </Select>
             </div>
             <div className='min-w-0'>
-              <Label htmlFor='billing-create-pay-external-ref'>Bank / external reference (optional)</Label>
+              <Label htmlFor='billing-create-pay-external-ref'>Bank / external reference</Label>
               <Input
                 id='billing-create-pay-external-ref'
                 value={createPaymentExternalRef}

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
 import { AdminPageErrorBanner } from '@/components/admin/admin-page-error-banner';
+import { StatusBanner } from '@/components/status-banner';
 
 import { useServicesPage, type ServicesView } from '@/hooks/use-services-page';
 import {
@@ -162,6 +163,12 @@ export function ServicesPage() {
   return (
     <div className='space-y-4'>
       <AdminPageErrorBanner title='Services' message={hasAnyError} />
+
+      {state.activeView === 'instances' && state.enrollmentCustomerPaymentError ? (
+        <StatusBanner variant='error' title='Customer payment'>
+          {state.enrollmentCustomerPaymentError}
+        </StatusBanner>
+      ) : null}
 
       <ServicesHeader activeView={state.activeView} onSetView={handleSetActiveView} />
 

--- a/apps/admin_web/src/hooks/use-services-page.ts
+++ b/apps/admin_web/src/hooks/use-services-page.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { toErrorMessage } from '@/hooks/hook-errors';
+import { createInitialCustomerPaymentAfterEnrollmentCreate } from '@/lib/billing-api';
 import { listEntityTags, type EntityTagRef } from '@/lib/entity-api';
 
 import { useDiscountCodes } from './use-discount-codes';
@@ -42,6 +43,7 @@ export function useServicesPage() {
   const [entityTags, setEntityTags] = useState<EntityTagRef[]>([]);
   const [entityTagsLoading, setEntityTagsLoading] = useState(false);
   const [entityTagsError, setEntityTagsError] = useState('');
+  const [enrollmentCustomerPaymentError, setEnrollmentCustomerPaymentError] = useState('');
 
   const serviceList = useServiceList();
   const selectedServiceId = selectedServiceIdState;
@@ -78,6 +80,10 @@ export function useServicesPage() {
       cancelled = true;
     };
   }, [activeView]);
+
+  useEffect(() => {
+    setEnrollmentCustomerPaymentError('');
+  }, [activeView, selectedInstanceId]);
 
   const serviceDetail = useServiceDetail(selectedServiceId);
   const instanceList = useInstanceList(
@@ -141,6 +147,20 @@ export function useServicesPage() {
       }
       await enrollmentList.refetch();
       await instanceList.refetch();
+      if (detail.operation === 'create' && detail.enrollment) {
+        try {
+          setEnrollmentCustomerPaymentError('');
+          await createInitialCustomerPaymentAfterEnrollmentCreate(detail.enrollment);
+        } catch (error) {
+          setEnrollmentCustomerPaymentError(
+            toErrorMessage(
+              error,
+              'Enrollment was saved, but automatic customer payment failed. Record it from Finance.',
+              { honorBackendMessage: true },
+            ),
+          );
+        }
+      }
     },
   });
 
@@ -180,5 +200,6 @@ export function useServicesPage() {
     locationError: locationList.error,
     discountCodes,
     venues,
+    enrollmentCustomerPaymentError,
   };
 }

--- a/apps/admin_web/src/lib/billing-api.ts
+++ b/apps/admin_web/src/lib/billing-api.ts
@@ -1,5 +1,6 @@
 import { adminApiRequest } from '@/lib/api-admin-client';
 import { unwrapPayload } from '@/lib/api-payload';
+import { getAdminDefaultCurrencyCode } from '@/lib/config';
 
 import type { components } from '@/types/generated/admin-api.generated';
 
@@ -202,6 +203,50 @@ export async function createManualInboundCustomerPayment(
     throw new Error('Create payment response missing payment.');
   }
   return root.payment;
+}
+
+/**
+ * After Services creates an enrollment, record a matching inbound customer payment:
+ * pending `bank_transfer` when amount is positive, or succeeded `free` at zero when amount is empty/zero.
+ */
+export async function createInitialCustomerPaymentAfterEnrollmentCreate(enrollment: {
+  id?: string | null;
+  amountPaid?: string | null;
+  currency?: string | null;
+}): Promise<void> {
+  const enrollmentId = enrollment.id?.trim() ?? '';
+  if (enrollmentId === '') {
+    throw new Error('Enrollment id is required to record customer payment.');
+  }
+  const amountRaw = enrollment.amountPaid?.trim() ?? '';
+  const parsed = amountRaw === '' ? 0 : Number.parseFloat(amountRaw);
+  const isZero = amountRaw === '' || (Number.isFinite(parsed) && Math.abs(parsed) < 1e-12);
+  const cur = enrollment.currency?.trim().toUpperCase() ?? '';
+  const currency = cur !== '' ? cur : getAdminDefaultCurrencyCode();
+
+  if (isZero) {
+    await createManualInboundCustomerPayment({
+      direction: 'inbound',
+      enrollmentId,
+      amount: '0',
+      currency,
+      method: 'free',
+      status: 'succeeded',
+      externalReference: null,
+    });
+    return;
+  }
+
+  const amount = Number.isFinite(parsed) ? String(amountRaw) : amountRaw;
+  await createManualInboundCustomerPayment({
+    direction: 'inbound',
+    enrollmentId,
+    amount,
+    currency,
+    method: 'bank_transfer',
+    status: 'pending',
+    externalReference: null,
+  });
 }
 
 export type BillingEnrollmentPickerRow = ApiSchemas['BillingEnrollmentPickerRow'];

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -247,8 +247,6 @@ describe('ClientInvoicesPanel', () => {
 
     const user = userEvent.setup();
     await user.selectOptions(screen.getByLabelText(/Enrollment \(recent\)/i), eid);
-    await user.clear(screen.getByLabelText(/Or paste enrollment UUID/i));
-    await user.type(screen.getByLabelText(/Or paste enrollment UUID/i), eid);
     const amountInput = document.getElementById('billing-create-pay-amount') as HTMLInputElement;
     await user.clear(amountInput);
     await user.type(amountInput, '10');
@@ -297,7 +295,7 @@ describe('ClientInvoicesPanel', () => {
     await waitFor(() => expect(billingMocks.listRecentEnrollmentsForInvoicing).toHaveBeenCalled());
 
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText(/Or paste enrollment UUID/i), eid);
+    await user.selectOptions(screen.getByLabelText(/Enrollment \(recent\)/i), eid);
     const amountInput = document.getElementById('billing-create-pay-amount') as HTMLInputElement;
     await user.clear(amountInput);
     await user.type(amountInput, '5');

--- a/apps/admin_web/tests/lib/billing-api.test.ts
+++ b/apps/admin_web/tests/lib/billing-api.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/lib/api-admin-client', () => ({
 
 import {
   compareBillingEnrollmentPickerRowsByEnrolledAtDesc,
+  createInitialCustomerPaymentAfterEnrollmentCreate,
   listRecentEnrollmentsForInvoicing,
 } from '@/lib/billing-api';
 
@@ -102,5 +103,84 @@ describe('listRecentEnrollmentsForInvoicing', () => {
     mockAdminApiRequest.mockRejectedValueOnce(new Error('Unavailable'));
 
     await expect(listRecentEnrollmentsForInvoicing()).rejects.toThrow('Unavailable');
+  });
+});
+
+describe('createInitialCustomerPaymentAfterEnrollmentCreate', () => {
+  beforeEach(() => {
+    mockAdminApiRequest.mockReset();
+  });
+
+  const paymentResponse = { payment: { id: 'pay-1' } };
+
+  it('posts pending bank_transfer for a positive amount', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce(paymentResponse);
+
+    await createInitialCustomerPaymentAfterEnrollmentCreate({
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      amountPaid: '120.50',
+      currency: 'hkd',
+    });
+
+    expect(mockAdminApiRequest).toHaveBeenCalledTimes(1);
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        endpointPath: '/v1/admin/billing/payments',
+        body: {
+          direction: 'inbound',
+          enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          amount: '120.50',
+          currency: 'HKD',
+          method: 'bank_transfer',
+          status: 'pending',
+          externalReference: null,
+        },
+      }),
+    );
+  });
+
+  it('posts succeeded free at zero when amount is empty', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce(paymentResponse);
+
+    await createInitialCustomerPaymentAfterEnrollmentCreate({
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      amountPaid: '',
+      currency: 'USD',
+    });
+
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: {
+          direction: 'inbound',
+          enrollmentId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          amount: '0',
+          currency: 'USD',
+          method: 'free',
+          status: 'succeeded',
+          externalReference: null,
+        },
+      }),
+    );
+  });
+
+  it('posts succeeded free when amount parses to zero', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce(paymentResponse);
+
+    await createInitialCustomerPaymentAfterEnrollmentCreate({
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      amountPaid: '0.00',
+      currency: 'HKD',
+    });
+
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          method: 'free',
+          status: 'succeeded',
+          amount: '0',
+        }),
+      }),
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change tightens the Finance **Record customer payment** editor and automatically creates a matching customer payment row when an admin adds an enrollment from **Services → Instances**.

## Record customer payment (Finance)

- Removed the **Or paste enrollment UUID** field; enrollment must be chosen from **Enrollment (recent)**.
- **Payment status** sits on the same grid row as the enrollment picker (two columns on wide viewports).
- Removed the zero-amount explanatory note under Amount.
- **Bank / external reference** label no longer says “(optional)”.
- Picker option text shows bill-to / party plus instance title when helpful, **without** enrollment UUID or currency in the label.
- Empty enrollment selection error copy now says **Select a recent enrollment.**

## Services → enrollment create

After a successful **Add enrollment**, the app calls the billing API to create an inbound customer payment:

- **Positive amount** (`amount_paid` parses to a value greater than zero): `pending`, `bank_transfer`, same amount and enrollment currency.
- **Zero or empty amount**: `succeeded`, `free`, amount `0`.

If that automatic payment fails (enrollment already saved), a **Customer payment** error banner appears on the Services page with the backend message when available; switching instance or tab clears the banner.

## Tests

- Extended `tests/lib/billing-api.test.ts` for the new helper.
- Updated `client-invoices-panel` tests for the removed UUID field.

## Validation

- `cd apps/admin_web && npm run lint`
- `npx vitest run tests/lib/billing-api.test.ts tests/components/admin/finance/client-invoices-panel.test.tsx`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7de408f-38ea-4008-8c1e-cd1e8e5ae06e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7de408f-38ea-4008-8c1e-cd1e8e5ae06e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

