### PR TITLE
Mailchimp admin bulk sync + remediation (P0–P2)

### DIFF
--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2807,7 +2807,9 @@ export interface paths {
          *     (default ``pending`` and ``failed``). Never include ``unsubscribed`` in ``only_statuses``:
          *     that would risk re-subscribing contacts who opted out in Mailchimp. Each row calls
          *     Mailchimp PUT + tag; unsubscribed or archived contacts are skipped without calling Mailchimp.
-         *     Use ``next_cursor`` until null. ``dry_run`` counts rows without calling Mailchimp.
+         *     Use ``next_cursor`` until null. ``dry_run`` counts rows without calling Mailchimp; when
+         *     ``dry_run`` is true, ``would_process`` mirrors that count and ``processed``/``skipped``
+         *     remain populated for backward compatibility.
          */
         post: {
             parameters: {
@@ -2866,7 +2868,11 @@ export interface paths {
          *     ``mailchimp_status`` is ``unsubscribed``. Default ``dry_run`` is ``true`` because this
          *     deletes or archives Mailchimp members; set ``dry_run`` to ``false`` to execute.
          *     ``mode=archive`` soft-archives (recoverable); ``mode=permanent`` is GDPR erase and
-         *     must only be used when explicitly required.
+         *     must only be used when explicitly required. Mailchimp offset pagination is eventually
+         *     consistent (webhooks or concurrent runs may shift rows between pages); archive mode
+         *     remains idempotent on Mailchimp. With ``mode=permanent`` and ``dry_run=false``, when
+         *     members are removed the response repeats ``next_offset`` equal to ``mailchimp_offset``
+         *     until a page removes zero rows, then advances by ``scanned`` when the page is full.
          */
         post: {
             parameters: {
@@ -7184,7 +7190,7 @@ export interface components {
              * @description Defaults to `pending` and `failed`. Must not include `unsubscribed` (non-compliant
              *     re-subscribe risk).
              */
-            only_statuses?: ("pending" | "failed" | "synced")[];
+            only_statuses?: ("pending" | "failed")[];
             tag_name: string;
             /** @default false */
             dry_run: boolean;
@@ -7195,6 +7201,8 @@ export interface components {
             reason: string;
             /** @description HTTP status from Mailchimp when `reason` is `mailchimp_api_error`. */
             status?: number | null;
+            /** @description Masked email for operator triage. */
+            lead_email_masked: string;
         };
         MailchimpSyncRunResponse: {
             processed: number;
@@ -7204,6 +7212,11 @@ export interface components {
             next_cursor: string | null;
             errors_sample: components["schemas"]["MailchimpSyncRunErrorSampleItem"][];
             dry_run: boolean;
+            /**
+             * @description When `dry_run` is true, equals the number of rows that would have been sent to Mailchimp.
+             *     Zero when `dry_run` is false.
+             */
+            would_process: number;
         };
         MailchimpOrphanCleanupRequest: {
             /** @default 200 */
@@ -7224,14 +7237,38 @@ export interface components {
             /** @description Mailchimp member status when scanned. */
             status: string;
         };
+        /**
+         * @description Mailchimp offset pagination is not transactionally consistent: concurrent audience changes
+         *     (for example webhook-driven unsubscribes) can shift which members appear between batches.
+         *     Archive mode remains idempotent on Mailchimp; permanent mode keeps the same offset while
+         *     removals occur (see `next_offset`).
+         */
         MailchimpOrphanCleanupResponse: {
             scanned: number;
             kept: number;
             removed: number;
             failed: number;
+            /**
+             * @description For `mode=archive` or any `dry_run` request, the next offset is `mailchimp_offset + scanned`
+             *     when the page is full (same length as `max_members`), otherwise null.
+             *     For `mode=permanent` with `dry_run=false`, when at least one member was removed this page,
+             *     repeats `mailchimp_offset` so the caller re-reads the same offset (permanent deletes shift
+             *     indices). When zero members were removed and the page is full, advances by `scanned`;
+             *     otherwise null.
+             */
             next_offset: number | null;
             removed_sample: components["schemas"]["MailchimpOrphanRemovedSampleItem"][];
             dry_run: boolean;
+            /**
+             * @description Archive mode only: members already in Mailchimp `archived` state skipped without API calls.
+             *     Zero in permanent mode (archived members are still eligible for permanent erase).
+             */
+            already_archived: number;
+            /**
+             * @description When `dry_run` is true, counts members that would be removed or archived. Zero when
+             *     `dry_run` is false; use `removed` for executed runs.
+             */
+            would_remove: number;
         };
         MailchimpSyncStatusResponse: {
             /** @description Keys are `pending`, `synced`, `failed`, `unsubscribed`. */

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2792,6 +2792,165 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/contacts/mailchimp-sync-run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run one Mailchimp upsert batch (DB → audience)
+         * @description Production-only. Paginated upsert for CRM contacts with the given ``only_statuses``
+         *     (default ``pending`` and ``failed``). Never include ``unsubscribed`` in ``only_statuses``:
+         *     that would risk re-subscribing contacts who opted out in Mailchimp. Each row calls
+         *     Mailchimp PUT + tag; unsubscribed or archived contacts are skipped without calling Mailchimp.
+         *     Use ``next_cursor`` until null. ``dry_run`` counts rows without calling Mailchimp.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["MailchimpSyncRunRequest"];
+                };
+            };
+            responses: {
+                /** @description Batch outcome and optional next cursor. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MailchimpSyncRunResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                /** @description Not production or Mailchimp list env not configured. */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/contacts/mailchimp-sync-orphans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reconcile Mailchimp audience orphans (one page)
+         * @description Production-only. Scans one Mailchimp list page starting at ``mailchimp_offset``.
+         *     Removes members whose email has no active CRM contact, or whose CRM row is archived or
+         *     ``mailchimp_status`` is ``unsubscribed``. Default ``dry_run`` is ``true`` because this
+         *     deletes or archives Mailchimp members; set ``dry_run`` to ``false`` to execute.
+         *     ``mode=archive`` soft-archives (recoverable); ``mode=permanent`` is GDPR erase and
+         *     must only be used when explicitly required.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["MailchimpOrphanCleanupRequest"];
+                };
+            };
+            responses: {
+                /** @description Page scan outcome and optional next offset. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MailchimpOrphanCleanupResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                /** @description Not production or Mailchimp list env not configured. */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/contacts/mailchimp-sync-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Mailchimp sync counters for admin progress UI
+         * @description Returns aggregate counts by ``mailchimp_status`` plus archived contacts that still
+         *     carry a ``mailchimp_subscriber_id``. ``last_run_summary`` is reserved for a future release
+         *     and is always null in v1.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Status snapshot. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MailchimpSyncStatusResponse"];
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/contacts": {
         parameters: {
             query?: never;
@@ -7015,6 +7174,73 @@ export interface components {
              *     (omit or null to clear only when source is not referral).
              */
             referral_contact_id?: string | null;
+        };
+        MailchimpSyncRunRequest: {
+            /** @default 50 */
+            max_contacts: number;
+            /** @description Opaque cursor from the prior response's `next_cursor`. */
+            cursor?: string | null;
+            /**
+             * @description Defaults to `pending` and `failed`. Must not include `unsubscribed` (non-compliant
+             *     re-subscribe risk).
+             */
+            only_statuses?: ("pending" | "failed" | "synced")[];
+            tag_name: string;
+            /** @default false */
+            dry_run: boolean;
+        };
+        MailchimpSyncRunErrorSampleItem: {
+            /** Format: uuid */
+            contact_id: string;
+            reason: string;
+            /** @description HTTP status from Mailchimp when `reason` is `mailchimp_api_error`. */
+            status?: number | null;
+        };
+        MailchimpSyncRunResponse: {
+            processed: number;
+            succeeded: number;
+            failed: number;
+            skipped: number;
+            next_cursor: string | null;
+            errors_sample: components["schemas"]["MailchimpSyncRunErrorSampleItem"][];
+            dry_run: boolean;
+        };
+        MailchimpOrphanCleanupRequest: {
+            /** @default 200 */
+            max_members: number;
+            /** @default 0 */
+            mailchimp_offset: number;
+            /**
+             * @default archive
+             * @enum {string}
+             */
+            mode: "archive" | "permanent";
+            /** @default true */
+            dry_run: boolean;
+        };
+        MailchimpOrphanRemovedSampleItem: {
+            /** @description Masked email for logs/UI samples. */
+            email: string;
+            /** @description Mailchimp member status when scanned. */
+            status: string;
+        };
+        MailchimpOrphanCleanupResponse: {
+            scanned: number;
+            kept: number;
+            removed: number;
+            failed: number;
+            next_offset: number | null;
+            removed_sample: components["schemas"]["MailchimpOrphanRemovedSampleItem"][];
+            dry_run: boolean;
+        };
+        MailchimpSyncStatusResponse: {
+            /** @description Keys are `pending`, `synced`, `failed`, `unsubscribed`. */
+            counts_by_status: {
+                [key: string]: number;
+            };
+            archived_with_mailchimp_record: number;
+            /** @description Reserved; always null in v1. */
+            last_run_summary: unknown;
         };
         /**
          * @description Persisted membership fields. `role` matches the contact's `contact_type` when the

--- a/backend/lambda/media_processor/handler.py
+++ b/backend/lambda/media_processor/handler.py
@@ -12,14 +12,12 @@ from sqlalchemy.orm import Session
 
 from app.db.engine import get_engine
 from app.db.models import (
-    Contact,
     ContactSource,
     ContactTag,
     ContactType,
     FunnelStage,
     LeadEventType,
     LeadType,
-    MailchimpSyncStatus,
     SalesLead,
     SalesLeadEvent,
     Tag,
@@ -38,8 +36,11 @@ from app.templates.transactional_shell_data import (
 )
 from app.services.mailchimp import (
     MailchimpApiError,
-    add_subscriber_with_tag,
     trigger_customer_journey,
+)
+from app.services.mailchimp_sync import (
+    is_retryable_mailchimp_exception,
+    upsert_contact_to_mailchimp,
 )
 from app.services.marketing_subscribe import subscribe_to_marketing
 from app.services.public_form_internal_notifications import (
@@ -141,13 +142,16 @@ def _process_message(message: dict[str, Any]) -> bool:
             was_mailchimp_synced = False
             journey_triggered = False
             if _should_sync_mailchimp_for_media(marketing_opt_in=marketing_opt_in):
-                was_mailchimp_synced = _sync_contact_to_mailchimp(
-                    contact=contact,
-                    first_name=first_name,
-                    tag_name=tag_name,
-                    merge_fields=_mailchimp_merge_fields_with_download_url(
-                        download_url
-                    ),
+                was_mailchimp_synced = (
+                    upsert_contact_to_mailchimp(
+                        contact=contact,
+                        tag_name=tag_name,
+                        merge_fields=_mailchimp_merge_fields_with_download_url(
+                            download_url
+                        ),
+                        logger=logger,
+                    )[0]
+                    == "synced"
                 )
                 journey_triggered = (
                     _trigger_mailchimp_journey(email=email)
@@ -216,11 +220,16 @@ def _process_message(message: dict[str, Any]) -> bool:
         was_mailchimp_synced = False
         journey_triggered = False
         if _should_sync_mailchimp_for_media(marketing_opt_in=marketing_opt_in):
-            was_mailchimp_synced = _sync_contact_to_mailchimp(
-                contact=contact,
-                first_name=first_name,
-                tag_name=tag_name,
-                merge_fields=_mailchimp_merge_fields_with_download_url(download_url),
+            was_mailchimp_synced = (
+                upsert_contact_to_mailchimp(
+                    contact=contact,
+                    tag_name=tag_name,
+                    merge_fields=_mailchimp_merge_fields_with_download_url(
+                        download_url
+                    ),
+                    logger=logger,
+                )[0]
+                == "synced"
             )
             if was_mailchimp_synced:
                 journey_triggered = _trigger_mailchimp_journey(email=email)
@@ -403,7 +412,7 @@ def _trigger_mailchimp_journey(*, email: str) -> bool:
             step_id=step_id,
             max_attempts=3,
             base_delay_seconds=1.0,
-            should_retry=_is_retryable_mailchimp_exception,
+            should_retry=is_retryable_mailchimp_exception,
             logger=logger,
             operation_name="mailchimp.trigger_customer_journey",
         )
@@ -422,60 +431,6 @@ def _trigger_mailchimp_journey(*, email: str) -> bool:
             extra={"lead_email": mask_email(email)},
         )
     return False
-
-
-def _sync_contact_to_mailchimp(
-    *,
-    contact: Contact,
-    first_name: str,
-    tag_name: str,
-    merge_fields: dict[str, str] | None = None,
-) -> bool:
-    if not contact.email:
-        contact.mailchimp_status = MailchimpSyncStatus.FAILED
-        logger.warning("Contact email is missing, skipping Mailchimp sync")
-        return False
-
-    try:
-        mailchimp_response = run_with_retry(
-            add_subscriber_with_tag,
-            email=contact.email,
-            first_name=first_name,
-            tag_name=tag_name,
-            merge_fields=merge_fields,
-            max_attempts=3,
-            base_delay_seconds=1.0,
-            should_retry=_is_retryable_mailchimp_exception,
-            logger=logger,
-            operation_name="mailchimp.add_subscriber_with_tag",
-        )
-        contact.mailchimp_status = MailchimpSyncStatus.SYNCED
-        subscriber_id = _optional_text(mailchimp_response.get("id"))
-        if subscriber_id:
-            contact.mailchimp_subscriber_id = subscriber_id
-        return True
-    except MailchimpApiError as exc:
-        contact.mailchimp_status = MailchimpSyncStatus.FAILED
-        logger.warning(
-            "Mailchimp API request failed",
-            extra={
-                "status": exc.status,
-                "lead_email": mask_email(contact.email),
-            },
-        )
-    except Exception:
-        contact.mailchimp_status = MailchimpSyncStatus.FAILED
-        logger.exception(
-            "Mailchimp sync failed unexpectedly",
-            extra={"lead_email": mask_email(contact.email)},
-        )
-    return False
-
-
-def _is_retryable_mailchimp_exception(exc: Exception) -> bool:
-    if isinstance(exc, MailchimpApiError):
-        return exc.status == 429 or exc.status >= 500
-    return isinstance(exc, (ConnectionError, TimeoutError))
 
 
 def _create_sales_lead_event(

--- a/backend/src/app/api/admin_contacts.py
+++ b/backend/src/app/api/admin_contacts.py
@@ -14,6 +14,11 @@ from app.api.admin_contact_notes import (
     list_contact_notes,
     update_contact_note,
 )
+from app.api.admin_contacts_mailchimp_sync import (
+    get_mailchimp_sync_summary,
+    run_mailchimp_orphan_cleanup,
+    run_mailchimp_sync_batch,
+)
 from app.api.admin_contacts_mutations import (
     create_contact,
     delete_contact,
@@ -83,6 +88,21 @@ def handle_admin_contacts_request(
             return _list_contacts(event)
         if method == "POST":
             return _create_contact(event, actor_sub=identity.user_sub)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 3 and parts[2] == "mailchimp-sync-run":
+        if method == "POST":
+            return run_mailchimp_sync_batch(event, actor_sub=identity.user_sub)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 3 and parts[2] == "mailchimp-sync-orphans":
+        if method == "POST":
+            return run_mailchimp_orphan_cleanup(event, actor_sub=identity.user_sub)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 3 and parts[2] == "mailchimp-sync-status":
+        if method == "GET":
+            return get_mailchimp_sync_summary(event)
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     contact_id = parse_uuid(parts[2])

--- a/backend/src/app/api/admin_contacts_mailchimp_sync.py
+++ b/backend/src/app/api/admin_contacts_mailchimp_sync.py
@@ -1,0 +1,392 @@
+"""Admin Mailchimp bulk sync and orphan cleanup endpoints."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.api.admin_entities_helpers import request_id
+from app.api.admin_request import encode_cursor, parse_body, parse_cursor
+from app.db.audit import set_audit_context
+from app.db.engine import get_engine
+from app.db.models.enums import MailchimpSyncStatus
+from app.db.repositories import ContactRepository
+from app.exceptions import ValidationError
+from app.api.admin_validators import validate_string_length
+from app.services.mailchimp import iter_audience_members
+from app.services.mailchimp_sync import remove_contact_from_mailchimp, upsert_contact_to_mailchimp
+from app.utils import json_response
+from app.utils.deployment import is_production
+from app.utils.logging import get_logger, mask_email
+
+logger = get_logger(__name__)
+
+_TAG_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9 \-]{1,100}$")
+_ALLOWED_SYNC_STATUSES = frozenset(
+    {
+        MailchimpSyncStatus.PENDING,
+        MailchimpSyncStatus.FAILED,
+        MailchimpSyncStatus.SYNCED,
+    }
+)
+
+
+def _mailchimp_env_ready() -> bool:
+    return bool(
+        os.getenv("MAILCHIMP_LIST_ID", "").strip()
+        and os.getenv("MAILCHIMP_SERVER_PREFIX", "").strip()
+    )
+
+
+def _require_production_mailchimp_or_409(event: Mapping[str, Any]) -> dict[str, Any] | None:
+    if not is_production():
+        return json_response(
+            409,
+            {
+                "error": (
+                    "Mailchimp bulk sync is only available when DEPLOYMENT_STAGE is production"
+                )
+            },
+            event=event,
+        )
+    if not _mailchimp_env_ready():
+        return json_response(
+            409,
+            {
+                "error": (
+                    "MAILCHIMP_LIST_ID and MAILCHIMP_SERVER_PREFIX must be configured "
+                    "for Mailchimp bulk operations"
+                )
+            },
+            event=event,
+        )
+    return None
+
+
+def _parse_tag_name(raw: Any) -> str:
+    tag = validate_string_length(
+        raw,
+        "tag_name",
+        max_length=100,
+        required=True,
+    )
+    if tag is None or not str(tag).strip():
+        raise ValidationError("tag_name is required", field="tag_name")
+    normalized = str(tag).strip()
+    if not _TAG_NAME_PATTERN.fullmatch(normalized):
+        raise ValidationError(
+            "tag_name must be 1–100 characters of letters, digits, spaces, or hyphens",
+            field="tag_name",
+        )
+    return normalized
+
+
+def _parse_mailchimp_offset(raw: Any) -> int:
+    if raw is None:
+        return 0
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValidationError(
+            "mailchimp_offset must be an integer", field="mailchimp_offset"
+        ) from exc
+    if value < 0 or value > 10_000_000:
+        raise ValidationError(
+            "mailchimp_offset must be between 0 and 10000000",
+            field="mailchimp_offset",
+        )
+    return value
+
+
+def _parse_max_contacts(raw: Any, *, field: str, default: int, cap: int) -> int:
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValidationError(f"{field} must be an integer", field=field) from exc
+    if value < 1 or value > cap:
+        raise ValidationError(f"{field} must be between 1 and {cap}", field=field)
+    return value
+
+
+def _parse_only_statuses(raw: Any) -> list[MailchimpSyncStatus]:
+    if raw is None:
+        return [MailchimpSyncStatus.PENDING, MailchimpSyncStatus.FAILED]
+    if not isinstance(raw, list):
+        raise ValidationError("only_statuses must be an array", field="only_statuses")
+    if not raw:
+        raise ValidationError("only_statuses cannot be empty", field="only_statuses")
+    parsed: list[MailchimpSyncStatus] = []
+    for item in raw:
+        if not isinstance(item, str):
+            raise ValidationError(
+                "only_statuses entries must be strings", field="only_statuses"
+            )
+        key = item.strip().lower()
+        try:
+            status = MailchimpSyncStatus(key)
+        except ValueError as exc:
+            raise ValidationError(
+                f"Invalid mailchimp_status filter: {item}", field="only_statuses"
+            ) from exc
+        if status == MailchimpSyncStatus.UNSUBSCRIBED:
+            raise ValidationError(
+                "only_statuses cannot include unsubscribed (would risk re-subscribing)",
+                field="only_statuses",
+            )
+        if status not in _ALLOWED_SYNC_STATUSES:
+            raise ValidationError(
+                f"only_statuses cannot include {status.value}", field="only_statuses"
+            )
+        parsed.append(status)
+    return parsed
+
+
+def run_mailchimp_sync_batch(
+    event: Mapping[str, Any],
+    *,
+    actor_sub: str,
+) -> dict[str, Any]:
+    err = _require_production_mailchimp_or_409(event)
+    if err is not None:
+        return err
+
+    body = parse_body(event)
+    max_contacts = _parse_max_contacts(
+        body.get("max_contacts"), field="max_contacts", default=50, cap=200
+    )
+    cursor_raw = body.get("cursor")
+    cursor: UUID | None = None
+    if cursor_raw not in (None, ""):
+        if not isinstance(cursor_raw, str):
+            raise ValidationError("cursor must be a string", field="cursor")
+        cursor = parse_cursor(cursor_raw)
+    only_statuses = _parse_only_statuses(body.get("only_statuses"))
+    tag_name = _parse_tag_name(body.get("tag_name"))
+    dry_run = bool(body.get("dry_run", False))
+
+    fetch_limit = max_contacts + 1
+    errors_sample: list[dict[str, Any]] = []
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
+        repository = ContactRepository(session)
+        rows = repository.list_for_mailchimp_sync(
+            limit=fetch_limit,
+            cursor=cursor,
+            statuses=only_statuses,
+        )
+        page = rows[:max_contacts]
+        has_more = len(rows) > max_contacts
+        next_cursor = encode_cursor(page[-1].id) if has_more and page else None
+
+        processed = 0
+        succeeded = 0
+        failed = 0
+        skipped = 0
+
+        for contact in page:
+            processed += 1
+            if dry_run:
+                skipped += 1
+                continue
+            outcome, err_status = upsert_contact_to_mailchimp(
+                contact=contact,
+                tag_name=tag_name,
+                merge_fields=None,
+                logger=logger,
+                session=session,
+            )
+            if outcome == "synced":
+                succeeded += 1
+            elif outcome == "failed":
+                failed += 1
+                if len(errors_sample) < 5:
+                    errors_sample.append(
+                        {
+                            "contact_id": str(contact.id),
+                            "reason": "mailchimp_api_error",
+                            "status": err_status,
+                        }
+                    )
+            else:
+                skipped += 1
+
+        if dry_run:
+            session.rollback()
+        else:
+            session.commit()
+
+    logger.info(
+        "Mailchimp sync batch complete",
+        extra={
+            "actor_sub": actor_sub,
+            "request_id": request_id(event),
+            "processed": processed,
+            "succeeded": succeeded,
+            "failed": failed,
+            "skipped": skipped,
+            "dry_run": dry_run,
+        },
+    )
+
+    return json_response(
+        200,
+        {
+            "processed": processed,
+            "succeeded": succeeded,
+            "failed": failed,
+            "skipped": skipped,
+            "next_cursor": next_cursor,
+            "errors_sample": errors_sample,
+            "dry_run": dry_run,
+        },
+        event=event,
+    )
+
+
+def run_mailchimp_orphan_cleanup(
+    event: Mapping[str, Any],
+    *,
+    actor_sub: str,
+) -> dict[str, Any]:
+    err = _require_production_mailchimp_or_409(event)
+    if err is not None:
+        return err
+
+    body = parse_body(event)
+    max_members = _parse_max_contacts(
+        body.get("max_members"), field="max_members", default=200, cap=1000
+    )
+    mailchimp_offset = _parse_mailchimp_offset(body.get("mailchimp_offset"))
+    mode_raw = body.get("mode", "archive")
+    if not isinstance(mode_raw, str):
+        raise ValidationError("mode must be a string", field="mode")
+    mode = mode_raw.strip().lower()
+    if mode not in ("archive", "permanent"):
+        raise ValidationError("mode must be archive or permanent", field="mode")
+    dry_run = bool(body.get("dry_run", True))
+
+    members = list(
+        iter_audience_members(
+            page_size=max_members,
+            start_offset=mailchimp_offset,
+            single_page=True,
+        )
+    )
+    scanned = len(members)
+    kept = 0
+    removed = 0
+    failed = 0
+    removed_sample: list[dict[str, str]] = []
+
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_id=actor_sub, request_id=request_id(event))
+        repository = ContactRepository(session)
+
+        for member in members:
+            raw_email = member.get("email_address")
+            if not isinstance(raw_email, str) or not raw_email.strip():
+                continue
+            email = raw_email.strip().lower()
+            mc_status = str(member.get("status") or "")
+            db_contact = repository.find_by_email(email)
+            should_keep = (
+                db_contact is not None
+                and db_contact.archived_at is None
+                and db_contact.mailchimp_status != MailchimpSyncStatus.UNSUBSCRIBED
+            )
+            if should_keep:
+                kept += 1
+                continue
+
+            if dry_run:
+                removed += 1
+                if len(removed_sample) < 5:
+                    removed_sample.append(
+                        {"email": mask_email(email), "status": mc_status or "unknown"}
+                    )
+                continue
+
+            outcome = remove_contact_from_mailchimp(
+                email=email,
+                mode="permanent" if mode == "permanent" else "archive",
+                logger=logger,
+            )
+            if outcome == "removed":
+                removed += 1
+                if db_contact is not None:
+                    db_contact.mailchimp_status = MailchimpSyncStatus.UNSUBSCRIBED
+                    db_contact.mailchimp_subscriber_id = None
+                if len(removed_sample) < 5:
+                    removed_sample.append(
+                        {"email": mask_email(email), "status": mc_status or "unknown"}
+                    )
+            elif outcome == "failed":
+                failed += 1
+            else:
+                removed += 1
+                if len(removed_sample) < 5:
+                    removed_sample.append(
+                        {"email": mask_email(email), "status": mc_status or "unknown"}
+                    )
+
+        if dry_run:
+            session.rollback()
+        else:
+            session.commit()
+
+    next_offset = (
+        mailchimp_offset + scanned if scanned == max_members and scanned > 0 else None
+    )
+
+    logger.info(
+        "Mailchimp orphan cleanup batch complete",
+        extra={
+            "actor_sub": actor_sub,
+            "request_id": request_id(event),
+            "scanned": scanned,
+            "kept": kept,
+            "removed": removed,
+            "failed": failed,
+            "dry_run": dry_run,
+        },
+    )
+
+    return json_response(
+        200,
+        {
+            "scanned": scanned,
+            "kept": kept,
+            "removed": removed,
+            "failed": failed,
+            "next_offset": next_offset,
+            "removed_sample": removed_sample,
+            "dry_run": dry_run,
+        },
+        event=event,
+    )
+
+
+def get_mailchimp_sync_summary(event: Mapping[str, Any]) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        repository = ContactRepository(session)
+        counts = repository.count_by_mailchimp_status()
+        archived_with_mailchimp = repository.count_archived_with_mailchimp_record()
+
+    counts_by_status = {status.value: counts[status] for status in MailchimpSyncStatus}
+    return json_response(
+        200,
+        {
+            "counts_by_status": counts_by_status,
+            "archived_with_mailchimp_record": archived_with_mailchimp,
+            "last_run_summary": None,
+        },
+        event=event,
+    )

--- a/backend/src/app/api/admin_contacts_mailchimp_sync.py
+++ b/backend/src/app/api/admin_contacts_mailchimp_sync.py
@@ -65,6 +65,9 @@ def _require_production_mailchimp_or_409(
             },
             event=event,
         )
+    # When `_mailchimp_runtime_ready()` is false but `is_production()` is true, audience
+    # env must be incomplete; the branch above always returns. Mypy cannot prove that.
+    return None
 
 
 def _parse_tag_name(raw: Any) -> str:

--- a/backend/src/app/api/admin_contacts_mailchimp_sync.py
+++ b/backend/src/app/api/admin_contacts_mailchimp_sync.py
@@ -19,7 +19,10 @@ from app.db.repositories import ContactRepository
 from app.exceptions import ValidationError
 from app.api.admin_validators import validate_string_length
 from app.services.mailchimp import iter_audience_members
-from app.services.mailchimp_sync import remove_contact_from_mailchimp, upsert_contact_to_mailchimp
+from app.services.mailchimp_sync import (
+    remove_contact_from_mailchimp,
+    upsert_contact_to_mailchimp,
+)
 from app.utils import json_response
 from app.utils.deployment import is_production
 from app.utils.logging import get_logger, mask_email
@@ -43,7 +46,9 @@ def _mailchimp_env_ready() -> bool:
     )
 
 
-def _require_production_mailchimp_or_409(event: Mapping[str, Any]) -> dict[str, Any] | None:
+def _require_production_mailchimp_or_409(
+    event: Mapping[str, Any],
+) -> dict[str, Any] | None:
     if not is_production():
         return json_response(
             409,

--- a/backend/src/app/api/admin_contacts_mailchimp_sync.py
+++ b/backend/src/app/api/admin_contacts_mailchimp_sync.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 from collections.abc import Mapping
 from typing import Any
@@ -12,14 +11,16 @@ from sqlalchemy.orm import Session
 
 from app.api.admin_entities_helpers import request_id
 from app.api.admin_request import encode_cursor, parse_body, parse_cursor
+from app.api.admin_validators import validate_string_length
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.models.enums import MailchimpSyncStatus
 from app.db.repositories import ContactRepository
 from app.exceptions import ValidationError
-from app.api.admin_validators import validate_string_length
-from app.services.mailchimp import iter_audience_members
+from app.services.mailchimp import ITER_AUDIENCE_MEMBER_FIELDS, iter_audience_members
 from app.services.mailchimp_sync import (
+    _mailchimp_audience_env_configured,
+    _mailchimp_runtime_ready,
     remove_contact_from_mailchimp,
     upsert_contact_to_mailchimp,
 )
@@ -29,26 +30,20 @@ from app.utils.logging import get_logger, mask_email
 
 logger = get_logger(__name__)
 
-_TAG_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9 \-]{1,100}$")
+_TAG_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9 ._\-]{1,100}$")
 _ALLOWED_SYNC_STATUSES = frozenset(
     {
         MailchimpSyncStatus.PENDING,
         MailchimpSyncStatus.FAILED,
-        MailchimpSyncStatus.SYNCED,
     }
 )
-
-
-def _mailchimp_env_ready() -> bool:
-    return bool(
-        os.getenv("MAILCHIMP_LIST_ID", "").strip()
-        and os.getenv("MAILCHIMP_SERVER_PREFIX", "").strip()
-    )
 
 
 def _require_production_mailchimp_or_409(
     event: Mapping[str, Any],
 ) -> dict[str, Any] | None:
+    if _mailchimp_runtime_ready():
+        return None
     if not is_production():
         return json_response(
             409,
@@ -59,7 +54,7 @@ def _require_production_mailchimp_or_409(
             },
             event=event,
         )
-    if not _mailchimp_env_ready():
+    if not _mailchimp_audience_env_configured():
         return json_response(
             409,
             {
@@ -70,7 +65,6 @@ def _require_production_mailchimp_or_409(
             },
             event=event,
         )
-    return None
 
 
 def _parse_tag_name(raw: Any) -> str:
@@ -85,7 +79,7 @@ def _parse_tag_name(raw: Any) -> str:
     normalized = str(tag).strip()
     if not _TAG_NAME_PATTERN.fullmatch(normalized):
         raise ValidationError(
-            "tag_name must be 1–100 characters of letters, digits, spaces, or hyphens",
+            "tag_name must be 1–100 characters of letters, digits, spaces, hyphens, dots, or underscores",
             field="tag_name",
         )
     return normalized
@@ -218,6 +212,7 @@ def run_mailchimp_sync_batch(
                             "contact_id": str(contact.id),
                             "reason": "mailchimp_api_error",
                             "status": err_status,
+                            "lead_email_masked": mask_email(contact.email or ""),
                         }
                     )
             else:
@@ -228,6 +223,7 @@ def run_mailchimp_sync_batch(
         else:
             session.commit()
 
+    would_process = processed if dry_run else 0
     logger.info(
         "Mailchimp sync batch complete",
         extra={
@@ -251,6 +247,7 @@ def run_mailchimp_sync_batch(
             "next_cursor": next_cursor,
             "errors_sample": errors_sample,
             "dry_run": dry_run,
+            "would_process": would_process,
         },
         event=event,
     )
@@ -283,12 +280,15 @@ def run_mailchimp_orphan_cleanup(
             page_size=max_members,
             start_offset=mailchimp_offset,
             single_page=True,
+            fields=ITER_AUDIENCE_MEMBER_FIELDS,
         )
     )
     scanned = len(members)
     kept = 0
     removed = 0
+    would_remove = 0
     failed = 0
+    already_archived = 0
     removed_sample: list[dict[str, str]] = []
 
     with Session(get_engine()) as session:
@@ -301,6 +301,9 @@ def run_mailchimp_orphan_cleanup(
                 continue
             email = raw_email.strip().lower()
             mc_status = str(member.get("status") or "")
+            if mode == "archive" and mc_status == "archived":
+                already_archived += 1
+                continue
             db_contact = repository.find_by_email(email)
             should_keep = (
                 db_contact is not None
@@ -312,7 +315,7 @@ def run_mailchimp_orphan_cleanup(
                 continue
 
             if dry_run:
-                removed += 1
+                would_remove += 1
                 if len(removed_sample) < 5:
                     removed_sample.append(
                         {"email": mask_email(email), "status": mc_status or "unknown"}
@@ -335,21 +338,23 @@ def run_mailchimp_orphan_cleanup(
                     )
             elif outcome == "failed":
                 failed += 1
-            else:
-                removed += 1
-                if len(removed_sample) < 5:
-                    removed_sample.append(
-                        {"email": mask_email(email), "status": mc_status or "unknown"}
-                    )
 
         if dry_run:
             session.rollback()
         else:
             session.commit()
 
-    next_offset = (
-        mailchimp_offset + scanned if scanned == max_members and scanned > 0 else None
-    )
+    if dry_run or mode == "archive":
+        next_offset = (
+            mailchimp_offset + scanned
+            if scanned == max_members and scanned > 0
+            else None
+        )
+    else:
+        if removed > 0:
+            next_offset = mailchimp_offset
+        else:
+            next_offset = mailchimp_offset + scanned if scanned == max_members else None
 
     logger.info(
         "Mailchimp orphan cleanup batch complete",
@@ -359,6 +364,8 @@ def run_mailchimp_orphan_cleanup(
             "scanned": scanned,
             "kept": kept,
             "removed": removed,
+            "would_remove": would_remove,
+            "already_archived": already_archived,
             "failed": failed,
             "dry_run": dry_run,
         },
@@ -374,6 +381,8 @@ def run_mailchimp_orphan_cleanup(
             "next_offset": next_offset,
             "removed_sample": removed_sample,
             "dry_run": dry_run,
+            "already_archived": already_archived,
+            "would_remove": would_remove,
         },
         event=event,
     )

--- a/backend/src/app/api/admin_contacts_mutations.py
+++ b/backend/src/app/api/admin_contacts_mutations.py
@@ -405,33 +405,34 @@ def update_contact(
                 "Email or Instagram handle is already in use",
                 field="email",
             ) from exc
-        if mailchimp_email_for_archive:
-            removal = remove_contact_from_mailchimp(
-                email=mailchimp_email_for_archive,
-                logger=logger,
-            )
-            if removal == "failed":
-                logger.warning(
-                    "Mailchimp remove after contact archive failed (best effort)",
-                    extra={
-                        "lead_email": mask_email(mailchimp_email_for_archive),
-                    },
-                )
         session.refresh(updated)
         loaded = repository.get_by_id_for_admin(contact_id)
         if loaded is None:
             raise DatabaseError("Failed to load contact after update")
         note_counts = repository.count_standalone_notes_for_contacts([loaded.id])
-        return json_response(
-            200,
-            {
-                "contact": serialize_contact_summary(
-                    loaded,
-                    standalone_note_count=note_counts.get(loaded.id, 0),
-                )
-            },
-            event=event,
+        payload = {
+            "contact": serialize_contact_summary(
+                loaded,
+                standalone_note_count=note_counts.get(loaded.id, 0),
+            )
+        }
+
+    # Avoid holding the DB session during Mailchimp retries (API Gateway ~30s limit).
+    if mailchimp_email_for_archive:
+        removal = remove_contact_from_mailchimp(
+            email=mailchimp_email_for_archive,
+            logger=logger,
+            max_attempts=2,
         )
+        if removal == "failed":
+            logger.warning(
+                "Mailchimp remove after contact archive failed (best effort)",
+                extra={
+                    "lead_email": mask_email(mailchimp_email_for_archive),
+                },
+            )
+
+    return json_response(200, payload, event=event)
 
 
 def delete_contact(
@@ -440,7 +441,11 @@ def delete_contact(
     contact_id: UUID,
     actor_sub: str,
 ) -> dict[str, Any]:
-    """Permanently delete one CRM contact and dependent CRM rows."""
+    """Permanently delete one CRM contact and dependent CRM rows.
+
+    Orphan cleanup may race this handler and also call Mailchimp archive for the same email;
+    duplicate archive calls are idempotent on Mailchimp (404 is treated as success).
+    """
     logger.info(
         "Deleting admin CRM contact",
         extra={"contact_id": str(contact_id), "actor_sub": actor_sub},
@@ -480,18 +485,20 @@ def delete_contact(
                 field="contact_id",
             ) from exc
 
-        if mailchimp_email_for_delete:
-            removal = remove_contact_from_mailchimp(
-                email=mailchimp_email_for_delete,
-                logger=logger,
+    # Avoid holding the DB session during Mailchimp retries (API Gateway ~30s limit).
+    if mailchimp_email_for_delete:
+        removal = remove_contact_from_mailchimp(
+            email=mailchimp_email_for_delete,
+            logger=logger,
+            max_attempts=2,
+        )
+        if removal == "failed":
+            logger.warning(
+                "Mailchimp remove after contact delete failed (best effort)",
+                extra={"lead_email": mask_email(mailchimp_email_for_delete)},
             )
-            if removal == "failed":
-                logger.warning(
-                    "Mailchimp remove after contact delete failed (best effort)",
-                    extra={"lead_email": mask_email(mailchimp_email_for_delete)},
-                )
 
-        return json_response(204, {}, event=event)
+    return json_response(204, {}, event=event)
 
 
 def _resolve_referral_contact_id_for_referral_source(

--- a/backend/src/app/api/admin_contacts_mutations.py
+++ b/backend/src/app/api/admin_contacts_mutations.py
@@ -41,12 +41,22 @@ from app.api.admin_validators import (
 from app.db.audit import set_audit_context
 from app.db.engine import get_engine
 from app.db.models import Contact, ContactSource
+from app.db.models.enums import MailchimpSyncStatus
 from app.db.models.note import Note
 from app.db.models.sales_lead import SalesLead
 from app.db.repositories import ContactRepository
 from app.exceptions import DatabaseError, NotFoundError, ValidationError
+from app.services.mailchimp_sync import remove_contact_from_mailchimp
 from app.utils import json_response
-from app.utils.logging import get_logger
+from app.utils.logging import get_logger, mask_email
+
+_MAILCHIMP_PUSH_REMOVE_STATUSES = frozenset(
+    {
+        MailchimpSyncStatus.SYNCED,
+        MailchimpSyncStatus.FAILED,
+        MailchimpSyncStatus.PENDING,
+    }
+)
 
 logger = get_logger(__name__)
 
@@ -253,6 +263,8 @@ def update_contact(
         if contact is None:
             raise NotFoundError("Contact", str(contact_id))
 
+        mailchimp_email_for_archive: str | None = None
+
         if "first_name" in body:
             contact.first_name = (
                 validate_string_length(
@@ -372,6 +384,13 @@ def update_contact(
             active = parse_optional_bool_body(body.get("active"), field="active")
             if active is None:
                 raise ValidationError("active is required", field="active")
+            becoming_archived = (not active) and contact.archived_at is None
+            if (
+                becoming_archived
+                and contact.email
+                and contact.mailchimp_status in _MAILCHIMP_PUSH_REMOVE_STATUSES
+            ):
+                mailchimp_email_for_archive = contact.email
             contact.archived_at = None if active else now
         if "tag_ids" in body:
             tag_ids = parse_uuid_list(body.get("tag_ids"), "tag_ids")
@@ -386,6 +405,18 @@ def update_contact(
                 "Email or Instagram handle is already in use",
                 field="email",
             ) from exc
+        if mailchimp_email_for_archive:
+            removal = remove_contact_from_mailchimp(
+                email=mailchimp_email_for_archive,
+                logger=logger,
+            )
+            if removal == "failed":
+                logger.warning(
+                    "Mailchimp remove after contact archive failed (best effort)",
+                    extra={
+                        "lead_email": mask_email(mailchimp_email_for_archive),
+                    },
+                )
         session.refresh(updated)
         loaded = repository.get_by_id_for_admin(contact_id)
         if loaded is None:
@@ -422,6 +453,13 @@ def delete_contact(
         if contact is None:
             raise NotFoundError("Contact", str(contact_id))
 
+        mailchimp_email_for_delete: str | None = None
+        if (
+            contact.email
+            and contact.mailchimp_status in _MAILCHIMP_PUSH_REMOVE_STATUSES
+        ):
+            mailchimp_email_for_delete = contact.email
+
         lead_ids = list(
             session.scalars(
                 select(SalesLead.id).where(SalesLead.contact_id == contact_id)
@@ -441,6 +479,17 @@ def delete_contact(
                 "Contact cannot be deleted while it is still referenced",
                 field="contact_id",
             ) from exc
+
+        if mailchimp_email_for_delete:
+            removal = remove_contact_from_mailchimp(
+                email=mailchimp_email_for_delete,
+                logger=logger,
+            )
+            if removal == "failed":
+                logger.warning(
+                    "Mailchimp remove after contact delete failed (best effort)",
+                    extra={"lead_email": mask_email(mailchimp_email_for_delete)},
+                )
 
         return json_response(204, {}, event=event)
 

--- a/backend/src/app/db/repositories/contact.py
+++ b/backend/src/app/db/repositories/contact.py
@@ -15,7 +15,12 @@ from app.db.models.family import Family, FamilyMember
 from app.db.models.location import Location
 from app.db.models.organization import Organization, OrganizationMember
 from app.db.models.tag import ContactTag
-from app.db.models.enums import ContactSource, ContactType, RelationshipType
+from app.db.models.enums import (
+    ContactSource,
+    ContactType,
+    MailchimpSyncStatus,
+    RelationshipType,
+)
 from app.db.repositories.base import BaseRepository
 
 _SOURCE_PRIORITY: dict[ContactSource, int] = {
@@ -344,6 +349,66 @@ class ContactRepository(BaseRepository[Contact]):
             statement = statement.where(Contact.contact_type == contact_type)
         count = self._session.execute(statement).scalar_one_or_none()
         return int(count or 0)
+
+    def list_for_mailchimp_sync(
+        self,
+        *,
+        limit: int,
+        cursor: UUID | None,
+        statuses: list[MailchimpSyncStatus],
+    ) -> list[Contact]:
+        """Contacts eligible for Mailchimp upsert batch (oldest first, stable cursor)."""
+        statement = select(Contact).where(
+            Contact.archived_at.is_(None),
+            Contact.email.is_not(None),
+            Contact.mailchimp_status.in_(statuses),
+        )
+        if cursor is not None:
+            cursor_created_at = (
+                select(Contact.created_at).where(Contact.id == cursor).scalar_subquery()
+            )
+            statement = statement.where(
+                or_(
+                    Contact.created_at > cursor_created_at,
+                    and_(
+                        Contact.created_at == cursor_created_at,
+                        Contact.id > cursor,
+                    ),
+                )
+            )
+        statement = statement.order_by(
+            Contact.created_at.asc(),
+            Contact.id.asc(),
+        ).limit(limit)
+        return list(self._session.execute(statement).scalars().all())
+
+    def count_by_mailchimp_status(self) -> dict[MailchimpSyncStatus, int]:
+        """Single aggregate: rows per ``MailchimpSyncStatus``."""
+        statement = select(Contact.mailchimp_status, func.count(Contact.id)).group_by(
+            Contact.mailchimp_status
+        )
+        rows = self._session.execute(statement).all()
+        counts: dict[MailchimpSyncStatus, int] = {s: 0 for s in MailchimpSyncStatus}
+        for status, raw_count in rows:
+            key: MailchimpSyncStatus | None = None
+            if isinstance(status, MailchimpSyncStatus):
+                key = status
+            elif isinstance(status, str):
+                try:
+                    key = MailchimpSyncStatus(status.lower())
+                except ValueError:
+                    continue
+            if key is not None:
+                counts[key] = int(raw_count)
+        return counts
+
+    def count_archived_with_mailchimp_record(self) -> int:
+        statement = select(func.count(Contact.id)).where(
+            Contact.archived_at.is_not(None),
+            Contact.mailchimp_subscriber_id.is_not(None),
+        )
+        value = self._session.execute(statement).scalar_one_or_none()
+        return int(value or 0)
 
     def get_by_id_for_admin(self, contact_id: UUID) -> Contact | None:
         statement = (

--- a/backend/src/app/services/mailchimp.py
+++ b/backend/src/app/services/mailchimp.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
-from typing import Any
+import os
+from typing import Any, Iterator
+from urllib.parse import urlencode
 
 from app.services.aws_clients import get_secretsmanager_client
 from app.services.aws_proxy import http_invoke
@@ -31,8 +33,6 @@ def _get_api_key() -> str:
     global _api_key_cache
     if _api_key_cache is not None:
         return _api_key_cache
-
-    import os
 
     secret_arn = os.getenv("MAILCHIMP_API_SECRET_ARN", "").strip()
     if not secret_arn:
@@ -79,6 +79,24 @@ def _encode_auth(api_key: str) -> str:
     return base64.b64encode(f"anystring:{api_key}".encode()).decode()
 
 
+def _mailchimp_base_url_and_auth() -> tuple[str, str]:
+    """Return (base_url, Authorization header value) for Mailchimp API calls."""
+    api_key = _get_api_key()
+    server_prefix = os.getenv("MAILCHIMP_SERVER_PREFIX", "").strip()
+    if not server_prefix:
+        raise RuntimeError("MAILCHIMP_SERVER_PREFIX is not configured")
+    base_url = f"https://{server_prefix}.api.mailchimp.com/3.0"
+    auth_header = f"Basic {_encode_auth(api_key)}"
+    return base_url, auth_header
+
+
+def _list_id_or_raise() -> str:
+    list_id = os.getenv("MAILCHIMP_LIST_ID", "").strip()
+    if not list_id:
+        raise RuntimeError("MAILCHIMP_LIST_ID is required")
+    return list_id
+
+
 def _status_code(response: dict[str, Any]) -> int:
     try:
         return int(response.get("status", 0))
@@ -100,6 +118,15 @@ def _parse_json(body: str) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+class MailchimpApiError(Exception):
+    """Raised when Mailchimp API returns a non-success status."""
+
+    def __init__(self, status: int, body: str):
+        self.status = status
+        self.body = body
+        super().__init__(f"Mailchimp API error {status}: {body}")
+
+
 def add_subscriber_with_tag(
     *,
     email: str,
@@ -112,8 +139,6 @@ def add_subscriber_with_tag(
     Optional ``merge_fields`` are merged into the member payload (Mailchimp merge
     field tags, e.g. FNAME, MMDLURL). Empty values are skipped.
     """
-    import os
-
     normalized_email = email.strip().lower()
     if not normalized_email:
         raise ValueError("email is required")
@@ -124,15 +149,9 @@ def add_subscriber_with_tag(
     if not normalized_tag_name:
         raise ValueError("tag_name is required")
 
-    api_key = _get_api_key()
-    list_id = os.getenv("MAILCHIMP_LIST_ID", "").strip()
-    server_prefix = os.getenv("MAILCHIMP_SERVER_PREFIX", "").strip()
-    if not list_id or not server_prefix:
-        raise RuntimeError("MAILCHIMP_LIST_ID and MAILCHIMP_SERVER_PREFIX are required")
-
+    list_id = _list_id_or_raise()
     subscriber_hash = _subscriber_hash(normalized_email)
-    base_url = f"https://{server_prefix}.api.mailchimp.com/3.0"
-    auth_header = f"Basic {_encode_auth(api_key)}"
+    base_url, auth_header = _mailchimp_base_url_and_auth()
 
     merge_payload: dict[str, str] = {"FNAME": normalized_first_name}
     if merge_fields:
@@ -211,8 +230,6 @@ def trigger_customer_journey(
 
     Requires ``MAILCHIMP_SERVER_PREFIX``. Raises ``MailchimpApiError`` on non-2xx.
     """
-    import os
-
     normalized_email = email.strip().lower()
     if not normalized_email:
         raise ValueError("email is required")
@@ -256,10 +273,151 @@ def trigger_customer_journey(
         raise MailchimpApiError(status, body)
 
 
-class MailchimpApiError(Exception):
-    """Raised when Mailchimp API returns a non-success status."""
+def archive_subscriber(*, email: str) -> bool:
+    """Archive a list member (soft-delete). 204 and 404 both return True."""
+    normalized_email = email.strip().lower()
+    if not normalized_email:
+        raise ValueError("email is required")
+    list_id = _list_id_or_raise()
+    base_url, auth_header = _mailchimp_base_url_and_auth()
+    subscriber_hash = _subscriber_hash(normalized_email)
+    member_url = f"{base_url}/lists/{list_id}/members/{subscriber_hash}"
+    response = http_invoke(
+        method="DELETE",
+        url=member_url,
+        headers={
+            "Authorization": auth_header,
+            "Content-Type": "application/json",
+        },
+        timeout=10,
+    )
+    status = _status_code(response)
+    body = _response_body(response)
+    if status == 204 or status == 404:
+        if status == 404:
+            logger.info(
+                "Mailchimp archive skipped (member not found)",
+                extra={"lead_email": mask_email(normalized_email)},
+            )
+        return True
+    if status < 200 or status >= 300:
+        logger.warning(
+            "Mailchimp archive failed",
+            extra={
+                "status": status,
+                "lead_email": mask_email(normalized_email),
+                "mailchimp_step": "archive_member",
+                "mailchimp_error_body": _error_body_for_log(body),
+            },
+        )
+        raise MailchimpApiError(status, body)
+    return True
 
-    def __init__(self, status: int, body: str):
-        self.status = status
-        self.body = body
-        super().__init__(f"Mailchimp API error {status}: {body}")
+
+def permanent_delete_subscriber(*, email: str) -> bool:
+    """Permanently erase a list member (GDPR). 204 and 404 both return True."""
+    normalized_email = email.strip().lower()
+    if not normalized_email:
+        raise ValueError("email is required")
+    list_id = _list_id_or_raise()
+    base_url, auth_header = _mailchimp_base_url_and_auth()
+    subscriber_hash = _subscriber_hash(normalized_email)
+    action_url = (
+        f"{base_url}/lists/{list_id}/members/{subscriber_hash}/actions/delete-permanent"
+    )
+    response = http_invoke(
+        method="POST",
+        url=action_url,
+        headers={
+            "Authorization": auth_header,
+            "Content-Type": "application/json",
+        },
+        body="{}",
+        timeout=10,
+    )
+    status = _status_code(response)
+    body = _response_body(response)
+    if status == 204 or status == 404:
+        if status == 404:
+            logger.info(
+                "Mailchimp permanent delete skipped (member not found)",
+                extra={"lead_email": mask_email(normalized_email)},
+            )
+        return True
+    if status < 200 or status >= 300:
+        logger.warning(
+            "Mailchimp permanent delete failed",
+            extra={
+                "status": status,
+                "lead_email": mask_email(normalized_email),
+                "mailchimp_step": "delete_member_permanent",
+                "mailchimp_error_body": _error_body_for_log(body),
+            },
+        )
+        raise MailchimpApiError(status, body)
+    return True
+
+
+def iter_audience_members(
+    *,
+    page_size: int = 200,
+    fields: tuple[str, ...] = (
+        "members.id",
+        "members.email_address",
+        "members.status",
+        "members.unique_email_id",
+        "total_items",
+    ),
+    start_offset: int = 0,
+    single_page: bool = False,
+) -> Iterator[dict[str, Any]]:
+    """Yield list members from the configured audience.
+
+    When ``single_page`` is True, only the first HTTP response (at ``start_offset``)
+    is fetched; otherwise all pages are walked until a short page.
+    """
+    if page_size < 1 or page_size > 1000:
+        raise ValueError("page_size must be between 1 and 1000")
+    list_id = _list_id_or_raise()
+    base_url, auth_header = _mailchimp_base_url_and_auth()
+    offset = max(0, start_offset)
+    while True:
+        query = urlencode(
+            {
+                "count": page_size,
+                "offset": offset,
+                "fields": ",".join(fields),
+            }
+        )
+        list_url = f"{base_url}/lists/{list_id}/members?{query}"
+        response = http_invoke(
+            method="GET",
+            url=list_url,
+            headers={
+                "Authorization": auth_header,
+                "Content-Type": "application/json",
+            },
+            timeout=15,
+        )
+        status = _status_code(response)
+        body = _response_body(response)
+        if status < 200 or status >= 300:
+            logger.warning(
+                "Mailchimp list members fetch failed",
+                extra={
+                    "status": status,
+                    "mailchimp_step": "list_members",
+                    "mailchimp_error_body": _error_body_for_log(body),
+                },
+            )
+            raise MailchimpApiError(status, body)
+        payload = _parse_json(body)
+        members = payload.get("members")
+        if not isinstance(members, list):
+            members = []
+        for member in members:
+            if isinstance(member, dict):
+                yield member
+        if single_page or len(members) < page_size:
+            break
+        offset += len(members)

--- a/backend/src/app/services/mailchimp.py
+++ b/backend/src/app/services/mailchimp.py
@@ -358,16 +358,19 @@ def permanent_delete_subscriber(*, email: str) -> bool:
     return True
 
 
+ITER_AUDIENCE_MEMBER_FIELDS: tuple[str, ...] = (
+    "members.id",
+    "members.email_address",
+    "members.status",
+    "members.unique_email_id",
+    "total_items",
+)
+
+
 def iter_audience_members(
     *,
     page_size: int = 200,
-    fields: tuple[str, ...] = (
-        "members.id",
-        "members.email_address",
-        "members.status",
-        "members.unique_email_id",
-        "total_items",
-    ),
+    fields: tuple[str, ...] = ITER_AUDIENCE_MEMBER_FIELDS,
     start_offset: int = 0,
     single_page: bool = False,
 ) -> Iterator[dict[str, Any]]:

--- a/backend/src/app/services/mailchimp_sync.py
+++ b/backend/src/app/services/mailchimp_sync.py
@@ -1,0 +1,150 @@
+"""Shared Mailchimp ↔ CRM contact sync helpers (media processor + admin batch)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from sqlalchemy.orm import Session
+
+from app.db.models.contact import Contact
+from app.db.models.enums import MailchimpSyncStatus
+from app.services.mailchimp import (
+    MailchimpApiError,
+    add_subscriber_with_tag,
+    archive_subscriber,
+    permanent_delete_subscriber,
+)
+from app.utils.logging import ContextLogger, mask_email
+from app.utils.retry import run_with_retry
+
+LoggerLike = logging.Logger | ContextLogger
+
+
+def is_retryable_mailchimp_exception(exc: Exception) -> bool:
+    if isinstance(exc, MailchimpApiError):
+        return exc.status == 429 or exc.status >= 500
+    return isinstance(exc, (ConnectionError, TimeoutError))
+
+
+def _optional_subscriber_id(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def upsert_contact_to_mailchimp(
+    *,
+    contact: Contact,
+    tag_name: str,
+    merge_fields: dict[str, str] | None = None,
+    logger: LoggerLike,
+    session: Session | None = None,
+) -> tuple[Literal["synced", "skipped", "failed"], int | None]:
+    """Push one contact to Mailchimp with tag; updates ``contact`` mailchimp fields.
+
+    Returns ``(outcome, http_status)`` where ``http_status`` is set on Mailchimp API failure.
+    """
+    if session is not None:
+        session.refresh(contact, attribute_names=["mailchimp_status", "archived_at"])
+
+    if not contact.email or not str(contact.email).strip():
+        contact.mailchimp_status = MailchimpSyncStatus.FAILED
+        logger.warning("Contact email is missing, skipping Mailchimp sync")
+        return "skipped", None
+
+    if contact.archived_at is not None:
+        return "skipped", None
+
+    if contact.mailchimp_status == MailchimpSyncStatus.UNSUBSCRIBED:
+        return "skipped", None
+
+    first_name = " ".join((contact.first_name or "").split()).strip()
+    if not first_name:
+        contact.mailchimp_status = MailchimpSyncStatus.FAILED
+        logger.warning(
+            "Contact first_name is missing, skipping Mailchimp sync",
+            extra={"lead_email": mask_email(contact.email)},
+        )
+        return "skipped", None
+
+    try:
+        mailchimp_response = run_with_retry(
+            add_subscriber_with_tag,
+            email=contact.email,
+            first_name=first_name,
+            tag_name=tag_name,
+            merge_fields=merge_fields,
+            max_attempts=3,
+            base_delay_seconds=1.0,
+            should_retry=is_retryable_mailchimp_exception,
+            logger=logger,
+            operation_name="mailchimp.add_subscriber_with_tag",
+        )
+        contact.mailchimp_status = MailchimpSyncStatus.SYNCED
+        subscriber_id = _optional_subscriber_id(mailchimp_response.get("id"))
+        if subscriber_id:
+            contact.mailchimp_subscriber_id = subscriber_id
+        return "synced", None
+    except MailchimpApiError as exc:
+        contact.mailchimp_status = MailchimpSyncStatus.FAILED
+        logger.warning(
+            "Mailchimp API request failed",
+            extra={
+                "status": exc.status,
+                "lead_email": mask_email(contact.email),
+            },
+        )
+        return "failed", exc.status
+    except Exception:
+        contact.mailchimp_status = MailchimpSyncStatus.FAILED
+        logger.exception(
+            "Mailchimp sync failed unexpectedly",
+            extra={"lead_email": mask_email(contact.email)},
+        )
+        return "failed", None
+
+
+def remove_contact_from_mailchimp(
+    *,
+    email: str,
+    mode: Literal["archive", "permanent"] = "archive",
+    logger: LoggerLike,
+) -> Literal["removed", "skipped", "failed"]:
+    """Remove one email from Mailchimp (archive or permanent). Caller clears DB row."""
+    normalized = (email or "").strip().lower()
+    if not normalized:
+        return "skipped"
+
+    op = permanent_delete_subscriber if mode == "permanent" else archive_subscriber
+
+    try:
+        run_with_retry(
+            op,
+            email=normalized,
+            max_attempts=3,
+            base_delay_seconds=1.0,
+            should_retry=is_retryable_mailchimp_exception,
+            logger=logger,
+            operation_name=(
+                "mailchimp.permanent_delete_subscriber"
+                if mode == "permanent"
+                else "mailchimp.archive_subscriber"
+            ),
+        )
+        return "removed"
+    except MailchimpApiError as exc:
+        logger.warning(
+            "Mailchimp remove request failed",
+            extra={
+                "status": exc.status,
+                "lead_email": mask_email(normalized),
+            },
+        )
+    except Exception:
+        logger.exception(
+            "Mailchimp remove failed unexpectedly",
+            extra={"lead_email": mask_email(normalized)},
+        )
+    return "failed"

--- a/backend/src/app/services/mailchimp_sync.py
+++ b/backend/src/app/services/mailchimp_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Literal
 
 from sqlalchemy.orm import Session
@@ -15,10 +16,22 @@ from app.services.mailchimp import (
     archive_subscriber,
     permanent_delete_subscriber,
 )
+from app.utils.deployment import is_production
 from app.utils.logging import ContextLogger, mask_email
 from app.utils.retry import run_with_retry
 
 LoggerLike = logging.Logger | ContextLogger
+
+
+def _mailchimp_audience_env_configured() -> bool:
+    return bool(
+        os.getenv("MAILCHIMP_LIST_ID", "").strip()
+        and os.getenv("MAILCHIMP_SERVER_PREFIX", "").strip()
+    )
+
+
+def _mailchimp_runtime_ready() -> bool:
+    return is_production() and _mailchimp_audience_env_configured()
 
 
 def is_retryable_mailchimp_exception(exc: Exception) -> bool:
@@ -46,6 +59,13 @@ def upsert_contact_to_mailchimp(
 
     Returns ``(outcome, http_status)`` where ``http_status`` is set on Mailchimp API failure.
     """
+    if not _mailchimp_runtime_ready():
+        logger.info(
+            "Mailchimp upsert skipped (non-production or env not configured)",
+            extra={"lead_email": mask_email(contact.email or "")},
+        )
+        return "skipped", None
+
     if session is not None:
         session.refresh(contact, attribute_names=["mailchimp_status", "archived_at"])
 
@@ -111,10 +131,18 @@ def remove_contact_from_mailchimp(
     email: str,
     mode: Literal["archive", "permanent"] = "archive",
     logger: LoggerLike,
+    max_attempts: int = 3,
 ) -> Literal["removed", "skipped", "failed"]:
     """Remove one email from Mailchimp (archive or permanent). Caller clears DB row."""
     normalized = (email or "").strip().lower()
     if not normalized:
+        return "skipped"
+
+    if not _mailchimp_runtime_ready():
+        logger.info(
+            "Mailchimp removal skipped (non-production or env not configured)",
+            extra={"lead_email": mask_email(normalized)},
+        )
         return "skipped"
 
     op = permanent_delete_subscriber if mode == "permanent" else archive_subscriber
@@ -123,7 +151,7 @@ def remove_contact_from_mailchimp(
         run_with_retry(
             op,
             email=normalized,
-            max_attempts=3,
+            max_attempts=max_attempts,
             base_delay_seconds=1.0,
             should_retry=is_retryable_mailchimp_exception,
             logger=logger,

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -33,6 +33,9 @@ info:
     - `GET|PATCH|DELETE /v1/admin/tags/{id}` (DELETE returns JSON with `deleted` and `usage_count`)
     - `GET /v1/admin/contacts/tags`
     - `GET /v1/admin/contacts/search`
+    - `POST /v1/admin/contacts/mailchimp-sync-run`
+    - `POST /v1/admin/contacts/mailchimp-sync-orphans`
+    - `GET /v1/admin/contacts/mailchimp-sync-status`
     - `GET|POST /v1/admin/contacts`
     - `GET|PATCH|DELETE /v1/admin/contacts/{id}`
     - `GET|POST /v1/admin/contacts/{id}/notes`
@@ -2074,6 +2077,96 @@ paths:
                 $ref: "#/components/schemas/EntityPickerListResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/contacts/mailchimp-sync-run:
+    post:
+      summary: Run one Mailchimp upsert batch (DB → audience)
+      description: |
+        Production-only. Paginated upsert for CRM contacts with the given ``only_statuses``
+        (default ``pending`` and ``failed``). Never include ``unsubscribed`` in ``only_statuses``:
+        that would risk re-subscribing contacts who opted out in Mailchimp. Each row calls
+        Mailchimp PUT + tag; unsubscribed or archived contacts are skipped without calling Mailchimp.
+        Use ``next_cursor`` until null. ``dry_run`` counts rows without calling Mailchimp.
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MailchimpSyncRunRequest"
+      responses:
+        "200":
+          description: Batch outcome and optional next cursor.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MailchimpSyncRunResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Not production or Mailchimp list env not configured.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/admin/contacts/mailchimp-sync-orphans:
+    post:
+      summary: Reconcile Mailchimp audience orphans (one page)
+      description: |
+        Production-only. Scans one Mailchimp list page starting at ``mailchimp_offset``.
+        Removes members whose email has no active CRM contact, or whose CRM row is archived or
+        ``mailchimp_status`` is ``unsubscribed``. Default ``dry_run`` is ``true`` because this
+        deletes or archives Mailchimp members; set ``dry_run`` to ``false`` to execute.
+        ``mode=archive`` soft-archives (recoverable); ``mode=permanent`` is GDPR erase and
+        must only be used when explicitly required.
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MailchimpOrphanCleanupRequest"
+      responses:
+        "200":
+          description: Page scan outcome and optional next offset.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MailchimpOrphanCleanupResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Not production or Mailchimp list env not configured.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/admin/contacts/mailchimp-sync-status:
+    get:
+      summary: Mailchimp sync counters for admin progress UI
+      description: |
+        Returns aggregate counts by ``mailchimp_status`` plus archived contacts that still
+        carry a ``mailchimp_subscriber_id``. ``last_run_summary`` is reserved for a future release
+        and is always null in v1.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Status snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MailchimpSyncStatusResponse"
         "403":
           $ref: "#/components/responses/Forbidden"
 
@@ -7899,6 +7992,161 @@ components:
           description: |
             When `source` is `referral`, must be set to a valid active contact UUID
             (omit or null to clear only when source is not referral).
+    MailchimpSyncRunRequest:
+      type: object
+      required:
+        - tag_name
+      properties:
+        max_contacts:
+          type: integer
+          minimum: 1
+          maximum: 200
+          default: 50
+        cursor:
+          type: string
+          nullable: true
+          description: Opaque cursor from the prior response's `next_cursor`.
+        only_statuses:
+          type: array
+          items:
+            type: string
+            enum:
+              - pending
+              - failed
+              - synced
+          description: |
+            Defaults to `pending` and `failed`. Must not include `unsubscribed` (non-compliant
+            re-subscribe risk).
+        tag_name:
+          type: string
+          minLength: 1
+          maxLength: 100
+          pattern: "^[a-zA-Z0-9 \\-]+$"
+        dry_run:
+          type: boolean
+          default: false
+    MailchimpSyncRunErrorSampleItem:
+      type: object
+      required:
+        - contact_id
+        - reason
+      properties:
+        contact_id:
+          type: string
+          format: uuid
+        reason:
+          type: string
+        status:
+          type: integer
+          nullable: true
+          description: HTTP status from Mailchimp when `reason` is `mailchimp_api_error`.
+    MailchimpSyncRunResponse:
+      type: object
+      required:
+        - processed
+        - succeeded
+        - failed
+        - skipped
+        - next_cursor
+        - errors_sample
+        - dry_run
+      properties:
+        processed:
+          type: integer
+        succeeded:
+          type: integer
+        failed:
+          type: integer
+        skipped:
+          type: integer
+        next_cursor:
+          type: string
+          nullable: true
+        errors_sample:
+          type: array
+          items:
+            $ref: "#/components/schemas/MailchimpSyncRunErrorSampleItem"
+        dry_run:
+          type: boolean
+    MailchimpOrphanCleanupRequest:
+      type: object
+      properties:
+        max_members:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 200
+        mailchimp_offset:
+          type: integer
+          minimum: 0
+          maximum: 10000000
+          default: 0
+        mode:
+          type: string
+          enum:
+            - archive
+            - permanent
+          default: archive
+        dry_run:
+          type: boolean
+          default: true
+    MailchimpOrphanRemovedSampleItem:
+      type: object
+      required:
+        - email
+        - status
+      properties:
+        email:
+          type: string
+          description: Masked email for logs/UI samples.
+        status:
+          type: string
+          description: Mailchimp member status when scanned.
+    MailchimpOrphanCleanupResponse:
+      type: object
+      required:
+        - scanned
+        - kept
+        - removed
+        - failed
+        - next_offset
+        - removed_sample
+        - dry_run
+      properties:
+        scanned:
+          type: integer
+        kept:
+          type: integer
+        removed:
+          type: integer
+        failed:
+          type: integer
+        next_offset:
+          type: integer
+          nullable: true
+        removed_sample:
+          type: array
+          items:
+            $ref: "#/components/schemas/MailchimpOrphanRemovedSampleItem"
+        dry_run:
+          type: boolean
+    MailchimpSyncStatusResponse:
+      type: object
+      required:
+        - counts_by_status
+        - archived_with_mailchimp_record
+        - last_run_summary
+      properties:
+        counts_by_status:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Keys are `pending`, `synced`, `failed`, `unsubscribed`.
+        archived_with_mailchimp_record:
+          type: integer
+        last_run_summary:
+          nullable: true
+          description: Reserved; always null in v1.
     AdminFamilyMember:
       type: object
       description: |

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -2088,7 +2088,9 @@ paths:
         (default ``pending`` and ``failed``). Never include ``unsubscribed`` in ``only_statuses``:
         that would risk re-subscribing contacts who opted out in Mailchimp. Each row calls
         Mailchimp PUT + tag; unsubscribed or archived contacts are skipped without calling Mailchimp.
-        Use ``next_cursor`` until null. ``dry_run`` counts rows without calling Mailchimp.
+        Use ``next_cursor`` until null. ``dry_run`` counts rows without calling Mailchimp; when
+        ``dry_run`` is true, ``would_process`` mirrors that count and ``processed``/``skipped``
+        remain populated for backward compatibility.
       security:
         - AdminBearerAuth: []
       requestBody:
@@ -2124,7 +2126,11 @@ paths:
         ``mailchimp_status`` is ``unsubscribed``. Default ``dry_run`` is ``true`` because this
         deletes or archives Mailchimp members; set ``dry_run`` to ``false`` to execute.
         ``mode=archive`` soft-archives (recoverable); ``mode=permanent`` is GDPR erase and
-        must only be used when explicitly required.
+        must only be used when explicitly required. Mailchimp offset pagination is eventually
+        consistent (webhooks or concurrent runs may shift rows between pages); archive mode
+        remains idempotent on Mailchimp. With ``mode=permanent`` and ``dry_run=false``, when
+        members are removed the response repeats ``next_offset`` equal to ``mailchimp_offset``
+        until a page removes zero rows, then advances by ``scanned`` when the page is full.
       security:
         - AdminBearerAuth: []
       requestBody:
@@ -8013,7 +8019,6 @@ components:
             enum:
               - pending
               - failed
-              - synced
           description: |
             Defaults to `pending` and `failed`. Must not include `unsubscribed` (non-compliant
             re-subscribe risk).
@@ -8021,7 +8026,7 @@ components:
           type: string
           minLength: 1
           maxLength: 100
-          pattern: "^[a-zA-Z0-9 \\-]+$"
+          pattern: "^[a-zA-Z0-9 ._\\-]+$"
         dry_run:
           type: boolean
           default: false
@@ -8030,6 +8035,7 @@ components:
       required:
         - contact_id
         - reason
+        - lead_email_masked
       properties:
         contact_id:
           type: string
@@ -8040,6 +8046,9 @@ components:
           type: integer
           nullable: true
           description: HTTP status from Mailchimp when `reason` is `mailchimp_api_error`.
+        lead_email_masked:
+          type: string
+          description: Masked email for operator triage.
     MailchimpSyncRunResponse:
       type: object
       required:
@@ -8050,6 +8059,7 @@ components:
         - next_cursor
         - errors_sample
         - dry_run
+        - would_process
       properties:
         processed:
           type: integer
@@ -8068,6 +8078,11 @@ components:
             $ref: "#/components/schemas/MailchimpSyncRunErrorSampleItem"
         dry_run:
           type: boolean
+        would_process:
+          type: integer
+          description: |
+            When `dry_run` is true, equals the number of rows that would have been sent to Mailchimp.
+            Zero when `dry_run` is false.
     MailchimpOrphanCleanupRequest:
       type: object
       properties:
@@ -8104,6 +8119,11 @@ components:
           description: Mailchimp member status when scanned.
     MailchimpOrphanCleanupResponse:
       type: object
+      description: |
+        Mailchimp offset pagination is not transactionally consistent: concurrent audience changes
+        (for example webhook-driven unsubscribes) can shift which members appear between batches.
+        Archive mode remains idempotent on Mailchimp; permanent mode keeps the same offset while
+        removals occur (see `next_offset`).
       required:
         - scanned
         - kept
@@ -8112,6 +8132,8 @@ components:
         - next_offset
         - removed_sample
         - dry_run
+        - already_archived
+        - would_remove
       properties:
         scanned:
           type: integer
@@ -8124,12 +8146,29 @@ components:
         next_offset:
           type: integer
           nullable: true
+          description: |
+            For `mode=archive` or any `dry_run` request, the next offset is `mailchimp_offset + scanned`
+            when the page is full (same length as `max_members`), otherwise null.
+            For `mode=permanent` with `dry_run=false`, when at least one member was removed this page,
+            repeats `mailchimp_offset` so the caller re-reads the same offset (permanent deletes shift
+            indices). When zero members were removed and the page is full, advances by `scanned`;
+            otherwise null.
         removed_sample:
           type: array
           items:
             $ref: "#/components/schemas/MailchimpOrphanRemovedSampleItem"
         dry_run:
           type: boolean
+        already_archived:
+          type: integer
+          description: |
+            Archive mode only: members already in Mailchimp `archived` state skipped without API calls.
+            Zero in permanent mode (archived members are still eligible for permanent erase).
+        would_remove:
+          type: integer
+          description: |
+            When `dry_run` is true, counts members that would be removed or archived. Zero when
+            `dry_run` is false; use `removed` for executed runs.
     MailchimpSyncStatusResponse:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -59,7 +59,9 @@ their primary responsibilities.
   downloads keyed by changing `s3_key` generally avoid that.
   `/v1/admin/contacts/*` (including `GET /v1/admin/contacts` optional `contact_type` filter;
   list and single-contact responses include read-only `family_location_summary` and
-  `organization_location_summary` when the contact is linked to a family or organisation that has a venue location),
+  `organization_location_summary` when the contact is linked to a family or organisation that has a venue location;
+  `POST /v1/admin/contacts/mailchimp-sync-run`, `POST /v1/admin/contacts/mailchimp-sync-orphans`, and
+  `GET /v1/admin/contacts/mailchimp-sync-status` for production Mailchimp audience sync, orphan cleanup, and status counters),
   `/v1/admin/tags/*` for CRM tag catalog administration (list with optional `include_archived` or
   `archived_only`, create, update, `PATCH` `archived` to restore, delete returns `deleted` +
   `usage_count`; system tag names are protected),

--- a/tests/api/test_admin_contacts_mailchimp_orphans.py
+++ b/tests/api/test_admin_contacts_mailchimp_orphans.py
@@ -10,6 +10,21 @@ from app.api import admin_contacts_mailchimp_sync as mcm
 from app.db.models.enums import MailchimpSyncStatus
 
 
+def _fake_iter(members: list[dict[str, Any]]):
+    def _iter(
+        *,
+        page_size: int,
+        start_offset: int,
+        single_page: bool,
+        fields: tuple[str, ...],
+    ):
+        assert single_page is True
+        assert isinstance(fields, tuple)
+        return iter(members)
+
+    return _iter
+
+
 def test_orphan_dry_run_no_archive_calls(
     monkeypatch: pytest.MonkeyPatch,
     api_gateway_event: Any,
@@ -22,11 +37,7 @@ def test_orphan_dry_run_no_archive_calls(
     members = [
         {"email_address": "orphan@example.com", "status": "subscribed"},
     ]
-    monkeypatch.setattr(
-        mcm,
-        "iter_audience_members",
-        lambda **kwargs: iter(members),
-    )
+    monkeypatch.setattr(mcm, "iter_audience_members", _fake_iter(members))
 
     called: list[Any] = []
 
@@ -43,7 +54,7 @@ def test_orphan_dry_run_no_archive_calls(
         def __enter__(self) -> "_FakeSession":
             return self
 
-        def __exit__(self, *_a: Any) -> None:
+        def __exit__(self, *_a: Any, **_k: Any) -> None:
             return None
 
         def execute(self, *_a: Any, **_k: Any) -> Any:
@@ -77,7 +88,8 @@ def test_orphan_dry_run_no_archive_calls(
     assert called == []
     body = json.loads(resp["body"])
     assert body["dry_run"] is True
-    assert body["removed"] >= 1
+    assert body["removed"] == 0
+    assert body["would_remove"] >= 1
 
 
 def test_orphan_next_offset_when_full_page(
@@ -90,11 +102,7 @@ def test_orphan_next_offset_when_full_page(
     monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
 
     members = [{"email_address": f"u{i}@example.com", "status": "subscribed"} for i in range(3)]
-    monkeypatch.setattr(
-        mcm,
-        "iter_audience_members",
-        lambda **kwargs: iter(members),
-    )
+    monkeypatch.setattr(mcm, "iter_audience_members", _fake_iter(members))
 
     class _FakeSession:
         def __init__(self, *_a: Any, **_k: Any) -> None:
@@ -103,7 +111,7 @@ def test_orphan_next_offset_when_full_page(
         def __enter__(self) -> "_FakeSession":
             return self
 
-        def __exit__(self, *_a: Any) -> None:
+        def __exit__(self, *_a: Any, **_k: Any) -> None:
             return None
 
         def execute(self, *_a: Any, **_k: Any) -> Any:
@@ -140,3 +148,140 @@ def test_orphan_next_offset_when_full_page(
     body = json.loads(resp["body"])
     assert body["scanned"] == 3
     assert body["next_offset"] == 3
+
+
+def test_orphan_permanent_next_offset_repeats_when_removed(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
+    members = [
+        {"email_address": "gone@example.com", "status": "subscribed"},
+    ]
+    monkeypatch.setattr(mcm, "iter_audience_members", _fake_iter(members))
+
+    monkeypatch.setattr(
+        mcm,
+        "remove_contact_from_mailchimp",
+        lambda **kwargs: "removed",
+    )
+
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def find_by_email(self, _email: str) -> Any:
+            return None
+
+    monkeypatch.setattr(mcm, "Session", _FakeSession)
+    monkeypatch.setattr(mcm, "get_engine", lambda: object())
+    monkeypatch.setattr(mcm, "ContactRepository", _FakeRepo)
+
+    offset = 40
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-orphans",
+        body=json.dumps(
+            {
+                "dry_run": False,
+                "mode": "permanent",
+                "max_members": 50,
+                "mailchimp_offset": offset,
+            }
+        ),
+        authorizer_context=admin_identity,
+    )
+    resp = mcm.run_mailchimp_orphan_cleanup(event, actor_sub="sub")
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["removed"] >= 1
+    assert body["next_offset"] == offset
+
+
+def test_orphan_archive_skips_already_archived_no_api(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
+    members = [
+        {"email_address": "old@example.com", "status": "archived"},
+    ]
+    monkeypatch.setattr(mcm, "iter_audience_members", _fake_iter(members))
+
+    called: list[Any] = []
+
+    def _no_remove(**_kwargs: Any) -> Any:
+        called.append(True)
+        return "removed"
+
+    monkeypatch.setattr(mcm, "remove_contact_from_mailchimp", _no_remove)
+
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def find_by_email(self, _email: str) -> Any:
+            return None
+
+    monkeypatch.setattr(mcm, "Session", _FakeSession)
+    monkeypatch.setattr(mcm, "get_engine", lambda: object())
+    monkeypatch.setattr(mcm, "ContactRepository", _FakeRepo)
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-orphans",
+        body=json.dumps({"dry_run": False, "mode": "archive", "max_members": 10}),
+        authorizer_context=admin_identity,
+    )
+    resp = mcm.run_mailchimp_orphan_cleanup(event, actor_sub="sub")
+    assert resp["statusCode"] == 200
+    assert called == []
+    body = json.loads(resp["body"])
+    assert body["already_archived"] == 1
+    assert body["removed"] == 0

--- a/tests/api/test_admin_contacts_mailchimp_orphans.py
+++ b/tests/api/test_admin_contacts_mailchimp_orphans.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.api import admin_contacts_mailchimp_sync as mcm
+from app.db.models.enums import MailchimpSyncStatus
+
+
+def test_orphan_dry_run_no_archive_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
+    members = [
+        {"email_address": "orphan@example.com", "status": "subscribed"},
+    ]
+    monkeypatch.setattr(
+        mcm,
+        "iter_audience_members",
+        lambda **kwargs: iter(members),
+    )
+
+    called: list[Any] = []
+
+    def _no_remove(**_kwargs: Any) -> Any:
+        called.append(True)
+        return "removed"
+
+    monkeypatch.setattr(mcm, "remove_contact_from_mailchimp", _no_remove)
+
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any) -> None:
+            return None
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def find_by_email(self, _email: str) -> Any:
+            return None
+
+    monkeypatch.setattr(mcm, "Session", _FakeSession)
+    monkeypatch.setattr(mcm, "get_engine", lambda: object())
+    monkeypatch.setattr(mcm, "ContactRepository", _FakeRepo)
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-orphans",
+        body=json.dumps({"dry_run": True, "max_members": 200}),
+        authorizer_context=admin_identity,
+    )
+    resp = mcm.run_mailchimp_orphan_cleanup(event, actor_sub="sub")
+    assert resp["statusCode"] == 200
+    assert called == []
+    body = json.loads(resp["body"])
+    assert body["dry_run"] is True
+    assert body["removed"] >= 1
+
+
+def test_orphan_next_offset_when_full_page(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
+    members = [{"email_address": f"u{i}@example.com", "status": "subscribed"} for i in range(3)]
+    monkeypatch.setattr(
+        mcm,
+        "iter_audience_members",
+        lambda **kwargs: iter(members),
+    )
+
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any) -> None:
+            return None
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def find_by_email(self, email: str) -> Any:
+            c = MagicMock()
+            c.archived_at = None
+            c.mailchimp_status = MailchimpSyncStatus.SYNCED
+            c.mailchimp_subscriber_id = "x"
+            return c
+
+    monkeypatch.setattr(mcm, "Session", _FakeSession)
+    monkeypatch.setattr(mcm, "get_engine", lambda: object())
+    monkeypatch.setattr(mcm, "ContactRepository", _FakeRepo)
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-orphans",
+        body=json.dumps({"dry_run": True, "max_members": 3, "mailchimp_offset": 0}),
+        authorizer_context=admin_identity,
+    )
+    resp = mcm.run_mailchimp_orphan_cleanup(event, actor_sub="sub")
+    body = json.loads(resp["body"])
+    assert body["scanned"] == 3
+    assert body["next_offset"] == 3

--- a/tests/api/test_admin_contacts_mailchimp_status.py
+++ b/tests/api/test_admin_contacts_mailchimp_status.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.api import admin_contacts_mailchimp_sync as mcm
+
+
+def test_mailchimp_sync_status_counts(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any) -> None:
+            return None
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def count_by_mailchimp_status(self) -> dict[Any, int]:
+            from app.db.models.enums import MailchimpSyncStatus
+
+            return {
+                MailchimpSyncStatus.PENDING: 2,
+                MailchimpSyncStatus.SYNCED: 3,
+                MailchimpSyncStatus.FAILED: 0,
+                MailchimpSyncStatus.UNSUBSCRIBED: 1,
+            }
+
+        def count_archived_with_mailchimp_record(self) -> int:
+            return 4
+
+    monkeypatch.setattr(mcm, "Session", _FakeSession)
+    monkeypatch.setattr(mcm, "get_engine", lambda: object())
+    monkeypatch.setattr(mcm, "ContactRepository", _FakeRepo)
+
+    event = api_gateway_event(
+        method="GET",
+        path="/v1/admin/contacts/mailchimp-sync-status",
+        authorizer_context=admin_identity,
+    )
+    resp = mcm.get_mailchimp_sync_summary(event)
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["counts_by_status"]["pending"] == 2
+    assert body["counts_by_status"]["synced"] == 3
+    assert body["archived_with_mailchimp_record"] == 4
+    assert body["last_run_summary"] is None

--- a/tests/api/test_admin_contacts_mailchimp_sync_run.py
+++ b/tests/api/test_admin_contacts_mailchimp_sync_run.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.api import admin_contacts_mailchimp_sync as mcm
+from app.db.models.enums import MailchimpSyncStatus
+from app.exceptions import ValidationError
+
+
+@pytest.fixture
+def production_mailchimp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
+
+def _identity_event(api_gateway_event: Any, admin_identity: dict[str, str]) -> dict[str, Any]:
+    return api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-run",
+        body=json.dumps(
+            {
+                "tag_name": "crm-bulk",
+                "max_contacts": 50,
+                "dry_run": False,
+            }
+        ),
+        authorizer_context=admin_identity,
+    )
+
+
+def test_sync_run_409_not_production(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "staging")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+    event = _identity_event(api_gateway_event, admin_identity)
+    resp = mcm.run_mailchimp_sync_batch(event, actor_sub="sub")
+    assert resp["statusCode"] == 409
+
+
+def test_sync_run_409_missing_list_id(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.delenv("MAILCHIMP_LIST_ID", raising=False)
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+    event = _identity_event(api_gateway_event, admin_identity)
+    resp = mcm.run_mailchimp_sync_batch(event, actor_sub="sub")
+    assert resp["statusCode"] == 409
+
+
+def test_sync_run_400_missing_tag_name(
+    production_mailchimp_env: None,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-run",
+        body=json.dumps({"max_contacts": 10}),
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(ValidationError, match="tag_name"):
+        mcm.run_mailchimp_sync_batch(event, actor_sub="sub")
+
+
+def test_sync_run_400_unsubscribed_in_only_statuses(
+    production_mailchimp_env: None,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-run",
+        body=json.dumps(
+            {
+                "tag_name": "crm-bulk",
+                "only_statuses": ["unsubscribed"],
+            }
+        ),
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(ValidationError, match="unsubscribed"):
+        mcm.run_mailchimp_sync_batch(event, actor_sub="sub")
+
+
+def test_sync_run_dry_run_skips_mailchimp(
+    production_mailchimp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    called: list[Any] = []
+
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any) -> None:
+            return None
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_for_mailchimp_sync(
+            self, *, limit: int, cursor: UUID | None, statuses: list[MailchimpSyncStatus]
+        ) -> list[Any]:
+            c = MagicMock()
+            c.id = uuid4()
+            c.email = "a@example.com"
+            c.first_name = "A"
+            c.archived_at = None
+            c.mailchimp_status = MailchimpSyncStatus.PENDING
+            return [c]
+
+    monkeypatch.setattr(mcm, "Session", _FakeSession)
+    monkeypatch.setattr(mcm, "get_engine", lambda: object())
+    monkeypatch.setattr(mcm, "ContactRepository", _FakeRepo)
+
+    def _no_upsert(**_kwargs: Any) -> tuple[str, int | None]:
+        called.append(True)
+        return "synced", None
+
+    monkeypatch.setattr(mcm, "upsert_contact_to_mailchimp", _no_upsert)
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-run",
+        body=json.dumps({"tag_name": "crm-bulk", "dry_run": True}),
+        authorizer_context=admin_identity,
+    )
+    resp = mcm.run_mailchimp_sync_batch(event, actor_sub="sub")
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["dry_run"] is True
+    assert body["processed"] == 1
+    assert called == []

--- a/tests/api/test_admin_contacts_mailchimp_sync_run.py
+++ b/tests/api/test_admin_contacts_mailchimp_sync_run.py
@@ -158,4 +158,139 @@ def test_sync_run_dry_run_skips_mailchimp(
     body = json.loads(resp["body"])
     assert body["dry_run"] is True
     assert body["processed"] == 1
+    assert body["would_process"] == 1
     assert called == []
+
+
+def test_sync_run_400_synced_in_only_statuses(
+    production_mailchimp_env: None,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-run",
+        body=json.dumps(
+            {
+                "tag_name": "crm-bulk",
+                "only_statuses": ["synced"],
+            }
+        ),
+        authorizer_context=admin_identity,
+    )
+    with pytest.raises(ValidationError, match="synced"):
+        mcm.run_mailchimp_sync_batch(event, actor_sub="sub")
+
+
+def test_sync_run_accepts_tag_name_with_dot_and_underscore(
+    production_mailchimp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_for_mailchimp_sync(
+            self, *, limit: int, cursor: UUID | None, statuses: list[MailchimpSyncStatus]
+        ) -> list[Any]:
+            return []
+
+    monkeypatch.setattr(mcm, "Session", _FakeSession)
+    monkeypatch.setattr(mcm, "get_engine", lambda: object())
+    monkeypatch.setattr(mcm, "ContactRepository", _FakeRepo)
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-run",
+        body=json.dumps({"tag_name": "crm.bulk_sync", "dry_run": True}),
+        authorizer_context=admin_identity,
+    )
+    resp = mcm.run_mailchimp_sync_batch(event, actor_sub="sub")
+    assert resp["statusCode"] == 200
+
+
+def test_sync_run_errors_sample_includes_lead_email_masked(
+    production_mailchimp_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class _FakeRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def list_for_mailchimp_sync(
+            self, *, limit: int, cursor: UUID | None, statuses: list[MailchimpSyncStatus]
+        ) -> list[Any]:
+            c = MagicMock()
+            c.id = uuid4()
+            c.email = "operator-visible@example.com"
+            c.first_name = "A"
+            c.archived_at = None
+            c.mailchimp_status = MailchimpSyncStatus.PENDING
+            return [c]
+
+    monkeypatch.setattr(mcm, "Session", _FakeSession)
+    monkeypatch.setattr(mcm, "get_engine", lambda: object())
+    monkeypatch.setattr(mcm, "ContactRepository", _FakeRepo)
+    monkeypatch.setattr(
+        mcm,
+        "upsert_contact_to_mailchimp",
+        lambda **_kwargs: ("failed", 503),
+    )
+
+    event = api_gateway_event(
+        method="POST",
+        path="/v1/admin/contacts/mailchimp-sync-run",
+        body=json.dumps({"tag_name": "crm-bulk", "dry_run": False}),
+        authorizer_context=admin_identity,
+    )
+    resp = mcm.run_mailchimp_sync_batch(event, actor_sub="sub")
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["failed"] == 1
+    assert body["errors_sample"]
+    sample = body["errors_sample"][0]
+    assert "lead_email_masked" in sample
+    assert sample["lead_email_masked"]
+    assert sample["lead_email_masked"] != "operator-visible@example.com"

--- a/tests/services/test_mailchimp_sync.py
+++ b/tests/services/test_mailchimp_sync.py
@@ -71,6 +71,9 @@ def test_upsert_skips_archived(monkeypatch: Any) -> None:
 
 
 def test_upsert_synced_updates_contact(monkeypatch: Any) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
     monkeypatch.setattr(
         "app.services.mailchimp_sync.run_with_retry",
         lambda op, *args, **kwargs: op(*args, **kwargs),
@@ -99,6 +102,9 @@ def test_upsert_synced_updates_contact(monkeypatch: Any) -> None:
 
 
 def test_upsert_failed_sets_status(monkeypatch: Any) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
     monkeypatch.setattr(
         "app.services.mailchimp_sync.run_with_retry",
         lambda *_a, **_k: (_ for _ in ()).throw(MailchimpApiError(500, "err")),
@@ -122,6 +128,9 @@ def test_upsert_failed_sets_status(monkeypatch: Any) -> None:
 
 
 def test_remove_calls_archive(monkeypatch: Any) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
     with patch(
         "app.services.mailchimp_sync.archive_subscriber",
         return_value=True,
@@ -138,3 +147,15 @@ def test_remove_calls_archive(monkeypatch: Any) -> None:
 def test_remove_skips_blank_email() -> None:
     log = MagicMock()
     assert remove_contact_from_mailchimp(email="  ", logger=log) == "skipped"
+
+
+def test_remove_skips_staging_even_with_mailchimp_env(monkeypatch: Any) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "staging")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+    with patch(
+        "app.services.mailchimp_sync.archive_subscriber",
+        side_effect=AssertionError("archive_subscriber must not run in staging"),
+    ):
+        log = MagicMock()
+        assert remove_contact_from_mailchimp(email="a@example.com", logger=log) == "skipped"

--- a/tests/services/test_mailchimp_sync.py
+++ b/tests/services/test_mailchimp_sync.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+
+from app.db.models.enums import MailchimpSyncStatus
+from app.services.mailchimp import MailchimpApiError
+from app.services.mailchimp_sync import (
+    remove_contact_from_mailchimp,
+    upsert_contact_to_mailchimp,
+)
+
+
+def test_upsert_skips_unsubscribed(monkeypatch: Any) -> None:
+    called: list[Any] = []
+
+    def _no_mc(**_kwargs: Any) -> dict[str, Any]:
+        called.append(True)
+        return {}
+
+    monkeypatch.setattr(
+        "app.services.mailchimp_sync.add_subscriber_with_tag",
+        _no_mc,
+    )
+    log = MagicMock()
+    contact = SimpleNamespace(
+        email="a@example.com",
+        first_name="Ann",
+        archived_at=None,
+        mailchimp_status=MailchimpSyncStatus.UNSUBSCRIBED,
+        mailchimp_subscriber_id=None,
+    )
+    outcome, status = upsert_contact_to_mailchimp(
+        contact=contact,
+        tag_name="crm-tag",
+        logger=log,
+    )
+    assert outcome == "skipped"
+    assert status is None
+    assert called == []
+
+
+def test_upsert_skips_archived(monkeypatch: Any) -> None:
+    called: list[Any] = []
+
+    def _no_mc(**_kwargs: Any) -> dict[str, Any]:
+        called.append(True)
+        return {}
+
+    monkeypatch.setattr(
+        "app.services.mailchimp_sync.add_subscriber_with_tag",
+        _no_mc,
+    )
+    log = MagicMock()
+    contact = SimpleNamespace(
+        email="a@example.com",
+        first_name="Ann",
+        archived_at=SimpleNamespace(),
+        mailchimp_status=MailchimpSyncStatus.PENDING,
+        mailchimp_subscriber_id=None,
+    )
+    outcome, _ = upsert_contact_to_mailchimp(
+        contact=contact,
+        tag_name="crm-tag",
+        logger=log,
+    )
+    assert outcome == "skipped"
+    assert called == []
+
+
+def test_upsert_synced_updates_contact(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        "app.services.mailchimp_sync.run_with_retry",
+        lambda op, *args, **kwargs: op(*args, **kwargs),
+    )
+    monkeypatch.setattr(
+        "app.services.mailchimp_sync.add_subscriber_with_tag",
+        lambda **_: {"id": "sub-99"},
+    )
+    log = MagicMock()
+    contact = SimpleNamespace(
+        email="a@example.com",
+        first_name="Ann",
+        archived_at=None,
+        mailchimp_status=MailchimpSyncStatus.PENDING,
+        mailchimp_subscriber_id=None,
+    )
+    outcome, err = upsert_contact_to_mailchimp(
+        contact=contact,
+        tag_name="crm-tag",
+        logger=log,
+    )
+    assert outcome == "synced"
+    assert err is None
+    assert contact.mailchimp_status == MailchimpSyncStatus.SYNCED
+    assert contact.mailchimp_subscriber_id == "sub-99"
+
+
+def test_upsert_failed_sets_status(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        "app.services.mailchimp_sync.run_with_retry",
+        lambda *_a, **_k: (_ for _ in ()).throw(MailchimpApiError(500, "err")),
+    )
+    log = MagicMock()
+    contact = SimpleNamespace(
+        email="a@example.com",
+        first_name="Ann",
+        archived_at=None,
+        mailchimp_status=MailchimpSyncStatus.PENDING,
+        mailchimp_subscriber_id=None,
+    )
+    outcome, err = upsert_contact_to_mailchimp(
+        contact=contact,
+        tag_name="crm-tag",
+        logger=log,
+    )
+    assert outcome == "failed"
+    assert err == 500
+    assert contact.mailchimp_status == MailchimpSyncStatus.FAILED
+
+
+def test_remove_calls_archive(monkeypatch: Any) -> None:
+    with patch(
+        "app.services.mailchimp_sync.archive_subscriber",
+        return_value=True,
+    ) as arch:
+        log = MagicMock()
+        outcome = remove_contact_from_mailchimp(
+            email="User@Example.com",
+            logger=log,
+        )
+    assert outcome == "removed"
+    arch.assert_called_once_with(email="user@example.com")
+
+
+def test_remove_skips_blank_email() -> None:
+    log = MagicMock()
+    assert remove_contact_from_mailchimp(email="  ", logger=log) == "skipped"

--- a/tests/test_admin_contacts_delete_archive_mailchimp.py
+++ b/tests/test_admin_contacts_delete_archive_mailchimp.py
@@ -15,6 +15,10 @@ def test_delete_contact_triggers_mailchimp_remove(
     api_gateway_event: Any,
     admin_identity: dict[str, str],
 ) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
     contact_id = uuid4()
     calls: list[str] = []
 
@@ -62,6 +66,7 @@ def test_delete_contact_triggers_mailchimp_remove(
     monkeypatch.setattr(mutations, "ContactRepository", lambda s: s.repo)
 
     def _capture_remove(**kwargs: Any) -> str:
+        assert kwargs.get("max_attempts") == 2
         calls.append(kwargs["email"])
         return "removed"
 
@@ -85,6 +90,10 @@ def test_delete_skips_mailchimp_when_unsubscribed(
     api_gateway_event: Any,
     admin_identity: dict[str, str],
 ) -> None:
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "production")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
     contact_id = uuid4()
     calls: list[str] = []
 
@@ -146,3 +155,77 @@ def test_delete_skips_mailchimp_when_unsubscribed(
         event, contact_id=contact_id, actor_sub=admin_identity["userSub"]
     )
     assert calls == []
+
+
+def test_delete_skips_mailchimp_remove_in_staging_without_calling_archive(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    """Per-row Mailchimp removal is production-only; staging must not hit Mailchimp APIs."""
+    monkeypatch.setenv("DEPLOYMENT_STAGE", "staging")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
+    contact_id = uuid4()
+
+    class _FakeContact:
+        def __init__(self) -> None:
+            self.email = "staging@example.com"
+            self.mailchimp_status = MailchimpSyncStatus.SYNCED
+
+    class _FakeRepo:
+        def get_by_id_for_admin(self, cid: Any) -> Any:
+            assert cid == contact_id
+            return _FakeContact()
+
+        def delete(self, _c: Any) -> None:
+            return None
+
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            self.repo = _FakeRepo()
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        def scalars(self, *_a: Any, **_k: Any) -> Any:
+            class _R:
+                def all(self) -> list[Any]:
+                    return []
+
+            return _R()
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    monkeypatch.setattr(mutations, "Session", _FakeSession)
+    monkeypatch.setattr(mutations, "get_engine", lambda: object())
+    monkeypatch.setattr(mutations, "ContactRepository", lambda s: s.repo)
+    monkeypatch.setattr(mutations, "set_audit_context", lambda *a, **k: None)
+
+    monkeypatch.setattr(
+        "app.services.mailchimp_sync.archive_subscriber",
+        lambda **_k: (_ for _ in ()).throw(
+            AssertionError("archive_subscriber must not run in staging")
+        ),
+    )
+
+    event = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/contacts/{contact_id}",
+        authorizer_context=admin_identity,
+    )
+    resp = mutations.delete_contact(
+        event, contact_id=contact_id, actor_sub=admin_identity["userSub"]
+    )
+    assert resp["statusCode"] == 204

--- a/tests/test_admin_contacts_delete_archive_mailchimp.py
+++ b/tests/test_admin_contacts_delete_archive_mailchimp.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.api import admin_contacts_mutations as mutations
+from app.db.models.enums import MailchimpSyncStatus
+
+
+def test_delete_contact_triggers_mailchimp_remove(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    contact_id = uuid4()
+    calls: list[str] = []
+
+    class _FakeContact:
+        def __init__(self) -> None:
+            self.email = "keep@example.com"
+            self.mailchimp_status = MailchimpSyncStatus.SYNCED
+
+    class _FakeRepo:
+        def get_by_id_for_admin(self, cid: Any) -> Any:
+            assert cid == contact_id
+            return _FakeContact()
+
+        def delete(self, _c: Any) -> None:
+            return None
+
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            self.repo = _FakeRepo()
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any) -> None:
+            return None
+
+        def scalars(self, *_a: Any, **_k: Any) -> Any:
+            class _R:
+                def all(self) -> list[Any]:
+                    return []
+
+            return _R()
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    monkeypatch.setattr(mutations, "Session", _FakeSession)
+    monkeypatch.setattr(mutations, "get_engine", lambda: object())
+    monkeypatch.setattr(mutations, "ContactRepository", lambda s: s.repo)
+
+    def _capture_remove(**kwargs: Any) -> str:
+        calls.append(kwargs["email"])
+        return "removed"
+
+    monkeypatch.setattr(mutations, "remove_contact_from_mailchimp", _capture_remove)
+    monkeypatch.setattr(mutations, "set_audit_context", lambda *a, **k: None)
+
+    event = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/contacts/{contact_id}",
+        authorizer_context=admin_identity,
+    )
+    resp = mutations.delete_contact(
+        event, contact_id=contact_id, actor_sub=admin_identity["userSub"]
+    )
+    assert resp["statusCode"] == 204
+    assert calls == ["keep@example.com"]
+
+
+def test_delete_skips_mailchimp_when_unsubscribed(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+) -> None:
+    contact_id = uuid4()
+    calls: list[str] = []
+
+    class _FakeContact:
+        def __init__(self) -> None:
+            self.email = "gone@example.com"
+            self.mailchimp_status = MailchimpSyncStatus.UNSUBSCRIBED
+
+    class _FakeRepo:
+        def get_by_id_for_admin(self, cid: Any) -> Any:
+            return _FakeContact()
+
+        def delete(self, _c: Any) -> None:
+            return None
+
+    class _FakeSession:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            self.repo = _FakeRepo()
+
+        def __enter__(self) -> "_FakeSession":
+            return self
+
+        def __exit__(self, *_a: Any) -> None:
+            return None
+
+        def scalars(self, *_a: Any, **_k: Any) -> Any:
+            class _R:
+                def all(self) -> list[Any]:
+                    return []
+
+            return _R()
+
+        def execute(self, *_a: Any, **_k: Any) -> Any:
+            return MagicMock()
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    monkeypatch.setattr(mutations, "Session", _FakeSession)
+    monkeypatch.setattr(mutations, "get_engine", lambda: object())
+    monkeypatch.setattr(mutations, "ContactRepository", lambda s: s.repo)
+
+    monkeypatch.setattr(
+        mutations,
+        "remove_contact_from_mailchimp",
+        lambda **kwargs: calls.append("bad") or "removed",
+    )
+    monkeypatch.setattr(mutations, "set_audit_context", lambda *a, **k: None)
+
+    event = api_gateway_event(
+        method="DELETE",
+        path=f"/v1/admin/contacts/{contact_id}",
+        authorizer_context=admin_identity,
+    )
+    mutations.delete_contact(
+        event, contact_id=contact_id, actor_sub=admin_identity["userSub"]
+    )
+    assert calls == []

--- a/tests/test_mailchimp_service.py
+++ b/tests/test_mailchimp_service.py
@@ -183,3 +183,70 @@ def test_mailchimp_truncates_long_error_body_in_logs(monkeypatch: Any) -> None:
     body = recorded[0].get("mailchimp_error_body", "")
     assert body.endswith("...(truncated)")
     assert len(body) < len(long_body)
+
+
+def test_archive_subscriber_204_and_404(monkeypatch: Any) -> None:
+    monkeypatch.setattr(mailchimp, "_api_key_cache", "fake-key-us12")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+
+    def del_204(**_kwargs: Any) -> dict[str, Any]:
+        return {"status": 204, "body": ""}
+
+    monkeypatch.setattr(mailchimp, "http_invoke", del_204)
+    assert mailchimp.archive_subscriber(email="a@example.com") is True
+
+    monkeypatch.setattr(
+        mailchimp,
+        "http_invoke",
+        lambda **_k: {"status": 404, "body": "{}"},
+    )
+    assert mailchimp.archive_subscriber(email="a@example.com") is True
+
+
+def test_archive_subscriber_500_raises(monkeypatch: Any) -> None:
+    monkeypatch.setattr(mailchimp, "_api_key_cache", "fake-key-us12")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+    monkeypatch.setattr(
+        mailchimp,
+        "http_invoke",
+        lambda **_k: {"status": 500, "body": "{}"},
+    )
+    with pytest.raises(mailchimp.MailchimpApiError):
+        mailchimp.archive_subscriber(email="a@example.com")
+
+
+def test_permanent_delete_subscriber_404(monkeypatch: Any) -> None:
+    monkeypatch.setattr(mailchimp, "_api_key_cache", "fake-key-us12")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+    monkeypatch.setattr(
+        mailchimp,
+        "http_invoke",
+        lambda **_k: {"status": 404, "body": ""},
+    )
+    assert mailchimp.permanent_delete_subscriber(email="a@example.com") is True
+
+
+def test_iter_audience_members_paginates_and_forwards_fields(monkeypatch: Any) -> None:
+    monkeypatch.setattr(mailchimp, "_api_key_cache", "fake-key-us12")
+    monkeypatch.setenv("MAILCHIMP_LIST_ID", "list1")
+    monkeypatch.setenv("MAILCHIMP_SERVER_PREFIX", "us12")
+    calls: list[str] = []
+    state = {"page": 0}
+
+    def fake_http_invoke(**kwargs: Any) -> dict[str, Any]:
+        calls.append(str(kwargs.get("url", "")))
+        state["page"] += 1
+        if state["page"] == 1:
+            members = [{"email_address": f"u{i}@example.com"} for i in range(100)]
+            return {"status": 200, "body": json.dumps({"members": members})}
+        members = [{"email_address": f"v{i}@example.com"} for i in range(50)]
+        return {"status": 200, "body": json.dumps({"members": members})}
+
+    monkeypatch.setattr(mailchimp, "http_invoke", fake_http_invoke)
+    out = list(mailchimp.iter_audience_members(page_size=100))
+    assert len(out) == 150
+    assert all("fields=" in u for u in calls)
+    assert all("members.email_address" in u for u in calls)

--- a/tests/test_media_processor_handler.py
+++ b/tests/test_media_processor_handler.py
@@ -212,7 +212,9 @@ def test_process_message_uses_keyword_session_for_contact_tag(
         "_ensure_share_link_url_for_asset",
         lambda **_: "https://media.example.com/v1/assets/share/TOKEN",
     )
-    monkeypatch.setattr(handler, "_sync_contact_to_mailchimp", lambda **_: True)
+    monkeypatch.setattr(
+        handler, "upsert_contact_to_mailchimp", lambda **_: ("synced", None)
+    )
     monkeypatch.setattr(handler, "_trigger_mailchimp_journey", lambda **_: True)
 
     was_processed = handler._process_message(
@@ -311,7 +313,9 @@ def test_process_message_opt_in_skips_second_subscribe_when_mailchimp_synced(
         lambda **_: "https://media.example.com/v1/assets/share/TOKEN",
     )
     monkeypatch.setattr(handler, "_send_user_download_email", lambda **_: None)
-    monkeypatch.setattr(handler, "_sync_contact_to_mailchimp", lambda **_: True)
+    monkeypatch.setattr(
+        handler, "upsert_contact_to_mailchimp", lambda **_: ("synced", None)
+    )
     monkeypatch.setattr(handler, "_trigger_mailchimp_journey", lambda **_: True)
     monkeypatch.setattr(handler, "subscribe_to_marketing", _fake_subscribe)
 
@@ -384,9 +388,9 @@ def test_process_message_require_consent_skips_mailchimp_without_opt_in(
         def create_with_event(self, *args: Any, **kwargs: Any) -> Any:
             return SimpleNamespace(id=UUID("dddddddd-dddd-dddd-dddd-dddddddddddd"))
 
-    def _fake_sync(**kwargs: Any) -> bool:
+    def _fake_sync(**kwargs: Any) -> tuple[str, int | None]:
         sync_calls.append(kwargs)
-        return True
+        return "synced", None
 
     monkeypatch.setenv("MAILCHIMP_REQUIRE_MARKETING_CONSENT", "true")
     monkeypatch.setattr(handler, "get_engine", lambda: object())
@@ -410,7 +414,7 @@ def test_process_message_require_consent_skips_mailchimp_without_opt_in(
         lambda **_: "https://media.example.com/v1/assets/share/TOKEN",
     )
     monkeypatch.setattr(handler, "_send_user_download_email", lambda **_: None)
-    monkeypatch.setattr(handler, "_sync_contact_to_mailchimp", _fake_sync)
+    monkeypatch.setattr(handler, "upsert_contact_to_mailchimp", _fake_sync)
     monkeypatch.setattr(handler, "_trigger_mailchimp_journey", lambda **_: True)
     monkeypatch.setattr(handler, "_send_media_lead_sales_recap", lambda **_: None)
     monkeypatch.setattr(handler, "_create_sales_lead_event", lambda **_: None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Follow-up

- **Mypy:** `_require_production_mailchimp_or_409` now ends with an explicit `return None` so mypy accepts all paths (`return` error at line 42). The branch is logically redundant when production + Mailchimp env are both satisfied (then `_mailchimp_runtime_ready()` is true and we return earlier); the comment documents why the fall-through exists for the type checker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02f72008-14b3-447d-88c0-077c3bdab8a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02f72008-14b3-447d-88c0-077c3bdab8a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

