### PR TITLE
Admin web: Mailchimp sync card on contacts panel

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -9,6 +9,7 @@ import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
 import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
 import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
 import { ContactNotesModal } from '@/components/admin/contacts/contact-notes-modal';
+import { MailchimpSyncCard } from '@/components/admin/contacts/mailchimp-sync-card';
 import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { ArchiveIcon, DeleteIcon, NoteIcon, RestoreIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
@@ -580,6 +581,7 @@ export function ContactsPanel({
         onClose={() => setNotesTarget(null)}
         onStandaloneNoteCountChange={onPatchStandaloneNoteCount}
       />
+      <MailchimpSyncCard />
       <AdminEditorCard
         title='Contact'
         description='Create a contact or select a row below to edit. When this contact is linked to a family or organisation, set location on that record instead. Mailchimp sync status is read-only from the API.'

--- a/apps/admin_web/src/components/admin/contacts/mailchimp-sync-card.tsx
+++ b/apps/admin_web/src/components/admin/contacts/mailchimp-sync-card.tsx
@@ -1,0 +1,477 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { MAILCHIMP_PRODUCTION_GATE_MESSAGE, useMailchimpSync } from '@/hooks/use-mailchimp-sync';
+import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+
+const TAG_NAME_REGEX = /^[a-zA-Z0-9 ._-]{1,100}$/;
+const DEFAULT_TAG_NAME = 'crm-bulk-sync';
+
+function formatRelativeAgo(fromMs: number): string {
+  const sec = Math.max(0, Math.floor((Date.now() - fromMs) / 1000));
+  if (sec < 10) {
+    return 'just now';
+  }
+  if (sec < 60) {
+    return `${sec}s ago`;
+  }
+  const min = Math.floor(sec / 60);
+  if (min < 60) {
+    return `${min}m ago`;
+  }
+  const hr = Math.floor(min / 60);
+  if (hr < 48) {
+    return `${hr}h ago`;
+  }
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+function countFor(status: Record<string, number> | undefined, key: string): number {
+  if (!status) {
+    return 0;
+  }
+  const v = status[key];
+  return typeof v === 'number' ? v : 0;
+}
+
+export function MailchimpSyncCard() {
+  const {
+    status,
+    statusLoading,
+    statusError,
+    refetchStatus,
+    productionGated,
+    syncRun,
+    startSyncRun,
+    abortSyncRun,
+    orphanRun,
+    startOrphanRun,
+    abortOrphanRun,
+  } = useMailchimpSync();
+
+  const [lastRefreshSnapshotMs, setLastRefreshSnapshotMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!status) {
+      return;
+    }
+    const id = window.setTimeout(() => {
+      setLastRefreshSnapshotMs(Date.now());
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [status]);
+
+  const [tagName, setTagName] = useState(DEFAULT_TAG_NAME);
+  const [maxContacts, setMaxContacts] = useState(100);
+  const [pendingChecked, setPendingChecked] = useState(true);
+  const [failedChecked, setFailedChecked] = useState(true);
+  const [syncDryRun, setSyncDryRun] = useState(true);
+  const [syncRunUsedDryRun, setSyncRunUsedDryRun] = useState(true);
+
+  const [orphanMaxMembers, setOrphanMaxMembers] = useState(200);
+  const [orphanMode, setOrphanMode] = useState<'archive' | 'permanent'>('archive');
+  const [orphanDryRun, setOrphanDryRun] = useState(true);
+  const [orphanRunUsedDryRun, setOrphanRunUsedDryRun] = useState(true);
+
+  const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
+  const [permanentConfirmOpen, setPermanentConfirmOpen] = useState(false);
+  const [permanentConfirmInput, setPermanentConfirmInput] = useState('');
+
+  const tagNameValid = TAG_NAME_REGEX.test(tagName.trim());
+  const onlyStatuses = useMemo(() => {
+    const list: ('pending' | 'failed')[] = [];
+    if (pendingChecked) {
+      list.push('pending');
+    }
+    if (failedChecked) {
+      list.push('failed');
+    }
+    return list;
+  }, [pendingChecked, failedChecked]);
+  const statusesSelectionValid = onlyStatuses.length > 0;
+
+  const relativeRefresh = useMemo(() => {
+    if (lastRefreshSnapshotMs === null) {
+      return '—';
+    }
+    return formatRelativeAgo(lastRefreshSnapshotMs);
+  }, [lastRefreshSnapshotMs]);
+
+  const gateNotice = (
+    <p className='rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700'>
+      {MAILCHIMP_PRODUCTION_GATE_MESSAGE}
+    </p>
+  );
+
+  function handleSyncPrimaryClick() {
+    if (syncRun.state === 'running') {
+      abortSyncRun();
+      return;
+    }
+    setSyncRunUsedDryRun(syncDryRun);
+    void startSyncRun({
+      tagName: tagName.trim(),
+      maxContacts,
+      onlyStatuses,
+      dryRun: syncDryRun,
+    });
+  }
+
+  function handleOrphanPrimaryClick() {
+    if (orphanRun.state === 'running') {
+      abortOrphanRun();
+      return;
+    }
+    if (orphanDryRun) {
+      setOrphanRunUsedDryRun(true);
+      void startOrphanRun({
+        maxMembers: orphanMaxMembers,
+        mode: orphanMode,
+        dryRun: true,
+      });
+      return;
+    }
+    if (orphanMode === 'archive') {
+      setArchiveConfirmOpen(true);
+      return;
+    }
+    setPermanentConfirmInput('');
+    setPermanentConfirmOpen(true);
+  }
+
+  function confirmArchiveOrphanRun() {
+    setArchiveConfirmOpen(false);
+    setOrphanRunUsedDryRun(false);
+    void startOrphanRun({
+      maxMembers: orphanMaxMembers,
+      mode: 'archive',
+      dryRun: false,
+    });
+  }
+
+  function confirmPermanentOrphanRun() {
+    setPermanentConfirmOpen(false);
+    setPermanentConfirmInput('');
+    setOrphanRunUsedDryRun(false);
+    void startOrphanRun({
+      maxMembers: orphanMaxMembers,
+      mode: 'permanent',
+      dryRun: false,
+    });
+  }
+
+  const syncPrimaryDisabled =
+    syncRun.state !== 'running' &&
+    (!tagNameValid || !statusesSelectionValid || statusLoading);
+
+  const orphanPrimaryDisabled = orphanRun.state !== 'running' && statusLoading;
+
+  const showSyncProgress = syncRun.state !== 'idle';
+  const showOrphanProgress = orphanRun.state !== 'idle';
+
+  return (
+    <Card title='Mailchimp sync'>
+      <div className='space-y-6'>
+        <div className='space-y-3'>
+          <div className='flex flex-wrap items-center justify-between gap-2'>
+            <h3 className='text-sm font-semibold text-slate-900'>Status snapshot</h3>
+            <Button
+              type='button'
+              variant='secondary'
+              size='sm'
+              disabled={statusLoading}
+              onClick={() => void refetchStatus()}
+            >
+              Refresh
+            </Button>
+          </div>
+          {statusError ? (
+            <p className='text-sm text-red-800' role='alert'>
+              {statusError}
+            </p>
+          ) : null}
+          <div className='grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-6'>
+            <div className='rounded-md border border-slate-200 bg-slate-50/80 p-2 text-center'>
+              <div className='text-xs font-medium text-slate-600'>Pending</div>
+              <div className='text-lg font-semibold text-slate-900'>
+                {countFor(status?.counts_by_status, 'pending')}
+              </div>
+            </div>
+            <div className='rounded-md border border-slate-200 bg-slate-50/80 p-2 text-center'>
+              <div className='text-xs font-medium text-slate-600'>Synced</div>
+              <div className='text-lg font-semibold text-slate-900'>
+                {countFor(status?.counts_by_status, 'synced')}
+              </div>
+            </div>
+            <div className='rounded-md border border-slate-200 bg-slate-50/80 p-2 text-center'>
+              <div className='text-xs font-medium text-slate-600'>Failed</div>
+              <div className='text-lg font-semibold text-slate-900'>
+                {countFor(status?.counts_by_status, 'failed')}
+              </div>
+            </div>
+            <div className='rounded-md border border-slate-200 bg-slate-50/80 p-2 text-center'>
+              <div className='text-xs font-medium text-slate-600'>Unsubscribed</div>
+              <div className='text-lg font-semibold text-slate-900'>
+                {countFor(status?.counts_by_status, 'unsubscribed')}
+              </div>
+            </div>
+            <div className='rounded-md border border-slate-200 bg-slate-50/80 p-2 text-center'>
+              <div className='text-xs font-medium text-slate-600'>Archived w/ MC record</div>
+              <div className='text-lg font-semibold text-slate-900'>
+                {status?.archived_with_mailchimp_record ?? 0}
+              </div>
+            </div>
+            <div className='rounded-md border border-slate-200 bg-slate-50/80 p-2 text-center'>
+              <div className='text-xs font-medium text-slate-600'>Last refreshed</div>
+              <div className='text-lg font-semibold text-slate-900'>{relativeRefresh}</div>
+            </div>
+          </div>
+        </div>
+
+        <AdminCollapsibleSection id='mailchimp-sync-push' title='Push CRM contacts to Mailchimp'>
+          {productionGated ? (
+            gateNotice
+          ) : (
+            <div className='space-y-4'>
+              <div className='space-y-2'>
+                <Label htmlFor='mailchimp-sync-tag-name'>tag_name</Label>
+                <Input
+                  id='mailchimp-sync-tag-name'
+                  value={tagName}
+                  onChange={(e) => setTagName(e.target.value)}
+                  autoComplete='off'
+                />
+                {!tagNameValid ? (
+                  <p className='text-xs text-red-700'>
+                    Use 1–100 characters: letters, numbers, spaces, dots, underscores, hyphens.
+                  </p>
+                ) : null}
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='mailchimp-sync-max-contacts'>max_contacts</Label>
+                <Input
+                  id='mailchimp-sync-max-contacts'
+                  type='number'
+                  min={1}
+                  max={200}
+                  value={maxContacts}
+                  onChange={(e) => setMaxContacts(Number.parseInt(e.target.value, 10) || 1)}
+                />
+              </div>
+              <fieldset className='space-y-2'>
+                <legend className='text-sm font-medium text-slate-800'>only_statuses</legend>
+                <div className='flex flex-wrap gap-4'>
+                  <label className='flex items-center gap-2 text-sm text-slate-800'>
+                    <input
+                      type='checkbox'
+                      checked={pendingChecked}
+                      onChange={(e) => setPendingChecked(e.target.checked)}
+                      className='h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500'
+                    />
+                    Pending
+                  </label>
+                  <label className='flex items-center gap-2 text-sm text-slate-800'>
+                    <input
+                      type='checkbox'
+                      checked={failedChecked}
+                      onChange={(e) => setFailedChecked(e.target.checked)}
+                      className='h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500'
+                    />
+                    Failed
+                  </label>
+                </div>
+              </fieldset>
+              <label className='flex items-center gap-2 text-sm text-slate-800'>
+                <input
+                  type='checkbox'
+                  checked={syncDryRun}
+                  onChange={(e) => setSyncDryRun(e.target.checked)}
+                  className='h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500'
+                />
+                dry_run (default on)
+              </label>
+              <div>
+                <Button
+                  type='button'
+                  variant={syncRun.state === 'running' ? 'secondary' : 'primary'}
+                  disabled={syncPrimaryDisabled}
+                  onClick={handleSyncPrimaryClick}
+                >
+                  {syncRun.state === 'running' ? 'Stop' : 'Run upsert batch'}
+                </Button>
+              </div>
+              {showSyncProgress ? (
+                <div className='space-y-3 rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-800'>
+                  <div className='font-medium text-slate-900'>Progress</div>
+                  <ul className='grid gap-1 sm:grid-cols-2'>
+                    <li>batches: {syncRun.totals.batches}</li>
+                    <li>processed: {syncRun.totals.processed}</li>
+                    {syncRunUsedDryRun ? (
+                      <li className='sm:col-span-2'>Would process: {syncRun.totals.wouldProcess}</li>
+                    ) : (
+                      <li>succeeded: {syncRun.totals.succeeded}</li>
+                    )}
+                    <li>failed: {syncRun.totals.failed}</li>
+                    <li>skipped: {syncRun.totals.skipped}</li>
+                  </ul>
+                  {syncRun.error ? (
+                    <p className='text-sm text-red-800' role='alert'>
+                      {syncRun.error}
+                    </p>
+                  ) : null}
+                  {syncRun.totals.errorsSample.length > 0 ? (
+                    <div className='space-y-1'>
+                      <div className='text-xs font-semibold uppercase tracking-wide text-slate-600'>
+                        errors_sample
+                      </div>
+                      <ul className='space-y-2 divide-y divide-slate-100'>
+                        {syncRun.totals.errorsSample.map((row) => (
+                          <li key={`${row.contact_id}-${row.lead_email_masked}-${row.reason}`} className='pt-2 first:pt-0'>
+                            <div className='font-medium text-slate-900'>{row.lead_email_masked}</div>
+                            <div className='text-xs text-slate-600'>
+                              {row.contact_id.slice(0, 8)} · {row.reason}
+                              {row.status != null ? ` · HTTP ${row.status}` : ''}
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          )}
+        </AdminCollapsibleSection>
+
+        <AdminCollapsibleSection id='mailchimp-sync-orphans' title='Reconcile Mailchimp orphans'>
+          {productionGated ? (
+            gateNotice
+          ) : (
+            <div className='space-y-4'>
+              <div className='space-y-2'>
+                <Label htmlFor='mailchimp-orphan-max'>max_members</Label>
+                <Input
+                  id='mailchimp-orphan-max'
+                  type='number'
+                  min={1}
+                  max={1000}
+                  value={orphanMaxMembers}
+                  onChange={(e) => setOrphanMaxMembers(Number.parseInt(e.target.value, 10) || 1)}
+                />
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='mailchimp-orphan-mode'>mode</Label>
+                <Select
+                  id='mailchimp-orphan-mode'
+                  value={orphanMode}
+                  onChange={(e) => setOrphanMode(e.target.value as 'archive' | 'permanent')}
+                >
+                  <option value='archive'>archive</option>
+                  <option value='permanent'>permanent</option>
+                </Select>
+              </div>
+              <label className='flex items-center gap-2 text-sm text-slate-800'>
+                <input
+                  type='checkbox'
+                  checked={orphanDryRun}
+                  onChange={(e) => setOrphanDryRun(e.target.checked)}
+                  className='h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500'
+                />
+                dry_run (default on)
+              </label>
+              <div>
+                <Button
+                  type='button'
+                  variant={orphanRun.state === 'running' ? 'secondary' : 'primary'}
+                  disabled={orphanPrimaryDisabled}
+                  onClick={handleOrphanPrimaryClick}
+                >
+                  {orphanRun.state === 'running' ? 'Stop' : 'Run orphan cleanup'}
+                </Button>
+              </div>
+              {showOrphanProgress ? (
+                <div className='space-y-3 rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-800'>
+                  <div className='font-medium text-slate-900'>Progress</div>
+                  <ul className='grid gap-1 sm:grid-cols-2'>
+                    <li>batches: {orphanRun.totals.batches}</li>
+                    <li>scanned: {orphanRun.totals.scanned}</li>
+                    <li>kept: {orphanRun.totals.kept}</li>
+                    <li>removed: {orphanRun.totals.removed}</li>
+                    <li>failed: {orphanRun.totals.failed}</li>
+                    {orphanRunUsedDryRun ? (
+                      <li className='sm:col-span-2'>Would remove: {orphanRun.totals.wouldRemove}</li>
+                    ) : null}
+                    <li className='sm:col-span-2'>
+                      Already archived (skipped): {orphanRun.totals.alreadyArchived}
+                    </li>
+                  </ul>
+                  {orphanRun.error ? (
+                    <p className='text-sm text-red-800' role='alert'>
+                      {orphanRun.error}
+                    </p>
+                  ) : null}
+                  {orphanRun.totals.removedSample.length > 0 ? (
+                    <div className='space-y-1'>
+                      <div className='text-xs font-semibold uppercase tracking-wide text-slate-600'>
+                        removed_sample
+                      </div>
+                      <ul className='space-y-2 divide-y divide-slate-100'>
+                        {orphanRun.totals.removedSample.map((row) => (
+                          <li key={`${row.email}-${row.status}`} className='pt-2 first:pt-0'>
+                            <div className='font-medium text-slate-900'>{row.email}</div>
+                            <div className='text-xs text-slate-600'>{row.status}</div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          )}
+        </AdminCollapsibleSection>
+      </div>
+
+      <ConfirmDialog
+        open={archiveConfirmOpen}
+        title='Archive Mailchimp orphans'
+        description='Archive members not found in CRM. Members can be unarchived by an administrator in Mailchimp.'
+        variant='danger'
+        confirmLabel='Archive'
+        onCancel={() => setArchiveConfirmOpen(false)}
+        onConfirm={confirmArchiveOrphanRun}
+      />
+      <ConfirmDialog
+        open={permanentConfirmOpen}
+        title='Permanent Mailchimp erase'
+        description='Permanently erase members not found in CRM. This is irreversible. Type PERMANENT to confirm.'
+        variant='danger'
+        confirmLabel='Erase permanently'
+        confirmDisabled={permanentConfirmInput !== 'PERMANENT'}
+        onCancel={() => {
+          setPermanentConfirmOpen(false);
+          setPermanentConfirmInput('');
+        }}
+        onConfirm={confirmPermanentOrphanRun}
+      >
+        <div className='space-y-2'>
+          <Label htmlFor='mailchimp-permanent-confirm'>Confirmation</Label>
+          <Input
+            id='mailchimp-permanent-confirm'
+            value={permanentConfirmInput}
+            onChange={(e) => setPermanentConfirmInput(e.target.value)}
+            autoComplete='off'
+          />
+        </div>
+      </ConfirmDialog>
+    </Card>
+  );
+}

--- a/apps/admin_web/src/components/admin/contacts/mailchimp-sync-card.tsx
+++ b/apps/admin_web/src/components/admin/contacts/mailchimp-sync-card.tsx
@@ -13,9 +13,16 @@ import { Select } from '@/components/ui/select';
 
 const TAG_NAME_REGEX = /^[a-zA-Z0-9 ._-]{1,100}$/;
 const DEFAULT_TAG_NAME = 'crm-bulk-sync';
+const MIN_MAX_CONTACTS = 1;
+const MAX_MAX_CONTACTS = 200;
+const MIN_MAX_MEMBERS = 1;
+const MAX_MAX_MEMBERS = 1000;
 
-function formatRelativeAgo(fromMs: number): string {
-  const sec = Math.max(0, Math.floor((Date.now() - fromMs) / 1000));
+const CARD_DESCRIPTION =
+  'Production-only. Push CRM contacts to the Mailchimp audience and reconcile orphans. Counters above are read-only in non-production environments.';
+
+function formatRelativeAgo(fromMs: number, nowMs: number): string {
+  const sec = Math.max(0, Math.floor((nowMs - fromMs) / 1000));
   if (sec < 10) {
     return 'just now';
   }
@@ -32,6 +39,14 @@ function formatRelativeAgo(fromMs: number): string {
   }
   const day = Math.floor(hr / 24);
   return `${day}d ago`;
+}
+
+function parseClampedInt(raw: string, min: number, max: number): number {
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) {
+    return min;
+  }
+  return Math.min(Math.max(parsed, min), max);
 }
 
 function countFor(status: Record<string, number> | undefined, key: string): number {
@@ -58,16 +73,29 @@ export function MailchimpSyncCard() {
   } = useMailchimpSync();
 
   const [lastRefreshSnapshotMs, setLastRefreshSnapshotMs] = useState<number | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
     if (!status) {
       return;
     }
-    const id = window.setTimeout(() => {
-      setLastRefreshSnapshotMs(Date.now());
-    }, 0);
-    return () => window.clearTimeout(id);
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) {
+        setLastRefreshSnapshotMs(Date.now());
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [status]);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setNowMs(Date.now());
+    }, 30_000);
+    return () => window.clearInterval(id);
+  }, []);
 
   const [tagName, setTagName] = useState(DEFAULT_TAG_NAME);
   const [maxContacts, setMaxContacts] = useState(100);
@@ -102,8 +130,8 @@ export function MailchimpSyncCard() {
     if (lastRefreshSnapshotMs === null) {
       return '—';
     }
-    return formatRelativeAgo(lastRefreshSnapshotMs);
-  }, [lastRefreshSnapshotMs]);
+    return formatRelativeAgo(lastRefreshSnapshotMs, nowMs);
+  }, [lastRefreshSnapshotMs, nowMs]);
 
   const gateNotice = (
     <p className='rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700'>
@@ -178,7 +206,7 @@ export function MailchimpSyncCard() {
   const showOrphanProgress = orphanRun.state !== 'idle';
 
   return (
-    <Card title='Mailchimp sync'>
+    <Card title='Mailchimp sync' description={CARD_DESCRIPTION}>
       <div className='space-y-6'>
         <div className='space-y-3'>
           <div className='flex flex-wrap items-center justify-between gap-2'>
@@ -194,9 +222,12 @@ export function MailchimpSyncCard() {
             </Button>
           </div>
           {statusError ? (
-            <p className='text-sm text-red-800' role='alert'>
-              {statusError}
-            </p>
+            <div className='flex flex-wrap items-start justify-between gap-2' role='alert'>
+              <p className='text-sm text-red-800'>{statusError}</p>
+              <Button type='button' variant='secondary' size='sm' onClick={() => void refetchStatus()}>
+                Retry
+              </Button>
+            </div>
           ) : null}
           <div className='grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-6'>
             <div className='rounded-md border border-slate-200 bg-slate-50/80 p-2 text-center'>
@@ -242,7 +273,7 @@ export function MailchimpSyncCard() {
           ) : (
             <div className='space-y-4'>
               <div className='space-y-2'>
-                <Label htmlFor='mailchimp-sync-tag-name'>tag_name</Label>
+                <Label htmlFor='mailchimp-sync-tag-name'>Tag name</Label>
                 <Input
                   id='mailchimp-sync-tag-name'
                   value={tagName}
@@ -256,48 +287,65 @@ export function MailchimpSyncCard() {
                 ) : null}
               </div>
               <div className='space-y-2'>
-                <Label htmlFor='mailchimp-sync-max-contacts'>max_contacts</Label>
+                <Label htmlFor='mailchimp-sync-max-contacts'>Batch size (1–200)</Label>
                 <Input
                   id='mailchimp-sync-max-contacts'
                   type='number'
-                  min={1}
-                  max={200}
+                  min={MIN_MAX_CONTACTS}
+                  max={MAX_MAX_CONTACTS}
                   value={maxContacts}
-                  onChange={(e) => setMaxContacts(Number.parseInt(e.target.value, 10) || 1)}
+                  onChange={(e) =>
+                    setMaxContacts(parseClampedInt(e.target.value, MIN_MAX_CONTACTS, MAX_MAX_CONTACTS))
+                  }
                 />
               </div>
               <fieldset className='space-y-2'>
-                <legend className='text-sm font-medium text-slate-800'>only_statuses</legend>
+                <legend className='text-sm font-medium text-slate-800'>Statuses to push</legend>
                 <div className='flex flex-wrap gap-4'>
-                  <label className='flex items-center gap-2 text-sm text-slate-800'>
+                  <div className='flex items-center gap-2'>
                     <input
+                      id='mailchimp-sync-status-pending'
                       type='checkbox'
                       checked={pendingChecked}
                       onChange={(e) => setPendingChecked(e.target.checked)}
                       className='h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500'
                     />
-                    Pending
-                  </label>
-                  <label className='flex items-center gap-2 text-sm text-slate-800'>
+                    <Label
+                      htmlFor='mailchimp-sync-status-pending'
+                      className='mb-0 inline align-middle text-sm font-normal text-slate-800'
+                    >
+                      Pending
+                    </Label>
+                  </div>
+                  <div className='flex items-center gap-2'>
                     <input
+                      id='mailchimp-sync-status-failed'
                       type='checkbox'
                       checked={failedChecked}
                       onChange={(e) => setFailedChecked(e.target.checked)}
                       className='h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500'
                     />
-                    Failed
-                  </label>
+                    <Label
+                      htmlFor='mailchimp-sync-status-failed'
+                      className='mb-0 inline align-middle text-sm font-normal text-slate-800'
+                    >
+                      Failed
+                    </Label>
+                  </div>
                 </div>
               </fieldset>
-              <label className='flex items-center gap-2 text-sm text-slate-800'>
+              <div className='flex items-center gap-2'>
                 <input
+                  id='mailchimp-sync-dry-run'
                   type='checkbox'
                   checked={syncDryRun}
                   onChange={(e) => setSyncDryRun(e.target.checked)}
                   className='h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500'
                 />
-                dry_run (default on)
-              </label>
+                <Label htmlFor='mailchimp-sync-dry-run' className='mb-0 inline align-middle text-sm font-normal text-slate-800'>
+                  Dry run (default on)
+                </Label>
+              </div>
               <div>
                 <Button
                   type='button'
@@ -317,10 +365,10 @@ export function MailchimpSyncCard() {
                     {syncRunUsedDryRun ? (
                       <li className='sm:col-span-2'>Would process: {syncRun.totals.wouldProcess}</li>
                     ) : (
-                      <li>succeeded: {syncRun.totals.succeeded}</li>
+                      <li>Succeeded: {syncRun.totals.succeeded}</li>
                     )}
-                    <li>failed: {syncRun.totals.failed}</li>
-                    <li>skipped: {syncRun.totals.skipped}</li>
+                    <li>Failed: {syncRun.totals.failed}</li>
+                    <li>Skipped: {syncRun.totals.skipped}</li>
                   </ul>
                   {syncRun.error ? (
                     <p className='text-sm text-red-800' role='alert'>
@@ -330,7 +378,7 @@ export function MailchimpSyncCard() {
                   {syncRun.totals.errorsSample.length > 0 ? (
                     <div className='space-y-1'>
                       <div className='text-xs font-semibold uppercase tracking-wide text-slate-600'>
-                        errors_sample
+                        Recent errors
                       </div>
                       <ul className='space-y-2 divide-y divide-slate-100'>
                         {syncRun.totals.errorsSample.map((row) => (
@@ -343,6 +391,9 @@ export function MailchimpSyncCard() {
                           </li>
                         ))}
                       </ul>
+                      {syncRun.totals.errorsSampleExtra > 0 ? (
+                        <p className='text-xs text-slate-600'>+{syncRun.totals.errorsSampleExtra} more</p>
+                      ) : null}
                     </div>
                   ) : null}
                 </div>
@@ -357,18 +408,20 @@ export function MailchimpSyncCard() {
           ) : (
             <div className='space-y-4'>
               <div className='space-y-2'>
-                <Label htmlFor='mailchimp-orphan-max'>max_members</Label>
+                <Label htmlFor='mailchimp-orphan-max'>Batch size (1–1000)</Label>
                 <Input
                   id='mailchimp-orphan-max'
                   type='number'
-                  min={1}
-                  max={1000}
+                  min={MIN_MAX_MEMBERS}
+                  max={MAX_MAX_MEMBERS}
                   value={orphanMaxMembers}
-                  onChange={(e) => setOrphanMaxMembers(Number.parseInt(e.target.value, 10) || 1)}
+                  onChange={(e) =>
+                    setOrphanMaxMembers(parseClampedInt(e.target.value, MIN_MAX_MEMBERS, MAX_MAX_MEMBERS))
+                  }
                 />
               </div>
               <div className='space-y-2'>
-                <Label htmlFor='mailchimp-orphan-mode'>mode</Label>
+                <Label htmlFor='mailchimp-orphan-mode'>Mode</Label>
                 <Select
                   id='mailchimp-orphan-mode'
                   value={orphanMode}
@@ -378,15 +431,18 @@ export function MailchimpSyncCard() {
                   <option value='permanent'>permanent</option>
                 </Select>
               </div>
-              <label className='flex items-center gap-2 text-sm text-slate-800'>
+              <div className='flex items-center gap-2'>
                 <input
+                  id='mailchimp-orphan-dry-run'
                   type='checkbox'
                   checked={orphanDryRun}
                   onChange={(e) => setOrphanDryRun(e.target.checked)}
                   className='h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500'
                 />
-                dry_run (default on)
-              </label>
+                <Label htmlFor='mailchimp-orphan-dry-run' className='mb-0 inline align-middle text-sm font-normal text-slate-800'>
+                  Dry run (default on)
+                </Label>
+              </div>
               <div>
                 <Button
                   type='button'
@@ -421,7 +477,7 @@ export function MailchimpSyncCard() {
                   {orphanRun.totals.removedSample.length > 0 ? (
                     <div className='space-y-1'>
                       <div className='text-xs font-semibold uppercase tracking-wide text-slate-600'>
-                        removed_sample
+                        Recent removals
                       </div>
                       <ul className='space-y-2 divide-y divide-slate-100'>
                         {orphanRun.totals.removedSample.map((row) => (
@@ -431,6 +487,9 @@ export function MailchimpSyncCard() {
                           </li>
                         ))}
                       </ul>
+                      {orphanRun.totals.removedSampleExtra > 0 ? (
+                        <p className='text-xs text-slate-600'>+{orphanRun.totals.removedSampleExtra} more</p>
+                      ) : null}
                     </div>
                   ) : null}
                 </div>
@@ -469,6 +528,8 @@ export function MailchimpSyncCard() {
             value={permanentConfirmInput}
             onChange={(e) => setPermanentConfirmInput(e.target.value)}
             autoComplete='off'
+            autoCapitalize='characters'
+            autoCorrect='off'
           />
         </div>
       </ConfirmDialog>

--- a/apps/admin_web/src/hooks/use-mailchimp-sync.ts
+++ b/apps/admin_web/src/hooks/use-mailchimp-sync.ts
@@ -1,0 +1,386 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { AdminApiError, isAbortRequestError } from '@/lib/api-admin-client';
+import {
+  getMailchimpSyncStatus,
+  runMailchimpOrphanCleanup,
+  runMailchimpSyncBatch,
+  type MailchimpOrphanRemovedSampleItem,
+  type MailchimpSyncRunErrorSampleItem,
+  type MailchimpSyncStatusResponse,
+} from '@/lib/mailchimp-sync-api';
+
+const MAX_SYNC_BATCHES = 1000;
+const MAX_ORPHAN_BATCHES = 1000;
+
+export const MAILCHIMP_PRODUCTION_GATE_MESSAGE =
+  'Mailchimp bulk sync is only available in production. Counters above are read-only in this environment.';
+
+const SESSION_EXPIRED_MESSAGE = 'Session expired — please sign in again.';
+
+export type SyncRunTotals = {
+  batches: number;
+  processed: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+  wouldProcess: number;
+  errorsSample: MailchimpSyncRunErrorSampleItem[];
+};
+
+export type OrphanRunTotals = {
+  batches: number;
+  scanned: number;
+  kept: number;
+  removed: number;
+  failed: number;
+  alreadyArchived: number;
+  wouldRemove: number;
+  removedSample: MailchimpOrphanRemovedSampleItem[];
+};
+
+export type RunState = 'idle' | 'running' | 'completed' | 'aborted' | 'errored';
+
+const emptySyncTotals = (): SyncRunTotals => ({
+  batches: 0,
+  processed: 0,
+  succeeded: 0,
+  failed: 0,
+  skipped: 0,
+  wouldProcess: 0,
+  errorsSample: [],
+});
+
+const emptyOrphanTotals = (): OrphanRunTotals => ({
+  batches: 0,
+  scanned: 0,
+  kept: 0,
+  removed: 0,
+  failed: 0,
+  alreadyArchived: 0,
+  wouldRemove: 0,
+  removedSample: [],
+});
+
+function mapAdminApiError(error: unknown): string {
+  if (error instanceof AdminApiError) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'Request failed.';
+}
+
+export interface UseMailchimpSync {
+  status: MailchimpSyncStatusResponse | null;
+  statusLoading: boolean;
+  statusError: string | null;
+  refetchStatus: () => Promise<void>;
+  productionGated: boolean;
+  syncRun: { state: RunState; totals: SyncRunTotals; error: string | null };
+  startSyncRun: (input: {
+    tagName: string;
+    maxContacts: number;
+    onlyStatuses: ('pending' | 'failed')[];
+    dryRun: boolean;
+  }) => Promise<void>;
+  abortSyncRun: () => void;
+  orphanRun: { state: RunState; totals: OrphanRunTotals; error: string | null };
+  startOrphanRun: (input: {
+    maxMembers: number;
+    mode: 'archive' | 'permanent';
+    dryRun: boolean;
+  }) => Promise<void>;
+  abortOrphanRun: () => void;
+}
+
+export function useMailchimpSync(): UseMailchimpSync {
+  const [status, setStatus] = useState<MailchimpSyncStatusResponse | null>(null);
+  const [statusLoading, setStatusLoading] = useState(true);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [productionGated, setProductionGated] = useState(false);
+
+  const [syncRun, setSyncRun] = useState<{
+    state: RunState;
+    totals: SyncRunTotals;
+    error: string | null;
+  }>({
+    state: 'idle',
+    totals: emptySyncTotals(),
+    error: null,
+  });
+
+  const [orphanRun, setOrphanRun] = useState<{
+    state: RunState;
+    totals: OrphanRunTotals;
+    error: string | null;
+  }>({
+    state: 'idle',
+    totals: emptyOrphanTotals(),
+    error: null,
+  });
+
+  const syncAbortRef = useRef<AbortController | null>(null);
+  const orphanAbortRef = useRef<AbortController | null>(null);
+
+  const refetchStatus = useCallback(async () => {
+    setStatusLoading(true);
+    setStatusError(null);
+    try {
+      const next = await getMailchimpSyncStatus();
+      setStatus(next);
+    } catch (error) {
+      setStatusError(mapAdminApiError(error));
+    } finally {
+      setStatusLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refetchStatus();
+  }, [refetchStatus]);
+
+  const abortSyncRun = useCallback(() => {
+    syncAbortRef.current?.abort();
+  }, []);
+
+  const abortOrphanRun = useCallback(() => {
+    orphanAbortRef.current?.abort();
+  }, []);
+
+  const startSyncRun = useCallback(
+    async (input: {
+      tagName: string;
+      maxContacts: number;
+      onlyStatuses: ('pending' | 'failed')[];
+      dryRun: boolean;
+    }) => {
+      const controller = new AbortController();
+      syncAbortRef.current = controller;
+      const { signal } = controller;
+
+      setSyncRun({
+        state: 'running',
+        totals: emptySyncTotals(),
+        error: null,
+      });
+      const dryRun = input.dryRun;
+
+      let cursor: string | null | undefined;
+      let batches = 0;
+
+      try {
+        while (batches < MAX_SYNC_BATCHES) {
+          const req: Parameters<typeof runMailchimpSyncBatch>[0] = {
+            tag_name: input.tagName.trim(),
+            max_contacts: input.maxContacts,
+            only_statuses: input.onlyStatuses,
+            dry_run: input.dryRun,
+          };
+          if (cursor != null && cursor !== '') {
+            req.cursor = cursor;
+          }
+          const response = await runMailchimpSyncBatch(req, signal);
+
+          batches += 1;
+          setSyncRun((prev) => ({
+            ...prev,
+            state: 'running',
+            totals: {
+              batches: prev.totals.batches + 1,
+              processed: prev.totals.processed + response.processed,
+              succeeded: prev.totals.succeeded + response.succeeded,
+              failed: prev.totals.failed + response.failed,
+              skipped: prev.totals.skipped + response.skipped,
+              wouldProcess: prev.totals.wouldProcess + (dryRun ? response.would_process : 0),
+              errorsSample: response.errors_sample.slice(0, 5),
+            },
+          }));
+
+          if (response.next_cursor === null) {
+            setSyncRun((prev) => ({
+              ...prev,
+              state: 'completed',
+              error: null,
+            }));
+            await refetchStatus();
+            return;
+          }
+
+          cursor = response.next_cursor;
+        }
+
+        setSyncRun((prev) => ({
+          ...prev,
+          state: 'errored',
+          error: 'Stopped: exceeded maximum batches per run.',
+        }));
+      } catch (error) {
+        if (isAbortRequestError(error)) {
+          setSyncRun((prev) => ({
+            ...prev,
+            state: 'aborted',
+            error: null,
+          }));
+          return;
+        }
+
+        if (error instanceof AdminApiError) {
+          if (error.statusCode === 401 || error.statusCode === 403) {
+            setSyncRun((prev) => ({
+              ...prev,
+              state: 'errored',
+              error: SESSION_EXPIRED_MESSAGE,
+            }));
+            return;
+          }
+          if (error.statusCode === 409) {
+            setProductionGated(true);
+            setSyncRun((prev) => ({
+              ...prev,
+              state: 'errored',
+              error: MAILCHIMP_PRODUCTION_GATE_MESSAGE,
+            }));
+            return;
+          }
+        }
+
+        setSyncRun((prev) => ({
+          ...prev,
+          state: 'errored',
+          error: mapAdminApiError(error),
+        }));
+      }
+    },
+    [refetchStatus]
+  );
+
+  const startOrphanRun = useCallback(
+    async (input: { maxMembers: number; mode: 'archive' | 'permanent'; dryRun: boolean }) => {
+      const controller = new AbortController();
+      orphanAbortRef.current = controller;
+      const { signal } = controller;
+
+      setOrphanRun({
+        state: 'running',
+        totals: emptyOrphanTotals(),
+        error: null,
+      });
+      const dryRun = input.dryRun;
+
+      let mailchimpOffset: number | null = 0;
+      let batches = 0;
+
+      try {
+        while (batches < MAX_ORPHAN_BATCHES && mailchimpOffset !== null) {
+          const response = await runMailchimpOrphanCleanup(
+            {
+              max_members: input.maxMembers,
+              mailchimp_offset: mailchimpOffset,
+              mode: input.mode,
+              dry_run: input.dryRun,
+            },
+            signal
+          );
+
+          batches += 1;
+          setOrphanRun((prev) => ({
+            ...prev,
+            state: 'running',
+            totals: {
+              batches: prev.totals.batches + 1,
+              scanned: prev.totals.scanned + response.scanned,
+              kept: prev.totals.kept + response.kept,
+              removed: prev.totals.removed + response.removed,
+              failed: prev.totals.failed + response.failed,
+              alreadyArchived: prev.totals.alreadyArchived + response.already_archived,
+              wouldRemove: prev.totals.wouldRemove + (dryRun ? response.would_remove : 0),
+              removedSample: response.removed_sample.slice(0, 5),
+            },
+          }));
+
+          if (response.next_offset === null) {
+            setOrphanRun((prev) => ({
+              ...prev,
+              state: 'completed',
+              error: null,
+            }));
+            await refetchStatus();
+            return;
+          }
+
+          mailchimpOffset = response.next_offset;
+        }
+
+        if (mailchimpOffset !== null) {
+          setOrphanRun((prev) => ({
+            ...prev,
+            state: 'errored',
+            error: 'Stopped: exceeded maximum batches per run.',
+          }));
+        }
+      } catch (error) {
+        if (isAbortRequestError(error)) {
+          setOrphanRun((prev) => ({
+            ...prev,
+            state: 'aborted',
+            error: null,
+          }));
+          return;
+        }
+
+        if (error instanceof AdminApiError) {
+          if (error.statusCode === 401 || error.statusCode === 403) {
+            setOrphanRun((prev) => ({
+              ...prev,
+              state: 'errored',
+              error: SESSION_EXPIRED_MESSAGE,
+            }));
+            return;
+          }
+          if (error.statusCode === 409) {
+            setProductionGated(true);
+            setOrphanRun((prev) => ({
+              ...prev,
+              state: 'errored',
+              error: MAILCHIMP_PRODUCTION_GATE_MESSAGE,
+            }));
+            return;
+          }
+        }
+
+        setOrphanRun((prev) => ({
+          ...prev,
+          state: 'errored',
+          error: mapAdminApiError(error),
+        }));
+      }
+    },
+    [refetchStatus]
+  );
+
+  return {
+    status,
+    statusLoading,
+    statusError,
+    refetchStatus,
+    productionGated,
+    syncRun: {
+      state: syncRun.state,
+      totals: syncRun.totals,
+      error: syncRun.error,
+    },
+    startSyncRun,
+    abortSyncRun,
+    orphanRun: {
+      state: orphanRun.state,
+      totals: orphanRun.totals,
+      error: orphanRun.error,
+    },
+    startOrphanRun,
+    abortOrphanRun,
+  };
+}

--- a/apps/admin_web/src/hooks/use-mailchimp-sync.ts
+++ b/apps/admin_web/src/hooks/use-mailchimp-sync.ts
@@ -20,6 +20,43 @@ export const MAILCHIMP_PRODUCTION_GATE_MESSAGE =
 
 const SESSION_EXPIRED_MESSAGE = 'Session expired — please sign in again.';
 
+function mergeErrorSamples(
+  prevSample: MailchimpSyncRunErrorSampleItem[],
+  incoming: MailchimpSyncRunErrorSampleItem[]
+): { list: MailchimpSyncRunErrorSampleItem[]; extra: number } {
+  const merged = [...incoming, ...prevSample];
+  const seen = new Set<string>();
+  const list: MailchimpSyncRunErrorSampleItem[] = [];
+  for (const row of merged) {
+    if (seen.has(row.contact_id)) {
+      continue;
+    }
+    seen.add(row.contact_id);
+    list.push(row);
+  }
+  const extra = Math.max(0, list.length - 5);
+  return { list: list.slice(0, 5), extra };
+}
+
+function mergeRemovedSamples(
+  prevSample: MailchimpOrphanRemovedSampleItem[],
+  incoming: MailchimpOrphanRemovedSampleItem[]
+): { list: MailchimpOrphanRemovedSampleItem[]; extra: number } {
+  const merged = [...incoming, ...prevSample];
+  const seen = new Set<string>();
+  const list: MailchimpOrphanRemovedSampleItem[] = [];
+  for (const row of merged) {
+    const key = `${row.email}\0${row.status}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    list.push(row);
+  }
+  const extra = Math.max(0, list.length - 5);
+  return { list: list.slice(0, 5), extra };
+}
+
 export type SyncRunTotals = {
   batches: number;
   processed: number;
@@ -28,6 +65,7 @@ export type SyncRunTotals = {
   skipped: number;
   wouldProcess: number;
   errorsSample: MailchimpSyncRunErrorSampleItem[];
+  errorsSampleExtra: number;
 };
 
 export type OrphanRunTotals = {
@@ -39,6 +77,7 @@ export type OrphanRunTotals = {
   alreadyArchived: number;
   wouldRemove: number;
   removedSample: MailchimpOrphanRemovedSampleItem[];
+  removedSampleExtra: number;
 };
 
 export type RunState = 'idle' | 'running' | 'completed' | 'aborted' | 'errored';
@@ -51,6 +90,7 @@ const emptySyncTotals = (): SyncRunTotals => ({
   skipped: 0,
   wouldProcess: 0,
   errorsSample: [],
+  errorsSampleExtra: 0,
 });
 
 const emptyOrphanTotals = (): OrphanRunTotals => ({
@@ -62,6 +102,7 @@ const emptyOrphanTotals = (): OrphanRunTotals => ({
   alreadyArchived: 0,
   wouldRemove: 0,
   removedSample: [],
+  removedSampleExtra: 0,
 });
 
 function mapAdminApiError(error: unknown): string {
@@ -125,22 +166,38 @@ export function useMailchimpSync(): UseMailchimpSync {
 
   const syncAbortRef = useRef<AbortController | null>(null);
   const orphanAbortRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
 
   const refetchStatus = useCallback(async () => {
     setStatusLoading(true);
     setStatusError(null);
     try {
       const next = await getMailchimpSyncStatus();
+      if (!isMountedRef.current) {
+        return;
+      }
+      setProductionGated(false);
       setStatus(next);
     } catch (error) {
+      if (!isMountedRef.current) {
+        return;
+      }
       setStatusError(mapAdminApiError(error));
     } finally {
-      setStatusLoading(false);
+      if (isMountedRef.current) {
+        setStatusLoading(false);
+      }
     }
   }, []);
 
   useEffect(() => {
+    isMountedRef.current = true;
     void refetchStatus();
+    return () => {
+      isMountedRef.current = false;
+      syncAbortRef.current?.abort();
+      orphanAbortRef.current?.abort();
+    };
   }, [refetchStatus]);
 
   const abortSyncRun = useCallback(() => {
@@ -162,6 +219,9 @@ export function useMailchimpSync(): UseMailchimpSync {
       syncAbortRef.current = controller;
       const { signal } = controller;
 
+      if (!isMountedRef.current) {
+        return;
+      }
       setSyncRun({
         state: 'running',
         totals: emptySyncTotals(),
@@ -185,22 +245,35 @@ export function useMailchimpSync(): UseMailchimpSync {
           }
           const response = await runMailchimpSyncBatch(req, signal);
 
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          setProductionGated(false);
+
           batches += 1;
-          setSyncRun((prev) => ({
-            ...prev,
-            state: 'running',
-            totals: {
-              batches: prev.totals.batches + 1,
-              processed: prev.totals.processed + response.processed,
-              succeeded: prev.totals.succeeded + response.succeeded,
-              failed: prev.totals.failed + response.failed,
-              skipped: prev.totals.skipped + response.skipped,
-              wouldProcess: prev.totals.wouldProcess + (dryRun ? response.would_process : 0),
-              errorsSample: response.errors_sample.slice(0, 5),
-            },
-          }));
+          setSyncRun((prev) => {
+            const merged = mergeErrorSamples(prev.totals.errorsSample, response.errors_sample);
+            return {
+              ...prev,
+              state: 'running',
+              totals: {
+                batches: prev.totals.batches + 1,
+                processed: prev.totals.processed + response.processed,
+                succeeded: prev.totals.succeeded + response.succeeded,
+                failed: prev.totals.failed + response.failed,
+                skipped: prev.totals.skipped + response.skipped,
+                wouldProcess: prev.totals.wouldProcess + (dryRun ? response.would_process : 0),
+                errorsSample: merged.list,
+                errorsSampleExtra: merged.extra,
+              },
+            };
+          });
 
           if (response.next_cursor === null) {
+            if (!isMountedRef.current) {
+              return;
+            }
             setSyncRun((prev) => ({
               ...prev,
               state: 'completed',
@@ -213,12 +286,18 @@ export function useMailchimpSync(): UseMailchimpSync {
           cursor = response.next_cursor;
         }
 
+        if (!isMountedRef.current) {
+          return;
+        }
         setSyncRun((prev) => ({
           ...prev,
           state: 'errored',
           error: 'Stopped: exceeded maximum batches per run.',
         }));
       } catch (error) {
+        if (!isMountedRef.current) {
+          return;
+        }
         if (isAbortRequestError(error)) {
           setSyncRun((prev) => ({
             ...prev,
@@ -264,6 +343,9 @@ export function useMailchimpSync(): UseMailchimpSync {
       orphanAbortRef.current = controller;
       const { signal } = controller;
 
+      if (!isMountedRef.current) {
+        return;
+      }
       setOrphanRun({
         state: 'running',
         totals: emptyOrphanTotals(),
@@ -286,23 +368,36 @@ export function useMailchimpSync(): UseMailchimpSync {
             signal
           );
 
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          setProductionGated(false);
+
           batches += 1;
-          setOrphanRun((prev) => ({
-            ...prev,
-            state: 'running',
-            totals: {
-              batches: prev.totals.batches + 1,
-              scanned: prev.totals.scanned + response.scanned,
-              kept: prev.totals.kept + response.kept,
-              removed: prev.totals.removed + response.removed,
-              failed: prev.totals.failed + response.failed,
-              alreadyArchived: prev.totals.alreadyArchived + response.already_archived,
-              wouldRemove: prev.totals.wouldRemove + (dryRun ? response.would_remove : 0),
-              removedSample: response.removed_sample.slice(0, 5),
-            },
-          }));
+          setOrphanRun((prev) => {
+            const merged = mergeRemovedSamples(prev.totals.removedSample, response.removed_sample);
+            return {
+              ...prev,
+              state: 'running',
+              totals: {
+                batches: prev.totals.batches + 1,
+                scanned: prev.totals.scanned + response.scanned,
+                kept: prev.totals.kept + response.kept,
+                removed: prev.totals.removed + response.removed,
+                failed: prev.totals.failed + response.failed,
+                alreadyArchived: prev.totals.alreadyArchived + response.already_archived,
+                wouldRemove: prev.totals.wouldRemove + (dryRun ? response.would_remove : 0),
+                removedSample: merged.list,
+                removedSampleExtra: merged.extra,
+              },
+            };
+          });
 
           if (response.next_offset === null) {
+            if (!isMountedRef.current) {
+              return;
+            }
             setOrphanRun((prev) => ({
               ...prev,
               state: 'completed',
@@ -315,6 +410,9 @@ export function useMailchimpSync(): UseMailchimpSync {
           mailchimpOffset = response.next_offset;
         }
 
+        if (!isMountedRef.current) {
+          return;
+        }
         if (mailchimpOffset !== null) {
           setOrphanRun((prev) => ({
             ...prev,
@@ -323,6 +421,9 @@ export function useMailchimpSync(): UseMailchimpSync {
           }));
         }
       } catch (error) {
+        if (!isMountedRef.current) {
+          return;
+        }
         if (isAbortRequestError(error)) {
           setOrphanRun((prev) => ({
             ...prev,

--- a/apps/admin_web/src/lib/mailchimp-sync-api.ts
+++ b/apps/admin_web/src/lib/mailchimp-sync-api.ts
@@ -1,0 +1,54 @@
+import { adminApiRequest } from '@/lib/api-admin-client';
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+
+export type MailchimpSyncStatusResponse = ApiSchemas['MailchimpSyncStatusResponse'];
+export type MailchimpSyncRunRequest = ApiSchemas['MailchimpSyncRunRequest'];
+export type MailchimpSyncRunResponse = ApiSchemas['MailchimpSyncRunResponse'];
+export type MailchimpSyncRunErrorSampleItem = ApiSchemas['MailchimpSyncRunErrorSampleItem'];
+export type MailchimpOrphanCleanupRequest = ApiSchemas['MailchimpOrphanCleanupRequest'];
+export type MailchimpOrphanCleanupResponse = ApiSchemas['MailchimpOrphanCleanupResponse'];
+export type MailchimpOrphanRemovedSampleItem = ApiSchemas['MailchimpOrphanRemovedSampleItem'];
+
+function stripEmptyCursor(req: MailchimpSyncRunRequest): MailchimpSyncRunRequest {
+  const { cursor, ...rest } = req;
+  if (cursor === null || cursor === undefined || cursor === '') {
+    return rest;
+  }
+  return { ...rest, cursor };
+}
+
+export async function getMailchimpSyncStatus(
+  signal?: AbortSignal
+): Promise<MailchimpSyncStatusResponse> {
+  return adminApiRequest<MailchimpSyncStatusResponse>({
+    endpointPath: '/v1/admin/contacts/mailchimp-sync-status',
+    method: 'GET',
+    signal,
+  });
+}
+
+export async function runMailchimpSyncBatch(
+  req: MailchimpSyncRunRequest,
+  signal?: AbortSignal
+): Promise<MailchimpSyncRunResponse> {
+  return adminApiRequest<MailchimpSyncRunResponse>({
+    endpointPath: '/v1/admin/contacts/mailchimp-sync-run',
+    method: 'POST',
+    body: stripEmptyCursor(req),
+    signal,
+  });
+}
+
+export async function runMailchimpOrphanCleanup(
+  req: MailchimpOrphanCleanupRequest,
+  signal?: AbortSignal
+): Promise<MailchimpOrphanCleanupResponse> {
+  return adminApiRequest<MailchimpOrphanCleanupResponse>({
+    endpointPath: '/v1/admin/contacts/mailchimp-sync-orphans',
+    method: 'POST',
+    body: req,
+    signal,
+  });
+}

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -45,6 +45,16 @@ vi.mock('@/lib/entity-api', async (importOriginal) => {
   };
 });
 
+vi.mock('@/lib/mailchimp-sync-api', () => ({
+  getMailchimpSyncStatus: vi.fn().mockResolvedValue({
+    counts_by_status: { pending: 0, synced: 0, failed: 0, unsubscribed: 0 },
+    archived_with_mailchimp_record: 0,
+    last_run_summary: null,
+  }),
+  runMailchimpSyncBatch: vi.fn(),
+  runMailchimpOrphanCleanup: vi.fn(),
+}));
+
 const noopRefresh = vi.fn().mockResolvedValue(undefined);
 
 function buildContactsHook(
@@ -616,5 +626,24 @@ describe('ContactsPanel', () => {
     await waitFor(() => {
       expect(refreshFamilyOrgLists).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('renders Mailchimp sync before Contact in heading order', () => {
+    const contacts = buildContactsHook();
+    render(
+      <ContactsPanel
+        contacts={contacts}
+        adminUsers={[]}
+        onPatchStandaloneNoteCount={vi.fn()}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+        refreshFamilyOrgLists={vi.fn()}
+      />
+    );
+    const headings = screen.getAllByRole('heading').map((el) => el.textContent ?? '');
+    expect(headings.indexOf('Mailchimp sync')).toBeLessThan(headings.indexOf('Contact'));
   });
 });

--- a/apps/admin_web/tests/components/admin/contacts/mailchimp-sync-card.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/mailchimp-sync-card.test.tsx
@@ -1,0 +1,357 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AdminApiError } from '@/lib/api-admin-client';
+
+const { getMailchimpSyncStatus, runMailchimpSyncBatch, runMailchimpOrphanCleanup } = vi.hoisted(
+  () => ({
+    getMailchimpSyncStatus: vi.fn(),
+    runMailchimpSyncBatch: vi.fn(),
+    runMailchimpOrphanCleanup: vi.fn(),
+  })
+);
+
+vi.mock('@/lib/mailchimp-sync-api', () => ({
+  getMailchimpSyncStatus,
+  runMailchimpSyncBatch,
+  runMailchimpOrphanCleanup,
+}));
+
+import { MailchimpSyncCard } from '@/components/admin/contacts/mailchimp-sync-card';
+
+const defaultStatus = {
+  counts_by_status: { pending: 2, synced: 3, failed: 1, unsubscribed: 4 },
+  archived_with_mailchimp_record: 5,
+  last_run_summary: null,
+};
+
+function baseSyncResponse(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    processed: 0,
+    succeeded: 0,
+    failed: 0,
+    skipped: 0,
+    next_cursor: null,
+    errors_sample: [],
+    dry_run: false,
+    would_process: 0,
+    ...overrides,
+  };
+}
+
+function baseOrphanResponse(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    scanned: 0,
+    kept: 0,
+    removed: 0,
+    failed: 0,
+    next_offset: null,
+    removed_sample: [],
+    dry_run: false,
+    would_remove: 0,
+    already_archived: 0,
+    ...overrides,
+  };
+}
+
+describe('MailchimpSyncCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMailchimpSyncStatus.mockResolvedValue(defaultStatus);
+    runMailchimpSyncBatch.mockResolvedValue(baseSyncResponse());
+    runMailchimpOrphanCleanup.mockResolvedValue(baseOrphanResponse());
+  });
+
+  it('renders title and the six counter tiles from a mocked status response', async () => {
+    render(<MailchimpSyncCard />);
+
+    expect(await screen.findByRole('heading', { name: 'Mailchimp sync' })).toBeInTheDocument();
+    expect(screen.getAllByText('Pending')[0].nextElementSibling).toHaveTextContent('2');
+    expect(screen.getByText('Synced').nextElementSibling).toHaveTextContent('3');
+    expect(screen.getAllByText('Failed')[0].nextElementSibling).toHaveTextContent('1');
+    expect(screen.getByText('Unsubscribed').nextElementSibling).toHaveTextContent('4');
+    expect(screen.getByText('Archived w/ MC record').nextElementSibling).toHaveTextContent('5');
+    expect(screen.getByText('Last refreshed')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Last refreshed').nextElementSibling?.textContent).not.toBe('—');
+    });
+  });
+
+  it('409 from runMailchimpSyncBatch shows the gate notice in action sections; status row stays', async () => {
+    const user = userEvent.setup();
+    runMailchimpSyncBatch.mockRejectedValue(
+      new AdminApiError({
+        statusCode: 409,
+        payload: { detail: 'nope' },
+        message: 'conflict',
+      })
+    );
+
+    render(<MailchimpSyncCard />);
+    await screen.findByRole('heading', { name: 'Mailchimp sync' });
+
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+    await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
+
+    const notices = await screen.findAllByText(
+      'Mailchimp bulk sync is only available in production. Counters above are read-only in this environment.'
+    );
+    expect(notices.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Pending')[0]).toBeInTheDocument();
+  });
+
+  it('only_statuses has exactly pending and failed checkboxes; submit disabled when both unchecked', async () => {
+    const user = userEvent.setup();
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Push CRM contacts to Mailchimp');
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+
+    const pushSection = screen.getByText('Push CRM contacts to Mailchimp').closest('details');
+    expect(pushSection).toBeTruthy();
+    const region = within(pushSection as HTMLElement);
+
+    expect(region.getByRole('checkbox', { name: 'Pending' })).toBeInTheDocument();
+    expect(region.getByRole('checkbox', { name: 'Failed' })).toBeInTheDocument();
+    expect(region.queryByRole('checkbox', { name: 'Synced' })).toBeNull();
+
+    await user.click(region.getByRole('checkbox', { name: 'Pending' }));
+    await user.click(region.getByRole('checkbox', { name: 'Failed' }));
+
+    expect(screen.getByRole('button', { name: 'Run upsert batch' })).toBeDisabled();
+  });
+
+  it('sync run loops twice; second body includes cursor and tag_name crm-bulk-sync', async () => {
+    const user = userEvent.setup();
+    const cursor = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    runMailchimpSyncBatch
+      .mockResolvedValueOnce(
+        baseSyncResponse({
+          next_cursor: cursor,
+          processed: 1,
+          would_process: 0,
+        })
+      )
+      .mockResolvedValueOnce(
+        baseSyncResponse({
+          next_cursor: null,
+          processed: 2,
+          would_process: 0,
+        })
+      );
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Push CRM contacts to Mailchimp');
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+
+    await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
+
+    await waitFor(() => expect(runMailchimpSyncBatch).toHaveBeenCalledTimes(2));
+    expect(runMailchimpSyncBatch.mock.calls[0][0]).not.toHaveProperty('cursor');
+    expect(runMailchimpSyncBatch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        tag_name: 'crm-bulk-sync',
+      }),
+      expect.any(AbortSignal)
+    );
+    expect(runMailchimpSyncBatch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        tag_name: 'crm-bulk-sync',
+        cursor,
+      }),
+      expect.any(AbortSignal)
+    );
+  });
+
+  it('dry-run sync shows Would process and hides Succeeded', async () => {
+    const user = userEvent.setup();
+    runMailchimpSyncBatch.mockResolvedValue(
+      baseSyncResponse({
+        dry_run: true,
+        would_process: 7,
+        succeeded: 99,
+      })
+    );
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Push CRM contacts to Mailchimp');
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+
+    await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
+
+    expect(await screen.findByText(/Would process: 7/)).toBeInTheDocument();
+    expect(screen.queryByText(/Succeeded:/)).toBeNull();
+  });
+
+  it('errors_sample shows lead_email_masked first', async () => {
+    const user = userEvent.setup();
+    runMailchimpSyncBatch.mockResolvedValue(
+      baseSyncResponse({
+        errors_sample: [
+          {
+            contact_id: '11111111-1111-1111-1111-111111111111',
+            reason: 'mailchimp_api_error',
+            status: 502,
+            lead_email_masked: 'ab***@ex***.com',
+          },
+        ],
+      })
+    );
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Push CRM contacts to Mailchimp');
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+    await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
+
+    expect(await screen.findByText('ab***@ex***.com')).toBeInTheDocument();
+  });
+
+  it('orphan dry-run shows Would remove and Already archived (skipped) independently', async () => {
+    const user = userEvent.setup();
+    runMailchimpOrphanCleanup.mockResolvedValue(
+      baseOrphanResponse({
+        dry_run: true,
+        would_remove: 11,
+        already_archived: 4,
+      })
+    );
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Reconcile Mailchimp orphans');
+    await user.click(screen.getByText('Reconcile Mailchimp orphans'));
+    await user.click(screen.getByRole('button', { name: 'Run orphan cleanup' }));
+
+    expect(await screen.findByText(/Would remove: 11/)).toBeInTheDocument();
+    expect(screen.getByText(/Already archived \(skipped\): 4/)).toBeInTheDocument();
+  });
+
+  it('orphan archive dry_run=false opens confirm and runs after accept', async () => {
+    const user = userEvent.setup();
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Reconcile Mailchimp orphans');
+    await user.click(screen.getByText('Reconcile Mailchimp orphans'));
+
+    const orphanDetails = screen.getByText('Reconcile Mailchimp orphans').closest('details');
+    const orphanRegion = within(orphanDetails as HTMLElement);
+    await user.click(orphanRegion.getByLabelText(/dry_run/i));
+    await user.click(orphanRegion.getByRole('button', { name: 'Run orphan cleanup' }));
+
+    expect(await screen.findByRole('heading', { name: 'Archive Mailchimp orphans' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Archive' }));
+
+    await waitFor(() => expect(runMailchimpOrphanCleanup).toHaveBeenCalled());
+    expect(runMailchimpOrphanCleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'archive', dry_run: false }),
+      expect.any(AbortSignal)
+    );
+  });
+
+  it('orphan permanent dry_run=false requires typing PERMANENT before destructive confirm', async () => {
+    const user = userEvent.setup();
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Reconcile Mailchimp orphans');
+    await user.click(screen.getByText('Reconcile Mailchimp orphans'));
+
+    const orphanDetails = screen.getByText('Reconcile Mailchimp orphans').closest('details');
+    const orphanRegion = within(orphanDetails as HTMLElement);
+    await user.selectOptions(orphanRegion.getByLabelText('mode'), 'permanent');
+    await user.click(orphanRegion.getByLabelText(/dry_run/i));
+    await user.click(orphanRegion.getByRole('button', { name: 'Run orphan cleanup' }));
+
+    const dialog = await screen.findByRole('heading', { name: 'Permanent Mailchimp erase' });
+    expect(dialog).toBeInTheDocument();
+
+    const eraseBtn = screen.getByRole('button', { name: 'Erase permanently' });
+    expect(eraseBtn).toBeDisabled();
+
+    await user.type(screen.getByLabelText('Confirmation'), 'PERMANENT');
+    expect(eraseBtn).not.toBeDisabled();
+    await user.click(eraseBtn);
+
+    await waitFor(() => expect(runMailchimpOrphanCleanup).toHaveBeenCalled());
+    expect(runMailchimpOrphanCleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'permanent', dry_run: false }),
+      expect.any(AbortSignal)
+    );
+  });
+
+  it('orphan loop passes server next_offset without client-side advancement', async () => {
+    const user = userEvent.setup();
+    runMailchimpOrphanCleanup
+      .mockResolvedValueOnce(baseOrphanResponse({ next_offset: 0, removed: 1, scanned: 10 }))
+      .mockResolvedValueOnce(baseOrphanResponse({ next_offset: 0, removed: 1, scanned: 10 }))
+      .mockResolvedValueOnce(baseOrphanResponse({ next_offset: 0, removed: 1, scanned: 10 }))
+      .mockResolvedValueOnce(baseOrphanResponse({ next_offset: null, removed: 0, scanned: 3 }));
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Reconcile Mailchimp orphans');
+    await user.click(screen.getByText('Reconcile Mailchimp orphans'));
+    await user.click(screen.getByRole('button', { name: 'Run orphan cleanup' }));
+
+    await waitFor(() => expect(runMailchimpOrphanCleanup).toHaveBeenCalledTimes(4));
+    expect(runMailchimpOrphanCleanup).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ mailchimp_offset: 0 }),
+      expect.any(AbortSignal)
+    );
+    expect(runMailchimpOrphanCleanup).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ mailchimp_offset: 0 }),
+      expect.any(AbortSignal)
+    );
+    expect(runMailchimpOrphanCleanup).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ mailchimp_offset: 0 }),
+      expect.any(AbortSignal)
+    );
+    expect(runMailchimpOrphanCleanup).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({ mailchimp_offset: 0 }),
+      expect.any(AbortSignal)
+    );
+  });
+
+  it('abort prevents the next sync batch call', async () => {
+    const user = userEvent.setup();
+    runMailchimpSyncBatch.mockImplementation((_req, signal) => {
+      return new Promise((_resolve, reject) => {
+        const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        signal?.addEventListener('abort', onAbort);
+      });
+    });
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Push CRM contacts to Mailchimp');
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+    await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
+
+    await waitFor(() => expect(runMailchimpSyncBatch).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'Stop' }));
+
+    await waitFor(() => {
+      expect(runMailchimpSyncBatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('after a successful sync run, getMailchimpSyncStatus is called once more', async () => {
+    const user = userEvent.setup();
+
+    render(<MailchimpSyncCard />);
+    await waitFor(() => expect(getMailchimpSyncStatus).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+    await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
+
+    await waitFor(() => expect(getMailchimpSyncStatus).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/admin_web/tests/components/admin/contacts/mailchimp-sync-card.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/mailchimp-sync-card.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AdminApiError } from '@/lib/api-admin-client';
+import { MAILCHIMP_PRODUCTION_GATE_MESSAGE } from '@/hooks/use-mailchimp-sync';
 
 const { getMailchimpSyncStatus, runMailchimpSyncBatch, runMailchimpOrphanCleanup } = vi.hoisted(
   () => ({
@@ -61,6 +62,10 @@ describe('MailchimpSyncCard', () => {
     getMailchimpSyncStatus.mockResolvedValue(defaultStatus);
     runMailchimpSyncBatch.mockResolvedValue(baseSyncResponse());
     runMailchimpOrphanCleanup.mockResolvedValue(baseOrphanResponse());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('renders title and the six counter tiles from a mocked status response', async () => {
@@ -183,7 +188,7 @@ describe('MailchimpSyncCard', () => {
     await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
 
     expect(await screen.findByText(/Would process: 7/)).toBeInTheDocument();
-    expect(screen.queryByText(/Succeeded:/)).toBeNull();
+    expect(screen.queryByText(/Succeeded:/i)).toBeNull();
   });
 
   it('errors_sample shows lead_email_masked first', async () => {
@@ -237,7 +242,7 @@ describe('MailchimpSyncCard', () => {
 
     const orphanDetails = screen.getByText('Reconcile Mailchimp orphans').closest('details');
     const orphanRegion = within(orphanDetails as HTMLElement);
-    await user.click(orphanRegion.getByLabelText(/dry_run/i));
+    await user.click(orphanRegion.getByLabelText(/Dry run/i));
     await user.click(orphanRegion.getByRole('button', { name: 'Run orphan cleanup' }));
 
     expect(await screen.findByRole('heading', { name: 'Archive Mailchimp orphans' })).toBeInTheDocument();
@@ -259,8 +264,8 @@ describe('MailchimpSyncCard', () => {
 
     const orphanDetails = screen.getByText('Reconcile Mailchimp orphans').closest('details');
     const orphanRegion = within(orphanDetails as HTMLElement);
-    await user.selectOptions(orphanRegion.getByLabelText('mode'), 'permanent');
-    await user.click(orphanRegion.getByLabelText(/dry_run/i));
+    await user.selectOptions(orphanRegion.getByLabelText('Mode'), 'permanent');
+    await user.click(orphanRegion.getByLabelText(/Dry run/i));
     await user.click(orphanRegion.getByRole('button', { name: 'Run orphan cleanup' }));
 
     const dialog = await screen.findByRole('heading', { name: 'Permanent Mailchimp erase' });
@@ -353,5 +358,74 @@ describe('MailchimpSyncCard', () => {
     await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
 
     await waitFor(() => expect(getMailchimpSyncStatus).toHaveBeenCalledTimes(2));
+  });
+
+  it('Last refreshed advances after timer tick (fake timers)', async () => {
+    vi.useFakeTimers();
+    const start = new Date('2025-06-01T12:00:00.000Z').getTime();
+    vi.setSystemTime(start);
+
+    render(<MailchimpSyncCard />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Last refreshed').nextElementSibling).toHaveTextContent('just now');
+
+    await act(async () => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    const label = screen.getByText('Last refreshed').nextElementSibling?.textContent ?? '';
+    expect(label).not.toBe('just now');
+    expect(label).toMatch(/\d+s ago/);
+  });
+
+  it('409 on sync then Refresh clears production gate and restores forms', async () => {
+    const user = userEvent.setup();
+    runMailchimpSyncBatch.mockRejectedValueOnce(
+      new AdminApiError({
+        statusCode: 409,
+        payload: { detail: 'nope' },
+        message: 'conflict',
+      })
+    );
+
+    render(<MailchimpSyncCard />);
+    await screen.findByRole('heading', { name: 'Mailchimp sync' });
+
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+    await user.click(screen.getByRole('button', { name: 'Run upsert batch' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(MAILCHIMP_PRODUCTION_GATE_MESSAGE).length).toBeGreaterThanOrEqual(1);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Tag name')).toBeInTheDocument();
+    });
+  });
+
+  it('clamps max_contacts input to 200 and max_members to 1000', async () => {
+    const user = userEvent.setup();
+
+    render(<MailchimpSyncCard />);
+    await screen.findByText('Push CRM contacts to Mailchimp');
+    await user.click(screen.getByText('Push CRM contacts to Mailchimp'));
+
+    const syncBatch = screen.getByLabelText(/Batch size \(1–200\)/);
+    await user.clear(syncBatch);
+    await user.type(syncBatch, '9999');
+    expect(syncBatch).toHaveValue(200);
+
+    await user.click(screen.getByText('Reconcile Mailchimp orphans'));
+    const orphanBatch = screen.getByLabelText(/Batch size \(1–1000\)/);
+    await user.clear(orphanBatch);
+    await user.type(orphanBatch, '5000');
+    expect(orphanBatch).toHaveValue(1000);
   });
 });

--- a/apps/admin_web/tests/hooks/use-mailchimp-sync.test.tsx
+++ b/apps/admin_web/tests/hooks/use-mailchimp-sync.test.tsx
@@ -1,0 +1,133 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AdminApiError } from '@/lib/api-admin-client';
+
+const { getMailchimpSyncStatus, runMailchimpSyncBatch, runMailchimpOrphanCleanup } = vi.hoisted(() => ({
+  getMailchimpSyncStatus: vi.fn(),
+  runMailchimpSyncBatch: vi.fn(),
+  runMailchimpOrphanCleanup: vi.fn(),
+}));
+
+vi.mock('@/lib/mailchimp-sync-api', () => ({
+  getMailchimpSyncStatus,
+  runMailchimpSyncBatch,
+  runMailchimpOrphanCleanup,
+}));
+
+import { useMailchimpSync } from '@/hooks/use-mailchimp-sync';
+
+const defaultStatus = {
+  counts_by_status: { pending: 0, synced: 0, failed: 0, unsubscribed: 0 },
+  archived_with_mailchimp_record: 0,
+  last_run_summary: null,
+};
+
+function baseSyncResponse(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    processed: 0,
+    succeeded: 0,
+    failed: 0,
+    skipped: 0,
+    next_cursor: null,
+    errors_sample: [],
+    dry_run: false,
+    would_process: 0,
+    ...overrides,
+  };
+}
+
+describe('useMailchimpSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMailchimpSyncStatus.mockResolvedValue(defaultStatus);
+    runMailchimpSyncBatch.mockResolvedValue(baseSyncResponse());
+    runMailchimpOrphanCleanup.mockResolvedValue({
+      scanned: 0,
+      kept: 0,
+      removed: 0,
+      failed: 0,
+      next_offset: null,
+      removed_sample: [],
+      dry_run: false,
+      would_remove: 0,
+      already_archived: 0,
+    });
+  });
+
+  it('aborts in-flight sync on unmount so a second batch is not requested', async () => {
+    let resolveBatch: (v: unknown) => void = () => {};
+    const pending = new Promise((r) => {
+      resolveBatch = r;
+    });
+    runMailchimpSyncBatch.mockReturnValueOnce(pending as Promise<unknown>);
+
+    const { result, unmount } = renderHook(() => useMailchimpSync());
+
+    await waitFor(() => expect(getMailchimpSyncStatus).toHaveBeenCalled());
+
+    await act(async () => {
+      void result.current.startSyncRun({
+        tagName: 'crm-bulk-sync',
+        maxContacts: 100,
+        onlyStatuses: ['pending', 'failed'],
+        dryRun: true,
+      });
+    });
+
+    await waitFor(() => expect(runMailchimpSyncBatch).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    await act(async () => {
+      resolveBatch(
+        baseSyncResponse({
+          next_cursor: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        })
+      );
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    expect(runMailchimpSyncBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears productionGated after a successful batch following a 409', async () => {
+    runMailchimpSyncBatch
+      .mockRejectedValueOnce(
+        new AdminApiError({
+          statusCode: 409,
+          payload: { detail: 'no' },
+          message: 'conflict',
+        })
+      )
+      .mockResolvedValueOnce(baseSyncResponse());
+
+    const { result } = renderHook(() => useMailchimpSync());
+    await waitFor(() => expect(getMailchimpSyncStatus).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.startSyncRun({
+        tagName: 'crm-bulk-sync',
+        maxContacts: 100,
+        onlyStatuses: ['pending', 'failed'],
+        dryRun: true,
+      });
+    });
+
+    await waitFor(() => expect(result.current.productionGated).toBe(true));
+
+    await act(async () => {
+      await result.current.startSyncRun({
+        tagName: 'crm-bulk-sync',
+        maxContacts: 100,
+        onlyStatuses: ['pending', 'failed'],
+        dryRun: true,
+      });
+    });
+
+    await waitFor(() => expect(result.current.productionGated).toBe(false));
+  });
+});

--- a/apps/public_www/tests/lib/structured-data.test.ts
+++ b/apps/public_www/tests/lib/structured-data.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import enContent from '@/content/en.json';
 import { publicCalendarFixture } from '../fixtures/public-calendar';
@@ -31,6 +31,7 @@ const originalEnvValues = Object.fromEntries(
 ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const key of ENV_KEYS) {
     const originalValue = originalEnvValues[key];
     if (typeof originalValue === 'string') {
@@ -127,6 +128,11 @@ describe('structured-data builders', () => {
   });
 
   it('adds Course.offers from MBA cohorts when lowest open price is available', () => {
+    vi.useFakeTimers();
+    // MBA cohort JSON-LD uses `isFutureCohort` (all sessions strictly after "today" in the site TZ).
+    // Pin "today" before fixture sessions so open prices stay available regardless of CI clock.
+    vi.setSystemTime(new Date('2026-04-01T12:00:00.000Z'));
+
     const mbaCohorts = normalizeMyBestAuntieCohortsFromPayload(publicCalendarFixture);
     const courseSchema = buildCourseSchema({
       locale: 'en',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Mailchimp sync operational card above the contact inline editor on the Contacts sub-tab, with read-only status counters, collapsible push and orphan sections, batch loops with abort, 409 production gate messaging, and archive/permanent confirmation flows (PERMANENT type-to-confirm for permanent erase).

## Follow-up fixes (P1 / P2) — admin Mailchimp card

- **Last refreshed** 30s ticker; **Card** production-only **description**; **productionGated** clears on successful status/batch; **unmount** aborts runs + skips stale setState; **clamped** batch sizes; **humanised** labels; **merged** error/removal samples with **+N more**; **Retry** on status error; permanent confirm **autoCapitalize** / **autoCorrect**; hook + card tests.

## CI fix — public_www

- **`tests/lib/structured-data.test.ts`**: `Course.offers` assertion failed when the real clock moved past fixture MBA sessions (`isFutureCohort` requires every session strictly after “today”). The test now pins the system time to **2026-04-01** with fake timers; **`vi.useRealTimers()`** runs in **`afterEach`** so other tests are unaffected.

## Validation

- `cd apps/admin_web && npm run lint` and `npx vitest run`
- `cd apps/public_www && npx vitest run tests/lib/structured-data.test.ts` (and full suite as needed)
- `bash scripts/validate-cursorrules.sh`

## Out of scope

No backend, OpenAPI, CDK, nav, or locale changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d38a56c1-2796-4603-b4db-af639b6d8a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d38a56c1-2796-4603-b4db-af639b6d8a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

