### PR TITLE
fix(admin_web): narrow payment row before manual payment seed

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -800,7 +800,7 @@ export function ClientInvoicesPanel() {
       return;
     }
     const row = payments.find((p) => p.id === selectedId) ?? null;
-    if (!isManualInboundPaymentEditable(row)) {
+    if (row === null || !isManualInboundPaymentEditable(row)) {
       resetManualPaymentCreateFields();
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`npm run build` failed in `client-invoices-panel.tsx` because TypeScript could not prove that `row` was non-null after `isManualInboundPaymentEditable(row)` (that helper returns a plain `boolean`, not a type predicate).

## Change

- Treat a missing list row the same as a non-editable row: `if (row === null || !isManualInboundPaymentEditable(row))` so the remainder of the effect narrows `row` to a defined payment summary.

## Validation

- `cd apps/admin_web && npm run build`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64c07a81-6f87-4b27-8549-6fd3dbcb4d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64c07a81-6f87-4b27-8549-6fd3dbcb4d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

