### PR TITLE
fix(api): make manual inbound enrollmentId optional in admin OpenAPI

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -3974,7 +3974,7 @@ export interface paths {
                 };
                 400: components["responses"]["BadRequest"];
                 403: components["responses"]["Forbidden"];
-                /** @description Duplicate manual inbound payment for the same enrollment and external reference (partial unique index on non-null `external_reference`; only applies when `enrollmentId` is set — no-enrollment payments are not deduplicated by external reference). */
+                /** @description Duplicate manual inbound payment for the same enrollment and external reference (partial unique index on non-null `external_reference`). */
                 409: {
                     headers: {
                         [name: string]: unknown;
@@ -6496,8 +6496,16 @@ export interface components {
              * @enum {string}
              */
             direction: "inbound";
-            /** Format: uuid */
-            enrollmentId: string;
+            /**
+             * Format: uuid
+             * @description Optional. Omit (or send `null`) to record a payment with no enrollment link (for example to settle a customized invoice that is not linked to any enrollment). When provided, currency must match the enrollment billing currency.
+             */
+            enrollmentId?: string | null;
+            /**
+             * Format: uuid
+             * @description Optional CRM contact for attribution. When `enrollmentId` is provided, `contactId` is derived from the enrollment unless explicitly overridden here.
+             */
+            contactId?: string | null;
             /** @description Decimal amount as string; must be non-negative. */
             amount: string;
             currency: string;

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -2892,8 +2892,7 @@ paths:
         "409":
           description: >
             Duplicate manual inbound payment for the same enrollment and external reference
-            (partial unique index on non-null `external_reference`; only applies when `enrollmentId`
-            is set — no-enrollment payments are not deduplicated by external reference).
+            (partial unique index on non-null `external_reference`).
           content:
             application/json:
               schema:
@@ -6696,7 +6695,6 @@ components:
       type: object
       required:
         - direction
-        - enrollmentId
         - amount
         - currency
         - method
@@ -6707,6 +6705,18 @@ components:
         enrollmentId:
           type: string
           format: uuid
+          nullable: true
+          description: >
+            Optional. Omit (or send `null`) to record a payment with no enrollment link
+            (for example to settle a customized invoice that is not linked to any
+            enrollment). When provided, currency must match the enrollment billing currency.
+        contactId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >
+            Optional CRM contact for attribution. When `enrollmentId` is provided,
+            `contactId` is derived from the enrollment unless explicitly overridden here.
         amount:
           type: string
           description: Decimal amount as string; must be non-negative.


### PR DESCRIPTION
Restores nullable optional enrollmentId (and contactId) on CreateManualInboundCustomerPaymentRequest so generated admin types match the Lambda contract and admin-web build passes with enrollmentId: null.