### PR TITLE
fix(ci): unblock dep bumps — widen Lambda bundler platforms and ignore disputed pyjwt advisory

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,9 +40,16 @@ jobs:
 
       - name: Run pip-audit
         working-directory: backend
+        # Ignored advisories:
+        # - PYSEC-2025-183 / CVE-2025-45768: disputed by the pyjwt maintainer
+        #   (advisory states "this is disputed by the Supplier because the key
+        #   length is chosen by the application that uses the library").
+        #   Affects all pyjwt versions with no published fix version, so it is
+        #   not actionable here. Application code that signs/verifies JWTs is
+        #   responsible for enforcing minimum key length.
         run: |
-          pip-audit -r requirements.txt --desc on --format json --output audit-results.json || true
-          pip-audit -r requirements.txt --desc on
+          pip-audit -r requirements.txt --desc on --ignore-vuln PYSEC-2025-183 --format json --output audit-results.json || true
+          pip-audit -r requirements.txt --desc on --ignore-vuln PYSEC-2025-183
 
       - name: Upload audit results
         uses: actions/upload-artifact@v7

--- a/backend/scripts/build_lambda_bundle.py
+++ b/backend/scripts/build_lambda_bundle.py
@@ -39,10 +39,24 @@ def _cleanup_bundle(output_dir: Path) -> None:
         cache_file.unlink()
 
 
+# Lambda Python 3.12 runs on Amazon Linux 2023 (glibc 2.34), so wheels tagged
+# manylinux_2_28 are compatible. Newer projects (for example psycopg-binary
+# 3.3.x) raised their manylinux baseline and no longer publish
+# manylinux_2_17_aarch64 wheels, so we must request the newer tags. We still
+# accept manylinux_2_17_aarch64 as a fallback for older transitive deps that
+# only publish that tag. pip will pick the most specific available wheel.
+_LAMBDA_PIP_PLATFORMS: tuple[str, ...] = (
+    "manylinux_2_28_aarch64",
+    "manylinux_2_27_aarch64",
+    "manylinux_2_17_aarch64",
+)
+
+
 def _requirements_cache_key(requirements: Path) -> str:
     hasher = hashlib.sha256()
     hasher.update(requirements.read_bytes())
-    hasher.update(b"\nplatform=manylinux_2_17_aarch64")
+    for platform in _LAMBDA_PIP_PLATFORMS:
+        hasher.update(f"\nplatform={platform}".encode())
     hasher.update(b"\nimplementation=cp")
     hasher.update(b"\npython_version=3.12")
     return hasher.hexdigest()
@@ -121,32 +135,34 @@ def _build_dependency_cache(
         shutil.rmtree(temp_cache_dir)
     temp_cache_dir.mkdir(parents=True, exist_ok=True)
 
+    pip_command: list[str] = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-r",
+        "requirements.txt",
+        "-t",
+        str(temp_cache_dir),
+        "--no-compile",
+        "--disable-pip-version-check",
+    ]
+    # Use Lambda-compatible wheels (Amazon Linux 2023 / manylinux_2_28 baseline,
+    # glibc 2.34) on ARM64 (Graviton2) - matches Lambda runtime config.
+    for platform in _LAMBDA_PIP_PLATFORMS:
+        pip_command.extend(["--platform", platform])
+    pip_command.extend(
+        [
+            "--only-binary=:all:",
+            "--implementation",
+            "cp",
+            "--python-version",
+            "3.12",
+        ]
+    )
+
     try:
-        _run_pip(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "-r",
-                "requirements.txt",
-                "-t",
-                str(temp_cache_dir),
-                "--no-compile",
-                "--disable-pip-version-check",
-                # Use Lambda-compatible wheels (Amazon Linux 2023 / manylinux)
-                # ARM64 architecture (Graviton2) - matches Lambda config
-                "--platform",
-                "manylinux_2_17_aarch64",
-                "--only-binary=:all:",
-                "--implementation",
-                "cp",
-                "--python-version",
-                "3.12",
-            ],
-            cwd=source_root,
-            env=env,
-        )
+        _run_pip(pip_command, cwd=source_root, env=env)
         _cleanup_bundle(temp_cache_dir)
         if cache_dir.exists():
             shutil.rmtree(cache_dir)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two CI-infra fixes needed to unblock the Dependabot database-group bump in #934, both rolled into one PR because they're the minimum set of changes required for any future Python dep bump to merge.

## 1. Lambda bundler: widen pip `--platform` to manylinux_2_28_aarch64

`backend/scripts/build_lambda_bundle.py` calls pip with a single `--platform manylinux_2_17_aarch64`. That tag worked for `psycopg-binary<=3.2.13`, but `psycopg-binary` 3.3.x **raised its manylinux baseline** and now only publishes `manylinux_2_27_aarch64.manylinux_2_28_aarch64` wheels. Any bump that pulls in `psycopg-binary>=3.3` (most recently #934) therefore fails the **Test Infrastructure** and **Checkov IaC Security** jobs with:

> ERROR: Could not find a version that satisfies the requirement psycopg-binary==3.3.4 … (from versions: 3.1.12 … 3.2.13)

**Change**: introduce `_LAMBDA_PIP_PLATFORMS = ("manylinux_2_28_aarch64", "manylinux_2_27_aarch64", "manylinux_2_17_aarch64")` and pass each as a separate `--platform` flag to `pip install`. pip selects the most specific matching wheel per requirement; older transitive deps that still tag only `_2_17` keep resolving. The dependency-cache hash key is updated to include the full platform tuple, so existing caches are invalidated and rebuilt against the new set.

**Safety**: AWS Lambda's Python 3.12 runtime runs on **Amazon Linux 2023** (glibc 2.34), which is fully compatible with `manylinux_2_28_aarch64`.

## 2. Security workflow: ignore disputed pyjwt advisory PYSEC-2025-183

OSV advisory [PYSEC-2025-183 / CVE-2025-45768](https://osv.dev/vulnerability/PYSEC-2025-183) was modified on 2026-05-20 (yesterday). Its own text states:

> pyjwt v2.10.1 was discovered to contain weak encryption. NOTE: this is **disputed by the Supplier** because the key length is chosen by the application that uses the library.

It affects every pyjwt version with **no fix-version** and **no closing event** in its range, so `pip-audit` started failing CI on every Python PR (and would also fail `main` on its next scheduled scan).

**Change**: pass `--ignore-vuln PYSEC-2025-183` to both `pip-audit` invocations in `.github/workflows/security.yml` with an inline comment documenting why. Application code is responsible for enforcing minimum JWT key length — that is the application's concern, not pyjwt's. The entry can be revisited if pyjwt ships an opt-in strict mode.

## Verification

Local sandbox (Python 3.12, ARM64-target resolution):

```bash
# Current backend/requirements.txt (psycopg 3.2.13)
✅ python3 backend/scripts/build_lambda_bundle.py --cache-only
   → Successfully installed psycopg-binary-3.2.13 …

# PR #934 candidate state (psycopg 3.3.4, sqlalchemy 2.0.49, alembic 1.18.4)
✅ python3 backend/scripts/build_lambda_bundle.py --cache-only
   → Successfully installed psycopg-binary-3.3.4 …
     (resolved psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl)

# pip-audit with new ignore flag, against current and PR #934 requirements
✅ pip-audit -r backend/requirements.txt --ignore-vuln PYSEC-2025-183
   → No known vulnerabilities found, 1 ignored
```

Repo guardrails:

- ✅ `bash scripts/validate-cursorrules.sh`
- ✅ `ruff check backend/ tests/ --config=backend/pyproject.toml`
- ✅ `ruff format --check backend/scripts/build_lambda_bundle.py --config=backend/pyproject.toml`

#934 has been rebased on top of this branch so its CI re-runs against both fixes.

## Risk

- **Cache invalidation**: the bundler dependency-cache key includes the platform list, so every dev machine and CI runner rebuilds the cache once on first run. Self-healing.
- **No production behavior change**: the bundled artifact set is identical for the current `requirements.txt`; only the wheel-resolution constraint widens.
- **pip-audit ignore is targeted**: only PYSEC-2025-183 is suppressed, and only because it is upstream-disputed with no fix. All other advisories continue to fail the build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5b29b41-e74a-48c7-b456-759f35ad8425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5b29b41-e74a-48c7-b456-759f35ad8425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

