### PR TITLE
fix(bulk-expense-import): diagnose empty/refused responses and fall b…

### DIFF
--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -48,6 +48,12 @@ def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, 
 _MAX_BULK_INVOICES = 100
 
 
+_BULK_SYSTEM_PROMPT = (
+    "You extract structured invoice rows from financial documents and "
+    "return strict JSON only."
+)
+
+
 def parse_bulk_expense_invoices_from_assets(
     assets: Sequence[Mapping[str, Any]],
     *,
@@ -55,7 +61,16 @@ def parse_bulk_expense_invoices_from_assets(
 ) -> list[dict[str, Any]]:
     """Parse many invoice rows from one combined PDF (or images) via OpenRouter.
 
-    Returns a list of normalized invoice dicts (same shape as ``parse_invoice_from_assets``).
+    Returns a list of normalized invoice dicts (same shape as
+    ``parse_invoice_from_assets``).
+
+    For PDFs, this loops over a small ordered list of OpenRouter PDF parser
+    engines (configured first, then one alternate). On every attempt, any
+    failure inside the parsing pipeline (HTTP error, empty/refused content,
+    unrepairable JSON, unknown wrapper shape, zero rows) advances to the next
+    engine. The S3 read for each attachment happens once and is reused across
+    attempts. The final raised ``RuntimeError`` includes the engines tried and
+    the last underlying error so the persisted job message stays diagnosable.
     """
     if not assets:
         raise ValueError("At least one asset is required for parsing")
@@ -68,33 +83,115 @@ def parse_bulk_expense_invoices_from_assets(
     has_pdf = any(
         _normalize_content_type(asset) == "application/pdf" for asset in assets
     )
-    body = _openrouter_chat_completion(
-        system_prompt=(
-            "You extract structured invoice rows from financial documents and "
-            "return strict JSON only."
-        ),
-        user_content_blocks=content,
-        has_pdf_attachment=has_pdf,
-        timeout=timeout,
+    engine_attempts: tuple[str | None, ...] = (
+        _bulk_pdf_engine_attempt_order() if has_pdf else (None,)
     )
-    raw_invoices = _parse_bulk_invoices_payload(body)
-    if not raw_invoices:
-        raise RuntimeError(
+
+    attempted_labels: list[str] = []
+    last_exc: Exception | None = None
+
+    for engine in engine_attempts:
+        attempted_labels.append(engine or "n/a")
+        try:
+            normalized = _attempt_bulk_parse(
+                content=content,
+                has_pdf=has_pdf,
+                timeout=timeout,
+                pdf_engine=engine,
+            )
+        except Exception as exc:
+            last_exc = exc
+            logger.warning(
+                "Bulk parse attempt failed; will try next engine if available",
+                extra={
+                    "pdf_engine": engine,
+                    "error": repr(exc),
+                    "remaining_engines": [
+                        e for e in engine_attempts[engine_attempts.index(engine) + 1 :]
+                    ],
+                },
+            )
+            continue
+        if normalized:
+            logger.info(
+                "Bulk invoice parse completed successfully",
+                extra={
+                    "invoice_count": len(normalized),
+                    "pdf_engine": engine,
+                    "engine_attempts": attempted_labels,
+                },
+            )
+            return normalized
+        last_exc = RuntimeError(
             "Parser found no invoice rows in this document. The PDF may be "
             "image-only without readable text, contain no extractable invoice "
             "data, or be in a layout the parser could not recognize as "
             "invoices. Try a clearer scan or a single-invoice import."
         )
+        logger.info(
+            "Bulk parse returned no rows; will try next engine if available",
+            extra={"pdf_engine": engine, "engine_attempts": attempted_labels},
+        )
+
+    engines_label = ", ".join(attempted_labels)
+    if last_exc is None:
+        raise RuntimeError(
+            f"Parser failed for bulk invoices across {len(attempted_labels)} "
+            f"attempt(s) ({engines_label}); no underlying error captured."
+        )
+    raise RuntimeError(
+        f"Parser failed for bulk invoices across {len(attempted_labels)} "
+        f"attempt(s) ({engines_label}); last error: {last_exc}"
+    )
+
+
+def _attempt_bulk_parse(
+    *,
+    content: list[dict[str, Any]],
+    has_pdf: bool,
+    timeout: int,
+    pdf_engine: str | None,
+) -> list[dict[str, Any]]:
+    """Run one bulk parse attempt with a specific PDF engine.
+
+    Returns the normalized invoice rows on success. Returns an empty list when
+    the response was usable but contained zero rows. Raises ``RuntimeError``
+    on any unrecoverable parse-pipeline failure (HTTP, empty content, JSON
+    unrepairable, unknown shape, too-many-invoices guard).
+    """
+    body = _openrouter_chat_completion(
+        system_prompt=_BULK_SYSTEM_PROMPT,
+        user_content_blocks=content,
+        has_pdf_attachment=has_pdf,
+        timeout=timeout,
+        pdf_engine_override=pdf_engine,
+    )
+    raw_invoices = _parse_bulk_invoices_payload(body)
+    if not raw_invoices:
+        return []
     if len(raw_invoices) > _MAX_BULK_INVOICES:
         raise RuntimeError(
             f"Parser returned too many invoices (max {_MAX_BULK_INVOICES})"
         )
-    normalized = [_normalize_result(entry) for entry in raw_invoices]
-    logger.info(
-        "Bulk invoice parse completed successfully",
-        extra={"invoice_count": len(normalized)},
-    )
-    return normalized
+    return [_normalize_result(entry) for entry in raw_invoices]
+
+
+_PDF_ENGINE_FALLBACKS: dict[str, tuple[str, ...]] = {
+    "mistral-ocr": ("pdf-text",),
+    "pdf-text": ("mistral-ocr",),
+    "native": ("mistral-ocr",),
+}
+
+
+def _bulk_pdf_engine_attempt_order() -> tuple[str, ...]:
+    """Configured PDF engine first, then one alternate engine.
+
+    Two attempts maximum to stay inside the bulk-import Lambda timeout
+    budget (~600s with a 240s per-call cap and a 60s repair retry).
+    """
+    configured = _pdf_parser_engine()
+    fallbacks = _PDF_ENGINE_FALLBACKS.get(configured, ())
+    return (configured, *fallbacks)
 
 
 def _openrouter_chat_completion(
@@ -103,8 +200,15 @@ def _openrouter_chat_completion(
     user_content_blocks: list[dict[str, Any]],
     has_pdf_attachment: bool,
     timeout: int,
+    pdf_engine_override: str | None = None,
 ) -> str:
-    """POST to OpenRouter and return the raw HTTP response body string."""
+    """POST to OpenRouter and return the raw HTTP response body string.
+
+    ``pdf_engine_override`` lets callers force a specific PDF parser engine
+    (``mistral-ocr``, ``pdf-text``, or ``native``). Used by the bulk-import
+    engine fallback loop when the configured engine yields an empty or
+    unusable response on a given document.
+    """
     endpoint_url = _require_env("OPENROUTER_CHAT_COMPLETIONS_URL")
     model = _require_env("OPENROUTER_MODEL")
     api_key = _get_api_key()
@@ -122,10 +226,11 @@ def _openrouter_chat_completion(
         ],
     }
     if has_pdf_attachment:
+        engine = pdf_engine_override or _pdf_parser_engine()
         payload["plugins"] = [
             {
                 "id": _PDF_PLUGIN_ID,
-                "pdf": {"engine": _pdf_parser_engine()},
+                "pdf": {"engine": engine},
             }
         ]
 
@@ -216,19 +321,47 @@ def _normalize_content_type(asset: Mapping[str, Any]) -> str:
 
 
 def _extract_message_text(body: str) -> str:
-    """Pull the model-generated text out of an OpenRouter chat completion body."""
+    """Pull the model-generated text out of an OpenRouter chat completion body.
+
+    Raises ``RuntimeError`` with a diagnostic message when the response cannot
+    yield usable text (top-level/per-choice error, model refusal, truncation,
+    content-filter block, or empty ``content`` for any other reason). This
+    avoids the previous failure mode where an empty string was passed to
+    ``json.loads`` and produced ``Expecting value: line 1 column 1 (char 0)``.
+    """
     payload = json.loads(body)
     if not isinstance(payload, dict):
         raise RuntimeError("OpenRouter response must be a JSON object")
+
+    top_error = payload.get("error")
+    if isinstance(top_error, dict):
+        message_text = top_error.get("message") or json.dumps(top_error)[:300]
+        code = top_error.get("code")
+        suffix = f" (code={code})" if code is not None else ""
+        raise RuntimeError(f"OpenRouter returned error: {message_text}{suffix}")
+    if isinstance(top_error, str) and top_error.strip():
+        raise RuntimeError(f"OpenRouter returned error: {top_error.strip()[:300]}")
+
     choices = payload.get("choices")
     if not isinstance(choices, list) or not choices:
         raise RuntimeError("OpenRouter response choices are missing")
     first_choice = choices[0]
     if not isinstance(first_choice, dict):
         raise RuntimeError("OpenRouter response choice has invalid shape")
+
+    choice_error = first_choice.get("error")
+    if isinstance(choice_error, dict):
+        message_text = choice_error.get("message") or json.dumps(choice_error)[:300]
+        raise RuntimeError(f"OpenRouter choice returned error: {message_text}")
+
     message = first_choice.get("message")
     if not isinstance(message, dict):
         raise RuntimeError("OpenRouter response message is missing")
+
+    refusal = message.get("refusal")
+    if isinstance(refusal, str) and refusal.strip():
+        raise RuntimeError(f"Model refused to extract: {refusal.strip()[:500]}")
+
     content = message.get("content")
     if isinstance(content, list):
         text_parts = [
@@ -239,12 +372,48 @@ def _extract_message_text(body: str) -> str:
         raw_text = "\n".join(part for part in text_parts if part)
     else:
         raw_text = str(content or "")
-    return (
+    cleaned = (
         raw_text.strip()
         .removeprefix("```json")
         .removeprefix("```")
         .removesuffix("```")
         .strip()
+    )
+    if cleaned:
+        return cleaned
+
+    raise _empty_response_error(payload, first_choice)
+
+
+def _empty_response_error(
+    payload: Mapping[str, Any], first_choice: Mapping[str, Any]
+) -> RuntimeError:
+    """Build a diagnostic ``RuntimeError`` for an empty model response."""
+    finish_reason = first_choice.get("finish_reason") or first_choice.get(
+        "finishReason"
+    )
+    usage = payload.get("usage") if isinstance(payload, dict) else None
+    completion_tokens = (
+        usage.get("completion_tokens") if isinstance(usage, dict) else None
+    )
+    details: list[str] = []
+    if finish_reason:
+        details.append(f"finish_reason={finish_reason}")
+    if completion_tokens is not None:
+        details.append(f"completion_tokens={completion_tokens}")
+    suffix = f" ({'; '.join(details)})" if details else ""
+
+    if finish_reason == "length":
+        return RuntimeError(
+            f"Model output was truncated before any JSON was produced{suffix}. "
+            "The document may be too long for one parse; try a smaller PDF."
+        )
+    if finish_reason == "content_filter":
+        return RuntimeError(f"Model output was blocked by the content filter{suffix}.")
+    return RuntimeError(
+        f"Model returned an empty response{suffix}. The PDF may be unreadable "
+        "to this engine, the model may have failed to extract any text, or "
+        "the request may have been rejected upstream."
     )
 
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -512,20 +512,30 @@ their primary responsibilities.
   fails `json.loads` (most often unescaped quotes inside line-item descriptions),
   the parser logs a redacted ±80-char snippet around the failure offset and
   retries once with a JSON-repair chat completion (no PDF re-attached, capped at
-  60s). A second failure marks the job `failed` with a snippet-bearing message
-  instead of a bare `JSONDecodeError`.   Once the response parses, the bulk parser
-  tolerates several wrapper shapes — alias keys (`invoices`, `records`, `data`,
-  `results`, `rows`, `items`, `expenses`, `transactions`, `charges`, `entries`),
-  any single unknown list-of-dicts value, or a top-level dict that itself looks
-  like one invoice (wrapped to a one-row import). An empty top-level object
-  (`{}`, the model's only way of saying "nothing to extract" under JSON mode)
-  is treated as zero rows and produces an actionable "no invoice rows in this
-  document" message instead of a wrapper-shape error. When none of the shapes
-  match, the job `failed` message reports the actual top-level keys for
-  diagnosis.
-- Timeout / budget: **600s** Lambda timeout with **720s** SQS visibility; OpenRouter bulk
-  calls cap at **240s** plus an optional **60s** JSON-repair retry, so DB writes
-  stay inside the Lambda window
+  60s). A second failure surfaces a snippet-bearing message instead of a bare
+  `JSONDecodeError`. Once the response parses, the bulk parser tolerates several
+  wrapper shapes — alias keys (`invoices`, `records`, `data`, `results`, `rows`,
+  `items`, `expenses`, `transactions`, `charges`, `entries`), any single unknown
+  list-of-dicts value, or a top-level dict that itself looks like one invoice
+  (wrapped to a one-row import). An empty top-level object (`{}`, the model's
+  only way of saying "nothing to extract" under JSON mode) is treated as zero
+  rows. When the model returns no usable text at all (empty `content`, refusal,
+  `finish_reason=length` truncation, content-filter block, or top-level error
+  in the OpenRouter envelope), the parser raises a diagnostic message naming
+  the cause and including `finish_reason` / `completion_tokens` rather than
+  feeding empty text to `json.loads`.
+- PDF engine fallback: bulk parses iterate over an ordered set of OpenRouter
+  PDF parser engines — the configured engine first, then one alternate
+  (`mistral-ocr` ↔ `pdf-text`; `native` → `mistral-ocr`). Any failure inside
+  the inner pipeline (HTTP error, empty/refused content, unrepairable JSON,
+  unknown wrapper shape, zero rows) advances to the next engine. The S3 read
+  for each attachment happens once and is reused across attempts. The final
+  `RuntimeError` names the engines tried and includes the last underlying
+  error so the persisted job message stays diagnosable.
+- Timeout / budget: **600s** Lambda timeout with **720s** SQS visibility;
+  OpenRouter bulk calls cap at **240s** per engine attempt (max two attempts)
+  plus an optional **60s** JSON-repair retry, so DB writes stay inside the
+  Lambda window
 - Concurrency: no per-function reserved concurrency in CDK (shared unreserved pool) so
   deploys remain valid when the account already reserves capacity on other Lambdas
 - Environment:

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -787,6 +787,204 @@ def test_parse_bulk_expense_invoices_accepts_data_alias(monkeypatch: Any) -> Non
     assert rows[0]["total"] == 8.0
 
 
+def test_extract_message_text_raises_on_top_level_error_object() -> None:
+    body = json.dumps({"error": {"message": "Upstream model overloaded", "code": 503}})
+    with pytest.raises(RuntimeError) as exc_info:
+        parser._extract_message_text(body)
+    msg = str(exc_info.value)
+    assert "Upstream model overloaded" in msg
+    assert "503" in msg
+
+
+def test_extract_message_text_raises_on_refusal() -> None:
+    body = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "refusal": "I cannot extract personal data from this document.",
+                    }
+                }
+            ]
+        }
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        parser._extract_message_text(body)
+    assert "Model refused to extract" in str(exc_info.value)
+    assert "personal data" in str(exc_info.value)
+
+
+def test_extract_message_text_raises_on_empty_content_with_truncation_hint() -> None:
+    body = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {"content": ""},
+                    "finish_reason": "length",
+                }
+            ],
+            "usage": {"completion_tokens": 0},
+        }
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        parser._extract_message_text(body)
+    msg = str(exc_info.value)
+    assert "truncated" in msg
+    assert "finish_reason=length" in msg
+
+
+def test_extract_message_text_raises_on_empty_content_with_stop_finish() -> None:
+    body = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {"content": None},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        parser._extract_message_text(body)
+    msg = str(exc_info.value)
+    assert "empty response" in msg
+    assert "finish_reason=stop" in msg
+
+
+def test_bulk_pdf_engine_attempt_order_pairs_each_engine_with_alternate(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
+    assert parser._bulk_pdf_engine_attempt_order() == ("mistral-ocr", "pdf-text")
+    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "pdf-text")
+    assert parser._bulk_pdf_engine_attempt_order() == ("pdf-text", "mistral-ocr")
+    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "native")
+    assert parser._bulk_pdf_engine_attempt_order() == ("native", "mistral-ocr")
+
+
+def test_parse_bulk_expense_invoices_falls_back_to_alternate_engine(
+    monkeypatch: Any,
+) -> None:
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    valid_body = _bulk_chat_completion_body(
+        json.dumps(
+            {
+                "invoices": [
+                    {
+                        "vendor_name": "Shop Z",
+                        "invoice_number": "F1",
+                        "invoice_date": "2026-04-05",
+                        "due_date": None,
+                        "currency": "USD",
+                        "subtotal": 7,
+                        "tax": 0,
+                        "total": 7,
+                        "line_items": [],
+                        "confidence": 0.95,
+                    }
+                ]
+            }
+        )
+    )
+    empty_body = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {"content": ""},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+
+    captured_engines: list[str | None] = []
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        payload = json.loads(kwargs["body"])
+        plugins = payload.get("plugins") or []
+        engine = plugins[0]["pdf"]["engine"] if plugins else None
+        captured_engines.append(engine)
+        if len(captured_engines) == 1:
+            return {"status": 200, "body": empty_body}
+        return {"status": 200, "body": valid_body}
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    rows = parser.parse_bulk_expense_invoices_from_assets(
+        [
+            {
+                "id": "asset-fb",
+                "s3_key": "k",
+                "file_name": "bulk.pdf",
+                "content_type": "application/pdf",
+            }
+        ],
+        timeout=25,
+    )
+    assert captured_engines == ["mistral-ocr", "pdf-text"], (
+        "expected one attempt with the configured engine and one with the alternate"
+    )
+    assert len(rows) == 1
+    assert rows[0]["vendor_name"] == "Shop Z"
+
+
+def test_parse_bulk_expense_invoices_exhausts_engines_and_names_them(
+    monkeypatch: Any,
+) -> None:
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    empty_body = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {"content": ""},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+    )
+
+    def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        return {"status": 200, "body": empty_body}
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        parser.parse_bulk_expense_invoices_from_assets(
+            [
+                {
+                    "id": "asset-exhaust",
+                    "s3_key": "k",
+                    "file_name": "bulk.pdf",
+                    "content_type": "application/pdf",
+                }
+            ],
+            timeout=25,
+        )
+
+    msg = str(exc_info.value)
+    assert "across 2 attempt(s)" in msg
+    assert "mistral-ocr" in msg
+    assert "pdf-text" in msg
+    assert "empty response" in msg
+
+
 def test_parse_bulk_expense_invoices_raises_descriptive_error_when_model_returns_empty_object(
     monkeypatch: Any,
 ) -> None:


### PR DESCRIPTION
…ack across PDF engines

Fourth iteration on the bulk-PDF parse failure surface. The user's most recent error was:

    RuntimeError('Parser returned invalid JSON for bulk invoices even after
                 repair: Expecting value: line 1 column 1 (char 0) near ......')

Root cause: `_extract_message_text` was silently returning "" whenever the OpenRouter `message.content` was empty / null (refusal, content filter, `finish_reason=length`, or PDF plugin returning nothing for the OCR engine). We then handed empty text to `json.loads`, attempted a JSON-repair on empty text (which also returned empty), and surfaced a confusing "...near ......" message — burning two LLM calls on a problem JSON repair cannot fix.

This change makes two coordinated improvements so any single PDF gets the strongest reasonable shot at parsing before failing with an actionable message.

Diagnostic extraction (`_extract_message_text`):

- Detects and raises `RuntimeError` for top-level `error` (string or dict), per-choice `error`, OpenAI-style `message.refusal`, and empty content.
- For empty content, includes `finish_reason` and `usage.completion_tokens` in the message and special-cases `length` ("truncated... try a smaller PDF") and `content_filter` ("blocked by the content filter").
- Non-empty path is unchanged.

PDF engine fallback in `parse_bulk_expense_invoices_from_assets`:

- New `_bulk_pdf_engine_attempt_order` returns the configured engine first, then one alternate (`mistral-ocr` <-> `pdf-text`; `native` -> `mistral-ocr`). Two attempts maximum to stay inside the 600s Lambda budget (240+240+60 = 540).
- New `_attempt_bulk_parse` runs one attempt with a specific engine. The S3 read happens once at the top and is reused across attempts.
- Loop catches HTTP errors, empty/refused content, unrepairable JSON, unknown wrapper shape, and zero rows; logs the engine and advances. On success returns immediately. On total exhaustion raises a `RuntimeError` that names the engines tried and embeds the last underlying error so the persisted job message stays diagnosable.
- `_openrouter_chat_completion` accepts a new `pdf_engine_override` parameter for engine fallback; `_request_json_repair` is unaffected (no PDF attached).

Tests in `tests/test_openrouter_expense_parser.py`:

- `_extract_message_text` raises on top-level error (with code), refusal, empty content with `finish_reason=length`, and empty content with `finish_reason=stop`.
- `_bulk_pdf_engine_attempt_order` returns the expected pairing for each configured engine.
- Bulk parse falls back to the alternate engine when the first returns empty content; asserts the second request used the alternate engine.
- Bulk parse exhausts both engines when both return empty content; the final error names both engines and includes the empty-response diagnostic.
- All previously-added tests (snippet on JSON repair failure, `{"data":...}` alias, `{}` -> no-rows, etc.) still pass — the success path is reached on the first engine attempt.

Docs: `docs/architecture/lambdas.md` documents the empty-response diagnostic and the PDF engine fallback ordering.

No DB schema or API contract change. The file was already over the `.cursorrules` 500-line guidance and grew further (~1029 lines); a follow-up split is reasonable but intentionally not done here.