### PR TITLE
Add Evolve Sprouts logo above poll page title

### DIFF
--- a/apps/training/src/components/polls/poll-page.tsx
+++ b/apps/training/src/components/polls/poll-page.tsx
@@ -1,5 +1,6 @@
 import { PollWizard } from '@/components/polls/poll-wizard';
 import type { PollContent, PollsCommonContent } from '@/content/poll-types';
+import { getPublicWwwHomeUrl } from '@/lib/public-www-url';
 
 export interface PollPageProps {
   poll: PollContent;
@@ -7,15 +8,33 @@ export interface PollPageProps {
 }
 
 export function PollPage({ poll, common }: PollPageProps) {
+  const publicWwwHomeUrl = getPublicWwwHomeUrl();
+
+  const logo = (
+    // eslint-disable-next-line @next/next/no-img-element -- static SVG from /public/images
+    <img
+      src='/images/evolvesprouts-logo.svg'
+      alt='Evolve Sprouts'
+      className='mx-auto h-14 w-auto'
+    />
+  );
+
   return (
     <main className='flex min-h-screen flex-col px-6 py-10'>
       <header className='mx-auto mb-8 w-full max-w-xl text-center'>
-        {/* eslint-disable-next-line @next/next/no-img-element -- static SVG from /public/images */}
-        <img
-          src='/images/evolvesprouts-logo.svg'
-          alt='Evolve Sprouts'
-          className='mx-auto mb-4 h-14 w-auto'
-        />
+        <div className='mb-4'>
+          {publicWwwHomeUrl ? (
+            <a
+              href={publicWwwHomeUrl}
+              className='inline-block rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-neutral-900'
+              aria-label='Go to the Evolve Sprouts website'
+            >
+              {logo}
+            </a>
+          ) : (
+            logo
+          )}
+        </div>
         <h1 className='es-type-title text-2xl'>{poll.title}</h1>
       </header>
       <PollWizard poll={poll} common={common} />

--- a/apps/training/src/components/polls/poll-page.tsx
+++ b/apps/training/src/components/polls/poll-page.tsx
@@ -10,6 +10,12 @@ export function PollPage({ poll, common }: PollPageProps) {
   return (
     <main className='flex min-h-screen flex-col px-6 py-10'>
       <header className='mx-auto mb-8 w-full max-w-xl text-center'>
+        {/* eslint-disable-next-line @next/next/no-img-element -- static SVG from /public/images */}
+        <img
+          src='/images/evolvesprouts-logo.svg'
+          alt='Evolve Sprouts'
+          className='mx-auto mb-4 h-14 w-auto'
+        />
         <h1 className='es-type-title text-2xl'>{poll.title}</h1>
       </header>
       <PollWizard poll={poll} common={common} />

--- a/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
+++ b/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
@@ -36,6 +36,7 @@ describe('WorkshopFoodJun26PollPage', () => {
       throw new Error('Expected workshop-food-jun-26 poll content');
     }
     render(<PollPage poll={poll} common={POLLS_COMMON} />);
+    expect(screen.getByRole('img', { name: 'Evolve Sprouts' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 1, name: poll.title })).toBeInTheDocument();
     const first = poll.questions[0];
     await waitFor(() => {

--- a/apps/training/tests/components/polls/poll-page.test.tsx
+++ b/apps/training/tests/components/polls/poll-page.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PollPage } from '@/components/polls/poll-page';
+import { getPollContent, POLLS_COMMON } from '@/lib/polls';
+
+const poll = getPollContent('workshop-food-jun-26');
+
+describe('PollPage branding', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('links the logo to the public website home when origin is configured', () => {
+    if (!poll) {
+      throw new Error('Expected workshop-food-jun-26 poll content');
+    }
+    vi.stubEnv('NEXT_PUBLIC_PUBLIC_WWW_ORIGIN', 'https://www.evolvesprouts.com');
+
+    render(<PollPage poll={poll} common={POLLS_COMMON} />);
+
+    const link = screen.getByRole('link', { name: 'Go to the Evolve Sprouts website' });
+    expect(link).toHaveAttribute('href', 'https://www.evolvesprouts.com/en/');
+    expect(screen.getByRole('img', { name: 'Evolve Sprouts' })).toBeInTheDocument();
+  });
+
+  it('renders the logo without a link when public origin is unset', () => {
+    if (!poll) {
+      throw new Error('Expected workshop-food-jun-26 poll content');
+    }
+    vi.stubEnv('NEXT_PUBLIC_PUBLIC_WWW_ORIGIN', '');
+
+    render(<PollPage poll={poll} common={POLLS_COMMON} />);
+
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByRole('img', { name: 'Evolve Sprouts' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the Evolve Sprouts logo centered at the top of participant poll pages (`PollPage`), directly above the poll title. The logo links to the main public website home (`{NEXT_PUBLIC_PUBLIC_WWW_ORIGIN}/en/`) when that env var is configured.

## Changes

- **`apps/training/src/components/polls/poll-page.tsx`**: Logo in header; wrapped in a link via `getPublicWwwHomeUrl()` (same pattern as `not-found.tsx`).
- **`apps/training/tests/components/polls/poll-page.test.tsx`**: Link vs. no-link behavior when `NEXT_PUBLIC_PUBLIC_WWW_ORIGIN` is set or empty.
- **`apps/training/tests/app/workshop-food-jun-26-page.test.tsx`**: Asserts logo image is present.

## Testing

- `cd apps/training && npm run test -- tests/components/polls/poll-page.test.tsx tests/app/workshop-food-jun-26-page.test.tsx` (6 tests passed)

## Notes

- Applies to all poll participant routes under `/polls/[slug]` via the shared `PollPage` component.
- Poll **control** pages (`/polls/[slug]/controls`) are unchanged.
- In production, ensure `NEXT_PUBLIC_PUBLIC_WWW_ORIGIN` is set on the training site so the link resolves.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec13b8a4-3e0a-428e-b48e-8e5cec02019a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec13b8a4-3e0a-428e-b48e-8e5cec02019a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

