### PR TITLE
Add completion certificates on Services admin tab

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -60,6 +60,8 @@ const CONTACT_NAME_FAMILY_EMOJI = '👨‍👩‍👧';
 const CONTACT_NAME_ORG_EMOJI = '🏢';
 /** Shown after the contact name when `relationship_type` is `client`. */
 const CONTACT_NAME_CLIENT_EMOJI = '🤝';
+/** Shown when the contact has at least one issued completion certificate. */
+const CONTACT_NAME_CERTIFICATE_EMOJI = '🎓';
 
 type ApiSchemas = components['schemas'];
 
@@ -96,6 +98,9 @@ function contactNameListSuffix(row: ApiSchemas['AdminContact']): string {
   }
   if (row.relationship_type === 'client') {
     parts.push(CONTACT_NAME_CLIENT_EMOJI);
+  }
+  if (row.has_completion_certificate) {
+    parts.push(CONTACT_NAME_CERTIFICATE_EMOJI);
   }
   return parts.length > 0 ? ` ${parts.join(' ')}` : '';
 }

--- a/apps/admin_web/src/components/admin/services/certificates-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/certificates-panel.tsx
@@ -1,0 +1,567 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  AdminDataTable,
+  AdminDataTableBody,
+  AdminDataTableCell,
+  AdminDataTableHead,
+  AdminDataTableHeadCell,
+  AdminDataTableOperationsHeadCell,
+} from '@/components/ui/admin-data-table';
+import { AdminEditorCard } from '@/components/ui/admin-editor-card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
+import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
+import { Select } from '@/components/ui/select';
+import { StatusBanner } from '@/components/status-banner';
+import { DeleteIcon } from '@/components/icons/action-icons';
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
+import { useServiceInstanceOptions } from '@/hooks/use-service-instance-options';
+import type { useCompletionCertificates } from '@/hooks/use-completion-certificates';
+import { toErrorMessage } from '@/hooks/hook-errors';
+import {
+  getCompletionCertificatePdfDownload,
+  previewCompletionCertificatePdf,
+  type CompletionCertificate,
+  type CompletionCertificateDraftPayload,
+} from '@/lib/completion-certificates-api';
+import { searchEntityContactsForPicker } from '@/lib/entity-api';
+import { formatDate, formatDiscountCodeInstanceOptionLabel, formatServiceTitleWithTier } from '@/lib/format';
+import { isAbortRequestError } from '@/lib/services-api';
+
+import type { ServiceSummary } from '@/types/services';
+
+export interface CertificatesPanelProps {
+  certificates: ReturnType<typeof useCompletionCertificates>;
+  serviceOptions: ServiceSummary[];
+}
+
+function todayIsoDate(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function buildDraftPayload(
+  contactId: string,
+  serviceId: string,
+  instanceId: string,
+  participationDate: string,
+  programTitle: string,
+  partnerOrganizationId: string,
+): CompletionCertificateDraftPayload | null {
+  if (!contactId.trim() || !serviceId.trim() || !instanceId.trim() || !participationDate.trim()) {
+    return null;
+  }
+  return {
+    contactId: contactId.trim(),
+    serviceId: serviceId.trim(),
+    instanceId: instanceId.trim(),
+    participationDate: participationDate.trim(),
+    programTitle: programTitle.trim() || null,
+    partnerOrganizationId: partnerOrganizationId.trim() || null,
+  };
+}
+
+export function CertificatesPanel({ certificates, serviceOptions }: CertificatesPanelProps) {
+  const {
+    certificates: rows,
+    filters,
+    setFilter,
+    isLoading,
+    isLoadingMore,
+    isSaving,
+    error,
+    hasMore,
+    loadMore,
+    issueCertificate,
+    voidCertificate,
+    deleteCertificate,
+  } = certificates;
+
+  const instanceOptions = useServiceInstanceOptions();
+  const [confirmDialogProps, requestConfirm] = useConfirmDialog();
+
+  const [contactId, setContactId] = useState('');
+  const [contactSearchInput, setContactSearchInput] = useState('');
+  const [contactSearchResults, setContactSearchResults] = useState<{ id: string; label: string }[]>([]);
+  const [serviceId, setServiceId] = useState('');
+  const [instanceId, setInstanceId] = useState('');
+  const [partnerOrganizationId, setPartnerOrganizationId] = useState('');
+  const [programTitle, setProgramTitle] = useState('');
+  const [participationDate, setParticipationDate] = useState(todayIsoDate());
+  const [editorError, setEditorError] = useState('');
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState('');
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
+  const previewAbortRef = useRef<AbortController | null>(null);
+
+  const selectedInstance = useMemo(
+    () => instanceOptions.instances.find((i) => i.id === instanceId) ?? null,
+    [instanceOptions.instances, instanceId],
+  );
+
+  const activePartners = useMemo(
+    () => (selectedInstance?.partnerOrganizations ?? []).filter((p) => p.active),
+    [selectedInstance],
+  );
+
+  const contactOptions = useMemo(() => {
+    const byId = new Map(contactSearchResults.map((r) => [r.id, r.label]));
+    const cid = contactId.trim();
+    if (cid && !byId.has(cid)) {
+      byId.set(cid, contactSearchInput.trim() || cid);
+    }
+    return Array.from(byId.entries()).map(([id, label]) => ({ id, label }));
+  }, [contactSearchResults, contactId, contactSearchInput]);
+
+  useEffect(() => {
+    const q = contactSearchInput.trim();
+    if (q.length < 2) {
+      setContactSearchResults([]);
+      return;
+    }
+    let cancelled = false;
+    const handle = setTimeout(() => {
+      void (async () => {
+        try {
+          const items = await searchEntityContactsForPicker({ query: q, limit: 50 });
+          if (!cancelled) {
+            setContactSearchResults(items);
+          }
+        } catch {
+          if (!cancelled) {
+            setContactSearchResults([]);
+          }
+        }
+      })();
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [contactSearchInput]);
+
+  useEffect(() => {
+    if (!serviceId.trim()) {
+      setInstanceId('');
+      instanceOptions.loadForService(null);
+      return;
+    }
+    void instanceOptions.loadForService(serviceId);
+  }, [serviceId, instanceOptions]);
+
+  useEffect(() => {
+    if (!selectedInstance) {
+      setPartnerOrganizationId('');
+      return;
+    }
+    const defaultTitle =
+      selectedInstance.resolvedTitle?.trim() ||
+      selectedInstance.title?.trim() ||
+      '';
+    setProgramTitle(defaultTitle);
+    if (activePartners.length === 1) {
+      setPartnerOrganizationId(activePartners[0].id);
+    } else if (
+      partnerOrganizationId &&
+      !activePartners.some((p) => p.id === partnerOrganizationId)
+    ) {
+      setPartnerOrganizationId('');
+    }
+  }, [selectedInstance, activePartners, partnerOrganizationId]);
+
+  const draftPayload = buildDraftPayload(
+    contactId,
+    serviceId,
+    instanceId,
+    participationDate,
+    programTitle,
+    partnerOrganizationId,
+  );
+
+  const refreshPreview = useCallback(async () => {
+    if (!draftPayload) {
+      setPreviewUrl('');
+      setPreviewError('');
+      return;
+    }
+    if (activePartners.length > 0 && !draftPayload.partnerOrganizationId) {
+      setPreviewUrl('');
+      setPreviewError('Select a partner organisation for this instance.');
+      return;
+    }
+    previewAbortRef.current?.abort();
+    const controller = new AbortController();
+    previewAbortRef.current = controller;
+    setPreviewLoading(true);
+    setPreviewError('');
+    try {
+      const { downloadUrl } = await previewCompletionCertificatePdf(
+        draftPayload,
+        controller.signal,
+      );
+      setPreviewUrl(downloadUrl);
+    } catch (caught) {
+      if (isAbortRequestError(caught)) {
+        return;
+      }
+      setPreviewUrl('');
+      setPreviewError(
+        toErrorMessage(caught, 'Could not render certificate preview.'),
+      );
+    } finally {
+      if (!controller.signal.aborted) {
+        setPreviewLoading(false);
+      }
+    }
+  }, [draftPayload, activePartners.length]);
+
+  useEffect(() => {
+    if (!draftPayload) {
+      setPreviewUrl('');
+      setPreviewError('');
+      return;
+    }
+    const handle = setTimeout(() => {
+      void refreshPreview();
+    }, 500);
+    return () => clearTimeout(handle);
+  }, [draftPayload, refreshPreview]);
+
+  function resetEditor() {
+    setContactId('');
+    setContactSearchInput('');
+    setContactSearchResults([]);
+    setServiceId('');
+    setInstanceId('');
+    setPartnerOrganizationId('');
+    setProgramTitle('');
+    setParticipationDate(todayIsoDate());
+    setEditorError('');
+    setPreviewUrl('');
+    setPreviewError('');
+    setSelectedRowId(null);
+  }
+
+  async function handleIssue() {
+    if (!draftPayload) {
+      setEditorError('Contact, service, instance, and participation date are required.');
+      return;
+    }
+    if (activePartners.length > 0 && !draftPayload.partnerOrganizationId) {
+      setEditorError('Select a partner organisation.');
+      return;
+    }
+    setEditorError('');
+    try {
+      await issueCertificate(draftPayload);
+      resetEditor();
+    } catch (caught) {
+      setEditorError(toErrorMessage(caught, 'Could not issue certificate.'));
+    }
+  }
+
+  async function handleDownloadRow(row: CompletionCertificate) {
+    if (row.status !== 'issued') {
+      return;
+    }
+    try {
+      const { downloadUrl } = await getCompletionCertificatePdfDownload(row.id);
+      window.open(downloadUrl, '_blank', 'noopener,noreferrer');
+    } catch (caught) {
+      setEditorError(toErrorMessage(caught, 'Could not download certificate.'));
+    }
+  }
+
+  async function handleVoidRow(row: CompletionCertificate) {
+    const ok = await requestConfirm({
+      title: 'Void certificate?',
+      description: `Void the certificate for ${row.recipient_display_name}? The contact will no longer show the award badge.`,
+      confirmLabel: 'Void',
+      variant: 'destructive',
+    });
+    if (!ok) {
+      return;
+    }
+    try {
+      await voidCertificate(row.id);
+    } catch (caught) {
+      setEditorError(toErrorMessage(caught, 'Could not void certificate.'));
+    }
+  }
+
+  async function handleDeleteRow(row: CompletionCertificate) {
+    const ok = await requestConfirm({
+      title: 'Delete certificate?',
+      description: `Permanently delete the certificate record for ${row.recipient_display_name}?`,
+      confirmLabel: 'Delete',
+      variant: 'destructive',
+    });
+    if (!ok) {
+      return;
+    }
+    try {
+      await deleteCertificate(row.id);
+      if (selectedRowId === row.id) {
+        resetEditor();
+      }
+    } catch (caught) {
+      setEditorError(toErrorMessage(caught, 'Could not delete certificate.'));
+    }
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <ConfirmDialog {...confirmDialogProps} />
+      {error ? (
+        <StatusBanner variant='error' title='Certificates'>
+          {error}
+        </StatusBanner>
+      ) : null}
+      <AdminEditorCard
+        title='Issue certificate'
+        description='Link a completed enrollment to a certificate. Preview updates when the form is valid.'
+        actions={
+          <>
+            <Button type='button' variant='secondary' onClick={() => void refreshPreview()} disabled={previewLoading}>
+              Refresh preview
+            </Button>
+            <Button type='button' onClick={() => void handleIssue()} disabled={isSaving || !draftPayload}>
+              Issue certificate
+            </Button>
+          </>
+        }
+      >
+        {editorError ? (
+          <StatusBanner variant='error' title='Certificate'>
+            {editorError}
+          </StatusBanner>
+        ) : null}
+        <div className='grid gap-4 md:grid-cols-2'>
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='cert-contact-search'>Contact search</Label>
+            <Input
+              id='cert-contact-search'
+              value={contactSearchInput}
+              onChange={(e) => setContactSearchInput(e.target.value)}
+              placeholder='Type at least 2 characters'
+            />
+            <Label htmlFor='cert-contact-id'>Contact</Label>
+            <Select
+              id='cert-contact-id'
+              value={contactId}
+              onChange={(e) => {
+                setContactId(e.target.value);
+                const label = contactOptions.find((o) => o.id === e.target.value)?.label;
+                if (label) {
+                  setContactSearchInput(label);
+                }
+              }}
+            >
+              <option value=''>Select contact</option>
+              {contactOptions.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='cert-service-id'>Service</Label>
+            <Select
+              id='cert-service-id'
+              value={serviceId}
+              onChange={(e) => {
+                setServiceId(e.target.value);
+                setInstanceId('');
+              }}
+            >
+              <option value=''>Select service</option>
+              {serviceOptions.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {formatServiceTitleWithTier(s.title, s.serviceTier)}
+                </option>
+              ))}
+            </Select>
+            <Label htmlFor='cert-instance-id'>Instance</Label>
+            <Select
+              id='cert-instance-id'
+              value={instanceId}
+              onChange={(e) => setInstanceId(e.target.value)}
+              disabled={!serviceId || instanceOptions.isLoading}
+            >
+              <option value=''>Select instance</option>
+              {instanceOptions.instances.map((inst) => (
+                <option key={inst.id} value={inst.id}>
+                  {formatDiscountCodeInstanceOptionLabel(inst)}
+                </option>
+              ))}
+            </Select>
+          </div>
+          {activePartners.length > 0 ? (
+            <div className='flex flex-col gap-2 md:col-span-2'>
+              <Label htmlFor='cert-partner-id'>Partner</Label>
+              <Select
+                id='cert-partner-id'
+                value={partnerOrganizationId}
+                onChange={(e) => setPartnerOrganizationId(e.target.value)}
+              >
+                <option value=''>Select partner</option>
+                {activePartners.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          ) : null}
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='cert-program-title'>Program title</Label>
+            <Input
+              id='cert-program-title'
+              value={programTitle}
+              onChange={(e) => setProgramTitle(e.target.value)}
+            />
+          </div>
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='cert-participation-date'>Participation date</Label>
+            <Input
+              id='cert-participation-date'
+              type='date'
+              value={participationDate}
+              onChange={(e) => setParticipationDate(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className='mt-4 flex flex-col gap-2'>
+          <p className='text-sm font-medium text-foreground'>Preview</p>
+          {previewLoading ? <p className='text-sm text-muted-foreground'>Rendering preview…</p> : null}
+          {previewError ? (
+            <StatusBanner variant='error' title='Preview'>
+              {previewError}
+            </StatusBanner>
+          ) : null}
+          {previewUrl ? (
+            <iframe
+              title='Certificate preview'
+              src={previewUrl}
+              className='certificates-preview-frame h-[32rem] w-full rounded-md border border-border bg-muted'
+            />
+          ) : (
+            <p className='text-sm text-muted-foreground'>
+              Complete the form to see a certificate preview.
+            </p>
+          )}
+        </div>
+      </AdminEditorCard>
+
+      <PaginatedTableCard
+        title='Issued certificates'
+        description='Void removes the award badge from the contact. Delete permanently removes the record.'
+        isLoading={isLoading}
+        isLoadingMore={isLoadingMore}
+        hasMore={hasMore}
+        onLoadMore={loadMore}
+        loadingLabel='Loading certificates…'
+        toolbar={
+          <AdminTableToolbar>
+            <div className='flex flex-wrap items-end gap-3'>
+              <div className='flex min-w-[10rem] flex-col gap-1'>
+                <Label htmlFor='cert-filter-status'>Status</Label>
+                <Select
+                  id='cert-filter-status'
+                  value={filters.status}
+                  onChange={(e) =>
+                    setFilter('status', e.target.value as typeof filters.status)
+                  }
+                >
+                  <option value=''>All</option>
+                  <option value='issued'>Issued</option>
+                  <option value='voided'>Voided</option>
+                </Select>
+              </div>
+            </div>
+          </AdminTableToolbar>
+        }
+      >
+        <AdminDataTable>
+          <AdminDataTableHead>
+            <AdminDataTableHeadCell>Recipient</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Program</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Instance</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Participation</AdminDataTableHeadCell>
+            <AdminDataTableHeadCell>Status</AdminDataTableHeadCell>
+            <AdminDataTableOperationsHeadCell />
+          </AdminDataTableHead>
+          <AdminDataTableBody>
+            {rows.map((row) => (
+              <tr
+                key={row.id}
+                className={selectedRowId === row.id ? 'bg-muted/50' : undefined}
+                onClick={() => setSelectedRowId(row.id)}
+              >
+                <AdminDataTableCell>{row.recipient_display_name}</AdminDataTableCell>
+                <AdminDataTableCell>{row.program_title}</AdminDataTableCell>
+                <AdminDataTableCell>{row.instance_label}</AdminDataTableCell>
+                <AdminDataTableCell>{formatDate(row.participation_date)}</AdminDataTableCell>
+                <AdminDataTableCell>{row.status}</AdminDataTableCell>
+                <AdminDataTableCell align='right'>
+                  <div className='flex justify-end gap-1'>
+                    {row.status === 'issued' ? (
+                      <>
+                        <Button
+                          type='button'
+                          variant='secondary'
+                          size='sm'
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleDownloadRow(row);
+                          }}
+                        >
+                          Download
+                        </Button>
+                        <Button
+                          type='button'
+                          variant='secondary'
+                          size='sm'
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleVoidRow(row);
+                          }}
+                        >
+                          Void
+                        </Button>
+                      </>
+                    ) : null}
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='icon'
+                      aria-label='Delete certificate'
+                      title='Delete certificate'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void handleDeleteRow(row);
+                      }}
+                    >
+                      <DeleteIcon />
+                    </Button>
+                  </div>
+                </AdminDataTableCell>
+              </tr>
+            ))}
+          </AdminDataTableBody>
+        </AdminDataTable>
+      </PaginatedTableCard>
+    </div>
+  );
+}

--- a/apps/admin_web/src/components/admin/services/certificates-tab.tsx
+++ b/apps/admin_web/src/components/admin/services/certificates-tab.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { CertificatesPanel } from '@/components/admin/services/certificates-panel';
+import { useCompletionCertificates } from '@/hooks/use-completion-certificates';
+import type { ServiceSummary } from '@/types/services';
+
+export interface CertificatesTabProps {
+  serviceOptions: ServiceSummary[];
+}
+
+export function CertificatesTab({ serviceOptions }: CertificatesTabProps) {
+  const certificates = useCompletionCertificates();
+  return (
+    <CertificatesPanel certificates={certificates} serviceOptions={serviceOptions} />
+  );
+}

--- a/apps/admin_web/src/components/admin/services/services-header.tsx
+++ b/apps/admin_web/src/components/admin/services/services-header.tsx
@@ -10,6 +10,7 @@ export const SERVICES_TAB_ITEMS: readonly AdminTabItem<ServicesView>[] = [
   { key: 'discount-codes', label: 'Discount Codes' },
   { key: 'venues', label: 'Venues' },
   { key: 'partners', label: 'Partners' },
+  { key: 'certificates', label: 'Certificates' },
 ] as const;
 
 export interface ServicesHeaderProps {

--- a/apps/admin_web/src/components/admin/services/services-page.tsx
+++ b/apps/admin_web/src/components/admin/services/services-page.tsx
@@ -22,6 +22,7 @@ import { InstanceDetailPanel } from './instance-detail-panel';
 import { InstanceListPanel } from './instance-list-panel';
 import { ServiceDetailPanel } from './service-detail-panel';
 import { ServiceListPanel } from './service-list-panel';
+import { CertificatesTab } from './certificates-tab';
 import { PartnersTab } from './partners-tab';
 import { ServicesHeader } from './services-header';
 
@@ -416,6 +417,8 @@ export function ServicesPage() {
           onUpdatePartial={state.venues.updateVenuePartial}
           onDelete={state.venues.deleteVenue}
         />
+      ) : state.activeView === 'certificates' ? (
+        <CertificatesTab serviceOptions={allServiceOptionsIncludingArchived} />
       ) : (
         <PartnersTab
           locations={state.locationList.locations}

--- a/apps/admin_web/src/hooks/use-completion-certificates.ts
+++ b/apps/admin_web/src/hooks/use-completion-certificates.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import {
+  deleteCompletionCertificate,
+  issueCompletionCertificate,
+  listCompletionCertificates,
+  voidCompletionCertificate,
+  type CompletionCertificateDraftPayload,
+  type CompletionCertificateListParams,
+} from '@/lib/completion-certificates-api';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+import { useListMutate } from './use-list-mutate';
+import { usePaginatedList } from './use-paginated-list';
+
+type CompletionCertificate = components['schemas']['CompletionCertificate'];
+
+export type CompletionCertificateFilters = {
+  contactId: string;
+  serviceId: string;
+  instanceId: string;
+  status: '' | components['schemas']['CompletionCertificateStatus'];
+};
+
+export const DEFAULT_COMPLETION_CERTIFICATE_FILTERS: CompletionCertificateFilters = {
+  contactId: '',
+  serviceId: '',
+  instanceId: '',
+  status: '',
+};
+
+export function useCompletionCertificates() {
+  const fetcher = useCallback(
+    (params: CompletionCertificateFilters & { cursor: string | null; limit: number }) => {
+      const apiParams: CompletionCertificateListParams = { limit: params.limit };
+      if (params.contactId.trim()) {
+        apiParams.contactId = params.contactId.trim();
+      }
+      if (params.serviceId.trim()) {
+        apiParams.serviceId = params.serviceId.trim();
+      }
+      if (params.instanceId.trim()) {
+        apiParams.instanceId = params.instanceId.trim();
+      }
+      if (params.status) {
+        apiParams.status = params.status;
+      }
+      return listCompletionCertificates(apiParams);
+    },
+    [],
+  );
+
+  const list = usePaginatedList<CompletionCertificate, CompletionCertificateFilters>({
+    fetcher,
+    defaultFilters: DEFAULT_COMPLETION_CERTIFICATE_FILTERS,
+    errorPrefix: 'Failed to load certificates',
+  });
+
+  const { refetch } = list;
+  const { isSaving, mutate } = useListMutate(refetch);
+
+  const issueCertificate = useCallback(
+    async (payload: CompletionCertificateDraftPayload) =>
+      mutate(async () => issueCompletionCertificate(payload)),
+    [mutate],
+  );
+
+  const voidCertificate = useCallback(
+    async (id: string) => mutate(async () => voidCompletionCertificate(id)),
+    [mutate],
+  );
+
+  const deleteCertificate = useCallback(
+    async (id: string) =>
+      mutate(async () => {
+        await deleteCompletionCertificate(id);
+      }),
+    [mutate],
+  );
+
+  return {
+    certificates: list.items,
+    filters: list.filters,
+    setFilter: list.setFilter,
+    isLoading: list.isLoading,
+    isLoadingMore: list.isLoadingMore,
+    isSaving,
+    error: list.error,
+    refetch: list.refetch,
+    loadMore: list.loadMore,
+    hasMore: list.hasMore,
+    totalCount: list.totalCount,
+    issueCertificate,
+    voidCertificate,
+    deleteCertificate,
+  };
+}

--- a/apps/admin_web/src/hooks/use-services-page.ts
+++ b/apps/admin_web/src/hooks/use-services-page.ts
@@ -18,7 +18,13 @@ import { useServiceDetail } from './use-service-detail';
 import { useServiceList } from './use-service-list';
 import { useServiceMutations } from './use-service-mutations';
 
-export type ServicesView = 'catalog' | 'instances' | 'discount-codes' | 'venues' | 'partners';
+export type ServicesView =
+  | 'catalog'
+  | 'instances'
+  | 'discount-codes'
+  | 'venues'
+  | 'partners'
+  | 'certificates';
 
 export const SERVICES_VIEW_KEYS: readonly ServicesView[] = [
   'catalog',
@@ -26,6 +32,7 @@ export const SERVICES_VIEW_KEYS: readonly ServicesView[] = [
   'discount-codes',
   'venues',
   'partners',
+  'certificates',
 ];
 export const DEFAULT_SERVICES_VIEW: ServicesView = 'instances';
 

--- a/apps/admin_web/src/lib/completion-certificates-api.ts
+++ b/apps/admin_web/src/lib/completion-certificates-api.ts
@@ -1,0 +1,148 @@
+import { adminApiRequest, unwrapPayload } from '@/lib/api-admin-client';
+
+import type { components } from '@/types/generated/admin-api.generated';
+
+type ApiSchemas = components['schemas'];
+
+export type CompletionCertificate = ApiSchemas['CompletionCertificate'];
+
+export interface CompletionCertificateListParams {
+  contactId?: string;
+  serviceId?: string;
+  instanceId?: string;
+  status?: ApiSchemas['CompletionCertificateStatus'];
+  limit?: number;
+}
+
+export interface CompletionCertificateDraftPayload {
+  contactId: string;
+  serviceId: string;
+  instanceId: string;
+  participationDate: string;
+  programTitle?: string | null;
+  partnerOrganizationId?: string | null;
+}
+
+function toIssueBody(payload: CompletionCertificateDraftPayload): ApiSchemas['IssueCompletionCertificateRequest'] {
+  return {
+    contact_id: payload.contactId,
+    service_id: payload.serviceId,
+    instance_id: payload.instanceId,
+    participation_date: payload.participationDate,
+    program_title: payload.programTitle?.trim() || null,
+    partner_organization_id: payload.partnerOrganizationId?.trim() || null,
+  };
+}
+
+export async function listCompletionCertificates(
+  params: CompletionCertificateListParams = {},
+  signal?: AbortSignal,
+): Promise<{ items: CompletionCertificate[]; nextCursor: string | null; totalCount: number }> {
+  const q = new URLSearchParams();
+  if (params.contactId?.trim()) {
+    q.set('contact_id', params.contactId.trim());
+  }
+  if (params.serviceId?.trim()) {
+    q.set('service_id', params.serviceId.trim());
+  }
+  if (params.instanceId?.trim()) {
+    q.set('instance_id', params.instanceId.trim());
+  }
+  if (params.status) {
+    q.set('status', params.status);
+  }
+  if (typeof params.limit === 'number') {
+    q.set('limit', String(params.limit));
+  }
+  const qs = q.toString();
+  const payload = await adminApiRequest<ApiSchemas['CompletionCertificateListResponse']>({
+    endpointPath: qs
+      ? `/v1/admin/completion-certificates?${qs}`
+      : '/v1/admin/completion-certificates',
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  return {
+    items: Array.isArray(root.items) ? root.items : [],
+    nextCursor: root.next_cursor ?? null,
+    totalCount: root.total_count ?? 0,
+  };
+}
+
+export async function previewCompletionCertificatePdf(
+  payload: CompletionCertificateDraftPayload,
+  signal?: AbortSignal,
+): Promise<{ downloadUrl: string; expiresAt: string }> {
+  const body = await adminApiRequest<ApiSchemas['PdfDownloadResponse']>({
+    endpointPath: '/v1/admin/completion-certificates/preview',
+    method: 'POST',
+    body: toIssueBody(payload),
+    signal,
+  });
+  const root = unwrapPayload(body);
+  if (!root.downloadUrl || !root.expiresAt) {
+    throw new Error('Preview response missing download URL.');
+  }
+  return { downloadUrl: root.downloadUrl, expiresAt: root.expiresAt };
+}
+
+export async function issueCompletionCertificate(
+  payload: CompletionCertificateDraftPayload,
+  signal?: AbortSignal,
+): Promise<CompletionCertificate> {
+  const body = await adminApiRequest<ApiSchemas['CompletionCertificateResponse']>({
+    endpointPath: '/v1/admin/completion-certificates',
+    method: 'POST',
+    body: toIssueBody(payload),
+    signal,
+  });
+  const root = unwrapPayload(body);
+  if (!root.certificate) {
+    throw new Error('Issue response missing certificate.');
+  }
+  return root.certificate;
+}
+
+export async function getCompletionCertificatePdfDownload(
+  id: string,
+  signal?: AbortSignal,
+): Promise<{ downloadUrl: string; expiresAt: string }> {
+  const body = await adminApiRequest<ApiSchemas['PdfDownloadResponse']>({
+    endpointPath: `/v1/admin/completion-certificates/${id}/pdf`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(body);
+  if (!root.downloadUrl || !root.expiresAt) {
+    throw new Error('PDF response missing download URL.');
+  }
+  return { downloadUrl: root.downloadUrl, expiresAt: root.expiresAt };
+}
+
+export async function voidCompletionCertificate(
+  id: string,
+  signal?: AbortSignal,
+): Promise<CompletionCertificate> {
+  const body = await adminApiRequest<ApiSchemas['CompletionCertificateResponse']>({
+    endpointPath: `/v1/admin/completion-certificates/${id}/void`,
+    method: 'POST',
+    signal,
+  });
+  const root = unwrapPayload(body);
+  if (!root.certificate) {
+    throw new Error('Void response missing certificate.');
+  }
+  return root.certificate;
+}
+
+export async function deleteCompletionCertificate(
+  id: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await adminApiRequest({
+    endpointPath: `/v1/admin/completion-certificates/${id}`,
+    method: 'DELETE',
+    signal,
+  });
+}

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -2315,6 +2315,286 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/completion-certificates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List completion certificates */
+        get: {
+            parameters: {
+                query?: {
+                    contact_id?: string;
+                    service_id?: string;
+                    instance_id?: string;
+                    status?: "issued" | "voided";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Certificate list. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CompletionCertificateListResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        put?: never;
+        /** Issue completion certificate */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["IssueCompletionCertificateRequest"];
+                };
+            };
+            responses: {
+                /** @description Certificate issued. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CompletionCertificateResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/completion-certificates/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview completion certificate PDF
+         * @description Renders a certificate PDF from the request payload without persisting a row.
+         *     Returns a short-lived CloudFront-signed download URL.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["PreviewCompletionCertificateRequest"];
+                };
+            };
+            responses: {
+                /** @description Signed preview URL. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PdfDownloadResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/completion-certificates/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Completion certificate identifier. */
+                id: components["parameters"]["CompletionCertificateId"];
+            };
+            cookie?: never;
+        };
+        /** Get completion certificate */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Completion certificate identifier. */
+                    id: components["parameters"]["CompletionCertificateId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Certificate detail. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CompletionCertificateResponse"];
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Delete completion certificate
+         * @description Permanently removes the certificate row and best-effort deletes the stored PDF.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Completion certificate identifier. */
+                    id: components["parameters"]["CompletionCertificateId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            deleted: boolean;
+                        };
+                    };
+                };
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/completion-certificates/{id}/pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Completion certificate identifier. */
+                id: components["parameters"]["CompletionCertificateId"];
+            };
+            cookie?: never;
+        };
+        /** Download issued completion certificate PDF */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Completion certificate identifier. */
+                    id: components["parameters"]["CompletionCertificateId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Signed download URL for an issued certificate. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PdfDownloadResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/completion-certificates/{id}/void": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Completion certificate identifier. */
+                id: components["parameters"]["CompletionCertificateId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Void completion certificate */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Completion certificate identifier. */
+                    id: components["parameters"]["CompletionCertificateId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Voided certificate. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CompletionCertificateResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/calendar/manual-blocks": {
         parameters: {
             query?: never;
@@ -7500,7 +7780,80 @@ export interface components {
              *     (`lead_id` is null). Lead-attached notes are excluded.
              */
             standalone_note_count: number;
+            /** @description True when the contact has at least one issued (non-voided) completion certificate. */
+            has_completion_certificate: boolean;
         };
+        PdfDownloadResponse: {
+            /** Format: uri */
+            downloadUrl: string;
+            /** Format: date-time */
+            expiresAt: string;
+        };
+        /** @enum {string} */
+        CompletionCertificateStatus: "issued" | "voided";
+        CompletionCertificate: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            contact_id: string;
+            contact_label: string;
+            /** Format: uuid */
+            instance_id: string;
+            instance_label: string;
+            /** Format: uuid */
+            service_id: string;
+            service_label: string;
+            /** Format: uuid */
+            enrollment_id: string;
+            /** Format: uuid */
+            partner_organization_id?: string | null;
+            /** Format: date */
+            participation_date: string;
+            recipient_display_name: string;
+            program_title: string;
+            partner_display_name?: string | null;
+            partner_signer_name?: string | null;
+            body_text: string;
+            status: components["schemas"]["CompletionCertificateStatus"];
+            /** Format: date-time */
+            issued_at: string;
+            issued_by: string;
+            /** Format: date-time */
+            voided_at?: string | null;
+            voided_by?: string | null;
+            issued_pdf_sha256?: string | null;
+            pdf_template_version?: string | null;
+            /** Format: date-time */
+            created_at?: string | null;
+            /** Format: date-time */
+            updated_at?: string | null;
+        };
+        CompletionCertificateListResponse: {
+            items: components["schemas"]["CompletionCertificate"][];
+            next_cursor?: string | null;
+            total_count: number;
+        };
+        CompletionCertificateResponse: {
+            certificate: components["schemas"]["CompletionCertificate"];
+        };
+        PreviewCompletionCertificateRequest: {
+            /** Format: uuid */
+            contact_id: string;
+            /** Format: uuid */
+            service_id: string;
+            /** Format: uuid */
+            instance_id: string;
+            /** Format: date */
+            participation_date: string;
+            /** @description Optional override; defaults to instance or service title. */
+            program_title?: string | null;
+            /**
+             * Format: uuid
+             * @description Required when the instance has linked partner organisations.
+             */
+            partner_organization_id?: string | null;
+        };
+        IssueCompletionCertificateRequest: components["schemas"]["PreviewCompletionCertificateRequest"];
         AdminContactListResponse: {
             items: components["schemas"]["AdminContact"][];
             next_cursor?: string | null;
@@ -7892,6 +8245,8 @@ export interface components {
         EnrollmentId: string;
         /** @description Discount code identifier. */
         DiscountCodeId: string;
+        /** @description Completion certificate identifier. */
+        CompletionCertificateId: string;
         /** @description CRM contact identifier. */
         AdminContactId: string;
         /** @description CRM note identifier. */

--- a/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/contacts-panel.test.tsx
@@ -281,6 +281,47 @@ describe('ContactsPanel', () => {
     );
   });
 
+  it('shows certificate emoji when has_completion_certificate is true', () => {
+    const row: components['schemas']['AdminContact'] = {
+      id: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+      email: null,
+      instagram_handle: null,
+      phone_region: null,
+      phone_national_number: null,
+      phone_e164: null,
+      contact_type: 'parent',
+      relationship_type: 'prospect',
+      source: 'manual',
+      mailchimp_status: 'pending',
+      active: true,
+      created_at: '2020-01-01T00:00:00.000Z',
+      updated_at: '2020-01-01T00:00:00.000Z',
+      tag_ids: [],
+      tags: [],
+      standalone_note_count: 0,
+      has_completion_certificate: true,
+      first_name: 'Grad',
+      last_name: 'uate',
+      family_ids: [],
+      organization_ids: [],
+      family_location_summary: null,
+      organization_location_summary: null,
+    };
+    render(
+      <ContactsPanel
+        contacts={buildContactsHook({ contacts: [row] })}
+        adminUsers={[]}
+        onPatchStandaloneNoteCount={vi.fn()}
+        tags={[]}
+        locations={[]}
+        geographicAreas={[]}
+        areasLoading={false}
+        refreshLocations={noopRefresh}
+      />
+    );
+    expect(screen.getByText(/Grad uate/)).toHaveTextContent('Grad uate 🎓');
+  });
+
   it('shows read-only family and organisation venue lines in the Location box when the row is selected', async () => {
     const user = userEvent.setup();
     const summary = {

--- a/apps/admin_web/tests/components/admin/services/services-page.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/services-page.test.tsx
@@ -147,6 +147,10 @@ vi.mock('@/components/admin/services/partners-tab', () => ({
   PartnersTab: () => <div data-testid='partners-tab-mock'>Partners</div>,
 }));
 
+vi.mock('@/components/admin/services/certificates-tab', () => ({
+  CertificatesTab: () => <div data-testid='certificates-tab-mock'>Certificates</div>,
+}));
+
 import { ServicesPage } from '@/components/admin/services/services-page';
 
 const INSTANCE_FOR_SEARCH: ServiceInstance = {
@@ -214,6 +218,12 @@ describe('ServicesPage', () => {
     expect(state.setActiveView).toHaveBeenCalledWith('venues');
     await user.click(screen.getByRole('button', { name: 'Partners' }));
     expect(state.setActiveView).toHaveBeenCalledWith('partners');
+  });
+
+  it('renders Certificates panel when active view is certificates', () => {
+    state.activeView = 'certificates';
+    render(<ServicesPage />);
+    expect(screen.getByTestId('certificates-tab-mock')).toBeInTheDocument();
   });
 
   it('renders Partners panel when active view is partners', () => {

--- a/backend/db/alembic/versions/0069_completion_certs.py
+++ b/backend/db/alembic/versions/0069_completion_certs.py
@@ -1,0 +1,126 @@
+"""Add ``completion_certificates`` for training completion PDFs.
+
+Seed-data assessment (``backend/db/seed/seed_data.sql``):
+1. Compatible: new table only.
+2. N/A.
+3. N/A.
+4. N/A (no seed rows required).
+5. N/A.
+6. N/A.
+
+Result: No seed updates required.
+
+Revision id: ``0069_completion_certs`` (22 chars, <= 32).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0069_completion_certs"
+down_revision: Union[str, None] = "0068_inst_capacity_left_override"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_completion_status = postgresql.ENUM(
+    "issued",
+    "voided",
+    name="completion_certificate_status",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _completion_status.create(bind, checkfirst=True)
+    op.create_table(
+        "completion_certificates",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("contact_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("instance_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("service_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("enrollment_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "partner_organization_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("participation_date", sa.Date(), nullable=False),
+        sa.Column("recipient_display_name", sa.Text(), nullable=False),
+        sa.Column("program_title", sa.Text(), nullable=False),
+        sa.Column("partner_display_name", sa.Text(), nullable=True),
+        sa.Column("partner_signer_name", sa.Text(), nullable=True),
+        sa.Column("body_text", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            _completion_status,
+            nullable=False,
+            server_default="issued",
+        ),
+        sa.Column("issued_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("issued_by", sa.Text(), nullable=False),
+        sa.Column("voided_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("voided_by", sa.Text(), nullable=True),
+        sa.Column("issued_pdf_s3_key", sa.Text(), nullable=True),
+        sa.Column("issued_pdf_sha256", sa.String(length=64), nullable=True),
+        sa.Column("pdf_template_version", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["contact_id"], ["contacts.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(
+            ["instance_id"], ["service_instances.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(["service_id"], ["services.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(
+            ["enrollment_id"], ["enrollments.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["partner_organization_id"],
+            ["organizations.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "completion_certificates_contact_idx",
+        "completion_certificates",
+        ["contact_id"],
+    )
+    op.create_index(
+        "completion_certificates_instance_idx",
+        "completion_certificates",
+        ["instance_id"],
+    )
+    op.create_index(
+        "completion_certificates_issued_at_idx",
+        "completion_certificates",
+        ["issued_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("completion_certificates_issued_at_idx", "completion_certificates")
+    op.drop_index("completion_certificates_instance_idx", "completion_certificates")
+    op.drop_index("completion_certificates_contact_idx", "completion_certificates")
+    op.drop_table("completion_certificates")
+    bind = op.get_bind()
+    _completion_status.drop(bind, checkfirst=True)

--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -964,6 +964,16 @@ export class ApiStack extends cdk.Stack {
           "Trading name shown on invoice PDF From block and public site; align with NEXT_PUBLIC_BUSINESS_NAME.",
       }
     );
+    const publicWwwCertificateEsFounderName = new cdk.CfnParameter(
+      this,
+      "PublicWwwCertificateEsFounderName",
+      {
+        type: "String",
+        default: "",
+        description:
+          "Evolve Sprouts founder name on completion certificate PDFs.",
+      }
+    );
     const publicWwwBusinessLegalName = new cdk.CfnParameter(
       this,
       "PublicWwwBusinessLegalName",
@@ -1869,6 +1879,7 @@ export class ApiStack extends cdk.Stack {
           BUSINESS_PHONE_NUMBER: publicWwwBusinessPhoneNumber.valueAsString,
           BILLING_EMAIL: publicWwwBillingEmail.valueAsString,
           BUSINESS_NAME: publicWwwBusinessName.valueAsString,
+          CERTIFICATE_ES_FOUNDER_NAME: publicWwwCertificateEsFounderName.valueAsString,
           BUSINESS_LEGAL_NAME: publicWwwBusinessLegalName.valueAsString,
           BUSINESS_ADDRESS: publicWwwBusinessAddress.valueAsString,
           BUSINESS_REGISTRATION: publicWwwBusinessRegistration.valueAsString,

--- a/backend/src/app/api/admin.py
+++ b/backend/src/app/api/admin.py
@@ -13,6 +13,9 @@ from app.api.assets import (
     handle_user_assets_request,
 )
 from app.api.admin_geographic_areas import handle_admin_geographic_areas_request
+from app.api.admin_completion_certificates import (
+    handle_admin_completion_certificates_request,
+)
 from app.api.admin_discount_codes import handle_admin_discount_codes_request
 from app.api.admin_expenses import handle_admin_expenses_request
 from app.api.admin_leads import handle_admin_leads_request
@@ -207,6 +210,11 @@ _ROUTES: tuple[
         "/v1/admin/discount-codes",
         False,
         handle_admin_discount_codes_request,
+    ),
+    (
+        "/v1/admin/completion-certificates",
+        False,
+        handle_admin_completion_certificates_request,
     ),
     (
         "/v1/admin/expenses",

--- a/backend/src/app/api/admin_completion_certificates.py
+++ b/backend/src/app/api/admin_completion_certificates.py
@@ -118,7 +118,9 @@ def _parse_issue_payload(body: Mapping[str, Any]) -> dict[str, Any]:
     program_title_override = None
     if program_title is not None:
         if not isinstance(program_title, str):
-            raise ValidationError("program_title must be a string", field="program_title")
+            raise ValidationError(
+                "program_title must be a string", field="program_title"
+            )
         program_title_override = program_title.strip() or None
     partner_organization_id = parse_optional_uuid(
         body.get("partner_organization_id"),
@@ -169,7 +171,7 @@ def _issue_certificate(event: Mapping[str, Any], *, actor_sub: str) -> dict[str,
     payload = _parse_issue_payload(body)
     request_id = event.get("requestContext", {}).get("requestId")
     with Session(get_engine()) as session:
-        set_audit_context(session, user_sub=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=request_id)
         draft = resolve_certificate_draft(
             session,
             contact_id=payload["contact_id"],
@@ -268,7 +270,7 @@ def _void_certificate(
 
     request_id = event.get("requestContext", {}).get("requestId")
     with Session(get_engine()) as session:
-        set_audit_context(session, user_sub=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=request_id)
         cert = session.get(CompletionCertificate, certificate_id)
         if cert is None:
             raise NotFoundError("CompletionCertificate", str(certificate_id))
@@ -288,7 +290,7 @@ def _delete_certificate(
 ) -> dict[str, Any]:
     request_id = event.get("requestContext", {}).get("requestId")
     with Session(get_engine()) as session:
-        set_audit_context(session, user_sub=actor_sub, request_id=request_id)
+        set_audit_context(session, user_id=actor_sub, request_id=request_id)
         cert = session.get(CompletionCertificate, certificate_id)
         if cert is None:
             raise NotFoundError("CompletionCertificate", str(certificate_id))

--- a/backend/src/app/api/admin_completion_certificates.py
+++ b/backend/src/app/api/admin_completion_certificates.py
@@ -1,0 +1,348 @@
+"""Admin completion certificate API handlers."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from datetime import date
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.admin_request import parse_body, parse_limit, parse_uuid, query_param
+from app.api.admin_services_payload_utils import parse_optional_uuid
+from app.api.assets.assets_common import (
+    delete_s3_object,
+    extract_identity,
+    generate_download_url,
+    signed_link_no_cache_headers,
+    split_route_parts,
+)
+from app.db.audit import set_audit_context
+from app.db.engine import get_engine
+from app.db.models import CompletionCertificate, Contact, Service, ServiceInstance
+from app.db.models.enums import CompletionCertificateStatus
+from app.exceptions import NotFoundError, ValidationError
+from app.services.completion_certificate_common import (
+    create_issued_certificate,
+    load_certificate_for_pdf,
+    render_draft_pdf_bytes,
+    resolve_certificate_draft,
+    upload_preview_pdf,
+)
+from app.utils import json_response
+from app.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_LIMIT = 50
+
+
+def _parse_required_uuid(value: Any, *, field: str) -> UUID:
+    parsed = parse_optional_uuid(value, field)
+    if parsed is None:
+        raise ValidationError(f"{field} is required", field=field)
+    return parsed
+
+
+def handle_admin_completion_certificates_request(
+    event: Mapping[str, Any],
+    method: str,
+    path: str,
+) -> dict[str, Any]:
+    """Handle /v1/admin/completion-certificates routes."""
+    logger.info(
+        "Handling admin completion-certificates route",
+        extra={"method": method, "path": path},
+    )
+    parts = split_route_parts(path)
+    if len(parts) < 2 or parts[0] != "admin" or parts[1] != "completion-certificates":
+        return json_response(404, {"error": "Not found"}, event=event)
+
+    identity = extract_identity(event)
+    if not identity.user_sub:
+        raise ValidationError("Authenticated user is required", field="authorization")
+
+    if len(parts) == 3 and parts[2] == "preview":
+        if method == "POST":
+            return _preview_certificate(event)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 2:
+        if method == "GET":
+            return _list_certificates(event)
+        if method == "POST":
+            return _issue_certificate(event, actor_sub=identity.user_sub)
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    certificate_id = parse_uuid(parts[2])
+    if len(parts) == 3:
+        if method == "GET":
+            return _get_certificate(event, certificate_id=certificate_id)
+        if method == "DELETE":
+            return _delete_certificate(
+                event, certificate_id=certificate_id, actor_sub=identity.user_sub
+            )
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 4 and parts[3] == "pdf" and method == "GET":
+        return _get_certificate_pdf(event, certificate_id=certificate_id)
+
+    if len(parts) == 4 and parts[3] == "void" and method == "POST":
+        return _void_certificate(
+            event, certificate_id=certificate_id, actor_sub=identity.user_sub
+        )
+
+    return json_response(404, {"error": "Not found"}, event=event)
+
+
+def _parse_issue_payload(body: Mapping[str, Any]) -> dict[str, Any]:
+    contact_id = _parse_required_uuid(body.get("contact_id"), field="contact_id")
+    service_id = _parse_required_uuid(body.get("service_id"), field="service_id")
+    instance_id = _parse_required_uuid(body.get("instance_id"), field="instance_id")
+    participation_raw = body.get("participation_date")
+    if not isinstance(participation_raw, str) or not participation_raw.strip():
+        raise ValidationError(
+            "participation_date is required", field="participation_date"
+        )
+    try:
+        participation_date = date.fromisoformat(participation_raw.strip())
+    except ValueError as exc:
+        raise ValidationError(
+            "participation_date must be YYYY-MM-DD",
+            field="participation_date",
+        ) from exc
+    program_title = body.get("program_title")
+    program_title_override = None
+    if program_title is not None:
+        if not isinstance(program_title, str):
+            raise ValidationError("program_title must be a string", field="program_title")
+        program_title_override = program_title.strip() or None
+    partner_organization_id = parse_optional_uuid(
+        body.get("partner_organization_id"),
+        field="partner_organization_id",
+    )
+    return {
+        "contact_id": contact_id,
+        "service_id": service_id,
+        "instance_id": instance_id,
+        "participation_date": participation_date,
+        "program_title_override": program_title_override,
+        "partner_organization_id": partner_organization_id,
+    }
+
+
+def _preview_certificate(event: Mapping[str, Any]) -> dict[str, Any]:
+    body = parse_body(event)
+    payload = _parse_issue_payload(body)
+    with Session(get_engine()) as session:
+        draft = resolve_certificate_draft(
+            session,
+            contact_id=payload["contact_id"],
+            service_id=payload["service_id"],
+            instance_id=payload["instance_id"],
+            participation_date=payload["participation_date"],
+            program_title_override=payload["program_title_override"],
+            partner_organization_id=payload["partner_organization_id"],
+        )
+        pdf_bytes = render_draft_pdf_bytes(draft)
+        s3_key = upload_preview_pdf(pdf_bytes)
+    download = generate_download_url(
+        s3_key=s3_key,
+        cache_bust_key=str(time.time_ns()),
+    )
+    return json_response(
+        200,
+        {
+            "downloadUrl": download["download_url"],
+            "expiresAt": download["expires_at"],
+        },
+        headers=signed_link_no_cache_headers(),
+        event=event,
+    )
+
+
+def _issue_certificate(event: Mapping[str, Any], *, actor_sub: str) -> dict[str, Any]:
+    body = parse_body(event)
+    payload = _parse_issue_payload(body)
+    request_id = event.get("requestContext", {}).get("requestId")
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_sub=actor_sub, request_id=request_id)
+        draft = resolve_certificate_draft(
+            session,
+            contact_id=payload["contact_id"],
+            service_id=payload["service_id"],
+            instance_id=payload["instance_id"],
+            participation_date=payload["participation_date"],
+            program_title_override=payload["program_title_override"],
+            partner_organization_id=payload["partner_organization_id"],
+        )
+        cert = create_issued_certificate(session, draft=draft, actor_sub=actor_sub)
+        session.commit()
+        session.refresh(cert)
+        serialized = serialize_completion_certificate(session, cert)
+    return json_response(201, {"certificate": serialized}, event=event)
+
+
+def _list_certificates(event: Mapping[str, Any]) -> dict[str, Any]:
+    limit = parse_limit(event, default=_DEFAULT_LIMIT)
+    contact_id = parse_optional_uuid(query_param(event, "contact_id"), "contact_id")
+    instance_id = parse_optional_uuid(query_param(event, "instance_id"), "instance_id")
+    service_id = parse_optional_uuid(query_param(event, "service_id"), "service_id")
+    status_raw = query_param(event, "status")
+    status_filter: CompletionCertificateStatus | None = None
+    if status_raw:
+        try:
+            status_filter = CompletionCertificateStatus(status_raw.strip().lower())
+        except ValueError as exc:
+            raise ValidationError("Invalid status filter", field="status") from exc
+
+    with Session(get_engine()) as session:
+        stmt = select(CompletionCertificate).order_by(
+            CompletionCertificate.issued_at.desc(),
+            CompletionCertificate.id.desc(),
+        )
+        if contact_id is not None:
+            stmt = stmt.where(CompletionCertificate.contact_id == contact_id)
+        if instance_id is not None:
+            stmt = stmt.where(CompletionCertificate.instance_id == instance_id)
+        if service_id is not None:
+            stmt = stmt.where(CompletionCertificate.service_id == service_id)
+        if status_filter is not None:
+            stmt = stmt.where(CompletionCertificate.status == status_filter)
+        rows = list(session.execute(stmt.limit(limit + 1)).scalars().all())
+        has_more = len(rows) > limit
+        page = rows[:limit]
+        items = [serialize_completion_certificate(session, row) for row in page]
+        return json_response(
+            200,
+            {
+                "items": items,
+                "next_cursor": None if not has_more else str(page[-1].id),
+                "total_count": len(items),
+            },
+            event=event,
+        )
+
+
+def _get_certificate(
+    event: Mapping[str, Any], *, certificate_id: UUID
+) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        cert = session.get(CompletionCertificate, certificate_id)
+        if cert is None:
+            raise NotFoundError("CompletionCertificate", str(certificate_id))
+        return json_response(
+            200,
+            {"certificate": serialize_completion_certificate(session, cert)},
+            event=event,
+        )
+
+
+def _get_certificate_pdf(
+    event: Mapping[str, Any], *, certificate_id: UUID
+) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        cert = load_certificate_for_pdf(session, certificate_id)
+        download = generate_download_url(
+            s3_key=cert.issued_pdf_s3_key or "",
+            cache_bust_key=str(time.time_ns()),
+        )
+    return json_response(
+        200,
+        {
+            "downloadUrl": download["download_url"],
+            "expiresAt": download["expires_at"],
+        },
+        headers=signed_link_no_cache_headers(),
+        event=event,
+    )
+
+
+def _void_certificate(
+    event: Mapping[str, Any], *, certificate_id: UUID, actor_sub: str
+) -> dict[str, Any]:
+    from datetime import UTC, datetime
+
+    request_id = event.get("requestContext", {}).get("requestId")
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_sub=actor_sub, request_id=request_id)
+        cert = session.get(CompletionCertificate, certificate_id)
+        if cert is None:
+            raise NotFoundError("CompletionCertificate", str(certificate_id))
+        if cert.status == CompletionCertificateStatus.VOIDED:
+            raise ValidationError("Certificate is already voided", field="id")
+        cert.status = CompletionCertificateStatus.VOIDED
+        cert.voided_at = datetime.now(UTC)
+        cert.voided_by = actor_sub
+        session.commit()
+        session.refresh(cert)
+        serialized = serialize_completion_certificate(session, cert)
+    return json_response(200, {"certificate": serialized}, event=event)
+
+
+def _delete_certificate(
+    event: Mapping[str, Any], *, certificate_id: UUID, actor_sub: str
+) -> dict[str, Any]:
+    request_id = event.get("requestContext", {}).get("requestId")
+    with Session(get_engine()) as session:
+        set_audit_context(session, user_sub=actor_sub, request_id=request_id)
+        cert = session.get(CompletionCertificate, certificate_id)
+        if cert is None:
+            raise NotFoundError("CompletionCertificate", str(certificate_id))
+        s3_key = (cert.issued_pdf_s3_key or "").strip()
+        session.delete(cert)
+        session.commit()
+    if s3_key:
+        try:
+            delete_s3_object(s3_key=s3_key)
+        except Exception:
+            logger.exception(
+                "Failed to delete completion certificate PDF from S3",
+                extra={"certificate_id": str(certificate_id)},
+            )
+    return json_response(200, {"deleted": True}, event=event)
+
+
+def serialize_completion_certificate(
+    session: Session, cert: CompletionCertificate
+) -> dict[str, Any]:
+    contact = session.get(Contact, cert.contact_id)
+    instance = session.get(ServiceInstance, cert.instance_id)
+    service = session.get(Service, cert.service_id)
+    contact_label = ""
+    if contact:
+        parts = [contact.first_name or "", contact.last_name or ""]
+        contact_label = " ".join(p for p in parts if p).strip() or (contact.email or "")
+    instance_label = instance.slug if instance else ""
+    service_label = service.title if service else ""
+    return {
+        "id": str(cert.id),
+        "contact_id": str(cert.contact_id),
+        "contact_label": contact_label,
+        "instance_id": str(cert.instance_id),
+        "instance_label": instance_label,
+        "service_id": str(cert.service_id),
+        "service_label": service_label,
+        "enrollment_id": str(cert.enrollment_id),
+        "partner_organization_id": str(cert.partner_organization_id)
+        if cert.partner_organization_id
+        else None,
+        "participation_date": cert.participation_date.isoformat(),
+        "recipient_display_name": cert.recipient_display_name,
+        "program_title": cert.program_title,
+        "partner_display_name": cert.partner_display_name,
+        "partner_signer_name": cert.partner_signer_name,
+        "body_text": cert.body_text,
+        "status": cert.status.value,
+        "issued_at": cert.issued_at,
+        "issued_by": cert.issued_by,
+        "voided_at": cert.voided_at,
+        "voided_by": cert.voided_by,
+        "issued_pdf_sha256": cert.issued_pdf_sha256,
+        "pdf_template_version": cert.pdf_template_version,
+        "created_at": cert.created_at,
+        "updated_at": cert.updated_at,
+    }

--- a/backend/src/app/api/admin_contacts.py
+++ b/backend/src/app/api/admin_contacts.py
@@ -46,6 +46,9 @@ from app.api.admin_validators import validate_string_length
 from app.api.assets.assets_common import extract_identity, split_route_parts
 from app.db.engine import get_engine
 from app.db.repositories import ContactRepository
+from app.services.completion_certificate_common import (
+    contact_ids_with_issued_certificates,
+)
 from app.exceptions import NotFoundError, ValidationError
 from app.utils import json_response
 from app.utils.logging import get_logger
@@ -226,6 +229,9 @@ def _list_contacts(event: Mapping[str, Any]) -> dict[str, Any]:
         note_counts = repository.count_standalone_notes_for_contacts(
             [r.id for r in page_rows]
         )
+        cert_contact_ids = contact_ids_with_issued_certificates(
+            session, [r.id for r in page_rows]
+        )
         return json_response(
             200,
             {
@@ -233,6 +239,7 @@ def _list_contacts(event: Mapping[str, Any]) -> dict[str, Any]:
                     serialize_contact_summary(
                         r,
                         standalone_note_count=note_counts.get(r.id, 0),
+                        has_completion_certificate=r.id in cert_contact_ids,
                     )
                     for r in page_rows
                 ],
@@ -250,12 +257,14 @@ def _get_contact(event: Mapping[str, Any], *, contact_id: UUID) -> dict[str, Any
         if contact is None:
             raise NotFoundError("Contact", str(contact_id))
         note_counts = repository.count_standalone_notes_for_contacts([contact.id])
+        cert_ids = contact_ids_with_issued_certificates(session, [contact.id])
         return json_response(
             200,
             {
                 "contact": serialize_contact_summary(
                     contact,
                     standalone_note_count=note_counts.get(contact.id, 0),
+                    has_completion_certificate=contact.id in cert_ids,
                 )
             },
             event=event,

--- a/backend/src/app/api/admin_entities_serializers.py
+++ b/backend/src/app/api/admin_entities_serializers.py
@@ -95,6 +95,7 @@ def serialize_contact_summary(
     contact: Contact,
     *,
     standalone_note_count: int = 0,
+    has_completion_certificate: bool = False,
 ) -> dict[str, Any]:
     logger.debug("Serializing contact summary", extra={"contact_id": str(contact.id)})
     family_ids = {str(m.family_id) for m in contact.family_members}
@@ -140,6 +141,7 @@ def serialize_contact_summary(
         "family_ids": sorted(family_ids),
         "organization_ids": sorted(organization_ids),
         "standalone_note_count": standalone_note_count,
+        "has_completion_certificate": has_completion_certificate,
     }
 
 

--- a/backend/src/app/db/models/__init__.py
+++ b/backend/src/app/db/models/__init__.py
@@ -7,6 +7,7 @@ from app.db.models.bulk_expense_import_job import (
     BulkExpenseImportJob,
     BulkExpenseImportJobStatus,
 )
+from app.db.models.completion_certificate import CompletionCertificate
 from app.db.models.contact import Contact
 from app.db.models.customer_invoice import CustomerInvoice, CustomerInvoiceLine
 from app.db.models.customer_payment import CustomerPayment
@@ -23,6 +24,7 @@ from app.db.models.enums import (
     BillingInvoiceStatus,
     BillingPaymentDirection,
     BillingPaymentStatus,
+    CompletionCertificateStatus,
     ConsultationFormat,
     ConsultationPricingModel,
     ContactSource,
@@ -94,6 +96,8 @@ __all__ = [
     "ConsultationDetails",
     "ConsultationFormat",
     "ConsultationPricingModel",
+    "CompletionCertificate",
+    "CompletionCertificateStatus",
     "Contact",
     "ContactSource",
     "ContactTag",

--- a/backend/src/app/db/models/completion_certificate.py
+++ b/backend/src/app/db/models/completion_certificate.py
@@ -1,0 +1,117 @@
+"""Completion certificate records (issued training PDFs)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Enum, ForeignKey, Index, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import DATE, TIMESTAMP
+
+from app.db.base import Base
+from app.db.models.enums import CompletionCertificateStatus
+
+if TYPE_CHECKING:
+    from app.db.models.contact import Contact
+    from app.db.models.enrollment import Enrollment
+    from app.db.models.organization import Organization
+    from app.db.models.service import Service
+    from app.db.models.service_instance import ServiceInstance
+
+
+def _completion_certificate_status_values(
+    _enum_cls: type[CompletionCertificateStatus] | None = None,
+) -> list[str]:
+    return [member.value for member in CompletionCertificateStatus]
+
+
+class CompletionCertificate(Base):
+    """Issued completion certificate linked to contact, instance, and enrollment."""
+
+    __tablename__ = "completion_certificates"
+    __table_args__ = (
+        Index("completion_certificates_contact_idx", "contact_id"),
+        Index("completion_certificates_instance_idx", "instance_id"),
+        Index("completion_certificates_issued_at_idx", "issued_at"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    contact_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("contacts.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    instance_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("service_instances.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    service_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("services.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    enrollment_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("enrollments.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    partner_organization_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    participation_date: Mapped[date] = mapped_column(DATE(), nullable=False)
+    recipient_display_name: Mapped[str] = mapped_column(Text(), nullable=False)
+    program_title: Mapped[str] = mapped_column(Text(), nullable=False)
+    partner_display_name: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    partner_signer_name: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    body_text: Mapped[str] = mapped_column(Text(), nullable=False)
+    status: Mapped[CompletionCertificateStatus] = mapped_column(
+        Enum(
+            CompletionCertificateStatus,
+            name="completion_certificate_status",
+            values_callable=_completion_certificate_status_values,
+            create_type=False,
+        ),
+        nullable=False,
+        server_default=CompletionCertificateStatus.ISSUED.value,
+    )
+    issued_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+    )
+    issued_by: Mapped[str] = mapped_column(Text(), nullable=False)
+    voided_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+    )
+    voided_by: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    issued_pdf_s3_key: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    issued_pdf_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    pdf_template_version: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    )
+
+    contact: Mapped["Contact"] = relationship("Contact")
+    instance: Mapped["ServiceInstance"] = relationship("ServiceInstance")
+    service: Mapped["Service"] = relationship("Service")
+    enrollment: Mapped["Enrollment"] = relationship("Enrollment")
+    partner_organization: Mapped["Organization | None"] = relationship(
+        "Organization"
+    )

--- a/backend/src/app/db/models/completion_certificate.py
+++ b/backend/src/app/db/models/completion_certificate.py
@@ -112,6 +112,4 @@ class CompletionCertificate(Base):
     instance: Mapped["ServiceInstance"] = relationship("ServiceInstance")
     service: Mapped["Service"] = relationship("Service")
     enrollment: Mapped["Enrollment"] = relationship("Enrollment")
-    partner_organization: Mapped["Organization | None"] = relationship(
-        "Organization"
-    )
+    partner_organization: Mapped["Organization | None"] = relationship("Organization")

--- a/backend/src/app/db/models/enums.py
+++ b/backend/src/app/db/models/enums.py
@@ -247,6 +247,13 @@ class EnrollmentStatus(str, enum.Enum):
     COMPLETED = "completed"
 
 
+class CompletionCertificateStatus(str, enum.Enum):
+    """Lifecycle status for completion certificates."""
+
+    ISSUED = "issued"
+    VOIDED = "voided"
+
+
 CAPACITY_ENROLLMENT_STATUSES: tuple[EnrollmentStatus, ...] = (
     EnrollmentStatus.REGISTERED,
     EnrollmentStatus.CONFIRMED,

--- a/backend/src/app/services/completion_certificate_common.py
+++ b/backend/src/app/services/completion_certificate_common.py
@@ -1,0 +1,328 @@
+"""Shared completion certificate issue/preview helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from app.db.models import (
+    CompletionCertificate,
+    Contact,
+    Enrollment,
+    Organization,
+    OrganizationMember,
+    ServiceInstance,
+)
+from app.db.models.service_instance import ServiceInstancePartnerOrganization
+from app.db.models.enums import CompletionCertificateStatus, EnrollmentStatus
+from app.exceptions import NotFoundError, ValidationError
+from app.services.completion_certificate_pdf import (
+    COMPLETION_CERTIFICATE_PDF_TEMPLATE_VERSION,
+    CompletionCertificatePdfContext,
+    build_certificate_body_text,
+    certificate_es_founder_name,
+    certificate_trading_name,
+    render_completion_certificate_pdf,
+)
+from app.services.customer_billing import store_pdf_in_assets_bucket
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def preview_pdf_s3_key() -> str:
+    return f"completion-certificates/preview/{uuid.uuid4()}.pdf"
+
+
+def issued_pdf_s3_key(certificate_id: UUID) -> str:
+    return f"completion-certificates/{certificate_id}.pdf"
+
+
+@dataclass(frozen=True)
+class ResolvedCertificateDraft:
+    contact_id: UUID
+    instance_id: UUID
+    service_id: UUID
+    enrollment_id: UUID
+    partner_organization_id: UUID | None
+    participation_date: date
+    recipient_display_name: str
+    program_title: str
+    partner_display_name: str | None
+    partner_signer_name: str | None
+    body_text: str
+    trading_name: str
+    es_founder_name: str
+
+
+def _contact_display_name(contact: Contact) -> str:
+    parts = [contact.first_name or "", contact.last_name or ""]
+    label = " ".join(p for p in parts if p).strip()
+    return label or (contact.email or "Recipient")
+
+
+def _partner_signer_name(session: Session, organization_id: UUID) -> str | None:
+    stmt = (
+        select(OrganizationMember)
+        .where(OrganizationMember.organization_id == organization_id)
+        .options(selectinload(OrganizationMember.contact))
+        .order_by(
+            OrganizationMember.is_primary_contact.desc(),
+            OrganizationMember.created_at.asc(),
+        )
+    )
+    members = list(session.execute(stmt).scalars().all())
+    for member in members:
+        if not member.is_primary_contact:
+            continue
+        contact = member.contact
+        if contact is None:
+            continue
+        name = _contact_display_name(contact)
+        if name:
+            return name
+    for member in members:
+        contact = member.contact
+        if contact is None:
+            continue
+        name = _contact_display_name(contact)
+        if name:
+            return name
+    return None
+
+
+def resolve_certificate_draft(
+    session: Session,
+    *,
+    contact_id: UUID,
+    service_id: UUID,
+    instance_id: UUID,
+    participation_date: date,
+    program_title_override: str | None,
+    partner_organization_id: UUID | None,
+) -> ResolvedCertificateDraft:
+    """Validate inputs and assemble snapshot fields for preview/issue."""
+    contact = session.get(Contact, contact_id)
+    if contact is None or contact.archived_at is not None:
+        raise ValidationError("contact_id not found", field="contact_id")
+
+    instance = session.execute(
+        select(ServiceInstance)
+        .where(ServiceInstance.id == instance_id)
+        .options(
+            selectinload(ServiceInstance.service),
+            selectinload(ServiceInstance.partner_organization_links).selectinload(
+                ServiceInstancePartnerOrganization.organization
+            ),
+        )
+    ).scalar_one_or_none()
+    if instance is None:
+        raise ValidationError("instance_id not found", field="instance_id")
+    if instance.service_id != service_id:
+        raise ValidationError(
+            "instance_id does not belong to service_id",
+            field="instance_id",
+        )
+
+    enrollment = session.execute(
+        select(Enrollment).where(
+            Enrollment.instance_id == instance_id,
+            Enrollment.contact_id == contact_id,
+            Enrollment.status == EnrollmentStatus.COMPLETED,
+        )
+    ).scalar_one_or_none()
+    if enrollment is None:
+        raise ValidationError(
+            "Contact must have a completed enrollment for this instance",
+            field="contact_id",
+        )
+
+    service = instance.service
+    default_program = (
+        instance.title if instance.title is not None else service.title
+    ).strip()
+    program_title = (program_title_override or default_program).strip()
+    if not program_title:
+        raise ValidationError("program_title is required", field="program_title")
+
+    trading_name = certificate_trading_name()
+    if not trading_name:
+        raise ValidationError(
+            "Certificate trading name is not configured",
+            field="program_title",
+        )
+    es_founder = certificate_es_founder_name()
+    if not es_founder:
+        raise ValidationError(
+            "Certificate founder name is not configured",
+            field="program_title",
+        )
+
+    active_partner_links = [
+        link
+        for link in sorted(
+            instance.partner_organization_links,
+            key=lambda row: row.sort_order,
+        )
+        if link.organization.archived_at is None
+    ]
+    resolved_partner_id: UUID | None = None
+    partner_display_name: str | None = None
+    partner_signer_name: str | None = None
+
+    if active_partner_links:
+        if partner_organization_id is None:
+            raise ValidationError(
+                "partner_organization_id is required when the instance has partners",
+                field="partner_organization_id",
+            )
+        allowed_ids = {link.organization_id for link in active_partner_links}
+        if partner_organization_id not in allowed_ids:
+            raise ValidationError(
+                "partner_organization_id is not linked to this instance",
+                field="partner_organization_id",
+            )
+        org = session.get(Organization, partner_organization_id)
+        if org is None:
+            raise ValidationError(
+                "partner_organization_id not found",
+                field="partner_organization_id",
+            )
+        resolved_partner_id = partner_organization_id
+        partner_display_name = org.name.strip()
+        partner_signer_name = _partner_signer_name(session, partner_organization_id)
+    elif partner_organization_id is not None:
+        raise ValidationError(
+            "partner_organization_id must be omitted when the instance has no partners",
+            field="partner_organization_id",
+        )
+
+    recipient_display_name = _contact_display_name(contact)
+    body_text = build_certificate_body_text(
+        trading_name=trading_name,
+        partner_display_name=partner_display_name,
+    )
+
+    return ResolvedCertificateDraft(
+        contact_id=contact_id,
+        instance_id=instance_id,
+        service_id=service_id,
+        enrollment_id=enrollment.id,
+        partner_organization_id=resolved_partner_id,
+        participation_date=participation_date,
+        recipient_display_name=recipient_display_name,
+        program_title=program_title,
+        partner_display_name=partner_display_name,
+        partner_signer_name=partner_signer_name,
+        body_text=body_text,
+        trading_name=trading_name,
+        es_founder_name=es_founder,
+    )
+
+
+def draft_to_pdf_context(draft: ResolvedCertificateDraft) -> CompletionCertificatePdfContext:
+    return CompletionCertificatePdfContext(
+        recipient_display_name=draft.recipient_display_name,
+        program_title=draft.program_title,
+        participation_date=draft.participation_date,
+        trading_name=draft.trading_name,
+        partner_display_name=draft.partner_display_name,
+        partner_signer_name=draft.partner_signer_name,
+        es_founder_name=draft.es_founder_name,
+        body_text=draft.body_text,
+    )
+
+
+def render_draft_pdf_bytes(draft: ResolvedCertificateDraft) -> bytes:
+    return render_completion_certificate_pdf(draft_to_pdf_context(draft))
+
+
+def upload_preview_pdf(pdf_bytes: bytes) -> str:
+    key = preview_pdf_s3_key()
+    store_pdf_in_assets_bucket(
+        s3_key=key,
+        body=pdf_bytes,
+        content_type="application/pdf",
+    )
+    return key
+
+
+def create_issued_certificate(
+    session: Session,
+    *,
+    draft: ResolvedCertificateDraft,
+    actor_sub: str,
+) -> CompletionCertificate:
+    """Persist certificate row and upload issued PDF."""
+    now = datetime.now(UTC)
+    cert = CompletionCertificate(
+        contact_id=draft.contact_id,
+        instance_id=draft.instance_id,
+        service_id=draft.service_id,
+        enrollment_id=draft.enrollment_id,
+        partner_organization_id=draft.partner_organization_id,
+        participation_date=draft.participation_date,
+        recipient_display_name=draft.recipient_display_name,
+        program_title=draft.program_title,
+        partner_display_name=draft.partner_display_name,
+        partner_signer_name=draft.partner_signer_name,
+        body_text=draft.body_text,
+        status=CompletionCertificateStatus.ISSUED,
+        issued_at=now,
+        issued_by=actor_sub,
+    )
+    session.add(cert)
+    session.flush()
+
+    pdf_bytes = render_draft_pdf_bytes(draft)
+    digest = _sha256_bytes(pdf_bytes)
+    key = issued_pdf_s3_key(cert.id)
+    store_pdf_in_assets_bucket(
+        s3_key=key,
+        body=pdf_bytes,
+        content_type="application/pdf",
+    )
+    cert.issued_pdf_s3_key = key
+    cert.issued_pdf_sha256 = digest
+    cert.pdf_template_version = COMPLETION_CERTIFICATE_PDF_TEMPLATE_VERSION
+    session.flush()
+    return cert
+
+
+def load_certificate_for_pdf(
+    session: Session, certificate_id: UUID
+) -> CompletionCertificate:
+    cert = session.get(CompletionCertificate, certificate_id)
+    if cert is None:
+        raise NotFoundError("CompletionCertificate", str(certificate_id))
+    if cert.status != CompletionCertificateStatus.ISSUED:
+        raise ValidationError(
+            "Certificate is voided; PDF download is not available",
+            field="id",
+        )
+    if not cert.issued_pdf_s3_key:
+        raise ValidationError("Certificate PDF is not available", field="id")
+    return cert
+
+
+def contact_ids_with_issued_certificates(
+    session: Session, contact_ids: list[UUID]
+) -> set[UUID]:
+    if not contact_ids:
+        return set()
+    stmt = (
+        select(CompletionCertificate.contact_id)
+        .where(
+            CompletionCertificate.contact_id.in_(contact_ids),
+            CompletionCertificate.status == CompletionCertificateStatus.ISSUED,
+        )
+        .distinct()
+    )
+    return set(session.execute(stmt).scalars().all())

--- a/backend/src/app/services/completion_certificate_common.py
+++ b/backend/src/app/services/completion_certificate_common.py
@@ -227,7 +227,9 @@ def resolve_certificate_draft(
     )
 
 
-def draft_to_pdf_context(draft: ResolvedCertificateDraft) -> CompletionCertificatePdfContext:
+def draft_to_pdf_context(
+    draft: ResolvedCertificateDraft,
+) -> CompletionCertificatePdfContext:
     return CompletionCertificatePdfContext(
         recipient_display_name=draft.recipient_display_name,
         program_title=draft.program_title,

--- a/backend/src/app/services/completion_certificate_pdf.py
+++ b/backend/src/app/services/completion_certificate_pdf.py
@@ -1,0 +1,208 @@
+"""Completion certificate PDF rendering (ReportLab)."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from datetime import date
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.pagesizes import landscape, A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
+
+from app.config.public_www import get_public_www
+
+COMPLETION_CERTIFICATE_PDF_TEMPLATE_VERSION = "completion-certificate-v1"
+
+_CERTIFICATE_BODY_TEMPLATE = (
+    "has successfully completed the {brand_line} training in "
+    "Montessori-informed newborn care, demonstrating the knowledge and practice "
+    "of respect-based, developmentally grounded caregiving in the first twelve "
+    "weeks of life."
+)
+
+_CREDENTIAL_FOOTER_PREFIX = "CERTIFIED CARETAKER HONG KONG"
+
+
+@dataclass(frozen=True)
+class CompletionCertificatePdfContext:
+    """Inputs for rendering a completion certificate PDF."""
+
+    recipient_display_name: str
+    program_title: str
+    participation_date: date
+    trading_name: str
+    partner_display_name: str | None
+    partner_signer_name: str | None
+    es_founder_name: str
+    body_text: str
+
+
+def build_certificate_body_text(
+    *,
+    trading_name: str,
+    partner_display_name: str | None,
+) -> str:
+    """Fill the global certificate body template (paragraph after recipient name)."""
+    if partner_display_name:
+        brand_line = f"{trading_name} × {partner_display_name}"
+    else:
+        brand_line = trading_name
+    return _CERTIFICATE_BODY_TEMPLATE.format(brand_line=brand_line)
+
+
+def certificate_trading_name() -> str:
+    return get_public_www("BUSINESS_NAME").strip()
+
+
+def certificate_es_founder_name() -> str:
+    return get_public_www("CERTIFICATE_ES_FOUNDER_NAME").strip()
+
+
+def _header_brand_line(ctx: CompletionCertificatePdfContext) -> str:
+    if ctx.partner_display_name:
+        return f"{ctx.trading_name.upper()} × {ctx.partner_display_name.upper()}"
+    return ctx.trading_name.upper()
+
+
+def _format_awarded_date(participation_date: date) -> str:
+    return f"AWARDED {participation_date.strftime('%d %B %Y').upper()}"
+
+
+def _credential_footer(participation_date: date) -> str:
+    return f"{_CREDENTIAL_FOOTER_PREFIX} · {participation_date.year}"
+
+
+def render_completion_certificate_pdf(ctx: CompletionCertificatePdfContext) -> bytes:
+    """Render a landscape completion certificate PDF."""
+    page_size = landscape(A4)
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=page_size,
+        leftMargin=18 * mm,
+        rightMargin=18 * mm,
+        topMargin=16 * mm,
+        bottomMargin=16 * mm,
+    )
+    styles = getSampleStyleSheet()
+    title_style = ParagraphStyle(
+        "CertTitle",
+        parent=styles["Heading1"],
+        fontName="Helvetica-Bold",
+        fontSize=22,
+        leading=26,
+        alignment=TA_CENTER,
+        textColor=colors.HexColor("#1a3d2e"),
+        spaceAfter=6,
+    )
+    brand_style = ParagraphStyle(
+        "CertBrand",
+        parent=styles["Normal"],
+        fontName="Helvetica-Bold",
+        fontSize=11,
+        leading=14,
+        alignment=TA_CENTER,
+        textColor=colors.HexColor("#4a6741"),
+        spaceAfter=10,
+    )
+    program_style = ParagraphStyle(
+        "CertProgram",
+        parent=styles["Normal"],
+        fontName="Helvetica-Bold",
+        fontSize=16,
+        leading=20,
+        alignment=TA_CENTER,
+        textColor=colors.HexColor("#2d4a3e"),
+        spaceAfter=14,
+    )
+    recipient_style = ParagraphStyle(
+        "CertRecipient",
+        parent=styles["Normal"],
+        fontName="Helvetica-Bold",
+        fontSize=20,
+        leading=24,
+        alignment=TA_CENTER,
+        textColor=colors.HexColor("#1a1a1a"),
+        spaceAfter=12,
+    )
+    body_style = ParagraphStyle(
+        "CertBody",
+        parent=styles["Normal"],
+        fontName="Helvetica",
+        fontSize=11,
+        leading=15,
+        alignment=TA_CENTER,
+        textColor=colors.HexColor("#333333"),
+        spaceAfter=18,
+    )
+    sig_name_style = ParagraphStyle(
+        "CertSigName",
+        parent=styles["Normal"],
+        fontName="Helvetica-Bold",
+        fontSize=11,
+        leading=13,
+        alignment=TA_CENTER,
+    )
+    date_style = ParagraphStyle(
+        "CertDate",
+        parent=styles["Normal"],
+        fontName="Helvetica-Bold",
+        fontSize=10,
+        leading=12,
+        alignment=TA_CENTER,
+        textColor=colors.HexColor("#4a6741"),
+        spaceBefore=8,
+        spaceAfter=6,
+    )
+    footer_style = ParagraphStyle(
+        "CertFooter",
+        parent=styles["Normal"],
+        fontName="Helvetica",
+        fontSize=8,
+        leading=10,
+        alignment=TA_CENTER,
+        textColor=colors.HexColor("#666666"),
+    )
+
+    story: list[object] = []
+    story.append(Spacer(1, 8 * mm))
+    story.append(Paragraph(_header_brand_line(ctx), brand_style))
+    story.append(Paragraph("CERTIFICATE OF COMPLETION", title_style))
+    story.append(Paragraph(ctx.program_title, program_style))
+    story.append(Paragraph("This certifies that", body_style))
+    story.append(Paragraph(ctx.recipient_display_name, recipient_style))
+    story.append(Paragraph(ctx.body_text, body_style))
+    story.append(Spacer(1, 6 * mm))
+
+    sig_blocks: list[str] = []
+    sig_blocks.append(
+        f'<para align="center"><b>{_escape_xml(ctx.es_founder_name)}</b><br/>'
+        f"FOUNDER · { _escape_xml(ctx.trading_name.upper()) }</para>"
+    )
+    if ctx.partner_display_name and ctx.partner_signer_name:
+        sig_blocks.append(
+            f'<para align="center"><b>{_escape_xml(ctx.partner_signer_name)}</b><br/>'
+            f"FOUNDER · { _escape_xml(ctx.partner_display_name.upper()) }</para>"
+        )
+    for block in sig_blocks:
+        story.append(Paragraph(block, sig_name_style))
+        story.append(Spacer(1, 4 * mm))
+
+    story.append(Paragraph(_format_awarded_date(ctx.participation_date), date_style))
+    story.append(Paragraph(_credential_footer(ctx.participation_date), footer_style))
+
+    doc.build(story)
+    return buf.getvalue()
+
+
+def _escape_xml(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -27,6 +27,11 @@ info:
     - `PATCH|DELETE /v1/admin/services/{id}/instances/{instanceId}/enrollments/{enrollmentId}`
     - `GET|POST /v1/admin/discount-codes`
     - `PUT|DELETE /v1/admin/discount-codes/{id}`
+    - `GET|POST /v1/admin/completion-certificates`
+    - `POST /v1/admin/completion-certificates/preview`
+    - `GET|DELETE /v1/admin/completion-certificates/{id}`
+    - `GET /v1/admin/completion-certificates/{id}/pdf`
+    - `POST /v1/admin/completion-certificates/{id}/void`
     - `GET|POST /v1/admin/calendar/manual-blocks` (GET requires `purpose`, `from`, `to`)
     - `GET|PATCH|DELETE /v1/admin/calendar/manual-blocks/{id}`
     - `GET|POST /v1/admin/tags` (optional `include_archived`, `archived_only`)
@@ -1739,6 +1744,178 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DiscountCodeResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/completion-certificates:
+    get:
+      summary: List completion certificates
+      security:
+        - AdminBearerAuth: []
+      parameters:
+        - name: contact_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: service_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: instance_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [issued, voided]
+      responses:
+        "200":
+          description: Certificate list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionCertificateListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      summary: Issue completion certificate
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IssueCompletionCertificateRequest"
+      responses:
+        "201":
+          description: Certificate issued.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionCertificateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/completion-certificates/preview:
+    post:
+      summary: Preview completion certificate PDF
+      description: |
+        Renders a certificate PDF from the request payload without persisting a row.
+        Returns a short-lived CloudFront-signed download URL.
+      security:
+        - AdminBearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreviewCompletionCertificateRequest"
+      responses:
+        "200":
+          description: Signed preview URL.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PdfDownloadResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/admin/completion-certificates/{id}:
+    parameters:
+      - $ref: "#/components/parameters/CompletionCertificateId"
+    get:
+      summary: Get completion certificate
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Certificate detail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionCertificateResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete completion certificate
+      description: Permanently removes the certificate row and best-effort deletes the stored PDF.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [deleted]
+                properties:
+                  deleted:
+                    type: boolean
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/completion-certificates/{id}/pdf:
+    parameters:
+      - $ref: "#/components/parameters/CompletionCertificateId"
+    get:
+      summary: Download issued completion certificate PDF
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Signed download URL for an issued certificate.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PdfDownloadResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/completion-certificates/{id}/void:
+    parameters:
+      - $ref: "#/components/parameters/CompletionCertificateId"
+    post:
+      summary: Void completion certificate
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Voided certificate.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionCertificateResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -4284,6 +4461,14 @@ components:
         type: string
         format: uuid
       description: Discount code identifier.
+    CompletionCertificateId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Completion certificate identifier.
     AdminContactId:
       name: id
       in: path
@@ -8072,6 +8257,7 @@ components:
         - family_ids
         - organization_ids
         - standalone_note_count
+        - has_completion_certificate
       properties:
         id:
           type: string
@@ -8186,6 +8372,162 @@ components:
           description: |
             Count of CRM notes on this contact that are not tied to a sales lead
             (`lead_id` is null). Lead-attached notes are excluded.
+        has_completion_certificate:
+          type: boolean
+          description: |
+            True when the contact has at least one issued (non-voided) completion certificate.
+    PdfDownloadResponse:
+      type: object
+      required: [downloadUrl, expiresAt]
+      properties:
+        downloadUrl:
+          type: string
+          format: uri
+        expiresAt:
+          type: string
+          format: date-time
+    CompletionCertificateStatus:
+      type: string
+      enum: [issued, voided]
+    CompletionCertificate:
+      type: object
+      required:
+        - id
+        - contact_id
+        - contact_label
+        - instance_id
+        - instance_label
+        - service_id
+        - service_label
+        - enrollment_id
+        - participation_date
+        - recipient_display_name
+        - program_title
+        - body_text
+        - status
+        - issued_at
+        - issued_by
+      properties:
+        id:
+          type: string
+          format: uuid
+        contact_id:
+          type: string
+          format: uuid
+        contact_label:
+          type: string
+        instance_id:
+          type: string
+          format: uuid
+        instance_label:
+          type: string
+        service_id:
+          type: string
+          format: uuid
+        service_label:
+          type: string
+        enrollment_id:
+          type: string
+          format: uuid
+        partner_organization_id:
+          type: string
+          format: uuid
+          nullable: true
+        participation_date:
+          type: string
+          format: date
+        recipient_display_name:
+          type: string
+        program_title:
+          type: string
+        partner_display_name:
+          type: string
+          nullable: true
+        partner_signer_name:
+          type: string
+          nullable: true
+        body_text:
+          type: string
+        status:
+          $ref: "#/components/schemas/CompletionCertificateStatus"
+        issued_at:
+          type: string
+          format: date-time
+        issued_by:
+          type: string
+        voided_at:
+          type: string
+          format: date-time
+          nullable: true
+        voided_by:
+          type: string
+          nullable: true
+        issued_pdf_sha256:
+          type: string
+          nullable: true
+        pdf_template_version:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+    CompletionCertificateListResponse:
+      type: object
+      required: [items, total_count]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/CompletionCertificate"
+        next_cursor:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+          minimum: 0
+    CompletionCertificateResponse:
+      type: object
+      required: [certificate]
+      properties:
+        certificate:
+          $ref: "#/components/schemas/CompletionCertificate"
+    PreviewCompletionCertificateRequest:
+      type: object
+      required:
+        - contact_id
+        - service_id
+        - instance_id
+        - participation_date
+      properties:
+        contact_id:
+          type: string
+          format: uuid
+        service_id:
+          type: string
+          format: uuid
+        instance_id:
+          type: string
+          format: uuid
+        participation_date:
+          type: string
+          format: date
+        program_title:
+          type: string
+          nullable: true
+          description: Optional override; defaults to instance or service title.
+        partner_organization_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Required when the instance has linked partner organisations.
+    IssueCompletionCertificateRequest:
+      allOf:
+        - $ref: "#/components/schemas/PreviewCompletionCertificateRequest"
     AdminContactListResponse:
       type: object
       required:

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -653,6 +653,12 @@ Migration `0055_customer_billing_ar` introduces:
   **`payment_unapplied_amount`** sums allocations **matching the parent payment's currency** only
   (one currency per payment; multi-currency allocation is not supported).
 - `customer_receipts`: one row per succeeded inbound payment (`customer_payment_id` unique).
+- `completion_certificates` (migration `0069_completion_certs`): issued training
+  completion PDFs linked to `contacts`, `service_instances`, `services`, and
+  `enrollments`. Snapshots recipient name, program title, partner branding, and body
+  text at issue time. `status` is `issued` or `voided`; voided rows drop the contact
+  award badge. Multiple issued rows per contact/instance are allowed. PDF object keys
+  live under `completion-certificates/` in the assets bucket.
 - `document_counters`: serialized numbering per scope and year; **invoices** use one
   global sequence per year (`INV-YYYY-NNNNNN`), while **receipts** keep a per-currency scope.
 - Audit: same `audit_trigger_func()` as `0054_add_audit_log` on all five billing tables.

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -133,7 +133,9 @@ their primary responsibilities.
   `location_id` (partner venue); and
   `GET /v1/admin/services/{id}/discount-code-usage-summary` for
   aggregate discount usage before service key changes; `DELETE /v1/admin/services/{id}`
-  returns `409` when the service still has instances), `/v1/admin/discount-codes/*`
+  returns `409` when the service still has instances), `/v1/admin/completion-certificates/*`
+  (preview, issue, list, void, delete, PDF download; requires a completed enrollment for
+  the contact and instance), `/v1/admin/discount-codes/*`
   (`POST` returns `409` with `field: code` when the code collides with the
   case-insensitive unique index; `PUT` accepts `discount_value` `0` only when the
   effective discount type after the update is `referral`, otherwise `discount_value`

--- a/tests/test_admin_completion_certificates.py
+++ b/tests/test_admin_completion_certificates.py
@@ -1,0 +1,83 @@
+"""Admin completion certificate API tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.api.admin_completion_certificates import (
+    _parse_issue_payload,
+    handle_admin_completion_certificates_request,
+)
+from app.exceptions import ValidationError
+from app.services.completion_certificate_pdf import (
+    build_certificate_body_text,
+    render_completion_certificate_pdf,
+    CompletionCertificatePdfContext,
+)
+
+
+def test_build_certificate_body_text_with_partner() -> None:
+    text = build_certificate_body_text(
+        trading_name="Evolve Sprouts",
+        partner_display_name="Parachute",
+    )
+    assert "Evolve Sprouts × Parachute" in text
+    assert "Montessori-informed" in text
+
+
+def test_render_completion_certificate_pdf_returns_bytes() -> None:
+    pdf = render_completion_certificate_pdf(
+        CompletionCertificatePdfContext(
+            recipient_display_name="Alex Example",
+            program_title="Montessori Postnatal Caretaker",
+            participation_date=date(2026, 6, 14),
+            trading_name="Evolve Sprouts",
+            partner_display_name="Parachute",
+            partner_signer_name="Rosalind",
+            es_founder_name="Ida De Gregorio",
+            body_text=build_certificate_body_text(
+                trading_name="Evolve Sprouts",
+                partner_display_name="Parachute",
+            ),
+        )
+    )
+    assert pdf.startswith(b"%PDF")
+
+
+def test_parse_issue_payload_requires_fields() -> None:
+    with pytest.raises(ValidationError):
+        _parse_issue_payload({})
+
+
+def test_parse_issue_payload_parses_uuids_and_date() -> None:
+    cid = uuid4()
+    sid = uuid4()
+    iid = uuid4()
+    pid = uuid4()
+    parsed = _parse_issue_payload(
+        {
+            "contact_id": str(cid),
+            "service_id": str(sid),
+            "instance_id": str(iid),
+            "participation_date": "2026-06-14",
+            "program_title": " Custom Program ",
+            "partner_organization_id": str(pid),
+        }
+    )
+    assert parsed["contact_id"] == cid
+    assert parsed["participation_date"] == date(2026, 6, 14)
+    assert parsed["program_title_override"] == "Custom Program"
+    assert parsed["partner_organization_id"] == pid
+
+
+def test_handle_unknown_route_returns_404(api_gateway_event: Any) -> None:
+    response = handle_admin_completion_certificates_request(
+        api_gateway_event(method="GET", path="/v1/admin/unknown"),
+        "GET",
+        "/v1/admin/unknown",
+    )
+    assert response["statusCode"] == 404


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Certificates** tab on the admin Services page (after Partners) to issue training completion PDFs linked to a contact and service instance.

## What changed

### Backend
- New `completion_certificates` table (migration `0069_completion_certs`) with snapshot fields and S3 PDF storage
- ReportLab renderer matching the sample layout (brand line, program title, recipient, global body template, signatures, awarded date)
- Admin API: list, preview, issue, get, PDF download, void, delete
- Requires a **completed** enrollment for the contact + instance
- Explicit **partner** picker when the instance has partner organisations
- `AdminContact.has_completion_certificate` for the contacts list badge

### Admin web
- Certificates tab with inline editor, debounced PDF preview (`iframe`), issue/download/void/delete
- Contacts list shows 🎓 when the contact has an issued (non-voided) certificate

### Infrastructure
- `PublicWwwCertificateEsFounderName` CDK parameter → `PUBLIC_WWW_CERTIFICATE_ES_FOUNDER_NAME` in the public www config secret

## Deploy notes

Set `PublicWwwCertificateEsFounderName` (and ensure `PublicWwwBusinessName` is set) before issuing certificates in production.

## Testing

- `pytest tests/test_admin_completion_certificates.py`
- `cd apps/admin_web && npx vitest run tests/components/admin/services/services-page.test.tsx tests/components/admin/contacts/contacts-panel.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f19cc35-e5ce-484c-8172-7e7f2dad0da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f19cc35-e5ce-484c-8172-7e7f2dad0da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

