### PR TITLE
fix(billing): reject zero payment allocations with 400

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -6475,6 +6475,7 @@ export interface components {
             invoiceId: string;
             /** Format: uuid */
             invoiceLineId?: string | null;
+            /** @description Must be strictly positive. Zero is rejected (matches the database constraint on `payment_allocations.allocated_amount`); use other billing flows for complimentary or fully discounted invoices rather than a zero payment allocation row. */
             allocatedAmount: string;
             currency: string;
         };

--- a/backend/src/app/api/admin_billing_allocations.py
+++ b/backend/src/app/api/admin_billing_allocations.py
@@ -40,6 +40,11 @@ def _create_allocation(
         raise ValidationError(
             "allocatedAmount must be a decimal number", field="allocatedAmount"
         ) from exc
+    if amt <= 0:
+        raise ValidationError(
+            "allocatedAmount must be greater than zero",
+            field="allocatedAmount",
+        )
     currency = str(body.get("currency") or "").upper()[:3]
     line_id_raw = body.get("invoiceLineId") or body.get("invoice_line_id")
     line_id: UUID | None = None

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -6801,6 +6801,10 @@ components:
           nullable: true
         allocatedAmount:
           type: string
+          description: >-
+            Must be strictly positive. Zero is rejected (matches the database constraint on
+            `payment_allocations.allocated_amount`); use other billing flows for complimentary
+            or fully discounted invoices rather than a zero payment allocation row.
         currency:
           type: string
           minLength: 3

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -137,6 +137,31 @@ def test_payment_unapplied_amount_subtracts_allocations() -> None:
     assert customer_billing.payment_unapplied_amount(session, pid) == Decimal("65")
 
 
+@pytest.mark.parametrize("allocated", ("0", "0.00", "-1"))
+def test_create_payment_allocation_rejects_non_positive_allocated_amount(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    allocated: str,
+) -> None:
+    """Zero or negative allocations violate DB CHECK; reject before flush (no 500)."""
+    body = {
+        "paymentId": str(uuid4()),
+        "invoiceId": str(uuid4()),
+        "allocatedAmount": allocated,
+        "currency": "HKD",
+    }
+    ev = api_gateway_event(
+        method="POST",
+        path="/v1/admin/billing/allocations",
+        body=json.dumps(body),
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(ValidationError, match="greater than zero"):
+        admin_billing.handle_admin_billing_request(
+            ev, "POST", "/v1/admin/billing/allocations"
+        )
+
+
 def test_next_invoice_number_increments_per_year(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Allocating a **zero** amount to an invoice failed with HTTP 500 because the API allowed the request through and PostgreSQL rejected the insert (`payment_allocations_positive` CHECK: `allocated_amount > 0`).

## Root cause

- `payment_unapplied_amount` is `payment.amount - sum(allocations)`; for a free payment, unapplied is `0`.
- The handler only rejected allocations when `amt > unapplied`; for `amt = 0`, that check passes.
- `session.flush()` then raised an uncaught `IntegrityError`, which the admin Lambda maps to **Internal server error**.

## Changes

- Validate `allocatedAmount` **before** opening a DB session: must be **strictly greater than zero** (same rule as the database).
- Document the rule on `CreatePaymentAllocationRequest.allocatedAmount` in `docs/api/admin.yaml` and regenerate admin web OpenAPI types.
- Add parametrized regression tests (`0`, `0.00`, `-1`).

## CloudWatch

The workspace image does not include the AWS CLI; credentials in the environment were used with **boto3** against `ap-southeast-1`. The log group `/aws/lambda/evolvesprouts-EvolvesproutsAdminFunction` exists, but filtered searches over the last seven days did not return matching lines for this failure (likely older or different log volume). The failure mode above matches a standard CHECK constraint violation on insert.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e519be5-361c-4579-ae3d-cbf2802f749d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e519be5-361c-4579-ae3d-cbf2802f749d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

