### PR TITLE
chore(deps): bump database group (alembic, psycopg, sqlalchemy)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,12 +8,12 @@ version = "0.1.0"
 description = "Backend services for Evolve Sprouts."
 requires-python = ">=3.12"
 dependencies = [
-  "alembic==1.18.3",
+  "alembic==1.18.4",
   "boto3==1.43.9",
   "pyjwt[crypto]==2.12.1",
   "pydantic==2.13.4",
-  "psycopg[binary]==3.2.13",
-  "sqlalchemy==2.0.46",
+  "psycopg[binary]==3.3.4",
+  "sqlalchemy==2.0.49",
   "phonenumbers==9.0.30",
   "pycountry==26.2.16",
   "reportlab==4.5.1",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,9 @@
-alembic==1.18.3
+alembic==1.18.4
 boto3==1.43.9
 pyjwt[crypto]==2.12.1
 pydantic==2.13.4
-psycopg[binary]==3.2.13
-sqlalchemy==2.0.46
+psycopg[binary]==3.3.4
+sqlalchemy==2.0.49
 phonenumbers==9.0.30
 pycountry==26.2.16
 reportlab==4.5.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes Dependabot PR #934, which has been open for months with a **dirty** merge state and automatic rebases disabled.

## What was wrong with #934

- Dependabot branched from an older `main` and only bumped `alembic`, `psycopg`, and `sqlalchemy`.
- `main` moved on (e.g. `boto3` 1.43.6 → 1.43.9), so GitHub reports the PR as **not mergeable** (conflicts in `backend/requirements.txt` and `backend/pyproject.toml`).
- Dependabot stopped auto-rebasing after 30 days.

## This PR

Applies the same database group updates on current `main`, keeping the newer `boto3` pin:

| Package | Before | After |
|---------|--------|-------|
| alembic | 1.18.3 | 1.18.4 |
| psycopg[binary] | 3.2.13 | 3.3.4 |
| sqlalchemy | 2.0.46 | 2.0.49 |

## Validation

- `pytest tests/ -x` — 1186 passed, 18 skipped

## After merge

Close #934 (Dependabot will not cleanly rebase it).

## Optional repo housekeeping

Dependabot noted missing labels `backend` and `dependencies` referenced in `.github/dependabot.yml`. Creating those labels will stop the warning on future PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fab11d2-7fb6-4011-9168-219533cbdfc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fab11d2-7fb6-4011-9168-219533cbdfc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

