### PR TITLE
Move draft invoice date above Create draft invoice button

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1574,52 +1574,27 @@ export function ClientInvoicesPanel() {
         }
       >
         <div className="space-y-4">
-          <div className="flex flex-wrap items-end gap-4">
-            <div className="min-w-[200px] max-w-md flex-1">
-              <Label htmlFor={draftModeId}>Draft type</Label>
-              <Select
-                id={draftModeId}
-                className="mt-1 w-full"
-                value={draftCreationMode}
-                onChange={(e) => {
-                  const v =
-                    e.target.value === "customized"
-                      ? "customized"
-                      : "enrollment";
-                  setDraftCreationMode(v);
-                  if (v === "enrollment") {
-                    setCustomizedFormSubmitEnabled(false);
-                  }
-                }}
-                disabled={editorBusy}
-              >
-                <option value="enrollment">Enrollment-based</option>
-                <option value="customized">Customized (manual lines)</option>
-              </Select>
-            </div>
-            <div className="min-w-[180px]">
-              <Label htmlFor={draftInvoiceDateId}>Invoice date</Label>
-              <Input
-                id={draftInvoiceDateId}
-                form={
-                  draftCreationMode === "enrollment"
-                    ? DRAFT_FORM_ID
-                    : CUSTOMIZED_DRAFT_INVOICE_FORM_ID
+          <div className="min-w-[200px] max-w-md">
+            <Label htmlFor={draftModeId}>Draft type</Label>
+            <Select
+              id={draftModeId}
+              className="mt-1 w-full"
+              value={draftCreationMode}
+              onChange={(e) => {
+                const v =
+                  e.target.value === "customized"
+                    ? "customized"
+                    : "enrollment";
+                setDraftCreationMode(v);
+                if (v === "enrollment") {
+                  setCustomizedFormSubmitEnabled(false);
                 }
-                type="date"
-                className="mt-1 w-full"
-                value={draftInvoiceDate}
-                onChange={(e) => setDraftInvoiceDate(e.target.value)}
-                onBlur={(e) => {
-                  if (e.target.value === "") {
-                    setDraftInvoiceDate(localTodayYmd());
-                  }
-                }}
-                min={draftInvoiceDateMin}
-                max={draftInvoiceDateMax}
-                disabled={editorBusy}
-              />
-            </div>
+              }}
+              disabled={editorBusy}
+            >
+              <option value="enrollment">Enrollment-based</option>
+              <option value="customized">Customized (manual lines)</option>
+            </Select>
           </div>
           {draftCreationMode === "enrollment" ? (
             <form
@@ -1934,6 +1909,29 @@ export function ClientInvoicesPanel() {
               }}
             />
           )}
+          <div className="min-w-[180px] max-w-xs">
+            <Label htmlFor={draftInvoiceDateId}>Invoice date</Label>
+            <Input
+              id={draftInvoiceDateId}
+              form={
+                draftCreationMode === "enrollment"
+                  ? DRAFT_FORM_ID
+                  : CUSTOMIZED_DRAFT_INVOICE_FORM_ID
+              }
+              type="date"
+              className="mt-1 w-full"
+              value={draftInvoiceDate}
+              onChange={(e) => setDraftInvoiceDate(e.target.value)}
+              onBlur={(e) => {
+                if (e.target.value === "") {
+                  setDraftInvoiceDate(localTodayYmd());
+                }
+              }}
+              min={draftInvoiceDateMin}
+              max={draftInvoiceDateMax}
+              disabled={editorBusy}
+            />
+          </div>
         </div>
       </AdminEditorCard>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the Finance **Create draft invoice** `AdminEditorCard`, the **Invoice date** label and date input were next to **Draft type** at the top. They are now rendered as the last block in the card body, immediately above the primary **Create draft invoice** action (which still lives in the card actions row per the admin editor pattern).

## Behavior

- Same `form` association to the active draft form (enrollment vs customized) so submit behavior is unchanged.
- Draft type remains at the top; enrollment picker / customized lines fill the middle; invoice date sits just above the button.

## Validation

- `npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx tests/components/admin/finance/finance-page.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3937f770-e4d1-4adf-a46c-7c493116598f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3937f770-e4d1-4adf-a46c-7c493116598f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

