### PR TITLE
Fix poll live results not shown when showResults is true

### DIFF
--- a/apps/training/src/components/polls/poll-wizard.tsx
+++ b/apps/training/src/components/polls/poll-wizard.tsx
@@ -325,7 +325,6 @@ function PollWizardActiveStep({
       return;
     }
     onSavingChange(false);
-    onPersistSuccess();
 
     if (question.showAnswer) {
       setStepPhase('feedback');
@@ -337,6 +336,11 @@ function PollWizardActiveStep({
       return;
     }
 
+    finishQuestionStep();
+  }
+
+  function finishQuestionStep(): void {
+    onPersistSuccess();
     if (!isLastStep) {
       onAdvance();
     }

--- a/apps/training/src/content/polls/workshop-food-jun-26.json
+++ b/apps/training/src/content/polls/workshop-food-jun-26.json
@@ -71,7 +71,7 @@
       "id": "onething",
       "type": "text",
       "screen": "Your one thing",
-      "question": "What is ONE thing you'll do differently — starting tomorrow?",
+      "question": "What is ONE thing you'll do differently — starting today?",
       "showAnswer": false,
       "showResults": false
     },

--- a/apps/training/tests/components/polls/poll-wizard-live-results.test.tsx
+++ b/apps/training/tests/components/polls/poll-wizard-live-results.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PollWizard } from '@/components/polls/poll-wizard';
+import { getPollContent, POLLS_COMMON } from '@/lib/polls';
+import * as pollsApi from '@/lib/polls-api';
+
+describe('PollWizard live results', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
+  });
+
+  it('shows live results after answering a showResults question before advancing', async () => {
+    const poll = getPollContent('workshop-food-jun-26');
+    if (!poll) {
+      throw new Error('expected poll fixture');
+    }
+
+    vi.spyOn(pollsApi, 'fetchPollControlState').mockResolvedValue({
+      pollSlug: poll.slug,
+      enabledQuestionIds: ['myth1'],
+    });
+    vi.spyOn(pollsApi, 'fetchPollSessionAnswers').mockResolvedValue({
+      pollSlug: poll.slug,
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      answers: [],
+    });
+    vi.spyOn(pollsApi, 'persistPollAnswer').mockResolvedValue();
+    vi.spyOn(pollsApi, 'fetchPollQuestionResults').mockResolvedValue({
+      pollSlug: poll.slug,
+      questionId: 'myth1',
+      questionType: 'truefalse',
+      totalResponses: 3,
+      buckets: [
+        { label: 'true', count: 1 },
+        { label: 'false', count: 2 },
+      ],
+    });
+
+    const user = userEvent.setup();
+    render(<PollWizard poll={poll} common={POLLS_COMMON} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Children must finish everything on their plate.'),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'False' }));
+    await user.click(screen.getByRole('button', { name: 'Finish' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Room results')).toBeInTheDocument();
+    });
+    expect(screen.getByText('3 responses so far')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Children must finish everything on their plate.'),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

For questions with `showResults: true` (for example the myth true/false items in `workshop-food-jun-26`), respondents never saw the live results panel after submitting an answer.

## Root cause

`PollWizard` called `onPersistSuccess()` immediately after the answer was saved. That added the question to `completedQuestionIds`, which updated `resumeStepIndex` to the **next** question before the `liveResults` interstitial could render. The active step jumped forward and remounted with `stepPhase: 'answer'`, so `PollLiveResultsPanel` never appeared.

## Fix

Defer marking a question complete until the respondent finishes any feedback/live-results interstitial (`finishQuestionStep()` runs on Continue, or immediately when neither interstitial applies).

## Copy change

Updated the `onething` question in `workshop-food-jun-26.json` from "starting tomorrow?" to "starting today?".

## Tests

- Added `poll-wizard-live-results.test.tsx` covering the myth question flow.
- All `tests/components/polls/` tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-664ef6b8-e311-44e4-8c77-d5798c68dc3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-664ef6b8-e311-44e4-8c77-d5798c68dc3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

