### PR TITLE
Admin web: filter Instances list by completion status

### DIFF
--- a/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/instance-list-panel.tsx
@@ -20,6 +20,7 @@ import { Label } from '@/components/ui/label';
 import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { Select } from '@/components/ui/select';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import type { InstancesListStatusFilter } from '@/hooks/use-services-page';
 import { useCopyFeedback } from '@/hooks/use-copy-feedback';
 import {
   formatEnumLabel,
@@ -64,6 +65,11 @@ export interface InstanceListPanelProps {
     value: string;
     onChange: (serviceType: string) => void;
   };
+  /** When set, show an instance lifecycle status filter above the table. */
+  statusFilter?: {
+    value: InstancesListStatusFilter;
+    onChange: (value: InstancesListStatusFilter) => void;
+  };
   searchFilter?: {
     value: string;
     onChange: (value: string) => void;
@@ -88,6 +94,7 @@ export function InstanceListPanel({
   onDeleteInstance,
   serviceFilter,
   serviceTypeFilter,
+  statusFilter,
   searchFilter,
   showServiceColumn = false,
   locationOptions = [],
@@ -147,12 +154,12 @@ export function InstanceListPanel({
         loadingLabel='Loading instances...'
         onLoadMore={onLoadMore}
         toolbar={
-          serviceFilter || serviceTypeFilter || searchFilter ? (
+          serviceFilter || serviceTypeFilter || statusFilter || searchFilter ? (
             <div className='mb-3 flex w-full min-w-0 flex-nowrap items-end gap-3'>
               {searchFilter ? (
                 <div
                   className={
-                    serviceTypeFilter || serviceFilter ? 'min-w-0 flex-[2]' : 'min-w-[220px] flex-1'
+                    serviceTypeFilter || statusFilter || serviceFilter ? 'min-w-0 flex-[2]' : 'min-w-[220px] flex-1'
                   }
                 >
                   <Label htmlFor='instances-filter-search'>Search instances</Label>
@@ -178,6 +185,25 @@ export function InstanceListPanel({
                         {formatEnumLabel(serviceType)}
                       </option>
                     ))}
+                  </Select>
+                </div>
+              ) : null}
+              {statusFilter ? (
+                <div className='min-w-0 flex-1'>
+                  <Label htmlFor='instances-filter-status'>Instance statuses</Label>
+                  <Select
+                    id='instances-filter-status'
+                    value={statusFilter.value}
+                    onChange={(event) => {
+                      const raw = event.target.value;
+                      if (raw === '' || raw === 'not_completed' || raw === 'completed') {
+                        statusFilter.onChange(raw);
+                      }
+                    }}
+                  >
+                    <option value=''>All statuses</option>
+                    <option value='not_completed'>Not Completed</option>
+                    <option value='completed'>Completed</option>
                   </Select>
                 </div>
               ) : null}

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -80,10 +80,19 @@ export function ServicesPage() {
     [state.locationList.locations]
   );
   const filteredInstances = useMemo(() => {
-    if (state.activeView !== 'instances' || !normalizedInstanceSearch) {
+    if (state.activeView !== 'instances') {
       return state.instanceList.instances;
     }
-    return state.instanceList.instances.filter((instance) => {
+    let rows = state.instanceList.instances;
+    if (state.instancesStatusFilter === 'completed') {
+      rows = rows.filter((instance) => instance.status === 'completed');
+    } else if (state.instancesStatusFilter === 'not_completed') {
+      rows = rows.filter((instance) => instance.status !== 'completed');
+    }
+    if (!normalizedInstanceSearch) {
+      return rows;
+    }
+    return rows.filter((instance) => {
       const tableTitle = formatInstanceTableTitle(instance);
       const parts: string[] = [
         tableTitle.trim() !== '' ? tableTitle : null,
@@ -125,6 +134,7 @@ export function ServicesPage() {
   }, [
     normalizedInstanceSearch,
     state.activeView,
+    state.instancesStatusFilter,
     state.instanceList.instances,
     instanceSearchLocationById,
   ]);
@@ -299,6 +309,10 @@ export function ServicesPage() {
             serviceTypeFilter={{
               value: state.instancesServiceTypeFilter,
               onChange: state.setInstancesServiceTypeFilter,
+            }}
+            statusFilter={{
+              value: state.instancesStatusFilter,
+              onChange: state.setInstancesStatusFilter,
             }}
             serviceFilter={{
               value: state.instancesServiceFilter,

--- a/apps/admin_web/src/hooks/use-services-page.ts
+++ b/apps/admin_web/src/hooks/use-services-page.ts
@@ -29,6 +29,11 @@ export const SERVICES_VIEW_KEYS: readonly ServicesView[] = [
 ];
 export const DEFAULT_SERVICES_VIEW: ServicesView = 'catalog';
 
+/** Instances list toolbar status filter; empty string means all statuses. */
+export type InstancesListStatusFilter = '' | 'not_completed' | 'completed';
+
+export const DEFAULT_INSTANCES_LIST_STATUS_FILTER: InstancesListStatusFilter = 'not_completed';
+
 export function useServicesPage() {
   const [activeView, setActiveView] = useQueryTabState<ServicesView>(
     SERVICES_VIEW_KEYS,
@@ -39,6 +44,9 @@ export function useServicesPage() {
   const [instanceOptionsCacheVersion, setInstanceOptionsCacheVersion] = useState(0);
   const [instancesServiceFilter, setInstancesServiceFilter] = useState<string>('');
   const [instancesServiceTypeFilter, setInstancesServiceTypeFilter] = useState<string>('');
+  const [instancesStatusFilter, setInstancesStatusFilter] = useState<InstancesListStatusFilter>(
+    DEFAULT_INSTANCES_LIST_STATUS_FILTER
+  );
   const [instancesSearchQuery, setInstancesSearchQuery] = useState<string>('');
   const [entityTags, setEntityTags] = useState<EntityTagRef[]>([]);
   const [entityTagsLoading, setEntityTagsLoading] = useState(false);
@@ -183,6 +191,8 @@ export function useServicesPage() {
     setInstancesServiceFilter,
     instancesServiceTypeFilter,
     setInstancesServiceTypeFilter,
+    instancesStatusFilter,
+    setInstancesStatusFilter,
     instancesSearchQuery,
     setInstancesSearchQuery,
     entityTags,

--- a/apps/admin_web/tests/components/admin/services/services-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/services-page.test.tsx
@@ -19,6 +19,8 @@ const { mockUseServicesPage, state } = vi.hoisted(() => {
     setInstancesServiceFilter: vi.fn(),
     instancesServiceTypeFilter: '',
     setInstancesServiceTypeFilter: vi.fn(),
+    instancesStatusFilter: 'not_completed' as const,
+    setInstancesStatusFilter: vi.fn(),
     instancesSearchQuery: '',
     setInstancesSearchQuery: vi.fn(),
     entityTags: [],
@@ -191,6 +193,7 @@ describe('ServicesPage', () => {
     state.activeView = 'catalog';
     state.instanceList.instances = [];
     state.instancesSearchQuery = '';
+    state.instancesStatusFilter = 'not_completed';
   });
 
   it('renders tabs-only header and switches views', async () => {
@@ -243,6 +246,40 @@ describe('ServicesPage', () => {
     await user.type(screen.getByLabelText('Search instances'), 'yoga');
 
     expect(state.setInstancesSearchQuery).toHaveBeenCalled();
+  });
+
+  it('wires instances status filter changes on Instances', async () => {
+    const user = userEvent.setup();
+    state.activeView = 'instances';
+    render(<ServicesPage />);
+
+    await user.selectOptions(screen.getByLabelText('Instance statuses'), 'completed');
+
+    expect(state.setInstancesStatusFilter).toHaveBeenCalledWith('completed');
+  });
+
+  it('filters instances to non-completed rows when status filter is Not Completed', () => {
+    state.activeView = 'instances';
+    state.instancesStatusFilter = 'not_completed';
+    state.instanceList.instances = [
+      {
+        ...INSTANCE_FOR_SEARCH,
+        id: 'inst-open',
+        status: 'open',
+        parentServiceTitle: 'Alpha Service',
+      },
+      {
+        ...INSTANCE_FOR_SEARCH,
+        id: 'inst-done',
+        status: 'completed',
+        parentServiceTitle: 'Beta Service',
+      },
+    ];
+
+    render(<ServicesPage />);
+
+    expect(screen.getByText('Alpha Service')).toBeInTheDocument();
+    expect(screen.queryByText('Beta Service')).not.toBeInTheDocument();
   });
 
   it('filters instances by cohort using the raw stored value only', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a completion-focused filter on the Services **Instances** table toolbar. Options match the product request: **All statuses**, **Not Completed** (any row whose API `status` is not `completed`), and **Completed** (`status === completed`).

The list defaults to **Not Completed** so completed runs stay out of the way unless the user widens the filter.

## Implementation notes

- State lives in `useServicesPage` as `instancesStatusFilter` with exported type `InstancesListStatusFilter` and default `not_completed`.
- Filtering runs in `ServicesPage` alongside the existing text search (status filter applies first, then search).
- The toolbar control uses the label **Instance statuses** so it does not collide with the instance editor **Status** field or enrollment **Status** (all three would otherwise match `getByLabelText('Status')`).

## Validation

- `cd apps/admin_web && npx vitest run tests/components/admin/services/services-page.test.tsx`
- `cd apps/admin_web && npm run lint`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d198af65-c260-4376-a44b-b66c918055d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d198af65-c260-4376-a44b-b66c918055d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

