### PR TITLE
Split poll showAnswer from live showResults with GET aggregates API

### DIFF
--- a/apps/training/src/app/globals.css
+++ b/apps/training/src/app/globals.css
@@ -9,3 +9,24 @@ body {
     'Segoe UI',
     sans-serif;
 }
+
+progress.poll-live-results-bar {
+  appearance: none;
+  border: none;
+  background-color: #e5e5e5;
+}
+
+progress.poll-live-results-bar::-webkit-progress-bar {
+  background-color: #e5e5e5;
+  border-radius: 9999px;
+}
+
+progress.poll-live-results-bar::-webkit-progress-value {
+  background-color: #171717;
+  border-radius: 9999px;
+}
+
+progress.poll-live-results-bar::-moz-progress-bar {
+  background-color: #171717;
+  border-radius: 9999px;
+}

--- a/apps/training/src/components/polls/poll-answer-panel.tsx
+++ b/apps/training/src/components/polls/poll-answer-panel.tsx
@@ -3,13 +3,13 @@
 import type { PollQuestion, PollsCommonContent } from '@/content/poll-types';
 import type { QuestionAnswerState } from '@/components/polls/poll-answer-state';
 
-export interface PollResultsPanelProps {
+export interface PollAnswerPanelProps {
   question: PollQuestion;
   common: PollsCommonContent;
   answer: QuestionAnswerState;
 }
 
-export function PollResultsPanel({ question, common, answer }: PollResultsPanelProps) {
+export function PollAnswerPanel({ question, common, answer }: PollAnswerPanelProps) {
   if (question.type === 'truefalse') {
     const isCorrect = answer.trueFalseValue === question.answer;
     return (

--- a/apps/training/src/components/polls/poll-live-results-panel.tsx
+++ b/apps/training/src/components/polls/poll-live-results-panel.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import type { PollQuestion, PollsCommonContent } from '@/content/poll-types';
+import {
+  fetchPollQuestionResults,
+  type PollQuestionResults,
+  PollApiError,
+} from '@/lib/polls-api';
+
+const LIVE_RESULTS_POLL_MS = 3000;
+
+export interface PollLiveResultsPanelProps {
+  pollSlug: string;
+  question: PollQuestion;
+  common: PollsCommonContent;
+}
+
+export function PollLiveResultsPanel({
+  pollSlug,
+  question,
+  common,
+}: PollLiveResultsPanelProps) {
+  const [results, setResults] = useState<PollQuestionResults | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (question.type !== 'select' && question.type !== 'truefalse') {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadResults(): Promise<void> {
+      try {
+        const next = await fetchPollQuestionResults({
+          pollSlug,
+          questionId: question.id,
+          questionType: question.type as 'select' | 'truefalse',
+        });
+        if (!cancelled) {
+          setResults(next);
+          setErrorMessage(null);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setErrorMessage(resolveLoadErrorMessage(error, common));
+        }
+      }
+    }
+
+    void loadResults();
+    const intervalId = window.setInterval(() => {
+      void loadResults();
+    }, LIVE_RESULTS_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [common, pollSlug, question]);
+
+  if (question.type !== 'select' && question.type !== 'truefalse') {
+    return null;
+  }
+
+  const buckets = mergeResultBuckets(question, results);
+  const maxCount = Math.max(1, ...buckets.map((bucket) => bucket.count));
+
+  return (
+    <section className='flex flex-col gap-4 rounded-lg border border-neutral-200 bg-neutral-50 p-4'>
+      <div className='flex flex-col gap-1'>
+        <h2 className='text-lg font-semibold text-neutral-900'>{common.liveResults.heading}</h2>
+        <p className='text-sm text-neutral-600'>
+          {formatTotalResponses(common.liveResults.totalResponsesTemplate, results?.totalResponses ?? 0)}
+        </p>
+      </div>
+      {errorMessage ? (
+        <p className='text-sm text-red-700' role='alert'>
+          {errorMessage}
+        </p>
+      ) : null}
+      <ul className='flex flex-col gap-3'>
+        {buckets.map((bucket) => (
+          <li key={bucket.label} className='flex flex-col gap-1'>
+            <div className='flex items-baseline justify-between gap-2 text-sm text-neutral-800'>
+              <span>{resolveBucketLabel(question, bucket.label, common)}</span>
+              <span className='tabular-nums text-neutral-600'>
+                {formatCountLabel(common.liveResults.countTemplate, bucket.count)}
+              </span>
+            </div>
+            <progress
+              className='poll-live-results-bar h-3 w-full overflow-hidden rounded-full'
+              value={bucket.count}
+              max={maxCount}
+            />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function mergeResultBuckets(
+  question: PollQuestion,
+  results: PollQuestionResults | null,
+): Array<{ label: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const bucket of results?.buckets ?? []) {
+    counts.set(bucket.label, bucket.count);
+  }
+
+  if (question.type === 'select') {
+    return question.options.map((label) => ({
+      label,
+      count: counts.get(label) ?? 0,
+    }));
+  }
+
+  return [
+    { label: 'true', count: counts.get('true') ?? 0 },
+    { label: 'false', count: counts.get('false') ?? 0 },
+  ];
+}
+
+function resolveBucketLabel(
+  question: PollQuestion,
+  label: string,
+  common: PollsCommonContent,
+): string {
+  if (question.type === 'truefalse') {
+    if (label === 'true') {
+      return common.truefalse.trueLabel;
+    }
+    if (label === 'false') {
+      return common.truefalse.falseLabel;
+    }
+  }
+  return label;
+}
+
+function formatTotalResponses(template: string, total: number): string {
+  return template.replace('{total}', String(total));
+}
+
+function formatCountLabel(template: string, count: number): string {
+  return template.replace('{count}', String(count));
+}
+
+function resolveLoadErrorMessage(error: unknown, common: PollsCommonContent): string {
+  if (error instanceof PollApiError && error.statusCode === 0) {
+    return common.errors.missingApiConfig;
+  }
+  return common.errors.resultsLoadFailed;
+}

--- a/apps/training/src/components/polls/poll-wizard.tsx
+++ b/apps/training/src/components/polls/poll-wizard.tsx
@@ -7,8 +7,9 @@ import {
   isAnswerValid,
   type QuestionAnswerState,
 } from '@/components/polls/poll-answer-state';
+import { PollAnswerPanel } from '@/components/polls/poll-answer-panel';
+import { PollLiveResultsPanel } from '@/components/polls/poll-live-results-panel';
 import { PollQuestionField } from '@/components/polls/poll-question-field';
-import { PollResultsPanel } from '@/components/polls/poll-results-panel';
 import type { PollContent, PollQuestion, PollsCommonContent } from '@/content/poll-types';
 import { getOrCreatePollSessionId } from '@/lib/poll-session';
 import { PollApiError, persistPollAnswer } from '@/lib/polls-api';
@@ -18,7 +19,7 @@ export interface PollWizardProps {
   common: PollsCommonContent;
 }
 
-type StepPhase = 'answer' | 'results';
+type StepPhase = 'answer' | 'feedback' | 'liveResults';
 
 export function PollWizard({ poll, common }: PollWizardProps) {
   const [stepIndex, setStepIndex] = useState(0);
@@ -58,37 +59,48 @@ export function PollWizard({ poll, common }: PollWizardProps) {
 
   const isFirstStep = stepIndex === 0;
   const isLastStep = stepIndex === totalSteps - 1;
-  const showingResults = stepPhase === 'results' && currentQuestion.showResults;
+  const showingFeedback = stepPhase === 'feedback' && currentQuestion.showAnswer;
+  const showingLiveResults =
+    stepPhase === 'liveResults' && currentQuestion.showResults;
+  const onInterstitial = showingFeedback || showingLiveResults;
   const primaryLabel = resolvePrimaryLabel({
     common,
     isLastStep,
-    showingResults,
+    onInterstitial,
   });
 
   return (
     <section className='mx-auto flex w-full max-w-xl flex-col gap-6'>
       <p className='text-sm text-neutral-600'>{progressLabel}</p>
-      {showingResults ? (
-        <PollResultsPanel
+      {showingFeedback ? (
+        <PollAnswerPanel
           question={currentQuestion}
           common={common}
           answer={currentAnswer}
         />
-      ) : (
+      ) : null}
+      {showingLiveResults ? (
+        <PollLiveResultsPanel
+          pollSlug={poll.slug}
+          question={currentQuestion}
+          common={common}
+        />
+      ) : null}
+      {!onInterstitial ? (
         <PollQuestionField
           question={currentQuestion}
           common={common}
           answer={currentAnswer}
           onAnswerChange={(patch) => updateAnswerState(currentQuestion.id, patch)}
         />
-      )}
+      ) : null}
       {errorMessage ? (
         <p className='text-sm text-red-700' role='alert'>
           {errorMessage}
         </p>
       ) : null}
       <div className='flex flex-wrap items-center justify-start gap-2'>
-        {!isFirstStep && !showingResults ? (
+        {!isFirstStep && !onInterstitial ? (
           <button
             type='button'
             className='rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-900'
@@ -131,7 +143,11 @@ export function PollWizard({ poll, common }: PollWizardProps) {
   async function handlePrimaryAction(): Promise<void> {
     setErrorMessage(null);
 
-    if (showingResults) {
+    if (onInterstitial) {
+      if (showingFeedback && currentQuestion.showResults) {
+        setStepPhase('liveResults');
+        return;
+      }
       advanceToNextQuestion();
       return;
     }
@@ -157,8 +173,13 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     }
     setIsSaving(false);
 
+    if (currentQuestion.showAnswer) {
+      setStepPhase('feedback');
+      return;
+    }
+
     if (currentQuestion.showResults) {
-      setStepPhase('results');
+      setStepPhase('liveResults');
       return;
     }
 
@@ -206,13 +227,13 @@ function validateAnswer(
 function resolvePrimaryLabel({
   common,
   isLastStep,
-  showingResults,
+  onInterstitial,
 }: {
   common: PollsCommonContent;
   isLastStep: boolean;
-  showingResults: boolean;
+  onInterstitial: boolean;
 }): string {
-  if (showingResults) {
+  if (onInterstitial) {
     return common.navigation.continue;
   }
   if (isLastStep) {

--- a/apps/training/src/content/poll-types.ts
+++ b/apps/training/src/content/poll-types.ts
@@ -5,6 +5,9 @@ export interface PollQuestionBase {
   id: string;
   screen: string;
   question: string;
+  /** Personal feedback after submit (correct/incorrect, presenter note, your answer). */
+  showAnswer: boolean;
+  /** Room-wide live aggregate bar chart from the server. */
   showResults: boolean;
 }
 
@@ -56,6 +59,11 @@ export interface PollsCommonContent {
   results: {
     yourAnswerTemplate: string;
   };
+  liveResults: {
+    heading: string;
+    totalResponsesTemplate: string;
+    countTemplate: string;
+  };
   completion: {
     title: string;
     description: string;
@@ -64,6 +72,7 @@ export interface PollsCommonContent {
     required: string;
     invalidEmail: string;
     persistFailed: string;
+    resultsLoadFailed: string;
     missingApiConfig: string;
   };
   a11y: {

--- a/apps/training/src/content/polls-common.json
+++ b/apps/training/src/content/polls-common.json
@@ -14,6 +14,11 @@
   "results": {
     "yourAnswerTemplate": "You answered: {answer}"
   },
+  "liveResults": {
+    "heading": "Room results",
+    "totalResponsesTemplate": "{total} responses so far",
+    "countTemplate": "{count}"
+  },
   "completion": {
     "title": "Thank you",
     "description": "Your responses have been saved."
@@ -22,6 +27,7 @@
     "required": "Please answer this question before continuing.",
     "invalidEmail": "Enter a valid email address.",
     "persistFailed": "We could not save your answer. Please try again.",
+    "resultsLoadFailed": "We could not load live results. Please try again.",
     "missingApiConfig": "This poll cannot be saved right now. Please try again later."
   },
   "a11y": {

--- a/apps/training/src/content/polls/workshop-food-jun-26.json
+++ b/apps/training/src/content/polls/workshop-food-jun-26.json
@@ -8,6 +8,7 @@
       "screen": "Who are you?",
       "question": "I am a...",
       "options": ["Parent", "Helper / Caregiver", "Grandparent", "Other"],
+      "showAnswer": false,
       "showResults": false
     },
     {
@@ -22,6 +23,7 @@
         "Mealtimes are stressful for everyone",
         "My child only eats a few things"
       ],
+      "showAnswer": true,
       "showResults": true,
       "presenterNote": "We asked you this as you arrived. Here's what you said."
     },
@@ -32,6 +34,7 @@
       "question": "Children must finish everything on their plate.",
       "answer": false,
       "answerNote": "Forcing children to finish teaches them to ignore their own fullness signals. A child who learns to stop when full builds a healthier relationship with food for life.",
+      "showAnswer": true,
       "showResults": true
     },
     {
@@ -41,6 +44,7 @@
       "question": "Fruit makes the body 'cold' and should be avoided.",
       "answer": false,
       "answerNote": "This is a common belief in Chinese culture but has no clinical basis. Fruit is essential for vitamins, fibre, and hydration. Serve at room temperature if the family prefers — but don't avoid it.",
+      "showAnswer": true,
       "showResults": true
     },
     {
@@ -50,6 +54,7 @@
       "question": "If a child refuses a food once, they don't like it.",
       "answer": false,
       "answerNote": "It takes 10–15 exposures before a child accepts a new food. Refusing is not rejecting. Keep offering without pressure — let them see it, touch it, smell it first.",
+      "showAnswer": true,
       "showResults": true
     },
     {
@@ -59,6 +64,7 @@
       "question": "Juice is just as good as whole fruit.",
       "answer": false,
       "answerNote": "Whole fruit has fibre which slows sugar absorption. A glass of orange juice has almost the same sugar as a can of soda. Offer whole fruit and water instead.",
+      "showAnswer": true,
       "showResults": true
     },
     {
@@ -66,6 +72,7 @@
       "type": "text",
       "screen": "Your one thing",
       "question": "What is ONE thing you'll do differently — starting tomorrow?",
+      "showAnswer": false,
       "showResults": false
     },
     {
@@ -73,6 +80,7 @@
       "type": "email",
       "screen": "Stay connected",
       "question": "Get tonight's resources and tips by email",
+      "showAnswer": false,
       "showResults": false
     }
   ]

--- a/apps/training/src/lib/polls-api.ts
+++ b/apps/training/src/lib/polls-api.ts
@@ -37,6 +37,53 @@ export function resolvePollApiConfig():
   return { baseUrl, apiKey };
 }
 
+export interface PollQuestionResultsBucket {
+  label: string;
+  count: number;
+}
+
+export interface PollQuestionResults {
+  pollSlug: string;
+  questionId: string;
+  questionType: 'select' | 'truefalse';
+  totalResponses: number;
+  buckets: PollQuestionResultsBucket[];
+}
+
+export interface FetchPollQuestionResultsInput {
+  pollSlug: string;
+  questionId: string;
+  questionType: 'select' | 'truefalse';
+}
+
+export async function fetchPollQuestionResults(
+  input: FetchPollQuestionResultsInput,
+): Promise<PollQuestionResults> {
+  const config = resolvePollApiConfig();
+  if (!config) {
+    throw new PollApiError('Poll API is not configured', 0);
+  }
+
+  const params = new URLSearchParams({
+    questionType: input.questionType,
+  });
+  const endpointPath = `${config.baseUrl}/v1/polls/${encodeURIComponent(input.pollSlug)}/questions/${encodeURIComponent(input.questionId)}/results?${params.toString()}`;
+
+  const response = await fetch(endpointPath, {
+    method: 'GET',
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new PollApiError('Failed to load poll results', response.status);
+  }
+
+  return (await response.json()) as PollQuestionResults;
+}
+
 export async function persistPollAnswer(
   input: PersistPollAnswerInput,
 ): Promise<void> {

--- a/apps/training/tests/components/polls/poll-answer-state.test.ts
+++ b/apps/training/tests/components/polls/poll-answer-state.test.ts
@@ -11,6 +11,7 @@ describe('isAnswerValid', () => {
     screen: 'Who are you?',
     question: 'I am a...',
     options: ['Parent'],
+    showAnswer: false,
     showResults: false,
   };
 
@@ -21,6 +22,7 @@ describe('isAnswerValid', () => {
     question: 'Test',
     answer: false,
     answerNote: 'Note',
+    showAnswer: true,
     showResults: true,
   };
 
@@ -33,19 +35,19 @@ describe('isAnswerValid', () => {
     ).toBe(true);
     expect(
       isAnswerValid(
-        { ...selectQuestion, type: 'text', showResults: false },
+        { ...selectQuestion, type: 'text', showAnswer: false, showResults: false },
         { ...emptyAnswerState(), freeText: 'hello' },
       ),
     ).toBe(true);
     expect(
       isAnswerValid(
-        { ...selectQuestion, type: 'email', showResults: false },
+        { ...selectQuestion, type: 'email', showAnswer: false, showResults: false },
         { ...emptyAnswerState(), freeText: 'a@b.co' },
       ),
     ).toBe(true);
     expect(
       isAnswerValid(
-        { ...selectQuestion, type: 'email', showResults: false },
+        { ...selectQuestion, type: 'email', showAnswer: false, showResults: false },
         { ...emptyAnswerState(), freeText: 'not-an-email' },
       ),
     ).toBe(false);

--- a/apps/training/tests/polls/poll-live-results-panel.test.tsx
+++ b/apps/training/tests/polls/poll-live-results-panel.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PollLiveResultsPanel } from '@/components/polls/poll-live-results-panel';
+import { POLLS_COMMON } from '@/lib/polls';
+import * as pollsApi from '@/lib/polls-api';
+
+describe('PollLiveResultsPanel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders select buckets with zero-filled options', async () => {
+    vi.spyOn(pollsApi, 'fetchPollQuestionResults').mockResolvedValue({
+      pollSlug: 'workshop-food-jun-26',
+      questionId: 'role',
+      questionType: 'select',
+      totalResponses: 2,
+      buckets: [{ label: 'Parent', count: 2 }],
+    });
+
+    render(
+      <PollLiveResultsPanel
+        pollSlug='workshop-food-jun-26'
+        question={{
+          id: 'role',
+          type: 'select',
+          screen: 'Who are you?',
+          question: 'I am a...',
+          options: ['Parent', 'Other'],
+          showAnswer: false,
+          showResults: true,
+        }}
+        common={POLLS_COMMON}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Room results')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Parent')).toBeInTheDocument();
+    expect(screen.getByText('Other')).toBeInTheDocument();
+    expect(screen.getByText('2 responses so far')).toBeInTheDocument();
+  });
+});

--- a/apps/training/tests/polls/polls-api.test.ts
+++ b/apps/training/tests/polls/polls-api.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { PollApiError, resolvePollApiConfig } from '@/lib/polls-api';
+import {
+  fetchPollQuestionResults,
+  PollApiError,
+  resolvePollApiConfig,
+} from '@/lib/polls-api';
 
 describe('resolvePollApiConfig', () => {
   afterEach(() => {
@@ -41,6 +45,43 @@ describe('resolvePollApiConfig', () => {
     vi.stubEnv('NEXT_PUBLIC_WWW_CRM_API_KEY', '');
 
     expect(resolvePollApiConfig()).toBeNull();
+  });
+});
+
+describe('fetchPollQuestionResults', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('requests results with questionType query param', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', '/www');
+    vi.stubEnv('NEXT_PUBLIC_TRAINING_API_KEY', 'poll-key');
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        pollSlug: 'workshop-food-jun-26',
+        questionId: 'role',
+        questionType: 'select',
+        totalResponses: 0,
+        buckets: [],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchPollQuestionResults({
+      pollSlug: 'workshop-food-jun-26',
+      questionId: 'role',
+      questionType: 'select',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/www/v1/polls/workshop-food-jun-26/questions/role/results?questionType=select',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { 'x-api-key': 'poll-key' },
+      }),
+    );
   });
 });
 

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2957,6 +2957,10 @@ export class ApiStack extends cdk.Stack {
     const polls = v1.addResource("polls");
     const pollBySlug = polls.addResource("{poll_slug}");
     addPublicApiKeyMethod(pollBySlug.addResource("answers"), "PUT");
+    const pollQuestionById = pollBySlug
+      .addResource("questions")
+      .addResource("{question_id}");
+    addPublicApiKeyMethod(pollQuestionById.addResource("results"), "GET");
     const publicDiscounts = v1.addResource("discounts");
     addPublicApiKeyMethod(publicDiscounts.addResource("validate"), "POST");
     const mailchimpWebhook = v1.addResource("mailchimp").addResource("webhook");

--- a/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
+++ b/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
@@ -64,6 +64,18 @@ function handler(event) {
     return request;
   }
 
+  var isPollQuestionResultsPath =
+    uri.indexOf('/www/v1/polls/') === 0 &&
+    uri.indexOf('/questions/') > 0 &&
+    uri.lastIndexOf('/results') === uri.length - 8;
+  if (
+    (method === 'GET' || method === 'OPTIONS') &&
+    isPollQuestionResultsPath
+  ) {
+    request.uri = uri.substring(4);
+    return request;
+  }
+
   return {
     statusCode: 403,
     statusDescription: 'Forbidden',

--- a/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
+++ b/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
@@ -17,6 +17,8 @@ const REQUIRED_ALLOWLIST_PATHS = [
 
 const REQUIRED_POLL_PUT_PREFIX = "/www/v1/polls/";
 const REQUIRED_POLL_PUT_SUFFIX = "/answers";
+const REQUIRED_POLL_RESULTS_SEGMENT = "/questions/";
+const REQUIRED_POLL_RESULTS_SUFFIX = "/results";
 
 function assertContainsAll(haystack: string, needles: string[], label: string): void {
   for (const needle of needles) {
@@ -57,6 +59,16 @@ function main(): void {
   if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes("method === 'OPTIONS'")) {
     throw new Error(
       "WWW_PROXY_ALLOWLIST_FUNCTION must allow OPTIONS for poll answer preflight",
+    );
+  }
+  if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes(REQUIRED_POLL_RESULTS_SEGMENT)) {
+    throw new Error(
+      "WWW_PROXY_ALLOWLIST_FUNCTION missing poll GET /questions/ segment rule",
+    );
+  }
+  if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes(REQUIRED_POLL_RESULTS_SUFFIX)) {
+    throw new Error(
+      "WWW_PROXY_ALLOWLIST_FUNCTION missing poll GET /results suffix rule",
     );
   }
 

--- a/backend/src/app/api/public_polls.py
+++ b/backend/src/app/api/public_polls.py
@@ -1,15 +1,19 @@
-"""Public training poll answer persistence (DynamoDB)."""
+"""Public training poll answer persistence and live results (DynamoDB)."""
 
 from __future__ import annotations
 
 import re
 from typing import Any
 from collections.abc import Mapping
+from urllib.parse import parse_qs, urlparse
 
 from app.api.admin_request import parse_body
 from app.api.validators import validate_email
 from app.exceptions import ValidationError
-from app.services.poll_responses_store import upsert_poll_answer
+from app.services.poll_responses_store import (
+    aggregate_poll_question_results,
+    upsert_poll_answer,
+)
 from app.utils import json_response
 from app.utils.logging import get_logger
 from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
@@ -17,6 +21,8 @@ from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
 logger = get_logger(__name__)
 
 _ANSWERS_SUFFIX = "/answers"
+_RESULTS_SUFFIX = "/results"
+_QUESTIONS_SEGMENT = "/questions/"
 _POLL_API_PREFIX = "/v1/polls/"
 _WWW_POLL_API_PREFIX = "/www/v1/polls/"
 
@@ -33,6 +39,7 @@ _SELECT_TYPES = frozenset({"select"})
 _TRUEFALSE_TYPES = frozenset({"truefalse"})
 _TEXT_TYPES = frozenset({"text"})
 _EMAIL_TYPES = frozenset({"email"})
+_AGGREGATABLE_TYPES = _SELECT_TYPES | _TRUEFALSE_TYPES
 
 
 def handle_public_polls_request(
@@ -41,35 +48,109 @@ def handle_public_polls_request(
     path: str,
 ) -> dict[str, Any]:
     """Route poll API requests under /v1/polls/* and /www/v1/polls/*."""
-    parsed = _parse_poll_answers_path(path)
-    if parsed is None:
-        return json_response(404, {"error": "Not found"}, event=event)
+    answers = _parse_poll_answers_path(path)
+    if answers is not None:
+        poll_slug, _suffix = answers
+        if method == "PUT":
+            return _handle_put_poll_answer(event, poll_slug=poll_slug)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
 
-    poll_slug, _suffix = parsed
-    if method == "PUT" and path.endswith(_ANSWERS_SUFFIX):
-        return _handle_put_poll_answer(event, poll_slug=poll_slug)
+    results = _parse_poll_question_results_path(path)
+    if results is not None:
+        poll_slug, question_id = results
+        if method == "GET":
+            return _handle_get_poll_question_results(
+                event,
+                poll_slug=poll_slug,
+                question_id=question_id,
+            )
+        return json_response(405, {"error": "Method not allowed"}, event=event)
 
-    return json_response(405, {"error": "Method not allowed"}, event=event)
+    return json_response(404, {"error": "Not found"}, event=event)
+
+
+def _parse_poll_path_remainder(path: str) -> str | None:
+    normalized = path.rstrip("/")
+    if normalized.startswith(_WWW_POLL_API_PREFIX):
+        return normalized[len(_WWW_POLL_API_PREFIX) :]
+    if normalized.startswith(_POLL_API_PREFIX):
+        return normalized[len(_POLL_API_PREFIX) :]
+    return None
 
 
 def _parse_poll_answers_path(path: str) -> tuple[str, str] | None:
-    normalized = path.rstrip("/")
-    if not normalized.endswith(_ANSWERS_SUFFIX):
+    remainder = _parse_poll_path_remainder(path)
+    if remainder is None or not remainder.endswith(_ANSWERS_SUFFIX):
         return None
+    poll_slug = remainder[: -len(_ANSWERS_SUFFIX)].strip("/")
+    if "/" in poll_slug or not poll_slug:
+        return None
+    if not PUBLIC_INSTANCE_SLUG_PATTERN.match(poll_slug):
+        return None
+    return poll_slug, _ANSWERS_SUFFIX
 
-    if normalized.startswith(_WWW_POLL_API_PREFIX):
-        remainder = normalized[len(_WWW_POLL_API_PREFIX) : -len(_ANSWERS_SUFFIX)]
-    elif normalized.startswith(_POLL_API_PREFIX):
-        remainder = normalized[len(_POLL_API_PREFIX) : -len(_ANSWERS_SUFFIX)]
-    else:
-        return None
 
-    remainder = remainder.strip("/")
-    if "/" in remainder or not remainder:
+def _parse_poll_question_results_path(path: str) -> tuple[str, str] | None:
+    remainder = _parse_poll_path_remainder(path)
+    if remainder is None or not remainder.endswith(_RESULTS_SUFFIX):
         return None
-    if not PUBLIC_INSTANCE_SLUG_PATTERN.match(remainder):
+    without_suffix = remainder[: -len(_RESULTS_SUFFIX)]
+    if _QUESTIONS_SEGMENT not in without_suffix:
         return None
-    return remainder, _ANSWERS_SUFFIX
+    poll_slug, question_id = without_suffix.split(_QUESTIONS_SEGMENT, 1)
+    poll_slug = poll_slug.strip("/")
+    question_id = question_id.strip("/")
+    if not poll_slug or not question_id or "/" in poll_slug or "/" in question_id:
+        return None
+    if not PUBLIC_INSTANCE_SLUG_PATTERN.match(poll_slug):
+        return None
+    if not _QUESTION_ID_PATTERN.match(question_id):
+        return None
+    return poll_slug, question_id
+
+
+def _handle_get_poll_question_results(
+    event: Mapping[str, Any],
+    *,
+    poll_slug: str,
+    question_id: str,
+) -> dict[str, Any]:
+    try:
+        question_type = _require_aggregatable_question_type(
+            _read_query_param(event, "questionType"),
+        )
+    except ValidationError as exc:
+        return json_response(exc.status_code, exc.to_dict(), event=event)
+
+    result = aggregate_poll_question_results(
+        poll_slug=poll_slug,
+        question_id=question_id,
+        question_type=question_type,
+    )
+    return json_response(200, result, event=event)
+
+
+def _read_query_param(event: Mapping[str, Any], name: str) -> Any:
+    query = event.get("queryStringParameters")
+    if isinstance(query, Mapping) and name in query:
+        return query.get(name)
+    raw_path = event.get("rawPath") or event.get("path") or ""
+    if not isinstance(raw_path, str) or "?" not in raw_path:
+        return None
+    parsed = urlparse(raw_path)
+    values = parse_qs(parsed.query).get(name)
+    if not values:
+        return None
+    return values[0]
+
+
+def _require_aggregatable_question_type(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValidationError("questionType query parameter is required")
+    normalized = value.strip().lower()
+    if normalized not in _AGGREGATABLE_TYPES:
+        raise ValidationError("questionType must be select or truefalse")
+    return normalized
 
 
 def _handle_put_poll_answer(

--- a/backend/src/app/services/poll_responses_store.py
+++ b/backend/src/app/services/poll_responses_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from collections import Counter
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, TypedDict
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -23,6 +23,11 @@ _SK_QUESTION_SEP = "#Q#"
 
 _dynamodb = None
 _table = None
+
+
+class _PollResultBucket(TypedDict):
+    label: str
+    count: int
 
 
 def _table_name() -> str:
@@ -125,6 +130,7 @@ def aggregate_poll_question_results(
     table = _get_table()
     items = _query_poll_items(table=table, poll_slug=poll_slug)
     matching = [item for item in items if item.get("questionId") == question_id]
+    buckets: list[_PollResultBucket]
 
     if question_type == "select":
         counts = Counter(
@@ -134,19 +140,17 @@ def aggregate_poll_question_results(
             and str(item["selectedOption"]).strip()
         )
         buckets = [
-            {"label": label, "count": count}
-            for label, count in sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))
+            _PollResultBucket(label=label, count=count)
+            for label, count in sorted(
+                counts.items(), key=lambda pair: (-pair[1], pair[0])
+            )
         ]
     elif question_type == "truefalse":
-        true_count = sum(
-            1 for item in matching if item.get("booleanAnswer") is True
-        )
-        false_count = sum(
-            1 for item in matching if item.get("booleanAnswer") is False
-        )
+        true_count = _count_boolean_answers(matching, expected=True)
+        false_count = _count_boolean_answers(matching, expected=False)
         buckets = [
-            {"label": "true", "count": true_count},
-            {"label": "false", "count": false_count},
+            _PollResultBucket(label="true", count=true_count),
+            _PollResultBucket(label="false", count=false_count),
         ]
     else:
         buckets = []
@@ -159,6 +163,15 @@ def aggregate_poll_question_results(
         "totalResponses": total,
         "buckets": buckets,
     }
+
+
+def _count_boolean_answers(items: list[dict[str, Any]], *, expected: bool) -> int:
+    total = 0
+    for item in items:
+        value = item.get("booleanAnswer")
+        if isinstance(value, bool) and value is expected:
+            total += 1
+    return total
 
 
 def _query_poll_items(*, table: Any, poll_slug: str) -> list[dict[str, Any]]:

--- a/backend/src/app/services/poll_responses_store.py
+++ b/backend/src/app/services/poll_responses_store.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import os
+from collections import Counter
 from datetime import UTC, datetime
 from typing import Any
 
 import boto3
+from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
 from app.exceptions import AppError
@@ -111,6 +113,67 @@ def upsert_poll_answer(
         "questionId": question_id,
         "updatedAt": now,
     }
+
+
+def aggregate_poll_question_results(
+    *,
+    poll_slug: str,
+    question_id: str,
+    question_type: str,
+) -> dict[str, Any]:
+    """Return live aggregate counts for one poll question across all sessions."""
+    table = _get_table()
+    items = _query_poll_items(table=table, poll_slug=poll_slug)
+    matching = [item for item in items if item.get("questionId") == question_id]
+
+    if question_type == "select":
+        counts = Counter(
+            str(item["selectedOption"]).strip()
+            for item in matching
+            if isinstance(item.get("selectedOption"), str)
+            and str(item["selectedOption"]).strip()
+        )
+        buckets = [
+            {"label": label, "count": count}
+            for label, count in sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))
+        ]
+    elif question_type == "truefalse":
+        true_count = sum(
+            1 for item in matching if item.get("booleanAnswer") is True
+        )
+        false_count = sum(
+            1 for item in matching if item.get("booleanAnswer") is False
+        )
+        buckets = [
+            {"label": "true", "count": true_count},
+            {"label": "false", "count": false_count},
+        ]
+    else:
+        buckets = []
+
+    total = sum(bucket["count"] for bucket in buckets)
+    return {
+        "pollSlug": poll_slug,
+        "questionId": question_id,
+        "questionType": question_type,
+        "totalResponses": total,
+        "buckets": buckets,
+    }
+
+
+def _query_poll_items(*, table: Any, poll_slug: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    query_kwargs: dict[str, Any] = {
+        "KeyConditionExpression": Key("pk").eq(_partition_key(poll_slug=poll_slug)),
+    }
+    while True:
+        response = table.query(**query_kwargs)
+        items.extend(response.get("Items", []))
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        query_kwargs["ExclusiveStartKey"] = last_key
+    return items
 
 
 def reset_table_for_tests() -> None:

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -19,7 +19,9 @@ info:
     - Public calendar availability (`/v1/calendar/availability`, `/www/v1/calendar/availability`).
     - Media lead capture (`/v1/assets/free/request`, `/www/v1/assets/free/request`).
     - Training poll answer persistence (`PUT /v1/polls/{poll_slug}/answers`,
-      `/www/v1/polls/{poll_slug}/answers`) for `apps/training` (DynamoDB; API key only).
+      `/www/v1/polls/{poll_slug}/answers`) and live per-question aggregates
+      (`GET /v1/polls/{poll_slug}/questions/{question_id}/results`, `/www/...`) for
+      `apps/training` (DynamoDB; API key only).
     - Public website endpoints consumed by `apps/public_www`, exposed via the
       CloudFront `/www/*` proxy allowlist in
       `backend/infrastructure/lib/public-www-stack.ts`.
@@ -938,6 +940,118 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Persistence failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/polls/{poll_slug}/questions/{question_id}/results:
+    get:
+      summary: Live aggregate results for one poll question (direct API path)
+      description: >
+        Returns room-wide response counts for a single poll question. Used by
+        `apps/training` when `showResults` is enabled on a question. Counts all
+        rows in DynamoDB `evolvesprouts-poll-responses` for the poll partition
+        with matching `questionId` (one row per session per question; re-answers
+        overwrite). Requires `questionType=select` or `questionType=truefalse`.
+        Requires API key.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: poll_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        - name: question_id
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        - name: questionType
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [select, truefalse]
+      responses:
+        "200":
+          description: Aggregated counts.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollQuestionResultsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Poll path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Aggregation failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /www/v1/polls/{poll_slug}/questions/{question_id}/results:
+    get:
+      summary: Live aggregate results for one poll question (training website proxy path)
+      description: Same as `GET /v1/polls/{poll_slug}/questions/{question_id}/results` for same-origin calls from `apps/training`.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: poll_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        - name: question_id
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        - name: questionType
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [select, truefalse]
+      responses:
+        "200":
+          description: Aggregated counts.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollQuestionResultsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Poll path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Aggregation failed.
           content:
             application/json:
               schema:
@@ -2091,6 +2205,43 @@ components:
           type: string
           format: date-time
           description: UTC timestamp when the answer row was last written.
+    PollQuestionResultsResponse:
+      type: object
+      required:
+        - pollSlug
+        - questionId
+        - questionType
+        - totalResponses
+        - buckets
+      properties:
+        pollSlug:
+          type: string
+        questionId:
+          type: string
+        questionType:
+          type: string
+          enum: [select, truefalse]
+        totalResponses:
+          type: integer
+          minimum: 0
+        buckets:
+          type: array
+          items:
+            $ref: "#/components/schemas/PollQuestionResultsBucket"
+    PollQuestionResultsBucket:
+      type: object
+      required:
+        - label
+        - count
+      properties:
+        label:
+          type: string
+          description: >
+            Option label for `select`, or `true` / `false` for `truefalse`
+            (client maps to localized True/False labels).
+        count:
+          type: integer
+          minimum: 0
     ReservationSubmissionAccepted:
       type: object
       required:

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -487,6 +487,7 @@ and [`docs/api/admin.yaml`](../api/admin.yaml).
 | `/v1/calendar/availability` | GET | None + API key | `EvolvesproutsAdminFunction` | Requires `purpose` (`consultation_booking` or `intro_call_booking`); returns slots + meta; consultation uses `Cache-Control: no-store` on 200 |
 | `/v1/assets/free` | GET | None + API key | `EvolvesproutsAdminFunction` | Lists public `client_document`-tagged assets; optional `language` query |
 | `/v1/polls/{poll_slug}/answers` | PUT | None + API key | `EvolvesproutsAdminFunction` | Upserts one training poll answer to DynamoDB `evolvesprouts-poll-responses` |
+| `/v1/polls/{poll_slug}/questions/{question_id}/results` | GET | None + API key | `EvolvesproutsAdminFunction` | Live aggregate counts for one poll question (`select` / `truefalse`) |
 | `/v1/admin/geographic-areas` | GET | Admin Group | `EvolvesproutsAdminFunction` | Geographic area lookup for address selection |
 | `/v1/admin/locations` | GET, POST | Admin Group | `EvolvesproutsAdminFunction` | |
 | `/v1/admin/locations/{id}` | GET, PUT, PATCH, DELETE | Admin Group | `EvolvesproutsAdminFunction` | |

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -42,6 +42,8 @@ their primary responsibilities.
   `/v1/contact-us`,
   `/v1/polls/{poll_slug}/answers` (PUT; API key; persists training poll answers to DynamoDB
   `evolvesprouts-poll-responses`; same contract as `/www/v1/polls/{poll_slug}/answers`),
+  `/v1/polls/{poll_slug}/questions/{question_id}/results` (GET; API key; live aggregates for
+  `select` / `truefalse` questions; same contract as `/www/v1/polls/.../results`),
   `/v1/admin/geographic-areas`,
   `/v1/mailchimp/webhook` (GET/POST),
   `/v1/admin/locations/*` (including `GET /v1/admin/locations?exclude_addresses=true`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -40,9 +40,10 @@ Flutter Mobile / Next.js Admin
 ### Public website (Next.js static export)
 - Public marketing site in `apps/public_www`.
 - Training and poll pages in `apps/training` (static export at `training.evolvesprouts.com`, not indexed).
-  Poll answers persist via `PUT /www/v1/polls/{poll_slug}/answers` to the shared DynamoDB
-  table `evolvesprouts-poll-responses` (content-driven JSON per poll under
-  `apps/training/src/content/polls/`).
+  Poll answers persist via `PUT /www/v1/polls/{poll_slug}/answers` and live per-question
+  aggregates load via `GET /www/v1/polls/{poll_slug}/questions/{question_id}/results`
+  against the shared DynamoDB table `evolvesprouts-poll-responses` (content-driven JSON
+  per poll under `apps/training/src/content/polls/`).
 - First-party marketing paths are defined once in `apps/public_www/src/lib/public-www-routes.ts` and
   imported by `apps/public_www/src/lib/routes.ts` and the admin Website QR presets so public and admin
   stay aligned.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -302,6 +302,8 @@ Current allowlisted public website POST paths include:
 
 Training poll persistence uses `PUT /www/v1/polls/{poll_slug}/answers` (prefix +
 `/answers` suffix rule in `WWW_PROXY_ALLOWLIST_FUNCTION`; not a fixed path per poll).
+Live poll aggregates use `GET /www/v1/polls/{poll_slug}/questions/{question_id}/results`
+(prefix + `/questions/` + `/results` suffix rule; not a fixed path per poll).
 
 ### Third-party invoice parser egress controls
 

--- a/tests/test_public_polls_api.py
+++ b/tests/test_public_polls_api.py
@@ -129,6 +129,106 @@ def test_put_poll_answer_rejects_invalid_session(api_gateway_event: Any) -> None
     assert resp["statusCode"] == 400
 
 
+def test_get_poll_question_results_aggregates_select(
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [
+            {
+                "questionId": "role",
+                "questionType": "select",
+                "selectedOption": "Parent",
+            },
+            {
+                "questionId": "role",
+                "questionType": "select",
+                "selectedOption": "Parent",
+            },
+            {
+                "questionId": "role",
+                "questionType": "select",
+                "selectedOption": "Grandparent",
+            },
+            {
+                "questionId": "challenge",
+                "questionType": "select",
+                "selectedOption": "Other",
+            },
+        ],
+    }
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    event = api_gateway_event(
+        method="GET",
+        path="/www/v1/polls/workshop-food-jun-26/questions/role/results",
+        query_params={"questionType": "select"},
+    )
+    resp = pp.handle_public_polls_request(
+        event,
+        "GET",
+        "/www/v1/polls/workshop-food-jun-26/questions/role/results",
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["totalResponses"] == 3
+    assert body["buckets"] == [
+        {"label": "Parent", "count": 2},
+        {"label": "Grandparent", "count": 1},
+    ]
+
+
+def test_get_poll_question_results_aggregates_truefalse(
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [
+            {"questionId": "myth1", "booleanAnswer": False},
+            {"questionId": "myth1", "booleanAnswer": True},
+            {"questionId": "myth1", "booleanAnswer": False},
+        ],
+    }
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    event = api_gateway_event(
+        method="GET",
+        path="/www/v1/polls/workshop-food-jun-26/questions/myth1/results",
+        query_params={"questionType": "truefalse"},
+    )
+    resp = pp.handle_public_polls_request(
+        event,
+        "GET",
+        "/www/v1/polls/workshop-food-jun-26/questions/myth1/results",
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["totalResponses"] == 3
+    assert body["buckets"] == [
+        {"label": "true", "count": 1},
+        {"label": "false", "count": 2},
+    ]
+
+
+def test_get_poll_question_results_requires_question_type(
+    api_gateway_event: Any,
+) -> None:
+    event = api_gateway_event(
+        method="GET",
+        path="/www/v1/polls/workshop-food-jun-26/questions/role/results",
+    )
+    resp = pp.handle_public_polls_request(
+        event,
+        "GET",
+        "/www/v1/polls/workshop-food-jun-26/questions/role/results",
+    )
+    assert resp["statusCode"] == 400
+
+
 def test_put_poll_answer_rejects_unknown_path(api_gateway_event: Any) -> None:
     event = api_gateway_event(
         method="PUT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Training poll JSON previously used `showResults` for the personal post-submit feedback screen (correct/incorrect, presenter note, your answer). That flag is now **`showAnswer`**.

**`showResults`** now means room-wide live aggregates: a bar chart that polls the server every 3 seconds and updates as more people answer.

## Changes

### Training (`apps/training`)
- `showAnswer` → `PollAnswerPanel` (renamed from `PollResultsPanel`)
- `showResults` → `PollLiveResultsPanel` with horizontal `<progress>` bars
- Wizard phases: answer → (optional) feedback → (optional) live results → next question
- Workshop poll: myth + challenge questions enable both flags

### Backend
- `GET /v1/polls/{poll_slug}/questions/{question_id}/results?questionType=select|truefalse`
- Aggregates all DynamoDB rows for the poll partition matching `questionId`
- API key auth (same as answer PUT)

### Infrastructure / docs
- API Gateway GET route, CloudFront allowlist for `/www/v1/polls/.../questions/.../results`
- OpenAPI + architecture docs updated

## Deploy notes

Requires CDK deploy (new API route) and training static export so CloudFront serves the updated allowlist function.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e868be1e-9dfa-451b-82f8-664c41913d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e868be1e-9dfa-451b-82f8-664c41913d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

