### PR TITLE
fix(bulk-expense-import): treat empty-object model response as zero rows

### DIFF
--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -79,7 +79,12 @@ def parse_bulk_expense_invoices_from_assets(
     )
     raw_invoices = _parse_bulk_invoices_payload(body)
     if not raw_invoices:
-        raise RuntimeError("Parser returned no invoice rows")
+        raise RuntimeError(
+            "Parser found no invoice rows in this document. The PDF may be "
+            "image-only without readable text, contain no extractable invoice "
+            "data, or be in a layout the parser could not recognize as "
+            "invoices. Try a clearer scan or a single-invoice import."
+        )
     if len(raw_invoices) > _MAX_BULK_INVOICES:
         raise RuntimeError(
             f"Parser returned too many invoices (max {_MAX_BULK_INVOICES})"
@@ -388,6 +393,13 @@ def _coerce_bulk_invoice_list(parsed: Any) -> list[Any]:
         return parsed
     if not isinstance(parsed, dict):
         raise RuntimeError("Bulk parser response payload has invalid shape")
+
+    # JSON mode forces an object, so ``{}`` is the model's only way of saying
+    # "I could not extract anything from this document". Treat it as zero rows
+    # rather than a malformed wrapper so the empty-result path produces an
+    # actionable message in ``parse_bulk_expense_invoices_from_assets``.
+    if not parsed:
+        return []
 
     for key in _BULK_LIST_KEY_ALIASES:
         candidate = parsed.get(key)

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -513,12 +513,16 @@ their primary responsibilities.
   the parser logs a redacted ±80-char snippet around the failure offset and
   retries once with a JSON-repair chat completion (no PDF re-attached, capped at
   60s). A second failure marks the job `failed` with a snippet-bearing message
-  instead of a bare `JSONDecodeError`. Once the response parses, the bulk parser
+  instead of a bare `JSONDecodeError`.   Once the response parses, the bulk parser
   tolerates several wrapper shapes — alias keys (`invoices`, `records`, `data`,
   `results`, `rows`, `items`, `expenses`, `transactions`, `charges`, `entries`),
   any single unknown list-of-dicts value, or a top-level dict that itself looks
-  like one invoice (wrapped to a one-row import). When none match, the job
-  `failed` message reports the actual top-level keys for diagnosis.
+  like one invoice (wrapped to a one-row import). An empty top-level object
+  (`{}`, the model's only way of saying "nothing to extract" under JSON mode)
+  is treated as zero rows and produces an actionable "no invoice rows in this
+  document" message instead of a wrapper-shape error. When none of the shapes
+  match, the job `failed` message reports the actual top-level keys for
+  diagnosis.
 - Timeout / budget: **600s** Lambda timeout with **720s** SQS visibility; OpenRouter bulk
   calls cap at **240s** plus an optional **60s** JSON-repair retry, so DB writes
   stay inside the Lambda window

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -722,6 +722,10 @@ def test_coerce_bulk_invoice_list_wraps_single_top_level_invoice() -> None:
     assert out == [single]
 
 
+def test_coerce_bulk_invoice_list_treats_empty_object_as_no_rows() -> None:
+    assert parser._coerce_bulk_invoice_list({}) == []
+
+
 def test_coerce_bulk_invoice_list_raises_with_keys_preview_on_unknown_shape() -> None:
     with pytest.raises(RuntimeError) as exc_info:
         parser._coerce_bulk_invoice_list({"alpha": "x", "beta": 2, "gamma": [1, 2, 3]})
@@ -781,6 +785,44 @@ def test_parse_bulk_expense_invoices_accepts_data_alias(monkeypatch: Any) -> Non
     assert len(rows) == 1
     assert rows[0]["vendor_name"] == "Shop X"
     assert rows[0]["total"] == 8.0
+
+
+def test_parse_bulk_expense_invoices_raises_descriptive_error_when_model_returns_empty_object(
+    monkeypatch: Any,
+) -> None:
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": 200,
+            "body": _bulk_chat_completion_body("{}"),
+        }
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        parser.parse_bulk_expense_invoices_from_assets(
+            [
+                {
+                    "id": "asset-empty",
+                    "s3_key": "k",
+                    "file_name": "bulk.pdf",
+                    "content_type": "application/pdf",
+                }
+            ],
+            timeout=25,
+        )
+
+    msg = str(exc_info.value)
+    assert "no invoice rows" in msg
+    assert "image-only" in msg
+    assert "<empty object>" not in msg
 
 
 def test_parse_bulk_expense_invoices_raises_with_snippet_when_repair_fails(


### PR DESCRIPTION
Follow-up after the wrapper-key fix. With `response_format={"type": "json_object"}` the model is forced to return an object, so when it has nothing to extract from the PDF its only escape valve is to return literally `{}`. The previous keys-preview path caught this but rendered as a confusing shape error:

    Status: Failed
    Message: RuntimeError('Bulk parser response must be an array or an object
                          with an array of invoice rows; got top-level keys:
                          <empty object>')

Changes:

- `_coerce_bulk_invoice_list`: empty top-level dict (`{}`) returns `[]` rather than raising. The downstream "no rows" check then produces the message; tightens the wrapper-shape error to fire only on dicts that actually have the wrong keys.
- `parse_bulk_expense_invoices_from_assets`: replaces the terse "Parser returned no invoice rows" with an actionable message that names the likely causes (image-only PDF, no extractable invoice data, layout the parser couldn't recognize) and points at single-invoice import as a workaround.

Tests in `tests/test_openrouter_expense_parser.py`:
- Unit test: `_coerce_bulk_invoice_list({}) == []`.
- End-to-end: a model response of `{}` raises the new descriptive `RuntimeError` with "no invoice rows" + "image-only" wording and no longer leaks "<empty object>".

Docs: extends the JSON-robustness paragraph in `docs/architecture/lambdas.md` to describe the empty-object → no-rows mapping.

No DB or API contract change.