### PR TITLE
Allow OPTIONS preflight on /www poll answer PUT paths

### DIFF
--- a/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
+++ b/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
@@ -53,10 +53,12 @@ function handler(event) {
     return request;
   }
 
-  if (
-    method === 'PUT' &&
+  var isPollAnswersPath =
     uri.indexOf('/www/v1/polls/') === 0 &&
-    uri.lastIndexOf('/answers') === uri.length - 8
+    uri.lastIndexOf('/answers') === uri.length - 8;
+  if (
+    (method === 'PUT' || method === 'OPTIONS') &&
+    isPollAnswersPath
   ) {
     request.uri = uri.substring(4);
     return request;

--- a/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
+++ b/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
@@ -54,6 +54,11 @@ function main(): void {
       "WWW_PROXY_ALLOWLIST_FUNCTION missing poll PUT /answers suffix rule",
     );
   }
+  if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes("method === 'OPTIONS'")) {
+    throw new Error(
+      "WWW_PROXY_ALLOWLIST_FUNCTION must allow OPTIONS for poll answer preflight",
+    );
+  }
 
   if (!MEDIA_REQUEST_PROXY_FUNCTION.includes("/www/v1/assets/free/request")) {
     throw new Error("MEDIA_REQUEST_PROXY_FUNCTION missing media request path");


### PR DESCRIPTION
Browsers send CORS preflight for PUT with x-api-key; CloudFront allowlist only permitted PUT, so OPTIONS returned 403 and poll save hung in headless Chrome.