### PR TITLE
Fix workshop poll test after challenge interstitial disabled

### DIFF
--- a/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
+++ b/apps/training/tests/app/workshop-food-jun-26-page.test.tsx
@@ -109,7 +109,7 @@ describe('WorkshopFoodJun26PollPage', () => {
     expect(backButton).toHaveClass('es-btn--outline');
   });
 
-  it('shows results step for challenge question before continuing', async () => {
+  it('advances from challenge to the next question without a results interstitial', async () => {
     if (!poll) {
       throw new Error('Expected workshop-food-jun-26 poll content');
     }
@@ -133,9 +133,19 @@ describe('WorkshopFoodJun26PollPage', () => {
     await user.click(screen.getByLabelText(challenge.options[0] ?? ''));
     await user.click(screen.getByRole('button', { name: POLLS_COMMON.navigation.next }));
 
-    expect(screen.getByText(challenge.presenterNote ?? '')).toBeInTheDocument();
+    const myth1 = poll.questions[2];
+    if (!myth1 || myth1.type !== 'truefalse') {
+      throw new Error('Expected myth1 truefalse question');
+    }
+    await waitFor(() => {
+      expect(screen.getByText(myth1.question)).toBeInTheDocument();
+    });
+    if (challenge.presenterNote) {
+      expect(screen.queryByText(challenge.presenterNote)).not.toBeInTheDocument();
+    }
     expect(
-      screen.getByRole('button', { name: POLLS_COMMON.navigation.continue }),
-    ).toBeInTheDocument();
+      screen.queryByRole('button', { name: POLLS_COMMON.navigation.continue }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: POLLS_COMMON.navigation.next })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI failure from [actions run 26577640852](https://github.com/lcacchiani/evolvesprouts/actions/runs/26577640852).

Recent updates to `workshop-food-jun-26.json` set `showAnswer` and `showResults` to `false` on the challenge question, so the poll wizard no longer shows the presenter-note interstitial after that step. The integration test still expected that screen.

## Changes

- Update `apps/training/tests/app/workshop-food-jun-26-page.test.tsx` to assert the wizard advances directly to the first myth question and does not show the continue interstitial or presenter note.

## Testing

- `cd apps/training && npm run test -- tests/app/workshop-food-jun-26-page.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f4e268a-ef7b-45c5-8dbd-b15968e6f723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f4e268a-ef7b-45c5-8dbd-b15968e6f723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

