### PR TITLE
fix(bulk-expense-import): retry once on transient OpenRouter failures (429 / envelope 504 / 5xx)

### DIFF
--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import re
+import time
 from typing import Any
 from collections.abc import Mapping, Sequence
 
@@ -19,6 +20,18 @@ logger = get_logger(__name__)
 _api_key_cache: str | None = None
 _PDF_PLUGIN_ID = "file-parser"
 _DEFAULT_PDF_ENGINE = "mistral-ocr"
+
+# Transient upstream failures that are worth a single fast retry inside the
+# same Lambda invocation. These cover provider rate limits (429), gateway
+# timeouts (504), and other temporarily-unavailable responses both as HTTP
+# status codes and as the ``error.code`` field that OpenRouter sometimes
+# returns inside a 200 envelope (for example ``code=504`` when the upstream
+# model timed out but the OpenRouter edge replied 200).
+_RETRYABLE_HTTP_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+_RETRYABLE_ENVELOPE_CODES = frozenset({408, 425, 429, 500, 502, 503, 504})
+_MAX_RETRY_ATTEMPTS = 2  # initial attempt + 1 retry
+_RETRY_BACKOFF_SECONDS = 1.5
+_MAX_RETRY_AFTER_SECONDS = 5.0
 
 
 def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
@@ -165,30 +178,146 @@ def _openrouter_chat_completion(
             }
         ]
 
-    response = http_invoke(
-        method="POST",
-        url=endpoint_url,
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        },
-        body=json.dumps(payload),
-        timeout=timeout,
-    )
+    serialized_payload = json.dumps(payload)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
 
-    status_code = int(response.get("status", 0) or 0)
-    body = str(response.get("body", "") or "")
-    if status_code < 200 or status_code >= 300:
-        preview = _format_openrouter_error_preview(body)
-        logger.warning(
-            "OpenRouter request failed",
-            extra={"status_code": status_code, "response_preview": preview or None},
+    last_status: int = 0
+    last_body: str = ""
+    last_envelope_code: int | None = None
+    for attempt in range(1, _MAX_RETRY_ATTEMPTS + 1):
+        response = http_invoke(
+            method="POST",
+            url=endpoint_url,
+            headers=headers,
+            body=serialized_payload,
+            timeout=timeout,
         )
-        detail = f": {preview}" if preview else ""
+
+        status_code = int(response.get("status", 0) or 0)
+        body = str(response.get("body", "") or "")
+        last_status = status_code
+        last_body = body
+
+        http_retryable = (
+            status_code < 200 or status_code >= 300
+        ) and status_code in _RETRYABLE_HTTP_STATUSES
+
+        envelope_code: int | None = None
+        if 200 <= status_code < 300:
+            envelope_code = _envelope_error_code(body)
+        envelope_retryable = (
+            envelope_code is not None and envelope_code in _RETRYABLE_ENVELOPE_CODES
+        )
+        last_envelope_code = envelope_code
+
+        if (http_retryable or envelope_retryable) and attempt < _MAX_RETRY_ATTEMPTS:
+            response_headers = response.get("headers")
+            delay = _retry_delay_seconds(response_headers)
+            preview = _format_openrouter_error_preview(body)
+            logger.warning(
+                "OpenRouter transient error; retrying",
+                extra={
+                    "attempt": attempt,
+                    "status_code": status_code,
+                    "envelope_error_code": envelope_code,
+                    "delay_seconds": delay,
+                    "response_preview": preview or None,
+                },
+            )
+            time.sleep(delay)
+            continue
+
+        if status_code < 200 or status_code >= 300:
+            preview = _format_openrouter_error_preview(body)
+            logger.warning(
+                "OpenRouter request failed",
+                extra={
+                    "status_code": status_code,
+                    "response_preview": preview or None,
+                    "attempts": attempt,
+                },
+            )
+            detail = f": {preview}" if preview else ""
+            raise RuntimeError(
+                f"OpenRouter request failed with status {status_code}{detail}"
+            )
+        return body
+
+    preview = _format_openrouter_error_preview(last_body)
+    detail = f": {preview}" if preview else ""
+    if last_status < 200 or last_status >= 300:
         raise RuntimeError(
-            f"OpenRouter request failed with status {status_code}{detail}"
+            f"OpenRouter request failed with status {last_status}{detail}"
         )
-    return body
+    if last_envelope_code is not None:
+        raise RuntimeError(
+            f"OpenRouter returned transient error (code={last_envelope_code}){detail}"
+        )
+    raise RuntimeError(f"OpenRouter request failed{detail}")
+
+
+def _envelope_error_code(body: str) -> int | None:
+    """Return the integer ``error.code`` from a 2xx OpenRouter body, or ``None``.
+
+    OpenRouter sometimes responds with HTTP 200 but a body of the form
+    ``{"error": {"message": "...", "code": 504}, ...}`` when the upstream
+    model call failed at the edge (gateway timeout, provider rate limit,
+    etc). Treat those identically to the matching HTTP status for retry
+    purposes.
+    """
+    if not body:
+        return None
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    err = payload.get("error")
+    if not isinstance(err, dict):
+        return None
+    code = err.get("code")
+    if isinstance(code, bool):
+        return None
+    if isinstance(code, int):
+        return code
+    if isinstance(code, str) and code.strip().lstrip("-").isdigit():
+        try:
+            return int(code.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _retry_delay_seconds(response_headers: Any) -> float:
+    """Return the backoff delay before the next attempt, honoring ``Retry-After``."""
+    if isinstance(response_headers, Mapping):
+        for key, value in response_headers.items():
+            if isinstance(key, str) and key.lower() == "retry-after":
+                parsed = _parse_retry_after_seconds(value)
+                if parsed is not None:
+                    return min(max(parsed, 0.0), _MAX_RETRY_AFTER_SECONDS)
+                break
+    return _RETRY_BACKOFF_SECONDS
+
+
+def _parse_retry_after_seconds(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+    return None
 
 
 def _format_openrouter_error_preview(body: str) -> str:

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -937,15 +937,17 @@ def test_parse_bulk_expense_invoices_makes_one_request_like_single_parser(
 def test_parse_bulk_expense_invoices_falls_back_to_single_on_provider_error(
     monkeypatch: Any,
 ) -> None:
-    """A 429 (or any RuntimeError) on the bulk call falls back to the single parser.
+    """A persistent 429 on the bulk call falls back to the single parser.
 
-    The fallback gives the single-invoice parser a shot at the document so
-    the user gets at least one row when the document contains one. When the
-    fallback also fails, a combined error message names both failures so
-    neither is hidden.
+    Each chat-completion call retries once on retryable upstream failures
+    (see ``_RETRYABLE_HTTP_STATUSES``), so a hard-failure scenario with two
+    parser attempts (bulk + single fallback) issues 2 retries each = 4
+    ``http_invoke`` calls in total before surfacing a combined error that
+    names both failures so neither is hidden.
     """
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
 
     class _FakeS3Client:
         def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
@@ -976,11 +978,211 @@ def test_parse_bulk_expense_invoices_falls_back_to_single_on_provider_error(
             timeout=25,
         )
 
-    assert call_count["n"] == 2, "expected bulk + single-fallback = 2 calls"
+    assert call_count["n"] == 4, (
+        "expected (bulk + 1 retry) + (single fallback + 1 retry) = 4 calls"
+    )
     msg = str(exc_info.value)
     assert "Bulk parse failed" in msg
     assert "single-invoice fallback also failed" in msg
     assert "status 429" in msg
+
+
+def test_openrouter_chat_completion_retries_once_on_429_then_succeeds(
+    monkeypatch: Any,
+) -> None:
+    """A 429 on the first attempt is retried once and the second response is used."""
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+
+    call_log: list[dict[str, Any]] = []
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        call_log.append(kwargs)
+        if len(call_log) == 1:
+            return {
+                "status": 429,
+                "body": '{"error":{"message":"Rate limited","code":429}}',
+            }
+        return {
+            "status": 200,
+            "body": _bulk_chat_completion_body('{"ok": true}'),
+        }
+
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    body = parser._openrouter_chat_completion(
+        system_prompt="s",
+        user_content_blocks=[{"type": "text", "text": "t"}],
+        has_pdf_attachment=False,
+        timeout=5,
+    )
+
+    assert len(call_log) == 2, "expected one initial call + one retry"
+    assert '"ok": true' in parser._extract_message_text(body)
+
+
+def test_openrouter_chat_completion_retries_on_envelope_504_in_2xx(
+    monkeypatch: Any,
+) -> None:
+    """A 200 response carrying an envelope ``error.code=504`` is retried.
+
+    Mirrors the second leg of the user-reported failure:
+        ``OpenRouter returned error: The operation was aborted (code=504)``
+    """
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+
+    call_log: list[dict[str, Any]] = []
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        call_log.append(kwargs)
+        if len(call_log) == 1:
+            return {
+                "status": 200,
+                "body": json.dumps(
+                    {
+                        "error": {
+                            "message": "The operation was aborted",
+                            "code": 504,
+                        }
+                    }
+                ),
+            }
+        return {
+            "status": 200,
+            "body": _bulk_chat_completion_body('{"recovered": true}'),
+        }
+
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    body = parser._openrouter_chat_completion(
+        system_prompt="s",
+        user_content_blocks=[{"type": "text", "text": "t"}],
+        has_pdf_attachment=False,
+        timeout=5,
+    )
+
+    assert len(call_log) == 2
+    assert '"recovered": true' in parser._extract_message_text(body)
+
+
+def test_openrouter_chat_completion_does_not_retry_on_400(monkeypatch: Any) -> None:
+    """A 400 (non-retryable) is surfaced immediately without a second attempt."""
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+
+    call_log: list[dict[str, Any]] = []
+
+    def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        call_log.append(_kwargs)
+        return {
+            "status": 400,
+            "body": '{"error":{"message":"Bad request","code":400}}',
+        }
+
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        parser._openrouter_chat_completion(
+            system_prompt="s",
+            user_content_blocks=[{"type": "text", "text": "t"}],
+            has_pdf_attachment=False,
+            timeout=5,
+        )
+
+    assert len(call_log) == 1, "non-retryable status must not be retried"
+    assert "status 400" in str(exc_info.value)
+
+
+def test_openrouter_chat_completion_persistent_429_raises_after_retry(
+    monkeypatch: Any,
+) -> None:
+    """When both attempts return 429 the final error still carries the status."""
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+
+    call_log: list[dict[str, Any]] = []
+
+    def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        call_log.append(_kwargs)
+        return {
+            "status": 429,
+            "body": '{"error":{"message":"Provider returned error","code":429}}',
+        }
+
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        parser._openrouter_chat_completion(
+            system_prompt="s",
+            user_content_blocks=[{"type": "text", "text": "t"}],
+            has_pdf_attachment=False,
+            timeout=5,
+        )
+
+    assert len(call_log) == 2, "expected one initial call + one retry"
+    msg = str(exc_info.value)
+    assert "status 429" in msg
+    assert "Provider returned error" in msg
+
+
+def test_openrouter_chat_completion_honors_retry_after_header(
+    monkeypatch: Any,
+) -> None:
+    """``Retry-After`` (in seconds) is honored, capped to ``_MAX_RETRY_AFTER_SECONDS``."""
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(parser.time, "sleep", lambda s: sleep_calls.append(s))
+
+    call_log: list[dict[str, Any]] = []
+
+    def _fake_http_invoke(**_kwargs: Any) -> dict[str, Any]:
+        call_log.append(_kwargs)
+        if len(call_log) == 1:
+            return {
+                "status": 503,
+                "headers": {"Retry-After": "2"},
+                "body": '{"error":{"message":"Service unavailable","code":503}}',
+            }
+        return {
+            "status": 200,
+            "body": _bulk_chat_completion_body('{"ok":true}'),
+        }
+
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    parser._openrouter_chat_completion(
+        system_prompt="s",
+        user_content_blocks=[{"type": "text", "text": "t"}],
+        has_pdf_attachment=False,
+        timeout=5,
+    )
+
+    assert len(call_log) == 2
+    assert sleep_calls == [2.0], (
+        "expected the Retry-After value (2s) to be used as the backoff"
+    )
+
+
+def test_retry_delay_seconds_caps_excessive_retry_after() -> None:
+    delay = parser._retry_delay_seconds({"Retry-After": "60"})
+    assert delay == parser._MAX_RETRY_AFTER_SECONDS
+
+
+def test_envelope_error_code_returns_none_for_non_json_or_no_error() -> None:
+    assert parser._envelope_error_code("") is None
+    assert parser._envelope_error_code("not json") is None
+    assert parser._envelope_error_code("{}") is None
+    assert parser._envelope_error_code('{"error":"plain string"}') is None
+    assert (
+        parser._envelope_error_code('{"error":{"message":"x","code":429}}') == 429
+    )
 
 
 def test_parse_bulk_expense_invoices_recovers_via_single_when_bulk_returns_empty(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Reported error

```
RuntimeError('Bulk parse failed: OpenRouter request failed with status 429:
             Provider returned error (code=429); single-invoice fallback also
             failed: OpenRouter returned error: The operation was aborted
             (code=504)')
```

Two distinct transient upstream failures stacked on top of each other:

1. Bulk attempt &rarr; **HTTP 429** from OpenRouter ("Provider returned error").
2. Single-invoice fallback &rarr; **HTTP 200** with **envelope** `error.code = 504` ("The operation was aborted").

Both are short-lived provider issues (rate limit + gateway timeout) but the parser previously surfaced either one as a permanent job failure on the first occurrence.

## Fix

Wrap `_openrouter_chat_completion` in a 2-attempt loop (initial + 1 retry) so the same Lambda invocation gives the provider a second chance before falling back. Both the single and bulk paths benefit consistently.

- Retry on HTTP statuses in `{408, 425, 429, 500, 502, 503, 504}`.
- Retry on 2xx responses whose body has `error.code` in the same set (matches the second leg of the user error: `code=504` inside a `200`).
- 1.5s default backoff. Honor `Retry-After` header up to a 5s cap.
- Non-retryable statuses (400/401/403/404/&hellip;) are surfaced immediately on the first attempt with the existing message format.

### Lambda timeout budget

| Path | Timeout | Worst-case after retry |
|---|---|---|
| Bulk lambda invocation | 600s | &mdash; |
| `parse_bulk_expense_invoices_from_assets` HTTP timeout | 240s | 240 &times; 2 + ~1.5s = 481.5s |
| Single-invoice fallback HTTP timeout | 30s | 30 &times; 2 + ~1.5s = 61.5s |
| Combined retried worst case | | ~543s &nbsp;&lt;&nbsp; 600s |

In practice 429s and envelope 504s return in seconds, not at the configured timeout.

## Files changed

- `backend/src/app/services/openrouter_expense_parser.py`
  - New constants: `_RETRYABLE_HTTP_STATUSES`, `_RETRYABLE_ENVELOPE_CODES`, `_MAX_RETRY_ATTEMPTS=2`, `_RETRY_BACKOFF_SECONDS=1.5`, `_MAX_RETRY_AFTER_SECONDS=5.0`.
  - Retry loop inside `_openrouter_chat_completion`.
  - Helpers: `_envelope_error_code(body)`, `_retry_delay_seconds(headers)`, `_parse_retry_after_seconds(value)`.
- `tests/test_openrouter_expense_parser.py`
  - New: `retries_once_on_429_then_succeeds`, `retries_on_envelope_504_in_2xx`, `does_not_retry_on_400`, `persistent_429_raises_after_retry`, `honors_retry_after_header`, `_retry_delay_seconds_caps_excessive_retry_after`, `_envelope_error_code_returns_none_for_non_json_or_no_error`.
  - Updated: `falls_back_to_single_on_provider_error` &mdash; expected `http_invoke` call count is now `4` (bulk &times; 2 + single &times; 2) since each parser leg retries once.

## Out of scope

- No DB schema / OpenAPI / CDK route / admin-web typing change.
- `docs/architecture/lambdas.md` already covers the bulk-import behavior at a level that does not need to describe internal retry semantics.

## Testing

- `pytest tests/` &rarr; 1136 passed, 17 skipped.
- `ruff check backend/ tests/ --config=backend/pyproject.toml` &rarr; All checks passed.
- `pre-commit run ruff-format --files <changed>` &rarr; Passed.
- `bash scripts/validate-cursorrules.sh` &rarr; `.cursorrules` compliance checks passed.

This is a backend-only Python change to OpenRouter HTTP retry semantics; no UI / build artifact is produced, so no walkthrough video applies. The new and updated unit tests directly exercise the user-reported failure shapes (HTTP 429, envelope `code=504` inside a 200, persistent 429 across both attempts, and `Retry-After` honoring).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b06e34f-84d0-4e37-825b-6028df9ee1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b06e34f-84d0-4e37-825b-6028df9ee1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

