### PR TITLE
Include training site in admin Website QR generator

### DIFF
--- a/.github/workflows/deploy-admin-web.yml
+++ b/.github/workflows/deploy-admin-web.yml
@@ -56,6 +56,7 @@ jobs:
           NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
           NEXT_PUBLIC_API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL }}
           NEXT_PUBLIC_PUBLIC_SITE_BASE_URL: ${{ vars.NEXT_PUBLIC_PUBLIC_SITE_BASE_URL }}
+          NEXT_PUBLIC_TRAINING_SITE_BASE_URL: ${{ vars.NEXT_PUBLIC_TRAINING_SITE_BASE_URL }}
 
       - name: Configure AWS credentials
         if: ${{ vars.AWS_ACCOUNT_ID != '' && vars.AWS_REGION != '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ mandatory `.cursorrules` integration anchors are removed or weakened.
 
 - **Admin web** requires Cognito env vars (`NEXT_PUBLIC_COGNITO_*`) for auth
   flows. Without them, the app renders but sign-in won't work.
+- **Admin web** Website QR also needs `NEXT_PUBLIC_PUBLIC_SITE_BASE_URL` (www)
+  and `NEXT_PUBLIC_TRAINING_SITE_BASE_URL` (training) for link previews.
 - **Public website** requires `NEXT_PUBLIC_SITE_ORIGIN` and
   `NEXT_PUBLIC_EMAIL` at minimum. Create `apps/public_www/.env.local` with:
   ```

--- a/apps/admin_web/.env.example
+++ b/apps/admin_web/.env.example
@@ -4,6 +4,8 @@ NEXT_PUBLIC_COGNITO_USER_POOL_ID=
 NEXT_PUBLIC_API_BASE_URL=
 # Public website origin for referral link previews (e.g. https://www.example.com)
 NEXT_PUBLIC_PUBLIC_SITE_BASE_URL=
+# Training website origin for Website QR presets (e.g. https://training.example.com)
+NEXT_PUBLIC_TRAINING_SITE_BASE_URL=
 # Optional GTM container for admin analytics (e.g. GTM-XXXX). When unset, admin dataLayer pushes are skipped.
 NEXT_PUBLIC_ADMIN_GTM_CONTAINER_ID=
 # ISO 4217; expense defaults and vendor spend totals use this currency (default HKD)

--- a/apps/admin_web/src/components/admin/website/website-qr-page.tsx
+++ b/apps/admin_web/src/components/admin/website/website-qr-page.tsx
@@ -39,6 +39,10 @@ function presetsForSite(site: QrSiteTarget) {
   return site === 'training' ? TRAINING_SITE_PAGE_PRESETS : PUBLIC_SITE_PAGE_PRESETS;
 }
 
+function defaultPresetForSite(site: QrSiteTarget): string {
+  return presetsForSite(site)[0]?.pathInput ?? '/';
+}
+
 export function WebsiteQrPage() {
   const publicSiteBaseUrl = useMemo(() => getPublicSiteBaseUrl(), []);
   const trainingSiteBaseUrl = useMemo(() => getTrainingSiteBaseUrl(), []);
@@ -54,12 +58,6 @@ export function WebsiteQrPage() {
   const isTrainingSite = siteTarget === 'training';
   const baseUrl = isTrainingSite ? trainingSiteBaseUrl : publicSiteBaseUrl;
   const pagePresets = presetsForSite(siteTarget);
-
-  useEffect(() => {
-    const firstPreset = presetsForSite(siteTarget)[0]?.pathInput ?? '/';
-    setPresetValue(firstPreset);
-    setCustomPathInput('');
-  }, [siteTarget]);
 
   const normalizedSrcForQuery = useMemo(
     () => (appendSrcQuery ? normalizePublicSiteSrcValue(srcQueryValue) : ''),
@@ -146,7 +144,12 @@ export function WebsiteQrPage() {
             <Select
               id='website-qr-site-target'
               value={siteTarget}
-              onChange={(event) => setSiteTarget(event.target.value as QrSiteTarget)}
+              onChange={(event) => {
+                const nextSite = event.target.value as QrSiteTarget;
+                setSiteTarget(nextSite);
+                setPresetValue(defaultPresetForSite(nextSite));
+                setCustomPathInput('');
+              }}
             >
               {QR_SITE_TARGET_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>

--- a/apps/admin_web/src/components/admin/website/website-qr-page.tsx
+++ b/apps/admin_web/src/components/admin/website/website-qr-page.tsx
@@ -8,19 +8,22 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { trackAdminAnalyticsEvent } from '@/lib/admin-analytics';
-import { getPublicSiteBaseUrl } from '@/lib/config';
+import { getPublicSiteBaseUrl, getTrainingSiteBaseUrl } from '@/lib/config';
 import { PUBLIC_SITE_PAGE_PRESETS } from '@/lib/public-site-page-presets';
 import {
   buildLocalizedPublicPageUrl,
+  buildSitePageUrl,
   normalizePublicSitePathInput,
   normalizePublicSiteSrcValue,
   sanitizePublicSiteSrcQueryInput,
 } from '@/lib/public-site-page-urls';
+import { QR_SITE_TARGET_OPTIONS, type QrSiteTarget } from '@/lib/qr-site-target';
 import {
   MY_BEST_AUNTIE_REFERRAL_LOCALES,
   REFERRAL_LOCALE_DISPLAY_LABELS,
   type MyBestAuntieReferralLocale,
 } from '@/lib/referral-links';
+import { TRAINING_SITE_PAGE_PRESETS } from '@/lib/training-site-page-presets';
 
 const CUSTOM_PRESET_VALUE = '__custom__';
 
@@ -32,14 +35,31 @@ function pathToDownloadBase(path: string): string {
   return trimmed.replace(/\//g, '-') || 'page';
 }
 
+function presetsForSite(site: QrSiteTarget) {
+  return site === 'training' ? TRAINING_SITE_PAGE_PRESETS : PUBLIC_SITE_PAGE_PRESETS;
+}
+
 export function WebsiteQrPage() {
-  const baseUrl = useMemo(() => getPublicSiteBaseUrl(), []);
+  const publicSiteBaseUrl = useMemo(() => getPublicSiteBaseUrl(), []);
+  const trainingSiteBaseUrl = useMemo(() => getTrainingSiteBaseUrl(), []);
+  const [siteTarget, setSiteTarget] = useState<QrSiteTarget>('public_www');
   const [locale, setLocale] = useState<MyBestAuntieReferralLocale>('en');
-  const [presetValue, setPresetValue] = useState<string>(PUBLIC_SITE_PAGE_PRESETS[0]?.pathInput ?? '/');
+  const [presetValue, setPresetValue] = useState<string>(
+    PUBLIC_SITE_PAGE_PRESETS[0]?.pathInput ?? '/',
+  );
   const [customPathInput, setCustomPathInput] = useState('');
   const [appendSrcQuery, setAppendSrcQuery] = useState(false);
   const [srcQueryValue, setSrcQueryValue] = useState('');
   const isCustom = presetValue === CUSTOM_PRESET_VALUE;
+  const isTrainingSite = siteTarget === 'training';
+  const baseUrl = isTrainingSite ? trainingSiteBaseUrl : publicSiteBaseUrl;
+  const pagePresets = presetsForSite(siteTarget);
+
+  useEffect(() => {
+    const firstPreset = presetsForSite(siteTarget)[0]?.pathInput ?? '/';
+    setPresetValue(firstPreset);
+    setCustomPathInput('');
+  }, [siteTarget]);
 
   const normalizedSrcForQuery = useMemo(
     () => (appendSrcQuery ? normalizePublicSiteSrcValue(srcQueryValue) : ''),
@@ -58,12 +78,18 @@ export function WebsiteQrPage() {
     if (!baseUrl || normalizedPathResult.error || !normalizedPathResult.path) {
       return '';
     }
+    if (isTrainingSite) {
+      return buildSitePageUrl({
+        baseUrl,
+        path: normalizedPathResult.path,
+      });
+    }
     return buildLocalizedPublicPageUrl({
       baseUrl,
       locale,
       path: normalizedPathResult.path,
     });
-  }, [baseUrl, locale, normalizedPathResult.error, normalizedPathResult.path]);
+  }, [baseUrl, isTrainingSite, locale, normalizedPathResult.error, normalizedPathResult.path]);
 
   const builtUrlForQr = useMemo(() => {
     if (!builtUrl) {
@@ -92,59 +118,81 @@ export function WebsiteQrPage() {
     }
     trackAdminAnalyticsEvent('admin_public_page_qr_opened', {
       public_site_path: pathForAnalytics,
-      locale,
+      locale: isTrainingSite ? 'none' : locale,
+      qr_site_target: siteTarget,
     });
-  }, [builtUrlForQr, locale, pathForAnalytics]);
+  }, [builtUrlForQr, isTrainingSite, locale, pathForAnalytics, siteTarget]);
 
   const configError = !baseUrl.trim()
-    ? 'Set NEXT_PUBLIC_PUBLIC_SITE_BASE_URL to generate public page links.'
+    ? isTrainingSite
+      ? 'Set NEXT_PUBLIC_TRAINING_SITE_BASE_URL to generate training site links.'
+      : 'Set NEXT_PUBLIC_PUBLIC_SITE_BASE_URL to generate public page links.'
     : '';
 
   const pathError = normalizedPathResult.error;
 
-  const downloadBase = `${normalizedSrcForQuery ? `${normalizedSrcForQuery}-` : ''}page-${pathToDownloadBase(normalizedPathResult.path || '/')}-${locale}`;
+  const downloadLocaleSuffix = isTrainingSite ? 'training' : locale;
+  const downloadBase = `${normalizedSrcForQuery ? `${normalizedSrcForQuery}-` : ''}page-${pathToDownloadBase(normalizedPathResult.path || '/')}-${downloadLocaleSuffix}`;
 
   return (
     <div className='space-y-6'>
       <AdminEditorCard
-        title='Public website QR codes'
-        description='Create printable QR codes that open pages on the public Evolve Sprouts site. Choose a locale and page; URLs match the static site (locale prefix and trailing slash).'
+        title='Website QR codes'
+        description='Create printable QR codes for the public website (www) or the training site. Choose the site, then a page path. Public URLs include a locale prefix and trailing slash; training URLs use paths only (no locale).'
       >
         <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
           <div>
-            <Label htmlFor='website-qr-locale'>Locale</Label>
+            <Label htmlFor='website-qr-site-target'>Site</Label>
             <Select
-              id='website-qr-locale'
-              value={locale}
-              onChange={(event) => setLocale(event.target.value as MyBestAuntieReferralLocale)}
-              disabled={Boolean(configError)}
+              id='website-qr-site-target'
+              value={siteTarget}
+              onChange={(event) => setSiteTarget(event.target.value as QrSiteTarget)}
             >
-              {MY_BEST_AUNTIE_REFERRAL_LOCALES.map((entry) => (
-                <option key={entry} value={entry}>
-                  {REFERRAL_LOCALE_DISPLAY_LABELS[entry]}
+              {QR_SITE_TARGET_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
                 </option>
               ))}
             </Select>
           </div>
-          <div>
-            <Label htmlFor='website-qr-preset-page'>Page</Label>
-            <Select
-              id='website-qr-preset-page'
-              value={isCustom ? CUSTOM_PRESET_VALUE : presetValue}
-              onChange={(event) => {
-                const next = event.target.value;
-                setPresetValue(next);
-              }}
-              disabled={Boolean(configError)}
-            >
-              {PUBLIC_SITE_PAGE_PRESETS.map((preset) => (
-                <option key={preset.pathInput} value={preset.pathInput}>
-                  {preset.label}
-                </option>
-              ))}
-              <option value={CUSTOM_PRESET_VALUE}>Custom path…</option>
-            </Select>
-          </div>
+          {!isTrainingSite ? (
+            <div>
+              <Label htmlFor='website-qr-locale'>Locale</Label>
+              <Select
+                id='website-qr-locale'
+                value={locale}
+                onChange={(event) => setLocale(event.target.value as MyBestAuntieReferralLocale)}
+                disabled={Boolean(configError)}
+              >
+                {MY_BEST_AUNTIE_REFERRAL_LOCALES.map((entry) => (
+                  <option key={entry} value={entry}>
+                    {REFERRAL_LOCALE_DISPLAY_LABELS[entry]}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          ) : (
+            <div className='hidden sm:block' aria-hidden='true' />
+          )}
+        </div>
+        <div className={isTrainingSite ? '' : 'sm:col-span-2'}>
+          <Label htmlFor='website-qr-preset-page'>Page</Label>
+          <Select
+            id='website-qr-preset-page'
+            value={isCustom ? CUSTOM_PRESET_VALUE : presetValue}
+            onChange={(event) => {
+              const next = event.target.value;
+              setPresetValue(next);
+            }}
+            disabled={Boolean(configError)}
+          >
+            {pagePresets.map((preset) => (
+              <option key={preset.pathInput} value={preset.pathInput}>
+                {preset.label}
+              </option>
+            ))}
+            <option value={CUSTOM_PRESET_VALUE}>Custom path…</option>
+          </Select>
         </div>
         {isCustom ? (
           <div>
@@ -153,13 +201,19 @@ export function WebsiteQrPage() {
               id='website-qr-custom-path'
               value={customPathInput}
               onChange={(event) => setCustomPathInput(event.target.value)}
-              placeholder='e.g. /about-us or /easter-2026-montessori-play-coaching-workshop'
+              placeholder={
+                isTrainingSite
+                  ? 'e.g. /polls/workshop-food-jun-26'
+                  : 'e.g. /about-us or /easter-2026-montessori-play-coaching-workshop'
+              }
               disabled={Boolean(configError)}
               autoComplete='off'
             />
             <p className='mt-1 text-xs text-slate-500'>
-              Site path only (letters, numbers, hyphens per segment). Omit the locale; it is added
-              automatically.
+              Site path only (letters, numbers, hyphens per segment).
+              {isTrainingSite
+                ? ' Omit the domain; the training site origin is added automatically.'
+                : ' Omit the locale; it is added automatically for the public website.'}
             </p>
           </div>
         ) : null}
@@ -204,12 +258,13 @@ export function WebsiteQrPage() {
         <PublicSiteQrExportPanel
           builtUrl={builtUrl && !pathError ? builtUrlForQr : ''}
           configError={configError}
-          previewAriaLabel={`QR code preview for public page ${pathForAnalytics || '/'}`}
+          previewAriaLabel={`QR code preview for ${isTrainingSite ? 'training' : 'public'} page ${pathForAnalytics || '/'}`}
           downloadFilenameBase={downloadBase}
           downloadEvent='admin_public_page_qr_downloaded'
           analyticsParams={{
             public_site_path: pathForAnalytics,
-            locale,
+            locale: isTrainingSite ? 'none' : locale,
+            qr_site_target: siteTarget,
           }}
           previewUrlPresentation='referral'
         />

--- a/apps/admin_web/src/lib/config.ts
+++ b/apps/admin_web/src/lib/config.ts
@@ -4,6 +4,7 @@ export interface AppConfig {
   cognitoUserPoolId: string;
   apiBaseUrl: string;
   publicSiteBaseUrl: string;
+  trainingSiteBaseUrl: string;
 }
 
 export const appConfig: AppConfig = {
@@ -12,6 +13,7 @@ export const appConfig: AppConfig = {
   cognitoUserPoolId: process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID ?? '',
   apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL ?? '',
   publicSiteBaseUrl: process.env.NEXT_PUBLIC_PUBLIC_SITE_BASE_URL ?? '',
+  trainingSiteBaseUrl: process.env.NEXT_PUBLIC_TRAINING_SITE_BASE_URL ?? '',
 };
 
 function trimTrailingSlashes(value: string) {
@@ -93,13 +95,13 @@ const FALLBACK_ADMIN_DEFAULT_CURRENCY = 'HKD';
  * ISO 4217 code for admin UI defaults (expense currency, vendor spend column, FX target).
  * Set `NEXT_PUBLIC_ADMIN_DEFAULT_CURRENCY` (e.g. HKD). Invalid or empty values fall back to HKD.
  */
-export function getPublicSiteBaseUrl(): string {
-  const raw = appConfig.publicSiteBaseUrl.trim();
-  if (!raw) {
+function normalizeSiteBaseUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
     return '';
   }
   try {
-    const parsed = new URL(raw.startsWith('http') ? raw : `https://${raw}`);
+    const parsed = new URL(trimmed.startsWith('http') ? trimmed : `https://${trimmed}`);
     if (!['https:', 'http:'].includes(parsed.protocol.toLowerCase())) {
       return '';
     }
@@ -107,6 +109,14 @@ export function getPublicSiteBaseUrl(): string {
   } catch {
     return '';
   }
+}
+
+export function getPublicSiteBaseUrl(): string {
+  return normalizeSiteBaseUrl(appConfig.publicSiteBaseUrl);
+}
+
+export function getTrainingSiteBaseUrl(): string {
+  return normalizeSiteBaseUrl(appConfig.trainingSiteBaseUrl);
 }
 
 export function getAdminDefaultCurrencyCode(): string {

--- a/apps/admin_web/src/lib/public-site-page-urls.ts
+++ b/apps/admin_web/src/lib/public-site-page-urls.ts
@@ -95,6 +95,31 @@ export interface BuildLocalizedPublicPageUrlInput {
  * Builds an absolute URL to a locale-prefixed public page. Paths use a trailing slash
  * to match the static-export site (`next.config` trailingSlash).
  */
+export interface BuildSitePageUrlInput {
+  baseUrl: string;
+  /** Normalized path from `normalizePublicSitePathInput` (`/` or `/about-us/`). */
+  path: string;
+}
+
+/**
+ * Builds an absolute URL to a site page without a locale prefix (training site).
+ * Paths use a trailing slash to match static export (`trailingSlash: true`).
+ */
+export function buildSitePageUrl(input: BuildSitePageUrlInput): string {
+  const base = trimTrailingSlashes(input.baseUrl.trim());
+  if (!base) {
+    return '';
+  }
+  const path = input.path.trim();
+  if (!path.startsWith('/')) {
+    return '';
+  }
+  const suffix = path === '/' ? '' : path.replace(/^\/+|\/+$/g, '');
+  const pathPart = suffix.length === 0 ? '/' : `/${suffix}/`;
+  const url = new URL(pathPart, `${base}/`);
+  return url.toString();
+}
+
 export function buildLocalizedPublicPageUrl(input: BuildLocalizedPublicPageUrlInput): string {
   const base = trimTrailingSlashes(input.baseUrl.trim());
   if (!base) {

--- a/apps/admin_web/src/lib/qr-site-target.ts
+++ b/apps/admin_web/src/lib/qr-site-target.ts
@@ -1,0 +1,6 @@
+export type QrSiteTarget = 'public_www' | 'training';
+
+export const QR_SITE_TARGET_OPTIONS: readonly { value: QrSiteTarget; label: string }[] = [
+  { value: 'public_www', label: 'Public website (www)' },
+  { value: 'training', label: 'Training site' },
+] as const;

--- a/apps/admin_web/src/lib/training-site-page-presets.ts
+++ b/apps/admin_web/src/lib/training-site-page-presets.ts
@@ -1,0 +1,23 @@
+import { TRAINING_ROUTES } from '@shared-training/training-routes';
+
+/**
+ * Curated training-site paths for QR presets (same paths as `TRAINING_ROUTES` in
+ * `apps/training/src/lib/training-routes.ts`).
+ */
+export interface TrainingSitePagePreset {
+  label: string;
+  /** Raw path input accepted by `normalizePublicSitePathInput` (with or without trailing slash). */
+  pathInput: string;
+}
+
+const PRESET_ROWS: readonly { label: string; routeKey: keyof typeof TRAINING_ROUTES }[] = [
+  { label: 'Home', routeKey: 'home' },
+  { label: 'Workshop food poll (Jun 26)', routeKey: 'pollsWorkshopFoodJun26' },
+] as const;
+
+export const TRAINING_SITE_PAGE_PRESETS: readonly TrainingSitePagePreset[] = PRESET_ROWS.map(
+  ({ label, routeKey }) => ({
+    label,
+    pathInput: TRAINING_ROUTES[routeKey],
+  }),
+);

--- a/apps/admin_web/tests/components/admin/website/website-qr-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/website/website-qr-page.test.tsx
@@ -5,6 +5,7 @@ import { WebsiteQrPage } from '@/components/admin/website/website-qr-page';
 
 vi.mock('@/lib/config', () => ({
   getPublicSiteBaseUrl: () => 'https://www.example.com',
+  getTrainingSiteBaseUrl: () => 'https://training.example.com',
 }));
 
 const generateSpy = vi.fn(async () => 'data:image/png;base64,AA');
@@ -93,6 +94,30 @@ describe('WebsiteQrPage', () => {
     });
   });
 
+  it('builds training site URL without locale when training site is selected', async () => {
+    render(<WebsiteQrPage />);
+
+    fireEvent.change(screen.getByLabelText('Site'), { target: { value: 'training' } });
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'https://training.example.com/' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText('Locale')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Page'), {
+      target: { value: '/polls/workshop-food-jun-26' },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('link', {
+          name: 'https://training.example.com/polls/workshop-food-jun-26/',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it('uses page- prefixed download filename and prepends normalized src when set', async () => {
     const originalCreateElement = document.createElement.bind(document);
     const createdAnchors: HTMLAnchorElement[] = [];
@@ -136,6 +161,40 @@ describe('WebsiteQrPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Download PNG (512)' }));
     await vi.waitFor(() => {
       expect(createdAnchors.at(-1)?.download).toBe('poster-page-home-en-512.png');
+    });
+  });
+
+  it('uses training suffix in download filename when training site is selected', async () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const createdAnchors: HTMLAnchorElement[] = [];
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string, options?: unknown) => {
+      if (tag !== 'a') {
+        return originalCreateElement(tag, options as DocumentCreateElementOptions | undefined);
+      }
+      const anchor = originalCreateElement('a', options as DocumentCreateElementOptions | undefined);
+      createdAnchors.push(anchor);
+      vi.spyOn(anchor, 'click').mockImplementation(() => {});
+      return anchor;
+    });
+
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    }) as typeof fetch;
+
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    render(<WebsiteQrPage />);
+
+    fireEvent.change(screen.getByLabelText('Site'), { target: { value: 'training' } });
+
+    await vi.waitFor(() => {
+      expect(generateSpy).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PNG (512)' }));
+    await vi.waitFor(() => {
+      expect(createdAnchors.at(-1)?.download).toBe('page-home-training-512.png');
     });
   });
 });

--- a/apps/admin_web/tests/lib/public-site-page-urls.test.ts
+++ b/apps/admin_web/tests/lib/public-site-page-urls.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildLocalizedPublicPageUrl,
+  buildSitePageUrl,
   normalizePublicSitePathInput,
   normalizePublicSiteSrcValue,
   sanitizePublicSiteSrcQueryInput,
@@ -52,6 +53,33 @@ describe('sanitizePublicSiteSrcQueryInput', () => {
   it('lowercases and maps invalid characters to hyphens', () => {
     expect(sanitizePublicSiteSrcQueryInput('Foo Bar')).toBe('foo-bar');
     expect(sanitizePublicSiteSrcQueryInput('a--')).toBe('a-');
+  });
+});
+
+describe('buildSitePageUrl', () => {
+  it('builds home and inner paths with trailing slash (no locale)', () => {
+    expect(
+      buildSitePageUrl({
+        baseUrl: 'https://training.example.com',
+        path: '/',
+      }),
+    ).toBe('https://training.example.com/');
+
+    expect(
+      buildSitePageUrl({
+        baseUrl: 'https://training.example.com',
+        path: '/polls/workshop-food-jun-26/',
+      }),
+    ).toBe('https://training.example.com/polls/workshop-food-jun-26/');
+  });
+
+  it('returns empty for invalid base', () => {
+    expect(
+      buildSitePageUrl({
+        baseUrl: '',
+        path: '/',
+      }),
+    ).toBe('');
   });
 });
 

--- a/apps/admin_web/tests/lib/training-site-page-presets.test.ts
+++ b/apps/admin_web/tests/lib/training-site-page-presets.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { TRAINING_SITE_PAGE_PRESETS } from '@/lib/training-site-page-presets';
+import { TRAINING_ROUTES } from '@shared-training/training-routes';
+
+describe('TRAINING_SITE_PAGE_PRESETS', () => {
+  it('uses only paths defined in shared TRAINING_ROUTES', () => {
+    const allowed = new Set<string>(Object.values(TRAINING_ROUTES));
+    for (const preset of TRAINING_SITE_PAGE_PRESETS) {
+      expect(allowed.has(preset.pathInput)).toBe(true);
+    }
+  });
+
+  it('lists each shared route at most once', () => {
+    const inputs = TRAINING_SITE_PAGE_PRESETS.map((p) => p.pathInput);
+    expect(new Set(inputs).size).toBe(inputs.length);
+  });
+});

--- a/apps/admin_web/tsconfig.json
+++ b/apps/admin_web/tsconfig.json
@@ -27,6 +27,9 @@
       ],
       "@shared-public-www/*": [
         "../public_www/src/lib/*"
+      ],
+      "@shared-training/*": [
+        "../training/src/lib/*"
       ]
     },
     "plugins": [

--- a/apps/admin_web/vitest.config.mts
+++ b/apps/admin_web/vitest.config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
       '@shared-config': path.resolve(__dirname, '../../shared/config'),
       '@shared-public-www': path.resolve(__dirname, '../public_www/src/lib'),
+      '@shared-training': path.resolve(__dirname, '../training/src/lib'),
     },
   },
   test: {

--- a/apps/training/src/lib/training-routes.ts
+++ b/apps/training/src/lib/training-routes.ts
@@ -1,0 +1,10 @@
+/**
+ * Canonical first-party path strings for the training website.
+ * Single source of truth for admin Website QR presets (`apps/admin_web`).
+ */
+export const TRAINING_ROUTES = {
+  home: '/',
+  pollsWorkshopFoodJun26: '/polls/workshop-food-jun-26',
+} as const;
+
+export type TrainingAppRoutePath = (typeof TRAINING_ROUTES)[keyof typeof TRAINING_ROUTES];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The admin **Website** QR tool only built URLs against the public www site (`NEXT_PUBLIC_PUBLIC_SITE_BASE_URL`). It now supports **training.evolvesprouts.com** as well.

## Changes

- **Site selector** on the Website QR page: *Public website (www)* vs *Training site*
- **Training presets** sourced from shared `TRAINING_ROUTES` (`/` home, `/polls/workshop-food-jun-26` workshop food poll)
- Training URLs use `buildSitePageUrl` (no locale prefix, trailing slash) — matching the training static export
- Public www behavior unchanged (locale + trailing slash)
- New env var: `NEXT_PUBLIC_TRAINING_SITE_BASE_URL` (documented in `.env.example`, wired into `deploy-admin-web.yml`)

## Deploy note

After merge, set the GitHub repository variable **`NEXT_PUBLIC_TRAINING_SITE_BASE_URL`** to `https://training.evolvesprouts.com` (or your environment’s training origin) and redeploy admin web so production QR previews resolve correctly.

## Testing

- `npx vitest run` for `website-qr-page`, `public-site-page-urls`, and `training-site-page-presets` tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8824b46-7ae0-454d-8be5-4fe047b2da72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8824b46-7ae0-454d-8be5-4fe047b2da72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

