### PR TITLE
Fix poll thank-you unlock and resume after refresh

### DIFF
--- a/apps/training/src/components/polls/poll-answer-state.ts
+++ b/apps/training/src/components/polls/poll-answer-state.ts
@@ -1,3 +1,6 @@
+import type { PollQuestion } from '@/content/poll-types';
+import type { PollSessionAnswerItem } from '@/lib/polls-api';
+
 export interface QuestionAnswerState {
   selectedOption: string;
   trueFalseValue: boolean | null;
@@ -12,7 +15,64 @@ export function emptyAnswerState(): QuestionAnswerState {
   };
 }
 
-import type { PollQuestion } from '@/content/poll-types';
+export function answerStateFromSessionItem(
+  item: PollSessionAnswerItem,
+): QuestionAnswerState {
+  if (item.questionType === 'select') {
+    return {
+      selectedOption: item.selectedOption?.trim() ?? '',
+      trueFalseValue: null,
+      freeText: '',
+    };
+  }
+  if (item.questionType === 'truefalse') {
+    return {
+      selectedOption: '',
+      trueFalseValue:
+        typeof item.booleanAnswer === 'boolean' ? item.booleanAnswer : null,
+      freeText: '',
+    };
+  }
+  return {
+    selectedOption: '',
+    trueFalseValue: null,
+    freeText: item.freeText?.trim() ?? '',
+  };
+}
+
+export function mergeSessionAnswers(
+  items: PollSessionAnswerItem[],
+): Record<string, QuestionAnswerState> {
+  const merged: Record<string, QuestionAnswerState> = {};
+  for (const item of items) {
+    if (!item.questionId?.trim()) {
+      continue;
+    }
+    merged[item.questionId] = answerStateFromSessionItem(item);
+  }
+  return merged;
+}
+
+export function findFirstUnansweredQuestionIndex(
+  questions: PollQuestion[],
+  answersByQuestionId: Record<string, QuestionAnswerState>,
+): number {
+  const index = questions.findIndex((question) => {
+    const answer = answersByQuestionId[question.id] ?? emptyAnswerState();
+    return !isAnswerValid(question, answer);
+  });
+  if (index < 0) {
+    return Math.max(0, questions.length - 1);
+  }
+  return index;
+}
+
+export function hasUnlockablePollQuestions(
+  allQuestions: PollQuestion[],
+  enabledQuestionIds: ReadonlySet<string>,
+): boolean {
+  return allQuestions.some((question) => !enabledQuestionIds.has(question.id));
+}
 
 export function isAnswerValid(question: PollQuestion, answer: QuestionAnswerState): boolean {
   if (question.type === 'select') {

--- a/apps/training/src/components/polls/poll-wizard.tsx
+++ b/apps/training/src/components/polls/poll-wizard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   emptyAnswerState,
+  hasUnlockablePollQuestions,
   isAnswerValid,
+  mergeSessionAnswers,
   type QuestionAnswerState,
 } from '@/components/polls/poll-answer-state';
 import { PollAnswerPanel } from '@/components/polls/poll-answer-panel';
@@ -12,7 +14,11 @@ import { PollLiveResultsPanel } from '@/components/polls/poll-live-results-panel
 import { PollQuestionField } from '@/components/polls/poll-question-field';
 import type { PollContent, PollQuestion, PollsCommonContent } from '@/content/poll-types';
 import { getOrCreatePollSessionId } from '@/lib/poll-session';
-import { PollApiError, persistPollAnswer } from '@/lib/polls-api';
+import {
+  fetchPollSessionAnswers,
+  PollApiError,
+  persistPollAnswer,
+} from '@/lib/polls-api';
 import { usePollControlState } from '@/lib/use-poll-control-state';
 
 export interface PollWizardProps {
@@ -25,14 +31,17 @@ type StepPhase = 'answer' | 'feedback' | 'liveResults';
 export function PollWizard({ poll, common }: PollWizardProps) {
   const [stepIndex, setStepIndex] = useState(0);
   const [stepPhase, setStepPhase] = useState<StepPhase>('answer');
-  const [isComplete, setIsComplete] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [isSessionLoading, setIsSessionLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [answersByQuestionId, setAnswersByQuestionId] = useState<
     Record<string, QuestionAnswerState>
   >({});
+  const [completedQuestionIds, setCompletedQuestionIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
 
-  const sessionId = useMemo(() => getOrCreatePollSessionId(), []);
+  const sessionId = useMemo(() => getOrCreatePollSessionId(poll.slug), [poll.slug]);
   const { enabledQuestionIds, isLoading: isControlLoading } = usePollControlState({
     pollSlug: poll.slug,
     allowWrites: false,
@@ -42,6 +51,121 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     () => poll.questions.filter((question) => enabledQuestionIds.has(question.id)),
     [enabledQuestionIds, poll.questions],
   );
+
+  const hasUnlockableQuestions = useMemo(
+    () => hasUnlockablePollQuestions(poll.questions, enabledQuestionIds),
+    [enabledQuestionIds, poll.questions],
+  );
+
+  const isCaughtUp = useMemo(() => {
+    if (activeQuestions.length === 0) {
+      return false;
+    }
+    return activeQuestions.every((question) => completedQuestionIds.has(question.id));
+  }, [activeQuestions, completedQuestionIds]);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setIsSessionLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadSessionAnswers(): Promise<void> {
+      setIsSessionLoading(true);
+      try {
+        const session = await fetchPollSessionAnswers(poll.slug, sessionId);
+        if (cancelled) {
+          return;
+        }
+        const mergedAnswers = mergeSessionAnswers(session.answers);
+        setAnswersByQuestionId((previous) => ({
+          ...previous,
+          ...mergedAnswers,
+        }));
+        setCompletedQuestionIds(
+          new Set(session.answers.map((item) => item.questionId).filter(Boolean)),
+        );
+      } catch {
+        if (!cancelled) {
+          // Resume is best-effort; the respondent can still answer from scratch.
+        }
+      } finally {
+        if (!cancelled) {
+          setIsSessionLoading(false);
+        }
+      }
+    }
+
+    void loadSessionAnswers();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [poll.slug, sessionId]);
+
+  const positionedAfterSessionLoadRef = useRef(false);
+  const wasCaughtUpRef = useRef(false);
+
+  useEffect(() => {
+    if (isSessionLoading) {
+      positionedAfterSessionLoadRef.current = false;
+    }
+  }, [isSessionLoading]);
+
+  useEffect(() => {
+    if (isControlLoading || isSessionLoading || activeQuestions.length === 0) {
+      return;
+    }
+    if (positionedAfterSessionLoadRef.current) {
+      return;
+    }
+    positionedAfterSessionLoadRef.current = true;
+    if (isCaughtUp) {
+      return;
+    }
+    const nextIndex = activeQuestions.findIndex(
+      (question) => !completedQuestionIds.has(question.id),
+    );
+    if (nextIndex >= 0) {
+      setStepIndex(nextIndex);
+      setStepPhase('answer');
+    }
+  }, [
+    activeQuestions,
+    completedQuestionIds,
+    isCaughtUp,
+    isControlLoading,
+    isSessionLoading,
+  ]);
+
+  useEffect(() => {
+    if (isControlLoading || isSessionLoading) {
+      return;
+    }
+    if (isCaughtUp) {
+      wasCaughtUpRef.current = true;
+      return;
+    }
+    if (!wasCaughtUpRef.current) {
+      return;
+    }
+    wasCaughtUpRef.current = false;
+    const nextIndex = activeQuestions.findIndex(
+      (question) => !completedQuestionIds.has(question.id),
+    );
+    if (nextIndex >= 0) {
+      setStepIndex(nextIndex);
+      setStepPhase('answer');
+    }
+  }, [
+    activeQuestions,
+    completedQuestionIds,
+    isCaughtUp,
+    isControlLoading,
+    isSessionLoading,
+  ]);
 
   const resolvedStepIndex =
     activeQuestions.length === 0 ? 0 : Math.min(stepIndex, activeQuestions.length - 1);
@@ -58,7 +182,9 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     total: totalSteps,
   });
 
-  if (!isControlLoading && activeQuestions.length === 0) {
+  const isBootstrapping = isControlLoading || isSessionLoading;
+
+  if (!isBootstrapping && activeQuestions.length === 0) {
     return (
       <section className='mx-auto flex w-full max-w-xl flex-col gap-3 text-center'>
         <h2 className='es-type-title text-2xl'>{common.waiting.title}</h2>
@@ -67,7 +193,7 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     );
   }
 
-  if (isControlLoading || !currentQuestion) {
+  if (isBootstrapping || !currentQuestion) {
     return (
       <section className='mx-auto flex w-full max-w-xl flex-col gap-3 text-center'>
         <p className='es-text-body text-base'>{common.waiting.description}</p>
@@ -75,11 +201,16 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     );
   }
 
-  if (isComplete) {
+  if (isCaughtUp) {
     return (
       <section className='mx-auto flex w-full max-w-xl flex-col gap-3 text-center'>
         <h2 className='es-type-title text-2xl'>{common.completion.title}</h2>
         <p className='es-text-body text-base'>{common.completion.description}</p>
+        {hasUnlockableQuestions ? (
+          <p className='es-text-body text-base'>
+            {common.completion.moreComingDescription}
+          </p>
+        ) : null}
       </section>
     );
   }
@@ -199,6 +330,11 @@ export function PollWizard({ poll, common }: PollWizardProps) {
       return;
     }
     setIsSaving(false);
+    setCompletedQuestionIds((previous) => {
+      const next = new Set(previous);
+      next.add(currentQuestion.id);
+      return next;
+    });
 
     if (currentQuestion.showAnswer) {
       setStepPhase('feedback');
@@ -210,16 +346,11 @@ export function PollWizard({ poll, common }: PollWizardProps) {
       return;
     }
 
-    if (isLastStep) {
-      setIsComplete(true);
-      return;
-    }
     advanceToNextQuestion();
   }
 
   function advanceToNextQuestion(): void {
     if (isLastStep) {
-      setIsComplete(true);
       return;
     }
     setStepIndex((index) => Math.min(index + 1, activeQuestions.length - 1));

--- a/apps/training/src/components/polls/poll-wizard.tsx
+++ b/apps/training/src/components/polls/poll-wizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import {
   emptyAnswerState,
@@ -28,20 +28,27 @@ export interface PollWizardProps {
 
 type StepPhase = 'answer' | 'feedback' | 'liveResults';
 
-export function PollWizard({ poll, common }: PollWizardProps) {
-  const [stepIndex, setStepIndex] = useState(0);
-  const [stepPhase, setStepPhase] = useState<StepPhase>('answer');
-  const [isSaving, setIsSaving] = useState(false);
-  const [isSessionLoading, setIsSessionLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [answersByQuestionId, setAnswersByQuestionId] = useState<
-    Record<string, QuestionAnswerState>
-  >({});
-  const [completedQuestionIds, setCompletedQuestionIds] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
+interface ManualNavigation {
+  stepIndex: number;
+  activeQuestionIdsKey: string;
+}
 
+export function PollWizard({ poll, common }: PollWizardProps) {
   const sessionId = useMemo(() => getOrCreatePollSessionId(poll.slug), [poll.slug]);
+  const {
+    isSessionLoading,
+    answersByQuestionId,
+    setAnswersByQuestionId,
+    completedQuestionIds,
+    setCompletedQuestionIds,
+  } = usePollSessionHydration(poll.slug, sessionId);
+
+  const [manualNavigation, setManualNavigation] = useState<ManualNavigation | null>(
+    null,
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
   const { enabledQuestionIds, isLoading: isControlLoading } = usePollControlState({
     pollSlug: poll.slug,
     allowWrites: false,
@@ -50,6 +57,11 @@ export function PollWizard({ poll, common }: PollWizardProps) {
   const activeQuestions = useMemo(
     () => poll.questions.filter((question) => enabledQuestionIds.has(question.id)),
     [enabledQuestionIds, poll.questions],
+  );
+
+  const activeQuestionIdsKey = useMemo(
+    () => activeQuestions.map((question) => question.id).join(','),
+    [activeQuestions],
   );
 
   const hasUnlockableQuestions = useMemo(
@@ -64,122 +76,35 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     return activeQuestions.every((question) => completedQuestionIds.has(question.id));
   }, [activeQuestions, completedQuestionIds]);
 
-  useEffect(() => {
-    if (!sessionId) {
-      setIsSessionLoading(false);
-      return;
-    }
+  const resumeStepIndex = useMemo(
+    () => resolveResumeStepIndex(activeQuestions, completedQuestionIds),
+    [activeQuestions, completedQuestionIds],
+  );
 
-    let cancelled = false;
-
-    async function loadSessionAnswers(): Promise<void> {
-      setIsSessionLoading(true);
-      try {
-        const session = await fetchPollSessionAnswers(poll.slug, sessionId);
-        if (cancelled) {
-          return;
-        }
-        const mergedAnswers = mergeSessionAnswers(session.answers);
-        setAnswersByQuestionId((previous) => ({
-          ...previous,
-          ...mergedAnswers,
-        }));
-        setCompletedQuestionIds(
-          new Set(session.answers.map((item) => item.questionId).filter(Boolean)),
-        );
-      } catch {
-        if (!cancelled) {
-          // Resume is best-effort; the respondent can still answer from scratch.
-        }
-      } finally {
-        if (!cancelled) {
-          setIsSessionLoading(false);
-        }
-      }
+  const effectiveStepIndex = useMemo(() => {
+    if (
+      manualNavigation !== null &&
+      manualNavigation.activeQuestionIdsKey === activeQuestionIdsKey
+    ) {
+      return clampStepIndex(manualNavigation.stepIndex, activeQuestions.length);
     }
-
-    void loadSessionAnswers();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [poll.slug, sessionId]);
-
-  const positionedAfterSessionLoadRef = useRef(false);
-  const wasCaughtUpRef = useRef(false);
-
-  useEffect(() => {
-    if (isSessionLoading) {
-      positionedAfterSessionLoadRef.current = false;
-    }
-  }, [isSessionLoading]);
-
-  useEffect(() => {
-    if (isControlLoading || isSessionLoading || activeQuestions.length === 0) {
-      return;
-    }
-    if (positionedAfterSessionLoadRef.current) {
-      return;
-    }
-    positionedAfterSessionLoadRef.current = true;
-    if (isCaughtUp) {
-      return;
-    }
-    const nextIndex = activeQuestions.findIndex(
-      (question) => !completedQuestionIds.has(question.id),
-    );
-    if (nextIndex >= 0) {
-      setStepIndex(nextIndex);
-      setStepPhase('answer');
-    }
+    return resumeStepIndex;
   }, [
-    activeQuestions,
-    completedQuestionIds,
-    isCaughtUp,
-    isControlLoading,
-    isSessionLoading,
+    activeQuestionIdsKey,
+    activeQuestions.length,
+    manualNavigation,
+    resumeStepIndex,
   ]);
 
-  useEffect(() => {
-    if (isControlLoading || isSessionLoading) {
-      return;
-    }
-    if (isCaughtUp) {
-      wasCaughtUpRef.current = true;
-      return;
-    }
-    if (!wasCaughtUpRef.current) {
-      return;
-    }
-    wasCaughtUpRef.current = false;
-    const nextIndex = activeQuestions.findIndex(
-      (question) => !completedQuestionIds.has(question.id),
-    );
-    if (nextIndex >= 0) {
-      setStepIndex(nextIndex);
-      setStepPhase('answer');
-    }
-  }, [
-    activeQuestions,
-    completedQuestionIds,
-    isCaughtUp,
-    isControlLoading,
-    isSessionLoading,
-  ]);
-
-  const resolvedStepIndex =
-    activeQuestions.length === 0 ? 0 : Math.min(stepIndex, activeQuestions.length - 1);
-
-  const totalSteps = activeQuestions.length;
-  const currentQuestion = activeQuestions[resolvedStepIndex];
+  const currentQuestion = activeQuestions[effectiveStepIndex];
   const currentAnswer = currentQuestion
     ? (answersByQuestionId[currentQuestion.id] ?? emptyAnswerState())
     : emptyAnswerState();
 
   const progressLabel = formatProgressLabel({
     template: common.a11y.progressTemplate,
-    current: totalSteps === 0 ? 0 : resolvedStepIndex + 1,
-    total: totalSteps,
+    current: activeQuestions.length === 0 ? 0 : effectiveStepIndex + 1,
+    total: activeQuestions.length,
   });
 
   const isBootstrapping = isControlLoading || isSessionLoading;
@@ -215,11 +140,105 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     );
   }
 
-  const isFirstStep = resolvedStepIndex === 0;
-  const isLastStep = resolvedStepIndex === totalSteps - 1;
-  const showingFeedback = stepPhase === 'feedback' && currentQuestion.showAnswer;
-  const showingLiveResults =
-    stepPhase === 'liveResults' && currentQuestion.showResults;
+  return (
+    <PollWizardActiveStep
+      key={currentQuestion.id}
+      poll={poll}
+      common={common}
+      sessionId={sessionId}
+      activeQuestions={activeQuestions}
+      activeQuestionIdsKey={activeQuestionIdsKey}
+      question={currentQuestion}
+      answer={currentAnswer}
+      stepIndex={effectiveStepIndex}
+      progressLabel={progressLabel}
+      isSaving={isSaving}
+      errorMessage={errorMessage}
+      onAnswerChange={(patch) => updateAnswerState(currentQuestion.id, patch)}
+      onBack={() => {
+        setErrorMessage(null);
+        setManualNavigation({
+          stepIndex: Math.max(0, effectiveStepIndex - 1),
+          activeQuestionIdsKey,
+        });
+      }}
+      onErrorMessage={setErrorMessage}
+      onSavingChange={setIsSaving}
+      onPersistSuccess={() => {
+        setCompletedQuestionIds((previous) => {
+          const next = new Set(previous);
+          next.add(currentQuestion.id);
+          return next;
+        });
+      }}
+      onAdvance={() => {
+        setManualNavigation({
+          stepIndex: Math.min(effectiveStepIndex + 1, activeQuestions.length - 1),
+          activeQuestionIdsKey,
+        });
+      }}
+    />
+  );
+
+  function updateAnswerState(
+    questionId: string,
+    patch: Partial<QuestionAnswerState>,
+  ): void {
+    setAnswersByQuestionId((previous) => ({
+      ...previous,
+      [questionId]: {
+        ...emptyAnswerState(),
+        ...previous[questionId],
+        ...patch,
+      },
+    }));
+  }
+}
+
+interface PollWizardActiveStepProps {
+  poll: PollContent;
+  common: PollsCommonContent;
+  sessionId: string;
+  activeQuestions: PollQuestion[];
+  activeQuestionIdsKey: string;
+  question: PollQuestion;
+  answer: QuestionAnswerState;
+  stepIndex: number;
+  progressLabel: string;
+  isSaving: boolean;
+  errorMessage: string | null;
+  onAnswerChange: (patch: Partial<QuestionAnswerState>) => void;
+  onBack: () => void;
+  onErrorMessage: (message: string | null) => void;
+  onSavingChange: (isSaving: boolean) => void;
+  onPersistSuccess: () => void;
+  onAdvance: () => void;
+}
+
+function PollWizardActiveStep({
+  poll,
+  common,
+  sessionId,
+  activeQuestions,
+  question,
+  answer,
+  stepIndex,
+  progressLabel,
+  isSaving,
+  errorMessage,
+  onAnswerChange,
+  onBack,
+  onErrorMessage,
+  onSavingChange,
+  onPersistSuccess,
+  onAdvance,
+}: PollWizardActiveStepProps) {
+  const [stepPhase, setStepPhase] = useState<StepPhase>('answer');
+
+  const isFirstStep = stepIndex === 0;
+  const isLastStep = stepIndex === activeQuestions.length - 1;
+  const showingFeedback = stepPhase === 'feedback' && question.showAnswer;
+  const showingLiveResults = stepPhase === 'liveResults' && question.showResults;
   const onInterstitial = showingFeedback || showingLiveResults;
   const primaryLabel = resolvePrimaryLabel({
     common,
@@ -231,25 +250,17 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     <section className='mx-auto flex w-full max-w-xl flex-col gap-6'>
       <p className='es-text-muted text-sm'>{progressLabel}</p>
       {showingFeedback ? (
-        <PollAnswerPanel
-          question={currentQuestion}
-          common={common}
-          answer={currentAnswer}
-        />
+        <PollAnswerPanel question={question} common={common} answer={answer} />
       ) : null}
       {showingLiveResults ? (
-        <PollLiveResultsPanel
-          pollSlug={poll.slug}
-          question={currentQuestion}
-          common={common}
-        />
+        <PollLiveResultsPanel pollSlug={poll.slug} question={question} common={common} />
       ) : null}
       {!onInterstitial ? (
         <PollQuestionField
-          question={currentQuestion}
+          question={question}
           common={common}
-          answer={currentAnswer}
-          onAnswerChange={(patch) => updateAnswerState(currentQuestion.id, patch)}
+          answer={answer}
+          onAnswerChange={onAnswerChange}
         />
       ) : null}
       {errorMessage ? (
@@ -263,11 +274,7 @@ export function PollWizard({ poll, common }: PollWizardProps) {
             type='button'
             className='es-btn es-btn--primary es-btn--outline es-focus-ring'
             disabled={isSaving}
-            onClick={() => {
-              setErrorMessage(null);
-              setStepIndex((index) => Math.max(0, Math.min(index, activeQuestions.length - 1) - 1));
-              setStepPhase('answer');
-            }}
+            onClick={onBack}
           >
             {common.navigation.back}
           </button>
@@ -284,78 +291,132 @@ export function PollWizard({ poll, common }: PollWizardProps) {
     </section>
   );
 
-  function updateAnswerState(
-    questionId: string,
-    patch: Partial<QuestionAnswerState>,
-  ): void {
-    setAnswersByQuestionId((previous) => ({
-      ...previous,
-      [questionId]: {
-        ...emptyAnswerState(),
-        ...previous[questionId],
-        ...patch,
-      },
-    }));
-  }
-
   async function handlePrimaryAction(): Promise<void> {
-    setErrorMessage(null);
+    onErrorMessage(null);
 
     if (onInterstitial) {
-      if (showingFeedback && currentQuestion.showResults) {
+      if (showingFeedback && question.showResults) {
         setStepPhase('liveResults');
         return;
       }
-      advanceToNextQuestion();
+      if (!isLastStep) {
+        onAdvance();
+      }
       return;
     }
 
-    const validationError = validateAnswer(currentQuestion, currentAnswer, common);
+    const validationError = validateAnswer(question, answer, common);
     if (validationError) {
-      setErrorMessage(validationError);
+      onErrorMessage(validationError);
       return;
     }
 
-    setIsSaving(true);
+    onSavingChange(true);
     try {
       await persistPollAnswer({
         pollSlug: poll.slug,
         sessionId,
-        question: currentQuestion,
-        answer: currentAnswer,
+        question,
+        answer,
       });
     } catch (error) {
-      setErrorMessage(resolvePersistErrorMessage(error, common));
-      setIsSaving(false);
+      onErrorMessage(resolvePersistErrorMessage(error, common));
+      onSavingChange(false);
       return;
     }
-    setIsSaving(false);
-    setCompletedQuestionIds((previous) => {
-      const next = new Set(previous);
-      next.add(currentQuestion.id);
-      return next;
-    });
+    onSavingChange(false);
+    onPersistSuccess();
 
-    if (currentQuestion.showAnswer) {
+    if (question.showAnswer) {
       setStepPhase('feedback');
       return;
     }
 
-    if (currentQuestion.showResults) {
+    if (question.showResults) {
       setStepPhase('liveResults');
       return;
     }
 
-    advanceToNextQuestion();
+    if (!isLastStep) {
+      onAdvance();
+    }
   }
+}
 
-  function advanceToNextQuestion(): void {
-    if (isLastStep) {
+type SessionHydrationStatus = 'pending' | 'ready' | 'skipped';
+
+function usePollSessionHydration(pollSlug: string, sessionId: string) {
+  const [status, setStatus] = useState<SessionHydrationStatus>(() =>
+    sessionId ? 'pending' : 'skipped',
+  );
+  const [answersByQuestionId, setAnswersByQuestionId] = useState<
+    Record<string, QuestionAnswerState>
+  >({});
+  const [completedQuestionIds, setCompletedQuestionIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  useEffect(() => {
+    if (!sessionId) {
       return;
     }
-    setStepIndex((index) => Math.min(index + 1, activeQuestions.length - 1));
-    setStepPhase('answer');
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const session = await fetchPollSessionAnswers(pollSlug, sessionId);
+        if (cancelled) {
+          return;
+        }
+        setAnswersByQuestionId(mergeSessionAnswers(session.answers));
+        setCompletedQuestionIds(
+          new Set(session.answers.map((item) => item.questionId).filter(Boolean)),
+        );
+      } catch {
+        // Resume is best-effort; the respondent can still answer from scratch.
+      } finally {
+        if (!cancelled) {
+          setStatus('ready');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pollSlug, sessionId]);
+
+  return {
+    isSessionLoading: status === 'pending',
+    answersByQuestionId,
+    setAnswersByQuestionId,
+    completedQuestionIds,
+    setCompletedQuestionIds,
+  };
+}
+
+function resolveResumeStepIndex(
+  activeQuestions: PollQuestion[],
+  completedQuestionIds: ReadonlySet<string>,
+): number {
+  if (activeQuestions.length === 0) {
+    return 0;
   }
+  const nextIndex = activeQuestions.findIndex(
+    (question) => !completedQuestionIds.has(question.id),
+  );
+  if (nextIndex >= 0) {
+    return nextIndex;
+  }
+  return activeQuestions.length - 1;
+}
+
+function clampStepIndex(stepIndex: number, activeQuestionCount: number): number {
+  if (activeQuestionCount === 0) {
+    return 0;
+  }
+  return Math.min(Math.max(0, stepIndex), activeQuestionCount - 1);
 }
 
 function resolvePersistErrorMessage(

--- a/apps/training/src/content/poll-types.ts
+++ b/apps/training/src/content/poll-types.ts
@@ -67,6 +67,7 @@ export interface PollsCommonContent {
   completion: {
     title: string;
     description: string;
+    moreComingDescription: string;
   };
   waiting: {
     title: string;

--- a/apps/training/src/content/polls-common.json
+++ b/apps/training/src/content/polls-common.json
@@ -21,7 +21,8 @@
   },
   "completion": {
     "title": "Thank you",
-    "description": "Your responses have been saved."
+    "description": "Your responses have been saved.",
+    "moreComingDescription": "Stay tuned for more questions!"
   },
   "waiting": {
     "title": "Please wait",

--- a/apps/training/src/lib/poll-session.ts
+++ b/apps/training/src/lib/poll-session.ts
@@ -1,14 +1,19 @@
-const STORAGE_KEY = 'evolvesprouts-poll-session-id';
+const STORAGE_KEY_PREFIX = 'evolvesprouts-poll-session-id';
 
-export function getOrCreatePollSessionId(): string {
+function storageKey(pollSlug: string): string {
+  return `${STORAGE_KEY_PREFIX}:${pollSlug}`;
+}
+
+export function getOrCreatePollSessionId(pollSlug: string): string {
   if (typeof window === 'undefined') {
     return '';
   }
-  const existing = window.sessionStorage.getItem(STORAGE_KEY)?.trim();
+  const key = storageKey(pollSlug);
+  const existing = window.sessionStorage.getItem(key)?.trim();
   if (existing) {
     return existing;
   }
   const created = crypto.randomUUID();
-  window.sessionStorage.setItem(STORAGE_KEY, created);
+  window.sessionStorage.setItem(key, created);
   return created;
 }

--- a/apps/training/src/lib/polls-api.ts
+++ b/apps/training/src/lib/polls-api.ts
@@ -57,6 +57,24 @@ export interface PollControlState {
   updatedAt?: string;
 }
 
+export interface PollSessionAnswerItem {
+  pollSlug?: string;
+  sessionId?: string;
+  questionId: string;
+  questionType: PollQuestion['type'];
+  selectedOption?: string;
+  booleanAnswer?: boolean;
+  freeText?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface PollSessionAnswers {
+  pollSlug: string;
+  sessionId: string;
+  answers: PollSessionAnswerItem[];
+}
+
 export type PollAggregatableQuestionType = 'select' | 'truefalse' | 'text' | 'email';
 
 export interface FetchPollQuestionResultsInput {
@@ -140,6 +158,32 @@ export async function persistPollControlState(
   }
 
   return (await response.json()) as PollControlState;
+}
+
+export async function fetchPollSessionAnswers(
+  pollSlug: string,
+  sessionId: string,
+): Promise<PollSessionAnswers> {
+  const config = resolvePollApiConfig();
+  if (!config) {
+    throw new PollApiError('Poll API is not configured', 0);
+  }
+
+  const params = new URLSearchParams({ sessionId });
+  const endpointPath = `${config.baseUrl}/v1/polls/${encodeURIComponent(pollSlug)}/answers?${params.toString()}`;
+  const response = await fetch(endpointPath, {
+    method: 'GET',
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new PollApiError('Failed to load poll session answers', response.status);
+  }
+
+  return (await response.json()) as PollSessionAnswers;
 }
 
 export async function persistPollAnswer(

--- a/apps/training/tests/components/polls/poll-answer-state.test.ts
+++ b/apps/training/tests/components/polls/poll-answer-state.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { isAnswerValid } from '@/components/polls/poll-answer-state';
+import {
+  answerStateFromSessionItem,
+  emptyAnswerState,
+  hasUnlockablePollQuestions,
+  isAnswerValid,
+  mergeSessionAnswers,
+} from '@/components/polls/poll-answer-state';
 import type { PollQuestion } from '@/content/poll-types';
-import { emptyAnswerState } from '@/components/polls/poll-answer-state';
 
 describe('isAnswerValid', () => {
   const selectQuestion: PollQuestion = {
@@ -51,5 +56,66 @@ describe('isAnswerValid', () => {
         { ...emptyAnswerState(), freeText: 'not-an-email' },
       ),
     ).toBe(false);
+  });
+});
+
+describe('session answer helpers', () => {
+  it('maps persisted rows into local answer state', () => {
+    expect(
+      answerStateFromSessionItem({
+        questionId: 'role',
+        questionType: 'select',
+        selectedOption: 'Parent',
+      }),
+    ).toEqual({
+      selectedOption: 'Parent',
+      trueFalseValue: null,
+      freeText: '',
+    });
+    expect(
+      answerStateFromSessionItem({
+        questionId: 'myth1',
+        questionType: 'truefalse',
+        booleanAnswer: false,
+      }).trueFalseValue,
+    ).toBe(false);
+  });
+
+  it('merges session answers by question id', () => {
+    const merged = mergeSessionAnswers([
+      {
+        questionId: 'role',
+        questionType: 'select',
+        selectedOption: 'Parent',
+      },
+    ]);
+    expect(merged.role?.selectedOption).toBe('Parent');
+  });
+
+  it('detects unlockable questions from poll content', () => {
+    const questions: PollQuestion[] = [
+      {
+        id: 'role',
+        type: 'select',
+        screen: 's',
+        question: 'q',
+        options: ['A'],
+        showAnswer: false,
+        showResults: false,
+      },
+      {
+        id: 'challenge',
+        type: 'select',
+        screen: 's',
+        question: 'q',
+        options: ['A'],
+        showAnswer: false,
+        showResults: false,
+      },
+    ];
+    expect(hasUnlockablePollQuestions(questions, new Set(['role']))).toBe(true);
+    expect(hasUnlockablePollQuestions(questions, new Set(['role', 'challenge']))).toBe(
+      false,
+    );
   });
 });

--- a/apps/training/tests/components/polls/poll-wizard-resume.test.tsx
+++ b/apps/training/tests/components/polls/poll-wizard-resume.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PollWizard } from '@/components/polls/poll-wizard';
+import { getPollContent, POLLS_COMMON } from '@/lib/polls';
+import * as pollsApi from '@/lib/polls-api';
+
+describe('PollWizard resume and completion', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
+  });
+
+  it('shows stay tuned copy when more poll questions can be unlocked', async () => {
+    const poll = getPollContent('workshop-food-jun-26');
+    if (!poll) {
+      throw new Error('expected poll fixture');
+    }
+
+    vi.spyOn(pollsApi, 'fetchPollControlState').mockResolvedValue({
+      pollSlug: poll.slug,
+      enabledQuestionIds: ['role'],
+    });
+    vi.spyOn(pollsApi, 'fetchPollSessionAnswers').mockResolvedValue({
+      pollSlug: poll.slug,
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      answers: [
+        {
+          questionId: 'role',
+          questionType: 'select',
+          selectedOption: 'Parent',
+        },
+      ],
+    });
+    vi.spyOn(pollsApi, 'persistPollAnswer').mockResolvedValue();
+
+    render(<PollWizard poll={poll} common={POLLS_COMMON} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Thank you')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Your responses have been saved.')).toBeInTheDocument();
+    expect(screen.getByText('Stay tuned for more questions!')).toBeInTheDocument();
+  });
+
+  it('returns to the wizard when control enables another question after thank you', async () => {
+    const poll = getPollContent('workshop-food-jun-26');
+    if (!poll) {
+      throw new Error('expected poll fixture');
+    }
+
+    let fetchCount = 0;
+    vi.spyOn(pollsApi, 'fetchPollControlState').mockImplementation(async () => {
+      fetchCount += 1;
+      return {
+        pollSlug: poll.slug,
+        enabledQuestionIds:
+          fetchCount === 1 ? ['role'] : ['role', 'challenge'],
+      };
+    });
+    vi.spyOn(pollsApi, 'fetchPollSessionAnswers').mockResolvedValue({
+      pollSlug: poll.slug,
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      answers: [
+        {
+          questionId: 'role',
+          questionType: 'select',
+          selectedOption: 'Parent',
+        },
+      ],
+    });
+    vi.spyOn(pollsApi, 'persistPollAnswer').mockResolvedValue();
+
+    render(<PollWizard poll={poll} common={POLLS_COMMON} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Thank you')).toBeInTheDocument();
+    });
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText('What is the biggest mealtime challenge in your home?'),
+        ).toBeInTheDocument();
+      },
+      { timeout: 4000 },
+    );
+    expect(screen.queryByText('Thank you')).toBeNull();
+  });
+
+  it('resumes at the first unanswered enabled question after refresh hydration', async () => {
+    const poll = getPollContent('workshop-food-jun-26');
+    if (!poll) {
+      throw new Error('expected poll fixture');
+    }
+
+    vi.spyOn(pollsApi, 'fetchPollControlState').mockResolvedValue({
+      pollSlug: poll.slug,
+      enabledQuestionIds: ['role', 'challenge', 'myth1'],
+    });
+    vi.spyOn(pollsApi, 'fetchPollSessionAnswers').mockResolvedValue({
+      pollSlug: poll.slug,
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      answers: [
+        {
+          questionId: 'role',
+          questionType: 'select',
+          selectedOption: 'Parent',
+        },
+      ],
+    });
+    vi.spyOn(pollsApi, 'persistPollAnswer').mockResolvedValue();
+
+    render(<PollWizard poll={poll} common={POLLS_COMMON} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('What is the biggest mealtime challenge in your home?'),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText('Question 2 of 3')).toBeInTheDocument();
+  });
+
+  it('scopes session ids per poll slug in session storage', () => {
+    const poll = getPollContent('workshop-food-jun-26');
+    if (!poll) {
+      throw new Error('expected poll fixture');
+    }
+
+    vi.spyOn(pollsApi, 'fetchPollControlState').mockResolvedValue({
+      pollSlug: poll.slug,
+      enabledQuestionIds: [],
+    });
+    vi.spyOn(pollsApi, 'fetchPollSessionAnswers').mockResolvedValue({
+      pollSlug: poll.slug,
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      answers: [],
+    });
+
+    render(<PollWizard poll={poll} common={POLLS_COMMON} />);
+
+    expect(
+      window.sessionStorage.getItem('evolvesprouts-poll-session-id:workshop-food-jun-26'),
+    ).toBeTruthy();
+    expect(window.sessionStorage.getItem('evolvesprouts-poll-session-id')).toBeNull();
+  });
+});

--- a/apps/training/tests/polls/polls-api.test.ts
+++ b/apps/training/tests/polls/polls-api.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchPollControlState,
   fetchPollQuestionResults,
+  fetchPollSessionAnswers,
   persistPollControlState,
   PollApiError,
   resolvePollApiConfig,
@@ -79,6 +80,38 @@ describe('fetchPollQuestionResults', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/www/v1/polls/workshop-food-jun-26/questions/role/results?questionType=select',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { 'x-api-key': 'poll-key' },
+      }),
+    );
+  });
+});
+
+describe('fetchPollSessionAnswers', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('requests session answers with sessionId query param', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', '/www');
+    vi.stubEnv('NEXT_PUBLIC_TRAINING_API_KEY', 'poll-key');
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        pollSlug: 'workshop-food-jun-26',
+        sessionId,
+        answers: [],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchPollSessionAnswers('workshop-food-jun-26', sessionId);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/www/v1/polls/workshop-food-jun-26/answers?sessionId=${sessionId}`,
       expect.objectContaining({
         method: 'GET',
         headers: { 'x-api-key': 'poll-key' },

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2959,6 +2959,7 @@ export class ApiStack extends cdk.Stack {
     addPublicApiKeyMethod(formBySlug.addResource("answers"), "PUT");
     const polls = v1.addResource("polls");
     const pollBySlug = polls.addResource("{poll_slug}");
+    addPublicApiKeyMethod(pollBySlug.addResource("answers"), "GET");
     addPublicApiKeyMethod(pollBySlug.addResource("answers"), "PUT");
     const pollControl = pollBySlug.addResource("control");
     addPublicApiKeyMethod(pollControl, "GET");

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -2959,8 +2959,9 @@ export class ApiStack extends cdk.Stack {
     addPublicApiKeyMethod(formBySlug.addResource("answers"), "PUT");
     const polls = v1.addResource("polls");
     const pollBySlug = polls.addResource("{poll_slug}");
-    addPublicApiKeyMethod(pollBySlug.addResource("answers"), "GET");
-    addPublicApiKeyMethod(pollBySlug.addResource("answers"), "PUT");
+    const pollAnswers = pollBySlug.addResource("answers");
+    addPublicApiKeyMethod(pollAnswers, "GET");
+    addPublicApiKeyMethod(pollAnswers, "PUT");
     const pollControl = pollBySlug.addResource("control");
     addPublicApiKeyMethod(pollControl, "GET");
     addPublicApiKeyMethod(pollControl, "PUT");

--- a/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
+++ b/backend/infrastructure/lib/cloudfront-www-proxy-functions.ts
@@ -68,7 +68,7 @@ function handler(event) {
     uri.indexOf('/www/v1/polls/') === 0 &&
     uri.lastIndexOf('/answers') === uri.length - 8;
   if (
-    (method === 'PUT' || method === 'OPTIONS') &&
+    (method === 'GET' || method === 'PUT' || method === 'OPTIONS') &&
     isPollAnswersPath
   ) {
     request.uri = uri.substring(4);

--- a/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
+++ b/backend/infrastructure/test/cloudfront-www-proxy-functions.test.ts
@@ -63,6 +63,14 @@ function main(): void {
       "WWW_PROXY_ALLOWLIST_FUNCTION missing poll PUT /answers suffix rule",
     );
   }
+  if (
+    !WWW_PROXY_ALLOWLIST_FUNCTION.includes("method === 'GET'") ||
+    !WWW_PROXY_ALLOWLIST_FUNCTION.includes("isPollAnswersPath")
+  ) {
+    throw new Error(
+      "WWW_PROXY_ALLOWLIST_FUNCTION missing poll GET /answers allowlist rule",
+    );
+  }
   if (!WWW_PROXY_ALLOWLIST_FUNCTION.includes("method === 'OPTIONS'")) {
     throw new Error(
       "WWW_PROXY_ALLOWLIST_FUNCTION must allow OPTIONS for poll answer preflight",

--- a/backend/src/app/api/public_polls.py
+++ b/backend/src/app/api/public_polls.py
@@ -13,6 +13,7 @@ from app.exceptions import ValidationError
 from app.services.poll_responses_store import (
     aggregate_poll_question_results,
     get_poll_control_state,
+    list_poll_answers_for_session,
     put_poll_control_state,
     upsert_poll_answer,
 )
@@ -56,6 +57,8 @@ def handle_public_polls_request(
         poll_slug, _suffix = answers
         if method == "PUT":
             return _handle_put_poll_answer(event, poll_slug=poll_slug)
+        if method == "GET":
+            return _handle_get_poll_session_answers(event, poll_slug=poll_slug)
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     results = _parse_poll_question_results_path(path)
@@ -238,6 +241,31 @@ def _validate_control_body(body: Mapping[str, Any]) -> list[str]:
         seen.add(normalized)
         enabled.append(normalized)
     return enabled
+
+
+def _handle_get_poll_session_answers(
+    event: Mapping[str, Any],
+    *,
+    poll_slug: str,
+) -> dict[str, Any]:
+    try:
+        session_id = _require_session_id(_read_query_param(event, "sessionId"))
+    except ValidationError as exc:
+        return json_response(exc.status_code, exc.to_dict(), event=event)
+
+    items = list_poll_answers_for_session(
+        poll_slug=poll_slug,
+        session_id=session_id,
+    )
+    return json_response(
+        200,
+        {
+            "pollSlug": poll_slug,
+            "sessionId": session_id,
+            "answers": items,
+        },
+        event=event,
+    )
 
 
 def _handle_put_poll_answer(

--- a/backend/src/app/services/poll_responses_store.py
+++ b/backend/src/app/services/poll_responses_store.py
@@ -303,6 +303,38 @@ def list_poll_summaries() -> list[dict[str, Any]]:
     ]
 
 
+def list_poll_answers_for_session(
+    *,
+    poll_slug: str,
+    session_id: str,
+) -> list[dict[str, Any]]:
+    """Return answer rows for one poll session (respondent resume)."""
+    table = _get_table()
+    try:
+        items = _query_poll_items(table=table, poll_slug=poll_slug)
+    except ClientError:
+        logger.exception(
+            "Failed to query poll session answers",
+            extra={"poll_slug": poll_slug},
+        )
+        raise AppError(
+            "Failed to list poll session answers",
+            status_code=500,
+        ) from None
+
+    sk_prefix = f"{_SK_PREFIX}{session_id}{_SK_QUESTION_SEP}"
+    matching = [
+        item
+        for item in items
+        if isinstance(item.get("sk"), str) and item["sk"].startswith(sk_prefix)
+    ]
+    serialized = [serialize_poll_answer_item(item) for item in matching]
+    serialized.sort(
+        key=lambda row: str(row.get("questionId") or ""),
+    )
+    return serialized
+
+
 def list_poll_answers(*, poll_slug: str) -> list[dict[str, Any]]:
     """Return all answer rows for one poll, sorted by updated time descending."""
     table = _get_table()

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -21,7 +21,9 @@ info:
     - Training form answer persistence (`PUT /v1/forms/{form_slug}/answers`,
       `/www/v1/forms/{form_slug}/answers`) for `apps/training` (DynamoDB; API key only).
     - Training poll answer persistence (`PUT /v1/polls/{poll_slug}/answers`,
-      `/www/v1/polls/{poll_slug}/answers`), facilitator control
+      `/www/v1/polls/{poll_slug}/answers`) and session resume
+      (`GET /v1/polls/{poll_slug}/answers?sessionId=…`, same `/www` prefix),
+      facilitator control
       (`GET`/`PUT /v1/polls/{poll_slug}/control`, `/www/.../control`), and live
       per-question aggregates (`GET /v1/polls/{poll_slug}/questions/{question_id}/results`,
       `/www/...`) for `apps/training` (DynamoDB; API key only).
@@ -949,6 +951,55 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
 
   /v1/polls/{poll_slug}/answers:
+    get:
+      summary: List persisted answers for one poll session (direct API path)
+      description: >
+        Returns all question answers stored for the given `sessionId` on this
+        poll. Used by `apps/training` on page load to resume the respondent
+        wizard after refresh. Requires API key.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: poll_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        - name: sessionId
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Client session id from browser session storage.
+      responses:
+        "200":
+          description: Session answers for the poll.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollSessionAnswersResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Poll path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Load failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     put:
       summary: Persist one poll question answer (direct API path)
       description: >
@@ -1339,6 +1390,51 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
 
   /www/v1/polls/{poll_slug}/answers:
+    get:
+      summary: List persisted answers for one poll session (training website proxy path)
+      description: Same as `GET /v1/polls/{poll_slug}/answers` for same-origin calls from `apps/training`.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: poll_slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        - name: sessionId
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Session answers for the poll.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollSessionAnswersResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Poll path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "405":
+          description: Method not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Load failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     put:
       summary: Persist one poll question answer (training website proxy path)
       description: Same as `PUT /v1/polls/{poll_slug}/answers` for same-origin calls from `apps/training`.
@@ -2534,6 +2630,50 @@ components:
           type: string
           format: date-time
           description: UTC timestamp when the answer row was last written.
+    PollSessionAnswerItem:
+      type: object
+      required:
+        - questionId
+        - questionType
+      properties:
+        pollSlug:
+          type: string
+        sessionId:
+          type: string
+          format: uuid
+        questionId:
+          type: string
+        questionType:
+          type: string
+          enum: [select, truefalse, text, email]
+        selectedOption:
+          type: string
+        booleanAnswer:
+          type: boolean
+        freeText:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    PollSessionAnswersResponse:
+      type: object
+      required:
+        - pollSlug
+        - sessionId
+        - answers
+      properties:
+        pollSlug:
+          type: string
+        sessionId:
+          type: string
+          format: uuid
+        answers:
+          type: array
+          items:
+            $ref: "#/components/schemas/PollSessionAnswerItem"
     PollControlStatePutRequest:
       type: object
       properties:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -42,8 +42,9 @@ their primary responsibilities.
   `/v1/contact-us`,
   `/v1/forms/{form_slug}/answers` (PUT; API key; persists training form answers to DynamoDB
   `evolvesprouts-poll-responses`; same contract as `/www/v1/forms/{form_slug}/answers`),
-  `/v1/polls/{poll_slug}/answers` (PUT; API key; persists training poll answers to DynamoDB
-  `evolvesprouts-poll-responses`; same contract as `/www/v1/polls/{poll_slug}/answers`),
+  `/v1/polls/{poll_slug}/answers` (GET lists answers for `sessionId`; PUT upserts one answer;
+  API key; DynamoDB `evolvesprouts-poll-responses`; same contract as
+  `/www/v1/polls/{poll_slug}/answers`),
   `/v1/polls/{poll_slug}/questions/{question_id}/results` (GET; API key; live aggregates for
   `select` / `truefalse` questions and free-text lists for `text` / `email`; same contract as
   `/www/v1/polls/.../results`),

--- a/tests/test_public_polls_api.py
+++ b/tests/test_public_polls_api.py
@@ -114,6 +114,78 @@ def test_put_poll_answer_persists_email(api_gateway_event: Any, mock_env: Any) -
     assert resp["statusCode"] == 200
 
 
+def test_get_poll_session_answers_returns_session_rows(
+    api_gateway_event: Any,
+    mock_env: Any,
+) -> None:
+    session_id = "550e8400-e29b-41d4-a716-446655440000"
+    table = MagicMock()
+    table.query.return_value = {
+        "Items": [
+            {
+                "pollSlug": "workshop-food-jun-26",
+                "sessionId": session_id,
+                "questionId": "role",
+                "questionType": "select",
+                "selectedOption": "Parent",
+                "sk": f"SESSION#{session_id}#Q#role",
+            },
+            {
+                "pollSlug": "workshop-food-jun-26",
+                "sessionId": "550e8400-e29b-41d4-a716-446655440001",
+                "questionId": "challenge",
+                "questionType": "select",
+                "selectedOption": "Other",
+                "sk": "SESSION#550e8400-e29b-41d4-a716-446655440001#Q#challenge",
+            },
+            {
+                "pollSlug": "workshop-food-jun-26",
+                "sessionId": session_id,
+                "questionId": "myth1",
+                "questionType": "truefalse",
+                "booleanAnswer": False,
+                "sk": f"SESSION#{session_id}#Q#myth1",
+            },
+        ],
+    }
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    event = api_gateway_event(
+        method="GET",
+        path="/www/v1/polls/workshop-food-jun-26/answers",
+        query_params={"sessionId": session_id},
+    )
+    resp = pp.handle_public_polls_request(
+        event,
+        "GET",
+        "/www/v1/polls/workshop-food-jun-26/answers",
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body["pollSlug"] == "workshop-food-jun-26"
+    assert body["sessionId"] == session_id
+    assert len(body["answers"]) == 2
+    question_ids = {row["questionId"] for row in body["answers"]}
+    assert question_ids == {"role", "myth1"}
+
+
+def test_get_poll_session_answers_rejects_invalid_session(
+    api_gateway_event: Any,
+) -> None:
+    event = api_gateway_event(
+        method="GET",
+        path="/www/v1/polls/workshop-food-jun-26/answers",
+        query_params={"sessionId": "not-a-uuid"},
+    )
+    resp = pp.handle_public_polls_request(
+        event,
+        "GET",
+        "/www/v1/polls/workshop-food-jun-26/answers",
+    )
+    assert resp["statusCode"] == 400
+
+
 def test_put_poll_answer_rejects_invalid_session(api_gateway_event: Any) -> None:
     body = {
         "sessionId": "not-a-uuid",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two participant poll issues on the training site:

1. **Thank-you screen stuck** — Completion is derived from persisted question ids instead of a sticky `isComplete` flag. When the facilitator enables another question, the wizard reopens on the first unanswered enabled question. The thank-you screen shows **"Stay tuned for more questions!"** under the saved message when the poll still has questions not yet enabled on control.

2. **Refresh restarts the poll** — Adds `GET /v1/polls/{poll_slug}/answers?sessionId=…` (and `/www` proxy) to load saved answers on mount and position the wizard on the first unanswered enabled question.

Also scopes poll session ids per slug in `sessionStorage` (`evolvesprouts-poll-session-id:<slug>`).

## API / infra

- New `GET` on poll answers (API Gateway + CloudFront allowlist)
- OpenAPI + `lambdas.md` updated

## Testing

- `pytest tests/test_public_polls_api.py`
- `npx vitest run` for training poll component/API tests
- CloudFront allowlist unit test
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1b2a36c-0466-4537-ac9b-ca4282634383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1b2a36c-0466-4537-ac9b-ca4282634383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

