### PR TITLE
Extend admin families search to family members

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -531,7 +531,7 @@ export function FamiliesPanel({
                   setDeleteActionError('');
                   setFilter('query', e.target.value);
                 }}
-                placeholder='Family name'
+                placeholder='Family name or member name / email'
               />
             </div>
             <div className='min-w-[140px]'>

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -3185,6 +3185,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
+                    /** @description Case-insensitive substring match on family name or on any linked member contact's first name, last name, email, or trimmed "first last" display label. */
                     query?: string;
                     active?: boolean;
                     cursor?: string;

--- a/backend/src/app/db/repositories/family.py
+++ b/backend/src/app/db/repositories/family.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, exists, func, or_, select
 from sqlalchemy.orm import Session, selectinload
 
-from app.db.models import Family, Location
-from app.db.models.family import FamilyMember
+from app.db.models import Contact, Family, FamilyMember, Location
 from app.db.models.tag import FamilyTag
 from app.db.repositories.base import BaseRepository
 from app.db.repositories.organization import _escape_like_pattern
@@ -19,6 +19,30 @@ class FamilyRepository(BaseRepository[Family]):
 
     def __init__(self, session: Session):
         super().__init__(session, Family)
+
+    @staticmethod
+    def _admin_list_query_filter(query: str) -> Any:
+        """Match family name or any linked member contact (name or email)."""
+        escaped = _escape_like_pattern(query.strip())
+        pattern = f"%{escaped}%"
+        full_name = func.trim(
+            func.concat(Contact.first_name, " ", func.coalesce(Contact.last_name, ""))
+        )
+        member_match = exists(
+            select(1)
+            .select_from(FamilyMember)
+            .join(Contact, FamilyMember.contact_id == Contact.id)
+            .where(
+                FamilyMember.family_id == Family.id,
+                or_(
+                    Contact.first_name.ilike(pattern, escape="\\"),
+                    Contact.last_name.ilike(pattern, escape="\\"),
+                    Contact.email.ilike(pattern, escape="\\"),
+                    full_name.ilike(pattern, escape="\\"),
+                ),
+            )
+        )
+        return or_(Family.family_name.ilike(pattern, escape="\\"), member_match)
 
     def list_for_admin(
         self,
@@ -47,9 +71,9 @@ class FamilyRepository(BaseRepository[Family]):
                 )
             )
         if query:
-            escaped = _escape_like_pattern(query.strip())
-            pattern = f"%{escaped}%"
-            statement = statement.where(Family.family_name.ilike(pattern, escape="\\"))
+            statement = statement.where(
+                FamilyRepository._admin_list_query_filter(query)
+            )
         if active is True:
             statement = statement.where(Family.archived_at.is_(None))
         if active is False:
@@ -68,9 +92,9 @@ class FamilyRepository(BaseRepository[Family]):
     ) -> int:
         statement = select(func.count(Family.id))
         if query:
-            escaped = _escape_like_pattern(query.strip())
-            pattern = f"%{escaped}%"
-            statement = statement.where(Family.family_name.ilike(pattern, escape="\\"))
+            statement = statement.where(
+                FamilyRepository._admin_list_query_filter(query)
+            )
         if active is True:
             statement = statement.where(Family.archived_at.is_(None))
         if active is False:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -2327,6 +2327,10 @@ paths:
       parameters:
         - name: query
           in: query
+          description: >
+            Case-insensitive substring match on family name or on any linked member
+            contact's first name, last name, email, or trimmed "first last" display
+            label.
           schema:
             type: string
         - name: active

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -71,7 +71,8 @@ their primary responsibilities.
   `GET|POST /v1/admin/contacts/{id}/notes` and `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`
   for standalone CRM notes on a contact (not tied to a sales lead), and `DELETE /v1/admin/contacts/{id}`
   for hard-deleting a contact after clearing blocking CRM rows),
-  `/v1/admin/families/picker`, `/v1/admin/families/*` (including `DELETE /v1/admin/families/{id}`
+  `/v1/admin/families/picker`, `/v1/admin/families/*` (`GET /v1/admin/families` optional `query`
+  matches family name and linked member contacts' names or email; including `DELETE /v1/admin/families/{id}`
   for hard-deleting a family after clearing blocking CRM rows; `POST /v1/admin/families/{id}/members`
   derives each member's role from the linked contact's `contact_type`; `PATCH /v1/admin/families/{id}/members/{memberId}`
   updates membership fields such as primary contact),

--- a/tests/test_family_repository_admin_list_filter.py
+++ b/tests/test_family_repository_admin_list_filter.py
@@ -1,0 +1,21 @@
+"""Compile-time checks for admin family list search SQL."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+
+from app.db.models import Family
+from app.db.repositories.family import FamilyRepository
+
+
+def test_admin_list_query_filter_compiles_for_postgres() -> None:
+    """Guard against invalid EXISTS/correlation in family list search."""
+    predicate = FamilyRepository._admin_list_query_filter("jo")
+    stmt = select(Family.id).where(predicate)
+    compiled = stmt.compile(
+        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": False}
+    )
+    sql = str(compiled).lower()
+    assert "exists" in sql
+    assert "family_members" in sql


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Contacts → **Families** table search field already sent a `query` parameter to `GET /v1/admin/families`, but the backend only matched `family_name`. The list (and `total_count`) now also match any linked member contact by first name, last name, email, or trimmed `first last` label (case-insensitive substring), using an `EXISTS` subquery so pagination and counts stay correct without duplicate rows.

## UI

- Search placeholder updated from “Family name” to “Family name or member name / email” so admins know member search is supported.

## Docs / contract

- `docs/api/admin.yaml`: documented the `query` parameter behavior.
- `docs/architecture/lambdas.md`: noted the list filter semantics for the CRM admin Lambda surface.
- Regenerated `apps/admin_web/src/types/generated/admin-api.generated.ts` via `npm run generate:admin-api-types`.

## Tests

- `tests/test_family_repository_admin_list_filter.py`: compiles the filter SQL for PostgreSQL to guard against broken `EXISTS` / correlation.
- `npx vitest run tests/components/admin/contacts/families-panel.test.tsx`
- `pytest tests/test_admin_router.py tests/test_admin_crm_routes.py tests/test_family_repository_admin_list_filter.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5063709-f2e7-414d-b6ec-b0b567406875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5063709-f2e7-414d-b6ec-b0b567406875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

