### PR TITLE
Admin: Customer payment editor label and enrollment display

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -152,6 +152,47 @@ function formatRecentEnrollmentPaymentSelectLabel(
   return "Enrollment";
 }
 
+/** Manual payment editor (update mode): party · instance/service · tier/cohort when enrollment row is known. */
+function formatManualPaymentEnrollmentEditLabel(
+  row: BillingEnrollmentPickerRow | undefined,
+  partyFallback: string,
+): string {
+  const party = row ? formatBillingEnrollmentPartyCell(row).trim() : "";
+  const inst = row
+    ? formatEnrollmentPickerInstanceServiceDisplay(row).trim()
+    : "";
+  const tierCohort = row
+    ? formatTierCohortDisplay(row.serviceTierName, row.instanceCohort).trim()
+    : "";
+  const parts: string[] = [];
+  if (party !== "") {
+    parts.push(party);
+  }
+  if (inst !== "") {
+    parts.push(inst);
+  }
+  if (tierCohort !== "") {
+    parts.push(tierCohort);
+  }
+  if (parts.length > 0) {
+    return parts.join(" · ");
+  }
+  const fb = partyFallback.trim();
+  return fb !== "" ? fb : "—";
+}
+
+function formatAmountSeedTwoDecimals(raw: string): string {
+  const t = raw.trim();
+  if (t === "") {
+    return "";
+  }
+  const n = Number.parseFloat(t);
+  if (!Number.isFinite(n)) {
+    return t;
+  }
+  return n.toFixed(2);
+}
+
 function currencySelectValue(
   code: string,
   options: readonly { value: string }[],
@@ -807,7 +848,9 @@ export function ClientInvoicesPanel() {
     const curRow = row;
     const seedFromList = () => {
       setCreatePaymentEnrollmentId(curRow.enrollmentId?.trim() ?? "");
-      setCreatePaymentAmount(curRow.amount?.trim() ?? "");
+      setCreatePaymentAmount(
+        formatAmountSeedTwoDecimals(curRow.amount?.trim() ?? ""),
+      );
       const cur =
         (curRow.currency ?? defaultCurrency).trim().toUpperCase() ||
         defaultCurrency;
@@ -825,7 +868,7 @@ export function ClientInvoicesPanel() {
       return;
     }
     setCreatePaymentEnrollmentId(detail.enrollmentId?.trim() ?? "");
-    setCreatePaymentAmount(detail.amount?.trim() ?? "");
+    setCreatePaymentAmount(formatAmountSeedTwoDecimals(detail.amount?.trim() ?? ""));
     const cur =
       (detail.currency ?? defaultCurrency).trim().toUpperCase() ||
       defaultCurrency;
@@ -1347,30 +1390,32 @@ export function ClientInvoicesPanel() {
     detail.status === "succeeded",
   );
 
-  const manualPaymentEnrollmentPartyDisplay = useMemo(() => {
+  const manualPaymentEnrollmentEditLabel = useMemo(() => {
     if (!manualPaymentIsUpdate || !selectedId) {
       return "";
     }
-    const fromDetail = detail?.id === selectedId ? detail.party : undefined;
-    return (
-      fromDetail ??
+    const enrollmentId =
+      detail?.id === selectedId && (detail.enrollmentId?.trim() ?? "") !== ""
+        ? detail.enrollmentId!.trim()
+        : createPaymentEnrollmentId.trim();
+    const partyFallback = (
+      (detail?.id === selectedId ? detail.party : undefined) ??
       payments.find((x) => x.id === selectedId)?.party ??
       ""
     ).trim();
-  }, [manualPaymentIsUpdate, selectedId, detail, payments]);
-
-  const manualPaymentEnrollmentIdDisplay = useMemo(() => {
-    if (!manualPaymentIsUpdate || !selectedId) {
-      return "";
+    if (enrollmentId === "") {
+      return partyFallback !== "" ? partyFallback : "—";
     }
-    if (
-      detail?.id === selectedId &&
-      (detail.enrollmentId?.trim() ?? "") !== ""
-    ) {
-      return detail.enrollmentId!.trim();
-    }
-    return createPaymentEnrollmentId.trim();
-  }, [manualPaymentIsUpdate, selectedId, detail, createPaymentEnrollmentId]);
+    const row = enrollmentPickerRows.find((r) => r.enrollmentId === enrollmentId);
+    return formatManualPaymentEnrollmentEditLabel(row, partyFallback);
+  }, [
+    manualPaymentIsUpdate,
+    selectedId,
+    detail,
+    payments,
+    createPaymentEnrollmentId,
+    enrollmentPickerRows,
+  ]);
 
   const handleCancelManualPayment = () => {
     setActionError("");
@@ -2169,7 +2214,7 @@ export function ClientInvoicesPanel() {
       </PaginatedTableCard>
 
       <AdminEditorCard
-        title="Record or update customer payment"
+        title="Customer payment"
         description="When creating, pick an enrollment from the same list as draft invoices. After you select a manual inbound payment row in the Customer payments table below, you can update fields here; enrollment cannot be changed once the payment exists. Currency must match the enrollment. Use Pending until funds clear, then Succeeded when appropriate."
         actions={
           <>
@@ -2222,13 +2267,8 @@ export function ClientInvoicesPanel() {
               {manualPaymentIsUpdate ? (
                 <div className="mt-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800">
                   <p className="font-medium text-slate-900">
-                    {manualPaymentEnrollmentPartyDisplay !== ""
-                      ? manualPaymentEnrollmentPartyDisplay
-                      : "—"}
-                  </p>
-                  <p className="mt-0.5 font-mono text-xs text-slate-600">
-                    {manualPaymentEnrollmentIdDisplay !== ""
-                      ? formatTruncatedId(manualPaymentEnrollmentIdDisplay)
+                    {manualPaymentEnrollmentEditLabel !== ""
+                      ? manualPaymentEnrollmentEditLabel
                       : "—"}
                   </p>
                 </div>
@@ -2339,7 +2379,7 @@ export function ClientInvoicesPanel() {
 
       <PaginatedTableCard
         title="Customer payments"
-        description="Recent customer payments and refunds. Select a row for allocation and refund source; manual inbound payments without Stripe can be edited in the Record or update customer payment card above. Pending inbound: confirm from Operations. Deletable orphan rows: delete from Operations (see server rules)."
+        description="Recent customer payments and refunds. Select a row for allocation and refund source; manual inbound payments without Stripe can be edited in the Customer payment card above. Pending inbound: confirm from Operations. Deletable orphan rows: delete from Operations (see server rules)."
         isLoading={listLoading}
         isLoadingMore={false}
         hasMore={false}

--- a/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/client-invoices-panel.test.tsx
@@ -371,6 +371,26 @@ describe('ClientInvoicesPanel', () => {
       createdAt: '2026-01-01T00:00:00+00:00',
       orphanPaymentDeletable: false,
     });
+    billingMocks.listRecentEnrollmentsForInvoicing.mockResolvedValue({
+      items: [
+        {
+          enrollmentId: eid,
+          partyDisplayName: 'Pat',
+          partyEmail: null,
+          billToKind: 'contact',
+          instanceTitle: 'Spring Workshop',
+          parentServiceTitle: 'Workshop Series',
+          serviceTierName: 'Standard',
+          instanceCohort: 'Group A',
+          amountPaid: '10',
+          currency: 'HKD',
+          enrolledAt: '2026-01-01T00:00:00+00:00',
+          invoiceLinked: true,
+          billToMergeKey: 'k1',
+        },
+      ],
+      truncated: false,
+    });
     billingMocks.listCustomerInvoices.mockResolvedValue({
       items: [],
       next_cursor: null,
@@ -388,6 +408,13 @@ describe('ClientInvoicesPanel', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Update customer payment' })).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByText('Pat · Spring Workshop · Standard · Group A'),
+    ).toBeInTheDocument();
+    expect(
+      (document.getElementById('billing-create-pay-amount') as HTMLInputElement).value,
+    ).toBe('10.00');
 
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Renamed the manual inbound payment inline editor card title from **Record or update customer payment** to **Customer payment**, and updated the Customer payments table description to reference the new name.
- In **update** mode, the read-only Enrollment field now shows a single line: **party · instance or parent service · tier/cohort** (using the same interpunct spacing as elsewhere), resolved from `listRecentEnrollmentsForInvoicing` when the enrollment id matches a picker row; otherwise it falls back to the payment party label.
- When loading an editable manual payment for editing, the amount field is seeded with **two decimal places** (e.g. `10` → `10.00`).

## Tests

- Extended the manual payment editor test with enrollment picker data and assertions for the combined enrollment label and rounded amount.

## Risk / notes

- If the enrollment is not present in the recent-enrollments list, only the party fallback is shown (same as before for party-only, without the truncated UUID line).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b868544b-cb73-43d4-a259-e841ac5f0762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b868544b-cb73-43d4-a259-e841ac5f0762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

