### PR TITLE
fix(bulk-expense-import): drop JSON mode + engine fallback chain (post-async cascade); keep transient retry

### DIFF
--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -21,21 +21,52 @@ _api_key_cache: str | None = None
 _PDF_PLUGIN_ID = "file-parser"
 _DEFAULT_PDF_ENGINE = "mistral-ocr"
 
-# Transient upstream failures that are worth a single fast retry inside the
-# same Lambda invocation. These cover provider rate limits (429), gateway
+# Transient upstream failures that are worth a fast retry inside the same
+# Lambda invocation. These cover provider rate limits (429), gateway
 # timeouts (504), and other temporarily-unavailable responses both as HTTP
 # status codes and as the ``error.code`` field that OpenRouter sometimes
 # returns inside a 200 envelope (for example ``code=504`` when the upstream
 # model timed out but the OpenRouter edge replied 200).
 _RETRYABLE_HTTP_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
 _RETRYABLE_ENVELOPE_CODES = frozenset({408, 425, 429, 500, 502, 503, 504})
-_MAX_RETRY_ATTEMPTS = 2  # initial attempt + 1 retry
-_RETRY_BACKOFF_SECONDS = 1.5
+_MAX_RETRY_ATTEMPTS = 3  # initial attempt + 2 retries
+# Exponential backoff between attempts (seconds): ``[i]`` is the wait BEFORE
+# attempt ``i + 2``. Length must be at least ``_MAX_RETRY_ATTEMPTS - 1``.
+_RETRY_BACKOFF_SCHEDULE_SECONDS: tuple[float, ...] = (2.0, 4.0)
 _MAX_RETRY_AFTER_SECONDS = 5.0
+
+# PDF parsing engines OpenRouter supports through the ``file-parser`` plugin.
+# Order matters: the configured engine (``OPENROUTER_PDF_ENGINE``, default
+# ``mistral-ocr``) is tried first, then the others in this canonical order.
+# Different engines fail in different ways on the same document — for example
+# ``mistral-ocr`` can return zero tokens on borderline scans that ``native``
+# (multi-modal vision) handles fine, and ``pdf-text`` works on text-based
+# PDFs that the OCR engines sometimes give up on. Chaining engines on
+# ``_EmptyResponseError`` recovers the document instead of failing the job.
+_SUPPORTED_PDF_ENGINES: tuple[str, ...] = ("mistral-ocr", "native", "pdf-text")
+
+
+class _EmptyResponseError(RuntimeError):
+    """Raised when OpenRouter responds 2xx but the model produced no usable text.
+
+    This is a different failure shape from refusals, top-level errors, or
+    invalid JSON — typically the PDF engine could not extract any text from
+    the document — so the single-invoice parser can recover by retrying
+    against another PDF engine. Subclassing ``RuntimeError`` keeps the
+    existing ``except RuntimeError`` paths working unchanged.
+    """
 
 
 def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
-    """Parse invoice details from expense attachment assets."""
+    """Parse invoice details from expense attachment assets.
+
+    For PDF inputs this iterates through ``_SUPPORTED_PDF_ENGINES`` (starting
+    with the configured engine) and falls through to the next engine only
+    when the current one returns an empty response (zero tokens / no
+    content). Transient HTTP / envelope errors are already retried inside
+    ``_openrouter_chat_completion``; refusals, 4xx errors, and other
+    non-empty failures propagate immediately.
+    """
     if not assets:
         raise ValueError("At least one asset is required for parsing")
 
@@ -47,15 +78,52 @@ def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, 
     has_pdf = any(
         _normalize_content_type(asset) == "application/pdf" for asset in assets
     )
-    body = _openrouter_chat_completion(
-        system_prompt="You extract invoice data and return strict JSON only.",
-        user_content_blocks=content,
-        has_pdf_attachment=has_pdf,
-        timeout=30,
+
+    if not has_pdf:
+        body = _openrouter_chat_completion(
+            system_prompt="You extract invoice data and return strict JSON only.",
+            user_content_blocks=content,
+            has_pdf_attachment=False,
+            timeout=30,
+        )
+        parsed = _parse_completion_body(body)
+        logger.info("Invoice parse completed successfully")
+        return _normalize_result(parsed)
+
+    engines = _pdf_engines_to_try()
+    last_empty: _EmptyResponseError | None = None
+    tried: list[str] = []
+    for engine in engines:
+        tried.append(engine)
+        try:
+            body = _openrouter_chat_completion(
+                system_prompt="You extract invoice data and return strict JSON only.",
+                user_content_blocks=content,
+                has_pdf_attachment=True,
+                timeout=30,
+                pdf_engine=engine,
+            )
+            parsed = _parse_completion_body(body)
+            logger.info(
+                "Invoice parse completed successfully",
+                extra={"pdf_engine": engine, "engines_tried": tried},
+            )
+            return _normalize_result(parsed)
+        except _EmptyResponseError as exc:
+            last_empty = exc
+            logger.warning(
+                "PDF engine returned empty response; trying next engine",
+                extra={
+                    "pdf_engine": engine,
+                    "engines_remaining": engines[engines.index(engine) + 1 :],
+                },
+            )
+            continue
+
+    raise RuntimeError(
+        "All PDF engines returned empty responses "
+        f"(tried: {', '.join(tried)}). Last detail: {last_empty}"
     )
-    parsed = _parse_completion_body(body)
-    logger.info("Invoice parse completed successfully")
-    return _normalize_result(parsed)
 
 
 _MAX_BULK_INVOICES = 100
@@ -152,8 +220,13 @@ def _openrouter_chat_completion(
     user_content_blocks: list[dict[str, Any]],
     has_pdf_attachment: bool,
     timeout: int,
+    pdf_engine: str | None = None,
 ) -> str:
-    """POST to OpenRouter and return the raw HTTP response body string."""
+    """POST to OpenRouter and return the raw HTTP response body string.
+
+    ``pdf_engine`` overrides the configured engine when ``has_pdf_attachment``
+    is true. ``None`` (default) uses ``_pdf_parser_engine()``.
+    """
     endpoint_url = _require_env("OPENROUTER_CHAT_COMPLETIONS_URL")
     model = _require_env("OPENROUTER_MODEL")
     api_key = _get_api_key()
@@ -171,10 +244,11 @@ def _openrouter_chat_completion(
         ],
     }
     if has_pdf_attachment:
+        engine = pdf_engine if pdf_engine is not None else _pdf_parser_engine()
         payload["plugins"] = [
             {
                 "id": _PDF_PLUGIN_ID,
-                "pdf": {"engine": _pdf_parser_engine()},
+                "pdf": {"engine": engine},
             }
         ]
 
@@ -215,7 +289,7 @@ def _openrouter_chat_completion(
 
         if (http_retryable or envelope_retryable) and attempt < _MAX_RETRY_ATTEMPTS:
             response_headers = response.get("headers")
-            delay = _retry_delay_seconds(response_headers)
+            delay = _retry_delay_seconds(response_headers, attempt)
             preview = _format_openrouter_error_preview(body)
             logger.warning(
                 "OpenRouter transient error; retrying",
@@ -292,8 +366,16 @@ def _envelope_error_code(body: str) -> int | None:
     return None
 
 
-def _retry_delay_seconds(response_headers: Any) -> float:
-    """Return the backoff delay before the next attempt, honoring ``Retry-After``."""
+def _retry_delay_seconds(response_headers: Any, attempt: int) -> float:
+    """Return the backoff delay before the next attempt, honoring ``Retry-After``.
+
+    ``attempt`` is the 1-indexed attempt that just failed (so the next
+    attempt is ``attempt + 1``). Without an explicit ``Retry-After``, the
+    delay is taken from the exponential schedule
+    ``_RETRY_BACKOFF_SCHEDULE_SECONDS`` (e.g. 2s, 4s, ...). The schedule is
+    indexed by ``attempt - 1``; if the schedule is shorter than the number
+    of retries, the last value is reused.
+    """
     if isinstance(response_headers, Mapping):
         for key, value in response_headers.items():
             if isinstance(key, str) and key.lower() == "retry-after":
@@ -301,7 +383,12 @@ def _retry_delay_seconds(response_headers: Any) -> float:
                 if parsed is not None:
                     return min(max(parsed, 0.0), _MAX_RETRY_AFTER_SECONDS)
                 break
-    return _RETRY_BACKOFF_SECONDS
+    if not _RETRY_BACKOFF_SCHEDULE_SECONDS:
+        return 0.0
+    idx = max(0, attempt - 1)
+    if idx >= len(_RETRY_BACKOFF_SCHEDULE_SECONDS):
+        idx = len(_RETRY_BACKOFF_SCHEDULE_SECONDS) - 1
+    return float(_RETRY_BACKOFF_SCHEDULE_SECONDS[idx])
 
 
 def _parse_retry_after_seconds(value: Any) -> float | None:
@@ -483,8 +570,14 @@ def _extract_message_text(body: str) -> str:
 
 def _empty_response_error(
     payload: Mapping[str, Any], first_choice: Mapping[str, Any]
-) -> RuntimeError:
-    """Build a diagnostic ``RuntimeError`` for an empty model response."""
+) -> _EmptyResponseError:
+    """Build a diagnostic ``_EmptyResponseError`` for an empty model response.
+
+    Returning the ``_EmptyResponseError`` subclass lets the single-invoice
+    parser distinguish "engine produced nothing" (recoverable by trying
+    another PDF engine) from "model refused / 4xx / invalid JSON" (not
+    recoverable by switching engines).
+    """
     finish_reason = first_choice.get("finish_reason") or first_choice.get(
         "finishReason"
     )
@@ -500,13 +593,15 @@ def _empty_response_error(
     suffix = f" ({'; '.join(details)})" if details else ""
 
     if finish_reason == "length":
-        return RuntimeError(
+        return _EmptyResponseError(
             f"Model output was truncated before any JSON was produced{suffix}. "
             "The document may be too long for one parse; try a smaller PDF."
         )
     if finish_reason == "content_filter":
-        return RuntimeError(f"Model output was blocked by the content filter{suffix}.")
-    return RuntimeError(
+        return _EmptyResponseError(
+            f"Model output was blocked by the content filter{suffix}."
+        )
+    return _EmptyResponseError(
         f"Model returned an empty response{suffix}. The PDF may be unreadable "
         "to this engine, the model may have failed to extract any text, or "
         "the request may have been rejected upstream."
@@ -1077,6 +1172,18 @@ def _pdf_parser_engine() -> str:
     if configured in {"pdf-text", "mistral-ocr", "native"}:
         return configured
     return _DEFAULT_PDF_ENGINE
+
+
+def _pdf_engines_to_try() -> list[str]:
+    """Return the PDF engines to try in order for the engine-fallback chain.
+
+    Always starts with the configured engine (default ``mistral-ocr``) and
+    appends the remaining supported engines in canonical order. Iteration
+    stops as soon as one engine produces a non-empty parse result.
+    """
+    primary = _pdf_parser_engine()
+    rest = [engine for engine in _SUPPORTED_PDF_ENGINES if engine != primary]
+    return [primary, *rest]
 
 
 def _require_env(name: str) -> str:

--- a/backend/src/app/services/openrouter_expense_parser.py
+++ b/backend/src/app/services/openrouter_expense_parser.py
@@ -35,37 +35,18 @@ _MAX_RETRY_ATTEMPTS = 3  # initial attempt + 2 retries
 _RETRY_BACKOFF_SCHEDULE_SECONDS: tuple[float, ...] = (2.0, 4.0)
 _MAX_RETRY_AFTER_SECONDS = 5.0
 
-# PDF parsing engines OpenRouter supports through the ``file-parser`` plugin.
-# Order matters: the configured engine (``OPENROUTER_PDF_ENGINE``, default
-# ``mistral-ocr``) is tried first, then the others in this canonical order.
-# Different engines fail in different ways on the same document — for example
-# ``mistral-ocr`` can return zero tokens on borderline scans that ``native``
-# (multi-modal vision) handles fine, and ``pdf-text`` works on text-based
-# PDFs that the OCR engines sometimes give up on. Chaining engines on
-# ``_EmptyResponseError`` recovers the document instead of failing the job.
-_SUPPORTED_PDF_ENGINES: tuple[str, ...] = ("mistral-ocr", "native", "pdf-text")
-
-
-class _EmptyResponseError(RuntimeError):
-    """Raised when OpenRouter responds 2xx but the model produced no usable text.
-
-    This is a different failure shape from refusals, top-level errors, or
-    invalid JSON — typically the PDF engine could not extract any text from
-    the document — so the single-invoice parser can recover by retrying
-    against another PDF engine. Subclassing ``RuntimeError`` keeps the
-    existing ``except RuntimeError`` paths working unchanged.
-    """
-
 
 def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     """Parse invoice details from expense attachment assets.
 
-    For PDF inputs this iterates through ``_SUPPORTED_PDF_ENGINES`` (starting
-    with the configured engine) and falls through to the next engine only
-    when the current one returns an empty response (zero tokens / no
-    content). Transient HTTP / envelope errors are already retried inside
-    ``_openrouter_chat_completion``; refusals, 4xx errors, and other
-    non-empty failures propagate immediately.
+    Single OpenRouter chat completion (with internal retry on transient
+    upstream errors), then parse the result. This is intentionally the same
+    one-call shape as the original synchronous parser at PR #1624 / commit
+    b6f8990b that was working before the bulk-import flow moved to async —
+    layered engine fallbacks were tried and rolled back because they
+    amplify rate limits and introduce more failure modes than they fix.
+    Unescaped-quote ``JSONDecodeError`` cases are still handled by
+    ``_loads_with_repair`` instead of by forcing JSON mode.
     """
     if not assets:
         raise ValueError("At least one asset is required for parsing")
@@ -78,52 +59,15 @@ def parse_invoice_from_assets(assets: Sequence[Mapping[str, Any]]) -> dict[str, 
     has_pdf = any(
         _normalize_content_type(asset) == "application/pdf" for asset in assets
     )
-
-    if not has_pdf:
-        body = _openrouter_chat_completion(
-            system_prompt="You extract invoice data and return strict JSON only.",
-            user_content_blocks=content,
-            has_pdf_attachment=False,
-            timeout=30,
-        )
-        parsed = _parse_completion_body(body)
-        logger.info("Invoice parse completed successfully")
-        return _normalize_result(parsed)
-
-    engines = _pdf_engines_to_try()
-    last_empty: _EmptyResponseError | None = None
-    tried: list[str] = []
-    for engine in engines:
-        tried.append(engine)
-        try:
-            body = _openrouter_chat_completion(
-                system_prompt="You extract invoice data and return strict JSON only.",
-                user_content_blocks=content,
-                has_pdf_attachment=True,
-                timeout=30,
-                pdf_engine=engine,
-            )
-            parsed = _parse_completion_body(body)
-            logger.info(
-                "Invoice parse completed successfully",
-                extra={"pdf_engine": engine, "engines_tried": tried},
-            )
-            return _normalize_result(parsed)
-        except _EmptyResponseError as exc:
-            last_empty = exc
-            logger.warning(
-                "PDF engine returned empty response; trying next engine",
-                extra={
-                    "pdf_engine": engine,
-                    "engines_remaining": engines[engines.index(engine) + 1 :],
-                },
-            )
-            continue
-
-    raise RuntimeError(
-        "All PDF engines returned empty responses "
-        f"(tried: {', '.join(tried)}). Last detail: {last_empty}"
+    body = _openrouter_chat_completion(
+        system_prompt="You extract invoice data and return strict JSON only.",
+        user_content_blocks=content,
+        has_pdf_attachment=has_pdf,
+        timeout=30,
     )
+    parsed = _parse_completion_body(body)
+    logger.info("Invoice parse completed successfully")
+    return _normalize_result(parsed)
 
 
 _MAX_BULK_INVOICES = 100
@@ -220,12 +164,18 @@ def _openrouter_chat_completion(
     user_content_blocks: list[dict[str, Any]],
     has_pdf_attachment: bool,
     timeout: int,
-    pdf_engine: str | None = None,
 ) -> str:
     """POST to OpenRouter and return the raw HTTP response body string.
 
-    ``pdf_engine`` overrides the configured engine when ``has_pdf_attachment``
-    is true. ``None`` (default) uses ``_pdf_parser_engine()``.
+    Note: this intentionally does NOT set ``response_format={"type":
+    "json_object"}``. JSON mode was added in commit ``3874b3b6`` to mask a
+    ``JSONDecodeError`` triggered by unescaped quotes in line-item
+    descriptions, but it caused models to emit empty ``{}`` /
+    ``completion_tokens=0`` on borderline PDFs (a worse failure shape).
+    The same JSONDecodeError it was meant to mask is now handled by the
+    ``_loads_with_repair`` pathway, so we drop JSON mode and let the model
+    emit natural JSON the same way it did in the original synchronous
+    parser at commit ``b6f8990b``.
     """
     endpoint_url = _require_env("OPENROUTER_CHAT_COMPLETIONS_URL")
     model = _require_env("OPENROUTER_MODEL")
@@ -234,21 +184,16 @@ def _openrouter_chat_completion(
     payload: dict[str, Any] = {
         "model": model,
         "temperature": 0,
-        # Force JSON-mode so the model cannot emit prose, fences, or partial
-        # objects. Combined with the schema prompts this dramatically reduces
-        # the JSONDecodeError rate on bulk parses with quoted descriptions.
-        "response_format": {"type": "json_object"},
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_content_blocks},
         ],
     }
     if has_pdf_attachment:
-        engine = pdf_engine if pdf_engine is not None else _pdf_parser_engine()
         payload["plugins"] = [
             {
                 "id": _PDF_PLUGIN_ID,
-                "pdf": {"engine": engine},
+                "pdf": {"engine": _pdf_parser_engine()},
             }
         ]
 
@@ -570,14 +515,8 @@ def _extract_message_text(body: str) -> str:
 
 def _empty_response_error(
     payload: Mapping[str, Any], first_choice: Mapping[str, Any]
-) -> _EmptyResponseError:
-    """Build a diagnostic ``_EmptyResponseError`` for an empty model response.
-
-    Returning the ``_EmptyResponseError`` subclass lets the single-invoice
-    parser distinguish "engine produced nothing" (recoverable by trying
-    another PDF engine) from "model refused / 4xx / invalid JSON" (not
-    recoverable by switching engines).
-    """
+) -> RuntimeError:
+    """Build a diagnostic ``RuntimeError`` for an empty model response."""
     finish_reason = first_choice.get("finish_reason") or first_choice.get(
         "finishReason"
     )
@@ -593,15 +532,13 @@ def _empty_response_error(
     suffix = f" ({'; '.join(details)})" if details else ""
 
     if finish_reason == "length":
-        return _EmptyResponseError(
+        return RuntimeError(
             f"Model output was truncated before any JSON was produced{suffix}. "
             "The document may be too long for one parse; try a smaller PDF."
         )
     if finish_reason == "content_filter":
-        return _EmptyResponseError(
-            f"Model output was blocked by the content filter{suffix}."
-        )
-    return _EmptyResponseError(
+        return RuntimeError(f"Model output was blocked by the content filter{suffix}.")
+    return RuntimeError(
         f"Model returned an empty response{suffix}. The PDF may be unreadable "
         "to this engine, the model may have failed to extract any text, or "
         "the request may have been rejected upstream."
@@ -1172,18 +1109,6 @@ def _pdf_parser_engine() -> str:
     if configured in {"pdf-text", "mistral-ocr", "native"}:
         return configured
     return _DEFAULT_PDF_ENGINE
-
-
-def _pdf_engines_to_try() -> list[str]:
-    """Return the PDF engines to try in order for the engine-fallback chain.
-
-    Always starts with the configured engine (default ``mistral-ocr``) and
-    appends the remaining supported engines in canonical order. Iteration
-    stops as soon as one engine produces a non-empty parse result.
-    """
-    primary = _pdf_parser_engine()
-    rest = [engine for engine in _SUPPORTED_PDF_ENGINES if engine != primary]
-    return [primary, *rest]
 
 
 def _require_env(name: str) -> str:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -535,19 +535,23 @@ their primary responsibilities.
 - Call pattern: the bulk parser issues exactly **one** OpenRouter chat
   completion per import (mirroring the single-invoice parser at
   `parse_invoice_from_assets`), with the same system prompt and the
-  configured PDF engine. The bulk path itself does NOT iterate engines;
-  engine fallback lives only in the single-invoice fallback below, so the
-  bulk path keeps the same call shape the user demanded.
+  configured PDF engine. **No JSON mode**; **no engine fallback chain**.
+  This is the original synchronous call shape from PR #1624 / commit
+  `b6f8990b` that worked before this path moved to async &mdash; layered
+  fixes (JSON mode, multi-engine retries) were tried in subsequent
+  iterations and rolled back because they introduced more failure modes
+  than they fixed. Unescaped-quote `JSONDecodeError` cases (the original
+  symptom that prompted JSON mode) are still handled, by the
+  `_loads_with_repair` pathway instead.
 - Transient retry (every chat completion): each `_openrouter_chat_completion`
   call retries up to **2 additional times** (3 attempts total) with
-  exponential backoff (2s, 4s) on transient upstream failures — HTTP
+  exponential backoff (2s, 4s) on transient upstream failures &mdash; HTTP
   status `408`, `425`, `429`, `500`, `502`, `503`, `504`, AND on 2xx
   responses whose envelope contains an `error.code` in the same set
   (OpenRouter sometimes returns 200 with `code=504` when an upstream model
   call timed out). `Retry-After` headers are honored, capped to 5s.
   Non-retryable statuses (4xx other than 408/425/429) propagate
-  immediately. The same retry policy applies to the JSON-repair sub-call
-  and to every engine attempt below.
+  immediately. The same retry policy applies to the JSON-repair sub-call.
 - Single-invoice fallback: when the one bulk attempt produces no usable
   rows for any reason (empty model response, refusal, JSON parse failure,
   HTTP error including 4xx/5xx after retries, or zero rows after coercion),
@@ -555,24 +559,6 @@ their primary responsibilities.
   attachment and returns its result wrapped as a one-element list. If the
   fallback also fails, both errors are surfaced together in one message so
   neither failure is hidden.
-- PDF engine fallback (single-invoice path only): for PDF inputs,
-  `parse_invoice_from_assets` walks the supported PDF engines in order —
-  starting with the configured `OPENROUTER_PDF_ENGINE` (default
-  `mistral-ocr`) and continuing through the remaining engines from
-  `{mistral-ocr, native, pdf-text}` — and falls through to the next engine
-  ONLY when the current one returns an `_EmptyResponseError` (empty
-  content / `completion_tokens=0` / truncation / content-filter block).
-  Refusals, 4xx responses, JSON parse failures, and other non-empty errors
-  stop the chain immediately so the failure mode is preserved instead of
-  amplified. Image and text inputs make a single chat completion call with
-  no engine fallback. Non-PDF callers can pass `pdf_engine=None` (default)
-  on `_openrouter_chat_completion` to use the configured engine.
-- Acceptance: the bulk path now satisfies "bulk works at least as well as
-  single" by chaining (a) bulk attempt with retry, (b) single-invoice
-  fallback whose first engine attempt also retries, and (c) two more PDF
-  engines for the single-invoice fallback if the first engine produces
-  nothing. When any of those produces a parseable response, the user gets
-  at least one row instead of a failed import.
 - 4xx error formatting: OpenRouter error bodies are condensed to their
   `error.message` + `error.code` before being raised or logged so the
   persisted bulk-import job row stays readable and does not echo unrelated

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -535,22 +535,44 @@ their primary responsibilities.
 - Call pattern: the bulk parser issues exactly **one** OpenRouter chat
   completion per import (mirroring the single-invoice parser at
   `parse_invoice_from_assets`), with the same system prompt and the
-  configured PDF engine. Earlier iterations layered a multi-engine retry on
-  top of this call; that turned every transient provider rate limit into a
-  guaranteed multi-failure cascade against the same account, so the bulk
-  path now matches the single path's reliability profile by doing the same
-  amount of work. If a specific PDF only parses with a non-default engine,
-  set `OPENROUTER_PDF_ENGINE` accordingly.
+  configured PDF engine. The bulk path itself does NOT iterate engines;
+  engine fallback lives only in the single-invoice fallback below, so the
+  bulk path keeps the same call shape the user demanded.
+- Transient retry (every chat completion): each `_openrouter_chat_completion`
+  call retries up to **2 additional times** (3 attempts total) with
+  exponential backoff (2s, 4s) on transient upstream failures — HTTP
+  status `408`, `425`, `429`, `500`, `502`, `503`, `504`, AND on 2xx
+  responses whose envelope contains an `error.code` in the same set
+  (OpenRouter sometimes returns 200 with `code=504` when an upstream model
+  call timed out). `Retry-After` headers are honored, capped to 5s.
+  Non-retryable statuses (4xx other than 408/425/429) propagate
+  immediately. The same retry policy applies to the JSON-repair sub-call
+  and to every engine attempt below.
 - Single-invoice fallback: when the one bulk attempt produces no usable
   rows for any reason (empty model response, refusal, JSON parse failure,
-  HTTP error including 4xx/5xx, or zero rows after coercion), the bulk
-  parser falls back to `parse_invoice_from_assets` on the same attachment
-  and returns its result wrapped as a one-element list. The acceptance
-  criterion this satisfies is "bulk works at least as well as single": when
-  the proven single-invoice path can extract anything from the PDF, the
-  bulk parser returns at least that one row instead of failing the entire
-  import. If the fallback also fails, both errors are surfaced together in
-  one message so neither failure is hidden.
+  HTTP error including 4xx/5xx after retries, or zero rows after coercion),
+  the bulk parser falls back to `parse_invoice_from_assets` on the same
+  attachment and returns its result wrapped as a one-element list. If the
+  fallback also fails, both errors are surfaced together in one message so
+  neither failure is hidden.
+- PDF engine fallback (single-invoice path only): for PDF inputs,
+  `parse_invoice_from_assets` walks the supported PDF engines in order —
+  starting with the configured `OPENROUTER_PDF_ENGINE` (default
+  `mistral-ocr`) and continuing through the remaining engines from
+  `{mistral-ocr, native, pdf-text}` — and falls through to the next engine
+  ONLY when the current one returns an `_EmptyResponseError` (empty
+  content / `completion_tokens=0` / truncation / content-filter block).
+  Refusals, 4xx responses, JSON parse failures, and other non-empty errors
+  stop the chain immediately so the failure mode is preserved instead of
+  amplified. Image and text inputs make a single chat completion call with
+  no engine fallback. Non-PDF callers can pass `pdf_engine=None` (default)
+  on `_openrouter_chat_completion` to use the configured engine.
+- Acceptance: the bulk path now satisfies "bulk works at least as well as
+  single" by chaining (a) bulk attempt with retry, (b) single-invoice
+  fallback whose first engine attempt also retries, and (c) two more PDF
+  engines for the single-invoice fallback if the first engine produces
+  nothing. When any of those produces a parseable response, the user gets
+  at least one row instead of a failed import.
 - 4xx error formatting: OpenRouter error bodies are condensed to their
   `error.message` + `error.code` before being raised or logged so the
   persisted bulk-import job row stays readable and does not echo unrelated

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -1513,5 +1513,3 @@ def test_parse_invoice_makes_a_single_chat_completion_call(monkeypatch: Any) -> 
     assert "response_format" not in sent_payload, "JSON mode is intentionally off"
     assert sent_payload["plugins"][0]["pdf"]["engine"] == "mistral-ocr"
     assert result["vendor_name"] == "Single Shop"
-
-

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -939,15 +939,21 @@ def test_parse_bulk_expense_invoices_falls_back_to_single_on_provider_error(
 ) -> None:
     """A persistent 429 on the bulk call falls back to the single parser.
 
-    Each chat-completion call retries once on retryable upstream failures
-    (see ``_RETRYABLE_HTTP_STATUSES``), so a hard-failure scenario with two
-    parser attempts (bulk + single fallback) issues 2 retries each = 4
-    ``http_invoke`` calls in total before surfacing a combined error that
+    Each chat-completion call retries up to ``_MAX_RETRY_ATTEMPTS - 1`` times
+    on retryable upstream failures, so a hard-failure scenario where every
+    attempt returns 429 issues:
+
+    - 3 attempts on the bulk call (initial + 2 retries), then
+    - 3 attempts on the single-invoice fallback's first PDF engine
+      (the engine fallback only chains on ``_EmptyResponseError``, NOT on
+      a transient HTTP error that has already been retried internally).
+
+    = 6 ``http_invoke`` calls total before surfacing a combined error that
     names both failures so neither is hidden.
     """
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
 
     class _FakeS3Client:
         def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
@@ -978,8 +984,9 @@ def test_parse_bulk_expense_invoices_falls_back_to_single_on_provider_error(
             timeout=25,
         )
 
-    assert call_count["n"] == 4, (
-        "expected (bulk + 1 retry) + (single fallback + 1 retry) = 4 calls"
+    assert call_count["n"] == 6, (
+        "expected (bulk x 3 attempts) + (single fallback first engine x 3 "
+        "attempts) = 6 http_invoke calls"
     )
     msg = str(exc_info.value)
     assert "Bulk parse failed" in msg
@@ -993,7 +1000,7 @@ def test_openrouter_chat_completion_retries_once_on_429_then_succeeds(
     """A 429 on the first attempt is retried once and the second response is used."""
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
 
     call_log: list[dict[str, Any]] = []
 
@@ -1032,7 +1039,7 @@ def test_openrouter_chat_completion_retries_on_envelope_504_in_2xx(
     """
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
 
     call_log: list[dict[str, Any]] = []
 
@@ -1072,7 +1079,7 @@ def test_openrouter_chat_completion_does_not_retry_on_400(monkeypatch: Any) -> N
     """A 400 (non-retryable) is surfaced immediately without a second attempt."""
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
 
     call_log: list[dict[str, Any]] = []
 
@@ -1097,13 +1104,17 @@ def test_openrouter_chat_completion_does_not_retry_on_400(monkeypatch: Any) -> N
     assert "status 400" in str(exc_info.value)
 
 
-def test_openrouter_chat_completion_persistent_429_raises_after_retry(
+def test_openrouter_chat_completion_persistent_429_raises_after_all_retries(
     monkeypatch: Any,
 ) -> None:
-    """When both attempts return 429 the final error still carries the status."""
+    """When every attempt returns 429 the final error still carries the status.
+
+    With ``_MAX_RETRY_ATTEMPTS = 3`` (initial + 2 retries) we expect exactly
+    3 ``http_invoke`` calls before the final ``RuntimeError`` propagates.
+    """
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SECONDS", 0.0)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
 
     call_log: list[dict[str, Any]] = []
 
@@ -1124,7 +1135,7 @@ def test_openrouter_chat_completion_persistent_429_raises_after_retry(
             timeout=5,
         )
 
-    assert len(call_log) == 2, "expected one initial call + one retry"
+    assert len(call_log) == parser._MAX_RETRY_ATTEMPTS == 3
     msg = str(exc_info.value)
     assert "status 429" in msg
     assert "Provider returned error" in msg
@@ -1171,8 +1182,17 @@ def test_openrouter_chat_completion_honors_retry_after_header(
 
 
 def test_retry_delay_seconds_caps_excessive_retry_after() -> None:
-    delay = parser._retry_delay_seconds({"Retry-After": "60"})
+    delay = parser._retry_delay_seconds({"Retry-After": "60"}, attempt=1)
     assert delay == parser._MAX_RETRY_AFTER_SECONDS
+
+
+def test_retry_delay_seconds_uses_exponential_schedule_when_no_retry_after() -> None:
+    """Without a ``Retry-After`` header the exponential schedule is used."""
+    schedule = parser._RETRY_BACKOFF_SCHEDULE_SECONDS
+    assert len(schedule) >= parser._MAX_RETRY_ATTEMPTS - 1
+    for attempt_index, expected in enumerate(schedule, start=1):
+        assert parser._retry_delay_seconds({}, attempt=attempt_index) == expected
+    assert parser._retry_delay_seconds({}, attempt=len(schedule) + 5) == schedule[-1]
 
 
 def test_envelope_error_code_returns_none_for_non_json_or_no_error() -> None:
@@ -1412,3 +1432,332 @@ def test_parse_bulk_expense_invoices_raises_with_snippet_when_repair_fails(
     msg = str(exc_info.value)
     assert "even after repair" in msg
     assert "MARKER_TOKEN" in msg
+
+
+# ---------------------------------------------------------------------------
+# PDF engine fallback (single-invoice parser)
+# ---------------------------------------------------------------------------
+
+
+def _empty_response_completion_body() -> str:
+    """An OpenRouter 200 body that triggers ``_EmptyResponseError``."""
+    return json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {"content": ""},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"completion_tokens": 0},
+        }
+    )
+
+
+def _success_completion_body(payload: dict[str, Any]) -> str:
+    return _bulk_chat_completion_body(json.dumps(payload))
+
+
+def test_pdf_engines_to_try_starts_with_configured_engine(monkeypatch: Any) -> None:
+    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "native")
+    engines = parser._pdf_engines_to_try()
+    assert engines[0] == "native"
+    assert set(engines) == {"native", "mistral-ocr", "pdf-text"}
+    assert len(engines) == len(set(engines)), "engines must be unique"
+
+
+def test_pdf_engines_to_try_uses_default_when_unconfigured(monkeypatch: Any) -> None:
+    monkeypatch.delenv("OPENROUTER_PDF_ENGINE", raising=False)
+    engines = parser._pdf_engines_to_try()
+    assert engines[0] == "mistral-ocr"
+    assert set(engines) == {"native", "mistral-ocr", "pdf-text"}
+
+
+def test_parse_invoice_falls_back_to_next_pdf_engine_on_empty_response(
+    monkeypatch: Any,
+) -> None:
+    """``mistral-ocr`` empty -> ``native`` empty -> ``pdf-text`` succeeds.
+
+    Mirrors the user-reported single-fallback failure where the OCR engine
+    returned ``completion_tokens=0`` on a PDF the other engines can read.
+    """
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    engines_seen: list[str] = []
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        sent = json.loads(kwargs["body"])
+        engine = sent["plugins"][0]["pdf"]["engine"]
+        engines_seen.append(engine)
+        if engine in ("mistral-ocr", "native"):
+            return {"status": 200, "body": _empty_response_completion_body()}
+        return {
+            "status": 200,
+            "body": _success_completion_body(
+                {
+                    "vendor_name": "Engine Recovered Shop",
+                    "invoice_number": "ENG1",
+                    "invoice_date": "2026-05-15",
+                    "due_date": None,
+                    "currency": "USD",
+                    "subtotal": 7,
+                    "tax": 0,
+                    "total": 7,
+                    "line_items": [],
+                    "confidence": 0.7,
+                }
+            ),
+        }
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    result = parser.parse_invoice_from_assets(
+        [
+            {
+                "id": "asset-engfb",
+                "s3_key": "k",
+                "file_name": "bulk.pdf",
+                "content_type": "application/pdf",
+            }
+        ]
+    )
+
+    assert engines_seen == ["mistral-ocr", "native", "pdf-text"]
+    assert result["vendor_name"] == "Engine Recovered Shop"
+    assert result["total"] == 7.0
+
+
+def test_parse_invoice_does_not_engine_fallback_for_non_pdf_inputs(
+    monkeypatch: Any,
+) -> None:
+    """Image inputs hit a single chat-completion call (no engine fallback)."""
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"png-bytes")}
+
+    call_log: list[dict[str, Any]] = []
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        call_log.append(kwargs)
+        return {"status": 200, "body": _empty_response_completion_body()}
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(parser._EmptyResponseError):
+        parser.parse_invoice_from_assets(
+            [
+                {
+                    "id": "asset-img",
+                    "s3_key": "k",
+                    "file_name": "invoice.png",
+                    "content_type": "image/png",
+                }
+            ]
+        )
+
+    assert len(call_log) == 1, "image inputs must not trigger engine fallback"
+
+
+def test_parse_invoice_raises_summary_when_all_pdf_engines_return_empty(
+    monkeypatch: Any,
+) -> None:
+    """When every PDF engine returns empty, the final error names all of them."""
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    engines_seen: list[str] = []
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        sent = json.loads(kwargs["body"])
+        engines_seen.append(sent["plugins"][0]["pdf"]["engine"])
+        return {"status": 200, "body": _empty_response_completion_body()}
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        parser.parse_invoice_from_assets(
+            [
+                {
+                    "id": "asset-allempty",
+                    "s3_key": "k",
+                    "file_name": "bulk.pdf",
+                    "content_type": "application/pdf",
+                }
+            ]
+        )
+
+    assert engines_seen == ["mistral-ocr", "native", "pdf-text"]
+    msg = str(exc_info.value)
+    assert "All PDF engines returned empty responses" in msg
+    for engine in ("mistral-ocr", "native", "pdf-text"):
+        assert engine in msg
+
+
+def test_parse_invoice_does_not_engine_fallback_on_non_empty_runtime_error(
+    monkeypatch: Any,
+) -> None:
+    """A 4xx (non-empty) error stops the engine chain immediately."""
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    call_log: list[dict[str, Any]] = []
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        call_log.append(kwargs)
+        return {
+            "status": 400,
+            "body": '{"error":{"message":"Bad request","code":400}}',
+        }
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        parser.parse_invoice_from_assets(
+            [
+                {
+                    "id": "asset-bad",
+                    "s3_key": "k",
+                    "file_name": "bulk.pdf",
+                    "content_type": "application/pdf",
+                }
+            ]
+        )
+
+    assert len(call_log) == 1, (
+        "a non-empty error must not trigger engine fallback (and is also not "
+        "retried because 400 is not in _RETRYABLE_HTTP_STATUSES)"
+    )
+    assert "status 400" in str(exc_info.value)
+
+
+def test_bulk_single_fallback_recovers_via_pdf_engine_chain(
+    monkeypatch: Any,
+) -> None:
+    """The user-reported scenario: bulk gets 429, single fallback engine chain wins.
+
+    Reproduction:
+
+    - Bulk calls (3 attempts, ``_MAX_RETRY_ATTEMPTS``): all 429.
+    - Single fallback first PDF engine (``mistral-ocr``): empty response.
+    - Single fallback second PDF engine (``native``): success.
+
+    Total 3 + 3 + 1 = 7 ``http_invoke`` calls, and the bulk parser returns
+    a one-row list built from the recovered single-invoice result. This is
+    the exact failure mode the user reported with the old code:
+    'OpenRouter request failed with status 429 ... Model returned an empty
+    response (completion_tokens=0)'.
+    """
+    _set_common_env(monkeypatch)
+    _mock_secrets(monkeypatch)
+    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
+
+    class _FakeS3Client:
+        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+            return {"Body": _FakeBody(b"%PDF-1.4")}
+
+    call_log: list[tuple[str, str | None]] = []
+
+    success_body = _success_completion_body(
+        {
+            "vendor_name": "Recovered After 429",
+            "invoice_number": "REC429",
+            "invoice_date": "2026-05-15",
+            "due_date": None,
+            "currency": "USD",
+            "subtotal": 12,
+            "tax": 0,
+            "total": 12,
+            "line_items": [],
+            "confidence": 0.6,
+        }
+    )
+
+    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        sent = json.loads(kwargs["body"])
+        prompt_text = sent["messages"][1]["content"][0]["text"]
+        engine = (
+            sent["plugins"][0]["pdf"]["engine"] if "plugins" in sent else None
+        )
+        is_bulk_prompt = "Extract every invoice" in prompt_text
+        call_log.append(("bulk" if is_bulk_prompt else "single", engine))
+
+        if is_bulk_prompt:
+            return {
+                "status": 429,
+                "body": '{"error":{"message":"Provider returned error","code":429}}',
+            }
+        if engine == "mistral-ocr":
+            return {"status": 200, "body": _empty_response_completion_body()}
+        return {"status": 200, "body": success_body}
+
+    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
+    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
+
+    rows = parser.parse_bulk_expense_invoices_from_assets(
+        [
+            {
+                "id": "asset-recover",
+                "s3_key": "k",
+                "file_name": "bulk.pdf",
+                "content_type": "application/pdf",
+            }
+        ],
+        timeout=25,
+    )
+
+    bulk_calls = [c for c in call_log if c[0] == "bulk"]
+    single_calls = [c for c in call_log if c[0] == "single"]
+    assert len(bulk_calls) == parser._MAX_RETRY_ATTEMPTS == 3
+    assert [c[1] for c in single_calls] == ["mistral-ocr", "native"]
+    assert len(rows) == 1
+    assert rows[0]["vendor_name"] == "Recovered After 429"
+    assert rows[0]["total"] == 12.0
+
+
+def test_empty_response_error_is_runtime_error_subclass() -> None:
+    err = parser._EmptyResponseError("boom")
+    assert isinstance(err, RuntimeError)
+    assert isinstance(err, parser._EmptyResponseError)
+    assert str(err) == "boom"
+
+
+def test_extract_message_text_raises_empty_response_error_subclass() -> None:
+    """``_EmptyResponseError`` is the concrete type raised on empty content."""
+    body = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {"content": ""},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"completion_tokens": 0},
+        }
+    )
+    with pytest.raises(parser._EmptyResponseError) as exc_info:
+        parser._extract_message_text(body)
+    assert "empty response" in str(exc_info.value)

--- a/tests/test_openrouter_expense_parser.py
+++ b/tests/test_openrouter_expense_parser.py
@@ -103,7 +103,10 @@ def test_parse_invoice_sends_images_as_image_url(monkeypatch: Any) -> None:
     assert image_input["type"] == "image_url"
     assert image_input["image_url"]["url"].startswith("data:image/png;base64,")
     assert "plugins" not in payload
-    assert payload["response_format"] == {"type": "json_object"}
+    assert "response_format" not in payload, (
+        "JSON mode is intentionally NOT set; see _openrouter_chat_completion "
+        "docstring for the rationale tied to commits 3874b3b6 and b6f8990b."
+    )
 
 
 def test_parse_invoice_sends_pdfs_as_file_with_explicit_plugin(
@@ -552,9 +555,19 @@ def _bulk_chat_completion_body(content_text: str) -> str:
     )
 
 
-def test_parse_bulk_expense_invoices_sets_json_response_format(
+def test_parse_bulk_expense_invoices_does_not_set_json_response_format(
     monkeypatch: Any,
 ) -> None:
+    """Bulk parse must NOT force JSON mode.
+
+    See ``_openrouter_chat_completion`` docstring: JSON mode (commit
+    3874b3b6) caused models to emit empty ``{}`` / ``completion_tokens=0``
+    responses on borderline PDFs, which is the exact cascade the user
+    flagged when migrating to async. The same ``JSONDecodeError`` it was
+    introduced to mask is now handled by the ``_loads_with_repair``
+    pathway, so the request payload reverts to the original sync-era shape
+    from commit b6f8990b.
+    """
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
 
@@ -606,7 +619,7 @@ def test_parse_bulk_expense_invoices_sets_json_response_format(
     )
 
     assert len(captured_payloads) == 1
-    assert captured_payloads[0]["response_format"] == {"type": "json_object"}
+    assert "response_format" not in captured_payloads[0]
 
 
 def test_parse_bulk_expense_invoices_repairs_invalid_json(monkeypatch: Any) -> None:
@@ -944,9 +957,8 @@ def test_parse_bulk_expense_invoices_falls_back_to_single_on_provider_error(
     attempt returns 429 issues:
 
     - 3 attempts on the bulk call (initial + 2 retries), then
-    - 3 attempts on the single-invoice fallback's first PDF engine
-      (the engine fallback only chains on ``_EmptyResponseError``, NOT on
-      a transient HTTP error that has already been retried internally).
+    - 3 attempts on the single-invoice fallback (single shape, no engine
+      chain; see commit reverting JSON mode + engine fallback for details).
 
     = 6 ``http_invoke`` calls total before surfacing a combined error that
     names both failures so neither is hidden.
@@ -1435,51 +1447,20 @@ def test_parse_bulk_expense_invoices_raises_with_snippet_when_repair_fails(
 
 
 # ---------------------------------------------------------------------------
-# PDF engine fallback (single-invoice parser)
+# Single-invoice parser shape (sync-era one-call shape — see commit b6f8990b)
 # ---------------------------------------------------------------------------
 
 
-def _empty_response_completion_body() -> str:
-    """An OpenRouter 200 body that triggers ``_EmptyResponseError``."""
-    return json.dumps(
-        {
-            "choices": [
-                {
-                    "message": {"content": ""},
-                    "finish_reason": "stop",
-                }
-            ],
-            "usage": {"completion_tokens": 0},
-        }
-    )
+def test_parse_invoice_makes_a_single_chat_completion_call(monkeypatch: Any) -> None:
+    """``parse_invoice_from_assets`` is one call, no engine chain.
 
-
-def _success_completion_body(payload: dict[str, Any]) -> str:
-    return _bulk_chat_completion_body(json.dumps(payload))
-
-
-def test_pdf_engines_to_try_starts_with_configured_engine(monkeypatch: Any) -> None:
-    monkeypatch.setenv("OPENROUTER_PDF_ENGINE", "native")
-    engines = parser._pdf_engines_to_try()
-    assert engines[0] == "native"
-    assert set(engines) == {"native", "mistral-ocr", "pdf-text"}
-    assert len(engines) == len(set(engines)), "engines must be unique"
-
-
-def test_pdf_engines_to_try_uses_default_when_unconfigured(monkeypatch: Any) -> None:
-    monkeypatch.delenv("OPENROUTER_PDF_ENGINE", raising=False)
-    engines = parser._pdf_engines_to_try()
-    assert engines[0] == "mistral-ocr"
-    assert set(engines) == {"native", "mistral-ocr", "pdf-text"}
-
-
-def test_parse_invoice_falls_back_to_next_pdf_engine_on_empty_response(
-    monkeypatch: Any,
-) -> None:
-    """``mistral-ocr`` empty -> ``native`` empty -> ``pdf-text`` succeeds.
-
-    Mirrors the user-reported single-fallback failure where the OCR engine
-    returned ``completion_tokens=0`` on a PDF the other engines can read.
+    The earlier engine fallback chain (added in PR #1681 then reverted
+    here) layered three engines on top of every single-invoice parse. That
+    multiplied the cost / rate-limit footprint of every call and was a
+    direct response to empty-response failures caused by JSON mode (see
+    ``_openrouter_chat_completion`` docstring). With JSON mode dropped the
+    chain is no longer needed; the parser is back to the original one-call
+    shape from commit b6f8990b that the user has consistently said worked.
     """
     _set_common_env(monkeypatch)
     _mock_secrets(monkeypatch)
@@ -1489,29 +1470,27 @@ def test_parse_invoice_falls_back_to_next_pdf_engine_on_empty_response(
         def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
             return {"Body": _FakeBody(b"%PDF-1.4")}
 
-    engines_seen: list[str] = []
+    call_log: list[dict[str, Any]] = []
 
     def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
-        sent = json.loads(kwargs["body"])
-        engine = sent["plugins"][0]["pdf"]["engine"]
-        engines_seen.append(engine)
-        if engine in ("mistral-ocr", "native"):
-            return {"status": 200, "body": _empty_response_completion_body()}
+        call_log.append(kwargs)
         return {
             "status": 200,
-            "body": _success_completion_body(
-                {
-                    "vendor_name": "Engine Recovered Shop",
-                    "invoice_number": "ENG1",
-                    "invoice_date": "2026-05-15",
-                    "due_date": None,
-                    "currency": "USD",
-                    "subtotal": 7,
-                    "tax": 0,
-                    "total": 7,
-                    "line_items": [],
-                    "confidence": 0.7,
-                }
+            "body": _bulk_chat_completion_body(
+                json.dumps(
+                    {
+                        "vendor_name": "Single Shop",
+                        "invoice_number": "S1",
+                        "invoice_date": "2026-05-15",
+                        "due_date": None,
+                        "currency": "USD",
+                        "subtotal": 4,
+                        "tax": 0,
+                        "total": 4,
+                        "line_items": [],
+                        "confidence": 0.9,
+                    }
+                )
             ),
         }
 
@@ -1521,7 +1500,7 @@ def test_parse_invoice_falls_back_to_next_pdf_engine_on_empty_response(
     result = parser.parse_invoice_from_assets(
         [
             {
-                "id": "asset-engfb",
+                "id": "asset-single",
                 "s3_key": "k",
                 "file_name": "bulk.pdf",
                 "content_type": "application/pdf",
@@ -1529,235 +1508,10 @@ def test_parse_invoice_falls_back_to_next_pdf_engine_on_empty_response(
         ]
     )
 
-    assert engines_seen == ["mistral-ocr", "native", "pdf-text"]
-    assert result["vendor_name"] == "Engine Recovered Shop"
-    assert result["total"] == 7.0
+    assert len(call_log) == 1, "single-invoice parser must make exactly one call"
+    sent_payload = json.loads(call_log[0]["body"])
+    assert "response_format" not in sent_payload, "JSON mode is intentionally off"
+    assert sent_payload["plugins"][0]["pdf"]["engine"] == "mistral-ocr"
+    assert result["vendor_name"] == "Single Shop"
 
 
-def test_parse_invoice_does_not_engine_fallback_for_non_pdf_inputs(
-    monkeypatch: Any,
-) -> None:
-    """Image inputs hit a single chat-completion call (no engine fallback)."""
-    _set_common_env(monkeypatch)
-    _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
-
-    class _FakeS3Client:
-        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
-            return {"Body": _FakeBody(b"png-bytes")}
-
-    call_log: list[dict[str, Any]] = []
-
-    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
-        call_log.append(kwargs)
-        return {"status": 200, "body": _empty_response_completion_body()}
-
-    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
-    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
-
-    with pytest.raises(parser._EmptyResponseError):
-        parser.parse_invoice_from_assets(
-            [
-                {
-                    "id": "asset-img",
-                    "s3_key": "k",
-                    "file_name": "invoice.png",
-                    "content_type": "image/png",
-                }
-            ]
-        )
-
-    assert len(call_log) == 1, "image inputs must not trigger engine fallback"
-
-
-def test_parse_invoice_raises_summary_when_all_pdf_engines_return_empty(
-    monkeypatch: Any,
-) -> None:
-    """When every PDF engine returns empty, the final error names all of them."""
-    _set_common_env(monkeypatch)
-    _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
-
-    class _FakeS3Client:
-        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
-            return {"Body": _FakeBody(b"%PDF-1.4")}
-
-    engines_seen: list[str] = []
-
-    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
-        sent = json.loads(kwargs["body"])
-        engines_seen.append(sent["plugins"][0]["pdf"]["engine"])
-        return {"status": 200, "body": _empty_response_completion_body()}
-
-    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
-    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
-
-    with pytest.raises(RuntimeError) as exc_info:
-        parser.parse_invoice_from_assets(
-            [
-                {
-                    "id": "asset-allempty",
-                    "s3_key": "k",
-                    "file_name": "bulk.pdf",
-                    "content_type": "application/pdf",
-                }
-            ]
-        )
-
-    assert engines_seen == ["mistral-ocr", "native", "pdf-text"]
-    msg = str(exc_info.value)
-    assert "All PDF engines returned empty responses" in msg
-    for engine in ("mistral-ocr", "native", "pdf-text"):
-        assert engine in msg
-
-
-def test_parse_invoice_does_not_engine_fallback_on_non_empty_runtime_error(
-    monkeypatch: Any,
-) -> None:
-    """A 4xx (non-empty) error stops the engine chain immediately."""
-    _set_common_env(monkeypatch)
-    _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
-
-    class _FakeS3Client:
-        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
-            return {"Body": _FakeBody(b"%PDF-1.4")}
-
-    call_log: list[dict[str, Any]] = []
-
-    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
-        call_log.append(kwargs)
-        return {
-            "status": 400,
-            "body": '{"error":{"message":"Bad request","code":400}}',
-        }
-
-    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
-    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
-
-    with pytest.raises(RuntimeError) as exc_info:
-        parser.parse_invoice_from_assets(
-            [
-                {
-                    "id": "asset-bad",
-                    "s3_key": "k",
-                    "file_name": "bulk.pdf",
-                    "content_type": "application/pdf",
-                }
-            ]
-        )
-
-    assert len(call_log) == 1, (
-        "a non-empty error must not trigger engine fallback (and is also not "
-        "retried because 400 is not in _RETRYABLE_HTTP_STATUSES)"
-    )
-    assert "status 400" in str(exc_info.value)
-
-
-def test_bulk_single_fallback_recovers_via_pdf_engine_chain(
-    monkeypatch: Any,
-) -> None:
-    """The user-reported scenario: bulk gets 429, single fallback engine chain wins.
-
-    Reproduction:
-
-    - Bulk calls (3 attempts, ``_MAX_RETRY_ATTEMPTS``): all 429.
-    - Single fallback first PDF engine (``mistral-ocr``): empty response.
-    - Single fallback second PDF engine (``native``): success.
-
-    Total 3 + 3 + 1 = 7 ``http_invoke`` calls, and the bulk parser returns
-    a one-row list built from the recovered single-invoice result. This is
-    the exact failure mode the user reported with the old code:
-    'OpenRouter request failed with status 429 ... Model returned an empty
-    response (completion_tokens=0)'.
-    """
-    _set_common_env(monkeypatch)
-    _mock_secrets(monkeypatch)
-    monkeypatch.setattr(parser, "_RETRY_BACKOFF_SCHEDULE_SECONDS", ())
-
-    class _FakeS3Client:
-        def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
-            return {"Body": _FakeBody(b"%PDF-1.4")}
-
-    call_log: list[tuple[str, str | None]] = []
-
-    success_body = _success_completion_body(
-        {
-            "vendor_name": "Recovered After 429",
-            "invoice_number": "REC429",
-            "invoice_date": "2026-05-15",
-            "due_date": None,
-            "currency": "USD",
-            "subtotal": 12,
-            "tax": 0,
-            "total": 12,
-            "line_items": [],
-            "confidence": 0.6,
-        }
-    )
-
-    def _fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
-        sent = json.loads(kwargs["body"])
-        prompt_text = sent["messages"][1]["content"][0]["text"]
-        engine = (
-            sent["plugins"][0]["pdf"]["engine"] if "plugins" in sent else None
-        )
-        is_bulk_prompt = "Extract every invoice" in prompt_text
-        call_log.append(("bulk" if is_bulk_prompt else "single", engine))
-
-        if is_bulk_prompt:
-            return {
-                "status": 429,
-                "body": '{"error":{"message":"Provider returned error","code":429}}',
-            }
-        if engine == "mistral-ocr":
-            return {"status": 200, "body": _empty_response_completion_body()}
-        return {"status": 200, "body": success_body}
-
-    monkeypatch.setattr(parser, "get_s3_client", lambda: _FakeS3Client())
-    monkeypatch.setattr(parser, "http_invoke", _fake_http_invoke)
-
-    rows = parser.parse_bulk_expense_invoices_from_assets(
-        [
-            {
-                "id": "asset-recover",
-                "s3_key": "k",
-                "file_name": "bulk.pdf",
-                "content_type": "application/pdf",
-            }
-        ],
-        timeout=25,
-    )
-
-    bulk_calls = [c for c in call_log if c[0] == "bulk"]
-    single_calls = [c for c in call_log if c[0] == "single"]
-    assert len(bulk_calls) == parser._MAX_RETRY_ATTEMPTS == 3
-    assert [c[1] for c in single_calls] == ["mistral-ocr", "native"]
-    assert len(rows) == 1
-    assert rows[0]["vendor_name"] == "Recovered After 429"
-    assert rows[0]["total"] == 12.0
-
-
-def test_empty_response_error_is_runtime_error_subclass() -> None:
-    err = parser._EmptyResponseError("boom")
-    assert isinstance(err, RuntimeError)
-    assert isinstance(err, parser._EmptyResponseError)
-    assert str(err) == "boom"
-
-
-def test_extract_message_text_raises_empty_response_error_subclass() -> None:
-    """``_EmptyResponseError`` is the concrete type raised on empty content."""
-    body = json.dumps(
-        {
-            "choices": [
-                {
-                    "message": {"content": ""},
-                    "finish_reason": "stop",
-                }
-            ],
-            "usage": {"completion_tokens": 0},
-        }
-    )
-    with pytest.raises(parser._EmptyResponseError) as exc_info:
-        parser._extract_message_text(body)
-    assert "empty response" in str(exc_info.value)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User feedback

> "before i moved to async, this parser used to work fine. its just when i moved to be async that it start being broken, so check the history"

I traced the parser file history end-to-end. The user's diagnosis is correct.

## What the history shows

| Commit | When | Parser change | Why it was added |
|---|---|---|---|
| `b6f8990b` | sync bulk import | one OpenRouter call, no JSON mode, no retries, no fallbacks | working baseline |
| `f8fdb08d` | async migration | **none** &mdash; parser file was untouched | only added SQS plumbing |
| `3874b3b6` | ~14h after async | **added `response_format: {"type": "json_object"}`** + JSON-repair pathway | mask a real `JSONDecodeError` from unescaped quotes in line-item descriptions |
| `fac4bae9` | next | tolerate alias wrapper keys (`data` / `results`) | model returned wrapper key the prompt didn't ask for |
| `13db0b44` | next | treat `{}` as zero rows | model emits `{}` under JSON mode when it can't comply |
| `eba5024b` | next | engine fallback (added) | empty / refused responses |
| `19857931` | next | native engine fallback + error formatting | same |
| `47654d0e` | next | mirror single, drop engine fallback | the previous fix amplified rate limits |
| `9a8b3a51` | next | simpler bulk prompt + single fallback | empty responses on prompt nuance |
| `85d195fc` (mine, merged in #1680) | next | retry on transient HTTP / envelope errors | **legitimate, orthogonal &mdash; real provider 429 / 504 issue** |
| `1478d0ab` (mine, this PR's old head) | next | exponential backoff + engine chain | recurrence of empty content |

**The key finding**: every parser change after the async migration was either (a) the addition of JSON mode in `3874b3b6`, or (b) symptomatic treatment of new failure modes that JSON mode introduced. The original `JSONDecodeError` symptom that prompted JSON mode is **already** handled by the `_loads_with_repair` pathway shipped in that same commit.

## Fix

This PR now reverts the root cause and the cascade that built on top of it, while keeping the legitimate orthogonal improvements.

### Reverted

- `response_format: {"type": "json_object"}` removed from `_openrouter_chat_completion`'s payload.
- `_EmptyResponseError` subclass removed; `_empty_response_error()` returns plain `RuntimeError` again.
- `parse_invoice_from_assets` restored to a single chat-completion call. Engine-iteration loop deleted.
- `_SUPPORTED_PDF_ENGINES`, `_pdf_engines_to_try()` deleted.
- `pdf_engine=` kwarg on `_openrouter_chat_completion` deleted.

### Kept

- Transient retry on `{408, 425, 429, 500, 502, 503, 504}` and matching envelope codes inside 200 responses, with exponential backoff `(2s, 4s)`, `Retry-After` honored. This is what fixes the original `429` / envelope `504` failure mode and is unrelated to JSON mode.
- `_loads_with_repair` &mdash; the proper handling for the unescaped-quote `JSONDecodeError` JSON mode was originally introduced to mask.
- Single-invoice fallback in `parse_bulk_expense_invoices_from_assets`.

### Net diff vs `origin/main`

`+92 / -427` lines. The parser is now within ~30 lines of the original sync `b6f8990b` shape, plus the clearly orthogonal transient-retry block.

## Files changed

- `backend/src/app/services/openrouter_expense_parser.py` &mdash; remove JSON mode, engine subclass, engine helpers, engine kwarg, engine loop. The `_openrouter_chat_completion` docstring now cites commit hashes for the rationale.
- `tests/test_openrouter_expense_parser.py`
  - `test_parse_invoice_sends_images_as_image_url` &mdash; asserts `response_format` is NOT in the payload, with rationale comment.
  - Renamed `sets_json_response_format` &rarr; `does_not_set_json_response_format` for the bulk path with inverted assertion + design-intent docstring.
  - New `test_parse_invoice_makes_a_single_chat_completion_call` locks in the one-call shape.
  - Removed engine-fallback tests from PR #1681.
  - Updated `falls_back_to_single_on_provider_error` docstring (call count of 6 unchanged: the deleted engine chain was already a no-op on persistent 429).
- `docs/architecture/lambdas.md` &mdash; bulk-import section now states explicitly *"No JSON mode; no engine fallback chain"*, cites the working sync commit hash, and explains why JSON mode was tried and rolled back.

## Out of scope

- No DB schema / OpenAPI / CDK route / admin-web typing change.
- The `JSONDecodeError`-on-unescaped-quotes case from commit `3874b3b6` continues to be handled by `_loads_with_repair` exactly as it was; this PR does not touch that code.

## Testing

- `pytest tests/test_openrouter_expense_parser.py` &rarr; 46 passed.
- `pytest tests/` &rarr; 1138 passed, 17 skipped.
- `ruff check backend/ tests/ --config=backend/pyproject.toml` &rarr; All checks passed.
- `pre-commit run ruff-format --files <changed>` &rarr; Passed.
- `bash scripts/validate-cursorrules.sh` &rarr; `.cursorrules` compliance checks passed.

Backend-only Python change &mdash; no UI surface, so no walkthrough video applies.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b06e34f-84d0-4e37-825b-6028df9ee1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b06e34f-84d0-4e37-825b-6028df9ee1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

