### PR TITLE
Add Website Polls tab with admin poll answer management

### DIFF
--- a/apps/admin_web/src/app/(dashboard)/website/page.tsx
+++ b/apps/admin_web/src/app/(dashboard)/website/page.tsx
@@ -1,5 +1,5 @@
-import { WebsiteQrPage } from '@/components/admin/website/website-qr-page';
+import { WebsitePage } from '@/components/admin/website/website-page';
 
 export default function WebsiteRoutePage() {
-  return <WebsiteQrPage />;
+  return <WebsitePage />;
 }

--- a/apps/admin_web/src/components/admin/website/website-page.tsx
+++ b/apps/admin_web/src/components/admin/website/website-page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { WebsitePollsPanel } from '@/components/admin/website/website-polls-panel';
+import { WebsiteQrPage } from '@/components/admin/website/website-qr-page';
+import { AdminTabStrip } from '@/components/ui/admin-tab-strip';
+import { useQueryTabState } from '@/hooks/use-query-tab-state';
+
+const TAB_ITEMS = [
+  { key: 'qr-codes', label: 'QR Codes' },
+  { key: 'polls', label: 'Polls' },
+] as const;
+
+type WebsiteView = (typeof TAB_ITEMS)[number]['key'];
+
+const WEBSITE_TAB_KEYS: readonly WebsiteView[] = TAB_ITEMS.map((item) => item.key);
+const DEFAULT_WEBSITE_VIEW: WebsiteView = 'qr-codes';
+
+export function WebsitePage() {
+  const [activeView, setActiveView] = useQueryTabState<WebsiteView>(
+    WEBSITE_TAB_KEYS,
+    DEFAULT_WEBSITE_VIEW
+  );
+
+  return (
+    <div className='space-y-6'>
+      <AdminTabStrip
+        items={TAB_ITEMS}
+        activeKey={activeView}
+        onChange={setActiveView}
+        aria-label='Website section views'
+      />
+      {activeView === 'qr-codes' ? <WebsiteQrPage /> : null}
+      {activeView === 'polls' ? <WebsitePollsPanel /> : null}
+    </div>
+  );
+}

--- a/apps/admin_web/src/components/admin/website/website-polls-panel.tsx
+++ b/apps/admin_web/src/components/admin/website/website-polls-panel.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { AdminPageErrorBanner } from '@/components/admin/admin-page-error-banner';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableCell,
+  AdminDataTableHead,
+  AdminDataTableHeadCell,
+} from '@/components/ui/admin-data-table';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Label } from '@/components/ui/label';
+import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { Select } from '@/components/ui/select';
+import { toErrorMessage } from '@/hooks/hook-errors';
+import {
+  clearAdminPollAnswers,
+  exportAdminPollAnswersCsv,
+  formatPollAnswerValue,
+  listAdminPollAnswers,
+  listAdminPolls,
+  type AdminPollAnswerRow,
+  type AdminPollSummary,
+} from '@/lib/polls-api';
+import { formatDate } from '@/lib/format';
+
+export function WebsitePollsPanel() {
+  const [polls, setPolls] = useState<AdminPollSummary[]>([]);
+  const [selectedPollSlug, setSelectedPollSlug] = useState('');
+  const [answers, setAnswers] = useState<AdminPollAnswerRow[]>([]);
+  const [pollsLoading, setPollsLoading] = useState(true);
+  const [answersLoading, setAnswersLoading] = useState(false);
+  const [pollsError, setPollsError] = useState('');
+  const [answersError, setAnswersError] = useState('');
+  const [actionError, setActionError] = useState('');
+  const [exporting, setExporting] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [clearDialogOpen, setClearDialogOpen] = useState(false);
+
+  const selectedPoll = useMemo(
+    () => polls.find((poll) => poll.pollSlug === selectedPollSlug) ?? null,
+    [polls, selectedPollSlug]
+  );
+
+  const loadPolls = useCallback(async (signal?: AbortSignal) => {
+    setPollsLoading(true);
+    setPollsError('');
+    try {
+      const items = await listAdminPolls(signal);
+      setPolls(items);
+      setSelectedPollSlug((current) => {
+        if (current && items.some((item) => item.pollSlug === current)) {
+          return current;
+        }
+        return items[0]?.pollSlug ?? '';
+      });
+    } catch (error) {
+      if (signal?.aborted) {
+        return;
+      }
+      setPollsError(toErrorMessage(error, 'Failed to load polls.'));
+    } finally {
+      if (!signal?.aborted) {
+        setPollsLoading(false);
+      }
+    }
+  }, []);
+
+  const loadAnswers = useCallback(async (pollSlug: string, signal?: AbortSignal) => {
+    if (!pollSlug) {
+      setAnswers([]);
+      setAnswersError('');
+      return;
+    }
+    setAnswersLoading(true);
+    setAnswersError('');
+    try {
+      const items = await listAdminPollAnswers(pollSlug, signal);
+      setAnswers(items);
+    } catch (error) {
+      if (signal?.aborted) {
+        return;
+      }
+      setAnswersError(toErrorMessage(error, 'Failed to load poll answers.'));
+    } finally {
+      if (!signal?.aborted) {
+        setAnswersLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadPolls(controller.signal);
+    return () => controller.abort();
+  }, [loadPolls]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadAnswers(selectedPollSlug, controller.signal);
+    return () => controller.abort();
+  }, [loadAnswers, selectedPollSlug]);
+
+  const handleExport = async () => {
+    if (!selectedPollSlug) {
+      return;
+    }
+    setActionError('');
+    setExporting(true);
+    try {
+      const blob = await exportAdminPollAnswersCsv(selectedPollSlug);
+      const downloadUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = downloadUrl;
+      anchor.download = `poll-${selectedPollSlug}-answers-${new Date().toISOString().slice(0, 10)}.csv`;
+      anchor.click();
+      URL.revokeObjectURL(downloadUrl);
+    } catch (error) {
+      setActionError(toErrorMessage(error, 'Failed to export poll answers.'));
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleClearConfirm = async () => {
+    if (!selectedPollSlug) {
+      return;
+    }
+    setActionError('');
+    setClearing(true);
+    try {
+      await clearAdminPollAnswers(selectedPollSlug);
+      setClearDialogOpen(false);
+      await Promise.all([loadPolls(), loadAnswers(selectedPollSlug)]);
+    } catch (error) {
+      setActionError(toErrorMessage(error, 'Failed to clear poll answers.'));
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  const toolbar = (
+    <div className='mb-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between'>
+      <div className='min-w-[240px] max-w-md flex-1'>
+        <Label htmlFor='website-polls-select'>Poll</Label>
+        <Select
+          id='website-polls-select'
+          value={selectedPollSlug}
+          onChange={(event) => setSelectedPollSlug(event.target.value)}
+          disabled={pollsLoading || polls.length === 0}
+        >
+          {polls.length === 0 ? (
+            <option value=''>No polls found</option>
+          ) : (
+            polls.map((poll) => (
+              <option key={poll.pollSlug} value={poll.pollSlug}>
+                {poll.pollSlug} ({poll.answerCount} answers)
+              </option>
+            ))
+          )}
+        </Select>
+      </div>
+      <div className='flex flex-wrap gap-2'>
+        <Button
+          type='button'
+          variant='outline'
+          onClick={() => void handleExport()}
+          disabled={!selectedPollSlug || exporting || answersLoading}
+        >
+          {exporting ? 'Exporting…' : 'Export answers'}
+        </Button>
+        <Button
+          type='button'
+          variant='outline'
+          onClick={() => setClearDialogOpen(true)}
+          disabled={!selectedPollSlug || clearing || answersLoading || answers.length === 0}
+        >
+          Clear answers
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className='space-y-4'>
+      {pollsError ? <AdminPageErrorBanner title='Polls' message={pollsError} /> : null}
+      {actionError ? <AdminPageErrorBanner title='Poll action' message={actionError} /> : null}
+
+      <PaginatedTableCard
+        title='Poll answers'
+        description={
+          selectedPoll
+            ? `${selectedPoll.answerCount} stored answer rows for ${selectedPoll.pollSlug}.`
+            : 'Choose a poll to view stored answers from DynamoDB.'
+        }
+        isLoading={answersLoading}
+        isLoadingMore={false}
+        hasMore={false}
+        error={answersError}
+        loadingLabel='Loading answers…'
+        onLoadMore={() => {}}
+        toolbar={toolbar}
+      >
+        <AdminDataTable tableClassName='min-w-[960px]'>
+          <AdminDataTableHead>
+            <tr>
+              <AdminDataTableHeadCell>Session</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Question</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Type</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Answer</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Updated</AdminDataTableHeadCell>
+            </tr>
+          </AdminDataTableHead>
+          <AdminDataTableBody>
+            {!answersLoading && answers.length === 0 ? (
+              <tr>
+                <AdminDataTableCell colSpan={5} className='text-slate-500'>
+                  {selectedPollSlug
+                    ? 'No answers stored for this poll yet.'
+                    : 'Select a poll to load answers.'}
+                </AdminDataTableCell>
+              </tr>
+            ) : (
+              answers.map((row) => (
+                <tr key={`${row.sessionId}-${row.questionId}`}>
+                  <AdminDataTableCell className='font-mono text-xs'>{row.sessionId}</AdminDataTableCell>
+                  <AdminDataTableCell>{row.questionId}</AdminDataTableCell>
+                  <AdminDataTableCell>{row.questionType}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatPollAnswerValue(row)}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatDate(row.updatedAt)}</AdminDataTableCell>
+                </tr>
+              ))
+            )}
+          </AdminDataTableBody>
+        </AdminDataTable>
+      </PaginatedTableCard>
+
+      <ConfirmDialog
+        open={clearDialogOpen}
+        title='Clear poll answers'
+        description={
+          selectedPollSlug
+            ? `Permanently delete all ${answers.length} stored answer rows for "${selectedPollSlug}"? This cannot be undone.`
+            : 'Permanently delete all stored answer rows for this poll? This cannot be undone.'
+        }
+        confirmLabel={clearing ? 'Clearing…' : 'Clear answers'}
+        cancelLabel='Cancel'
+        variant='danger'
+        confirmDisabled={clearing}
+        onConfirm={() => void handleClearConfirm()}
+        onCancel={() => {
+          if (!clearing) {
+            setClearDialogOpen(false);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/admin_web/src/lib/polls-api.ts
+++ b/apps/admin_web/src/lib/polls-api.ts
@@ -1,0 +1,119 @@
+import { ensureFreshTokens } from './auth';
+import { adminApiRequest } from './api-admin-client';
+import { unwrapPayload } from './api-payload';
+import { getApiBaseUrl } from './config';
+import { isRecord } from './type-guards';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+
+export type AdminPollSummary = ApiSchemas['AdminPollSummary'];
+export type AdminPollAnswerRow = ApiSchemas['AdminPollAnswerRow'];
+export type AdminPollClearAnswersResponse = ApiSchemas['AdminPollClearAnswersResponse'];
+
+function parsePollSummary(value: unknown): AdminPollSummary {
+  const row = isRecord(value) ? value : {};
+  return {
+    pollSlug: typeof row.pollSlug === 'string' ? row.pollSlug : '',
+    answerCount: typeof row.answerCount === 'number' ? row.answerCount : 0,
+  };
+}
+
+function parsePollAnswerRow(value: unknown): AdminPollAnswerRow {
+  const row = isRecord(value) ? value : {};
+  const parsed: AdminPollAnswerRow = {
+    pollSlug: typeof row.pollSlug === 'string' ? row.pollSlug : '',
+    sessionId: typeof row.sessionId === 'string' ? row.sessionId : '',
+    questionId: typeof row.questionId === 'string' ? row.questionId : '',
+    questionType:
+      row.questionType === 'select' ||
+      row.questionType === 'truefalse' ||
+      row.questionType === 'text' ||
+      row.questionType === 'email'
+        ? row.questionType
+        : 'text',
+    createdAt: typeof row.createdAt === 'string' ? row.createdAt : '',
+    updatedAt: typeof row.updatedAt === 'string' ? row.updatedAt : '',
+  };
+  if (typeof row.selectedOption === 'string') {
+    parsed.selectedOption = row.selectedOption;
+  }
+  if (typeof row.booleanAnswer === 'boolean') {
+    parsed.booleanAnswer = row.booleanAnswer;
+  }
+  if (typeof row.freeText === 'string') {
+    parsed.freeText = row.freeText;
+  }
+  return parsed;
+}
+
+export async function listAdminPolls(signal?: AbortSignal): Promise<AdminPollSummary[]> {
+  const payload = await adminApiRequest<ApiSchemas['AdminPollListResponse']>({
+    endpointPath: '/v1/admin/polls',
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  return Array.isArray(root.items) ? root.items.map((item) => parsePollSummary(item)) : [];
+}
+
+export async function listAdminPollAnswers(
+  pollSlug: string,
+  signal?: AbortSignal
+): Promise<AdminPollAnswerRow[]> {
+  const payload = await adminApiRequest<ApiSchemas['AdminPollAnswerListResponse']>({
+    endpointPath: `/v1/admin/polls/${encodeURIComponent(pollSlug)}/answers`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  return Array.isArray(root.items) ? root.items.map((item) => parsePollAnswerRow(item)) : [];
+}
+
+export async function clearAdminPollAnswers(pollSlug: string): Promise<AdminPollClearAnswersResponse> {
+  const payload = await adminApiRequest<ApiSchemas['AdminPollClearAnswersResponse']>({
+    endpointPath: `/v1/admin/polls/${encodeURIComponent(pollSlug)}/answers`,
+    method: 'DELETE',
+  });
+  const root = unwrapPayload(payload);
+  return {
+    pollSlug: typeof root.pollSlug === 'string' ? root.pollSlug : pollSlug,
+    deletedCount: typeof root.deletedCount === 'number' ? root.deletedCount : 0,
+  };
+}
+
+export async function exportAdminPollAnswersCsv(pollSlug: string): Promise<Blob> {
+  const tokens = await ensureFreshTokens();
+  if (!tokens) {
+    throw new Error('Your session has expired. Please sign in again.');
+  }
+
+  const response = await fetch(
+    `${getApiBaseUrl()}/v1/admin/polls/${encodeURIComponent(pollSlug)}/answers/export`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'text/csv',
+        Authorization: `Bearer ${tokens.idToken}`,
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`CSV export failed with status ${response.status}.`);
+  }
+  return response.blob();
+}
+
+export function formatPollAnswerValue(row: AdminPollAnswerRow): string {
+  if (typeof row.selectedOption === 'string' && row.selectedOption.trim()) {
+    return row.selectedOption;
+  }
+  if (typeof row.booleanAnswer === 'boolean') {
+    return row.booleanAnswer ? 'True' : 'False';
+  }
+  if (typeof row.freeText === 'string' && row.freeText.trim()) {
+    return row.freeText;
+  }
+  return '—';
+}

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5429,6 +5429,163 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/polls": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List training poll slugs with answer counts
+         * @description Returns distinct poll slugs discovered in the DynamoDB poll responses table,
+         *     each with the number of stored answer rows.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Poll summary list. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminPollListResponse"];
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/polls/{poll_slug}/answers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Training poll slug (kebab-case). */
+                poll_slug: components["parameters"]["PollSlug"];
+            };
+            cookie?: never;
+        };
+        /** List all stored answers for a poll */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Training poll slug (kebab-case). */
+                    poll_slug: components["parameters"]["PollSlug"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Poll answer rows for the selected poll. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminPollAnswerListResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Clear all stored answers for a poll
+         * @description Permanently deletes every answer row for the poll slug in DynamoDB.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Training poll slug (kebab-case). */
+                    poll_slug: components["parameters"]["PollSlug"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Poll answers cleared. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminPollClearAnswersResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/polls/{poll_slug}/answers/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Training poll slug (kebab-case). */
+                poll_slug: components["parameters"]["PollSlug"];
+            };
+            cookie?: never;
+        };
+        /** Export poll answers as CSV */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Training poll slug (kebab-case). */
+                    poll_slug: components["parameters"]["PollSlug"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description CSV export generated. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/csv": string;
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/assets": {
         parameters: {
             query?: never;
@@ -7034,6 +7191,35 @@ export interface components {
         AdminTagListResponse: {
             items: components["schemas"]["AdminTagRef"][];
         };
+        AdminPollSummary: {
+            pollSlug: string;
+            answerCount: number;
+        };
+        AdminPollListResponse: {
+            items: components["schemas"]["AdminPollSummary"][];
+        };
+        AdminPollAnswerRow: {
+            pollSlug: string;
+            /** Format: uuid */
+            sessionId: string;
+            questionId: string;
+            /** @enum {string} */
+            questionType: "select" | "truefalse" | "text" | "email";
+            selectedOption?: string;
+            booleanAnswer?: boolean;
+            freeText?: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        AdminPollAnswerListResponse: {
+            items: components["schemas"]["AdminPollAnswerRow"][];
+        };
+        AdminPollClearAnswersResponse: {
+            pollSlug: string;
+            deletedCount: number;
+        };
         AdminTagResponse: {
             tag: components["schemas"]["AdminTagRef"];
         };
@@ -7509,6 +7695,8 @@ export interface components {
         LocationId: string;
         /** @description Sales lead identifier. */
         LeadId: string;
+        /** @description Training poll slug (kebab-case). */
+        PollSlug: string;
         /** @description Service identifier. */
         ServiceId: string;
         /** @description Service instance identifier. */

--- a/apps/admin_web/tests/components/admin/website/website-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/website/website-page.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { WebsitePage } from '@/components/admin/website/website-page';
+
+vi.mock('@/lib/config', () => ({
+  getPublicSiteBaseUrl: () => 'https://www.example.com',
+  getTrainingSiteBaseUrl: () => 'https://training.example.com',
+}));
+
+vi.mock('@/lib/qr-code-image', () => ({
+  generatePublicSiteQrPngDataUrl: vi.fn(async () => 'data:image/png;base64,AA'),
+}));
+
+vi.mock('@/components/admin/website/website-polls-panel', () => ({
+  WebsitePollsPanel: () => <div>Polls panel</div>,
+}));
+
+describe('WebsitePage', () => {
+  afterEach(() => {
+    window.history.replaceState(null, '', '/website');
+  });
+
+  it('shows QR Codes tab by default', () => {
+    render(<WebsitePage />);
+    expect(screen.getByRole('group', { name: 'Website section views' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'QR Codes', pressed: true })).toBeInTheDocument();
+    expect(screen.getByText('Website QR codes')).toBeInTheDocument();
+  });
+
+  it('switches to Polls tab', () => {
+    render(<WebsitePage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Polls' }));
+    expect(screen.getByText('Polls panel')).toBeInTheDocument();
+    expect(screen.queryByText('Website QR codes')).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin_web/tests/components/admin/website/website-polls-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/website/website-polls-panel.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { WebsitePollsPanel } from '@/components/admin/website/website-polls-panel';
+
+const listAdminPolls = vi.fn();
+const listAdminPollAnswers = vi.fn();
+const exportAdminPollAnswersCsv = vi.fn();
+const clearAdminPollAnswers = vi.fn();
+
+vi.mock('@/lib/polls-api', () => ({
+  listAdminPolls: (...args: unknown[]) => listAdminPolls(...args),
+  listAdminPollAnswers: (...args: unknown[]) => listAdminPollAnswers(...args),
+  exportAdminPollAnswersCsv: (...args: unknown[]) => exportAdminPollAnswersCsv(...args),
+  clearAdminPollAnswers: (...args: unknown[]) => clearAdminPollAnswers(...args),
+  formatPollAnswerValue: (row: { selectedOption?: string; booleanAnswer?: boolean; freeText?: string }) =>
+    row.selectedOption ?? (row.booleanAnswer ? 'True' : row.freeText ?? '—'),
+}));
+
+describe('WebsitePollsPanel', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads polls and answers for the selected poll', async () => {
+    listAdminPolls.mockResolvedValue([
+      { pollSlug: 'workshop-food-jun-26', answerCount: 1 },
+    ]);
+    listAdminPollAnswers.mockResolvedValue([
+      {
+        pollSlug: 'workshop-food-jun-26',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        questionId: 'role',
+        questionType: 'select',
+        selectedOption: 'Parent',
+        createdAt: '2026-06-26T10:00:00Z',
+        updatedAt: '2026-06-26T10:00:00Z',
+      },
+    ]);
+
+    render(<WebsitePollsPanel />);
+
+    await waitFor(() => {
+      expect(listAdminPollAnswers).toHaveBeenCalledWith('workshop-food-jun-26', expect.any(AbortSignal));
+    });
+
+    expect(screen.getByText('Parent')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Export answers' })).toBeEnabled();
+  });
+
+  it('exports answers as CSV', async () => {
+    listAdminPolls.mockResolvedValue([
+      { pollSlug: 'workshop-food-jun-26', answerCount: 1 },
+    ]);
+    listAdminPollAnswers.mockResolvedValue([]);
+    exportAdminPollAnswersCsv.mockResolvedValue(new Blob(['csv'], { type: 'text/csv' }));
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    render(<WebsitePollsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Export answers' })).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export answers' }));
+
+    await waitFor(() => {
+      expect(exportAdminPollAnswersCsv).toHaveBeenCalledWith('workshop-food-jun-26');
+    });
+
+    createObjectURL.mockRestore();
+    revokeObjectURL.mockRestore();
+  });
+
+  it('clears answers after confirmation', async () => {
+    listAdminPolls.mockResolvedValue([
+      { pollSlug: 'workshop-food-jun-26', answerCount: 1 },
+    ]);
+    listAdminPollAnswers.mockResolvedValue([
+      {
+        pollSlug: 'workshop-food-jun-26',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        questionId: 'role',
+        questionType: 'select',
+        selectedOption: 'Parent',
+        createdAt: '2026-06-26T10:00:00Z',
+        updatedAt: '2026-06-26T10:00:00Z',
+      },
+    ]);
+    clearAdminPollAnswers.mockResolvedValue({ pollSlug: 'workshop-food-jun-26', deletedCount: 1 });
+
+    render(<WebsitePollsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Clear answers' })).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Clear answers' })[0]);
+    const dialog = screen.getByRole('alertdialog', { name: 'Clear poll answers' });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Clear answers' }));
+
+    await waitFor(() => {
+      expect(clearAdminPollAnswers).toHaveBeenCalledWith('workshop-food-jun-26');
+    });
+  });
+});

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -37,6 +37,7 @@ from app.api.admin_audit_logs import handle_admin_audit_logs_request
 from app.api.admin_calendar_manual_blocks import (
     handle_admin_calendar_manual_blocks_request,
 )
+from app.api.admin_polls import handle_admin_polls_request
 from app.api.public_calendar_availability import handle_public_calendar_availability
 from app.api.public_events import handle_public_events
 from app.api.public_contact import handle_public_contact_us
@@ -239,6 +240,11 @@ _ROUTES: tuple[
         "/v1/admin/organizations",
         False,
         handle_admin_organizations_request,
+    ),
+    (
+        "/v1/admin/polls",
+        False,
+        handle_admin_polls_request,
     ),
     ("/v1/admin/assets", False, handle_admin_assets_request),
     ("/v1/user/assets", False, handle_user_assets_request),

--- a/backend/src/app/api/admin_polls.py
+++ b/backend/src/app/api/admin_polls.py
@@ -1,0 +1,161 @@
+"""Admin poll response management (DynamoDB training poll answers)."""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from app.api.assets.assets_common import extract_identity, split_route_parts
+from app.exceptions import ValidationError
+from app.services.poll_responses_store import (
+    clear_poll_answers,
+    list_poll_answers,
+    list_poll_summaries,
+)
+from app.utils import json_response
+from app.utils.logging import get_logger
+from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
+from app.utils.responses import get_cors_headers, get_security_headers
+
+logger = get_logger(__name__)
+
+
+def handle_admin_polls_request(
+    event: Mapping[str, Any],
+    method: str,
+    path: str,
+) -> dict[str, Any]:
+    """Handle /v1/admin/polls routes."""
+    parts = split_route_parts(path)
+    if len(parts) < 2 or parts[0] != "admin" or parts[1] != "polls":
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    identity = extract_identity(event)
+    if not identity.user_sub:
+        raise ValidationError("Authenticated user is required", field="authorization")
+
+    if len(parts) == 2:
+        if method != "GET":
+            return json_response(405, {"error": "Method not allowed"}, event=event)
+        return _list_polls(event)
+
+    poll_slug = _parse_poll_slug(parts[2])
+    if len(parts) == 3:
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    if len(parts) == 4 and parts[3] == "answers":
+        if method == "GET":
+            return _list_poll_answers(event, poll_slug=poll_slug)
+        if method == "DELETE":
+            return _clear_poll_answers(event, poll_slug=poll_slug)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 5 and parts[3] == "answers" and parts[4] == "export":
+        if method != "GET":
+            return json_response(405, {"error": "Method not allowed"}, event=event)
+        return _export_poll_answers(event, poll_slug=poll_slug)
+
+    return json_response(404, {"error": "Not found"}, event=event)
+
+
+def _parse_poll_slug(value: str) -> str:
+    normalized = value.strip()
+    if not normalized or not PUBLIC_INSTANCE_SLUG_PATTERN.match(normalized):
+        raise ValidationError("poll slug must be a kebab-case identifier")
+    return normalized
+
+
+def _list_polls(event: Mapping[str, Any]) -> dict[str, Any]:
+    items = list_poll_summaries()
+    return json_response(200, {"items": items}, event=event)
+
+
+def _list_poll_answers(
+    event: Mapping[str, Any],
+    *,
+    poll_slug: str,
+) -> dict[str, Any]:
+    items = list_poll_answers(poll_slug=poll_slug)
+    return json_response(200, {"items": items}, event=event)
+
+
+def _clear_poll_answers(
+    event: Mapping[str, Any],
+    *,
+    poll_slug: str,
+) -> dict[str, Any]:
+    deleted_count = clear_poll_answers(poll_slug=poll_slug)
+    logger.info(
+        "Cleared poll answers",
+        extra={
+            "poll_slug": poll_slug,
+            "deleted_count": deleted_count,
+        },
+    )
+    return json_response(
+        200,
+        {
+            "pollSlug": poll_slug,
+            "deletedCount": deleted_count,
+        },
+        event=event,
+    )
+
+
+def _export_poll_answers(
+    event: Mapping[str, Any],
+    *,
+    poll_slug: str,
+) -> dict[str, Any]:
+    items = list_poll_answers(poll_slug=poll_slug)
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        [
+            "Poll Slug",
+            "Session ID",
+            "Question ID",
+            "Question Type",
+            "Selected Option",
+            "Boolean Answer",
+            "Free Text",
+            "Created At",
+            "Updated At",
+        ]
+    )
+    for item in items:
+        writer.writerow(
+            [
+                item.get("pollSlug") or poll_slug,
+                item.get("sessionId") or "",
+                item.get("questionId") or "",
+                item.get("questionType") or "",
+                item.get("selectedOption") or "",
+                _format_boolean_csv(item.get("booleanAnswer")),
+                item.get("freeText") or "",
+                item.get("createdAt") or "",
+                item.get("updatedAt") or "",
+            ]
+        )
+
+    filename = f"poll-{poll_slug}-answers-{datetime.now(UTC).date().isoformat()}.csv"
+    response_headers = {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": f'attachment; filename="{filename}"',
+        **get_security_headers(),
+        **get_cors_headers(event),
+    }
+    return {
+        "statusCode": 200,
+        "headers": response_headers,
+        "body": output.getvalue(),
+    }
+
+
+def _format_boolean_csv(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return ""

--- a/backend/src/app/services/poll_responses_store.py
+++ b/backend/src/app/services/poll_responses_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections import Counter
 from datetime import UTC, datetime
+from collections.abc import Mapping
 from typing import Any, TypedDict
 
 import boto3
@@ -172,6 +173,139 @@ def _count_boolean_answers(items: list[dict[str, Any]], *, expected: bool) -> in
         if isinstance(value, bool) and value is expected:
             total += 1
     return total
+
+
+def list_poll_summaries() -> list[dict[str, Any]]:
+    """Return distinct poll slugs with answer row counts from DynamoDB."""
+    table = _get_table()
+    slug_counts: Counter[str] = Counter()
+    scan_kwargs: dict[str, Any] = {
+        "ProjectionExpression": "pk, pollSlug",
+    }
+    try:
+        while True:
+            response = table.scan(**scan_kwargs)
+            for item in response.get("Items", []):
+                slug = _extract_poll_slug_from_item(item)
+                if slug:
+                    slug_counts[slug] += 1
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            scan_kwargs["ExclusiveStartKey"] = last_key
+    except ClientError:
+        logger.exception("Failed to scan poll responses table")
+        raise AppError(
+            "Failed to list poll responses",
+            status_code=500,
+        ) from None
+
+    return [
+        {"pollSlug": slug, "answerCount": count}
+        for slug, count in sorted(slug_counts.items())
+    ]
+
+
+def list_poll_answers(*, poll_slug: str) -> list[dict[str, Any]]:
+    """Return all answer rows for one poll, sorted by updated time descending."""
+    table = _get_table()
+    try:
+        items = _query_poll_items(table=table, poll_slug=poll_slug)
+    except ClientError:
+        logger.exception(
+            "Failed to query poll answers",
+            extra={"poll_slug": poll_slug},
+        )
+        raise AppError(
+            "Failed to list poll answers",
+            status_code=500,
+        ) from None
+
+    serialized = [serialize_poll_answer_item(item) for item in items]
+    serialized.sort(
+        key=lambda row: (
+            str(row.get("updatedAt") or ""),
+            str(row.get("sessionId") or ""),
+            str(row.get("questionId") or ""),
+        ),
+        reverse=True,
+    )
+    return serialized
+
+
+def serialize_poll_answer_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Map a DynamoDB poll answer item to an admin API payload."""
+    row: dict[str, Any] = {
+        "pollSlug": item.get("pollSlug"),
+        "sessionId": item.get("sessionId"),
+        "questionId": item.get("questionId"),
+        "questionType": item.get("questionType"),
+        "createdAt": item.get("createdAt"),
+        "updatedAt": item.get("updatedAt"),
+    }
+    selected_option = item.get("selectedOption")
+    if isinstance(selected_option, str):
+        row["selectedOption"] = selected_option
+    boolean_answer = item.get("booleanAnswer")
+    if isinstance(boolean_answer, bool):
+        row["booleanAnswer"] = boolean_answer
+    free_text = item.get("freeText")
+    if isinstance(free_text, str):
+        row["freeText"] = free_text
+    return row
+
+
+def clear_poll_answers(*, poll_slug: str) -> int:
+    """Delete all answer rows for one poll. Returns the number of rows removed."""
+    table = _get_table()
+    try:
+        items = _query_poll_items(table=table, poll_slug=poll_slug)
+    except ClientError:
+        logger.exception(
+            "Failed to query poll answers for clear",
+            extra={"poll_slug": poll_slug},
+        )
+        raise AppError(
+            "Failed to clear poll answers",
+            status_code=500,
+        ) from None
+
+    if not items:
+        return 0
+
+    try:
+        with table.batch_writer() as batch:
+            for item in items:
+                batch.delete_item(
+                    Key={
+                        "pk": item["pk"],
+                        "sk": item["sk"],
+                    }
+                )
+    except ClientError:
+        logger.exception(
+            "Failed to delete poll answers",
+            extra={"poll_slug": poll_slug},
+        )
+        raise AppError(
+            "Failed to clear poll answers",
+            status_code=500,
+        ) from None
+
+    return len(items)
+
+
+def _extract_poll_slug_from_item(item: Mapping[str, Any]) -> str | None:
+    poll_slug = item.get("pollSlug")
+    if isinstance(poll_slug, str):
+        normalized = poll_slug.strip()
+        if normalized:
+            return normalized
+    pk = item.get("pk")
+    if isinstance(pk, str) and pk.startswith(_PK_PREFIX):
+        normalized = pk[len(_PK_PREFIX) :].strip()
+        return normalized or None
+    return None
 
 
 def _query_poll_items(*, table: Any, poll_slug: str) -> list[dict[str, Any]]:

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -51,6 +51,9 @@ info:
     - `POST /v1/admin/organizations/{id}/members`
     - `PATCH /v1/admin/organizations/{id}/members/{memberId}`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
+    - `GET /v1/admin/polls` (lists poll slugs with answer counts from DynamoDB)
+    - `GET|DELETE /v1/admin/polls/{poll_slug}/answers` (`DELETE` removes all stored answers for the poll)
+    - `GET /v1/admin/polls/{poll_slug}/answers/export` (CSV export of all answers for the poll)
     - `GET|POST /v1/admin/expenses`
     - `POST /v1/admin/expenses/import-from-bulk-pdf` (returns **202** with a job id; poll `GET /v1/admin/expenses/bulk-import-jobs/{job_id}` until `succeeded`, `succeeded_with_errors`, or `failed`)
     - `GET /v1/admin/expenses/bulk-import-jobs` (creator-scoped list of recent jobs)
@@ -3995,6 +3998,78 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/admin/polls:
+    get:
+      summary: List training poll slugs with answer counts
+      description: |
+        Returns distinct poll slugs discovered in the DynamoDB poll responses table,
+        each with the number of stored answer rows.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Poll summary list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminPollListResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/polls/{poll_slug}/answers:
+    parameters:
+      - $ref: "#/components/parameters/PollSlug"
+    get:
+      summary: List all stored answers for a poll
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Poll answer rows for the selected poll.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminPollAnswerListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      summary: Clear all stored answers for a poll
+      description: Permanently deletes every answer row for the poll slug in DynamoDB.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Poll answers cleared.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminPollClearAnswersResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/polls/{poll_slug}/answers/export:
+    parameters:
+      - $ref: "#/components/parameters/PollSlug"
+    get:
+      summary: Export poll answers as CSV
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: CSV export generated.
+          content:
+            text/csv:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /v1/user/assets:
     get:
       summary: List user assets
@@ -4086,6 +4161,14 @@ components:
         type: string
         format: uuid
       description: Sales lead identifier.
+    PollSlug:
+      name: poll_slug
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+      description: Training poll slug (kebab-case).
     ServiceId:
       name: id
       in: path
@@ -7629,6 +7712,84 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AdminTagRef"
+    AdminPollSummary:
+      type: object
+      required:
+        - pollSlug
+        - answerCount
+      properties:
+        pollSlug:
+          type: string
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        answerCount:
+          type: integer
+          minimum: 0
+    AdminPollListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminPollSummary"
+    AdminPollAnswerRow:
+      type: object
+      required:
+        - pollSlug
+        - sessionId
+        - questionId
+        - questionType
+        - createdAt
+        - updatedAt
+      properties:
+        pollSlug:
+          type: string
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        sessionId:
+          type: string
+          format: uuid
+        questionId:
+          type: string
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        questionType:
+          type: string
+          enum: [select, truefalse, text, email]
+        selectedOption:
+          type: string
+          maxLength: 500
+        booleanAnswer:
+          type: boolean
+        freeText:
+          type: string
+          maxLength: 4000
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    AdminPollAnswerListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminPollAnswerRow"
+    AdminPollClearAnswersResponse:
+      type: object
+      required:
+        - pollSlug
+        - deletedCount
+      properties:
+        pollSlug:
+          type: string
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        deletedCount:
+          type: integer
+          minimum: 0
     AdminTagResponse:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -93,6 +93,10 @@ their primary responsibilities.
   for non-vendor orgs; `POST /v1/admin/organizations/{id}/members` derives each member's role from the
   linked contact's `contact_type`; `PATCH /v1/admin/organizations/{id}/members/{memberId}` updates
   membership fields such as primary contact),
+  `/v1/admin/polls` (lists poll slugs with answer counts from DynamoDB
+  `evolvesprouts-poll-responses`), `/v1/admin/polls/{poll_slug}/answers`
+  (`GET` lists all stored answer rows; `DELETE` clears all rows for the poll),
+  `/v1/admin/polls/{poll_slug}/answers/export` (`GET`; CSV export),
   `/v1/admin/leads/*`, `/v1/admin/users`, `/v1/admin/instructors`,
   `GET /v1/admin/audit-logs` and `GET /v1/admin/audit-logs/{id}` (read-only `audit_log` history; list supports filters `table`, `record_id`, `user_id`, `email`, `action`, `since`, `cursor`, `limit`; `email` resolves via Cognito `list_users`; optional `user_email` per row),
   `/v1/admin/services/*` (including `GET /v1/admin/services/instances` for

--- a/tests/test_admin_polls_api.py
+++ b/tests/test_admin_polls_api.py
@@ -1,0 +1,181 @@
+"""Tests for admin poll response management routes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.api import admin_polls
+from app.exceptions import ValidationError
+from app.services import poll_responses_store as store
+
+
+@pytest.fixture(autouse=True)
+def reset_poll_store() -> None:
+    store.reset_table_for_tests()
+    yield
+    store.reset_table_for_tests()
+
+
+def _identity_event(api_gateway_event: Any, *, method: str, path: str) -> dict[str, Any]:
+    return api_gateway_event(
+        method=method,
+        path=path,
+        headers={"authorization": "Bearer test-token"},
+    )
+
+
+def test_list_polls_requires_auth(api_gateway_event: Any) -> None:
+    with pytest.raises(ValidationError, match="Authenticated user is required"):
+        admin_polls.handle_admin_polls_request(
+            api_gateway_event(method="GET", path="/v1/admin/polls"),
+            "GET",
+            "/v1/admin/polls",
+        )
+
+
+def test_list_polls_returns_summaries(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.scan.return_value = {
+        "Items": [
+            {"pk": "POLL#workshop-food-jun-26", "pollSlug": "workshop-food-jun-26"},
+            {"pk": "POLL#workshop-food-jun-26", "pollSlug": "workshop-food-jun-26"},
+        ]
+    }
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+    monkeypatch.setattr(
+        admin_polls,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_polls.handle_admin_polls_request(
+        _identity_event(api_gateway_event, method="GET", path="/v1/admin/polls"),
+        "GET",
+        "/v1/admin/polls",
+    )
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["items"] == [{"pollSlug": "workshop-food-jun-26", "answerCount": 2}]
+
+
+def test_list_poll_answers_returns_rows(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [
+            {
+                "pk": "POLL#workshop-food-jun-26",
+                "sk": "SESSION#550e8400-e29b-41d4-a716-446655440000#Q#role",
+                "pollSlug": "workshop-food-jun-26",
+                "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+                "questionId": "role",
+                "questionType": "select",
+                "selectedOption": "Parent",
+                "createdAt": "2026-06-26T10:00:00Z",
+                "updatedAt": "2026-06-26T10:00:00Z",
+            }
+        ]
+    }
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+    monkeypatch.setattr(
+        admin_polls,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_polls.handle_admin_polls_request(
+        _identity_event(
+            api_gateway_event,
+            method="GET",
+            path="/v1/admin/polls/workshop-food-jun-26/answers",
+        ),
+        "GET",
+        "/v1/admin/polls/workshop-food-jun-26/answers",
+    )
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert len(body["items"]) == 1
+    assert body["items"][0]["selectedOption"] == "Parent"
+
+
+def test_clear_poll_answers_deletes_rows(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [
+            {
+                "pk": "POLL#workshop-food-jun-26",
+                "sk": "SESSION#550e8400-e29b-41d4-a716-446655440000#Q#role",
+            }
+        ]
+    }
+    batch = MagicMock()
+    batch.__enter__ = MagicMock(return_value=batch)
+    batch.__exit__ = MagicMock(return_value=False)
+    table.batch_writer.return_value = batch
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+    monkeypatch.setattr(
+        admin_polls,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_polls.handle_admin_polls_request(
+        _identity_event(
+            api_gateway_event,
+            method="DELETE",
+            path="/v1/admin/polls/workshop-food-jun-26/answers",
+        ),
+        "DELETE",
+        "/v1/admin/polls/workshop-food-jun-26/answers",
+    )
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body == {"pollSlug": "workshop-food-jun-26", "deletedCount": 1}
+    batch.delete_item.assert_called_once()
+
+
+def test_export_poll_answers_returns_csv(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.query.return_value = {"Items": []}
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+    monkeypatch.setattr(
+        admin_polls,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_polls.handle_admin_polls_request(
+        _identity_event(
+            api_gateway_event,
+            method="GET",
+            path="/v1/admin/polls/workshop-food-jun-26/answers/export",
+        ),
+        "GET",
+        "/v1/admin/polls/workshop-food-jun-26/answers/export",
+    )
+    assert response["statusCode"] == 200
+    assert response["headers"]["Content-Type"] == "text/csv; charset=utf-8"
+    assert "Poll Slug" in response["body"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Splits the admin **Website** page into two tabs:

1. **QR Codes** — existing Website QR code generator (unchanged behavior)
2. **Polls** — manage training poll answers stored in DynamoDB

The Polls tab provides:
- A dropdown of all poll slugs discovered in the poll responses table (with answer counts)
- A table of all stored answers for the selected poll (session, question, type, answer, updated time)
- **Export answers** — downloads a CSV of all answers for the selected poll
- **Clear answers** — permanently deletes all answer rows for the selected poll (with confirmation dialog)

## Backend

New authenticated admin routes:
- `GET /v1/admin/polls` — list poll slugs with answer counts
- `GET /v1/admin/polls/{poll_slug}/answers` — list all answer rows
- `GET /v1/admin/polls/{poll_slug}/answers/export` — CSV export
- `DELETE /v1/admin/polls/{poll_slug}/answers` — clear all answers for a poll

Extended `poll_responses_store.py` with scan/list/clear helpers. Admin Lambda already had DynamoDB read/write access to the poll responses table.

## Frontend

- New `WebsitePage` wrapper with `AdminTabStrip` (`?tab=polls` for Polls tab)
- New `WebsitePollsPanel` component following admin table/toolbar patterns
- New `polls-api.ts` client with generated OpenAPI types

## Testing

- `pytest tests/test_admin_polls_api.py`
- `vitest run tests/components/admin/website/`
- `npm run lint` (admin web)
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b86e1839-04ce-41f4-9b31-216e430a26f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b86e1839-04ce-41f4-9b31-216e430a26f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

