### PR TITLE
Set Instances and Client Invoices as default admin tabs

### DIFF
--- a/apps/admin_web/src/components/admin/finance/finance-header.tsx
+++ b/apps/admin_web/src/components/admin/finance/finance-header.tsx
@@ -15,7 +15,7 @@ export const FINANCE_TAB_KEYS: readonly FinanceView[] = FINANCE_TAB_ITEMS.map(
   (item) => item.key
 );
 
-export const DEFAULT_FINANCE_VIEW: FinanceView = 'expenses';
+export const DEFAULT_FINANCE_VIEW: FinanceView = 'client-invoices';
 
 export interface FinanceHeaderProps {
   activeView: FinanceView;

--- a/apps/admin_web/src/hooks/use-services-page.ts
+++ b/apps/admin_web/src/hooks/use-services-page.ts
@@ -27,7 +27,7 @@ export const SERVICES_VIEW_KEYS: readonly ServicesView[] = [
   'venues',
   'partners',
 ];
-export const DEFAULT_SERVICES_VIEW: ServicesView = 'catalog';
+export const DEFAULT_SERVICES_VIEW: ServicesView = 'instances';
 
 /** Instances list toolbar status filter; empty string means all statuses. */
 export type InstancesListStatusFilter = '' | 'not_completed' | 'completed';

--- a/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/finance/finance-page.test.tsx
@@ -120,22 +120,23 @@ describe('FinancePage', () => {
     expect(screen.getByRole('button', { name: 'Vendors' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Client Invoices' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Tax' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Expense Details' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Create draft invoice' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Vendors' }));
     expect(screen.getByRole('heading', { name: 'Vendors' })).toBeInTheDocument();
     expect(mockListAllAdminExpenses).toHaveBeenCalled();
     expect(window.location.search).toBe('?tab=vendors');
 
-    await user.click(screen.getByRole('button', { name: 'Client Invoices' }));
-    expect(screen.getByRole('heading', { name: 'Create draft invoice' })).toBeInTheDocument();
-    expect(window.location.search).toBe('?tab=client-invoices');
-
     await user.click(screen.getByRole('button', { name: 'Tax' }));
     expect(screen.getByRole('heading', { name: 'Tax fiscal snapshot' })).toBeInTheDocument();
     expect(window.location.search).toBe('?tab=tax');
 
     await user.click(screen.getByRole('button', { name: 'Expenses' }));
+    expect(screen.getByRole('heading', { name: 'Expense Details' })).toBeInTheDocument();
+    expect(window.location.search).toBe('?tab=expenses');
+
+    await user.click(screen.getByRole('button', { name: 'Client Invoices' }));
+    expect(screen.getByRole('heading', { name: 'Create draft invoice' })).toBeInTheDocument();
     expect(window.location.search).toBe('');
   });
 
@@ -148,6 +149,7 @@ describe('FinancePage', () => {
   });
 
   it('renders expense editor before bulk PDF import and submitted expenses list', () => {
+    window.history.replaceState(null, '', '/finance?tab=expenses');
     render(<FinancePage />);
 
     const editorHeading = screen.getByRole('heading', { name: 'Expense Details' });
@@ -167,6 +169,7 @@ describe('FinancePage', () => {
   });
 
   it('renders expense currency as a dropdown', () => {
+    window.history.replaceState(null, '', '/finance?tab=expenses');
     render(<FinancePage />);
     const currencyField = screen.getByLabelText('Currency');
     expect(currencyField.tagName).toBe('SELECT');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates admin web in-area tab defaults:

- **Services** → **Instances** (was Service Catalogue)
- **Finance** → **Client Invoices** (was Expenses)

Tab selection still uses the existing `?tab=` query parameter via `useQueryTabState`; only the default when the param is absent or invalid changes.

## Changes

- `DEFAULT_SERVICES_VIEW` in `use-services-page.ts`
- `DEFAULT_FINANCE_VIEW` in `finance-header.tsx`
- Finance page tests adjusted for default view and URL cleanup when returning to Client Invoices

## Testing

- `cd apps/admin_web && npx vitest run tests/components/admin/finance/finance-page.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bd09f3b-40bb-42c6-82e4-7a577920c2e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bd09f3b-40bb-42c6-82e4-7a577920c2e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

