### PR TITLE
fix(bulk-expense-import): add native engine fallback and clean OpenRo…

### DIFF
--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -177,17 +177,24 @@ def _attempt_bulk_parse(
 
 
 _PDF_ENGINE_FALLBACKS: dict[str, tuple[str, ...]] = {
-    "mistral-ocr": ("pdf-text",),
-    "pdf-text": ("mistral-ocr",),
-    "native": ("mistral-ocr",),
+    # ``native`` bypasses the OpenRouter file-parser plugin entirely and lets
+    # the (multimodal) model handle the PDF directly, so it is ordered last
+    # for the two plugin-backed engines: when the plugin layer rejects a PDF
+    # with HTTP 4xx, ``native`` is the most likely engine to recover.
+    "mistral-ocr": ("pdf-text", "native"),
+    "pdf-text": ("mistral-ocr", "native"),
+    "native": ("mistral-ocr", "pdf-text"),
 }
 
 
 def _bulk_pdf_engine_attempt_order() -> tuple[str, ...]:
-    """Configured PDF engine first, then one alternate engine.
+    """Configured PDF engine first, then alternates.
 
-    Two attempts maximum to stay inside the bulk-import Lambda timeout
-    budget (~600s with a 240s per-call cap and a 60s repair retry).
+    Up to three attempts. Engine attempts that fail with an HTTP 4xx (such as
+    a file-parser plugin rejection) typically return in seconds, so the wall
+    time stays dominated by whichever attempt actually runs the model. The
+    configured 600s Lambda timeout absorbs the worst-case sequential 240s
+    timeouts only for the rare case where every engine stalls.
     """
     configured = _pdf_parser_engine()
     fallbacks = _PDF_ENGINE_FALLBACKS.get(configured, ())
@@ -248,9 +255,7 @@ def _openrouter_chat_completion(
     status_code = int(response.get("status", 0) or 0)
     body = str(response.get("body", "") or "")
     if status_code < 200 or status_code >= 300:
-        preview = body.replace("\n", " ").replace("\r", " ").strip()
-        if len(preview) > 500:
-            preview = f"{preview[:500]}..."
+        preview = _format_openrouter_error_preview(body)
         logger.warning(
             "OpenRouter request failed",
             extra={"status_code": status_code, "response_preview": preview or None},
@@ -260,6 +265,44 @@ def _openrouter_chat_completion(
             f"OpenRouter request failed with status {status_code}{detail}"
         )
     return body
+
+
+def _format_openrouter_error_preview(body: str) -> str:
+    """Return a short, human-readable summary of an OpenRouter error body.
+
+    OpenRouter typically returns ``{"error": {"message": "...", "code": N,
+    "metadata": {...}}, "user_id": "..."}`` on 4xx/5xx responses. Surface only
+    the actionable message + code so the persisted bulk-import job row stays
+    readable and does not leak unrelated fields like ``user_id`` or the full
+    metadata blob.
+    """
+    text = body.strip()
+    if not text:
+        return ""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        flat = text.replace("\n", " ").replace("\r", " ")
+        return flat[:500] + ("..." if len(flat) > 500 else "")
+
+    if isinstance(payload, dict):
+        err = payload.get("error")
+        if isinstance(err, dict):
+            message = str(err.get("message") or "").strip()
+            code = err.get("code")
+            if message and code is not None:
+                return f"{message} (code={code})"
+            if message:
+                return message
+            return json.dumps(err)[:500]
+        if isinstance(err, str) and err.strip():
+            return err.strip()[:500]
+        msg = payload.get("message")
+        if isinstance(msg, str) and msg.strip():
+            return msg.strip()[:500]
+
+    flat = text.replace("\n", " ").replace("\r", " ")
+    return flat[:500] + ("..." if len(flat) > 500 else "")
 
 
 def _build_attachment_content(asset: Mapping[str, Any]) -> dict[str, Any]:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -525,17 +525,25 @@ their primary responsibilities.
   the cause and including `finish_reason` / `completion_tokens` rather than
   feeding empty text to `json.loads`.
 - PDF engine fallback: bulk parses iterate over an ordered set of OpenRouter
-  PDF parser engines — the configured engine first, then one alternate
-  (`mistral-ocr` ↔ `pdf-text`; `native` → `mistral-ocr`). Any failure inside
-  the inner pipeline (HTTP error, empty/refused content, unrepairable JSON,
-  unknown wrapper shape, zero rows) advances to the next engine. The S3 read
-  for each attachment happens once and is reused across attempts. The final
-  `RuntimeError` names the engines tried and includes the last underlying
-  error so the persisted job message stays diagnosable.
+  PDF parser engines — the configured engine first, then up to two alternates.
+  For the file-parser-plugin engines the chain ends with `native`, which
+  bypasses the plugin and lets a multimodal model handle the PDF directly:
+  `mistral-ocr` → `pdf-text` → `native`; `pdf-text` → `mistral-ocr` →
+  `native`; `native` → `mistral-ocr` → `pdf-text`. Any failure inside the
+  inner pipeline (HTTP error including file-parser plugin 4xx, empty/refused
+  content, unrepairable JSON, unknown wrapper shape, zero rows) advances to
+  the next engine. The S3 read for each attachment happens once and is
+  reused across attempts. OpenRouter 4xx/5xx error bodies are condensed to
+  their `error.message` + `error.code` before being raised or logged so the
+  persisted bulk-import job row stays readable and does not echo unrelated
+  fields like `user_id` or the full response metadata.
 - Timeout / budget: **600s** Lambda timeout with **720s** SQS visibility;
-  OpenRouter bulk calls cap at **240s** per engine attempt (max two attempts)
-  plus an optional **60s** JSON-repair retry, so DB writes stay inside the
-  Lambda window
+  OpenRouter bulk calls cap at **240s** per engine attempt (max three
+  attempts) plus an optional **60s** JSON-repair retry. Failed engine
+  attempts (e.g. file-parser plugin 4xx) typically return in seconds, so
+  total wall time is dominated by whichever attempt actually runs the model;
+  worst-case sequential 240s timeouts on every engine is the only path that
+  pressures the Lambda window.
 - Concurrency: no per-function reserved concurrency in CDK (shared unreserved pool) so
   deploys remain valid when the account already reserves capacity on other Lambdas
 - Environment:

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -852,15 +852,27 @@ def test_extract_message_text_raises_on_empty_content_with_stop_finish() -> None
     assert "finish_reason=stop" in msg
 
 
-def test_bulk_pdf_engine_attempt_order_pairs_each_engine_with_alternate(
+def test_bulk_pdf_engine_attempt_order_pairs_each_engine_with_alternates(
     monkeypatch: Any,
 ) -> None:
     monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
-    assert parser._bulk_pdf_engine_attempt_order() == ("mistral-ocr", "pdf-text")
+    assert parser._bulk_pdf_engine_attempt_order() == (
+        "mistral-ocr",
+        "pdf-text",
+        "native",
+    )
     monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "pdf-text")
-    assert parser._bulk_pdf_engine_attempt_order() == ("pdf-text", "mistral-ocr")
+    assert parser._bulk_pdf_engine_attempt_order() == (
+        "pdf-text",
+        "mistral-ocr",
+        "native",
+    )
     monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "native")
-    assert parser._bulk_pdf_engine_attempt_order() == ("native", "mistral-ocr")
+    assert parser._bulk_pdf_engine_attempt_order() == (
+        "native",
+        "mistral-ocr",
+        "pdf-text",
+    )
 
 
 def test_parse_bulk_expense_invoices_falls_back_to_alternate_engine(
@@ -979,10 +991,135 @@ def test_parse_bulk_expense_invoices_exhausts_engines_and_names_them(
         )
 
     msg = str(exc_info.value)
-    assert "across 2 attempt(s)" in msg
+    assert "across 3 attempt(s)" in msg
     assert "mistral-ocr" in msg
     assert "pdf-text" in msg
+    assert "native" in msg
     assert "empty response" in msg
+
+
+def test_format_openrouter_error_preview_extracts_message_and_code() -> None:
+    body = (
+        '{"error":{"message":"Failed to parse Evolve Sprouts Invoices.pdf",'
+        '"code":400,"metadata":{"provider_name":null}},'
+        '"user_id":"user_3B4yKT1KyjP6dHEWd77RJxoki98"}'
+    )
+    preview = parser._format_openrouter_error_preview(body)
+    assert preview == "Failed to parse Evolve Sprouts Invoices.pdf (code=400)"
+    assert "user_id" not in preview
+    assert "metadata" not in preview
+
+
+def test_format_openrouter_error_preview_handles_plain_string_error() -> None:
+    assert (
+        parser._format_openrouter_error_preview('{"error":"rate limited"}')
+        == "rate limited"
+    )
+
+
+def test_format_openrouter_error_preview_falls_back_for_non_json() -> None:
+    body = "Internal Server Error\nrequest-id: abc"
+    out = parser._format_openrouter_error_preview(body)
+    assert "Internal Server Error" in out
+    assert "request-id: abc" in out
+
+
+def test_openrouter_chat_completion_4xx_raises_clean_error(monkeypatch: Any) -> None:
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+
+    body = (
+        '{"error":{"message":"Failed to parse Evolve Sprouts Invoices.pdf",'
+        '"code":400,"metadata":{"provider_name":null}},'
+        '"user_id":"user_3B4yKT1KyjP6dHEWd77RJxoki98"}'
+    )
+
+    def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        return {"status": 400, "body": body}
+
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        parser._openrouter_chat_completion(
+            system_prompt="s",
+            user_content_blocks=[{"type": "text", "text": "t"}],
+            has_pdf_attachment=False,
+            timeout=5,
+        )
+    msg = str(exc_info.value)
+    assert "status 400" in msg
+    assert "Failed to parse Evolve Sprouts Invoices.pdf" in msg
+    assert "code=400" in msg
+    assert "user_id" not in msg
+    assert "metadata" not in msg
+
+
+def test_parse_bulk_expense_invoices_falls_back_to_native_after_plugin_400(
+    monkeypatch: Any,
+) -> None:
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    plugin_400_body = (
+        '{"error":{"message":"Failed to parse Evolve Sprouts Invoices.pdf",'
+        '"code":400,"metadata":{"provider_name":null}},'
+        '"user_id":"user_abc"}'
+    )
+    valid_body = _bulk_chat_completion_body(
+        json.dumps(
+            {
+                "invoices": [
+                    {
+                        "vendor_name": "Native Shop",
+                        "invoice_number": "N1",
+                        "invoice_date": "2026-05-06",
+                        "due_date": None,
+                        "currency": "USD",
+                        "subtotal": 12,
+                        "tax": 0,
+                        "total": 12,
+                        "line_items": [],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )
+    )
+
+    captured_engines: list[str | None] = []
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        payload = json.loads(kwargs["body"])
+        plugins = payload.get("plugins") or []
+        engine = plugins[0]["pdf"]["engine"] if plugins else None
+        captured_engines.append(engine)
+        if engine in ("mistral-ocr", "pdf-text"):
+            return {"status": 400, "body": plugin_400_body}
+        return {"status": 200, "body": valid_body}
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    rows = parser.parse_bulk_expense_invoices_from_assets(
+        [
+            {
+                "id": "asset-native",
+                "s3_key": "k",
+                "file_name": "bulk.pdf",
+                "content_type": "application/pdf",
+            }
+        ],
+        timeout=25,
+    )
+
+    assert captured_engines == ["mistral-ocr", "pdf-text", "native"]
+    assert len(rows) == 1
+    assert rows[0]["vendor_name"] == "Native Shop"
 
 
 def test_parse_bulk_expense_invoices_raises_descriptive_error_when_model_returns_empty_object(


### PR DESCRIPTION
…uter error formatting

Fifth iteration. The user's most recent failure was an OpenRouter HTTP 400 from the PDF file-parser plugin itself — the plugin rejected the document before the model ever saw it:

    RuntimeError('Parser failed for bulk invoices across 2 attempt(s)
                 (mistral-ocr, pdf-text); last error: OpenRouter request
                 failed with status 400: {"error":{"message":"Failed
                 to parse Evolve Sprouts Invoices.pdf","code":400,
                 "metadata":{"provider_name":null}},
                 "user_id":"user_3B4yKT1KyjP6dHEWd77RJxoki98"}')

Two coordinated fixes.

1. Engine fallback now ends with `native`, which bypasses the OpenRouter file-parser plugin entirely and hands the PDF to the (multimodal) model directly — exactly the right next step when the plugin layer rejects a document. `_PDF_ENGINE_FALLBACKS` becomes: mistral-ocr -> (pdf-text, native)
       pdf-text    -> (mistral-ocr, native)
       native      -> (mistral-ocr, pdf-text)
   Up to three attempts. HTTP 4xx attempts (like the user's case) typically
   return in seconds, so wall time stays dominated by whichever attempt
   actually runs the model; the 600s Lambda timeout is only pressured if
   every engine stalls.

2. New `_format_openrouter_error_preview` helper. When a 4xx/5xx response body is JSON of the shape `{"error":{"message":..., "code":..., "metadata":...}, "user_id":...}`, it returns just "<message> (code=<code>)". Falls back to truncated raw text for non-JSON bodies. Wired into the `_openrouter_chat_completion` 4xx raise and warning log so the persisted bulk-import job row no longer leaks `user_id` or the full metadata blob.

Tests in `tests/test_openrouter_expense_parser.py`:
- `_format_openrouter_error_preview` extracts message+code from OpenRouter envelopes, handles plain string `error`, and falls back for non-JSON.
- `_openrouter_chat_completion` raises a clean message on 4xx (asserts no "user_id" or "metadata" in the message text).
- `_bulk_pdf_engine_attempt_order` returns the new 3-engine ordering for each configured engine.
- Bulk parse falls back through the full chain (mistral-ocr 400 -> pdf-text 400 -> native success) and asserts the third request used the `native` engine.
- `_extract_message_text` exhaustion test now expects all 3 engines named in the final error.
- All previously-added tests still pass; the success path is reached on the first engine attempt for those scenarios.

Docs: `docs/architecture/lambdas.md` documents the 3-engine fallback chain, the role of `native` against file-parser plugin 4xx, and the condensed-error formatting.