### PR TITLE
Heal missing bill-to address on issued invoice PDFs

### DIFF
--- a/backend/src/app/api/admin_billing_invoice_queries.py
+++ b/backend/src/app/api/admin_billing_invoice_queries.py
@@ -14,6 +14,7 @@ from app.api.admin_billing_common import DEFAULT_BILLING_LIST_LIMIT, _session_wi
 from app.api.admin_billing_invoice_draft_helpers import (
     _resolve_bill_to_party_from_invoice_fks,
 )
+from app.api.admin_billing_invoices import maybe_refresh_issued_bill_to_snapshot
 from app.api.admin_billing_invoice_serializers import (
     parse_optional_invoice_settlement,
     parse_optional_invoice_status,
@@ -212,11 +213,16 @@ def get_invoice_pdf_download(
             raise NotFoundError("CustomerInvoice", str(invoice_id))
         # Drafts: re-resolve the bill-to snapshot from current CRM data so PDF
         # previews reflect address/email/name edits made after draft creation.
-        # Issued and void invoices keep their persisted snapshot so their PDFs
-        # remain stable artifacts.
+        # Issued invoices: heal missing ``bill_to_location_text`` only — older
+        # issued invoices may have an empty snapshot because the resolver did not
+        # yet support the contact-membership fallback. Issued invoices that
+        # already have a populated snapshot are never touched (PDF stays
+        # byte-stable). Void invoices keep their persisted snapshot.
         if inv.status == BillingInvoiceStatus.DRAFT:
             _resolve_bill_to_party_from_invoice_fks(session, inv=inv)
             session.flush()
+        elif inv.status == BillingInvoiceStatus.ISSUED:
+            maybe_refresh_issued_bill_to_snapshot(session, inv)
         s3_key = ensure_invoice_pdf_storage(session, inv)
         download = generate_download_url(
             s3_key=s3_key,

--- a/backend/src/app/api/admin_billing_invoices.py
+++ b/backend/src/app/api/admin_billing_invoices.py
@@ -78,6 +78,53 @@ def _validate_bill_to_fk_for_issue(inv: CustomerInvoice) -> None:
             )
 
 
+def maybe_refresh_issued_bill_to_snapshot(
+    session: Session, inv: CustomerInvoice
+) -> bool:
+    """Heal an issued invoice whose ``bill_to_location_text`` is missing.
+
+    Older issued invoices may have an empty ``bill_to_location_text`` because the
+    snapshot resolver did not yet support the contact-membership fallback for
+    member contacts (admin contact mutations forbid setting ``Contact.location_id``
+    when the contact is linked to a family or organisation; see
+    ``admin_billing_invoice_draft_helpers._resolve_bill_to_party_from_invoice_fks``).
+
+    To repair these without violating issued-invoice immutability for already
+    populated snapshots, this helper:
+
+    - returns ``False`` when ``bill_to_location_text`` is already non-empty (no-op
+      so issued PDFs with valid addresses remain byte-stable);
+    - otherwise re-resolves the bill-to party; if re-resolution yields a non-empty
+      location, persists the new ``bill_to_*`` columns + regenerated
+      ``bill_to_snapshot`` JSON and re-renders the issued PDF;
+    - otherwise restores the original (empty) state and leaves the invoice
+      untouched.
+
+    Invoice number, totals, lines, and dates are never modified — only the
+    bill-to snapshot fields and the issued PDF artifact are regenerated, and
+    only when the address was missing.
+    """
+    existing = (inv.bill_to_location_text or "").strip()
+    if existing:
+        return False
+    prev_name = inv.bill_to_display_name
+    prev_email = inv.bill_to_email
+    prev_loc = inv.bill_to_location_text
+    prev_snap = inv.bill_to_snapshot
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)
+    new_loc = (inv.bill_to_location_text or "").strip()
+    if not new_loc:
+        inv.bill_to_display_name = prev_name
+        inv.bill_to_email = prev_email
+        inv.bill_to_location_text = prev_loc
+        inv.bill_to_snapshot = prev_snap
+        return False
+    inv.bill_to_snapshot = _build_bill_to_snapshot(session, inv)
+    session.flush()
+    refresh_invoice_pdf(session, inv)
+    return True
+
+
 def _build_bill_to_snapshot(session: Session, inv: CustomerInvoice) -> dict[str, Any]:
     snap: dict[str, Any] = {
         "kind": inv.bill_to_kind.value,

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -671,6 +671,12 @@ Migration `0055_customer_billing_ar` introduces:
   back to the first family-membership family with a `location_id` (rendered without the
   venue name to match FAMILY bill-to convention), then to the first organization
   membership with a `location_id` (with venue name, matching ORGANIZATION bill-to).
+  ISSUED invoices whose `bill_to_location_text` is empty are healed on PDF download:
+  the resolver runs again, and if it now produces a non-empty location text, the
+  `bill_to_*` columns + `bill_to_snapshot` JSON are updated and the issued PDF is
+  regenerated in place. Issued invoices with a populated snapshot are never modified
+  (the issued PDF stays byte-stable). Invoice number, totals, lines, and dates are
+  never touched by the heal path.
 - Migration `0066_cp_enroll_extref_uq` adds a partial unique index on
   `customer_payments (enrollment_id, external_reference)` when `external_reference` is not null,
   so duplicate manual inbound references for the same enrollment return HTTP 409 from the admin API.

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -1994,6 +1994,217 @@ def test_get_invoice_pdf_refreshes_bill_to_snapshot_for_draft(
     assert inv.bill_to_location_text == "Harbour Studio\n1 Pier\nCentral"
 
 
+def test_get_invoice_pdf_heals_empty_bill_to_snapshot_for_issued(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Older issued invoices with an empty bill_to_location_text get healed.
+
+    Reproduces the report that contact-billed invoices issued before the
+    contact-membership fallback existed render without an address. On PDF
+    download, the resolver runs again, the now-populated snapshot is
+    persisted, and the issued PDF is regenerated in place. Issued invoices
+    that already have a populated snapshot are exercised by
+    ``test_get_invoice_pdf_does_not_refresh_bill_to_snapshot_for_issued``.
+    """
+    from app.db.models import Family, Location
+
+    inv_id = uuid4()
+    cid = uuid4()
+    fid = uuid4()
+    lid = uuid4()
+    contact = SimpleNamespace(
+        id=cid,
+        email="kid@example.com",
+        first_name="Sam",
+        last_name="Ng",
+        location_id=None,
+    )
+    fam = SimpleNamespace(id=fid, family_name="Ng Family", location_id=lid)
+    loc = SimpleNamespace(name="Ng Family Home", address="1 Lane\nKowloon")
+    inv = SimpleNamespace(
+        id=inv_id,
+        status=BillingInvoiceStatus.ISSUED,
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact_id=cid,
+        bill_to_family_id=None,
+        bill_to_organization_id=None,
+        bill_to_display_name=None,
+        bill_to_email=None,
+        bill_to_location_text=None,
+        bill_to_snapshot=None,
+        issued_pdf_s3_key="billing/invoices/issued/x.pdf",
+        lines=[],
+    )
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+        s.execute.return_value.scalar_one_or_none.return_value = inv
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is Contact and pk == cid:
+                return contact
+            if model is Family and pk == fid:
+                return fam
+            if model is Location and pk == lid:
+                return loc
+            if model is CustomerInvoice and pk == inv_id:
+                return inv
+            return None
+
+        s.get.side_effect = _get
+
+        # Family-membership query returns the family; subsequent queries (e.g.
+        # _build_bill_to_snapshot's CustomerInvoice loads via session.get) are
+        # unaffected.
+        fam_result = MagicMock()
+        fam_result.scalar_one_or_none.return_value = fam
+        # First execute: invoice load; second execute: family-membership lookup.
+        invoice_result = MagicMock()
+        invoice_result.scalar_one_or_none.return_value = inv
+        s.execute.side_effect = [invoice_result, fam_result]
+        yield s
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+
+    refresh_calls: list[Any] = []
+
+    def _spy_refresh(_session: Any, _inv: Any) -> None:
+        refresh_calls.append(_inv)
+
+    monkeypatch.setattr(
+        admin_billing_invoices_mod,
+        "refresh_invoice_pdf",
+        _spy_refresh,
+    )
+    monkeypatch.setattr(
+        admin_billing_invoice_queries_mod,
+        "ensure_invoice_pdf_storage",
+        lambda _session, _inv: "billing/invoices/issued/x.pdf",
+    )
+    monkeypatch.setattr(
+        admin_billing_invoice_queries_mod,
+        "generate_download_url",
+        lambda *, s3_key, cache_bust_key=None: {
+            "download_url": "https://cdn.example.com/signed",
+            "expires_at": "2026-12-31T00:00:00+00:00",
+        },
+    )
+
+    ev = api_gateway_event(
+        method="GET",
+        path=f"/v1/admin/billing/invoices/{inv_id}/pdf",
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "GET", f"/v1/admin/billing/invoices/{inv_id}/pdf"
+    )
+    assert r["statusCode"] == 200
+    # Snapshot was healed from the family-membership location.
+    assert inv.bill_to_display_name == "Sam Ng"
+    assert inv.bill_to_email == "kid@example.com"
+    assert inv.bill_to_location_text == "1 Lane\nKowloon"
+    # Issued PDF was regenerated in place.
+    assert refresh_calls == [inv]
+
+
+def test_get_invoice_pdf_does_not_heal_when_resolution_still_empty(
+    api_gateway_event: Any,
+    admin_identity: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If re-resolution still yields no address, leave issued invoice unchanged."""
+    inv_id = uuid4()
+    cid = uuid4()
+    contact = SimpleNamespace(
+        id=cid,
+        email="orphan@example.com",
+        first_name="Drew",
+        last_name="Park",
+        location_id=None,
+    )
+    inv = SimpleNamespace(
+        id=inv_id,
+        status=BillingInvoiceStatus.ISSUED,
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact_id=cid,
+        bill_to_family_id=None,
+        bill_to_organization_id=None,
+        bill_to_display_name="Original Name",
+        bill_to_email="original@example.com",
+        bill_to_location_text=None,
+        bill_to_snapshot={"kind": "contact", "location_text": None},
+        issued_pdf_s3_key="billing/invoices/issued/x.pdf",
+        lines=[],
+    )
+
+    @contextmanager
+    def _fake_session(_u: str, _r: str | None) -> Any:
+        s = MagicMock()
+
+        def _get(model: Any, pk: Any) -> Any:
+            if model is Contact and pk == cid:
+                return contact
+            if model is CustomerInvoice and pk == inv_id:
+                return inv
+            return None
+
+        s.get.side_effect = _get
+
+        invoice_result = MagicMock()
+        invoice_result.scalar_one_or_none.return_value = inv
+        empty_result = MagicMock()
+        empty_result.scalar_one_or_none.return_value = None
+        # Sequence: invoice load, family-membership query (None), org-membership
+        # query (None).
+        s.execute.side_effect = [invoice_result, empty_result, empty_result]
+        yield s
+
+    _patch_billing_sessions(monkeypatch, _fake_session)
+
+    refresh_calls: list[Any] = []
+
+    def _spy_refresh(_session: Any, _inv: Any) -> None:
+        refresh_calls.append(_inv)
+
+    monkeypatch.setattr(
+        admin_billing_invoices_mod,
+        "refresh_invoice_pdf",
+        _spy_refresh,
+    )
+    monkeypatch.setattr(
+        admin_billing_invoice_queries_mod,
+        "ensure_invoice_pdf_storage",
+        lambda _session, _inv: "billing/invoices/issued/x.pdf",
+    )
+    monkeypatch.setattr(
+        admin_billing_invoice_queries_mod,
+        "generate_download_url",
+        lambda *, s3_key, cache_bust_key=None: {
+            "download_url": "https://cdn.example.com/signed",
+            "expires_at": "2026-12-31T00:00:00+00:00",
+        },
+    )
+
+    ev = api_gateway_event(
+        method="GET",
+        path=f"/v1/admin/billing/invoices/{inv_id}/pdf",
+        authorizer_context=admin_identity,
+    )
+    r = admin_billing.handle_admin_billing_request(
+        ev, "GET", f"/v1/admin/billing/invoices/{inv_id}/pdf"
+    )
+    assert r["statusCode"] == 200
+    # Original snapshot preserved; PDF not regenerated.
+    assert inv.bill_to_display_name == "Original Name"
+    assert inv.bill_to_email == "original@example.com"
+    assert inv.bill_to_location_text is None
+    assert inv.bill_to_snapshot == {"kind": "contact", "location_text": None}
+    assert refresh_calls == []
+
+
 def test_get_invoice_pdf_does_not_refresh_bill_to_snapshot_for_issued(
     api_gateway_event: Any,
     admin_identity: dict[str, str],


### PR DESCRIPTION
Even with the contact-membership fallback in the resolver and the draft-refresh on PDF download, issued invoices issued before the fix landed had their bill_to_location_text frozen as null and the persisted PDF never re-rendered: ensure_invoice_pdf_storage short-circuits to the stored issued PDF blob, so the resolver never ran again for those rows. Users still saw no address on the Bill To block.

Add maybe_refresh_issued_bill_to_snapshot in admin_billing_invoices. On PDF download for an ISSUED invoice, when bill_to_location_text is empty:

  1. Capture the prior bill_to_* columns + bill_to_snapshot JSON.
  2. Re-resolve via _resolve_bill_to_party_from_invoice_fks (which now includes the contact-membership family/organization fallback).
  3. If re-resolution produces a non-empty location, persist the new columns, rebuild bill_to_snapshot via _build_bill_to_snapshot, and re-render the issued PDF via refresh_invoice_pdf in place.
  4. If re-resolution still yields no address, restore every captured prior value so the invoice is byte-identical to before.

Issued invoices whose bill_to_location_text is already populated are never inspected — the helper returns False immediately so those PDFs remain stable artifacts. Invoice number, totals, lines, and dates are never touched by this code path.

Wire it into get_invoice_pdf_download next to the existing draft refresh, gated on inv.status == ISSUED.

Add two regression tests:
  - issued invoice with empty snapshot + family-membership location heals the snapshot and triggers refresh_invoice_pdf;
  - issued invoice with empty snapshot but no resolvable membership location restores the prior state and does not re-render.

Document the heal path alongside the existing draft-refresh and membership-fallback notes in database-schema.md.