### PR TITLE
fix(admin): vertically center line override enrollment labels

### DIFF
--- a/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
+++ b/apps/admin_web/src/components/admin/finance/client-invoices-panel.tsx
@@ -1835,7 +1835,7 @@ export function ClientInvoicesPanel() {
                       return (
                         <div
                           key={row.enrollmentId}
-                          className={`flex flex-wrap items-start gap-x-4 gap-y-2 border px-3 py-2 ${
+                          className={`flex flex-wrap items-center gap-x-4 gap-y-2 border px-3 py-2 ${
                             needsAmt
                               ? "border-amber-300 bg-amber-50"
                               : "border-slate-200"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In **Create draft invoice** → **Line totals override**, each row shows `party · service · tier` beside the line total input. The row container used `items-start`, so the label sat at the top of the bordered box while the input was vertically centered on its own.

## Change

- Update the line override row flex container from `items-start` to `items-center` in `client-invoices-panel.tsx`.

## Testing

- `npx vitest run tests/components/admin/finance/client-invoices-panel.test.tsx` (40 tests passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e256a28c-def3-4b39-9835-78138b19f91f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e256a28c-def3-4b39-9835-78138b19f91f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

