### PR TITLE
Promote family and members to client when enrollment moves to a family

### DIFF
--- a/backend/src/app/api/admin_enrollments.py
+++ b/backend/src/app/api/admin_enrollments.py
@@ -37,6 +37,9 @@ from app.db.repositories import (
     ServiceInstanceRepository,
 )
 from app.exceptions import NotFoundError, ValidationError
+from app.services.billing_enrollment_confirmation import (
+    promote_prospect_party_for_enrollment,
+)
 from app.utils import json_response
 from app.utils.logging import get_logger
 
@@ -273,6 +276,8 @@ def _update_enrollment(
                 enrollment.bill_to_organization_id = oid
                 enrollment.bill_to_contact_id = None
                 enrollment.bill_to_family_id = None
+
+            promote_prospect_party_for_enrollment(session, enrollment)
 
         if "status" in payload:
             enrollment.status = payload["status"]

--- a/backend/src/app/services/billing_enrollment_confirmation.py
+++ b/backend/src/app/services/billing_enrollment_confirmation.py
@@ -33,7 +33,7 @@ def _distinct_enrollment_ids_on_invoice(
     return [eid for eid in rows if eid is not None]
 
 
-def _promote_prospect_party_for_enrollment(
+def promote_prospect_party_for_enrollment(
     session: Session, enrollment: Enrollment
 ) -> None:
     """Set party relationship to client when it is still prospect (contact, family, or org)."""
@@ -89,7 +89,7 @@ def _confirm_registered_enrollments_for_invoice(
             continue
         enrollment.status = EnrollmentStatus.CONFIRMED
         enrollment.cancelled_at = None
-        _promote_prospect_party_for_enrollment(session, enrollment)
+        promote_prospect_party_for_enrollment(session, enrollment)
         logger.info(
             "Enrollment status set to confirmed from billing milestone",
             extra={

--- a/tests/test_admin_enrollments_api.py
+++ b/tests/test_admin_enrollments_api.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
+from types import SimpleNamespace
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -8,7 +10,8 @@ import pytest
 
 from app.api import admin_enrollments
 from app.api.admin_services_payloads import parse_update_enrollment_payload
-from app.db.models.enums import BillingBillToKind, EnrollmentStatus
+from app.db.models import Contact, Family
+from app.db.models.enums import BillingBillToKind, EnrollmentStatus, RelationshipType
 from app.exceptions import ValidationError
 
 
@@ -361,11 +364,25 @@ def test_parse_update_enrollment_payload_rejects_both_promote_fields() -> None:
         )
 
 
+class _FakeScalarResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._rows)
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
 def test_promote_contact_enrollment_to_family_updates_row(monkeypatch: Any, api_gateway_event: Any) -> None:
     target_instance_id = uuid4()
     enrollment_id = uuid4()
     contact_uuid = uuid4()
     family_id = uuid4()
+    member_id = uuid4()
+    family_row = SimpleNamespace(id=family_id, relationship_type=RelationshipType.PROSPECT)
+    member_contact = SimpleNamespace(id=member_id, relationship_type=RelationshipType.PROSPECT)
 
     class _MutableEnrollment:
         instance_id = target_instance_id
@@ -402,13 +419,22 @@ def test_promote_contact_enrollment_to_family_updates_row(monkeypatch: Any, api_
             pass
 
     class _FakeSession:
+        def __init__(self) -> None:
+            self._scalar_queues: list[list[Any]] = [[member_id]]
+
         def commit(self) -> None:
             return None
 
+        def scalars(self, _stmt: object) -> _FakeScalarResult:
+            if not self._scalar_queues:
+                raise AssertionError("unexpected scalars() call")
+            return _FakeScalarResult(self._scalar_queues.pop(0))
+
         def get(self, model: Any, eid: Any) -> Any:
-            name = getattr(model, "__name__", "")
-            if name == "Family" and eid == family_id:
-                return object()
+            if model is Family and eid == family_id:
+                return family_row
+            if model is Contact and eid == member_id:
+                return member_contact
             return None
 
     class _SessionCtx:
@@ -475,6 +501,8 @@ def test_promote_contact_enrollment_to_family_updates_row(monkeypatch: Any, api_
     assert row.bill_to_kind == BillingBillToKind.FAMILY
     assert row.bill_to_family_id == family_id
     assert row.bill_to_contact_id is None
+    assert family_row.relationship_type == RelationshipType.CLIENT
+    assert member_contact.relationship_type == RelationshipType.CLIENT
 
 
 def test_delete_enrollment_decrements_discount_usage(monkeypatch: Any, api_gateway_event: Any) -> None:

--- a/tests/test_billing_enrollment_confirmation.py
+++ b/tests/test_billing_enrollment_confirmation.py
@@ -139,6 +139,31 @@ def test_confirm_family_promotes_family_and_members() -> None:
     assert contact2.relationship_type == RelationshipType.CLIENT
 
 
+def test_promote_prospect_party_for_enrollment_family_and_members() -> None:
+    """Public helper promotes family + member contacts (used outside billing confirmation)."""
+    fid = uuid4()
+    c1, c2 = uuid4(), uuid4()
+    en = SimpleNamespace(
+        organization_id=None,
+        family_id=fid,
+        contact_id=None,
+    )
+    fam = SimpleNamespace(id=fid, relationship_type=RelationshipType.PROSPECT)
+    contact1 = SimpleNamespace(id=c1, relationship_type=RelationshipType.PROSPECT)
+    contact2 = SimpleNamespace(id=c2, relationship_type=RelationshipType.CLIENT)
+    session = _FakeSession()
+    session.scalar_queues.append([c1, c2])
+    session.families[fid] = fam
+    session.contacts[c1] = contact1
+    session.contacts[c2] = contact2
+
+    bec.promote_prospect_party_for_enrollment(session, en)  # type: ignore[arg-type]
+
+    assert fam.relationship_type == RelationshipType.CLIENT
+    assert contact1.relationship_type == RelationshipType.CLIENT
+    assert contact2.relationship_type == RelationshipType.CLIENT
+
+
 def test_confirm_org_promotes_org_and_prospect_members_only() -> None:
     eid = uuid4()
     oid = uuid4()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When an admin updates an enrollment with `promote_to_family_id` or `promote_to_organization_id`, the enrollment row is reassigned from a standalone contact to a family or organization. This change reuses `promote_prospect_party_for_enrollment` from billing enrollment confirmation so that:

- **Family promotion**: the target family and all of its member contacts are upgraded from `prospect` to `client` when they are still prospects (unchanged contacts are left as-is).
- **Organization promotion**: the same helper also promotes the organization and prospect organization members, matching the billing confirmation behavior for consistency.

## Implementation

- Renamed the billing helper from `_promote_prospect_party_for_enrollment` to public `promote_prospect_party_for_enrollment`.
- `admin_enrollments._update_enrollment` calls that helper once after the promote mutation.

## Tests

- Extended `test_promote_contact_enrollment_to_family_updates_row` with a session fake that supports `scalars` / `get` and asserts family and member `relationship_type` become `client`.
- Added `test_promote_prospect_party_for_enrollment_family_and_members` for the public helper.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-981aba50-dcff-4479-9b83-b87d5b4ffa5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-981aba50-dcff-4479-9b83-b87d5b4ffa5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

