### PR TITLE
Complete enrollments when a service instance is marked completed

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -1953,7 +1953,10 @@ export interface paths {
                 404: components["responses"]["NotFound"];
             };
         };
-        /** Update service instance */
+        /**
+         * Update service instance
+         * @description When `status` is set to `completed`, every enrollment on the instance that is still `registered` or `confirmed` is updated to `completed` in the same request (cancelled, waitlisted, and already-completed rows are left unchanged).
+         */
         put: {
             parameters: {
                 query?: never;

--- a/backend/src/app/api/admin_service_instances.py
+++ b/backend/src/app/api/admin_service_instances.py
@@ -33,13 +33,18 @@ from app.db.models import (
     EventCategory,
     EventTicketTier,
     InstanceSessionSlot,
+    InstanceStatus,
     Service,
     ServiceInstance,
     ServiceType,
     TrainingFormat,
     TrainingInstanceDetails,
 )
-from app.db.repositories import ServiceInstanceRepository, ServiceRepository
+from app.db.repositories import (
+    EnrollmentRepository,
+    ServiceInstanceRepository,
+    ServiceRepository,
+)
 from app.exceptions import NotFoundError, ValidationError
 from app.services.eventbrite_events import enqueue_eventbrite_instance_sync_by_id
 from app.utils import json_response
@@ -585,6 +590,10 @@ def _update_instance(
             instance.cover_image_s3_key = payload["cover_image_s3_key"]
         if "status" in payload:
             instance.status = payload["status"]
+            if payload["status"] == InstanceStatus.COMPLETED:
+                EnrollmentRepository(
+                    session
+                ).mark_registered_or_confirmed_enrollments_completed(instance.id)
         if "delivery_mode" in payload:
             instance.delivery_mode = payload["delivery_mode"]
         if "location_id" in payload:

--- a/backend/src/app/db/repositories/enrollment.py
+++ b/backend/src/app/db/repositories/enrollment.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
@@ -182,3 +182,23 @@ class EnrollmentRepository(BaseRepository[Enrollment]):
         self._session.flush()
         self._session.refresh(enrollment)
         return enrollment
+
+    def mark_registered_or_confirmed_enrollments_completed(
+        self, instance_id: UUID
+    ) -> None:
+        """Set registered/confirmed enrollments to completed for a finished instance.
+
+        Cancelled, waitlisted, and already-completed rows are unchanged so capacity
+        counts stay aligned with seated bookings.
+        """
+        stmt = (
+            update(Enrollment)
+            .where(Enrollment.instance_id == instance_id)
+            .where(
+                Enrollment.status.in_(
+                    (EnrollmentStatus.REGISTERED, EnrollmentStatus.CONFIRMED)
+                )
+            )
+            .values(status=EnrollmentStatus.COMPLETED)
+        )
+        self._session.execute(stmt)

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1519,6 +1519,10 @@ paths:
           $ref: "#/components/responses/NotFound"
     put:
       summary: Update service instance
+      description: >
+        When `status` is set to `completed`, every enrollment on the instance that is
+        still `registered` or `confirmed` is updated to `completed` in the same request
+        (cancelled, waitlisted, and already-completed rows are left unchanged).
       security:
         - AdminBearerAuth: []
       requestBody:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -91,7 +91,10 @@ their primary responsibilities.
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for
   cross-service instance listing with optional `service_id` / `service_type`
   filters; instance create/update accepts optional `cohort`, and
-  `tag_ids` with `tags` / `tag_ids` echoed on instance responses; `session_slots`
+  `tag_ids` with `tags` / `tag_ids` echoed on instance responses; completing an instance
+  (`status: completed`) bulk-updates `registered` / `confirmed` enrollments on that
+  instance to `completed` (cancelled, waitlisted, and already-completed rows unchanged);
+  `session_slots`
   `starts_at` / `ends_at` on create/update must be timezone-aware (RFC 3339 with
   `Z` or a numeric offset; naive strings are rejected); instance JSON
   includes `resolved_*` fields (title, slug, description, delivery mode, location,

--- a/tests/test_enrollment_instance_completion_promotion.py
+++ b/tests/test_enrollment_instance_completion_promotion.py
@@ -1,0 +1,28 @@
+"""Unit tests for bulk enrollment completion when a service instance completes."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy.sql.dml import Update
+
+from app.db.repositories.enrollment import EnrollmentRepository
+
+
+def test_mark_registered_or_confirmed_enrollments_completed_issues_update() -> None:
+    captured: list[object] = []
+
+    class _FakeSession:
+        def execute(self, stmt: object) -> object:
+            captured.append(stmt)
+
+            class _Result:
+                rowcount = 0
+
+            return _Result()
+
+    repo = EnrollmentRepository(_FakeSession())  # type: ignore[arg-type]
+    instance_id = uuid4()
+    repo.mark_registered_or_confirmed_enrollments_completed(instance_id)
+    assert len(captured) == 1
+    assert isinstance(captured[0], Update)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When an admin updates a service instance with `status: completed`, the API now bulk-updates every enrollment on that instance that is still `registered` or `confirmed` to `completed` in the same database transaction.

Cancelled, waitlisted, and already-completed enrollments are left unchanged so capacity counts (which treat `completed` as seated capacity) do not incorrectly include waitlisted contacts.

## Changes

- `EnrollmentRepository.mark_registered_or_confirmed_enrollments_completed` runs a single SQLAlchemy `UPDATE` filtered by instance id and status.
- `admin_service_instances._update_instance` invokes that helper whenever the payload sets the instance status to `completed`.
- Documented behavior in `docs/api/admin.yaml` and `docs/architecture/lambdas.md`.
- Regenerated `apps/admin_web/src/types/generated/admin-api.generated.ts` from `docs/api/admin.yaml` (required for `npm run lint` / `check:admin-api-types`).
- Added a small unit test that asserts the repository issues an `UPDATE` statement.

## Testing

- `pytest tests/test_enrollment_instance_completion_promotion.py -v`
- `cd apps/admin_web && npm run generate:admin-api-types && npm run lint`
- `pre-commit run ruff-format --all-files`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-015ce948-b4a2-4449-acf4-5a9061d0d3d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-015ce948-b4a2-4449-acf4-5a9061d0d3d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

