### PR TITLE
fix(bulk-expense-import): mirror the single-invoice parser exactly (o…

### DIFF
--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -48,12 +48,6 @@ def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, 
 _MAX_BULK_INVOICES = 100
 
 
-_BULK_SYSTEM_PROMPT = (
-    "You extract structured invoice rows from financial documents and "
-    "return strict JSON only."
-)
-
-
 def parse_bulk_expense_invoices_from_assets(
     assets: Sequence[Mapping[str, Any]],
     *,
@@ -62,15 +56,14 @@ def parse_bulk_expense_invoices_from_assets(
     """Parse many invoice rows from one combined PDF (or images) via OpenRouter.
 
     Returns a list of normalized invoice dicts (same shape as
-    ``parse_invoice_from_assets``).
-
-    For PDFs, this loops over a small ordered list of OpenRouter PDF parser
-    engines (configured first, then one alternate). On every attempt, any
-    failure inside the parsing pipeline (HTTP error, empty/refused content,
-    unrepairable JSON, unknown wrapper shape, zero rows) advances to the next
-    engine. The S3 read for each attachment happens once and is reused across
-    attempts. The final raised ``RuntimeError`` includes the engines tried and
-    the last underlying error so the persisted job message stays diagnosable.
+    ``parse_invoice_from_assets``). Mirrors the single-invoice parser's call
+    pattern exactly — one OpenRouter chat completion, the same system prompt,
+    the configured PDF engine — so the bulk path inherits the single path's
+    reliability and is not amplified to multiple requests in quick succession
+    (which previously turned a single provider rate-limit into a multi-engine
+    failure cascade). The only differences from ``parse_invoice_from_assets``
+    are the user-message schema prompt (asks for an array of rows) and the
+    array-aware response handling.
     """
     if not assets:
         raise ValueError("At least one asset is required for parsing")
@@ -83,122 +76,30 @@ def parse_bulk_expense_invoices_from_assets(
     has_pdf = any(
         _normalize_content_type(asset) == "application/pdf" for asset in assets
     )
-    engine_attempts: tuple[str | None, ...] = (
-        _bulk_pdf_engine_attempt_order() if has_pdf else (None,)
+    body = _openrouter_chat_completion(
+        system_prompt="You extract invoice data and return strict JSON only.",
+        user_content_blocks=content,
+        has_pdf_attachment=has_pdf,
+        timeout=timeout,
     )
-
-    attempted_labels: list[str] = []
-    last_exc: Exception | None = None
-
-    for engine in engine_attempts:
-        attempted_labels.append(engine or "n/a")
-        try:
-            normalized = _attempt_bulk_parse(
-                content=content,
-                has_pdf=has_pdf,
-                timeout=timeout,
-                pdf_engine=engine,
-            )
-        except Exception as exc:
-            last_exc = exc
-            logger.warning(
-                "Bulk parse attempt failed; will try next engine if available",
-                extra={
-                    "pdf_engine": engine,
-                    "error": repr(exc),
-                    "remaining_engines": [
-                        e for e in engine_attempts[engine_attempts.index(engine) + 1 :]
-                    ],
-                },
-            )
-            continue
-        if normalized:
-            logger.info(
-                "Bulk invoice parse completed successfully",
-                extra={
-                    "invoice_count": len(normalized),
-                    "pdf_engine": engine,
-                    "engine_attempts": attempted_labels,
-                },
-            )
-            return normalized
-        last_exc = RuntimeError(
+    raw_invoices = _parse_bulk_invoices_payload(body)
+    if not raw_invoices:
+        raise RuntimeError(
             "Parser found no invoice rows in this document. The PDF may be "
             "image-only without readable text, contain no extractable invoice "
             "data, or be in a layout the parser could not recognize as "
             "invoices. Try a clearer scan or a single-invoice import."
         )
-        logger.info(
-            "Bulk parse returned no rows; will try next engine if available",
-            extra={"pdf_engine": engine, "engine_attempts": attempted_labels},
-        )
-
-    engines_label = ", ".join(attempted_labels)
-    if last_exc is None:
-        raise RuntimeError(
-            f"Parser failed for bulk invoices across {len(attempted_labels)} "
-            f"attempt(s) ({engines_label}); no underlying error captured."
-        )
-    raise RuntimeError(
-        f"Parser failed for bulk invoices across {len(attempted_labels)} "
-        f"attempt(s) ({engines_label}); last error: {last_exc}"
-    )
-
-
-def _attempt_bulk_parse(
-    *,
-    content: list[dict[str, Any]],
-    has_pdf: bool,
-    timeout: int,
-    pdf_engine: str | None,
-) -> list[dict[str, Any]]:
-    """Run one bulk parse attempt with a specific PDF engine.
-
-    Returns the normalized invoice rows on success. Returns an empty list when
-    the response was usable but contained zero rows. Raises ``RuntimeError``
-    on any unrecoverable parse-pipeline failure (HTTP, empty content, JSON
-    unrepairable, unknown shape, too-many-invoices guard).
-    """
-    body = _openrouter_chat_completion(
-        system_prompt=_BULK_SYSTEM_PROMPT,
-        user_content_blocks=content,
-        has_pdf_attachment=has_pdf,
-        timeout=timeout,
-        pdf_engine_override=pdf_engine,
-    )
-    raw_invoices = _parse_bulk_invoices_payload(body)
-    if not raw_invoices:
-        return []
     if len(raw_invoices) > _MAX_BULK_INVOICES:
         raise RuntimeError(
             f"Parser returned too many invoices (max {_MAX_BULK_INVOICES})"
         )
-    return [_normalize_result(entry) for entry in raw_invoices]
-
-
-_PDF_ENGINE_FALLBACKS: dict[str, tuple[str, ...]] = {
-    # ``native`` bypasses the OpenRouter file-parser plugin entirely and lets
-    # the (multimodal) model handle the PDF directly, so it is ordered last
-    # for the two plugin-backed engines: when the plugin layer rejects a PDF
-    # with HTTP 4xx, ``native`` is the most likely engine to recover.
-    "mistral-ocr": ("pdf-text", "native"),
-    "pdf-text": ("mistral-ocr", "native"),
-    "native": ("mistral-ocr", "pdf-text"),
-}
-
-
-def _bulk_pdf_engine_attempt_order() -> tuple[str, ...]:
-    """Configured PDF engine first, then alternates.
-
-    Up to three attempts. Engine attempts that fail with an HTTP 4xx (such as
-    a file-parser plugin rejection) typically return in seconds, so the wall
-    time stays dominated by whichever attempt actually runs the model. The
-    configured 600s Lambda timeout absorbs the worst-case sequential 240s
-    timeouts only for the rare case where every engine stalls.
-    """
-    configured = _pdf_parser_engine()
-    fallbacks = _PDF_ENGINE_FALLBACKS.get(configured, ())
-    return (configured, *fallbacks)
+    normalized = [_normalize_result(entry) for entry in raw_invoices]
+    logger.info(
+        "Bulk invoice parse completed successfully",
+        extra={"invoice_count": len(normalized)},
+    )
+    return normalized
 
 
 def _openrouter_chat_completion(
@@ -207,15 +108,8 @@ def _openrouter_chat_completion(
     user_content_blocks: list[dict[str, Any]],
     has_pdf_attachment: bool,
     timeout: int,
-    pdf_engine_override: str | None = None,
 ) -> str:
-    """POST to OpenRouter and return the raw HTTP response body string.
-
-    ``pdf_engine_override`` lets callers force a specific PDF parser engine
-    (``mistral-ocr``, ``pdf-text``, or ``native``). Used by the bulk-import
-    engine fallback loop when the configured engine yields an empty or
-    unusable response on a given document.
-    """
+    """POST to OpenRouter and return the raw HTTP response body string."""
     endpoint_url = _require_env("OPENROUTER_CHAT_COMPLETIONS_URL")
     model = _require_env("OPENROUTER_MODEL")
     api_key = _get_api_key()
@@ -233,11 +127,10 @@ def _openrouter_chat_completion(
         ],
     }
     if has_pdf_attachment:
-        engine = pdf_engine_override or _pdf_parser_engine()
         payload["plugins"] = [
             {
                 "id": _PDF_PLUGIN_ID,
-                "pdf": {"engine": engine},
+                "pdf": {"engine": _pdf_parser_engine()},
             }
         ]
 

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -524,26 +524,22 @@ their primary responsibilities.
   in the OpenRouter envelope), the parser raises a diagnostic message naming
   the cause and including `finish_reason` / `completion_tokens` rather than
   feeding empty text to `json.loads`.
-- PDF engine fallback: bulk parses iterate over an ordered set of OpenRouter
-  PDF parser engines — the configured engine first, then up to two alternates.
-  For the file-parser-plugin engines the chain ends with `native`, which
-  bypasses the plugin and lets a multimodal model handle the PDF directly:
-  `mistral-ocr` → `pdf-text` → `native`; `pdf-text` → `mistral-ocr` →
-  `native`; `native` → `mistral-ocr` → `pdf-text`. Any failure inside the
-  inner pipeline (HTTP error including file-parser plugin 4xx, empty/refused
-  content, unrepairable JSON, unknown wrapper shape, zero rows) advances to
-  the next engine. The S3 read for each attachment happens once and is
-  reused across attempts. OpenRouter 4xx/5xx error bodies are condensed to
-  their `error.message` + `error.code` before being raised or logged so the
+- Call pattern: the bulk parser issues exactly **one** OpenRouter chat
+  completion per import (mirroring the single-invoice parser at
+  `parse_invoice_from_assets`), with the same system prompt and the
+  configured PDF engine. Earlier iterations layered a multi-engine retry on
+  top of this call; that turned every transient provider rate limit into a
+  guaranteed multi-failure cascade against the same account, so the bulk
+  path now matches the single path's reliability profile by doing the same
+  amount of work. If a specific PDF only parses with a non-default engine,
+  set `OPENROUTER_PDF_ENGINE` accordingly.
+- 4xx error formatting: OpenRouter error bodies are condensed to their
+  `error.message` + `error.code` before being raised or logged so the
   persisted bulk-import job row stays readable and does not echo unrelated
   fields like `user_id` or the full response metadata.
 - Timeout / budget: **600s** Lambda timeout with **720s** SQS visibility;
-  OpenRouter bulk calls cap at **240s** per engine attempt (max three
-  attempts) plus an optional **60s** JSON-repair retry. Failed engine
-  attempts (e.g. file-parser plugin 4xx) typically return in seconds, so
-  total wall time is dominated by whichever attempt actually runs the model;
-  worst-case sequential 240s timeouts on every engine is the only path that
-  pressures the Lambda window.
+  the OpenRouter bulk call caps at **240s** plus an optional **60s**
+  JSON-repair retry, so DB writes stay inside the Lambda window.
 - Concurrency: no per-function reserved concurrency in CDK (shared unreserved pool) so
   deploys remain valid when the account already reserves capacity on other Lambdas
 - Environment:

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -852,81 +852,49 @@ def test_extract_message_text_raises_on_empty_content_with_stop_finish() -> None
     assert "finish_reason=stop" in msg
 
 
-def test_bulk_pdf_engine_attempt_order_pairs_each_engine_with_alternates(
+def test_parse_bulk_expense_invoices_makes_one_request_like_single_parser(
     monkeypatch: Any,
 ) -> None:
-    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
-    assert parser._bulk_pdf_engine_attempt_order() == (
-        "mistral-ocr",
-        "pdf-text",
-        "native",
-    )
-    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "pdf-text")
-    assert parser._bulk_pdf_engine_attempt_order() == (
-        "pdf-text",
-        "mistral-ocr",
-        "native",
-    )
-    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "native")
-    assert parser._bulk_pdf_engine_attempt_order() == (
-        "native",
-        "mistral-ocr",
-        "pdf-text",
-    )
+    """Bulk parse must mirror the single-invoice parser: one OpenRouter call.
 
-
-def test_parse_bulk_expense_invoices_falls_back_to_alternate_engine(
-    monkeypatch: Any,
-) -> None:
+    Doing multiple back-to-back calls (the previous engine-fallback design)
+    amplifies a transient provider rate limit into a guaranteed failure
+    across every retry.
+    """
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
-    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
 
     class _FakeS3Client:
         def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
             return {"Body": _FakeBody(b"%PDF-1.4")}
 
-    valid_body = _bulk_chat_completion_body(
-        json.dumps(
-            {
-                "invoices": [
-                    {
-                        "vendor_name": "Shop Z",
-                        "invoice_number": "F1",
-                        "invoice_date": "2026-04-05",
-                        "due_date": None,
-                        "currency": "USD",
-                        "subtotal": 7,
-                        "tax": 0,
-                        "total": 7,
-                        "line_items": [],
-                        "confidence": 0.95,
-                    }
-                ]
-            }
-        )
-    )
-    empty_body = json.dumps(
-        {
-            "choices": [
-                {
-                    "message": {"content": ""},
-                    "finish_reason": "stop",
-                }
-            ]
-        }
-    )
-
-    captured_engines: list[str | None] = []
+    captured_calls: list[dict[str, Any]] = []
 
     def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
-        payload = json.loads(kwargs["body"])
-        plugins = payload.get("plugins") or []
-        engine = plugins[0]["pdf"]["engine"] if plugins else None
-        captured_engines.append(engine)
-        if len(captured_engines) == 1:
-            return {"status": 200, "body": empty_body}
-        return {"status": 200, "body": valid_body}
+        captured_calls.append(kwargs)
+        return {
+            "status": 200,
+            "body": _bulk_chat_completion_body(
+                json.dumps(
+                    {
+                        "invoices": [
+                            {
+                                "vendor_name": "Once Shop",
+                                "invoice_number": "1",
+                                "invoice_date": "2026-05-15",
+                                "due_date": None,
+                                "currency": "USD",
+                                "subtotal": 4,
+                                "tax": 0,
+                                "total": 4,
+                                "line_items": [],
+                                "confidence": 0.9,
+                            }
+                        ]
+                    }
+                )
+            ),
+        }
 
     monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
     monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
@@ -934,7 +902,7 @@ def test_parse_bulk_expense_invoices_falls_back_to_alternate_engine(
     rows = parser.parse_bulk_expense_invoices_from_assets(
         [
             {
-                "id": "asset-fb",
+                "id": "asset-once",
                 "s3_key": "k",
                 "file_name": "bulk.pdf",
                 "content_type": "application/pdf",
@@ -942,19 +910,76 @@ def test_parse_bulk_expense_invoices_falls_back_to_alternate_engine(
         ],
         timeout=25,
     )
-    assert captured_engines == ["mistral-ocr", "pdf-text"], (
-        "expected one attempt with the configured engine and one with the alternate"
-    )
+
+    assert len(captured_calls) == 1
+    sent_payload = json.loads(captured_calls[0]["body"])
+    assert sent_payload["messages"][0]["content"] == (
+        "You extract invoice data and return strict JSON only."
+    ), "bulk parser must use the same system prompt as the single-invoice parser"
     assert len(rows) == 1
-    assert rows[0]["vendor_name"] == "Shop Z"
+    assert rows[0]["vendor_name"] == "Once Shop"
 
 
-def test_parse_bulk_expense_invoices_exhausts_engines_and_names_them(
+def test_parse_bulk_expense_invoices_surfaces_provider_rate_limit_directly(
     monkeypatch: Any,
 ) -> None:
+    """A 429 from the provider must surface immediately, not be retried.
+
+    Previously the bulk path retried across three PDF engines on every
+    failure, turning a transient single 429 into a guaranteed three-fold
+    failure (and consuming three requests against the rate-limited account).
+    """
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
-    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    call_count = {"n": 0}
+
+    def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        call_count["n"] += 1
+        return {
+            "status": 429,
+            "body": '{"error":{"message":"Provider returned error","code":429}}',
+        }
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        parser.parse_bulk_expense_invoices_from_assets(
+            [
+                {
+                    "id": "asset-429",
+                    "s3_key": "k",
+                    "file_name": "bulk.pdf",
+                    "content_type": "application/pdf",
+                }
+            ],
+            timeout=25,
+        )
+
+    assert call_count["n"] == 1, "bulk parser must not retry across engines on 4xx"
+    msg = str(exc_info.value)
+    assert "status 429" in msg
+    assert "Provider returned error" in msg
+    assert "code=429" in msg
+    assert "across" not in msg, "no engine-fallback wrapping on the error"
+
+
+def test_parse_bulk_expense_invoices_surfaces_empty_content_directly(
+    monkeypatch: Any,
+) -> None:
+    """When the model returns empty content the diagnostic surfaces directly.
+
+    No engine-fallback wrapping (which would multiply requests against a
+    rate-limited account); just the empty-response diagnostic from
+    ``_extract_message_text``.
+    """
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
 
     class _FakeS3Client:
         def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
@@ -971,7 +996,10 @@ def test_parse_bulk_expense_invoices_exhausts_engines_and_names_them(
         }
     )
 
+    call_count = {"n": 0}
+
     def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        call_count["n"] += 1
         return {"status": 200, "body": empty_body}
 
     monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
@@ -981,7 +1009,7 @@ def test_parse_bulk_expense_invoices_exhausts_engines_and_names_them(
         parser.parse_bulk_expense_invoices_from_assets(
             [
                 {
-                    "id": "asset-exhaust",
+                    "id": "asset-empty-content",
                     "s3_key": "k",
                     "file_name": "bulk.pdf",
                     "content_type": "application/pdf",
@@ -990,12 +1018,11 @@ def test_parse_bulk_expense_invoices_exhausts_engines_and_names_them(
             timeout=25,
         )
 
+    assert call_count["n"] == 1
     msg = str(exc_info.value)
-    assert "across 3 attempt(s)" in msg
-    assert "mistral-ocr" in msg
-    assert "pdf-text" in msg
-    assert "native" in msg
     assert "empty response" in msg
+    assert "finish_reason=stop" in msg
+    assert "across" not in msg
 
 
 def test_format_openrouter_error_preview_extracts_message_and_code() -> None:
@@ -1052,74 +1079,6 @@ def test_openrouter_chat_completion_4xx_raises_clean_error(monkeypatch: Any) -> 
     assert "code=400" in msg
     assert "user_id" not in msg
     assert "metadata" not in msg
-
-
-def test_parse_bulk_expense_invoices_falls_back_to_native_after_plugin_400(
-    monkeypatch: Any,
-) -> None:
-    _set_common_env(monkeypatch)
-    _mock_secrets(monkeypatch)
-    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "mistral-ocr")
-
-    class _FakeS3Client:
-        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
-            return {"Body": _FakeBody(b"%PDF-1.4")}
-
-    plugin_400_body = (
-        '{"error":{"message":"Failed to parse Evolve Sprouts Invoices.pdf",'
-        '"code":400,"metadata":{"provider_name":null}},'
-        '"user_id":"user_abc"}'
-    )
-    valid_body = _bulk_chat_completion_body(
-        json.dumps(
-            {
-                "invoices": [
-                    {
-                        "vendor_name": "Native Shop",
-                        "invoice_number": "N1",
-                        "invoice_date": "2026-05-06",
-                        "due_date": None,
-                        "currency": "USD",
-                        "subtotal": 12,
-                        "tax": 0,
-                        "total": 12,
-                        "line_items": [],
-                        "confidence": 0.9,
-                    }
-                ]
-            }
-        )
-    )
-
-    captured_engines: list[str | None] = []
-
-    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
-        payload = json.loads(kwargs["body"])
-        plugins = payload.get("plugins") or []
-        engine = plugins[0]["pdf"]["engine"] if plugins else None
-        captured_engines.append(engine)
-        if engine in ("mistral-ocr", "pdf-text"):
-            return {"status": 400, "body": plugin_400_body}
-        return {"status": 200, "body": valid_body}
-
-    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
-    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
-
-    rows = parser.parse_bulk_expense_invoices_from_assets(
-        [
-            {
-                "id": "asset-native",
-                "s3_key": "k",
-                "file_name": "bulk.pdf",
-                "content_type": "application/pdf",
-            }
-        ],
-        timeout=25,
-    )
-
-    assert captured_engines == ["mistral-ocr", "pdf-text", "native"]
-    assert len(rows) == 1
-    assert rows[0]["vendor_name"] == "Native Shop"
 
 
 def test_parse_bulk_expense_invoices_raises_descriptive_error_when_model_returns_empty_object(


### PR DESCRIPTION
…ne OpenRouter call, no engine fallback)

The user pointed out that the single-invoice parser works perfectly on the same PDFs that the bulk parser keeps failing on. The structural difference was simple: the bulk parser was making three OpenRouter calls in quick succession (one per PDF engine: mistral-ocr, pdf-text, native), and each new robustness layer added in earlier iterations was making things worse:

- A transient provider 429 turned into a guaranteed three-fold failure ("Provider returned error (code=429)" on every engine).
- Each new failure mode I patched was, ironically, surfaced *because* of the multi-call retry shape — single-call code paths simply do not see these patterns repeatedly.

This iteration removes the retry surface entirely and aligns the bulk parser with the proven single-invoice parser. Differences from `parse_invoice_from_assets` are now only the two that are intrinsic to the use case: the user-message schema prompt asks for an array of rows, and the response is interpreted as that array.

Removed code in `backend/src/app/services/openrouter_expense_parser.py`:

- Engine fallback machinery: `_attempt_bulk_parse`, `_bulk_pdf_engine_attempt_order`, `_PDF_ENGINE_FALLBACKS`, `_BULK_SYSTEM_PROMPT`.
- The engine-attempts loop in `parse_bulk_expense_invoices_from_assets`.
- `pdf_engine_override` parameter on `_openrouter_chat_completion` (no longer used).

Bulk parser now does:

1. Build content with `_bulk_schema_prompt()` + the PDF attachment (single S3 read).
2. ONE `_openrouter_chat_completion` call with the SAME system prompt as the single parser ("You extract invoice data and return strict JSON only.") and the configured PDF engine.
3. `_parse_bulk_invoices_payload` → array-aware extraction (still keeps JSON-mode + JSON-repair + wrapper coercion + empty-content diagnostic from earlier iterations — these are zero-extra-API-call safety nets, not retry layers).
4. Normalize each row, return.

What the call pattern looks like now:

| Path                              | OpenRouter calls (success) | Calls (broken JSON, repair recovers) |
|-----------------------------------|----------------------------|---------------------------------------|
| Single invoice parser (unchanged) | 1                          | 2                                     |
| Bulk parser (after this change)   | 1                          | 2                                     |
| Bulk parser (previous iteration)  | 3 worst-case               | 6 worst-case                          |

Tests in `tests/test_openrouter_expense_parser.py`:

- New `test_parse_bulk_expense_invoices_makes_one_request_like_single_parser` asserts exactly one HTTP call on success and that the system prompt matches the single-invoice parser verbatim.
- New `test_parse_bulk_expense_invoices_surfaces_provider_rate_limit_directly` reproduces the user's most recent failure: a 429 from the provider must surface immediately (with cleaned message), not be retried across engines, not be wrapped with "across N attempt(s)".
- New `test_parse_bulk_expense_invoices_surfaces_empty_content_directly` asserts empty-content diagnostics surface on a single attempt.
- Removed: `test_bulk_pdf_engine_attempt_order_*`, `test_parse_bulk_expense_invoices_falls_back_to_alternate_engine`, `test_parse_bulk_expense_invoices_falls_back_to_native_after_plugin_400`, `test_parse_bulk_expense_invoices_exhausts_engines_and_names_them`.
- All other previously-added tests (JSON repair, alias keys, snippet failure, empty-object → no-rows, error formatting) unchanged and still passing.

Docs: `docs/architecture/lambdas.md` replaces the multi-engine fallback section with a short note that the bulk parser now mirrors the single parser's single-call pattern; documents the env override for the rare PDF that requires a non-default engine. Worst-case parse budget is back to 240s + optional 60s JSON-repair retry.

Trade-off acknowledged: if a specific PDF requires a non-default engine (e.g. text-based PDF that only `pdf-text` handles cleanly), the user will hit a parse error and need to set `OPENROUTER_PDF_ENGINE`. That's the same trade the single parser already makes.