### PR TITLE
Admin web: show service and tier in line totals override

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1795,10 +1795,15 @@ export function ClientInvoicesPanel() {
                       );
                       const instanceServiceDisplay =
                         formatEnrollmentPickerInstanceServiceDisplay(row);
-                      const partyLabelForA11y =
-                        partyCellDisplay !== ""
-                          ? partyCellDisplay
-                          : (row.partyDisplayName?.trim() ?? "enrollment");
+                      const partyPart =
+                        partyCellDisplay !== "" ? partyCellDisplay : "—";
+                      const servicePart =
+                        instanceServiceDisplay !== ""
+                          ? instanceServiceDisplay
+                          : "—";
+                      const tierPart =
+                        tierCohortDisplay !== "" ? tierCohortDisplay : "—";
+                      const lineOverrideEnrollmentLabel = `${partyPart} · ${servicePart} · ${tierPart}`;
                       return (
                         <div
                           key={row.enrollmentId}
@@ -1808,18 +1813,8 @@ export function ClientInvoicesPanel() {
                               : "border-slate-200"
                           }`}
                         >
-                          <span className="min-w-0 max-w-[22rem] shrink-0 text-sm break-words">
-                            {partyCellDisplay !== "" ? partyCellDisplay : "—"}
-                          </span>
-                          <span className="min-w-0 shrink-0 text-sm">
-                            {instanceServiceDisplay !== ""
-                              ? instanceServiceDisplay
-                              : "—"}
-                          </span>
-                          <span className="max-w-[14rem] min-w-0 shrink-0 break-words text-sm">
-                            {tierCohortDisplay !== ""
-                              ? tierCohortDisplay
-                              : "—"}
+                          <span className="min-w-0 flex-1 text-sm break-words">
+                            {lineOverrideEnrollmentLabel}
                           </span>
                           {needsAmt ? (
                             <p className="w-full basis-full text-xs text-amber-900">
@@ -1832,13 +1827,7 @@ export function ClientInvoicesPanel() {
                               className="sr-only"
                               htmlFor={`billing-line-override-${row.enrollmentId}`}
                             >
-                              Line total for {partyLabelForA11y}
-                              {instanceServiceDisplay !== ""
-                                ? `, ${instanceServiceDisplay}`
-                                : ""}
-                              {tierCohortDisplay !== ""
-                                ? `, ${tierCohortDisplay}`
-                                : ""}
+                              Line total for {lineOverrideEnrollmentLabel}
                             </Label>
                             <Input
                               id={`billing-line-override-${row.enrollmentId}`}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the client billing draft invoice flow, the **Line totals override** list shows each selected enrollment as one readable line:

`party · instance/service · tier/cohort`

(Unicode middle dot `·` with spaces, consistent with other billing labels.) Empty segments show `—` so the two separators stay predictable.

Enrollment UUIDs are not shown; ids remain used for form wiring and `lineTotalsByEnrollmentId`.

## Testing

- `cd apps/admin_web && npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx`
- `cd apps/admin_web && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f738a5fd-1d99-4a97-8db6-f9cbb1937e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f738a5fd-1d99-4a97-8db6-f9cbb1937e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

