### PR TITLE
Admin contacts: client relationship emoji in name column

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -57,6 +57,8 @@ import type { components } from '@/types/generated/admin-api.generated';
 const CONTACT_NAME_FAMILY_EMOJI = '👨‍👩‍👧';
 /** Shown after the contact name in the list when `organization_ids` is non-empty. */
 const CONTACT_NAME_ORG_EMOJI = '🏢';
+/** Shown after the contact name when `relationship_type` is `client`. */
+const CONTACT_NAME_CLIENT_EMOJI = '🤝';
 
 type ApiSchemas = components['schemas'];
 
@@ -83,13 +85,16 @@ const SOURCES: ApiSchemas['EntityContactSource'][] = [
   'manual',
 ];
 
-function contactNameMembershipSuffix(row: ApiSchemas['AdminContact']): string {
+function contactNameListSuffix(row: ApiSchemas['AdminContact']): string {
   const parts: string[] = [];
   if (row.family_ids.length > 0) {
     parts.push(CONTACT_NAME_FAMILY_EMOJI);
   }
   if (row.organization_ids.length > 0) {
     parts.push(CONTACT_NAME_ORG_EMOJI);
+  }
+  if (row.relationship_type === 'client') {
+    parts.push(CONTACT_NAME_CLIENT_EMOJI);
   }
   return parts.length > 0 ? ` ${parts.join(' ')}` : '';
 }
@@ -955,7 +960,7 @@ export function ContactsPanel({
           <AdminDataTableBody>
             {rows.map((row) => {
               const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
-              const membershipSuffix = contactNameMembershipSuffix(row);
+              const nameListSuffix = contactNameListSuffix(row);
               return (
                 <tr
                   key={row.id}
@@ -966,14 +971,17 @@ export function ContactsPanel({
                 >
                   <AdminDataTableCell>
                     {name}
-                    {membershipSuffix ? (
+                    {nameListSuffix ? (
                       <>
-                        <span aria-hidden>{membershipSuffix}</span>
+                        <span aria-hidden>{nameListSuffix}</span>
                         {row.family_ids.length > 0 ? (
                           <span className='sr-only'>, linked to a family</span>
                         ) : null}
                         {row.organization_ids.length > 0 ? (
                           <span className='sr-only'>, linked to an organisation</span>
+                        ) : null}
+                        {row.relationship_type === 'client' ? (
+                          <span className='sr-only'>, client relationship</span>
                         ) : null}
                       </>
                     ) : null}

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -209,6 +209,68 @@ describe('ContactsPanel', () => {
     expect(screen.getByText(/Pat Both/)).toHaveTextContent('Pat Both 👨‍👩‍👧 🏢');
   });
 
+  it('shows client emoji after the name when relationship_type is client', () => {
+    const baseRow = {
+      id: '11111111-1111-1111-1111-111111111111',
+      email: null,
+      instagram_handle: null,
+      phone_region: null,
+      phone_national_number: null,
+      phone_e164: null,
+      contact_type: 'parent' as const,
+      relationship_type: 'prospect' as const,
+      source: 'manual' as const,
+      mailchimp_status: 'pending' as const,
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+      tag_ids: [],
+      tags: [],
+      standalone_note_count: 0,
+    };
+    const clientOnly: components['schemas']['AdminContact'] = {
+      ...baseRow,
+      id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      first_name: 'Cara',
+      last_name: 'Client',
+      family_ids: [],
+      organization_ids: [],
+      family_location_summary: null,
+      organization_location_summary: null,
+      relationship_type: 'client',
+    };
+    const clientInFamily: components['schemas']['AdminContact'] = {
+      ...baseRow,
+      id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+      first_name: 'Finn',
+      last_name: 'FamilyClient',
+      family_ids: ['fam-1'],
+      organization_ids: [],
+      family_location_summary: null,
+      organization_location_summary: null,
+      relationship_type: 'client',
+    };
+    const contacts = buildContactsHook({ contacts: [clientOnly, clientInFamily] });
+
+    render(
+      <ContactsPanel
+        contacts={contacts}
+        adminUsers={[]}
+        onPatchStandaloneNoteCount={vi.fn()}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+      />
+    );
+
+    expect(screen.getByText(/Cara Client/)).toHaveTextContent('Cara Client 🤝');
+    expect(screen.getByText(/Finn FamilyClient/)).toHaveTextContent(
+      'Finn FamilyClient 👨‍👩‍👧 🤝'
+    );
+  });
+
   it('shows read-only family and organisation venue lines in the Location box when the row is selected', async () => {
     const user = userEvent.setup();
     const summary = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The contacts table already appends emojis when a contact is linked to a family (👨‍👩‍👧) or organisation (🏢). This change appends **🤝** when the contact’s CRM **relationship** is **client** (`relationship_type === 'client'`), in that order after family and organisation indicators.

## Tests

- Extended `contacts-panel.test.tsx` with cases for client-only and client + family rows.
- `npm run lint` and targeted `vitest run` for the contacts panel tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1130f832-1e37-48ec-8c5a-fc5a33afcc97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1130f832-1e37-48ec-8c5a-fc5a33afcc97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

