### PR TITLE
Fix contact-billed invoice PDFs missing the address (heal issued + iterate memberships)

### DIFF
--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -241,10 +241,18 @@ def _contact_membership_location_snapshot(
     When a contact is linked to a family or organization, ``Contact.location_id`` is
     intentionally null — admin contact mutations forbid setting it, so the address is
     owned by the family/organization record (see ``admin_contacts_mutations``). For
-    CONTACT bill-to invoices we still want the address on the PDF, so fall back to the
-    first family the contact belongs to that has a ``location_id`` (rendered without
-    the venue name, matching the FAMILY bill-to branch), then the first organization
-    with a ``location_id`` (with venue name, matching the ORGANIZATION branch).
+    CONTACT bill-to invoices we still want the address on the PDF, so iterate through
+    each family the contact belongs to, mirroring the FAMILY bill-to resolution
+    (use ``family.location_id`` first; if absent, fall back to the family's primary
+    contact's ``location_id`` for legacy data where the address sat on the primary
+    contact instead of the family). Render with ``include_venue_name=False`` to match
+    the FAMILY bill-to convention. Then iterate through the contact's organization
+    memberships using ``organization.location_id`` with ``include_venue_name=True``
+    (matching the ORGANIZATION branch). Return the first non-empty snapshot text;
+    if no membership yields an address, return ``None``.
+
+    Iterating (rather than ``LIMIT 1``) handles the case where a contact belongs to
+    multiple families/orgs and only some have a populated address.
     """
     contact_id = getattr(contact, "id", None)
     if contact_id is None:
@@ -253,15 +261,26 @@ def _contact_membership_location_snapshot(
         select(Family)
         .join(FamilyMember, FamilyMember.family_id == Family.id)
         .where(FamilyMember.contact_id == contact_id)
-        .where(Family.location_id.is_not(None))
         .order_by(Family.family_name, FamilyMember.id)
-        .limit(1)
     )
-    fam = session.execute(fam_stmt).scalar_one_or_none()
-    if fam is not None:
+    for fam in session.execute(fam_stmt).scalars():
+        loc_id = getattr(fam, "location_id", None)
+        if loc_id is None:
+            primary_stmt = (
+                select(Contact)
+                .join(FamilyMember, FamilyMember.contact_id == Contact.id)
+                .where(FamilyMember.family_id == fam.id)
+                .where(FamilyMember.is_primary_contact.is_(True))
+                .limit(1)
+            )
+            primary = session.execute(primary_stmt).scalar_one_or_none()
+            if primary is not None:
+                loc_id = getattr(primary, "location_id", None)
+        if loc_id is None:
+            continue
         text = _bill_to_location_snapshot_text(
             session,
-            getattr(fam, "location_id", None),
+            loc_id,
             include_venue_name=False,
         )
         if text:
@@ -273,15 +292,15 @@ def _contact_membership_location_snapshot(
             OrganizationMember.organization_id == Organization.id,
         )
         .where(OrganizationMember.contact_id == contact_id)
-        .where(Organization.location_id.is_not(None))
         .order_by(Organization.name, OrganizationMember.id)
-        .limit(1)
     )
-    org = session.execute(org_stmt).scalar_one_or_none()
-    if org is not None:
+    for org in session.execute(org_stmt).scalars():
+        loc_id = getattr(org, "location_id", None)
+        if loc_id is None:
+            continue
         text = _bill_to_location_snapshot_text(
             session,
-            getattr(org, "location_id", None),
+            loc_id,
             include_venue_name=True,
         )
         if text:

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -2041,7 +2041,6 @@ def test_get_invoice_pdf_heals_empty_bill_to_snapshot_for_issued(
     @contextmanager
     def _fake_session(_u: str, _r: str | None) -> Any:
         s = MagicMock()
-        s.execute.return_value.scalar_one_or_none.return_value = inv
 
         def _get(model: Any, pk: Any) -> Any:
             if model is Contact and pk == cid:
@@ -2056,15 +2055,26 @@ def test_get_invoice_pdf_heals_empty_bill_to_snapshot_for_issued(
 
         s.get.side_effect = _get
 
-        # Family-membership query returns the family; subsequent queries (e.g.
-        # _build_bill_to_snapshot's CustomerInvoice loads via session.get) are
-        # unaffected.
-        fam_result = MagicMock()
-        fam_result.scalar_one_or_none.return_value = fam
-        # First execute: invoice load; second execute: family-membership lookup.
-        invoice_result = MagicMock()
-        invoice_result.scalar_one_or_none.return_value = inv
-        s.execute.side_effect = [invoice_result, fam_result]
+        # Differentiate execute calls: invoice load (selectinload from
+        # customer_invoices) returns the invoice; family iteration via
+        # ``scalars()`` returns ``[fam]``; org iteration returns ``[]``.
+        def _execute(stmt: Any) -> Any:
+            compiled = str(stmt).lower()
+            result = MagicMock()
+            if "from customer_invoices" in compiled:
+                result.scalar_one_or_none.return_value = inv
+                return result
+            if "is_primary_contact" in compiled:
+                result.scalar_one_or_none.return_value = None
+                return result
+            if "from families" in compiled or "join family_members" in compiled:
+                result.scalars.return_value = [fam]
+                return result
+            result.scalar_one_or_none.return_value = None
+            result.scalars.return_value = []
+            return result
+
+        s.execute.side_effect = _execute
         yield s
 
     _patch_billing_sessions(monkeypatch, _fake_session)
@@ -2153,13 +2163,17 @@ def test_get_invoice_pdf_does_not_heal_when_resolution_still_empty(
 
         s.get.side_effect = _get
 
-        invoice_result = MagicMock()
-        invoice_result.scalar_one_or_none.return_value = inv
-        empty_result = MagicMock()
-        empty_result.scalar_one_or_none.return_value = None
-        # Sequence: invoice load, family-membership query (None), org-membership
-        # query (None).
-        s.execute.side_effect = [invoice_result, empty_result, empty_result]
+        def _execute(stmt: Any) -> Any:
+            compiled = str(stmt).lower()
+            result = MagicMock()
+            if "from customer_invoices" in compiled:
+                result.scalar_one_or_none.return_value = inv
+                return result
+            result.scalar_one_or_none.return_value = None
+            result.scalars.return_value = []
+            return result
+
+        s.execute.side_effect = _execute
         yield s
 
     _patch_billing_sessions(monkeypatch, _fake_session)
@@ -5353,6 +5367,40 @@ def test_resolve_bill_to_party_from_invoice_fks_contact_includes_location_text()
     assert inv.bill_to_location_text == "Harbour Studio\n1 Pier\nCentral"
 
 
+def _membership_execute_factory(
+    *,
+    families: list[Any] | None = None,
+    organizations: list[Any] | None = None,
+    primary_contact: Any | None = None,
+):
+    """Build a ``session.execute`` side_effect for the contact-membership fallback.
+
+    Differentiates queries by inspecting the compiled SQL: the family/organization
+    membership lookups iterate via ``scalars()``; the primary-contact-by-family
+    lookup (used when a family has no own ``location_id``) uses
+    ``scalar_one_or_none()``.
+    """
+
+    def _execute(stmt: Any) -> Any:
+        compiled = str(stmt).lower()
+        result = MagicMock()
+        if "is_primary_contact" in compiled:
+            result.scalar_one_or_none.return_value = primary_contact
+            return result
+        if "from families" in compiled or "join family_members" in compiled:
+            result.scalars.return_value = list(families or [])
+            return result
+        if "from organizations" in compiled or "join organization_members" in compiled:
+            result.scalars.return_value = list(organizations or [])
+            return result
+        # Fallback for any other queries (e.g. invoice loads in the heal path).
+        result.scalar_one_or_none.return_value = None
+        result.scalars.return_value = []
+        return result
+
+    return _execute
+
+
 def test_resolve_bill_to_party_from_invoice_fks_contact_falls_back_to_family_location() -> None:
     """Contact bill-to with no own location uses the contact's family location.
 
@@ -5391,10 +5439,7 @@ def test_resolve_bill_to_party_from_invoice_fks_contact_falls_back_to_family_loc
         return None
 
     session.get.side_effect = _get
-
-    fam_result = MagicMock()
-    fam_result.scalar_one_or_none.return_value = fam
-    session.execute.return_value = fam_result
+    session.execute.side_effect = _membership_execute_factory(families=[fam])
 
     inv = SimpleNamespace(
         bill_to_kind=BillingBillToKind.CONTACT,
@@ -5405,6 +5450,65 @@ def test_resolve_bill_to_party_from_invoice_fks_contact_falls_back_to_family_loc
     )
     _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
     assert inv.bill_to_location_text == "1 Lane\nKowloon"
+
+
+def test_resolve_bill_to_party_from_invoice_fks_contact_uses_family_primary_location_fallback() -> None:
+    """Contact bill-to: when family has no own location, use primary contact's location.
+
+    Mirrors the FAMILY bill-to branch's primary-contact-location fallback so legacy
+    data where the family entity has no ``location_id`` but its primary contact does
+    still surfaces an address on contact-billed invoices.
+    """
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Contact, Location
+
+    cid = uuid4()
+    fid = uuid4()
+    pid = uuid4()
+    lid = uuid4()
+    contact = SimpleNamespace(
+        id=cid,
+        email="kid@example.com",
+        first_name="Sam",
+        last_name="Ng",
+        location_id=None,
+    )
+    fam = SimpleNamespace(id=fid, family_name="Ng Family", location_id=None)
+    primary = SimpleNamespace(
+        id=pid,
+        first_name="Pat",
+        last_name="Ng",
+        email="pat@example.com",
+        location_id=lid,
+    )
+    loc = SimpleNamespace(name="Ng Home", address="3 Avenue\nCentral")
+
+    session = MagicMock()
+
+    def _get(model: Any, pk: Any) -> Any:
+        if model is Contact and pk == cid:
+            return contact
+        if model is Location and pk == lid:
+            return loc
+        return None
+
+    session.get.side_effect = _get
+    session.execute.side_effect = _membership_execute_factory(
+        families=[fam],
+        primary_contact=primary,
+    )
+
+    inv = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact_id=cid,
+        bill_to_display_name=None,
+        bill_to_email=None,
+        bill_to_location_text=None,
+    )
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
+    assert inv.bill_to_location_text == "3 Avenue\nCentral"
 
 
 def test_resolve_bill_to_party_from_invoice_fks_contact_falls_back_to_organization_location() -> None:
@@ -5441,19 +5545,9 @@ def test_resolve_bill_to_party_from_invoice_fks_contact_falls_back_to_organizati
         return None
 
     session.get.side_effect = _get
-
-    fam_result = MagicMock()
-    fam_result.scalar_one_or_none.return_value = None
-    org_result = MagicMock()
-    org_result.scalar_one_or_none.return_value = org
-
-    def _execute(stmt: Any) -> Any:
-        compiled = str(stmt).lower()
-        if "families" in compiled or "family_members" in compiled:
-            return fam_result
-        return org_result
-
-    session.execute.side_effect = _execute
+    session.execute.side_effect = _membership_execute_factory(
+        organizations=[org],
+    )
 
     inv = SimpleNamespace(
         bill_to_kind=BillingBillToKind.CONTACT,
@@ -5534,10 +5628,7 @@ def test_resolve_bill_to_party_from_invoice_fks_contact_no_membership_location_r
         return None
 
     session.get.side_effect = _get
-
-    none_result = MagicMock()
-    none_result.scalar_one_or_none.return_value = None
-    session.execute.return_value = none_result
+    session.execute.side_effect = _membership_execute_factory()
 
     inv = SimpleNamespace(
         bill_to_kind=BillingBillToKind.CONTACT,

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -51,6 +51,98 @@ def _inv_line(**kwargs: object) -> SimpleNamespace:
     return SimpleNamespace(**defaults)
 
 
+def test_contact_bill_to_with_family_membership_renders_address_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: CONTACT bill-to → membership fallback resolver → PDF includes address.
+
+    Reproduces the production report ("contact has a location but the address
+    isn't on the PDF") by wiring the real resolver to the real renderer. The
+    contact has no own ``location_id`` (admin contact mutations forbid it for
+    family-linked contacts); the address must surface from the family's
+    ``location_id`` via ``_contact_membership_location_snapshot``.
+    """
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Contact, Family, Location
+
+    _base_invoice_env(monkeypatch)
+
+    cid = uuid4()
+    fid = uuid4()
+    lid = uuid4()
+    contact = SimpleNamespace(
+        id=cid,
+        email="parent@example.com",
+        first_name="Pat",
+        last_name="Ng",
+        location_id=None,
+    )
+    fam = SimpleNamespace(id=fid, family_name="Ng Family", location_id=lid)
+    loc = SimpleNamespace(name="Ng Family Home", address="1 Lane\nKowloon")
+
+    session = MagicMock()
+
+    def _get(model: object, pk: object) -> object | None:
+        if model is Contact and pk == cid:
+            return contact
+        if model is Family and pk == fid:
+            return fam
+        if model is Location and pk == lid:
+            return loc
+        return None
+
+    session.get.side_effect = _get
+    fam_result = MagicMock()
+    fam_result.scalar_one_or_none.return_value = fam
+    session.execute.return_value = fam_result
+
+    inv = SimpleNamespace(
+        invoice_number="INV-MEM-1",
+        currency="HKD",
+        subtotal=Decimal("100"),
+        tax_total=Decimal("0"),
+        total=Decimal("100"),
+        bill_to_kind=BillingBillToKind.CONTACT,
+        bill_to_contact_id=cid,
+        bill_to_family_id=None,
+        bill_to_organization_id=None,
+        bill_to_display_name=None,
+        bill_to_email=None,
+        bill_to_location_text=None,
+        issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+        invoice_date=date(2026, 1, 1),
+        due_date=date(2026, 1, 8),
+        status=BillingInvoiceStatus.ISSUED,
+    )
+
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)
+
+    assert inv.bill_to_display_name == "Pat Ng"
+    assert inv.bill_to_email == "parent@example.com"
+    # Family fallback drops the venue name.
+    assert inv.bill_to_location_text == "1 Lane\nKowloon"
+
+    pdf = render_invoice_pdf(
+        invoice=inv,
+        lines=[
+            _inv_line(
+                description="Workshop",
+                unit_amount=Decimal("100"),
+                line_total=Decimal("100"),
+            )
+        ],
+        preview=False,
+    )
+    text = _pdf_text(pdf)
+    assert "Pat Ng" in text
+    assert "1 Lane" in text
+    assert "Kowloon" in text
+    # Email is suppressed when a location snapshot is present (postal block).
+    assert "parent@example.com" not in text
+
+
 def test_bill_to_location_text_renders_in_pdf(monkeypatch: pytest.MonkeyPatch) -> None:
     _base_invoice_env(monkeypatch)
     inv = SimpleNamespace(

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -94,9 +94,21 @@ def test_contact_bill_to_with_family_membership_renders_address_end_to_end(
         return None
 
     session.get.side_effect = _get
-    fam_result = MagicMock()
-    fam_result.scalar_one_or_none.return_value = fam
-    session.execute.return_value = fam_result
+
+    def _execute(stmt: object) -> MagicMock:
+        compiled = str(stmt).lower()
+        result = MagicMock()
+        if "is_primary_contact" in compiled:
+            result.scalar_one_or_none.return_value = None
+            return result
+        if "from families" in compiled or "join family_members" in compiled:
+            result.scalars.return_value = [fam]
+            return result
+        result.scalars.return_value = []
+        result.scalar_one_or_none.return_value = None
+        return result
+
+    session.execute.side_effect = _execute
 
     inv = SimpleNamespace(
         invoice_number="INV-MEM-1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Follow-up to #1705. That PR landed the draft-refresh-on-PDF-download path and the initial contact-membership fallback resolver, but two cases were still failing in production:

1. **Issued invoices issued before the fix had their `bill_to_location_text` frozen empty**, and `ensure_invoice_pdf_storage` short-circuits to the persisted PDF, so the resolver never ran again on download. Users still saw no address on these older issued invoices.
2. **The membership fallback only matched families/orgs whose own `location_id` was set**, but the FAMILY bill-to branch ALSO falls back to the family's primary-contact location (legacy data where the address sits on the primary contact, not the family entity). A contact-billed invoice for that family fell through with an empty snapshot while the matching FAMILY-billed invoice rendered the address.

## What

- **`backend/src/app/api/admin_billing_invoices.py`** — add `maybe_refresh_issued_bill_to_snapshot`. Conservative data-healing for issued invoices on PDF download:
  1. No-op when `bill_to_location_text` is already non-empty (issued PDFs with valid addresses stay byte-stable).
  2. Otherwise re-resolve. If the resolver now produces a non-empty location, persist the new `bill_to_*` columns + regenerated `bill_to_snapshot` JSON and re-render the issued PDF via `refresh_invoice_pdf`.
  3. If re-resolution still yields no address, restore every captured prior value — the invoice is byte-identical to before. Invoice number, totals, lines, and dates are never modified.
- **`backend/src/app/api/admin_billing_invoice_queries.py`** — wire the heal into `get_invoice_pdf_download` for `inv.status == ISSUED` (sits next to the existing draft refresh).
- **`backend/src/app/api/admin_billing_invoice_draft_helpers.py`** — rework `_contact_membership_location_snapshot` to mirror the FAMILY bill-to resolution exactly:
  - iterate every family the contact belongs to (ordered by `family_name`, then `family_members.id`); for each, use `family.location_id`, else fall back to that family's primary contact's `location_id`; render with `include_venue_name=False`;
  - if no family yields an address, iterate the contact's organisation memberships using `organization.location_id` with `include_venue_name=True`;
  - return the first non-empty snapshot text.
  Iterating (instead of `LIMIT 1`) also handles contacts in multiple families/orgs where only one has a populated address.

## Files changed

- `backend/src/app/api/admin_billing_invoice_queries.py` — heal hook on ISSUED PDF download.
- `backend/src/app/api/admin_billing_invoices.py` — `maybe_refresh_issued_bill_to_snapshot` helper.
- `backend/src/app/api/admin_billing_invoice_draft_helpers.py` — full membership iteration + primary-contact-location fallback.
- `tests/test_admin_billing.py` — regression tests for each branch (family with own location; family with no own location but primary contact has one; organisation fallback; no membership location → no-op; contact's own location wins; issued heal fires; issued heal restores prior state when re-resolution still empty).
- `tests/test_customer_invoice_pdf.py` — end-to-end render test: real resolver → real `render_invoice_pdf` → `pypdf` text extraction asserts the family address appears in the Bill To block.

## Edge cases

- Contact in multiple families/orgs: deterministic ordering by name, then membership id; first family/org with a resolvable address wins.
- Family with no own `location_id` but primary contact has `location_id`: covered (legacy data path).
- Contact with own `location_id`: existing behaviour — fallback never consulted.
- Contact with no membership address at all: snapshot resolves to `None` (PDF Bill To shows name + email only, as before the fix).
- Issued invoice with populated snapshot: untouched (PDF byte-stable, `issued_pdf_sha256` unchanged).
- Issued invoice with empty snapshot but no resolvable membership location: state restored, PDF not regenerated.
- Void invoices: snapshot preserved; the heal path is gated on `ISSUED` status.

## Testing

- ✅ `pytest tests/ -x -q` — 1196 passed, 18 skipped.
- ✅ `ruff check backend/ tests/ --config=backend/pyproject.toml` — clean.
- ✅ `pre-commit run ruff-format` — passed.
- ✅ `bash scripts/validate-cursorrules.sh` — passed.

The end-to-end PDF render test in `tests/test_customer_invoice_pdf.py` (`test_contact_bill_to_with_family_membership_renders_address_end_to_end`) wires the real resolver to the real renderer and uses `pypdf` to extract text from the rendered PDF — proving that, for a CONTACT bill-to invoice whose contact has no own `location_id`, the family's address surfaces in the Bill To block.

## Deployment note

#1705 was merged with only the draft-refresh + initial-fallback portion. This PR carries the remaining fixes and must be deployed for already-issued invoices to render correctly and for contact-membership families with legacy data layout (no own `location_id`, primary-contact has `location_id`) to surface the address on contact-billed PDFs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36bce1e5-d924-4cf8-8c5b-ef644fccb64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36bce1e5-d924-4cf8-8c5b-ef644fccb64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

