### PR TITLE
Add poll facilitator controls with live results on training site

### DIFF
--- a/apps/training/src/app/polls/[slug]/controls/page.tsx
+++ b/apps/training/src/app/polls/[slug]/controls/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { PollControlPage } from '@/components/polls/poll-control-page';
+import {
+  getAllPollSlugs,
+  getPollContent,
+  isValidPollSlug,
+  POLLS_COMMON,
+} from '@/lib/polls';
+
+interface PollControlsRouteProps {
+  params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllPollSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: PollControlsRouteProps): Promise<Metadata> {
+  const { slug } = await params;
+  if (!isValidPollSlug(slug)) {
+    return {};
+  }
+  const poll = getPollContent(slug);
+  if (!poll) {
+    return {};
+  }
+  return {
+    title: `${POLLS_COMMON.control.title} — ${poll.title}`,
+    robots: {
+      index: false,
+      follow: false,
+      noarchive: true,
+    },
+  };
+}
+
+export default async function PollControlsRoutePage({ params }: PollControlsRouteProps) {
+  const { slug } = await params;
+  if (!isValidPollSlug(slug)) {
+    notFound();
+  }
+  const poll = getPollContent(slug);
+  if (!poll || poll.slug !== slug) {
+    notFound();
+  }
+
+  return <PollControlPage poll={poll} common={POLLS_COMMON} />;
+}

--- a/apps/training/src/components/polls/poll-control-page.tsx
+++ b/apps/training/src/components/polls/poll-control-page.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { PollControlQuestionCard } from '@/components/polls/poll-control-question-card';
+import type { PollContent, PollsCommonContent } from '@/content/poll-types';
+import { usePollControlState } from '@/lib/use-poll-control-state';
+
+export interface PollControlPageProps {
+  poll: PollContent;
+  common: PollsCommonContent;
+}
+
+export function PollControlPage({ poll, common }: PollControlPageProps) {
+  const { enabledQuestionIds, isLoading, errorMessage, isQuestionEnabled, toggleQuestion } =
+    usePollControlState({ pollSlug: poll.slug, allowWrites: true });
+
+  const bannerMessage = resolveBannerMessage(errorMessage, common);
+
+  return (
+    <main className='flex min-h-screen flex-col px-6 py-10'>
+      <header className='mx-auto mb-8 w-full max-w-3xl text-center'>
+        <h1 className='text-2xl font-semibold text-neutral-900'>{common.control.title}</h1>
+        <p className='mt-2 text-base text-neutral-700'>{poll.title}</p>
+        <p className='mt-1 text-sm text-neutral-600'>{common.control.description}</p>
+      </header>
+      {bannerMessage ? (
+        <p className='mx-auto mb-4 w-full max-w-3xl text-sm text-red-700' role='alert'>
+          {bannerMessage}
+        </p>
+      ) : null}
+      <div className='mx-auto flex w-full max-w-3xl flex-col gap-6'>
+        {poll.questions.map((question) => (
+          <PollControlQuestionCard
+            key={question.id}
+            pollSlug={poll.slug}
+            question={question}
+            common={common}
+            enabled={isQuestionEnabled(question.id)}
+            disabled={isLoading}
+            onToggle={() => {
+              void toggleQuestion(question.id);
+            }}
+          />
+        ))}
+      </div>
+      {!isLoading && enabledQuestionIds.size === 0 ? (
+        <p className='mx-auto mt-6 w-full max-w-3xl text-center text-sm text-neutral-600'>
+          {common.waiting.description}
+        </p>
+      ) : null}
+    </main>
+  );
+}
+
+function resolveBannerMessage(
+  code: string | null,
+  common: PollsCommonContent,
+): string | null {
+  if (code === 'load') {
+    return common.control.loadFailed;
+  }
+  if (code === 'update' || code === 'config') {
+    return common.control.updateFailed;
+  }
+  return null;
+}

--- a/apps/training/src/components/polls/poll-control-question-card.tsx
+++ b/apps/training/src/components/polls/poll-control-question-card.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { PollLiveResultsPanel } from '@/components/polls/poll-live-results-panel';
+import { PollTextResultsPanel } from '@/components/polls/poll-text-results-panel';
+import type { PollQuestion, PollsCommonContent } from '@/content/poll-types';
+
+export interface PollControlQuestionCardProps {
+  pollSlug: string;
+  question: PollQuestion;
+  common: PollsCommonContent;
+  enabled: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}
+
+export function PollControlQuestionCard({
+  pollSlug,
+  question,
+  common,
+  enabled,
+  disabled,
+  onToggle,
+}: PollControlQuestionCardProps) {
+  const toggleId = `poll-control-toggle-${question.id}`;
+
+  return (
+    <article className='flex flex-col gap-4 rounded-xl border border-neutral-200 bg-white p-5 shadow-sm'>
+      <div className='flex flex-wrap items-start justify-between gap-4'>
+        <div className='flex min-w-0 flex-1 flex-col gap-1'>
+          <p className='text-xs font-medium uppercase tracking-wide text-neutral-500'>
+            {question.screen}
+          </p>
+          <h2 className='text-lg font-semibold text-neutral-900'>{question.question}</h2>
+          {!enabled ? (
+            <p className='text-sm text-neutral-600'>{common.control.skippedLabel}</p>
+          ) : null}
+        </div>
+        <label
+          htmlFor={toggleId}
+          className='flex shrink-0 items-center gap-2 text-sm font-medium text-neutral-900'
+        >
+          <span>{enabled ? common.control.questionOnLabel : common.control.questionOffLabel}</span>
+          <input
+            id={toggleId}
+            type='checkbox'
+            className='h-5 w-5 rounded border-neutral-300'
+            checked={enabled}
+            disabled={disabled}
+            onChange={onToggle}
+          />
+        </label>
+      </div>
+      {question.type === 'select' || question.type === 'truefalse' ? (
+        <PollLiveResultsPanel
+          pollSlug={pollSlug}
+          question={{
+            ...question,
+            showResults: true,
+          }}
+          common={common}
+        />
+      ) : (
+        <PollTextResultsPanel pollSlug={pollSlug} question={question} common={common} />
+      )}
+    </article>
+  );
+}

--- a/apps/training/src/components/polls/poll-live-results-panel.tsx
+++ b/apps/training/src/components/polls/poll-live-results-panel.tsx
@@ -37,7 +37,7 @@ export function PollLiveResultsPanel({
         const next = await fetchPollQuestionResults({
           pollSlug,
           questionId: question.id,
-          questionType: question.type as 'select' | 'truefalse',
+          questionType: question.type,
         });
         if (!cancelled) {
           setResults(next);

--- a/apps/training/src/components/polls/poll-text-results-panel.tsx
+++ b/apps/training/src/components/polls/poll-text-results-panel.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import type { PollQuestion, PollsCommonContent } from '@/content/poll-types';
+import {
+  fetchPollQuestionResults,
+  PollApiError,
+  type PollQuestionResults,
+} from '@/lib/polls-api';
+
+const LIVE_RESULTS_POLL_MS = 3000;
+
+export interface PollTextResultsPanelProps {
+  pollSlug: string;
+  question: PollQuestion;
+  common: PollsCommonContent;
+}
+
+export function PollTextResultsPanel({
+  pollSlug,
+  question,
+  common,
+}: PollTextResultsPanelProps) {
+  const [results, setResults] = useState<PollQuestionResults | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (question.type !== 'text' && question.type !== 'email') {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadResults(): Promise<void> {
+      try {
+        const next = await fetchPollQuestionResults({
+          pollSlug,
+          questionId: question.id,
+          questionType: question.type,
+        });
+        if (!cancelled) {
+          setResults(next);
+          setErrorMessage(null);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setErrorMessage(resolveLoadErrorMessage(error, common));
+        }
+      }
+    }
+
+    void loadResults();
+    const intervalId = window.setInterval(() => {
+      void loadResults();
+    }, LIVE_RESULTS_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [common, pollSlug, question]);
+
+  if (question.type !== 'text' && question.type !== 'email') {
+    return null;
+  }
+
+  const responses = results?.responses ?? [];
+
+  return (
+    <section className='flex flex-col gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4'>
+      <div className='flex flex-col gap-1'>
+        <h3 className='text-base font-semibold text-neutral-900'>
+          {common.control.textResponsesHeading}
+        </h3>
+        <p className='text-sm text-neutral-600'>
+          {formatTotalResponses(common.liveResults.totalResponsesTemplate, results?.totalResponses ?? 0)}
+        </p>
+      </div>
+      {errorMessage ? (
+        <p className='text-sm text-red-700' role='alert'>
+          {errorMessage}
+        </p>
+      ) : null}
+      {responses.length === 0 && !errorMessage ? (
+        <p className='text-sm text-neutral-600'>{common.control.noTextResponses}</p>
+      ) : (
+        <ul className='flex max-h-48 flex-col gap-2 overflow-y-auto text-sm text-neutral-800'>
+          {responses.map((response, index) => (
+            <li
+              key={`${response}-${index}`}
+              className='rounded-md border border-neutral-200 bg-white px-3 py-2'
+            >
+              {response}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function formatTotalResponses(template: string, total: number): string {
+  return template.replace('{total}', String(total));
+}
+
+function resolveLoadErrorMessage(error: unknown, common: PollsCommonContent): string {
+  if (error instanceof PollApiError && error.statusCode === 0) {
+    return common.errors.missingApiConfig;
+  }
+  return common.errors.resultsLoadFailed;
+}

--- a/apps/training/src/components/polls/poll-wizard.tsx
+++ b/apps/training/src/components/polls/poll-wizard.tsx
@@ -13,6 +13,7 @@ import { PollQuestionField } from '@/components/polls/poll-question-field';
 import type { PollContent, PollQuestion, PollsCommonContent } from '@/content/poll-types';
 import { getOrCreatePollSessionId } from '@/lib/poll-session';
 import { PollApiError, persistPollAnswer } from '@/lib/polls-api';
+import { usePollControlState } from '@/lib/use-poll-control-state';
 
 export interface PollWizardProps {
   poll: PollContent;
@@ -32,17 +33,47 @@ export function PollWizard({ poll, common }: PollWizardProps) {
   >({});
 
   const sessionId = useMemo(() => getOrCreatePollSessionId(), []);
-  const totalSteps = poll.questions.length;
-  const currentQuestion = poll.questions[stepIndex];
+  const { enabledQuestionIds, isLoading: isControlLoading } = usePollControlState({
+    pollSlug: poll.slug,
+    allowWrites: false,
+  });
+
+  const activeQuestions = useMemo(
+    () => poll.questions.filter((question) => enabledQuestionIds.has(question.id)),
+    [enabledQuestionIds, poll.questions],
+  );
+
+  const resolvedStepIndex =
+    activeQuestions.length === 0 ? 0 : Math.min(stepIndex, activeQuestions.length - 1);
+
+  const totalSteps = activeQuestions.length;
+  const currentQuestion = activeQuestions[resolvedStepIndex];
   const currentAnswer = currentQuestion
     ? (answersByQuestionId[currentQuestion.id] ?? emptyAnswerState())
     : emptyAnswerState();
 
   const progressLabel = formatProgressLabel({
     template: common.a11y.progressTemplate,
-    current: Math.min(stepIndex + 1, totalSteps),
+    current: totalSteps === 0 ? 0 : resolvedStepIndex + 1,
     total: totalSteps,
   });
+
+  if (!isControlLoading && activeQuestions.length === 0) {
+    return (
+      <section className='mx-auto flex w-full max-w-xl flex-col gap-3 text-center'>
+        <h2 className='text-2xl font-semibold text-neutral-900'>{common.waiting.title}</h2>
+        <p className='text-base text-neutral-700'>{common.waiting.description}</p>
+      </section>
+    );
+  }
+
+  if (isControlLoading || !currentQuestion) {
+    return (
+      <section className='mx-auto flex w-full max-w-xl flex-col gap-3 text-center'>
+        <p className='text-base text-neutral-700'>{common.waiting.description}</p>
+      </section>
+    );
+  }
 
   if (isComplete) {
     return (
@@ -53,12 +84,8 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     );
   }
 
-  if (!currentQuestion) {
-    return null;
-  }
-
-  const isFirstStep = stepIndex === 0;
-  const isLastStep = stepIndex === totalSteps - 1;
+  const isFirstStep = resolvedStepIndex === 0;
+  const isLastStep = resolvedStepIndex === totalSteps - 1;
   const showingFeedback = stepPhase === 'feedback' && currentQuestion.showAnswer;
   const showingLiveResults =
     stepPhase === 'liveResults' && currentQuestion.showResults;
@@ -107,7 +134,7 @@ export function PollWizard({ poll, common }: PollWizardProps) {
             disabled={isSaving}
             onClick={() => {
               setErrorMessage(null);
-              setStepIndex((index) => Math.max(0, index - 1));
+              setStepIndex((index) => Math.max(0, Math.min(index, activeQuestions.length - 1) - 1));
               setStepPhase('answer');
             }}
           >
@@ -195,7 +222,7 @@ export function PollWizard({ poll, common }: PollWizardProps) {
       setIsComplete(true);
       return;
     }
-    setStepIndex((index) => index + 1);
+    setStepIndex((index) => Math.min(index + 1, activeQuestions.length - 1));
     setStepPhase('answer');
   }
 }

--- a/apps/training/src/content/poll-types.ts
+++ b/apps/training/src/content/poll-types.ts
@@ -68,6 +68,21 @@ export interface PollsCommonContent {
     title: string;
     description: string;
   };
+  waiting: {
+    title: string;
+    description: string;
+  };
+  control: {
+    title: string;
+    description: string;
+    questionOnLabel: string;
+    questionOffLabel: string;
+    skippedLabel: string;
+    textResponsesHeading: string;
+    noTextResponses: string;
+    updateFailed: string;
+    loadFailed: string;
+  };
   errors: {
     required: string;
     invalidEmail: string;
@@ -110,4 +125,8 @@ export function getPollContent(slug: string): PollContent | null {
 
 export function buildPollPath(slug: PollSlug | string): string {
   return `/polls/${slug}/`;
+}
+
+export function buildPollControlsPath(slug: PollSlug | string): string {
+  return `/polls/${slug}/controls/`;
 }

--- a/apps/training/src/content/polls-common.json
+++ b/apps/training/src/content/polls-common.json
@@ -23,6 +23,21 @@
     "title": "Thank you",
     "description": "Your responses have been saved."
   },
+  "waiting": {
+    "title": "Please wait",
+    "description": "The presenter will open the next question shortly."
+  },
+  "control": {
+    "title": "Poll control",
+    "description": "Turn questions on for participants to answer. Off questions stay listed here but are skipped on the poll page.",
+    "questionOnLabel": "On",
+    "questionOffLabel": "Off",
+    "skippedLabel": "Skipped for participants",
+    "textResponsesHeading": "Responses",
+    "noTextResponses": "No responses yet.",
+    "updateFailed": "Could not update question visibility. Please try again.",
+    "loadFailed": "Could not load poll control. Please refresh."
+  },
   "errors": {
     "required": "Please answer this question before continuing.",
     "invalidEmail": "Enter a valid email address.",

--- a/apps/training/src/lib/polls-api.ts
+++ b/apps/training/src/lib/polls-api.ts
@@ -45,15 +45,24 @@ export interface PollQuestionResultsBucket {
 export interface PollQuestionResults {
   pollSlug: string;
   questionId: string;
-  questionType: 'select' | 'truefalse';
+  questionType: PollAggregatableQuestionType;
   totalResponses: number;
   buckets: PollQuestionResultsBucket[];
+  responses?: string[];
 }
+
+export interface PollControlState {
+  pollSlug: string;
+  enabledQuestionIds: string[];
+  updatedAt?: string;
+}
+
+export type PollAggregatableQuestionType = 'select' | 'truefalse' | 'text' | 'email';
 
 export interface FetchPollQuestionResultsInput {
   pollSlug: string;
   questionId: string;
-  questionType: 'select' | 'truefalse';
+  questionType: PollAggregatableQuestionType;
 }
 
 export async function fetchPollQuestionResults(
@@ -82,6 +91,55 @@ export async function fetchPollQuestionResults(
   }
 
   return (await response.json()) as PollQuestionResults;
+}
+
+export async function fetchPollControlState(pollSlug: string): Promise<PollControlState> {
+  const config = resolvePollApiConfig();
+  if (!config) {
+    throw new PollApiError('Poll API is not configured', 0);
+  }
+
+  const endpointPath = `${config.baseUrl}/v1/polls/${encodeURIComponent(pollSlug)}/control`;
+  const response = await fetch(endpointPath, {
+    method: 'GET',
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new PollApiError('Failed to load poll control state', response.status);
+  }
+
+  return (await response.json()) as PollControlState;
+}
+
+export async function persistPollControlState(
+  pollSlug: string,
+  enabledQuestionIds: string[],
+): Promise<PollControlState> {
+  const config = resolvePollApiConfig();
+  if (!config) {
+    throw new PollApiError('Poll API is not configured', 0);
+  }
+
+  const endpointPath = `${config.baseUrl}/v1/polls/${encodeURIComponent(pollSlug)}/control`;
+  const response = await fetch(endpointPath, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': config.apiKey,
+    },
+    body: JSON.stringify({ enabledQuestionIds }),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new PollApiError('Failed to update poll control state', response.status);
+  }
+
+  return (await response.json()) as PollControlState;
 }
 
 export async function persistPollAnswer(

--- a/apps/training/src/lib/polls.ts
+++ b/apps/training/src/lib/polls.ts
@@ -1,4 +1,5 @@
 export {
+  buildPollControlsPath,
   buildPollPath,
   getAllPollSlugs,
   getPollContent,

--- a/apps/training/src/lib/use-poll-control-state.ts
+++ b/apps/training/src/lib/use-poll-control-state.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  fetchPollControlState,
+  persistPollControlState,
+  PollApiError,
+} from '@/lib/polls-api';
+
+const CONTROL_POLL_MS = 2500;
+
+export interface UsePollControlStateOptions {
+  pollSlug: string;
+  /** When false, only polls GET (participant view). Default true for facilitator. */
+  allowWrites?: boolean;
+}
+
+export interface UsePollControlStateResult {
+  enabledQuestionIds: ReadonlySet<string>;
+  isLoading: boolean;
+  errorMessage: string | null;
+  isQuestionEnabled: (questionId: string) => boolean;
+  toggleQuestion: (questionId: string) => Promise<void>;
+}
+
+export function usePollControlState({
+  pollSlug,
+  allowWrites = true,
+}: UsePollControlStateOptions): UsePollControlStateResult {
+  const [enabledQuestionIds, setEnabledQuestionIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const enabledRef = useRef(enabledQuestionIds);
+
+  useEffect(() => {
+    enabledRef.current = enabledQuestionIds;
+  }, [enabledQuestionIds]);
+
+  const applyState = useCallback((ids: string[]) => {
+    setEnabledQuestionIds(new Set(ids));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load(): Promise<void> {
+      try {
+        const state = await fetchPollControlState(pollSlug);
+        if (!cancelled) {
+          applyState(state.enabledQuestionIds);
+          setErrorMessage(null);
+        }
+      } catch {
+        if (!cancelled) {
+          setErrorMessage('load');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void load();
+    const intervalId = window.setInterval(() => {
+      void load();
+    }, CONTROL_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [applyState, pollSlug]);
+
+  const isQuestionEnabled = useCallback(
+    (questionId: string) => enabledQuestionIds.has(questionId),
+    [enabledQuestionIds],
+  );
+
+  const toggleQuestion = useCallback(
+    async (questionId: string) => {
+      if (!allowWrites) {
+        return;
+      }
+
+      const next = new Set(enabledRef.current);
+      if (next.has(questionId)) {
+        next.delete(questionId);
+      } else {
+        next.add(questionId);
+      }
+      const nextIds = [...next];
+      const previous = enabledRef.current;
+      setEnabledQuestionIds(next);
+      setErrorMessage(null);
+
+      try {
+        const state = await persistPollControlState(pollSlug, nextIds);
+        applyState(state.enabledQuestionIds);
+      } catch (error) {
+        setEnabledQuestionIds(previous);
+        if (error instanceof PollApiError && error.statusCode === 0) {
+          setErrorMessage('config');
+        } else {
+          setErrorMessage('update');
+        }
+      }
+    },
+    [allowWrites, applyState, pollSlug],
+  );
+
+  return {
+    enabledQuestionIds,
+    isLoading,
+    errorMessage,
+    isQuestionEnabled,
+    toggleQuestion,
+  };
+}

--- a/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
+++ b/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -8,20 +8,39 @@ import { getPollContent, POLLS_COMMON } from '@/lib/polls';
 
 const poll = getPollContent('workshop-food-jun-26');
 
-vi.mock('@/lib/polls-api', () => ({
-  persistPollAnswer: vi.fn().mockResolvedValue(undefined),
-  resolvePollApiConfig: vi.fn().mockReturnValue({ baseUrl: '/www', apiKey: 'test-key' }),
-}));
+vi.mock('@/lib/polls-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/polls-api')>();
+  return {
+    ...actual,
+    persistPollAnswer: vi.fn().mockResolvedValue(undefined),
+    fetchPollControlState: vi.fn().mockResolvedValue({
+      pollSlug: 'workshop-food-jun-26',
+      enabledQuestionIds: [
+        'role',
+        'challenge',
+        'myth1',
+        'myth2',
+        'myth3',
+        'myth4',
+        'onething',
+        'email',
+      ],
+    }),
+    resolvePollApiConfig: vi.fn().mockReturnValue({ baseUrl: '/www', apiKey: 'test-key' }),
+  };
+});
 
 describe('WorkshopFoodJun26PollPage', () => {
-  it('renders poll title and first question screen', () => {
+  it('renders poll title and first question screen', async () => {
     if (!poll) {
       throw new Error('Expected workshop-food-jun-26 poll content');
     }
     render(<PollPage poll={poll} common={POLLS_COMMON} />);
     expect(screen.getByRole('heading', { level: 1, name: poll.title })).toBeInTheDocument();
     const first = poll.questions[0];
-    expect(screen.getByText(first?.screen ?? '')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(first?.screen ?? '')).toBeInTheDocument();
+    });
     expect(screen.getByText(first?.question ?? '')).toBeInTheDocument();
   });
 
@@ -45,6 +64,9 @@ describe('WorkshopFoodJun26PollPage', () => {
     if (!first || first.type !== 'select') {
       throw new Error('Expected first question to be select');
     }
+    await waitFor(() => {
+      expect(screen.getByLabelText(first.options[0] ?? '')).toBeInTheDocument();
+    });
     await user.click(screen.getByLabelText(first.options[0] ?? ''));
     await user.click(screen.getByRole('button', { name: POLLS_COMMON.navigation.next }));
 
@@ -64,6 +86,9 @@ describe('WorkshopFoodJun26PollPage', () => {
     if (!role || role.type !== 'select') {
       throw new Error('Expected role select question');
     }
+    await waitFor(() => {
+      expect(screen.getByLabelText(role.options[0] ?? '')).toBeInTheDocument();
+    });
     await user.click(screen.getByLabelText(role.options[0] ?? ''));
     await user.click(screen.getByRole('button', { name: POLLS_COMMON.navigation.next }));
 

--- a/apps/training/tests/components/polls/poll-wizard-control.test.tsx
+++ b/apps/training/tests/components/polls/poll-wizard-control.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PollWizard } from '@/components/polls/poll-wizard';
+import { getPollContent, POLLS_COMMON } from '@/lib/polls';
+import * as pollsApi from '@/lib/polls-api';
+
+describe('PollWizard control gating', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows waiting state when no questions are enabled', async () => {
+    const poll = getPollContent('workshop-food-jun-26');
+    if (!poll) {
+      throw new Error('expected poll fixture');
+    }
+
+    vi.spyOn(pollsApi, 'fetchPollControlState').mockResolvedValue({
+      pollSlug: poll.slug,
+      enabledQuestionIds: [],
+    });
+
+    render(<PollWizard poll={poll} common={POLLS_COMMON} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Please wait')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('The presenter will open the next question shortly.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/training/tests/polls/poll-control-page.test.tsx
+++ b/apps/training/tests/polls/poll-control-page.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PollControlPage } from '@/components/polls/poll-control-page';
+import { getPollContent, POLLS_COMMON } from '@/lib/polls';
+import * as pollsApi from '@/lib/polls-api';
+
+describe('PollControlPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders questions and toggles visibility', async () => {
+    const poll = getPollContent('workshop-food-jun-26');
+    if (!poll) {
+      throw new Error('expected poll fixture');
+    }
+
+    vi.spyOn(pollsApi, 'fetchPollControlState').mockResolvedValue({
+      pollSlug: poll.slug,
+      enabledQuestionIds: [],
+    });
+    vi.spyOn(pollsApi, 'persistPollControlState').mockResolvedValue({
+      pollSlug: poll.slug,
+      enabledQuestionIds: ['role'],
+      updatedAt: '2026-05-27T00:00:00Z',
+    });
+    vi.spyOn(pollsApi, 'fetchPollQuestionResults').mockResolvedValue({
+      pollSlug: poll.slug,
+      questionId: 'role',
+      questionType: 'select',
+      totalResponses: 0,
+      buckets: [],
+    });
+
+    const user = userEvent.setup();
+    render(<PollControlPage poll={poll} common={POLLS_COMMON} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Poll control')).toBeInTheDocument();
+    });
+
+    const roleToggle = document.getElementById('poll-control-toggle-role');
+    if (!(roleToggle instanceof HTMLInputElement)) {
+      throw new Error('expected role toggle');
+    }
+    await user.click(roleToggle);
+
+    await waitFor(() => {
+      expect(pollsApi.persistPollControlState).toHaveBeenCalledWith(poll.slug, ['role']);
+    });
+  });
+});

--- a/apps/training/tests/polls/polls-api.test.ts
+++ b/apps/training/tests/polls/polls-api.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  fetchPollControlState,
   fetchPollQuestionResults,
+  persistPollControlState,
   PollApiError,
   resolvePollApiConfig,
 } from '@/lib/polls-api';
@@ -80,6 +82,56 @@ describe('fetchPollQuestionResults', () => {
       expect.objectContaining({
         method: 'GET',
         headers: { 'x-api-key': 'poll-key' },
+      }),
+    );
+  });
+});
+
+describe('poll control API', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads control state', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', '/www');
+    vi.stubEnv('NEXT_PUBLIC_TRAINING_API_KEY', 'poll-key');
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        pollSlug: 'workshop-food-jun-26',
+        enabledQuestionIds: ['role'],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const state = await fetchPollControlState('workshop-food-jun-26');
+    expect(state.enabledQuestionIds).toEqual(['role']);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/www/v1/polls/workshop-food-jun-26/control',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('persists control state', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', '/www');
+    vi.stubEnv('NEXT_PUBLIC_TRAINING_API_KEY', 'poll-key');
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        pollSlug: 'workshop-food-jun-26',
+        enabledQuestionIds: ['myth1'],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await persistPollControlState('workshop-food-jun-26', ['myth1']);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/www/v1/polls/workshop-food-jun-26/control',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ enabledQuestionIds: ['myth1'] }),
       }),
     );
   });

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2957,8 +2957,9 @@ export class ApiStack extends cdk.Stack {
     const polls = v1.addResource("polls");
     const pollBySlug = polls.addResource("{poll_slug}");
     addPublicApiKeyMethod(pollBySlug.addResource("answers"), "PUT");
-    addPublicApiKeyMethod(pollBySlug.addResource("control"), "GET");
-    addPublicApiKeyMethod(pollBySlug.addResource("control"), "PUT");
+    const pollControl = pollBySlug.addResource("control");
+    addPublicApiKeyMethod(pollControl, "GET");
+    addPublicApiKeyMethod(pollControl, "PUT");
     const pollQuestionById = pollBySlug
       .addResource("questions")
       .addResource("{question_id}");

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2957,6 +2957,8 @@ export class ApiStack extends cdk.Stack {
     const polls = v1.addResource("polls");
     const pollBySlug = polls.addResource("{poll_slug}");
     addPublicApiKeyMethod(pollBySlug.addResource("answers"), "PUT");
+    addPublicApiKeyMethod(pollBySlug.addResource("control"), "GET");
+    addPublicApiKeyMethod(pollBySlug.addResource("control"), "PUT");
     const pollQuestionById = pollBySlug
       .addResource("questions")
       .addResource("{question_id}");

--- a/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
+++ b/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
@@ -76,6 +76,17 @@ function handler(event) {
     return request;
   }
 
+  var isPollControlPath =
+    uri.indexOf('/www/v1/polls/') === 0 &&
+    uri.lastIndexOf('/control') === uri.length - 8;
+  if (
+    (method === 'GET' || method === 'PUT' || method === 'OPTIONS') &&
+    isPollControlPath
+  ) {
+    request.uri = uri.substring(4);
+    return request;
+  }
+
   return {
     statusCode: 403,
     statusDescription: 'Forbidden',

--- a/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
+++ b/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
@@ -19,6 +19,7 @@ const REQUIRED_POLL_PUT_PREFIX = "/www/v1/polls/";
 const REQUIRED_POLL_PUT_SUFFIX = "/answers";
 const REQUIRED_POLL_RESULTS_SEGMENT = "/questions/";
 const REQUIRED_POLL_RESULTS_SUFFIX = "/results";
+const REQUIRED_POLL_CONTROL_SUFFIX = "/control";
 
 function assertContainsAll(haystack: string, needles: string[], label: string): void {
   for (const needle of needles) {
@@ -69,6 +70,11 @@ function main(): void {
   if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes(REQUIRED_POLL_RESULTS_SUFFIX)) {
     throw new Error(
       "WWW_PROXY_ALLOWLIST_FUNCTION missing poll GET /results suffix rule",
+    );
+  }
+  if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes(REQUIRED_POLL_CONTROL_SUFFIX)) {
+    throw new Error(
+      "WWW_PROXY_ALLOWLIST_FUNCTION missing poll /control suffix rule",
     );
   }
 

--- a/backend/src/app/api/public_polls.py
+++ b/backend/src/app/api/public_polls.py
@@ -12,6 +12,8 @@ from app.api.validators import validate_email
 from app.exceptions import ValidationError
 from app.services.poll_responses_store import (
     aggregate_poll_question_results,
+    get_poll_control_state,
+    put_poll_control_state,
     upsert_poll_answer,
 )
 from app.utils import json_response
@@ -21,6 +23,7 @@ from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
 logger = get_logger(__name__)
 
 _ANSWERS_SUFFIX = "/answers"
+_CONTROL_SUFFIX = "/control"
 _RESULTS_SUFFIX = "/results"
 _QUESTIONS_SEGMENT = "/questions/"
 _POLL_API_PREFIX = "/v1/polls/"
@@ -39,7 +42,7 @@ _SELECT_TYPES = frozenset({"select"})
 _TRUEFALSE_TYPES = frozenset({"truefalse"})
 _TEXT_TYPES = frozenset({"text"})
 _EMAIL_TYPES = frozenset({"email"})
-_AGGREGATABLE_TYPES = _SELECT_TYPES | _TRUEFALSE_TYPES
+_AGGREGATABLE_TYPES = _SELECT_TYPES | _TRUEFALSE_TYPES | _TEXT_TYPES | _EMAIL_TYPES
 
 
 def handle_public_polls_request(
@@ -66,6 +69,15 @@ def handle_public_polls_request(
             )
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
+    control = _parse_poll_control_path(path)
+    if control is not None:
+        poll_slug = control
+        if method == "GET":
+            return _handle_get_poll_control(event, poll_slug=poll_slug)
+        if method == "PUT":
+            return _handle_put_poll_control(event, poll_slug=poll_slug)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
     return json_response(404, {"error": "Not found"}, event=event)
 
 
@@ -76,6 +88,18 @@ def _parse_poll_path_remainder(path: str) -> str | None:
     if normalized.startswith(_POLL_API_PREFIX):
         return normalized[len(_POLL_API_PREFIX) :]
     return None
+
+
+def _parse_poll_control_path(path: str) -> str | None:
+    remainder = _parse_poll_path_remainder(path)
+    if remainder is None or not remainder.endswith(_CONTROL_SUFFIX):
+        return None
+    poll_slug = remainder[: -len(_CONTROL_SUFFIX)].strip("/")
+    if "/" in poll_slug or not poll_slug:
+        return None
+    if not PUBLIC_INSTANCE_SLUG_PATTERN.match(poll_slug):
+        return None
+    return poll_slug
 
 
 def _parse_poll_answers_path(path: str) -> tuple[str, str] | None:
@@ -149,8 +173,71 @@ def _require_aggregatable_question_type(value: Any) -> str:
         raise ValidationError("questionType query parameter is required")
     normalized = value.strip().lower()
     if normalized not in _AGGREGATABLE_TYPES:
-        raise ValidationError("questionType must be select or truefalse")
+        raise ValidationError("questionType must be select, truefalse, text, or email")
     return normalized
+
+
+def _handle_get_poll_control(
+    event: Mapping[str, Any],
+    *,
+    poll_slug: str,
+) -> dict[str, Any]:
+    result = get_poll_control_state(poll_slug=poll_slug)
+    return json_response(200, result, event=event)
+
+
+def _handle_put_poll_control(
+    event: Mapping[str, Any],
+    *,
+    poll_slug: str,
+) -> dict[str, Any]:
+    try:
+        body = parse_body(event)
+    except ValidationError as exc:
+        return json_response(exc.status_code, exc.to_dict(), event=event)
+
+    try:
+        enabled_question_ids = _validate_control_body(body)
+    except ValidationError as exc:
+        return json_response(exc.status_code, exc.to_dict(), event=event)
+
+    result = put_poll_control_state(
+        poll_slug=poll_slug,
+        enabled_question_ids=enabled_question_ids,
+    )
+    logger.info(
+        "Updated poll control state",
+        extra={
+            "poll_slug": poll_slug,
+            "enabled_count": len(enabled_question_ids),
+        },
+    )
+    return json_response(200, result, event=event)
+
+
+def _validate_control_body(body: Mapping[str, Any]) -> list[str]:
+    raw = body.get("enabledQuestionIds")
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValidationError("enabledQuestionIds must be an array")
+    enabled: list[str] = []
+    seen: set[str] = set()
+    for value in raw:
+        if not isinstance(value, str):
+            raise ValidationError("enabledQuestionIds entries must be strings")
+        normalized = value.strip()
+        if not normalized:
+            continue
+        if not _QUESTION_ID_PATTERN.match(normalized):
+            raise ValidationError(
+                "enabledQuestionIds entries must be kebab-case identifiers"
+            )
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        enabled.append(normalized)
+    return enabled
 
 
 def _handle_put_poll_answer(

--- a/backend/src/app/services/poll_responses_store.py
+++ b/backend/src/app/services/poll_responses_store.py
@@ -20,6 +20,7 @@ _TABLE_ENV = "POLL_RESPONSES_TABLE_NAME"
 _PK_PREFIX = "POLL#"
 _SK_PREFIX = "SESSION#"
 _SK_QUESTION_SEP = "#Q#"
+_SK_CONTROL = "CONTROL"
 
 _dynamodb = None
 _table = None
@@ -132,6 +133,8 @@ def aggregate_poll_question_results(
     matching = [item for item in items if item.get("questionId") == question_id]
     buckets: list[_PollResultBucket]
 
+    responses: list[str] = []
+
     if question_type == "select":
         counts = Counter(
             str(item["selectedOption"]).strip()
@@ -145,6 +148,7 @@ def aggregate_poll_question_results(
                 counts.items(), key=lambda pair: (-pair[1], pair[0])
             )
         ]
+        total = sum(bucket["count"] for bucket in buckets)
     elif question_type == "truefalse":
         true_count = _count_boolean_answers(matching, expected=True)
         false_count = _count_boolean_answers(matching, expected=False)
@@ -152,16 +156,109 @@ def aggregate_poll_question_results(
             _PollResultBucket(label="true", count=true_count),
             _PollResultBucket(label="false", count=false_count),
         ]
+        total = sum(bucket["count"] for bucket in buckets)
+    elif question_type in ("text", "email"):
+        buckets = []
+        for item in matching:
+            value = item.get("freeText")
+            if isinstance(value, str):
+                normalized = value.strip()
+                if normalized:
+                    responses.append(normalized)
+        total = len(responses)
     else:
         buckets = []
+        total = 0
 
-    total = sum(bucket["count"] for bucket in buckets)
-    return {
+    result: dict[str, Any] = {
         "pollSlug": poll_slug,
         "questionId": question_id,
         "questionType": question_type,
         "totalResponses": total,
         "buckets": buckets,
+    }
+    if responses:
+        result["responses"] = responses
+    return result
+
+
+def get_poll_control_state(*, poll_slug: str) -> dict[str, Any]:
+    """Return facilitator toggles for which questions are open to respondents."""
+    table = _get_table()
+    key = {
+        "pk": _partition_key(poll_slug=poll_slug),
+        "sk": _SK_CONTROL,
+    }
+    try:
+        item = table.get_item(Key=key).get("Item")
+    except ClientError:
+        logger.exception(
+            "Failed to load poll control state",
+            extra={"poll_slug": poll_slug},
+        )
+        raise AppError(
+            "Failed to load poll control state",
+            status_code=500,
+        ) from None
+
+    enabled: list[str] = []
+    if item and isinstance(item.get("enabledQuestionIds"), list):
+        for value in item["enabledQuestionIds"]:
+            if isinstance(value, str) and value.strip():
+                enabled.append(value.strip())
+
+    updated_at = item.get("updatedAt") if isinstance(item, dict) else None
+    if isinstance(updated_at, str):
+        return {
+            "pollSlug": poll_slug,
+            "enabledQuestionIds": enabled,
+            "updatedAt": updated_at,
+        }
+    return {
+        "pollSlug": poll_slug,
+        "enabledQuestionIds": enabled,
+    }
+
+
+def put_poll_control_state(
+    *,
+    poll_slug: str,
+    enabled_question_ids: list[str],
+) -> dict[str, Any]:
+    """Replace the set of questions respondents may answer (default is none)."""
+    table = _get_table()
+    key = {
+        "pk": _partition_key(poll_slug=poll_slug),
+        "sk": _SK_CONTROL,
+    }
+    now = _now_iso()
+    item: dict[str, Any] = {
+        **key,
+        "pollSlug": poll_slug,
+        "enabledQuestionIds": enabled_question_ids,
+        "updatedAt": now,
+    }
+    try:
+        existing = table.get_item(Key=key).get("Item")
+        if existing and existing.get("createdAt"):
+            item["createdAt"] = existing["createdAt"]
+        else:
+            item["createdAt"] = now
+        table.put_item(Item=item)
+    except ClientError:
+        logger.exception(
+            "Failed to persist poll control state",
+            extra={"poll_slug": poll_slug},
+        )
+        raise AppError(
+            "Failed to persist poll control state",
+            status_code=500,
+        ) from None
+
+    return {
+        "pollSlug": poll_slug,
+        "enabledQuestionIds": enabled_question_ids,
+        "updatedAt": now,
     }
 
 

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -19,9 +19,10 @@ info:
     - Public calendar availability (`/v1/calendar/availability`, `/www/v1/calendar/availability`).
     - Media lead capture (`/v1/assets/free/request`, `/www/v1/assets/free/request`).
     - Training poll answer persistence (`PUT /v1/polls/{poll_slug}/answers`,
-      `/www/v1/polls/{poll_slug}/answers`) and live per-question aggregates
-      (`GET /v1/polls/{poll_slug}/questions/{question_id}/results`, `/www/...`) for
-      `apps/training` (DynamoDB; API key only).
+      `/www/v1/polls/{poll_slug}/answers`), facilitator control
+      (`GET`/`PUT /v1/polls/{poll_slug}/control`, `/www/.../control`), and live
+      per-question aggregates (`GET /v1/polls/{poll_slug}/questions/{question_id}/results`,
+      `/www/...`) for `apps/training` (DynamoDB; API key only).
     - Public website endpoints consumed by `apps/public_www`, exposed via the
       CloudFront `/www/*` proxy allowlist in
       `backend/infrastructure/lib/public-www-stack.ts`.
@@ -945,15 +946,108 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /v1/polls/{poll_slug}/control:
+    get:
+      summary: Poll facilitator control state (direct API path)
+      description: >
+        Returns which poll questions are currently open for respondents.
+        Stored at DynamoDB sort key `CONTROL` under partition `POLL#<poll_slug>`.
+        When `enabledQuestionIds` is empty (default), respondents wait until the
+        facilitator enables at least one question. Requires API key.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: poll_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+      responses:
+        "200":
+          description: Current control state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollControlStateResponse"
+        "404":
+          description: Poll path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Load failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: Update poll facilitator control state (direct API path)
+      description: >
+        Replaces the set of question ids that respondents may answer. Questions
+        not listed remain visible on the facilitator control page but are skipped
+        on the participant poll flow.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: poll_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PollControlStatePutRequest"
+      responses:
+        "200":
+          description: Control state updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollControlStateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Poll path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Persistence failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /v1/polls/{poll_slug}/questions/{question_id}/results:
     get:
       summary: Live aggregate results for one poll question (direct API path)
       description: >
         Returns room-wide response counts for a single poll question. Used by
-        `apps/training` when `showResults` is enabled on a question. Counts all
-        rows in DynamoDB `evolvesprouts-poll-responses` for the poll partition
-        with matching `questionId` (one row per session per question; re-answers
-        overwrite). Requires `questionType=select` or `questionType=truefalse`.
+        `apps/training` when `showResults` is enabled on a question, and on the
+        facilitator control page for every question. Counts all rows in DynamoDB
+        `evolvesprouts-poll-responses` for the poll partition with matching
+        `questionId` (one row per session per question; re-answers overwrite).
+        Requires `questionType` of `select`, `truefalse`, `text`, or `email`.
+        For `text` and `email`, returns a `responses` array of answer strings.
         Requires API key.
       security:
         - ApiKeyAuth: []
@@ -975,7 +1069,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [select, truefalse]
+            enum: [select, truefalse, text, email]
       responses:
         "200":
           description: Aggregated counts.
@@ -999,6 +1093,90 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Aggregation failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /www/v1/polls/{poll_slug}/control:
+    get:
+      summary: Poll facilitator control state (training website proxy path)
+      description: Same as `GET /v1/polls/{poll_slug}/control` for same-origin calls from `apps/training`.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: poll_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+      responses:
+        "200":
+          description: Current control state.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollControlStateResponse"
+        "404":
+          description: Poll path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Load failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      summary: Update poll facilitator control state (training website proxy path)
+      description: Same as `PUT /v1/polls/{poll_slug}/control` for same-origin calls from `apps/training`.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: poll_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PollControlStatePutRequest"
+      responses:
+        "200":
+          description: Control state updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollControlStateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Poll path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Persistence failed.
           content:
             application/json:
               schema:
@@ -1028,7 +1206,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [select, truefalse]
+            enum: [select, truefalse, text, email]
       responses:
         "200":
           description: Aggregated counts.
@@ -2205,6 +2383,33 @@ components:
           type: string
           format: date-time
           description: UTC timestamp when the answer row was last written.
+    PollControlStatePutRequest:
+      type: object
+      properties:
+        enabledQuestionIds:
+          type: array
+          items:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+          description: >
+            Question ids currently open to respondents. Omitted or empty means
+            all questions are off (default).
+    PollControlStateResponse:
+      type: object
+      required:
+        - pollSlug
+        - enabledQuestionIds
+      properties:
+        pollSlug:
+          type: string
+        enabledQuestionIds:
+          type: array
+          items:
+            type: string
+        updatedAt:
+          type: string
+          format: date-time
+          description: UTC timestamp when control state was last written.
     PollQuestionResultsResponse:
       type: object
       required:
@@ -2220,7 +2425,7 @@ components:
           type: string
         questionType:
           type: string
-          enum: [select, truefalse]
+          enum: [select, truefalse, text, email]
         totalResponses:
           type: integer
           minimum: 0
@@ -2228,6 +2433,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PollQuestionResultsBucket"
+        responses:
+          type: array
+          items:
+            type: string
+          description: >
+            Free-text answers for `text` and `email` questions (presenter
+            control view). Omitted for `select` and `truefalse`.
     PollQuestionResultsBucket:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -43,7 +43,11 @@ their primary responsibilities.
   `/v1/polls/{poll_slug}/answers` (PUT; API key; persists training poll answers to DynamoDB
   `evolvesprouts-poll-responses`; same contract as `/www/v1/polls/{poll_slug}/answers`),
   `/v1/polls/{poll_slug}/questions/{question_id}/results` (GET; API key; live aggregates for
-  `select` / `truefalse` questions; same contract as `/www/v1/polls/.../results`),
+  `select` / `truefalse` questions and free-text lists for `text` / `email`; same contract as
+  `/www/v1/polls/.../results`),
+  `/v1/polls/{poll_slug}/control` (GET, PUT; API key; facilitator toggles for which questions
+  respondents may answer; stored at DynamoDB sort key `CONTROL`; default is all off;
+  same contract as `/www/v1/polls/{poll_slug}/control`),
   `/v1/admin/geographic-areas`,
   `/v1/mailchimp/webhook` (GET/POST),
   `/v1/admin/locations/*` (including `GET /v1/admin/locations?exclude_addresses=true`

--- a/tests/test_public_polls_api.py
+++ b/tests/test_public_polls_api.py
@@ -229,6 +229,98 @@ def test_get_poll_question_results_requires_question_type(
     assert resp["statusCode"] == 400
 
 
+def test_get_poll_control_defaults_to_all_off(
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.get_item.return_value = {"Item": None}
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    event = api_gateway_event(
+        method="GET",
+        path="/www/v1/polls/workshop-food-jun-26/control",
+    )
+    resp = pp.handle_public_polls_request(
+        event,
+        "GET",
+        "/www/v1/polls/workshop-food-jun-26/control",
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["enabledQuestionIds"] == []
+
+
+def test_put_poll_control_persists_enabled_questions(
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.get_item.return_value = {"Item": None}
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    event = api_gateway_event(
+        method="PUT",
+        path="/www/v1/polls/workshop-food-jun-26/control",
+        body=json.dumps({"enabledQuestionIds": ["role", "myth1"]}),
+        headers={"content-type": "application/json"},
+    )
+    resp = pp.handle_public_polls_request(
+        event,
+        "PUT",
+        "/www/v1/polls/workshop-food-jun-26/control",
+    )
+    assert resp["statusCode"] == 200
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["enabledQuestionIds"] == ["role", "myth1"]
+    assert item["sk"] == "CONTROL"
+
+
+def test_get_poll_question_results_lists_text_responses(
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [
+            {
+                "questionId": "onething",
+                "questionType": "text",
+                "freeText": "Offer fruit daily",
+            },
+            {
+                "questionId": "onething",
+                "questionType": "text",
+                "freeText": "  ",
+            },
+            {
+                "questionId": "onething",
+                "questionType": "text",
+                "freeText": "Smaller portions",
+            },
+        ],
+    }
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    event = api_gateway_event(
+        method="GET",
+        path="/www/v1/polls/workshop-food-jun-26/questions/onething/results",
+        query_params={"questionType": "text"},
+    )
+    resp = pp.handle_public_polls_request(
+        event,
+        "GET",
+        "/www/v1/polls/workshop-food-jun-26/questions/onething/results",
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["totalResponses"] == 2
+    assert body["responses"] == ["Offer fruit daily", "Smaller portions"]
+
+
 def test_put_poll_answer_rejects_unknown_path(api_gateway_event: Any) -> None:
     event = api_gateway_event(
         method="PUT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a facilitator **controls** page for training polls and shared backend state so presenters can open questions one at a time while participants only see enabled questions.

- **Facilitator UI:** `/polls/{slug}/controls/` — toggle each question on/off (default **all off**), with live results for every question (bar charts for select/true-false, response list for text/email).
- **Participant UI:** `/polls/{slug}/` polls control state every ~2.5s; shows a waiting message until at least one question is enabled; skips disabled questions in the wizard.
- **API:** `GET`/`PUT /v1/polls/{poll_slug}/control` (and `/www/...` proxy) stores `enabledQuestionIds` in DynamoDB sort key `CONTROL`.
- **Results:** `GET .../results` now supports `questionType=text|email` with a `responses` array for the control view.

## Test plan

- [x] `pytest tests/test_public_polls_api.py`
- [x] `cd apps/training && npm run test`
- [x] `cd apps/training && npm run lint`
- [x] `cd backend/infrastructure && npm run test:infra` (CloudFront allowlist assertions)
- [ ] Deploy backend + training site, then verify `/polls/workshop-food-jun-26/controls/` toggles gate the participant poll in another browser
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c458e5a0-b81d-4578-84cb-3ba2caae70a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c458e5a0-b81d-4578-84cb-3ba2caae70a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

