### PR TITLE
Sync CRM family relationship to all member contacts

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -3315,7 +3315,12 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        /** Update CRM family */
+        /**
+         * Update CRM family
+         * @description When `relationship_type` is present, the server applies the same value to every linked
+         *     member contact's CRM `relationship_type` (contacts belong to at most one family), so
+         *     family and member records stay aligned.
+         */
         patch: {
             parameters: {
                 query?: never;

--- a/backend/src/app/api/admin_families.py
+++ b/backend/src/app/api/admin_families.py
@@ -231,6 +231,10 @@ def _update_family(
                 field="relationship_type",
                 allowed=FAMILY_RELATIONSHIP_TYPES,
             )
+            for membership in family.family_members:
+                contact = membership.contact
+                if contact is not None:
+                    contact.relationship_type = family.relationship_type
         if "location_id" in body:
             loc = parse_optional_uuid(body.get("location_id"), "location_id")
             ensure_location_exists(session, loc)

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -2402,6 +2402,10 @@ paths:
           $ref: "#/components/responses/NotFound"
     patch:
       summary: Update CRM family
+      description: |
+        When `relationship_type` is present, the server applies the same value to every linked
+        member contact's CRM `relationship_type` (contacts belong to at most one family), so
+        family and member records stay aligned.
       security:
         - AdminBearerAuth: []
       requestBody:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -72,7 +72,8 @@ their primary responsibilities.
   for standalone CRM notes on a contact (not tied to a sales lead), and `DELETE /v1/admin/contacts/{id}`
   for hard-deleting a contact after clearing blocking CRM rows),
   `/v1/admin/families/picker`, `/v1/admin/families/*` (`GET /v1/admin/families` optional `query`
-  matches family name and linked member contacts' names or email; including `DELETE /v1/admin/families/{id}`
+  matches family name and linked member contacts' names or email; `PATCH /v1/admin/families/{id}` with
+  `relationship_type` updates that field on the family and on every member contact; including `DELETE /v1/admin/families/{id}`
   for hard-deleting a family after clearing blocking CRM rows; `POST /v1/admin/families/{id}/members`
   derives each member's role from the linked contact's `contact_type`; `PATCH /v1/admin/families/{id}/members/{memberId}`
   updates membership fields such as primary contact),

--- a/tests/test_admin_families_relationship_sync.py
+++ b/tests/test_admin_families_relationship_sync.py
@@ -1,0 +1,117 @@
+"""CRM family PATCH aligns member contacts' relationship_type with the family."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from unittest.mock import MagicMock
+
+from app.api import admin_families
+from app.api.assets.assets_common import RequestIdentity
+from app.db.models import RelationshipType
+
+
+def _admin_identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_sub="admin-sub",
+        groups={"admin"},
+        organization_ids=set(),
+    )
+
+
+@pytest.fixture
+def families_session(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    session = MagicMock()
+
+    class _SessionCtx:
+        def __init__(self, _engine: Any) -> None:
+            pass
+
+        def __enter__(self) -> MagicMock:
+            return session
+
+        def __exit__(self, *_args: Any) -> bool:
+            return False
+
+    monkeypatch.setattr(admin_families, "Session", _SessionCtx)
+    monkeypatch.setattr(admin_families, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        admin_families,
+        "extract_identity",
+        lambda _event: _admin_identity(),
+    )
+    monkeypatch.setattr(admin_families, "set_audit_context", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        admin_families,
+        "serialize_family_summary",
+        lambda _fam: {"serialized": True},
+    )
+    return session
+
+
+def test_patch_family_relationship_propagates_to_all_member_contacts(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    families_session: MagicMock,
+) -> None:
+    fam_id = uuid4()
+    member_row_id = uuid4()
+    member_row_id2 = uuid4()
+
+    class _StubContact:
+        def __init__(self, rel: RelationshipType) -> None:
+            self.relationship_type = rel
+
+    contact_a = _StubContact(RelationshipType.PROSPECT)
+    contact_b = _StubContact(RelationshipType.PAST_CLIENT)
+
+    class _StubMember:
+        def __init__(self, mid: UUID, contact: _StubContact) -> None:
+            self.id = mid
+            self.contact = contact
+
+    class _StubFamily:
+        family_tags: list[Any] = []
+
+        def __init__(self) -> None:
+            self.id = fam_id
+            self.family_name = "Unit"
+            self.relationship_type = RelationshipType.PROSPECT
+            self.family_members = [
+                _StubMember(member_row_id, contact_a),
+                _StubMember(member_row_id2, contact_b),
+            ]
+
+    stub_family = _StubFamily()
+
+    class _FakeFamilyRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_for_admin(self, fid: UUID) -> _StubFamily | None:
+            assert fid == fam_id
+            return stub_family
+
+        def update(self, _family: Any) -> None:
+            return None
+
+    monkeypatch.setattr(admin_families, "FamilyRepository", _FakeFamilyRepo)
+
+    event = api_gateway_event(
+        method="PATCH",
+        path=f"/v1/admin/families/{fam_id}",
+        body=json.dumps({"relationship_type": "client"}),
+    )
+    response = admin_families.handle_admin_families_request(
+        event,
+        "PATCH",
+        f"/v1/admin/families/{fam_id}",
+    )
+
+    assert response["statusCode"] == 200
+    assert contact_a.relationship_type == RelationshipType.CLIENT
+    assert contact_b.relationship_type == RelationshipType.CLIENT
+    assert stub_family.relationship_type == RelationshipType.CLIENT


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updating **Relationship** on a CRM family in Admin Web only changed `families.relationship_type`, while each member still had their own `contacts.relationship_type`. That made the Contacts tab and other surfaces disagree with the family record.

## Changes

- **`PATCH /v1/admin/families/{id}`**: When `relationship_type` is present in the body, the handler now sets the same value on every linked member contact (the product allows at most one family per contact).
- **Docs**: OpenAPI operation description and `docs/architecture/lambdas.md` describe the aligned behavior.
- **Tests**: `tests/test_admin_families_relationship_sync.py` asserts propagation for a multi-member family.
- **Admin web CI**: Regenerated `apps/admin_web/src/types/generated/admin-api.generated.ts` via `npm run generate:admin-api-types` so `npm run lint` passes after the OpenAPI edit.

## Notes

No Admin Web UI changes were required; the existing **Update family** action already sends `relationship_type` to this endpoint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a6d721e-98c6-4431-bc50-514c65b783eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a6d721e-98c6-4431-bc50-514c65b783eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

