### PR TITLE
Admin web: show service and tier in line totals override

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1787,33 +1787,58 @@ export function ClientInvoicesPanel() {
                   <div className="space-y-2">
                     {selectedEnrollmentRows.map((row) => {
                       const needsAmt = enrollmentNeedsAmountConfirmation(row);
+                      const partyCellDisplay =
+                        formatBillingEnrollmentPartyCell(row);
+                      const tierCohortDisplay = formatTierCohortDisplay(
+                        row.serviceTierName,
+                        row.instanceCohort,
+                      );
+                      const instanceServiceDisplay =
+                        formatEnrollmentPickerInstanceServiceDisplay(row);
+                      const partyLabelForA11y =
+                        partyCellDisplay !== ""
+                          ? partyCellDisplay
+                          : (row.partyDisplayName?.trim() ?? "enrollment");
                       return (
                         <div
                           key={row.enrollmentId}
-                          className={`flex flex-wrap items-center gap-3 border px-3 py-2 ${
+                          className={`flex flex-wrap items-start gap-x-4 gap-y-2 border px-3 py-2 ${
                             needsAmt
                               ? "border-amber-300 bg-amber-50"
                               : "border-slate-200"
                           }`}
                         >
-                          <span className="min-w-[180px] flex-1 text-sm">
-                            {row.partyDisplayName}
+                          <span className="min-w-0 max-w-[22rem] shrink-0 text-sm break-words">
+                            {partyCellDisplay !== "" ? partyCellDisplay : "—"}
                           </span>
-                          <span className="font-mono text-xs text-slate-600">
-                            {row.enrollmentId}
+                          <span className="min-w-0 shrink-0 text-sm">
+                            {instanceServiceDisplay !== ""
+                              ? instanceServiceDisplay
+                              : "—"}
+                          </span>
+                          <span className="max-w-[14rem] min-w-0 shrink-0 break-words text-sm">
+                            {tierCohortDisplay !== ""
+                              ? tierCohortDisplay
+                              : "—"}
                           </span>
                           {needsAmt ? (
-                            <p className="w-full text-xs text-amber-900">
+                            <p className="w-full basis-full text-xs text-amber-900">
                               This enrollment has no recorded amount; enter a
                               line total (use 0 for a zero-dollar line).
                             </p>
                           ) : null}
-                          <div className="flex items-center gap-2">
+                          <div className="ml-auto flex shrink-0 items-center gap-2">
                             <Label
                               className="sr-only"
                               htmlFor={`billing-line-override-${row.enrollmentId}`}
                             >
-                              Line total for {row.partyDisplayName}
+                              Line total for {partyLabelForA11y}
+                              {instanceServiceDisplay !== ""
+                                ? `, ${instanceServiceDisplay}`
+                                : ""}
+                              {tierCohortDisplay !== ""
+                                ? `, ${tierCohortDisplay}`
+                                : ""}
                             </Label>
                             <Input
                               id={`billing-line-override-${row.enrollmentId}`}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the client billing draft invoice flow, the **Line totals override** list no longer shows each enrollment UUID. It now shows the same **party**, **instance/service**, and **tier/cohort** display strings as the enrollment picker table, using the existing `formatBillingEnrollmentPartyCell`, `formatEnrollmentPickerInstanceServiceDisplay`, and `formatTierCohortDisplay` helpers.

## Why

Operators need to match override rows to table rows by human-readable service and cohort labels, not by internal enrollment ids (ids are still used for form state and API `lineTotalsByEnrollmentId`).

## Testing

- `cd apps/admin_web && npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx`
- `cd apps/admin_web && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f738a5fd-1d99-4a97-8db6-f9cbb1937e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f738a5fd-1d99-4a97-8db6-f9cbb1937e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

