### PR TITLE
Add training forms and admin Website Forms tab

### DIFF
--- a/apps/admin_web/src/components/admin/website/website-forms-panel.tsx
+++ b/apps/admin_web/src/components/admin/website/website-forms-panel.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { AdminPageErrorBanner } from '@/components/admin/admin-page-error-banner';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableCell,
+  AdminDataTableHead,
+  AdminDataTableHeadCell,
+} from '@/components/ui/admin-data-table';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Label } from '@/components/ui/label';
+import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { Select } from '@/components/ui/select';
+import { toErrorMessage } from '@/hooks/hook-errors';
+import {
+  clearAdminFormAnswers,
+  exportAdminFormAnswersCsv,
+  formatFormAnswerValue,
+  listAdminFormAnswers,
+  listAdminForms,
+  type AdminFormAnswerRow,
+  type AdminFormSummary,
+} from '@/lib/forms-api';
+import { formatDate } from '@/lib/format';
+
+export function WebsiteFormsPanel() {
+  const [forms, setForms] = useState<AdminFormSummary[]>([]);
+  const [selectedFormSlug, setSelectedFormSlug] = useState('');
+  const [answers, setAnswers] = useState<AdminFormAnswerRow[]>([]);
+  const [formsLoading, setFormsLoading] = useState(true);
+  const [answersLoading, setAnswersLoading] = useState(false);
+  const [formsError, setFormsError] = useState('');
+  const [answersError, setAnswersError] = useState('');
+  const [actionError, setActionError] = useState('');
+  const [exporting, setExporting] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [clearDialogOpen, setClearDialogOpen] = useState(false);
+
+  const selectedForm = useMemo(
+    () => forms.find((form) => form.formSlug === selectedFormSlug) ?? null,
+    [forms, selectedFormSlug]
+  );
+
+  const loadForms = useCallback(async (signal?: AbortSignal) => {
+    setFormsLoading(true);
+    setFormsError('');
+    try {
+      const items = await listAdminForms(signal);
+      setForms(items);
+      setSelectedFormSlug((current) => {
+        if (current && items.some((item) => item.formSlug === current)) {
+          return current;
+        }
+        return items[0]?.formSlug ?? '';
+      });
+    } catch (error) {
+      if (signal?.aborted) {
+        return;
+      }
+      setFormsError(toErrorMessage(error, 'Failed to load forms.'));
+    } finally {
+      if (!signal?.aborted) {
+        setFormsLoading(false);
+      }
+    }
+  }, []);
+
+  const loadAnswers = useCallback(async (formSlug: string, signal?: AbortSignal) => {
+    if (!formSlug) {
+      setAnswers([]);
+      setAnswersError('');
+      return;
+    }
+    setAnswersLoading(true);
+    setAnswersError('');
+    try {
+      const items = await listAdminFormAnswers(formSlug, signal);
+      setAnswers(items);
+    } catch (error) {
+      if (signal?.aborted) {
+        return;
+      }
+      setAnswersError(toErrorMessage(error, 'Failed to load form answers.'));
+    } finally {
+      if (!signal?.aborted) {
+        setAnswersLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadForms(controller.signal);
+    return () => controller.abort();
+  }, [loadForms]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadAnswers(selectedFormSlug, controller.signal);
+    return () => controller.abort();
+  }, [loadAnswers, selectedFormSlug]);
+
+  const handleExport = async () => {
+    if (!selectedFormSlug) {
+      return;
+    }
+    setActionError('');
+    setExporting(true);
+    try {
+      const blob = await exportAdminFormAnswersCsv(selectedFormSlug);
+      const downloadUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = downloadUrl;
+      anchor.download = `form-${selectedFormSlug}-answers-${new Date().toISOString().slice(0, 10)}.csv`;
+      anchor.click();
+      URL.revokeObjectURL(downloadUrl);
+    } catch (error) {
+      setActionError(toErrorMessage(error, 'Failed to export form answers.'));
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleClearConfirm = async () => {
+    if (!selectedFormSlug) {
+      return;
+    }
+    setActionError('');
+    setClearing(true);
+    try {
+      await clearAdminFormAnswers(selectedFormSlug);
+      setClearDialogOpen(false);
+      await Promise.all([loadForms(), loadAnswers(selectedFormSlug)]);
+    } catch (error) {
+      setActionError(toErrorMessage(error, 'Failed to clear form answers.'));
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  const toolbar = (
+    <div className='mb-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between'>
+      <div className='min-w-[240px] max-w-md flex-1'>
+        <Label htmlFor='website-forms-select'>Form</Label>
+        <Select
+          id='website-forms-select'
+          value={selectedFormSlug}
+          onChange={(event) => setSelectedFormSlug(event.target.value)}
+          disabled={formsLoading || forms.length === 0}
+        >
+          {forms.length === 0 ? (
+            <option value=''>No forms found</option>
+          ) : (
+            forms.map((form) => (
+              <option key={form.formSlug} value={form.formSlug}>
+                {form.formSlug} ({form.answerCount} answers)
+              </option>
+            ))
+          )}
+        </Select>
+      </div>
+      <div className='flex flex-wrap gap-2'>
+        <Button
+          type='button'
+          variant='outline'
+          onClick={() => void handleExport()}
+          disabled={!selectedFormSlug || exporting || answersLoading}
+        >
+          {exporting ? 'Exporting…' : 'Export answers'}
+        </Button>
+        <Button
+          type='button'
+          variant='outline'
+          onClick={() => setClearDialogOpen(true)}
+          disabled={!selectedFormSlug || clearing || answersLoading || answers.length === 0}
+        >
+          Clear answers
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className='space-y-4'>
+      {formsError ? <AdminPageErrorBanner title='Forms' message={formsError} /> : null}
+      {actionError ? <AdminPageErrorBanner title='Form action' message={actionError} /> : null}
+
+      <PaginatedTableCard
+        title='Form answers'
+        description={
+          selectedForm
+            ? `${selectedForm.answerCount} stored answer rows for ${selectedForm.formSlug}.`
+            : 'Choose a form to view stored answers from DynamoDB.'
+        }
+        isLoading={answersLoading}
+        isLoadingMore={false}
+        hasMore={false}
+        error={answersError}
+        loadingLabel='Loading answers…'
+        onLoadMore={() => {}}
+        toolbar={toolbar}
+      >
+        <AdminDataTable tableClassName='min-w-[960px]'>
+          <AdminDataTableHead>
+            <tr>
+              <AdminDataTableHeadCell>Session</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Question</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Type</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Answer</AdminDataTableHeadCell>
+              <AdminDataTableHeadCell>Updated</AdminDataTableHeadCell>
+            </tr>
+          </AdminDataTableHead>
+          <AdminDataTableBody>
+            {!answersLoading && answers.length === 0 ? (
+              <tr>
+                <AdminDataTableCell colSpan={5} className='text-slate-500'>
+                  {selectedFormSlug
+                    ? 'No answers stored for this form yet.'
+                    : 'Select a form to load answers.'}
+                </AdminDataTableCell>
+              </tr>
+            ) : (
+              answers.map((row) => (
+                <tr key={`${row.sessionId}-${row.questionId}`}>
+                  <AdminDataTableCell className='font-mono text-xs'>{row.sessionId}</AdminDataTableCell>
+                  <AdminDataTableCell>{row.questionId}</AdminDataTableCell>
+                  <AdminDataTableCell>{row.questionType}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatFormAnswerValue(row)}</AdminDataTableCell>
+                  <AdminDataTableCell>{formatDate(row.updatedAt)}</AdminDataTableCell>
+                </tr>
+              ))
+            )}
+          </AdminDataTableBody>
+        </AdminDataTable>
+      </PaginatedTableCard>
+
+      <ConfirmDialog
+        open={clearDialogOpen}
+        title='Clear form answers'
+        description={
+          selectedFormSlug
+            ? `Permanently delete all ${answers.length} stored answer rows for "${selectedFormSlug}"? This cannot be undone.`
+            : 'Permanently delete all stored answer rows for this form? This cannot be undone.'
+        }
+        confirmLabel={clearing ? 'Clearing…' : 'Clear answers'}
+        cancelLabel='Cancel'
+        variant='danger'
+        confirmDisabled={clearing}
+        onConfirm={() => void handleClearConfirm()}
+        onCancel={() => {
+          if (!clearing) {
+            setClearDialogOpen(false);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/admin_web/src/components/admin/website/website-page.tsx
+++ b/apps/admin_web/src/components/admin/website/website-page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { WebsiteFormsPanel } from '@/components/admin/website/website-forms-panel';
 import { WebsitePollsPanel } from '@/components/admin/website/website-polls-panel';
 import { WebsiteQrPage } from '@/components/admin/website/website-qr-page';
 import { AdminTabStrip } from '@/components/ui/admin-tab-strip';
@@ -7,6 +8,7 @@ import { useQueryTabState } from '@/hooks/use-query-tab-state';
 
 const TAB_ITEMS = [
   { key: 'qr-codes', label: 'QR Codes' },
+  { key: 'forms', label: 'Forms' },
   { key: 'polls', label: 'Polls' },
 ] as const;
 
@@ -30,6 +32,7 @@ export function WebsitePage() {
         aria-label='Website section views'
       />
       {activeView === 'qr-codes' ? <WebsiteQrPage /> : null}
+      {activeView === 'forms' ? <WebsiteFormsPanel /> : null}
       {activeView === 'polls' ? <WebsitePollsPanel /> : null}
     </div>
   );

--- a/apps/admin_web/src/lib/forms-api.ts
+++ b/apps/admin_web/src/lib/forms-api.ts
@@ -1,0 +1,112 @@
+import { ensureFreshTokens } from './auth';
+import { adminApiRequest } from './api-admin-client';
+import { unwrapPayload } from './api-payload';
+import { getApiBaseUrl } from './config';
+import { isRecord } from './type-guards';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+
+export type AdminFormSummary = ApiSchemas['AdminFormSummary'];
+export type AdminFormAnswerRow = ApiSchemas['AdminFormAnswerRow'];
+export type AdminFormClearAnswersResponse = ApiSchemas['AdminFormClearAnswersResponse'];
+
+function parseFormSummary(value: unknown): AdminFormSummary {
+  const row = isRecord(value) ? value : {};
+  return {
+    formSlug: typeof row.formSlug === 'string' ? row.formSlug : '',
+    answerCount: typeof row.answerCount === 'number' ? row.answerCount : 0,
+  };
+}
+
+function parseFormAnswerRow(value: unknown): AdminFormAnswerRow {
+  const row = isRecord(value) ? value : {};
+  const parsed: AdminFormAnswerRow = {
+    formSlug: typeof row.formSlug === 'string' ? row.formSlug : '',
+    sessionId: typeof row.sessionId === 'string' ? row.sessionId : '',
+    questionId: typeof row.questionId === 'string' ? row.questionId : '',
+    questionType:
+      row.questionType === 'select' || row.questionType === 'text' || row.questionType === 'email'
+        ? row.questionType
+        : 'text',
+    createdAt: typeof row.createdAt === 'string' ? row.createdAt : '',
+    updatedAt: typeof row.updatedAt === 'string' ? row.updatedAt : '',
+  };
+  if (typeof row.selectedOption === 'string') {
+    parsed.selectedOption = row.selectedOption;
+  }
+  if (typeof row.freeText === 'string') {
+    parsed.freeText = row.freeText;
+  }
+  return parsed;
+}
+
+export async function listAdminForms(signal?: AbortSignal): Promise<AdminFormSummary[]> {
+  const payload = await adminApiRequest<ApiSchemas['AdminFormListResponse']>({
+    endpointPath: '/v1/admin/forms',
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  return Array.isArray(root.items) ? root.items.map((item) => parseFormSummary(item)) : [];
+}
+
+export async function listAdminFormAnswers(
+  formSlug: string,
+  signal?: AbortSignal
+): Promise<AdminFormAnswerRow[]> {
+  const payload = await adminApiRequest<ApiSchemas['AdminFormAnswerListResponse']>({
+    endpointPath: `/v1/admin/forms/${encodeURIComponent(formSlug)}/answers`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  return Array.isArray(root.items) ? root.items.map((item) => parseFormAnswerRow(item)) : [];
+}
+
+export async function clearAdminFormAnswers(
+  formSlug: string
+): Promise<AdminFormClearAnswersResponse> {
+  const payload = await adminApiRequest<ApiSchemas['AdminFormClearAnswersResponse']>({
+    endpointPath: `/v1/admin/forms/${encodeURIComponent(formSlug)}/answers`,
+    method: 'DELETE',
+  });
+  const root = unwrapPayload(payload);
+  return {
+    formSlug: typeof root.formSlug === 'string' ? root.formSlug : formSlug,
+    deletedCount: typeof root.deletedCount === 'number' ? root.deletedCount : 0,
+  };
+}
+
+export async function exportAdminFormAnswersCsv(formSlug: string): Promise<Blob> {
+  const tokens = await ensureFreshTokens();
+  if (!tokens) {
+    throw new Error('Your session has expired. Please sign in again.');
+  }
+
+  const response = await fetch(
+    `${getApiBaseUrl()}/v1/admin/forms/${encodeURIComponent(formSlug)}/answers/export`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'text/csv',
+        Authorization: `Bearer ${tokens.idToken}`,
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`CSV export failed with status ${response.status}.`);
+  }
+  return response.blob();
+}
+
+export function formatFormAnswerValue(row: AdminFormAnswerRow): string {
+  if (typeof row.selectedOption === 'string' && row.selectedOption.trim()) {
+    return row.selectedOption;
+  }
+  if (typeof row.freeText === 'string' && row.freeText.trim()) {
+    return row.freeText;
+  }
+  return '—';
+}

--- a/apps/admin_web/src/lib/training-site-page-presets.ts
+++ b/apps/admin_web/src/lib/training-site-page-presets.ts
@@ -12,6 +12,7 @@ export interface TrainingSitePagePreset {
 
 const PRESET_ROWS: readonly { label: string; routeKey: keyof typeof TRAINING_ROUTES }[] = [
   { label: 'Home', routeKey: 'home' },
+  { label: 'Workshop feedback form', routeKey: 'formsWorkshopFeedback' },
   { label: 'Workshop food poll (Jun 26)', routeKey: 'pollsWorkshopFoodJun26' },
 ] as const;
 

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -5429,6 +5429,163 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/forms": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List training form slugs with answer counts
+         * @description Returns distinct form slugs discovered in the DynamoDB responses table,
+         *     each with the number of stored answer rows.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Form summary list. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminFormListResponse"];
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/forms/{form_slug}/answers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Training form slug (kebab-case). */
+                form_slug: components["parameters"]["FormSlug"];
+            };
+            cookie?: never;
+        };
+        /** List all stored answers for a form */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Training form slug (kebab-case). */
+                    form_slug: components["parameters"]["FormSlug"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Form answer rows for the selected form. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminFormAnswerListResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Clear all stored answers for a form
+         * @description Permanently deletes every answer row for the form slug in DynamoDB.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Training form slug (kebab-case). */
+                    form_slug: components["parameters"]["FormSlug"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Form answers cleared. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AdminFormClearAnswersResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/forms/{form_slug}/answers/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Training form slug (kebab-case). */
+                form_slug: components["parameters"]["FormSlug"];
+            };
+            cookie?: never;
+        };
+        /** Export form answers as CSV */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Training form slug (kebab-case). */
+                    form_slug: components["parameters"]["FormSlug"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description CSV export generated. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/csv": string;
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/polls": {
         parameters: {
             query?: never;
@@ -7191,6 +7348,34 @@ export interface components {
         AdminTagListResponse: {
             items: components["schemas"]["AdminTagRef"][];
         };
+        AdminFormSummary: {
+            formSlug: string;
+            answerCount: number;
+        };
+        AdminFormListResponse: {
+            items: components["schemas"]["AdminFormSummary"][];
+        };
+        AdminFormAnswerRow: {
+            formSlug: string;
+            /** Format: uuid */
+            sessionId: string;
+            questionId: string;
+            /** @enum {string} */
+            questionType: "select" | "text" | "email";
+            selectedOption?: string;
+            freeText?: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        AdminFormAnswerListResponse: {
+            items: components["schemas"]["AdminFormAnswerRow"][];
+        };
+        AdminFormClearAnswersResponse: {
+            formSlug: string;
+            deletedCount: number;
+        };
         AdminPollSummary: {
             pollSlug: string;
             answerCount: number;
@@ -7695,6 +7880,8 @@ export interface components {
         LocationId: string;
         /** @description Sales lead identifier. */
         LeadId: string;
+        /** @description Training form slug (kebab-case). */
+        FormSlug: string;
         /** @description Training poll slug (kebab-case). */
         PollSlug: string;
         /** @description Service identifier. */

--- a/apps/admin_web/tests/components/admin/website/website-forms-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/website/website-forms-panel.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { WebsiteFormsPanel } from '@/components/admin/website/website-forms-panel';
+
+const listAdminForms = vi.fn();
+const listAdminFormAnswers = vi.fn();
+const exportAdminFormAnswersCsv = vi.fn();
+const clearAdminFormAnswers = vi.fn();
+
+vi.mock('@/lib/forms-api', () => ({
+  listAdminForms: (...args: unknown[]) => listAdminForms(...args),
+  listAdminFormAnswers: (...args: unknown[]) => listAdminFormAnswers(...args),
+  exportAdminFormAnswersCsv: (...args: unknown[]) => exportAdminFormAnswersCsv(...args),
+  clearAdminFormAnswers: (...args: unknown[]) => clearAdminFormAnswers(...args),
+  formatFormAnswerValue: (row: { selectedOption?: string; freeText?: string }) =>
+    row.selectedOption ?? row.freeText ?? '—',
+}));
+
+describe('WebsiteFormsPanel', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads forms and answers for the selected form', async () => {
+    listAdminForms.mockResolvedValue([{ formSlug: 'workshop-feedback', answerCount: 1 }]);
+    listAdminFormAnswers.mockResolvedValue([
+      {
+        formSlug: 'workshop-feedback',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        questionId: 'name',
+        questionType: 'text',
+        freeText: 'Alex',
+        createdAt: '2026-06-26T10:00:00Z',
+        updatedAt: '2026-06-26T10:00:00Z',
+      },
+    ]);
+
+    render(<WebsiteFormsPanel />);
+
+    await waitFor(() => {
+      expect(listAdminFormAnswers).toHaveBeenCalledWith(
+        'workshop-feedback',
+        expect.any(AbortSignal)
+      );
+    });
+
+    expect(screen.getByText('Alex')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Export answers' })).toBeEnabled();
+  });
+});

--- a/apps/admin_web/tests/components/admin/website/website-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/website/website-page.test.tsx
@@ -12,6 +12,10 @@ vi.mock('@/lib/qr-code-image', () => ({
   generatePublicSiteQrPngDataUrl: vi.fn(async () => 'data:image/png;base64,AA'),
 }));
 
+vi.mock('@/components/admin/website/website-forms-panel', () => ({
+  WebsiteFormsPanel: () => <div>Forms panel</div>,
+}));
+
 vi.mock('@/components/admin/website/website-polls-panel', () => ({
   WebsitePollsPanel: () => <div>Polls panel</div>,
 }));
@@ -26,6 +30,13 @@ describe('WebsitePage', () => {
     expect(screen.getByRole('group', { name: 'Website section views' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'QR Codes', pressed: true })).toBeInTheDocument();
     expect(screen.getByText('Website QR codes')).toBeInTheDocument();
+  });
+
+  it('switches to Forms tab', () => {
+    render(<WebsitePage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Forms' }));
+    expect(screen.getByText('Forms panel')).toBeInTheDocument();
+    expect(screen.queryByText('Website QR codes')).not.toBeInTheDocument();
   });
 
   it('switches to Polls tab', () => {

--- a/apps/training/src/app/forms/[slug]/page.tsx
+++ b/apps/training/src/app/forms/[slug]/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { FormPage } from '@/components/forms/form-page';
+import {
+  FORMS_COMMON,
+  getAllFormSlugs,
+  getFormContent,
+  isValidFormSlug,
+} from '@/lib/forms';
+
+interface FormRouteProps {
+  params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+  return getAllFormSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: FormRouteProps): Promise<Metadata> {
+  const { slug } = await params;
+  if (!isValidFormSlug(slug)) {
+    return {};
+  }
+  const form = getFormContent(slug);
+  if (!form) {
+    return {};
+  }
+  return {
+    title: form.title,
+    robots: {
+      index: false,
+      follow: false,
+      noarchive: true,
+    },
+  };
+}
+
+export default async function FormRoutePage({ params }: FormRouteProps) {
+  const { slug } = await params;
+  if (!isValidFormSlug(slug)) {
+    notFound();
+  }
+  const form = getFormContent(slug);
+  if (!form || form.slug !== slug) {
+    notFound();
+  }
+
+  return <FormPage form={form} common={FORMS_COMMON} />;
+}

--- a/apps/training/src/components/forms/form-answer-state.ts
+++ b/apps/training/src/components/forms/form-answer-state.ts
@@ -1,0 +1,34 @@
+import type { FormQuestion } from '@/content/form-types';
+
+export interface FormAnswerState {
+  selectedOption: string;
+  freeText: string;
+}
+
+export function emptyFormAnswerState(): FormAnswerState {
+  return {
+    selectedOption: '',
+    freeText: '',
+  };
+}
+
+export function isFormAnswerValid(question: FormQuestion, answer: FormAnswerState): boolean {
+  if (question.type === 'select') {
+    return answer.selectedOption.trim().length > 0;
+  }
+  if (question.type === 'email') {
+    return isValidEmail(answer.freeText);
+  }
+  if (question.type === 'text') {
+    return answer.freeText.trim().length > 0;
+  }
+  return false;
+}
+
+function isValidEmail(value: string): boolean {
+  const normalized = value.trim();
+  if (!normalized) {
+    return false;
+  }
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized);
+}

--- a/apps/training/src/components/forms/form-page.tsx
+++ b/apps/training/src/components/forms/form-page.tsx
@@ -1,0 +1,43 @@
+import { FormWizard } from '@/components/forms/form-wizard';
+import type { FormContent, FormsCommonContent } from '@/content/form-types';
+import { getPublicWwwHomeUrl } from '@/lib/public-www-url';
+
+export interface FormPageProps {
+  form: FormContent;
+  common: FormsCommonContent;
+}
+
+export function FormPage({ form, common }: FormPageProps) {
+  const publicWwwHomeUrl = getPublicWwwHomeUrl();
+
+  const logo = (
+    // eslint-disable-next-line @next/next/no-img-element -- static SVG from /public/images
+    <img
+      src='/images/evolvesprouts-logo.svg'
+      alt='Evolve Sprouts'
+      className='mx-auto h-28 w-auto'
+    />
+  );
+
+  return (
+    <main className='flex min-h-screen flex-col px-6 py-10'>
+      <header className='mx-auto mb-8 w-full max-w-xl text-center'>
+        <div className='mb-4'>
+          {publicWwwHomeUrl ? (
+            <a
+              href={publicWwwHomeUrl}
+              className='inline-block rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-neutral-900'
+              aria-label='Go to the Evolve Sprouts website'
+            >
+              {logo}
+            </a>
+          ) : (
+            logo
+          )}
+        </div>
+        <h1 className='es-type-title text-2xl'>{form.title}</h1>
+      </header>
+      <FormWizard form={form} common={common} />
+    </main>
+  );
+}

--- a/apps/training/src/components/forms/form-question-field.tsx
+++ b/apps/training/src/components/forms/form-question-field.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import type { FormQuestion } from '@/content/form-types';
+import type { FormAnswerState } from '@/components/forms/form-answer-state';
+
+export interface FormQuestionFieldProps {
+  question: FormQuestion;
+  answer: FormAnswerState;
+  onAnswerChange: (patch: Partial<FormAnswerState>) => void;
+}
+
+export function FormQuestionField({
+  question,
+  answer,
+  onAnswerChange,
+}: FormQuestionFieldProps) {
+  return (
+    <div className='flex w-full flex-col gap-4'>
+      <div className='flex flex-col gap-1'>
+        <p className='es-type-eyebrow'>{question.screen}</p>
+        <h2 className='es-text-heading text-xl font-semibold'>{question.question}</h2>
+      </div>
+      {question.type === 'select' ? (
+        <fieldset className='flex flex-col gap-2'>
+          {question.options.map((option) => {
+            const inputId = `${question.id}-${slugifyOption(option)}`;
+            return (
+              <label
+                key={option}
+                htmlFor={inputId}
+                className={`poll-option-label flex cursor-pointer items-start gap-3 rounded-inner border px-3 py-2 es-bg-surface-white ${answer.selectedOption === option ? 'poll-option-label--selected' : ''}`}
+              >
+                <input
+                  id={inputId}
+                  type='radio'
+                  name={question.id}
+                  className='es-accent-brand es-focus-ring mt-1 h-4 w-4 shrink-0'
+                  checked={answer.selectedOption === option}
+                  onChange={() => onAnswerChange({ selectedOption: option })}
+                />
+                <span className='es-text-body text-base'>{option}</span>
+              </label>
+            );
+          })}
+        </fieldset>
+      ) : null}
+      {question.type === 'text' ? (
+        <textarea
+          className='es-focus-ring es-form-input min-h-28 w-full'
+          value={answer.freeText}
+          onChange={(event) => onAnswerChange({ freeText: event.target.value })}
+        />
+      ) : null}
+      {question.type === 'email' ? (
+        <input
+          type='email'
+          autoComplete='email'
+          className='es-focus-ring es-form-input w-full'
+          value={answer.freeText}
+          onChange={(event) => onAnswerChange({ freeText: event.target.value })}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function slugifyOption(option: string): string {
+  return option
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}

--- a/apps/training/src/components/forms/form-wizard.tsx
+++ b/apps/training/src/components/forms/form-wizard.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import {
+  emptyFormAnswerState,
+  isFormAnswerValid,
+  type FormAnswerState,
+} from '@/components/forms/form-answer-state';
+import { FormQuestionField } from '@/components/forms/form-question-field';
+import type { FormContent, FormQuestion, FormsCommonContent } from '@/content/form-types';
+import { getOrCreateFormSessionId } from '@/lib/form-session';
+import { FormApiError, persistFormAnswer } from '@/lib/forms-api';
+
+export interface FormWizardProps {
+  form: FormContent;
+  common: FormsCommonContent;
+}
+
+export function FormWizard({ form, common }: FormWizardProps) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [isComplete, setIsComplete] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [answersByQuestionId, setAnswersByQuestionId] = useState<
+    Record<string, FormAnswerState>
+  >({});
+
+  const sessionId = useMemo(() => getOrCreateFormSessionId(), []);
+  const questions = form.questions;
+  const totalSteps = questions.length;
+  const resolvedStepIndex = totalSteps === 0 ? 0 : Math.min(stepIndex, totalSteps - 1);
+  const currentQuestion = questions[resolvedStepIndex];
+  const currentAnswer = currentQuestion
+    ? (answersByQuestionId[currentQuestion.id] ?? emptyFormAnswerState())
+    : emptyFormAnswerState();
+
+  const progressLabel = formatProgressLabel({
+    template: common.a11y.progressTemplate,
+    current: totalSteps === 0 ? 0 : resolvedStepIndex + 1,
+    total: totalSteps,
+  });
+
+  if (isComplete || totalSteps === 0) {
+    return (
+      <section className='mx-auto flex w-full max-w-xl flex-col gap-3 text-center'>
+        <h2 className='es-type-title text-2xl'>{common.completion.title}</h2>
+        <p className='es-text-body text-base'>{common.completion.description}</p>
+      </section>
+    );
+  }
+
+  if (!currentQuestion) {
+    return null;
+  }
+
+  const isFirstStep = resolvedStepIndex === 0;
+  const isLastStep = resolvedStepIndex === totalSteps - 1;
+  const primaryLabel = isLastStep ? common.navigation.finish : common.navigation.next;
+
+  return (
+    <section className='mx-auto flex w-full max-w-xl flex-col gap-6'>
+      <p className='es-text-muted text-sm'>{progressLabel}</p>
+      <FormQuestionField
+        question={currentQuestion}
+        answer={currentAnswer}
+        onAnswerChange={(patch) => updateAnswerState(currentQuestion.id, patch)}
+      />
+      {errorMessage ? (
+        <p className='es-text-danger text-sm' role='alert'>
+          {errorMessage}
+        </p>
+      ) : null}
+      <div className='flex flex-wrap items-center justify-start gap-2'>
+        {!isFirstStep ? (
+          <button
+            type='button'
+            className='es-btn es-btn--primary es-btn--outline es-focus-ring'
+            disabled={isSaving}
+            onClick={() => {
+              setErrorMessage(null);
+              setStepIndex((index) => Math.max(0, index - 1));
+            }}
+          >
+            {common.navigation.back}
+          </button>
+        ) : null}
+        <button
+          type='button'
+          className='es-btn es-btn--primary es-focus-ring'
+          disabled={isSaving}
+          onClick={() => void handlePrimaryAction()}
+        >
+          {primaryLabel}
+        </button>
+      </div>
+    </section>
+  );
+
+  function updateAnswerState(questionId: string, patch: Partial<FormAnswerState>): void {
+    setAnswersByQuestionId((previous) => ({
+      ...previous,
+      [questionId]: {
+        ...emptyFormAnswerState(),
+        ...previous[questionId],
+        ...patch,
+      },
+    }));
+  }
+
+  async function handlePrimaryAction(): Promise<void> {
+    setErrorMessage(null);
+
+    const validationError = validateAnswer(currentQuestion, currentAnswer, common);
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await persistFormAnswer({
+        formSlug: form.slug,
+        sessionId,
+        question: currentQuestion,
+        answer: currentAnswer,
+      });
+    } catch (error) {
+      setErrorMessage(resolvePersistErrorMessage(error, common));
+      setIsSaving(false);
+      return;
+    }
+    setIsSaving(false);
+
+    if (isLastStep) {
+      setIsComplete(true);
+      return;
+    }
+    setStepIndex((index) => Math.min(index + 1, totalSteps - 1));
+  }
+}
+
+function resolvePersistErrorMessage(error: unknown, common: FormsCommonContent): string {
+  if (error instanceof FormApiError && error.statusCode === 0) {
+    return common.errors.missingApiConfig;
+  }
+  return common.errors.persistFailed;
+}
+
+function validateAnswer(
+  question: FormQuestion,
+  answer: FormAnswerState,
+  common: FormsCommonContent,
+): string | null {
+  if (!isFormAnswerValid(question, answer)) {
+    if (question.type === 'email') {
+      return common.errors.invalidEmail;
+    }
+    return common.errors.required;
+  }
+  return null;
+}
+
+function formatProgressLabel({
+  template,
+  current,
+  total,
+}: {
+  template: string;
+  current: number;
+  total: number;
+}): string {
+  return template
+    .replace('{current}', String(current))
+    .replace('{total}', String(total));
+}

--- a/apps/training/src/content/form-types.ts
+++ b/apps/training/src/content/form-types.ts
@@ -1,0 +1,81 @@
+import formsCommonJson from '@/content/forms-common.json';
+import workshopFeedbackJson from '@/content/forms/workshop-feedback.json';
+
+export interface FormQuestionBase {
+  id: string;
+  screen: string;
+  question: string;
+}
+
+export interface FormSelectQuestion extends FormQuestionBase {
+  type: 'select';
+  options: string[];
+}
+
+export interface FormTextQuestion extends FormQuestionBase {
+  type: 'text';
+}
+
+export interface FormEmailQuestion extends FormQuestionBase {
+  type: 'email';
+}
+
+export type FormQuestion = FormSelectQuestion | FormTextQuestion | FormEmailQuestion;
+
+export interface FormContent {
+  title: string;
+  slug: string;
+  questions: FormQuestion[];
+}
+
+export interface FormsCommonContent {
+  navigation: {
+    back: string;
+    next: string;
+    finish: string;
+  };
+  completion: {
+    title: string;
+    description: string;
+  };
+  errors: {
+    required: string;
+    invalidEmail: string;
+    persistFailed: string;
+    missingApiConfig: string;
+  };
+  a11y: {
+    progressTemplate: string;
+  };
+}
+
+export const FORMS_COMMON = formsCommonJson as FormsCommonContent;
+
+const workshopFeedback = workshopFeedbackJson as FormContent;
+
+const FORMS = {
+  'workshop-feedback': workshopFeedback,
+} satisfies Record<string, FormContent>;
+
+export type FormSlug = keyof typeof FORMS;
+
+const FORM_SLUGS = Object.freeze(Object.keys(FORMS) as FormSlug[]);
+
+export function getAllFormSlugs(): FormSlug[] {
+  return [...FORM_SLUGS];
+}
+
+export function isValidFormSlug(slug: string): slug is FormSlug {
+  return slug in FORMS;
+}
+
+export function getFormContent(slug: string): FormContent | null {
+  if (!isValidFormSlug(slug)) {
+    return null;
+  }
+  return FORMS[slug];
+}
+
+export function buildFormPath(slug: FormSlug | string): string {
+  return `/forms/${slug}/`;
+}

--- a/apps/training/src/content/forms-common.json
+++ b/apps/training/src/content/forms-common.json
@@ -1,0 +1,20 @@
+{
+  "navigation": {
+    "back": "Back",
+    "next": "Next",
+    "finish": "Submit"
+  },
+  "completion": {
+    "title": "Thank you",
+    "description": "Your responses have been saved."
+  },
+  "errors": {
+    "required": "Please answer this question before continuing.",
+    "invalidEmail": "Enter a valid email address.",
+    "persistFailed": "We could not save your answer. Please try again.",
+    "missingApiConfig": "This form cannot be saved right now. Please try again later."
+  },
+  "a11y": {
+    "progressTemplate": "Question {current} of {total}"
+  }
+}

--- a/apps/training/src/content/forms/workshop-feedback.json
+++ b/apps/training/src/content/forms/workshop-feedback.json
@@ -1,0 +1,31 @@
+{
+  "title": "Workshop feedback",
+  "slug": "workshop-feedback",
+  "questions": [
+    {
+      "id": "name",
+      "type": "text",
+      "screen": "About you",
+      "question": "Your name"
+    },
+    {
+      "id": "email",
+      "type": "email",
+      "screen": "Contact",
+      "question": "Email address"
+    },
+    {
+      "id": "rating",
+      "type": "select",
+      "screen": "Overall",
+      "question": "How would you rate this workshop?",
+      "options": ["Excellent", "Good", "Fair", "Needs improvement"]
+    },
+    {
+      "id": "comments",
+      "type": "text",
+      "screen": "Feedback",
+      "question": "What was most helpful, or what could we improve?"
+    }
+  ]
+}

--- a/apps/training/src/lib/form-session.ts
+++ b/apps/training/src/lib/form-session.ts
@@ -1,0 +1,14 @@
+const STORAGE_KEY = 'evolvesprouts-form-session-id';
+
+export function getOrCreateFormSessionId(): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  const existing = window.sessionStorage.getItem(STORAGE_KEY);
+  if (existing) {
+    return existing;
+  }
+  const created = crypto.randomUUID();
+  window.sessionStorage.setItem(STORAGE_KEY, created);
+  return created;
+}

--- a/apps/training/src/lib/forms-api.ts
+++ b/apps/training/src/lib/forms-api.ts
@@ -1,0 +1,99 @@
+import type { FormQuestion } from '@/content/form-types';
+import type { FormAnswerState } from '@/components/forms/form-answer-state';
+
+const API_BASE_URL_ENV = 'NEXT_PUBLIC_API_BASE_URL';
+const API_KEY_ENV = 'NEXT_PUBLIC_TRAINING_API_KEY';
+const API_KEY_FALLBACK_ENV = 'NEXT_PUBLIC_WWW_CRM_API_KEY';
+const WWW_PREFIX = '/www';
+
+export interface PersistFormAnswerInput {
+  formSlug: string;
+  sessionId: string;
+  question: FormQuestion;
+  answer: FormAnswerState;
+}
+
+export class FormApiError extends Error {
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'FormApiError';
+    this.statusCode = statusCode;
+  }
+}
+
+export function resolveFormApiConfig(): { baseUrl: string; apiKey: string } | null {
+  const apiKey =
+    process.env[API_KEY_ENV]?.trim() ||
+    process.env[API_KEY_FALLBACK_ENV]?.trim() ||
+    '';
+  const baseUrl = normalizeFormApiBaseUrl(process.env[API_BASE_URL_ENV]?.trim() ?? '');
+  if (!apiKey || !baseUrl) {
+    return null;
+  }
+  return { baseUrl, apiKey };
+}
+
+export async function persistFormAnswer(input: PersistFormAnswerInput): Promise<void> {
+  const config = resolveFormApiConfig();
+  if (!config) {
+    throw new FormApiError('Form API is not configured', 0);
+  }
+
+  const endpointPath = `${config.baseUrl}/v1/forms/${encodeURIComponent(input.formSlug)}/answers`;
+  const body = buildPersistBody(input);
+
+  const response = await fetch(endpointPath, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': config.apiKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new FormApiError('Failed to persist form answer', response.status);
+  }
+}
+
+function buildPersistBody(input: PersistFormAnswerInput): Record<string, unknown> {
+  const base = {
+    formSlug: input.formSlug,
+    sessionId: input.sessionId,
+    questionId: input.question.id,
+    questionType: input.question.type,
+  };
+
+  if (input.question.type === 'select') {
+    return {
+      ...base,
+      selectedOption: input.answer.selectedOption.trim(),
+    };
+  }
+
+  return {
+    ...base,
+    freeText: input.answer.freeText.trim(),
+  };
+}
+
+function normalizeFormApiBaseUrl(raw: string): string {
+  if (!raw) {
+    return '';
+  }
+  if (raw === WWW_PREFIX || raw.startsWith(`${WWW_PREFIX}/`)) {
+    return WWW_PREFIX;
+  }
+  try {
+    const parsed = new URL(raw);
+    const pathname = parsed.pathname.replace(/\/$/, '') || '';
+    if (pathname !== WWW_PREFIX) {
+      return '';
+    }
+    return `${parsed.origin}${WWW_PREFIX}`;
+  } catch {
+    return '';
+  }
+}

--- a/apps/training/src/lib/forms.ts
+++ b/apps/training/src/lib/forms.ts
@@ -1,0 +1,8 @@
+export {
+  buildFormPath,
+  FORMS_COMMON,
+  getAllFormSlugs,
+  getFormContent,
+  isValidFormSlug,
+} from '@/content/form-types';
+export type { FormContent, FormQuestion, FormsCommonContent, FormSlug } from '@/content/form-types';

--- a/apps/training/src/lib/training-routes.ts
+++ b/apps/training/src/lib/training-routes.ts
@@ -4,6 +4,7 @@
  */
 export const TRAINING_ROUTES = {
   home: '/',
+  formsWorkshopFeedback: '/forms/workshop-feedback',
   pollsWorkshopFoodJun26: '/polls/workshop-food-jun-26',
 } as const;
 

--- a/apps/training/tests/components/forms/form-page.test.tsx
+++ b/apps/training/tests/components/forms/form-page.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FormPage } from '@/components/forms/form-page';
+import { FORMS_COMMON, getFormContent } from '@/lib/forms';
+
+const form = getFormContent('workshop-feedback');
+
+describe('FormPage branding', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('links the logo to the public website home when origin is configured', () => {
+    if (!form) {
+      throw new Error('Expected workshop-feedback form content');
+    }
+    vi.stubEnv('NEXT_PUBLIC_PUBLIC_WWW_ORIGIN', 'https://www.evolvesprouts.com');
+
+    render(<FormPage form={form} common={FORMS_COMMON} />);
+
+    const link = screen.getByRole('link', { name: 'Go to the Evolve Sprouts website' });
+    expect(link).toHaveAttribute('href', 'https://www.evolvesprouts.com/en/');
+    expect(screen.getByRole('img', { name: 'Evolve Sprouts' })).toBeInTheDocument();
+  });
+
+  it('renders the logo without a link when public origin is unset', () => {
+    if (!form) {
+      throw new Error('Expected workshop-feedback form content');
+    }
+    vi.stubEnv('NEXT_PUBLIC_PUBLIC_WWW_ORIGIN', '');
+
+    render(<FormPage form={form} common={FORMS_COMMON} />);
+
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByRole('img', { name: 'Evolve Sprouts' })).toBeInTheDocument();
+  });
+});

--- a/apps/training/tests/content/forms-registry.test.ts
+++ b/apps/training/tests/content/forms-registry.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildFormPath,
+  getAllFormSlugs,
+  getFormContent,
+  isValidFormSlug,
+} from '@/lib/forms';
+
+describe('forms registry', () => {
+  it('returns registered slugs and resolves content', () => {
+    const slugs = getAllFormSlugs();
+    expect(slugs).toContain('workshop-feedback');
+    const content = getFormContent('workshop-feedback');
+    expect(content?.title).toBeTruthy();
+    expect(content?.slug).toBe('workshop-feedback');
+    expect(content?.questions.length).toBeGreaterThan(0);
+  });
+
+  it('validates slugs', () => {
+    expect(isValidFormSlug('workshop-feedback')).toBe(true);
+    expect(isValidFormSlug('missing')).toBe(false);
+    expect(getFormContent('missing')).toBeNull();
+  });
+
+  it('builds form paths', () => {
+    expect(buildFormPath('workshop-feedback')).toBe('/forms/workshop-feedback/');
+  });
+
+  it('every content json file is registered with matching slug field', () => {
+    const dir = path.resolve(__dirname, '../../src/content/forms');
+    const files = readdirSync(dir).filter((name) => name.endsWith('.json'));
+    const registered = new Set(getAllFormSlugs());
+    for (const fileName of files) {
+      const slug = fileName.replace(/\.json$/, '');
+      expect(registered.has(slug)).toBe(true);
+      const raw = JSON.parse(readFileSync(path.join(dir, fileName), 'utf8')) as {
+        slug: string;
+      };
+      expect(raw.slug).toBe(slug);
+    }
+  });
+
+  it('uses dynamic form route page', () => {
+    const appFormPage = path.resolve(__dirname, '../../src/app/forms/[slug]/page.tsx');
+    expect(existsSync(appFormPage)).toBe(true);
+  });
+});

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2954,6 +2954,9 @@ export class ApiStack extends cdk.Stack {
     addPublicApiKeyMethod(reservations, "POST");
     addPublicApiKeyMethod(reservations.addResource("payment-intent"), "POST");
     addPublicApiKeyMethod(v1.addResource("contact-us"), "POST");
+    const forms = v1.addResource("forms");
+    const formBySlug = forms.addResource("{form_slug}");
+    addPublicApiKeyMethod(formBySlug.addResource("answers"), "PUT");
     const polls = v1.addResource("polls");
     const pollBySlug = polls.addResource("{poll_slug}");
     addPublicApiKeyMethod(pollBySlug.addResource("answers"), "PUT");

--- a/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
+++ b/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
@@ -53,6 +53,17 @@ function handler(event) {
     return request;
   }
 
+  var isFormAnswersPath =
+    uri.indexOf('/www/v1/forms/') === 0 &&
+    uri.lastIndexOf('/answers') === uri.length - 8;
+  if (
+    (method === 'PUT' || method === 'OPTIONS') &&
+    isFormAnswersPath
+  ) {
+    request.uri = uri.substring(4);
+    return request;
+  }
+
   var isPollAnswersPath =
     uri.indexOf('/www/v1/polls/') === 0 &&
     uri.lastIndexOf('/answers') === uri.length - 8;

--- a/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
+++ b/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
@@ -15,6 +15,7 @@ const REQUIRED_ALLOWLIST_PATHS = [
   "/www/v1/contact-us",
 ];
 
+const REQUIRED_FORM_PUT_PREFIX = "/www/v1/forms/";
 const REQUIRED_POLL_PUT_PREFIX = "/www/v1/polls/";
 const REQUIRED_POLL_PUT_SUFFIX = "/answers";
 const REQUIRED_POLL_RESULTS_SEGMENT = "/questions/";
@@ -47,6 +48,11 @@ function main(): void {
     "WWW_PROXY_ALLOWLIST_FUNCTION",
   );
 
+  if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes(REQUIRED_FORM_PUT_PREFIX)) {
+    throw new Error(
+      "WWW_PROXY_ALLOWLIST_FUNCTION missing form PUT prefix allowlist rule",
+    );
+  }
   if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes(REQUIRED_POLL_PUT_PREFIX)) {
     throw new Error(
       "WWW_PROXY_ALLOWLIST_FUNCTION missing poll PUT prefix allowlist rule",

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -37,10 +37,12 @@ from app.api.admin_audit_logs import handle_admin_audit_logs_request
 from app.api.admin_calendar_manual_blocks import (
     handle_admin_calendar_manual_blocks_request,
 )
+from app.api.admin_forms import handle_admin_forms_request
 from app.api.admin_polls import handle_admin_polls_request
 from app.api.public_calendar_availability import handle_public_calendar_availability
 from app.api.public_events import handle_public_events
 from app.api.public_contact import handle_public_contact_us
+from app.api.public_forms import handle_public_forms_request
 from app.api.public_polls import handle_public_polls_request
 from app.api.public_reservation_payments import handle_public_reservation_payment_intent
 from app.api.public_reservations import _handle_public_reservation
@@ -135,6 +137,16 @@ _ROUTES: tuple[
         "/v1/contact-us",
         True,
         lambda event, method, _path: handle_public_contact_us(event, method),
+    ),
+    (
+        "/v1/forms",
+        False,
+        handle_public_forms_request,
+    ),
+    (
+        "/www/v1/forms",
+        False,
+        handle_public_forms_request,
     ),
     (
         "/v1/polls",
@@ -240,6 +252,11 @@ _ROUTES: tuple[
         "/v1/admin/organizations",
         False,
         handle_admin_organizations_request,
+    ),
+    (
+        "/v1/admin/forms",
+        False,
+        handle_admin_forms_request,
     ),
     (
         "/v1/admin/polls",

--- a/backend/src/app/api/admin_forms.py
+++ b/backend/src/app/api/admin_forms.py
@@ -1,0 +1,153 @@
+"""Admin form response management (DynamoDB training form answers)."""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from app.api.assets.assets_common import extract_identity, split_route_parts
+from app.exceptions import ValidationError
+from app.services.form_responses_store import (
+    clear_form_answers,
+    list_form_answers,
+    list_form_summaries,
+)
+from app.utils import json_response
+from app.utils.logging import get_logger
+from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
+from app.utils.responses import get_cors_headers, get_security_headers
+
+logger = get_logger(__name__)
+
+
+def handle_admin_forms_request(
+    event: Mapping[str, Any],
+    method: str,
+    path: str,
+) -> dict[str, Any]:
+    """Handle /v1/admin/forms routes."""
+    parts = split_route_parts(path)
+    if len(parts) < 2 or parts[0] != "admin" or parts[1] != "forms":
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    identity = extract_identity(event)
+    if not identity.user_sub:
+        raise ValidationError("Authenticated user is required", field="authorization")
+
+    if len(parts) == 2:
+        if method != "GET":
+            return json_response(405, {"error": "Method not allowed"}, event=event)
+        return _list_forms(event)
+
+    form_slug = _parse_form_slug(parts[2])
+    if len(parts) == 3:
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    if len(parts) == 4 and parts[3] == "answers":
+        if method == "GET":
+            return _list_form_answers(event, form_slug=form_slug)
+        if method == "DELETE":
+            return _clear_form_answers(event, form_slug=form_slug)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 5 and parts[3] == "answers" and parts[4] == "export":
+        if method != "GET":
+            return json_response(405, {"error": "Method not allowed"}, event=event)
+        return _export_form_answers(event, form_slug=form_slug)
+
+    return json_response(404, {"error": "Not found"}, event=event)
+
+
+def _parse_form_slug(value: str) -> str:
+    normalized = value.strip()
+    if not normalized or not PUBLIC_INSTANCE_SLUG_PATTERN.match(normalized):
+        raise ValidationError("form slug must be a kebab-case identifier")
+    return normalized
+
+
+def _list_forms(event: Mapping[str, Any]) -> dict[str, Any]:
+    items = list_form_summaries()
+    return json_response(200, {"items": items}, event=event)
+
+
+def _list_form_answers(
+    event: Mapping[str, Any],
+    *,
+    form_slug: str,
+) -> dict[str, Any]:
+    items = list_form_answers(form_slug=form_slug)
+    return json_response(200, {"items": items}, event=event)
+
+
+def _clear_form_answers(
+    event: Mapping[str, Any],
+    *,
+    form_slug: str,
+) -> dict[str, Any]:
+    deleted_count = clear_form_answers(form_slug=form_slug)
+    logger.info(
+        "Cleared form answers",
+        extra={
+            "form_slug": form_slug,
+            "deleted_count": deleted_count,
+        },
+    )
+    return json_response(
+        200,
+        {
+            "formSlug": form_slug,
+            "deletedCount": deleted_count,
+        },
+        event=event,
+    )
+
+
+def _export_form_answers(
+    event: Mapping[str, Any],
+    *,
+    form_slug: str,
+) -> dict[str, Any]:
+    items = list_form_answers(form_slug=form_slug)
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        [
+            "Form Slug",
+            "Session ID",
+            "Question ID",
+            "Question Type",
+            "Selected Option",
+            "Free Text",
+            "Created At",
+            "Updated At",
+        ]
+    )
+    for item in items:
+        writer.writerow(
+            [
+                item.get("formSlug") or form_slug,
+                item.get("sessionId") or "",
+                item.get("questionId") or "",
+                item.get("questionType") or "",
+                item.get("selectedOption") or "",
+                item.get("freeText") or "",
+                item.get("createdAt") or "",
+                item.get("updatedAt") or "",
+            ]
+        )
+
+    filename = f"form-{form_slug}-answers-{datetime.now(UTC).date().isoformat()}.csv"
+    response_headers = {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": f'attachment; filename="{filename}"',
+        **get_security_headers(),
+        **get_cors_headers(event),
+    }
+    return {
+        "statusCode": 200,
+        "headers": response_headers,
+        "body": output.getvalue(),
+    }

--- a/backend/src/app/api/public_forms.py
+++ b/backend/src/app/api/public_forms.py
@@ -1,0 +1,199 @@
+"""Public training form answer persistence (DynamoDB)."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from app.api.admin_request import parse_body
+from app.api.validators import validate_email
+from app.exceptions import ValidationError
+from app.services.form_responses_store import upsert_form_answer
+from app.utils import json_response
+from app.utils.logging import get_logger
+from app.utils.public_slug import PUBLIC_INSTANCE_SLUG_PATTERN
+
+logger = get_logger(__name__)
+
+_ANSWERS_SUFFIX = "/answers"
+_FORM_API_PREFIX = "/v1/forms/"
+_WWW_FORM_API_PREFIX = "/www/v1/forms/"
+
+_MAX_SELECTED_OPTION = 500
+_MAX_FREE_TEXT = 4000
+
+_QUESTION_ID_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_SESSION_ID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+_SELECT_TYPES = frozenset({"select"})
+_TEXT_TYPES = frozenset({"text"})
+_EMAIL_TYPES = frozenset({"email"})
+
+
+def handle_public_forms_request(
+    event: Mapping[str, Any],
+    method: str,
+    path: str,
+) -> dict[str, Any]:
+    """Route form API requests under /v1/forms/* and /www/v1/forms/*."""
+    answers = _parse_form_answers_path(path)
+    if answers is not None:
+        form_slug, _suffix = answers
+        if method == "PUT":
+            return _handle_put_form_answer(event, form_slug=form_slug)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    return json_response(404, {"error": "Not found"}, event=event)
+
+
+def _parse_form_path_remainder(path: str) -> str | None:
+    normalized = path.rstrip("/")
+    if normalized.startswith(_WWW_FORM_API_PREFIX):
+        return normalized[len(_WWW_FORM_API_PREFIX) :]
+    if normalized.startswith(_FORM_API_PREFIX):
+        return normalized[len(_FORM_API_PREFIX) :]
+    return None
+
+
+def _parse_form_answers_path(path: str) -> tuple[str, str] | None:
+    remainder = _parse_form_path_remainder(path)
+    if remainder is None or not remainder.endswith(_ANSWERS_SUFFIX):
+        return None
+    form_slug = remainder[: -len(_ANSWERS_SUFFIX)].strip("/")
+    if "/" in form_slug or not form_slug:
+        return None
+    if not PUBLIC_INSTANCE_SLUG_PATTERN.match(form_slug):
+        return None
+    return form_slug, _ANSWERS_SUFFIX
+
+
+def _handle_put_form_answer(
+    event: Mapping[str, Any],
+    *,
+    form_slug: str,
+) -> dict[str, Any]:
+    try:
+        body = parse_body(event)
+    except ValidationError as exc:
+        return json_response(exc.status_code, exc.to_dict(), event=event)
+
+    try:
+        normalized = _validate_put_body(body, form_slug=form_slug)
+    except ValidationError as exc:
+        return json_response(exc.status_code, exc.to_dict(), event=event)
+
+    result = upsert_form_answer(**normalized)
+    logger.info(
+        "Persisted form answer",
+        extra={
+            "form_slug": form_slug,
+            "question_id": normalized["question_id"],
+        },
+    )
+    return json_response(
+        200,
+        {
+            "formSlug": result["formSlug"],
+            "sessionId": result["sessionId"],
+            "questionId": result["questionId"],
+            "updatedAt": result["updatedAt"],
+        },
+        event=event,
+    )
+
+
+def _validate_put_body(
+    body: Mapping[str, Any],
+    *,
+    form_slug: str,
+) -> dict[str, Any]:
+    session_id = _require_session_id(body.get("sessionId"))
+    question_id = _require_question_id(body.get("questionId"))
+    question_type = _require_question_type(body.get("questionType"))
+
+    body_form_slug = body.get("formSlug")
+    if body_form_slug is not None:
+        if not isinstance(body_form_slug, str):
+            raise ValidationError("formSlug must be a string")
+        normalized_body_slug = body_form_slug.strip()
+        if normalized_body_slug != form_slug:
+            raise ValidationError("formSlug does not match URL")
+
+    base = {
+        "form_slug": form_slug,
+        "session_id": session_id,
+        "question_id": question_id,
+        "question_type": question_type,
+    }
+
+    if question_type in _SELECT_TYPES:
+        selected_option = _require_non_empty_string(
+            body.get("selectedOption"),
+            field="selectedOption",
+        )
+        if len(selected_option) > _MAX_SELECTED_OPTION:
+            raise ValidationError(
+                f"selectedOption must be at most {_MAX_SELECTED_OPTION} characters"
+            )
+        return {
+            **base,
+            "selected_option": selected_option,
+            "free_text": None,
+        }
+
+    free_text = _require_non_empty_string(body.get("freeText"), field="freeText")
+    if len(free_text) > _MAX_FREE_TEXT:
+        raise ValidationError(f"freeText must be at most {_MAX_FREE_TEXT} characters")
+
+    if question_type in _EMAIL_TYPES:
+        validated_email = validate_email(free_text)
+        if not validated_email:
+            raise ValidationError("freeText must be a valid email address")
+        free_text = validated_email
+
+    return {
+        **base,
+        "selected_option": None,
+        "free_text": free_text,
+    }
+
+
+def _require_session_id(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValidationError("sessionId is required")
+    normalized = value.strip()
+    if not _SESSION_ID_PATTERN.match(normalized):
+        raise ValidationError("sessionId must be a UUID")
+    return normalized.lower()
+
+
+def _require_question_id(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValidationError("questionId is required")
+    normalized = value.strip()
+    if not _QUESTION_ID_PATTERN.match(normalized):
+        raise ValidationError("questionId must be a kebab-case identifier")
+    return normalized
+
+
+def _require_question_type(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValidationError("questionType is required")
+    normalized = value.strip().lower()
+    allowed = _SELECT_TYPES | _TEXT_TYPES | _EMAIL_TYPES
+    if normalized not in allowed:
+        raise ValidationError("questionType must be select, text, or email")
+    return normalized
+
+
+def _require_non_empty_string(value: Any, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValidationError(f"{field} is required")
+    normalized = value.strip()
+    if not normalized:
+        raise ValidationError(f"{field} is required")
+    return normalized

--- a/backend/src/app/services/form_responses_store.py
+++ b/backend/src/app/services/form_responses_store.py
@@ -1,0 +1,278 @@
+"""DynamoDB persistence for training-site form answers (shared poll-responses table)."""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+from datetime import UTC, datetime
+from collections.abc import Mapping
+from typing import Any
+
+import boto3
+from boto3.dynamodb.conditions import Attr, Key
+from botocore.exceptions import ClientError
+
+from app.exceptions import AppError
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_TABLE_ENV = "POLL_RESPONSES_TABLE_NAME"
+_PK_PREFIX = "FORM#"
+_SK_PREFIX = "SESSION#"
+_SK_QUESTION_SEP = "#Q#"
+
+_dynamodb = None
+_table = None
+
+
+def _table_name() -> str:
+    name = os.environ.get(_TABLE_ENV, "").strip()
+    if not name:
+        raise AppError(
+            "Form responses table is not configured",
+            status_code=500,
+        )
+    return name
+
+
+def _get_table():
+    global _dynamodb, _table
+    if _table is None:
+        _dynamodb = boto3.resource("dynamodb")
+        _table = _dynamodb.Table(_table_name())
+    return _table
+
+
+def _partition_key(*, form_slug: str) -> str:
+    return f"{_PK_PREFIX}{form_slug}"
+
+
+def _sort_key(*, session_id: str, question_id: str) -> str:
+    return f"{_SK_PREFIX}{session_id}{_SK_QUESTION_SEP}{question_id}"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def upsert_form_answer(
+    *,
+    form_slug: str,
+    session_id: str,
+    question_id: str,
+    question_type: str,
+    selected_option: str | None = None,
+    free_text: str | None = None,
+) -> dict[str, Any]:
+    """Persist one question answer; overwrites prior value for the same session/question."""
+    table = _get_table()
+    key = {
+        "pk": _partition_key(form_slug=form_slug),
+        "sk": _sort_key(session_id=session_id, question_id=question_id),
+    }
+    now = _now_iso()
+    item: dict[str, Any] = {
+        **key,
+        "formSlug": form_slug,
+        "sessionId": session_id,
+        "questionId": question_id,
+        "questionType": question_type,
+        "updatedAt": now,
+    }
+    if selected_option is not None:
+        item["selectedOption"] = selected_option
+    if free_text is not None:
+        item["freeText"] = free_text
+
+    try:
+        existing = table.get_item(Key=key).get("Item")
+        if existing and existing.get("createdAt"):
+            item["createdAt"] = existing["createdAt"]
+        else:
+            item["createdAt"] = now
+        table.put_item(Item=item)
+    except ClientError:
+        logger.exception(
+            "Failed to persist form answer",
+            extra={
+                "form_slug": form_slug,
+                "question_id": question_id,
+            },
+        )
+        raise AppError(
+            "Failed to persist form answer",
+            status_code=500,
+        ) from None
+
+    return {
+        "formSlug": form_slug,
+        "sessionId": session_id,
+        "questionId": question_id,
+        "updatedAt": now,
+    }
+
+
+def list_form_summaries() -> list[dict[str, Any]]:
+    """Return distinct form slugs with answer row counts from DynamoDB."""
+    table = _get_table()
+    slug_counts: Counter[str] = Counter()
+    scan_kwargs: dict[str, Any] = {
+        "FilterExpression": Attr("pk").begins_with(_PK_PREFIX),
+        "ProjectionExpression": "pk, formSlug, sk",
+    }
+    try:
+        while True:
+            response = table.scan(**scan_kwargs)
+            for item in response.get("Items", []):
+                sk = item.get("sk")
+                if not isinstance(sk, str) or not sk.startswith(_SK_PREFIX):
+                    continue
+                slug = _extract_form_slug_from_item(item)
+                if slug:
+                    slug_counts[slug] += 1
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            scan_kwargs["ExclusiveStartKey"] = last_key
+    except ClientError:
+        logger.exception("Failed to scan form responses table")
+        raise AppError(
+            "Failed to list form responses",
+            status_code=500,
+        ) from None
+
+    return [
+        {"formSlug": slug, "answerCount": count}
+        for slug, count in sorted(slug_counts.items())
+    ]
+
+
+def list_form_answers(*, form_slug: str) -> list[dict[str, Any]]:
+    """Return all answer rows for one form, sorted by updated time descending."""
+    table = _get_table()
+    try:
+        items = _query_form_items(table=table, form_slug=form_slug)
+    except ClientError:
+        logger.exception(
+            "Failed to query form answers",
+            extra={"form_slug": form_slug},
+        )
+        raise AppError(
+            "Failed to list form answers",
+            status_code=500,
+        ) from None
+
+    serialized = [serialize_form_answer_item(item) for item in items]
+    serialized.sort(
+        key=lambda row: (
+            str(row.get("updatedAt") or ""),
+            str(row.get("sessionId") or ""),
+            str(row.get("questionId") or ""),
+        ),
+        reverse=True,
+    )
+    return serialized
+
+
+def serialize_form_answer_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Map a DynamoDB form answer item to an admin API payload."""
+    row: dict[str, Any] = {
+        "formSlug": item.get("formSlug"),
+        "sessionId": item.get("sessionId"),
+        "questionId": item.get("questionId"),
+        "questionType": item.get("questionType"),
+        "createdAt": item.get("createdAt"),
+        "updatedAt": item.get("updatedAt"),
+    }
+    selected_option = item.get("selectedOption")
+    if isinstance(selected_option, str):
+        row["selectedOption"] = selected_option
+    free_text = item.get("freeText")
+    if isinstance(free_text, str):
+        row["freeText"] = free_text
+    return row
+
+
+def clear_form_answers(*, form_slug: str) -> int:
+    """Delete all answer rows for one form. Returns the number of rows removed."""
+    table = _get_table()
+    try:
+        items = _query_form_items(table=table, form_slug=form_slug)
+    except ClientError:
+        logger.exception(
+            "Failed to query form answers for clear",
+            extra={"form_slug": form_slug},
+        )
+        raise AppError(
+            "Failed to clear form answers",
+            status_code=500,
+        ) from None
+
+    if not items:
+        return 0
+
+    try:
+        with table.batch_writer() as batch:
+            for item in items:
+                batch.delete_item(
+                    Key={
+                        "pk": item["pk"],
+                        "sk": item["sk"],
+                    }
+                )
+    except ClientError:
+        logger.exception(
+            "Failed to delete form answers",
+            extra={"form_slug": form_slug},
+        )
+        raise AppError(
+            "Failed to clear form answers",
+            status_code=500,
+        ) from None
+
+    return len(items)
+
+
+def _extract_form_slug_from_item(item: Mapping[str, Any]) -> str | None:
+    form_slug = item.get("formSlug")
+    if isinstance(form_slug, str):
+        normalized = form_slug.strip()
+        if normalized:
+            return normalized
+    pk = item.get("pk")
+    if isinstance(pk, str) and pk.startswith(_PK_PREFIX):
+        normalized = pk[len(_PK_PREFIX) :].strip()
+        return normalized or None
+    return None
+
+
+def _query_form_items(*, table: Any, form_slug: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    query_kwargs: dict[str, Any] = {
+        "KeyConditionExpression": Key("pk").eq(_partition_key(form_slug=form_slug)),
+    }
+    while True:
+        response = table.query(**query_kwargs)
+        for item in response.get("Items", []):
+            sk = item.get("sk")
+            if isinstance(sk, str) and sk.startswith(_SK_PREFIX):
+                items.append(item)
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        query_kwargs["ExclusiveStartKey"] = last_key
+    return items
+
+
+def reset_table_for_tests() -> None:
+    """Clear cached table handle (unit tests only)."""
+    global _dynamodb, _table
+    _dynamodb = None
+    _table = None
+
+
+def configure_table_for_tests(table: Any) -> None:
+    """Inject a mock table (unit tests only)."""
+    global _table
+    _table = table

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -51,6 +51,9 @@ info:
     - `POST /v1/admin/organizations/{id}/members`
     - `PATCH /v1/admin/organizations/{id}/members/{memberId}`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
+    - `GET /v1/admin/forms` (lists form slugs with answer counts from DynamoDB)
+    - `GET|DELETE /v1/admin/forms/{form_slug}/answers` (`DELETE` removes all stored answers for the form)
+    - `GET /v1/admin/forms/{form_slug}/answers/export` (CSV export of all answers for the form)
     - `GET /v1/admin/polls` (lists poll slugs with answer counts from DynamoDB)
     - `GET|DELETE /v1/admin/polls/{poll_slug}/answers` (`DELETE` removes all stored answers for the poll)
     - `GET /v1/admin/polls/{poll_slug}/answers/export` (CSV export of all answers for the poll)
@@ -3998,6 +4001,78 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/admin/forms:
+    get:
+      summary: List training form slugs with answer counts
+      description: |
+        Returns distinct form slugs discovered in the DynamoDB responses table,
+        each with the number of stored answer rows.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Form summary list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminFormListResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/forms/{form_slug}/answers:
+    parameters:
+      - $ref: "#/components/parameters/FormSlug"
+    get:
+      summary: List all stored answers for a form
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Form answer rows for the selected form.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminFormAnswerListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      summary: Clear all stored answers for a form
+      description: Permanently deletes every answer row for the form slug in DynamoDB.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Form answers cleared.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminFormClearAnswersResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/forms/{form_slug}/answers/export:
+    parameters:
+      - $ref: "#/components/parameters/FormSlug"
+    get:
+      summary: Export form answers as CSV
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: CSV export generated.
+          content:
+            text/csv:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /v1/admin/polls:
     get:
       summary: List training poll slugs with answer counts
@@ -4161,6 +4236,14 @@ components:
         type: string
         format: uuid
       description: Sales lead identifier.
+    FormSlug:
+      name: form_slug
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+      description: Training form slug (kebab-case).
     PollSlug:
       name: poll_slug
       in: path
@@ -7712,6 +7795,82 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AdminTagRef"
+    AdminFormSummary:
+      type: object
+      required:
+        - formSlug
+        - answerCount
+      properties:
+        formSlug:
+          type: string
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        answerCount:
+          type: integer
+          minimum: 0
+    AdminFormListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminFormSummary"
+    AdminFormAnswerRow:
+      type: object
+      required:
+        - formSlug
+        - sessionId
+        - questionId
+        - questionType
+        - createdAt
+        - updatedAt
+      properties:
+        formSlug:
+          type: string
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        sessionId:
+          type: string
+          format: uuid
+        questionId:
+          type: string
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        questionType:
+          type: string
+          enum: [select, text, email]
+        selectedOption:
+          type: string
+          maxLength: 500
+        freeText:
+          type: string
+          maxLength: 4000
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    AdminFormAnswerListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminFormAnswerRow"
+    AdminFormClearAnswersResponse:
+      type: object
+      required:
+        - formSlug
+        - deletedCount
+      properties:
+        formSlug:
+          type: string
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+        deletedCount:
+          type: integer
+          minimum: 0
     AdminPollSummary:
       type: object
       required:

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -18,6 +18,8 @@ info:
     - Public calendar feed (`/v1/calendar/public`, `/www/v1/calendar/public`).
     - Public calendar availability (`/v1/calendar/availability`, `/www/v1/calendar/availability`).
     - Media lead capture (`/v1/assets/free/request`, `/www/v1/assets/free/request`).
+    - Training form answer persistence (`PUT /v1/forms/{form_slug}/answers`,
+      `/www/v1/forms/{form_slug}/answers`) for `apps/training` (DynamoDB; API key only).
     - Training poll answer persistence (`PUT /v1/polls/{poll_slug}/answers`,
       `/www/v1/polls/{poll_slug}/answers`), facilitator control
       (`GET`/`PUT /v1/polls/{poll_slug}/control`, `/www/.../control`), and live
@@ -892,6 +894,60 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /v1/forms/{form_slug}/answers:
+    put:
+      summary: Persist one form question answer (direct API path)
+      description: >
+        Upserts a single question answer for a training-site form session.
+        Used by `apps/training` when the respondent advances to the next question.
+        Answers are stored in the shared DynamoDB table `evolvesprouts-poll-responses`
+        (partition key `FORM#<form_slug>`, sort key `SESSION#<session_id>#Q#<question_id>`).
+        Re-submitting the same session and question overwrites the prior row.
+        Requires API key; Turnstile is not used on this route.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: form_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+          description: Form identifier (for example `workshop-feedback`).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FormAnswerPutRequest"
+      responses:
+        "200":
+          description: Answer persisted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FormAnswerPutResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Form path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Persistence failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /v1/polls/{poll_slug}/answers:
     put:
       summary: Persist one poll question answer (direct API path)
@@ -1230,6 +1286,53 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Aggregation failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /www/v1/forms/{form_slug}/answers:
+    put:
+      summary: Persist one form question answer (training website proxy path)
+      description: Same as `PUT /v1/forms/{form_slug}/answers` for same-origin calls from `apps/training`.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: form_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FormAnswerPutRequest"
+      responses:
+        "200":
+          description: Answer persisted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FormAnswerPutResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Form path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Persistence failed.
           content:
             application/json:
               schema:
@@ -2332,6 +2435,54 @@ components:
         "data[id]":
           type: string
           maxLength: 64
+    FormAnswerPutRequest:
+      type: object
+      required:
+        - sessionId
+        - questionId
+        - questionType
+      properties:
+        formSlug:
+          type: string
+          pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+          description: Optional; when present must match the `{form_slug}` path segment.
+        sessionId:
+          type: string
+          format: uuid
+          description: Client-generated session id (stored in browser session storage).
+        questionId:
+          type: string
+          pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        questionType:
+          type: string
+          enum: [select, text, email]
+        selectedOption:
+          type: string
+          maxLength: 500
+          description: Selected option label for `select` questions.
+        freeText:
+          type: string
+          maxLength: 4000
+          description: Response body for `text` and `email` questions.
+    FormAnswerPutResponse:
+      type: object
+      required:
+        - formSlug
+        - sessionId
+        - questionId
+        - updatedAt
+      properties:
+        formSlug:
+          type: string
+        sessionId:
+          type: string
+          format: uuid
+        questionId:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+          description: UTC timestamp when the answer row was last written.
     PollAnswerPutRequest:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -40,6 +40,8 @@ their primary responsibilities.
   `purpose=consultation_booking` uses `Cache-Control: no-store` on success; intro-call uses the standard public cacheable GET headers),
   `/v1/discounts/validate`,
   `/v1/contact-us`,
+  `/v1/forms/{form_slug}/answers` (PUT; API key; persists training form answers to DynamoDB
+  `evolvesprouts-poll-responses`; same contract as `/www/v1/forms/{form_slug}/answers`),
   `/v1/polls/{poll_slug}/answers` (PUT; API key; persists training poll answers to DynamoDB
   `evolvesprouts-poll-responses`; same contract as `/www/v1/polls/{poll_slug}/answers`),
   `/v1/polls/{poll_slug}/questions/{question_id}/results` (GET; API key; live aggregates for
@@ -97,6 +99,10 @@ their primary responsibilities.
   for non-vendor orgs; `POST /v1/admin/organizations/{id}/members` derives each member's role from the
   linked contact's `contact_type`; `PATCH /v1/admin/organizations/{id}/members/{memberId}` updates
   membership fields such as primary contact),
+  `/v1/admin/forms` (lists form slugs with answer counts from DynamoDB
+  `evolvesprouts-poll-responses`), `/v1/admin/forms/{form_slug}/answers`
+  (`GET` lists all stored answer rows; `DELETE` clears all rows for the form),
+  `/v1/admin/forms/{form_slug}/answers/export` (`GET`; CSV export),
   `/v1/admin/polls` (lists poll slugs with answer counts from DynamoDB
   `evolvesprouts-poll-responses`), `/v1/admin/polls/{poll_slug}/answers`
   (`GET` lists all stored answer rows; `DELETE` clears all rows for the poll),

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -39,10 +39,12 @@ Flutter Mobile / Next.js Admin
 
 ### Public website (Next.js static export)
 - Public marketing site in `apps/public_www`.
-- Training and poll pages in `apps/training` (static export at `training.evolvesprouts.com`, not indexed).
-  Poll answers persist via `PUT /www/v1/polls/{poll_slug}/answers` and live per-question
-  aggregates load via `GET /www/v1/polls/{poll_slug}/questions/{question_id}/results`
-  against the shared DynamoDB table `evolvesprouts-poll-responses` (content-driven JSON
+- Training form and poll pages in `apps/training` (static export at `training.evolvesprouts.com`, not indexed).
+  Form answers persist via `PUT /www/v1/forms/{form_slug}/answers` against the shared
+  DynamoDB table `evolvesprouts-poll-responses` (content-driven JSON per form under
+  `apps/training/src/content/forms/`). Poll answers persist via
+  `PUT /www/v1/polls/{poll_slug}/answers` and live per-question aggregates load via
+  `GET /www/v1/polls/{poll_slug}/questions/{question_id}/results` (content-driven JSON
   per poll under `apps/training/src/content/polls/`).
 - First-party marketing paths are defined once in `apps/public_www/src/lib/public-www-routes.ts` and
   imported by `apps/public_www/src/lib/routes.ts` and the admin Website QR presets so public and admin

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -300,6 +300,8 @@ Current allowlisted public website POST paths include:
 - `/www/v1/reservations`
 - `/www/v1/reservations/payment-intent`
 
+Training form persistence uses `PUT /www/v1/forms/{form_slug}/answers` (prefix +
+`/answers` suffix rule in `WWW_PROXY_ALLOWLIST_FUNCTION`; not a fixed path per form).
 Training poll persistence uses `PUT /www/v1/polls/{poll_slug}/answers` (prefix +
 `/answers` suffix rule in `WWW_PROXY_ALLOWLIST_FUNCTION`; not a fixed path per poll).
 Live poll aggregates use `GET /www/v1/polls/{poll_slug}/questions/{question_id}/results`

--- a/tests/test_admin_forms_api.py
+++ b/tests/test_admin_forms_api.py
@@ -1,0 +1,75 @@
+"""Tests for admin form response management routes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.api import admin_forms
+from app.exceptions import ValidationError
+from app.services import form_responses_store as store
+
+
+@pytest.fixture(autouse=True)
+def reset_form_store() -> None:
+    store.reset_table_for_tests()
+    yield
+    store.reset_table_for_tests()
+
+
+def _identity_event(api_gateway_event: Any, *, method: str, path: str) -> dict[str, Any]:
+    return api_gateway_event(
+        method=method,
+        path=path,
+        headers={"authorization": "Bearer test-token"},
+    )
+
+
+def test_list_forms_requires_auth(api_gateway_event: Any) -> None:
+    with pytest.raises(ValidationError, match="Authenticated user is required"):
+        admin_forms.handle_admin_forms_request(
+            api_gateway_event(method="GET", path="/v1/admin/forms"),
+            "GET",
+            "/v1/admin/forms",
+        )
+
+
+def test_list_forms_returns_summaries(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    table = MagicMock()
+    table.scan.return_value = {
+        "Items": [
+            {
+                "pk": "FORM#workshop-feedback",
+                "formSlug": "workshop-feedback",
+                "sk": "SESSION#550e8400-e29b-41d4-a716-446655440000#Q#name",
+            },
+            {
+                "pk": "FORM#workshop-feedback",
+                "formSlug": "workshop-feedback",
+                "sk": "SESSION#550e8400-e29b-41d4-a716-446655440000#Q#email",
+            },
+        ]
+    }
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+    monkeypatch.setattr(
+        admin_forms,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_forms.handle_admin_forms_request(
+        _identity_event(api_gateway_event, method="GET", path="/v1/admin/forms"),
+        "GET",
+        "/v1/admin/forms",
+    )
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["items"] == [{"formSlug": "workshop-feedback", "answerCount": 2}]

--- a/tests/test_public_forms_api.py
+++ b/tests/test_public_forms_api.py
@@ -1,0 +1,92 @@
+"""Tests for PUT /v1/forms/{form_slug}/answers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.api import public_forms as pf
+from app.services import form_responses_store as store
+
+
+@pytest.fixture(autouse=True)
+def reset_form_store() -> None:
+    store.reset_table_for_tests()
+    yield
+    store.reset_table_for_tests()
+
+
+def _event(api_gateway_event: Any, *, body: dict[str, Any]) -> dict[str, Any]:
+    return api_gateway_event(
+        method="PUT",
+        path="/www/v1/forms/workshop-feedback/answers",
+        body=json.dumps(body),
+        headers={"content-type": "application/json"},
+    )
+
+
+def test_put_form_answer_persists_select(api_gateway_event: Any, mock_env: Any) -> None:
+    table = MagicMock()
+    table.get_item.return_value = {"Item": None}
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    body = {
+        "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+        "questionId": "rating",
+        "questionType": "select",
+        "selectedOption": "Excellent",
+    }
+    resp = pf.handle_public_forms_request(
+        _event(api_gateway_event, body=body),
+        "PUT",
+        "/www/v1/forms/workshop-feedback/answers",
+    )
+    assert resp["statusCode"] == 200
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["selectedOption"] == "Excellent"
+    assert item["pk"] == "FORM#workshop-feedback"
+
+
+def test_put_form_answer_persists_text(api_gateway_event: Any, mock_env: Any) -> None:
+    table = MagicMock()
+    table.get_item.return_value = {"Item": None}
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    body = {
+        "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+        "questionId": "comments",
+        "questionType": "text",
+        "freeText": "Great workshop",
+    }
+    resp = pf.handle_public_forms_request(
+        _event(api_gateway_event, body=body),
+        "PUT",
+        "/www/v1/forms/workshop-feedback/answers",
+    )
+    assert resp["statusCode"] == 200
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["freeText"] == "Great workshop"
+
+
+def test_put_form_answer_rejects_truefalse(api_gateway_event: Any, mock_env: Any) -> None:
+    table = MagicMock()
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    body = {
+        "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+        "questionId": "rating",
+        "questionType": "truefalse",
+        "booleanAnswer": True,
+    }
+    resp = pf.handle_public_forms_request(
+        _event(api_gateway_event, body=body),
+        "PUT",
+        "/www/v1/forms/workshop-feedback/answers",
+    )
+    assert resp["statusCode"] == 400


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **forms** feature for the training site, modeled on polls but without facilitator controls, live results, or quiz feedback. Form definitions stay in JSON under `apps/training/src/content/forms/`; responses persist to the shared DynamoDB `poll-responses` table using `FORM#` partition keys.

## Training (`apps/training`)

- Static route `/forms/{slug}/` with registry in `form-types.ts` (starter: `workshop-feedback`)
- Shared copy in `forms-common.json`
- Linear wizard (`FormWizard`) for `select`, `text`, and `email` fields — all questions available immediately (no waiting/control page)
- `PUT /www/v1/forms/{slug}/answers` via `forms-api.ts` and session storage

## Admin (`apps/admin_web`)

- **Website → Forms** tab (between QR Codes and Polls)
- List/export/clear stored answers from DynamoDB (same UX pattern as Polls tab)
- QR preset for workshop feedback form

## Backend

- `public_forms.py`, `admin_forms.py`, `form_responses_store.py`
- API Gateway `PUT /v1/forms/{form_slug}/answers`
- CloudFront allowlist for `/www/v1/forms/.../answers`
- OpenAPI updates in `docs/api/public.yaml` and `docs/api/admin.yaml`

## How to add a new form

1. Add `apps/training/src/content/forms/{slug}.json`
2. Register import in `form-types.ts`
3. Rebuild/deploy the training static site

## Tests

- Python: `tests/test_public_forms_api.py`, `tests/test_admin_forms_api.py`
- Training/admin Vitest for registry, form page, forms panel, website tabs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20fbe4b3-9aca-4eb5-8861-271464c14caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20fbe4b3-9aca-4eb5-8861-271464c14caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

