### PR TITLE
fix(admin): Tax tab revenue date uses invoice document date

### DIFF
--- a/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/tax-fiscal-year-panel.tsx
@@ -130,7 +130,7 @@ export function TaxFiscalYearPanel() {
   return (
     <PaginatedTableCard
       title='Tax'
-      description={`Hong Kong fiscal year ${fyMeta.start} to ${fyMeta.end}. Expenses use invoice date when set; otherwise paid date. Revenue uses issued invoice totals by issue date.`}
+      description={`Hong Kong fiscal year ${fyMeta.start} to ${fyMeta.end}. Expenses use invoice date when set; otherwise paid date. Revenue uses issued invoice totals by the invoice date (issue timestamp if missing).`}
       isLoading={isLoading}
       isLoadingMore={false}
       hasMore={false}
@@ -208,7 +208,11 @@ export function TaxFiscalYearPanel() {
                   {row.needsInvoiceDateWarning ? (
                     <span
                       className='inline-flex items-center gap-1 text-xs font-medium text-amber-700'
-                      title='Vendor invoice date missing — classified using paid date'
+                      title={
+                        row.kind === 'revenue'
+                          ? 'Invoice date missing — classified using issue timestamp'
+                          : 'Vendor invoice date missing — classified using paid date'
+                      }
                     >
                       <WarningTriangleIcon className='h-4 w-4 shrink-0 text-amber-600' aria-hidden />
                       Needs date

--- a/apps/admin_web/src/lib/tax-fiscal-year-report.ts
+++ b/apps/admin_web/src/lib/tax-fiscal-year-report.ts
@@ -34,6 +34,18 @@ function expenseClassificationDate(expense: Expense): {
   return { date: paid, needsInvoiceDateWarning: true };
 }
 
+function revenueClassificationDate(inv: CustomerInvoiceSummary): {
+  date: string | null;
+  needsInvoiceDateWarning: boolean;
+} {
+  const invoiceOk = parseIsoDateOnly(inv.invoiceDate ?? null);
+  if (invoiceOk) {
+    return { date: invoiceOk, needsInvoiceDateWarning: false };
+  }
+  const issued = formatInstantAsHongKongDateString(inv.issuedAt ?? null);
+  return { date: issued, needsInvoiceDateWarning: true };
+}
+
 export function buildTaxFiscalYearRows(
   expenses: Expense[],
   issuedInvoices: CustomerInvoiceSummary[],
@@ -75,8 +87,8 @@ export function buildTaxFiscalYearRows(
     if (inv.status !== 'issued') {
       continue;
     }
-    const issued = formatInstantAsHongKongDateString(inv.issuedAt ?? null);
-    if (!issued || !isDateInInclusiveRange(issued, start, end)) {
+    const { date: revenueDate, needsInvoiceDateWarning } = revenueClassificationDate(inv);
+    if (!revenueDate || !isDateInInclusiveRange(revenueDate, start, end)) {
       continue;
     }
     const name = inv.billToDisplayName?.trim() ?? '';
@@ -85,13 +97,13 @@ export function buildTaxFiscalYearRows(
       name !== '' && num !== '' ? `${name} (${num})` : name !== '' ? name : num !== '' ? num : 'Invoice';
     revenueRows.push({
       kind: 'revenue',
-      classificationDate: issued,
+      classificationDate: revenueDate,
       description,
       currency: inv.currency?.trim().toUpperCase() ?? '',
       amount: inv.total?.trim() ?? '',
       tax: inv.taxTotal?.trim() ?? '',
       referenceId: invId,
-      needsInvoiceDateWarning: false,
+      needsInvoiceDateWarning,
       invoiceNumber: inv.invoiceNumber ?? null,
     });
   }

--- a/apps/admin_web/tests/lib/tax-fiscal-year-report.test.ts
+++ b/apps/admin_web/tests/lib/tax-fiscal-year-report.test.ts
@@ -85,7 +85,7 @@ describe('tax-fiscal-year-report', () => {
     expect(buildTaxFiscalYearRows([voided, paid], [], 2025, 'voided')[0]?.referenceId).toBe('v');
   });
 
-  it('includes expenses matching the status filter in range and revenue by issued date', () => {
+  it('includes expenses matching the status filter in range and revenue by invoice date', () => {
     const rows = buildTaxFiscalYearRows(
       [
         expenseStub({
@@ -107,6 +107,7 @@ describe('tax-fiscal-year-report', () => {
           taxTotal: '50',
           total: '950',
           billToDisplayName: 'Family A',
+          invoiceDate: '2025-08-01',
           issuedAt: '2025-08-01T08:00:00.000Z',
         } satisfies CustomerInvoiceSummary,
       ],
@@ -115,7 +116,59 @@ describe('tax-fiscal-year-report', () => {
     );
     expect(rows.map((r) => r.kind)).toEqual(['revenue', 'expense']);
     expect(rows[0]?.kind).toBe('revenue');
+    expect(rows[0]?.classificationDate).toBe('2025-08-01');
     expect(rows[1]?.kind).toBe('expense');
+  });
+
+  it('classifies revenue by invoiceDate when it differs from issuedAt calendar day', () => {
+    const rows = buildTaxFiscalYearRows(
+      [],
+      [
+        {
+          id: 'i-cross',
+          status: 'issued',
+          invoiceNumber: 'INV-X',
+          currency: 'HKD',
+          subtotal: '100',
+          taxTotal: '0',
+          total: '100',
+          billToDisplayName: 'Client',
+          invoiceDate: '2025-07-31',
+          issuedAt: '2025-08-01T02:00:00.000Z',
+        } satisfies CustomerInvoiceSummary,
+      ],
+      2025,
+      'paid',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kind).toBe('revenue');
+    expect(rows[0]?.classificationDate).toBe('2025-07-31');
+    expect(rows[0]?.needsInvoiceDateWarning).toBe(false);
+  });
+
+  it('flags revenue missing invoice date when classified by issue timestamp', () => {
+    const rows = buildTaxFiscalYearRows(
+      [],
+      [
+        {
+          id: 'i-legacy',
+          status: 'issued',
+          invoiceNumber: 'INV-L',
+          currency: 'HKD',
+          subtotal: '50',
+          taxTotal: '0',
+          total: '50',
+          billToDisplayName: 'Client',
+          invoiceDate: null,
+          issuedAt: '2025-06-15T12:00:00.000Z',
+        } satisfies CustomerInvoiceSummary,
+      ],
+      2025,
+      'paid',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.classificationDate).toBe('2025-06-15');
+    expect(rows[0]?.needsInvoiceDateWarning).toBe(true);
   });
 
   it('flags missing invoice date when using paid date', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Finance → Tax fiscal-year table showed revenue using the Hong Kong calendar day derived from `issuedAt` only. Issued customer invoices also expose `invoiceDate` (the date stored on the invoice at issue time, aligned with the PDF snapshot).

## Changes

- **Classification and Date column**: Revenue rows now use `invoiceDate` when present, matching the invoice’s issued document date. If `invoiceDate` is missing (legacy data), the row falls back to the Hong Kong date from `issuedAt` and shows the existing “Needs date” indicator with a revenue-specific tooltip.
- **Copy**: Panel description updated to describe revenue as classified by invoice date with fallback.
- **Tests**: Added coverage for `invoiceDate` precedence over `issuedAt` and for the missing-invoice-date warning on revenue.

## Validation

- `npx vitest run tests/lib/tax-fiscal-year-report.test.ts`
- `npm run lint` in `apps/admin_web`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-662ca512-1ce6-4f28-8c6f-e12c97357fb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-662ca512-1ce6-4f28-8c6f-e12c97357fb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

