### PR TITLE
Fix poll back button and selected option border styling

### DIFF
--- a/apps/training/src/app/globals.css
+++ b/apps/training/src/app/globals.css
@@ -1,6 +1,15 @@
 @import 'tailwindcss';
 @import '../../../../shared/styles/evolve-sprouts.css';
 
+.poll-option-label {
+  border-width: 2px;
+  border-color: var(--es-color-border-panel-soft);
+}
+
+.poll-option-label--selected {
+  border-color: var(--es-color-brand-orange);
+}
+
 progress.poll-live-results-bar {
   appearance: none;
   border: none;

--- a/apps/training/src/components/polls/poll-question-field.tsx
+++ b/apps/training/src/components/polls/poll-question-field.tsx
@@ -30,7 +30,7 @@ export function PollQuestionField({
               <label
                 key={option}
                 htmlFor={inputId}
-                className={`flex cursor-pointer items-start gap-3 rounded-inner border px-3 py-2 es-border-panel-soft es-bg-surface-white ${answer.selectedOption === option ? 'es-border-panel' : ''}`}
+                className={`poll-option-label flex cursor-pointer items-start gap-3 rounded-inner border px-3 py-2 es-bg-surface-white ${answer.selectedOption === option ? 'poll-option-label--selected' : ''}`}
               >
                 <input
                   id={inputId}

--- a/apps/training/src/components/polls/poll-wizard.tsx
+++ b/apps/training/src/components/polls/poll-wizard.tsx
@@ -130,7 +130,7 @@ export function PollWizard({ poll, common }: PollWizardProps) {
         {!isFirstStep && !onInterstitial ? (
           <button
             type='button'
-            className='es-btn es-btn--outline es-focus-ring'
+            className='es-btn es-btn--primary es-focus-ring'
             disabled={isSaving}
             onClick={() => {
               setErrorMessage(null);

--- a/apps/training/src/components/polls/poll-wizard.tsx
+++ b/apps/training/src/components/polls/poll-wizard.tsx
@@ -130,7 +130,7 @@ export function PollWizard({ poll, common }: PollWizardProps) {
         {!isFirstStep && !onInterstitial ? (
           <button
             type='button'
-            className='es-btn es-btn--primary es-focus-ring'
+            className='es-btn es-btn--primary es-btn--outline es-focus-ring'
             disabled={isSaving}
             onClick={() => {
               setErrorMessage(null);

--- a/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
+++ b/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
@@ -76,6 +76,39 @@ describe('WorkshopFoodJun26PollPage', () => {
     expect(screen.getByText(second?.screen ?? '')).toBeInTheDocument();
   });
 
+  it('styles back like next and marks selected options with an orange border class', async () => {
+    if (!poll) {
+      throw new Error('Expected workshop-food-jun-26 poll content');
+    }
+    const user = userEvent.setup();
+    render(<PollPage poll={poll} common={POLLS_COMMON} />);
+
+    const first = poll.questions[0];
+    if (!first || first.type !== 'select') {
+      throw new Error('Expected first question to be select');
+    }
+    const firstOption = first.options[0] ?? '';
+    await waitFor(() => {
+      expect(screen.getByLabelText(firstOption)).toBeInTheDocument();
+    });
+
+    const optionLabel = screen.getByLabelText(firstOption).closest('label');
+    expect(optionLabel).toHaveClass('poll-option-label');
+    expect(optionLabel).not.toHaveClass('poll-option-label--selected');
+
+    await user.click(screen.getByLabelText(firstOption));
+    expect(optionLabel).toHaveClass('poll-option-label--selected');
+
+    const nextButton = screen.getByRole('button', { name: POLLS_COMMON.navigation.next });
+    expect(nextButton).toHaveClass('es-btn--primary');
+
+    await user.click(nextButton);
+
+    const backButton = await screen.findByRole('button', { name: POLLS_COMMON.navigation.back });
+    expect(backButton).toHaveClass('es-btn--primary');
+    expect(backButton).not.toHaveClass('es-btn--outline');
+  });
+
   it('shows results step for challenge question before continuing', async () => {
     if (!poll) {
       throw new Error('Expected workshop-food-jun-26 poll content');

--- a/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
+++ b/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
@@ -106,7 +106,7 @@ describe('WorkshopFoodJun26PollPage', () => {
 
     const backButton = await screen.findByRole('button', { name: POLLS_COMMON.navigation.back });
     expect(backButton).toHaveClass('es-btn--primary');
-    expect(backButton).not.toHaveClass('es-btn--outline');
+    expect(backButton).toHaveClass('es-btn--outline');
   });
 
   it('shows results step for challenge question before continuing', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Back button**: Uses the same CTA pattern as the Ida intro section — both `es-btn--primary` (sizing, padding, radius) and `es-btn--outline` (white fill, orange border/text). Next/Finish/Continue stay solid primary.
- **Selected options**: Poll-scoped classes (`poll-option-label` / `poll-option-label--selected`) give selected select answers an orange border.

## Scope

Styling changes are limited to the training polls UI (`apps/training` only).

## Test plan

- [x] `npm run test -- tests/app/workshop-food-jun-26-page.test.tsx`
- [x] Test verifies Back has both `es-btn--primary` and `es-btn--outline`; Next remains primary-only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7223f12b-f3ae-43e3-a71d-5a3be00a38e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7223f12b-f3ae-43e3-a71d-5a3be00a38e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

