### PR TITLE
Public calendar: include finished events from the last 90 days

### DIFF
--- a/backend/src/app/db/repositories/service_instance.py
+++ b/backend/src/app/db/repositories/service_instance.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select
@@ -29,6 +29,9 @@ from app.db.repositories.base import BaseRepository
 
 InstanceDetails = TrainingInstanceDetails | list[EventTicketTier] | None
 
+# ~3 calendar months: finished event instances remain visible on the public calendar feed.
+PUBLIC_CALENDAR_FINISHED_EVENT_LOOKBACK = timedelta(days=90)
+
 _PUBLIC_CALENDAR_BLOCKER_DEFAULT_TYPES: tuple[ServiceType, ...] = (
     ServiceType.EVENT,
     ServiceType.TRAINING_COURSE,
@@ -43,7 +46,8 @@ def public_calendar_blocker_instance_predicates(
 
     Pass ``service_types`` to mirror :meth:`ServiceInstanceRepository.list_public_offerings`
     (when ``None``, defaults to event + training_course). Excludes list limit, slug,
-    service_key filters, earliest-slot ordering, and the ``ends_at >= now`` feed filter.
+    service_key filters, earliest-slot ordering, and the public calendar feed-only
+    visibility rules (active session cutoff and finished-event lookback).
     """
     types_tuple = (
         _PUBLIC_CALENDAR_BLOCKER_DEFAULT_TYPES if not service_types else service_types
@@ -257,6 +261,11 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
     ) -> list[ServiceInstance]:
         """List public calendar rows for published event and training services.
 
+        Rows include instances with any session not yet ended (``ends_at >= now``),
+        plus **event**-type instances whose last session ended within
+        :data:`PUBLIC_CALENDAR_FINISHED_EVENT_LOOKBACK` (training courses never
+        match this historical branch).
+
         When ``slug`` is set, it is compared to ``lower(service_instances.slug)``;
         the public handler passes a pre-normalized lowercase slug, and callers
         that pass mixed case are still matched defensively via ``lower()`` on the
@@ -289,12 +298,29 @@ class ServiceInstanceRepository(BaseRepository[ServiceInstance]):
                 )
             )
         )
+        has_active_or_upcoming_slot = ServiceInstance.session_slots.any(
+            InstanceSessionSlot.ends_at >= now - datetime.resolution
+        )
+        latest_session_end = (
+            select(func.max(InstanceSessionSlot.ends_at))
+            .where(InstanceSessionSlot.instance_id == ServiceInstance.id)
+            .correlate(ServiceInstance)
+            .scalar_subquery()
+        )
+        lookback_start = now - PUBLIC_CALENDAR_FINISHED_EVENT_LOOKBACK
+        finished_recent_event = and_(
+            Service.service_type == ServiceType.EVENT,
+            latest_session_end.isnot(None),
+            latest_session_end < now,
+            latest_session_end >= lookback_start,
+        )
+        feed_scope = (
+            or_(has_active_or_upcoming_slot, finished_recent_event)
+            if ServiceType.EVENT in types_tuple
+            else has_active_or_upcoming_slot
+        )
         statement = (
-            statement.where(
-                ServiceInstance.session_slots.any(
-                    InstanceSessionSlot.ends_at >= now - datetime.resolution
-                )
-            )
+            statement.where(feed_scope)
             .options(
                 selectinload(ServiceInstance.session_slots).joinedload(
                     InstanceSessionSlot.location

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -271,8 +271,17 @@ paths:
         Source of truth is the backend `service_instances` projection for
         published `event` and `training_course` services (consultation is never
         included). Instances with an empty `service_instances.slug` are
-        omitted from this feed. Results are ordered by the earliest upcoming session slot,
-        then `service_instances.id` for a stable tie-break.
+        omitted from this feed.
+
+        Visibility: each instance must either have at least one session slot with
+        `ends_at` not before the server clock (upcoming or in progress), **or**
+        (only when the parent service type is `event`) have all slots ended with the
+        latest `ends_at` within the prior 90 days. Fully concluded `training_course`
+        instances are never returned on this feed.
+
+        Results are ordered by the earliest upcoming session slot,
+        then `service_instances.id` for a stable tie-break (finished `event` rows
+        sort with a null earliest-upcoming value).
 
         Optional filters: `service_type`, `slug`, `service_key`. Filters
         combine via logical AND; contradictory combinations return `events: []`.
@@ -291,7 +300,8 @@ paths:
             enum: [event, training_course]
           description: >
             Restrict feed to one service type. Omitted = both event and
-            training_course are returned. Consultation is never exposed.
+            training_course are returned (finished-event lookback applies only to
+            `event`). Consultation is never exposed.
         - name: slug
           in: query
           required: false
@@ -351,8 +361,17 @@ paths:
         Source of truth is the backend `service_instances` projection for
         published `event` and `training_course` services (consultation is never
         included). Instances with an empty `service_instances.slug` are
-        omitted from this feed. Results are ordered by the earliest upcoming session slot,
-        then `service_instances.id` for a stable tie-break.
+        omitted from this feed.
+
+        Visibility: each instance must either have at least one session slot with
+        `ends_at` not before the server clock (upcoming or in progress), **or**
+        (only when the parent service type is `event`) have all slots ended with the
+        latest `ends_at` within the prior 90 days. Fully concluded `training_course`
+        instances are never returned on this feed.
+
+        Results are ordered by the earliest upcoming session slot,
+        then `service_instances.id` for a stable tie-break (finished `event` rows
+        sort with a null earliest-upcoming value).
 
         Optional filters: `service_type`, `slug`, `service_key`. Filters
         combine via logical AND; contradictory combinations return `events: []`.
@@ -371,7 +390,8 @@ paths:
             enum: [event, training_course]
           description: >
             Restrict feed to one service type. Omitted = both event and
-            training_course are returned. Consultation is never exposed.
+            training_course are returned (finished-event lookback applies only to
+            `event`). Consultation is never exposed.
         - name: slug
           in: query
           required: false

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -464,7 +464,7 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 |--------------|--------|---------------|-------------|-------|
 | `/health` | GET | IAM | `HealthCheckFunction` | Health check |
 | `/v1/assets/free/request` | POST | None + API key | `EvolvesproutsAdminFunction` | Publishes `media_request.submitted` to SNS |
-| `/v1/calendar/public` | GET | None + API key | `EvolvesproutsAdminFunction` | Public event feed for `service_type=event` instances |
+| `/v1/calendar/public` | GET | None + API key | `EvolvesproutsAdminFunction` | Public calendar: published `event` and `training_course` instances (active sessions or **event** rows finished within ~90 days) |
 | `/v1/calendar/availability` | GET | None + API key | `EvolvesproutsAdminFunction` | Requires `purpose` (`consultation_booking` or `intro_call_booking`); returns slots + meta; consultation uses `Cache-Control: no-store` on 200 |
 | `/v1/assets/free` | GET | None + API key | `EvolvesproutsAdminFunction` | Lists public `client_document`-tagged assets; optional `language` query |
 | `/v1/admin/geographic-areas` | GET | Admin Group | `EvolvesproutsAdminFunction` | Geographic area lookup for address selection |

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -591,7 +591,7 @@ that intersect nominal local windows (09:00–12:00 → `am`, 14:00–18:00 → 
 `CALENDAR_BLOCKERS_WALL_TIMEZONE` (default `Asia/Hong_Kong`). Session-derived eligibility
 reuses the same SQL predicates as `ServiceInstanceRepository.list_public_offerings`
 (via `public_calendar_blocker_instance_predicates`), excluding feed-only filters
-(``ends_at >= now``, slug/service_key/limit).
+(active session cutoff, finished-event lookback, slug/service_key/limit).
 
 **Public `purpose`:** Only `consultation_booking` is allowed in this release; other
 values return **400**.

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -160,6 +160,7 @@ their primary responsibilities.
   `/www/v1/calendar/public` (public calendar feed: returns **event** and
   **training_course** `service_instances` for published services; consultation
   is intentionally excluded. Instances with an empty `service_instances.slug` are omitted.
+  Visibility: instances with any session not yet ended, or **event** instances whose last session ended within the prior 90 days (finished **training_course** rows are omitted).
   Each item includes `service_type`,
   `slug` (public instance slug from `service_instances.slug`), parent `service_key`
   (nullable `services.service_key`; required for public discount validate and reservation
@@ -174,7 +175,7 @@ their primary responsibilities.
   from `services.booking_system` or defaults from service type (MBA training
   cohorts default to `my-best-auntie-booking` when `services.service_key` is
   `my-best-auntie-training-course`). Results order by earliest upcoming session slot ascending
-  with `service_instances.id` as tie-break. Optional query filters:
+  with `service_instances.id` as tie-break (finished **event** rows sort after active rows). Optional query filters:
   `slug` (matched case-insensitively against `service_instances.slug`), `service_type`,
   `service_key` (matched case-insensitively against `services.service_key`; invalid values
   ignored). `slug` echoes from `service_instances`; when `max_capacity` is set,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -49,7 +49,7 @@ Flutter Mobile / Next.js Admin
   `service_instance_slug` (validate) and `serviceInstanceSlug` (reservations) for **events**
   and **MBA**; consultation tiers and intro-call identify catalog rows by `service_key` only on those routes.
   The public calendar feed (`GET /v1/calendar/public`) exposes the same `slug` field for events and
-  training courses. Family consultation venue copy for the booking modal lives in
+  training courses; finished **event** instances remain listed for roughly 90 days after their last session ends. Family consultation venue copy for the booking modal lives in
   `apps/public_www/src/content/family-consultations.json` (per tier `service_key`).
 - Hosted on S3 + CloudFront in one stack with separate staging and
   production assets.

--- a/tests/db/repositories/test_service_instance_public_offerings.py
+++ b/tests/db/repositories/test_service_instance_public_offerings.py
@@ -179,3 +179,124 @@ def test_list_public_offerings_omits_empty_slug_instances() -> None:
         ids = [r.id for r in rows if r.id in (inst_null, inst_slug)]
         assert inst_null not in ids
         assert inst_slug in ids
+
+
+@pytest.mark.skipif(_database_url() is None, reason="TEST_DATABASE_URL not set")
+def test_list_public_offerings_includes_recent_finished_events_only() -> None:
+    """Finished ``event`` instances within 90 days stay on the public feed."""
+    url = _database_url()
+    assert url is not None
+    engine = create_engine(_sqlalchemy_engine_url(url))
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    ref = datetime(2035, 3, 1, 10, 0, 0, tzinfo=UTC)
+    ends_recent = ref - timedelta(days=20)
+    starts_recent = ends_recent - timedelta(hours=2)
+    ends_old = ref - timedelta(days=120)
+    starts_old = ends_old - timedelta(hours=2)
+
+    area_id = uuid4()
+    loc_id = uuid4()
+    service_id = uuid4()
+    inst_recent = uuid4()
+    inst_old = uuid4()
+
+    with SessionLocal() as session:
+        session.add(
+            GeographicArea(
+                id=area_id,
+                parent_id=None,
+                name="Area FE",
+                name_translations={},
+                level="country",
+                code="HK",
+                active=True,
+                display_order=0,
+                sovereign_country_id=None,
+            )
+        )
+        session.add(
+            Location(
+                id=loc_id,
+                area_id=area_id,
+                name="Venue FE",
+                address="2 St",
+                lat=None,
+                lng=None,
+            )
+        )
+        session.add(
+            Service(
+                id=service_id,
+                service_type=ServiceType.EVENT,
+                title="Finished Feed Svc",
+                service_key=f"fin-feed-{service_id.hex[:8]}",
+                booking_system=None,
+                description=None,
+                cover_image_s3_key=None,
+                delivery_mode=ServiceDeliveryMode.IN_PERSON,
+                status=ServiceStatus.PUBLISHED,
+                created_by="pytest",
+                location_id=loc_id,
+            )
+        )
+        session.add(
+            EventDetails(
+                service_id=service_id,
+                event_category=EventCategory.WORKSHOP,
+                default_price=Decimal("10.00"),
+                default_currency="HKD",
+            )
+        )
+        for inst_id, slug_suffix, starts_at, ends_at in (
+            (inst_recent, inst_recent.hex[:8], starts_recent, ends_recent),
+            (inst_old, inst_old.hex[:8], starts_old, ends_old),
+        ):
+            session.add(
+                ServiceInstance(
+                    id=inst_id,
+                    service_id=service_id,
+                    title=f"Finished {slug_suffix}",
+                    slug=f"pytest-fin-ev-{slug_suffix}",
+                    description=None,
+                    cover_image_s3_key=None,
+                    status=InstanceStatus.COMPLETED,
+                    delivery_mode=ServiceDeliveryMode.IN_PERSON,
+                    location_id=loc_id,
+                    max_capacity=10,
+                    waitlist_enabled=False,
+                    instructor_id=None,
+                    cohort=None,
+                    notes=None,
+                    external_url=None,
+                    created_by="pytest",
+                )
+            )
+            session.add(
+                InstanceSessionSlot(
+                    instance_id=inst_id,
+                    location_id=loc_id,
+                    starts_at=starts_at,
+                    ends_at=ends_at,
+                    sort_order=0,
+                )
+            )
+            session.add(
+                EventTicketTier(
+                    instance_id=inst_id,
+                    name="tier",
+                    description=None,
+                    price=Decimal("10.00"),
+                    currency="HKD",
+                    max_quantity=None,
+                    sort_order=0,
+                )
+            )
+        session.commit()
+
+    with SessionLocal() as session:
+        repo = ServiceInstanceRepository(session)
+        rows = repo.list_public_offerings(limit=200, now=ref)
+        row_ids = {r.id for r in rows}
+        assert inst_recent in row_ids
+        assert inst_old not in row_ids

--- a/tests/test_public_events_repository.py
+++ b/tests/test_public_events_repository.py
@@ -39,6 +39,8 @@ def test_list_public_offerings_default_types_and_ordering_sql() -> None:
     assert "service_instances.status IN" in sql
     assert "min(instance_session_slots.starts_at)" in sql.lower()
     assert "instance_session_slots.ends_at >=" in sql
+    assert "max(instance_session_slots.ends_at)" in sql.lower()
+    assert "services.service_type = 'event'" in sql
     assert "ORDER BY" in sql.upper()
     assert "service_instances.id ASC" in sql
     assert "service_instances.slug != ''" in sql
@@ -79,6 +81,24 @@ def test_list_public_offerings_service_key_filter() -> None:
     assert "lower(services.service_key) = 'my-best-auntie-training-course'" in sql
     assert "services.service_type IN ('event', 'training_course')" in sql
     assert "services.status = 'published'" in sql
+
+
+def test_list_public_offerings_training_course_only_omits_finished_event_branch_sql() -> None:
+    mock_session = MagicMock()
+    exec_result = MagicMock()
+    exec_result.unique.return_value.scalars.return_value.all.return_value = []
+    mock_session.execute.return_value = exec_result
+
+    repo = ServiceInstanceRepository(mock_session)
+    now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    repo.list_public_offerings(
+        limit=5,
+        now=now,
+        service_types={ServiceType.TRAINING_COURSE},
+    )
+    stmt = mock_session.execute.call_args[0][0]
+    sql = _compiled_sql(stmt)
+    assert "max(instance_session_slots.ends_at)" not in sql.lower()
 
 
 def test_list_public_offerings_service_key_combines_with_other_filters() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The public calendar SQL feed (`ServiceInstanceRepository.list_public_offerings`, used by `GET /v1/calendar/public` and `GET /www/v1/calendar/public`) previously returned only instances with at least one session slot whose `ends_at` was still in the future. Fully concluded **event** workshops and other one-off events therefore disappeared from the API immediately after the last slot ended.

This change keeps published **`event`** instances on the feed when their **last** session ended within the prior **90 days** (approximate three-month window). **`training_course`** instances are unchanged: they still require a non-ended session slot.

## Implementation notes

- New module constant `PUBLIC_CALENDAR_FINISHED_EVENT_LOOKBACK` (`timedelta(days=90)`) in `service_instance.py`.
- When `service_type=training_course` is the only requested type, the finished-event branch is omitted from the query (same shape as before).

## Documentation and tests

- `docs/api/public.yaml` (both calendar paths), `lambdas.md`, `overview.md`, `decisions.md`, and `aws-assets-map.md` updated to match behavior.
- SQL compilation tests extended; optional PostgreSQL integration test added (`TEST_DATABASE_URL`).

## Seed data

No database migration or seed change: eligibility is query-time only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61832f97-fbac-485b-8cad-30f66271fbe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61832f97-fbac-485b-8cad-30f66271fbe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

