### PR TITLE
Add workshop exit feedback survey with emoji rating and capped multiselect

### DIFF
--- a/apps/admin_web/src/lib/forms-api.ts
+++ b/apps/admin_web/src/lib/forms-api.ts
@@ -27,7 +27,13 @@ function parseFormAnswerRow(value: unknown): AdminFormAnswerRow {
     sessionId: typeof row.sessionId === 'string' ? row.sessionId : '',
     questionId: typeof row.questionId === 'string' ? row.questionId : '',
     questionType:
-      row.questionType === 'select' || row.questionType === 'text' || row.questionType === 'email'
+      row.questionType === 'select' ||
+      row.questionType === 'multiselect' ||
+      row.questionType === 'rating' ||
+      row.questionType === 'segmented' ||
+      row.questionType === 'consent' ||
+      row.questionType === 'text' ||
+      row.questionType === 'email'
         ? row.questionType
         : 'text',
     createdAt: typeof row.createdAt === 'string' ? row.createdAt : '',
@@ -35,6 +41,17 @@ function parseFormAnswerRow(value: unknown): AdminFormAnswerRow {
   };
   if (typeof row.selectedOption === 'string') {
     parsed.selectedOption = row.selectedOption;
+  }
+  if (Array.isArray(row.selectedOptions)) {
+    parsed.selectedOptions = row.selectedOptions.filter(
+      (option): option is string => typeof option === 'string' && option.trim().length > 0
+    );
+  }
+  if (typeof row.ratingValue === 'number' && Number.isFinite(row.ratingValue)) {
+    parsed.ratingValue = row.ratingValue;
+  }
+  if (typeof row.booleanAnswer === 'boolean') {
+    parsed.booleanAnswer = row.booleanAnswer;
   }
   if (typeof row.freeText === 'string') {
     parsed.freeText = row.freeText;
@@ -102,8 +119,17 @@ export async function exportAdminFormAnswersCsv(formSlug: string): Promise<Blob>
 }
 
 export function formatFormAnswerValue(row: AdminFormAnswerRow): string {
+  if (typeof row.ratingValue === 'number') {
+    return String(row.ratingValue);
+  }
   if (typeof row.selectedOption === 'string' && row.selectedOption.trim()) {
     return row.selectedOption;
+  }
+  if (Array.isArray(row.selectedOptions) && row.selectedOptions.length > 0) {
+    return row.selectedOptions.join('; ');
+  }
+  if (typeof row.booleanAnswer === 'boolean') {
+    return row.booleanAnswer ? 'yes' : 'no';
   }
   if (typeof row.freeText === 'string' && row.freeText.trim()) {
     return row.freeText;

--- a/apps/admin_web/src/lib/forms-api.ts
+++ b/apps/admin_web/src/lib/forms-api.ts
@@ -129,7 +129,11 @@ export function formatFormAnswerValue(row: AdminFormAnswerRow): string {
     return row.selectedOptions.join('; ');
   }
   if (typeof row.booleanAnswer === 'boolean') {
-    return row.booleanAnswer ? 'yes' : 'no';
+    const consentBase = row.booleanAnswer ? 'yes' : 'no';
+    if (row.questionType === 'consent' && typeof row.freeText === 'string' && row.freeText.trim()) {
+      return `${consentBase}; ${row.freeText.trim()}`;
+    }
+    return consentBase;
   }
   if (typeof row.freeText === 'string' && row.freeText.trim()) {
     return row.freeText;

--- a/apps/admin_web/src/lib/training-site-page-presets.ts
+++ b/apps/admin_web/src/lib/training-site-page-presets.ts
@@ -13,6 +13,7 @@ export interface TrainingSitePagePreset {
 const PRESET_ROWS: readonly { label: string; routeKey: keyof typeof TRAINING_ROUTES }[] = [
   { label: 'Home', routeKey: 'home' },
   { label: 'Workshop feedback form', routeKey: 'formsWorkshopFeedback' },
+  { label: 'Workshop exit feedback', routeKey: 'formsWorkshopExitFeedback' },
   { label: 'Workshop food poll (Jun 26)', routeKey: 'pollsWorkshopFoodJun26' },
 ] as const;
 

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -7643,8 +7643,11 @@ export interface components {
             sessionId: string;
             questionId: string;
             /** @enum {string} */
-            questionType: "select" | "text" | "email";
+            questionType: "select" | "multiselect" | "rating" | "segmented" | "consent" | "text" | "email";
             selectedOption?: string;
+            selectedOptions?: string[];
+            ratingValue?: number;
+            booleanAnswer?: boolean;
             freeText?: string;
             /** Format: date-time */
             createdAt: string;

--- a/apps/admin_web/tests/lib/forms-api-format.test.ts
+++ b/apps/admin_web/tests/lib/forms-api-format.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatFormAnswerValue } from '@/lib/forms-api';
+import type { AdminFormAnswerRow } from '@/lib/forms-api';
+
+describe('formatFormAnswerValue', () => {
+  it('appends consent follow-up text for consent rows', () => {
+    const row: AdminFormAnswerRow = {
+      formSlug: 'workshop-exit-feedback',
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      questionId: 'share-consent',
+      questionType: 'consent',
+      booleanAnswer: true,
+      freeText: 'Year 3',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    expect(formatFormAnswerValue(row)).toBe('yes; Year 3');
+  });
+});

--- a/apps/training/src/app/globals.css
+++ b/apps/training/src/app/globals.css
@@ -90,6 +90,11 @@ progress.poll-live-results-bar::-moz-progress-bar {
   transition: transform 0.12s ease, border-color 0.12s ease, background-color 0.12s ease;
 }
 
+.form-rating-option:focus-within {
+  outline: 2px solid var(--es-focus-ring-color, rgba(0, 0, 0, 0.4));
+  outline-offset: 2px;
+}
+
 .form-rating-option:active {
   transform: scale(0.92);
 }
@@ -163,6 +168,11 @@ progress.poll-live-results-bar::-moz-progress-bar {
   cursor: pointer;
   transition: transform 0.12s ease, background-color 0.12s ease, border-color 0.12s ease,
     color 0.12s ease;
+}
+
+.form-segmented-option:focus-within {
+  outline: 2px solid var(--es-focus-ring-color, rgba(0, 0, 0, 0.4));
+  outline-offset: 2px;
 }
 
 .form-segmented-option:active {

--- a/apps/training/src/app/globals.css
+++ b/apps/training/src/app/globals.css
@@ -30,3 +30,235 @@ progress.poll-live-results-bar::-moz-progress-bar {
   background-color: var(--es-color-brand-orange-strong);
   border-radius: 9999px;
 }
+
+/* Scroll-layout workshop feedback form */
+.form-scroll-title {
+  color: var(--es-color-brand-teal, #2a9d8f);
+  text-align: center;
+}
+
+.form-scroll-subtitle {
+  color: var(--es-color-text-muted);
+}
+
+.form-scroll-duration {
+  color: var(--es-color-brand-clay, #e8734a);
+}
+
+.form-scroll-brand-primary {
+  color: var(--es-color-brand-teal, #2a9d8f);
+  font-weight: 700;
+}
+
+.form-scroll-brand-separator {
+  color: var(--es-color-text-muted);
+  margin-inline: 0.35rem;
+}
+
+.form-scroll-card {
+  background-color: var(--es-color-surface-white, #fff);
+  border-color: var(--es-color-border-panel-soft);
+  box-shadow: 0 1px 3px rgb(38 70 83 / 5%);
+}
+
+.form-scroll-question {
+  color: var(--es-color-text-heading);
+}
+
+.form-scroll-question-number {
+  color: var(--es-color-brand-gold, #e9c46a);
+}
+
+.form-scroll-hint {
+  color: var(--es-color-text-muted);
+}
+
+.form-rating-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.form-rating-option {
+  flex: 1;
+  aspect-ratio: 1;
+  border: 1.5px solid var(--es-color-border-panel-soft);
+  border-radius: 0.8125rem;
+  background-color: var(--es-color-surface-white, #fff);
+  font-size: 1.625rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.12s ease, border-color 0.12s ease, background-color 0.12s ease;
+}
+
+.form-rating-option:active {
+  transform: scale(0.92);
+}
+
+.form-rating-option--selected {
+  border-color: var(--es-color-brand-teal, #2a9d8f);
+  background-color: #effaf8;
+  transform: scale(1.04);
+}
+
+.form-rating-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.66rem;
+  color: var(--es-color-text-muted);
+}
+
+.form-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.form-chip {
+  border: 1.5px solid var(--es-color-border-panel-soft);
+  border-radius: 9999px;
+  background-color: var(--es-color-surface-white, #fff);
+  padding: 0.625rem 0.875rem;
+  font-size: 0.84rem;
+  font-weight: 500;
+  color: var(--es-color-text-heading);
+  cursor: pointer;
+  transition: transform 0.12s ease, background-color 0.12s ease, border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.form-chip:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+.form-chip--selected {
+  background-color: var(--es-color-brand-teal, #2a9d8f);
+  border-color: var(--es-color-brand-teal, #2a9d8f);
+  color: #fff;
+  font-weight: 700;
+}
+
+.form-chip--locked {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.form-segmented-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.form-segmented-option {
+  flex: 1;
+  border: 1.5px solid var(--es-color-border-panel-soft);
+  border-radius: 0.8125rem;
+  background-color: var(--es-color-surface-white, #fff);
+  padding: 0.875rem 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--es-color-text-heading);
+  cursor: pointer;
+  transition: transform 0.12s ease, background-color 0.12s ease, border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.form-segmented-option:active {
+  transform: scale(0.96);
+}
+
+.form-segmented-option--selected.form-segmented-option--yes {
+  background-color: var(--es-color-brand-teal, #2a9d8f);
+  border-color: transparent;
+  color: #fff;
+}
+
+.form-segmented-option--selected.form-segmented-option--maybe {
+  background-color: var(--es-color-brand-sand, #f4a261);
+  border-color: transparent;
+  color: #fff;
+}
+
+.form-segmented-option--selected.form-segmented-option--no {
+  background-color: var(--es-color-brand-clay, #e8734a);
+  border-color: transparent;
+  color: #fff;
+}
+
+.form-scroll-textarea {
+  border-radius: 0.75rem;
+}
+
+.form-consent-row {
+  display: flex;
+  gap: 0.6875rem;
+  align-items: flex-start;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+
+.form-consent-checkbox {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-top: 0.0625rem;
+  border: 1.8px solid var(--es-color-border-panel-soft);
+  border-radius: 0.4375rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.form-consent-checkbox--checked {
+  background-color: var(--es-color-brand-teal, #2a9d8f);
+  border-color: var(--es-color-brand-teal, #2a9d8f);
+}
+
+.form-consent-checkmark {
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.form-consent-text {
+  color: var(--es-color-text-heading);
+}
+
+.form-scroll-submit {
+  border: none;
+  border-radius: 0.875rem;
+  background-color: var(--es-color-brand-clay, #e8734a);
+  color: #fff;
+  padding: 1.0625rem;
+  font-size: 1.0625rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.12s ease, opacity 0.12s ease;
+}
+
+.form-scroll-submit:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.form-scroll-submit:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.form-scroll-thanks-title {
+  color: var(--es-color-brand-teal, #2a9d8f);
+}
+
+.form-scroll-again {
+  border: 1.5px solid var(--es-color-brand-teal, #2a9d8f);
+  border-radius: 0.75rem;
+  background-color: var(--es-color-surface-white, #fff);
+  color: var(--es-color-brand-teal, #2a9d8f);
+  padding: 0.8125rem 1.625rem;
+  font-weight: 700;
+  font-size: 0.875rem;
+  cursor: pointer;
+}

--- a/apps/training/src/app/globals.css
+++ b/apps/training/src/app/globals.css
@@ -96,8 +96,12 @@ progress.poll-live-results-bar::-moz-progress-bar {
 
 .form-rating-option--selected {
   border-color: var(--es-color-brand-teal, #2a9d8f);
-  background-color: #effaf8;
+  background-color: var(--es-color-rating-selected-bg, #effaf8);
   transform: scale(1.04);
+}
+
+.form-scroll-required-marker {
+  color: var(--es-color-text-muted);
 }
 
 .form-rating-labels {

--- a/apps/training/src/components/forms/form-answer-state.ts
+++ b/apps/training/src/components/forms/form-answer-state.ts
@@ -1,20 +1,48 @@
 import type { FormQuestion } from '@/content/form-types';
+import { isQuestionRequired } from '@/content/form-types';
 
 export interface FormAnswerState {
   selectedOption: string;
+  selectedOptions: string[];
+  ratingValue: number | null;
+  trueFalseValue: boolean | null;
   freeText: string;
 }
 
 export function emptyFormAnswerState(): FormAnswerState {
   return {
     selectedOption: '',
+    selectedOptions: [],
+    ratingValue: null,
+    trueFalseValue: null,
     freeText: '',
   };
 }
 
 export function isFormAnswerValid(question: FormQuestion, answer: FormAnswerState): boolean {
-  if (question.type === 'select') {
+  if (!isQuestionRequired(question)) {
+    if (question.type === 'consent') {
+      return isConsentAnswerValid(question, answer, false);
+    }
+    if (question.type === 'text' && answer.freeText.trim().length === 0) {
+      return true;
+    }
+    if (question.type === 'multiselect' && answer.selectedOptions.length === 0) {
+      return true;
+    }
+  }
+
+  if (question.type === 'select' || question.type === 'segmented') {
     return answer.selectedOption.trim().length > 0;
+  }
+  if (question.type === 'multiselect') {
+    return answer.selectedOptions.length > 0;
+  }
+  if (question.type === 'rating') {
+    return answer.ratingValue !== null;
+  }
+  if (question.type === 'consent') {
+    return isConsentAnswerValid(question, answer, isQuestionRequired(question));
   }
   if (question.type === 'email') {
     return isValidEmail(answer.freeText);
@@ -25,10 +53,41 @@ export function isFormAnswerValid(question: FormQuestion, answer: FormAnswerStat
   return false;
 }
 
+function isConsentAnswerValid(
+  question: Extract<FormQuestion, { type: 'consent' }>,
+  answer: FormAnswerState,
+  required: boolean,
+): boolean {
+  if (!answer.trueFalseValue) {
+    if (!required) {
+      return true;
+    }
+    return false;
+  }
+  if (question.followUp?.required) {
+    return answer.freeText.trim().length > 0;
+  }
+  return true;
+}
+
 function isValidEmail(value: string): boolean {
   const normalized = value.trim();
   if (!normalized) {
     return false;
   }
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized);
+}
+
+export function toggleMultiselectOption(
+  current: string[],
+  option: string,
+  maxSelections: number,
+): string[] {
+  if (current.includes(option)) {
+    return current.filter((value) => value !== option);
+  }
+  if (current.length >= maxSelections) {
+    return current;
+  }
+  return [...current, option];
 }

--- a/apps/training/src/components/forms/form-answer-state.ts
+++ b/apps/training/src/components/forms/form-answer-state.ts
@@ -1,4 +1,4 @@
-import type { FormQuestion } from '@/content/form-types';
+import type { FormQuestion, FormsCommonContent } from '@/content/form-types';
 import { isQuestionRequired } from '@/content/form-types';
 
 export interface FormAnswerState {
@@ -36,6 +36,9 @@ export function isFormAnswerValid(question: FormQuestion, answer: FormAnswerStat
     return answer.selectedOption.trim().length > 0;
   }
   if (question.type === 'multiselect') {
+    if (answer.selectedOptions.length > question.maxSelections) {
+      return false;
+    }
     return answer.selectedOptions.length > 0;
   }
   if (question.type === 'rating') {
@@ -76,6 +79,34 @@ function isValidEmail(value: string): boolean {
     return false;
   }
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized);
+}
+
+export function getFormValidationError(
+  question: FormQuestion,
+  answer: FormAnswerState,
+  common: Pick<FormsCommonContent, 'errors'>,
+): string | null {
+  if (question.type === 'multiselect') {
+    if (answer.selectedOptions.length > question.maxSelections) {
+      return common.errors.maxSelectionsTemplate.replace(
+        '{max}',
+        String(question.maxSelections),
+      );
+    }
+    if (isQuestionRequired(question) && answer.selectedOptions.length === 0) {
+      return common.errors.required;
+    }
+    return null;
+  }
+
+  if (isFormAnswerValid(question, answer)) {
+    return null;
+  }
+
+  if (question.type === 'email') {
+    return common.errors.invalidEmail;
+  }
+  return common.errors.required;
 }
 
 export function toggleMultiselectOption(

--- a/apps/training/src/components/forms/form-page.tsx
+++ b/apps/training/src/components/forms/form-page.tsx
@@ -1,3 +1,4 @@
+import { FormScrollSurvey } from '@/components/forms/form-scroll-survey';
 import { FormWizard } from '@/components/forms/form-wizard';
 import type { FormContent, FormsCommonContent } from '@/content/form-types';
 import { getPublicWwwHomeUrl } from '@/lib/public-www-url';
@@ -35,9 +36,21 @@ export function FormPage({ form, common }: FormPageProps) {
             logo
           )}
         </div>
-        <h1 className='es-type-title text-2xl'>{form.title}</h1>
+        <h1
+          className={
+            form.layout === 'scroll'
+              ? 'form-scroll-title text-3xl font-extrabold'
+              : 'es-type-title text-2xl'
+          }
+        >
+          {form.title}
+        </h1>
       </header>
-      <FormWizard form={form} common={common} />
+      {form.layout === 'scroll' ? (
+        <FormScrollSurvey form={form} common={common} />
+      ) : (
+        <FormWizard form={form} common={common} />
+      )}
     </main>
   );
 }

--- a/apps/training/src/components/forms/form-question-field.tsx
+++ b/apps/training/src/components/forms/form-question-field.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FormQuestion, FormsCommonContent } from '@/content/form-types';
+import { isQuestionRequired } from '@/content/form-types';
 import type { FormAnswerState } from '@/components/forms/form-answer-state';
 import { toggleMultiselectOption } from '@/components/forms/form-answer-state';
 
@@ -10,6 +11,8 @@ export interface FormQuestionFieldProps {
   answer: FormAnswerState;
   onAnswerChange: (patch: Partial<FormAnswerState>) => void;
   variant?: 'wizard' | 'scroll';
+  /** 1-based display index for scroll layout (derived from question order). */
+  displayNumber?: number;
 }
 
 export function FormQuestionField({
@@ -18,9 +21,19 @@ export function FormQuestionField({
   answer,
   onAnswerChange,
   variant = 'wizard',
+  displayNumber,
 }: FormQuestionFieldProps) {
   const headingId = `${question.id}-heading`;
   const isScroll = variant === 'scroll';
+  const required = isQuestionRequired(question);
+  const numberPrefix =
+    displayNumber !== undefined
+      ? displayNumber
+      : question.number !== undefined
+        ? question.number
+        : undefined;
+
+  const resolvedHint = resolveQuestionHint(question, common);
 
   return (
     <div className={`flex w-full flex-col ${isScroll ? 'gap-3' : 'gap-4'}`}>
@@ -34,14 +47,20 @@ export function FormQuestionField({
               : 'es-text-heading text-xl font-semibold'
           }
         >
-          {question.number !== undefined ? (
-            <span className='form-scroll-question-number'>{question.number}. </span>
+          {numberPrefix !== undefined ? (
+            <span className='form-scroll-question-number'>{numberPrefix}. </span>
           ) : null}
           {question.question}
+          {required && isScroll ? (
+            <span className='form-scroll-required-marker text-sm font-medium'>
+              {' '}
+              ({common.scroll.requiredMarker})
+            </span>
+          ) : null}
         </h2>
-        {question.hint ? (
+        {resolvedHint ? (
           <p className={isScroll ? 'form-scroll-hint text-sm' : 'es-text-muted text-sm'}>
-            {question.hint}
+            {resolvedHint}
           </p>
         ) : null}
       </div>
@@ -49,7 +68,6 @@ export function FormQuestionField({
         <RatingField
           question={question}
           headingId={headingId}
-          common={common}
           answer={answer}
           onAnswerChange={onAnswerChange}
         />
@@ -76,7 +94,6 @@ export function FormQuestionField({
         <ConsentField
           question={question}
           headingId={headingId}
-          common={common}
           answer={answer}
           onAnswerChange={onAnswerChange}
         />
@@ -129,43 +146,51 @@ export function FormQuestionField({
   );
 }
 
+function resolveQuestionHint(question: FormQuestion, common: FormsCommonContent): string | undefined {
+  if (question.hint) {
+    return question.hint;
+  }
+  if (question.type === 'multiselect') {
+    return common.multiselect.pickUpToTemplate.replace('{max}', String(question.maxSelections));
+  }
+  return undefined;
+}
+
 function RatingField({
   question,
   headingId,
-  common,
   answer,
   onAnswerChange,
 }: {
   question: Extract<FormQuestion, { type: 'rating' }>;
   headingId: string;
-  common: FormsCommonContent;
   answer: FormAnswerState;
   onAnswerChange: (patch: Partial<FormAnswerState>) => void;
 }) {
-  const groupLabel = common.a11y.ratingGroupTemplate.replace('{question}', question.question);
-
   return (
-    <div className='flex flex-col gap-2'>
-      <div
-        role='radiogroup'
-        aria-labelledby={headingId}
-        aria-label={groupLabel}
-        className='form-rating-row'
-      >
+    <fieldset aria-labelledby={headingId} className='flex flex-col gap-2 border-0 p-0'>
+      <div className='form-rating-row'>
         {question.options.map((option) => {
           const isSelected = answer.ratingValue === option.value;
+          const inputId = `${question.id}-rating-${option.value}`;
           return (
-            <button
+            <label
               key={option.value}
-              type='button'
-              role='radio'
-              aria-checked={isSelected}
-              aria-label={option.ariaLabel ?? `Rating ${option.value}`}
-              className={`form-rating-option es-focus-ring ${isSelected ? 'form-rating-option--selected' : ''}`}
-              onClick={() => onAnswerChange({ ratingValue: option.value })}
+              htmlFor={inputId}
+              className={`form-rating-option ${isSelected ? 'form-rating-option--selected' : ''}`}
             >
+              <input
+                id={inputId}
+                type='radio'
+                name={`${question.id}-rating`}
+                className='sr-only'
+                checked={isSelected}
+                value={option.value}
+                onChange={() => onAnswerChange({ ratingValue: option.value })}
+              />
               <span aria-hidden='true'>{option.emoji}</span>
-            </button>
+              <span className='sr-only'>{option.ariaLabel ?? `Rating ${option.value}`}</span>
+            </label>
           );
         })}
       </div>
@@ -175,7 +200,7 @@ function RatingField({
           <span>{question.maxLabel ?? ''}</span>
         </div>
       ) : null}
-    </div>
+    </fieldset>
   );
 }
 
@@ -198,11 +223,7 @@ function MultiselectField({
 
   if (isScroll) {
     return (
-      <div
-        role='group'
-        aria-labelledby={headingId}
-        className='form-chip-row'
-      >
+      <div role='group' aria-labelledby={headingId} className='form-chip-row'>
         {question.options.map((option) => {
           const isSelected = answer.selectedOptions.includes(option);
           const isLocked = atMax && !isSelected;
@@ -285,49 +306,55 @@ function SegmentedField({
   onAnswerChange: (patch: Partial<FormAnswerState>) => void;
 }) {
   return (
-    <div role='radiogroup' aria-labelledby={headingId} className='form-segmented-row'>
+    <fieldset aria-labelledby={headingId} className='form-segmented-row border-0 p-0'>
       {question.options.map((option) => {
         const isSelected = answer.selectedOption === option.value;
         const variantClass = option.variant ? `form-segmented-option--${option.variant}` : '';
+        const inputId = `${question.id}-segmented-${slugifyOption(option.value)}`;
         return (
-          <button
+          <label
             key={option.value}
-            type='button'
-            role='radio'
-            aria-checked={isSelected}
-            className={`form-segmented-option es-focus-ring ${variantClass} ${isSelected ? 'form-segmented-option--selected' : ''}`}
-            onClick={() => onAnswerChange({ selectedOption: option.value })}
+            htmlFor={inputId}
+            className={`form-segmented-option ${variantClass} ${isSelected ? 'form-segmented-option--selected' : ''}`}
           >
+            <input
+              id={inputId}
+              type='radio'
+              name={`${question.id}-segmented`}
+              className='sr-only'
+              checked={isSelected}
+              value={option.value}
+              onChange={() => onAnswerChange({ selectedOption: option.value })}
+            />
             {option.label}
-          </button>
+          </label>
         );
       })}
-    </div>
+    </fieldset>
   );
 }
 
 function ConsentField({
   question,
   headingId,
-  common,
   answer,
   onAnswerChange,
 }: {
   question: Extract<FormQuestion, { type: 'consent' }>;
   headingId: string;
-  common: FormsCommonContent;
   answer: FormAnswerState;
   onAnswerChange: (patch: Partial<FormAnswerState>) => void;
 }) {
   const isChecked = answer.trueFalseValue === true;
   const showFollowUp = Boolean(question.followUp) && isChecked;
+  const consentTextId = `${question.id}-consent-text`;
 
   return (
     <div className='flex flex-col gap-3'>
       <button
         type='button'
         className='form-consent-row es-focus-ring'
-        aria-labelledby={headingId}
+        aria-labelledby={`${headingId} ${consentTextId}`}
         aria-pressed={isChecked}
         onClick={() =>
           onAnswerChange({
@@ -342,7 +369,10 @@ function ConsentField({
         >
           {isChecked ? <span className='form-consent-checkmark'>✓</span> : null}
         </span>
-        <span className='form-consent-text text-left text-sm leading-snug'>
+        <span
+          id={consentTextId}
+          className='form-consent-text text-left text-sm leading-snug'
+        >
           {question.consentText}
         </span>
       </button>
@@ -350,7 +380,7 @@ function ConsentField({
         <input
           type='text'
           className='es-focus-ring es-form-input w-full'
-          aria-label={common.a11y.consentCheckboxLabel}
+          aria-label={question.followUp.placeholder}
           placeholder={question.followUp.placeholder}
           value={answer.freeText}
           onChange={(event) => onAnswerChange({ freeText: event.target.value })}

--- a/apps/training/src/components/forms/form-question-field.tsx
+++ b/apps/training/src/components/forms/form-question-field.tsx
@@ -26,12 +26,7 @@ export function FormQuestionField({
   const headingId = `${question.id}-heading`;
   const isScroll = variant === 'scroll';
   const required = isQuestionRequired(question);
-  const numberPrefix =
-    displayNumber !== undefined
-      ? displayNumber
-      : question.number !== undefined
-        ? question.number
-        : undefined;
+  const numberPrefix = displayNumber;
 
   const resolvedHint = resolveQuestionHint(question, common);
 

--- a/apps/training/src/components/forms/form-question-field.tsx
+++ b/apps/training/src/components/forms/form-question-field.tsx
@@ -1,29 +1,86 @@
 'use client';
 
-import type { FormQuestion } from '@/content/form-types';
+import type { FormQuestion, FormsCommonContent } from '@/content/form-types';
 import type { FormAnswerState } from '@/components/forms/form-answer-state';
+import { toggleMultiselectOption } from '@/components/forms/form-answer-state';
 
 export interface FormQuestionFieldProps {
   question: FormQuestion;
+  common: FormsCommonContent;
   answer: FormAnswerState;
   onAnswerChange: (patch: Partial<FormAnswerState>) => void;
+  variant?: 'wizard' | 'scroll';
 }
 
 export function FormQuestionField({
   question,
+  common,
   answer,
   onAnswerChange,
+  variant = 'wizard',
 }: FormQuestionFieldProps) {
   const headingId = `${question.id}-heading`;
+  const isScroll = variant === 'scroll';
 
   return (
-    <div className='flex w-full flex-col gap-4'>
+    <div className={`flex w-full flex-col ${isScroll ? 'gap-3' : 'gap-4'}`}>
       <div className='flex flex-col gap-1'>
-        <p className='es-type-eyebrow'>{question.screen}</p>
-        <h2 id={headingId} className='es-text-heading text-xl font-semibold'>
+        {question.screen ? <p className='es-type-eyebrow'>{question.screen}</p> : null}
+        <h2
+          id={headingId}
+          className={
+            isScroll
+              ? 'form-scroll-question text-lg font-bold'
+              : 'es-text-heading text-xl font-semibold'
+          }
+        >
+          {question.number !== undefined ? (
+            <span className='form-scroll-question-number'>{question.number}. </span>
+          ) : null}
           {question.question}
         </h2>
+        {question.hint ? (
+          <p className={isScroll ? 'form-scroll-hint text-sm' : 'es-text-muted text-sm'}>
+            {question.hint}
+          </p>
+        ) : null}
       </div>
+      {question.type === 'rating' ? (
+        <RatingField
+          question={question}
+          headingId={headingId}
+          common={common}
+          answer={answer}
+          onAnswerChange={onAnswerChange}
+        />
+      ) : null}
+      {question.type === 'multiselect' ? (
+        <MultiselectField
+          question={question}
+          headingId={headingId}
+          common={common}
+          answer={answer}
+          onAnswerChange={onAnswerChange}
+          isScroll={isScroll}
+        />
+      ) : null}
+      {question.type === 'segmented' ? (
+        <SegmentedField
+          question={question}
+          headingId={headingId}
+          answer={answer}
+          onAnswerChange={onAnswerChange}
+        />
+      ) : null}
+      {question.type === 'consent' ? (
+        <ConsentField
+          question={question}
+          headingId={headingId}
+          common={common}
+          answer={answer}
+          onAnswerChange={onAnswerChange}
+        />
+      ) : null}
       {question.type === 'select' ? (
         <fieldset aria-labelledby={headingId} className='flex flex-col gap-2'>
           {question.options.map((option) => {
@@ -50,8 +107,9 @@ export function FormQuestionField({
       ) : null}
       {question.type === 'text' ? (
         <textarea
-          className='es-focus-ring es-form-input min-h-28 w-full'
+          className={`es-focus-ring es-form-input w-full ${isScroll ? 'form-scroll-textarea min-h-[4.5rem]' : 'min-h-28'}`}
           aria-labelledby={headingId}
+          placeholder={question.placeholder}
           value={answer.freeText}
           onChange={(event) => onAnswerChange({ freeText: event.target.value })}
         />
@@ -62,6 +120,238 @@ export function FormQuestionField({
           autoComplete='email'
           className='es-focus-ring es-form-input w-full'
           aria-labelledby={headingId}
+          placeholder={question.placeholder}
+          value={answer.freeText}
+          onChange={(event) => onAnswerChange({ freeText: event.target.value })}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function RatingField({
+  question,
+  headingId,
+  common,
+  answer,
+  onAnswerChange,
+}: {
+  question: Extract<FormQuestion, { type: 'rating' }>;
+  headingId: string;
+  common: FormsCommonContent;
+  answer: FormAnswerState;
+  onAnswerChange: (patch: Partial<FormAnswerState>) => void;
+}) {
+  const groupLabel = common.a11y.ratingGroupTemplate.replace('{question}', question.question);
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <div
+        role='radiogroup'
+        aria-labelledby={headingId}
+        aria-label={groupLabel}
+        className='form-rating-row'
+      >
+        {question.options.map((option) => {
+          const isSelected = answer.ratingValue === option.value;
+          return (
+            <button
+              key={option.value}
+              type='button'
+              role='radio'
+              aria-checked={isSelected}
+              aria-label={option.ariaLabel ?? `Rating ${option.value}`}
+              className={`form-rating-option es-focus-ring ${isSelected ? 'form-rating-option--selected' : ''}`}
+              onClick={() => onAnswerChange({ ratingValue: option.value })}
+            >
+              <span aria-hidden='true'>{option.emoji}</span>
+            </button>
+          );
+        })}
+      </div>
+      {question.minLabel || question.maxLabel ? (
+        <div className='form-rating-labels'>
+          <span>{question.minLabel ?? ''}</span>
+          <span>{question.maxLabel ?? ''}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MultiselectField({
+  question,
+  headingId,
+  common,
+  answer,
+  onAnswerChange,
+  isScroll,
+}: {
+  question: Extract<FormQuestion, { type: 'multiselect' }>;
+  headingId: string;
+  common: FormsCommonContent;
+  answer: FormAnswerState;
+  onAnswerChange: (patch: Partial<FormAnswerState>) => void;
+  isScroll: boolean;
+}) {
+  const atMax = answer.selectedOptions.length >= question.maxSelections;
+
+  if (isScroll) {
+    return (
+      <div
+        role='group'
+        aria-labelledby={headingId}
+        className='form-chip-row'
+      >
+        {question.options.map((option) => {
+          const isSelected = answer.selectedOptions.includes(option);
+          const isLocked = atMax && !isSelected;
+          return (
+            <button
+              key={option}
+              type='button'
+              aria-pressed={isSelected}
+              disabled={isLocked}
+              aria-label={
+                isLocked
+                  ? `${option} (${common.multiselect.lockedAriaLabel})`
+                  : option
+              }
+              className={`form-chip es-focus-ring ${isSelected ? 'form-chip--selected' : ''} ${isLocked ? 'form-chip--locked' : ''}`}
+              onClick={() =>
+                onAnswerChange({
+                  selectedOptions: toggleMultiselectOption(
+                    answer.selectedOptions,
+                    option,
+                    question.maxSelections,
+                  ),
+                })
+              }
+            >
+              {option}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <fieldset aria-labelledby={headingId} className='flex flex-col gap-2'>
+      {question.options.map((option) => {
+        const inputId = `${question.id}-${slugifyOption(option)}`;
+        const isSelected = answer.selectedOptions.includes(option);
+        const isLocked = atMax && !isSelected;
+        return (
+          <label
+            key={option}
+            htmlFor={inputId}
+            className={`poll-option-label flex cursor-pointer items-start gap-3 rounded-inner border px-3 py-2 es-bg-surface-white ${isSelected ? 'poll-option-label--selected' : ''} ${isLocked ? 'pointer-events-none opacity-50' : ''}`}
+          >
+            <input
+              id={inputId}
+              type='checkbox'
+              name={question.id}
+              className='es-accent-brand es-focus-ring mt-1 h-4 w-4 shrink-0'
+              checked={isSelected}
+              disabled={isLocked}
+              onChange={() =>
+                onAnswerChange({
+                  selectedOptions: toggleMultiselectOption(
+                    answer.selectedOptions,
+                    option,
+                    question.maxSelections,
+                  ),
+                })
+              }
+            />
+            <span className='es-text-body text-base'>{option}</span>
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}
+
+function SegmentedField({
+  question,
+  headingId,
+  answer,
+  onAnswerChange,
+}: {
+  question: Extract<FormQuestion, { type: 'segmented' }>;
+  headingId: string;
+  answer: FormAnswerState;
+  onAnswerChange: (patch: Partial<FormAnswerState>) => void;
+}) {
+  return (
+    <div role='radiogroup' aria-labelledby={headingId} className='form-segmented-row'>
+      {question.options.map((option) => {
+        const isSelected = answer.selectedOption === option.value;
+        const variantClass = option.variant ? `form-segmented-option--${option.variant}` : '';
+        return (
+          <button
+            key={option.value}
+            type='button'
+            role='radio'
+            aria-checked={isSelected}
+            className={`form-segmented-option es-focus-ring ${variantClass} ${isSelected ? 'form-segmented-option--selected' : ''}`}
+            onClick={() => onAnswerChange({ selectedOption: option.value })}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ConsentField({
+  question,
+  headingId,
+  common,
+  answer,
+  onAnswerChange,
+}: {
+  question: Extract<FormQuestion, { type: 'consent' }>;
+  headingId: string;
+  common: FormsCommonContent;
+  answer: FormAnswerState;
+  onAnswerChange: (patch: Partial<FormAnswerState>) => void;
+}) {
+  const isChecked = answer.trueFalseValue === true;
+  const showFollowUp = Boolean(question.followUp) && isChecked;
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <button
+        type='button'
+        className='form-consent-row es-focus-ring'
+        aria-labelledby={headingId}
+        aria-pressed={isChecked}
+        onClick={() =>
+          onAnswerChange({
+            trueFalseValue: !isChecked,
+            freeText: !isChecked ? answer.freeText : '',
+          })
+        }
+      >
+        <span
+          className={`form-consent-checkbox ${isChecked ? 'form-consent-checkbox--checked' : ''}`}
+          aria-hidden='true'
+        >
+          {isChecked ? <span className='form-consent-checkmark'>✓</span> : null}
+        </span>
+        <span className='form-consent-text text-left text-sm leading-snug'>
+          {question.consentText}
+        </span>
+      </button>
+      {showFollowUp && question.followUp ? (
+        <input
+          type='text'
+          className='es-focus-ring es-form-input w-full'
+          aria-label={common.a11y.consentCheckboxLabel}
+          placeholder={question.followUp.placeholder}
           value={answer.freeText}
           onChange={(event) => onAnswerChange({ freeText: event.target.value })}
         />

--- a/apps/training/src/components/forms/form-scroll-survey.tsx
+++ b/apps/training/src/components/forms/form-scroll-survey.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import {
+  emptyFormAnswerState,
+  isFormAnswerValid,
+  type FormAnswerState,
+} from '@/components/forms/form-answer-state';
+import { FormQuestionField } from '@/components/forms/form-question-field';
+import type { FormContent, FormQuestion, FormsCommonContent } from '@/content/form-types';
+import { isQuestionRequired } from '@/content/form-types';
+import { getOrCreateFormSessionId } from '@/lib/form-session';
+import { FormApiError, persistFormAnswer } from '@/lib/forms-api';
+
+export interface FormScrollSurveyProps {
+  form: FormContent;
+  common: FormsCommonContent;
+}
+
+export function FormScrollSurvey({ form, common }: FormScrollSurveyProps) {
+  const [isComplete, setIsComplete] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [answersByQuestionId, setAnswersByQuestionId] = useState<
+    Record<string, FormAnswerState>
+  >({});
+
+  const sessionId = useMemo(() => getOrCreateFormSessionId(form.slug), [form.slug]);
+  const questions = form.questions;
+
+  const canSubmit = useMemo(() => {
+    return questions
+      .filter((question) => isQuestionRequired(question))
+      .every((question) =>
+        isFormAnswerValid(question, answersByQuestionId[question.id] ?? emptyFormAnswerState()),
+      );
+  }, [answersByQuestionId, questions]);
+
+  if (isComplete) {
+    return (
+      <section className='form-scroll-thanks flex flex-col items-center gap-4 text-center'>
+        <p className='text-5xl' aria-hidden='true'>
+          🌱
+        </p>
+        <h2 className='form-scroll-thanks-title text-2xl font-bold'>{common.completion.title}</h2>
+        <p className='es-text-body max-w-sm text-base leading-relaxed'>
+          {form.completion?.description ?? common.completion.description}
+        </p>
+        {form.completion?.allowAnother ? (
+          <button
+            type='button'
+            className='form-scroll-again es-focus-ring'
+            onClick={() => {
+              setAnswersByQuestionId({});
+              setIsComplete(false);
+              setErrorMessage(null);
+            }}
+          >
+            {form.completion.anotherLabel ?? common.scroll.submitAnotherLabel}
+          </button>
+        ) : null}
+      </section>
+    );
+  }
+
+  return (
+    <section className='mx-auto flex w-full max-w-[30rem] flex-col gap-4'>
+      {form.intro ? (
+        <div className='flex flex-col gap-2 text-center'>
+          {form.intro.partnerName ? (
+            <p className='form-scroll-brand text-sm font-semibold'>
+              <span className='form-scroll-brand-primary'>Evolve Sprouts</span>
+              <span className='form-scroll-brand-separator'>
+                {common.scroll.brandPartnerSeparator}
+              </span>
+              <span>{form.intro.partnerName}</span>
+            </p>
+          ) : null}
+          <p className='form-scroll-subtitle text-sm leading-snug'>{form.intro.subtitle}</p>
+          <p className='form-scroll-duration text-xs font-bold uppercase tracking-wide'>
+            ⏱ {form.intro.durationLabel}
+          </p>
+        </div>
+      ) : null}
+
+      {questions.map((question) => (
+        <article key={question.id} className='form-scroll-card rounded-2xl border p-4'>
+          <FormQuestionField
+            question={question}
+            common={common}
+            variant='scroll'
+            answer={answersByQuestionId[question.id] ?? emptyFormAnswerState()}
+            onAnswerChange={(patch) => updateAnswerState(question.id, patch)}
+          />
+        </article>
+      ))}
+
+      {errorMessage ? (
+        <p className='es-text-danger text-sm' role='alert'>
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <button
+        type='button'
+        className='form-scroll-submit es-focus-ring w-full'
+        disabled={!canSubmit || isSaving}
+        onClick={() => void handleSubmit()}
+      >
+        {common.scroll.submitLabel}
+      </button>
+    </section>
+  );
+
+  function updateAnswerState(questionId: string, patch: Partial<FormAnswerState>): void {
+    setAnswersByQuestionId((previous) => ({
+      ...previous,
+      [questionId]: {
+        ...emptyFormAnswerState(),
+        ...previous[questionId],
+        ...patch,
+      },
+    }));
+  }
+
+  async function handleSubmit(): Promise<void> {
+    setErrorMessage(null);
+
+    const validationError = findFirstValidationError(questions, answersByQuestionId, common);
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      for (const question of questions) {
+        const answer = answersByQuestionId[question.id] ?? emptyFormAnswerState();
+        if (!shouldPersistAnswer(question, answer)) {
+          continue;
+        }
+        await persistFormAnswer({
+          formSlug: form.slug,
+          sessionId,
+          question,
+          answer,
+        });
+      }
+    } catch (error) {
+      setErrorMessage(resolvePersistErrorMessage(error, common));
+      setIsSaving(false);
+      return;
+    }
+    setIsSaving(false);
+    setIsComplete(true);
+  }
+}
+
+function shouldPersistAnswer(question: FormQuestion, answer: FormAnswerState): boolean {
+  if (question.type === 'multiselect') {
+    return answer.selectedOptions.length > 0;
+  }
+  if (question.type === 'text' || question.type === 'email') {
+    return answer.freeText.trim().length > 0;
+  }
+  if (question.type === 'consent') {
+    return answer.trueFalseValue === true || isQuestionRequired(question);
+  }
+  return isFormAnswerValid(question, answer);
+}
+
+function findFirstValidationError(
+  questions: FormQuestion[],
+  answersByQuestionId: Record<string, FormAnswerState>,
+  common: FormsCommonContent,
+): string | null {
+  for (const question of questions) {
+    const answer = answersByQuestionId[question.id] ?? emptyFormAnswerState();
+    if (!isFormAnswerValid(question, answer)) {
+      if (question.type === 'email') {
+        return common.errors.invalidEmail;
+      }
+      if (question.type === 'multiselect' && isQuestionRequired(question)) {
+        return formatMaxSelectionsError(common, question.maxSelections);
+      }
+      return common.errors.required;
+    }
+  }
+  return null;
+}
+
+function formatMaxSelectionsError(common: FormsCommonContent, max: number): string {
+  return common.errors.maxSelectionsTemplate.replace('{max}', String(max));
+}
+
+function resolvePersistErrorMessage(error: unknown, common: FormsCommonContent): string {
+  if (error instanceof FormApiError && error.statusCode === 0) {
+    return common.errors.missingApiConfig;
+  }
+  return common.errors.persistFailed;
+}

--- a/apps/training/src/components/forms/form-scroll-survey.tsx
+++ b/apps/training/src/components/forms/form-scroll-survey.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import {
   emptyFormAnswerState,
-  isFormAnswerValid,
+  getFormValidationError,
   type FormAnswerState,
 } from '@/components/forms/form-answer-state';
 import { FormQuestionField } from '@/components/forms/form-question-field';
 import type { FormContent, FormQuestion, FormsCommonContent } from '@/content/form-types';
 import { isQuestionRequired } from '@/content/form-types';
-import { getOrCreateFormSessionId } from '@/lib/form-session';
+import { getOrCreateFormSessionId, resetFormSessionId } from '@/lib/form-session';
 import { FormApiError, persistFormAnswer } from '@/lib/forms-api';
 
 export interface FormScrollSurveyProps {
@@ -25,17 +25,10 @@ export function FormScrollSurvey({ form, common }: FormScrollSurveyProps) {
   const [answersByQuestionId, setAnswersByQuestionId] = useState<
     Record<string, FormAnswerState>
   >({});
+  const [sessionId, setSessionId] = useState(() => getOrCreateFormSessionId(form.slug));
 
-  const sessionId = useMemo(() => getOrCreateFormSessionId(form.slug), [form.slug]);
   const questions = form.questions;
-
-  const canSubmit = useMemo(() => {
-    return questions
-      .filter((question) => isQuestionRequired(question))
-      .every((question) =>
-        isFormAnswerValid(question, answersByQuestionId[question.id] ?? emptyFormAnswerState()),
-      );
-  }, [answersByQuestionId, questions]);
+  const brandName = form.intro?.brandName ?? common.scroll.brandName;
 
   if (isComplete) {
     return (
@@ -52,6 +45,7 @@ export function FormScrollSurvey({ form, common }: FormScrollSurveyProps) {
             type='button'
             className='form-scroll-again es-focus-ring'
             onClick={() => {
+              setSessionId(resetFormSessionId(form.slug));
               setAnswersByQuestionId({});
               setIsComplete(false);
               setErrorMessage(null);
@@ -70,7 +64,7 @@ export function FormScrollSurvey({ form, common }: FormScrollSurveyProps) {
         <div className='flex flex-col gap-2 text-center'>
           {form.intro.partnerName ? (
             <p className='form-scroll-brand text-sm font-semibold'>
-              <span className='form-scroll-brand-primary'>Evolve Sprouts</span>
+              <span className='form-scroll-brand-primary'>{brandName}</span>
               <span className='form-scroll-brand-separator'>
                 {common.scroll.brandPartnerSeparator}
               </span>
@@ -84,12 +78,13 @@ export function FormScrollSurvey({ form, common }: FormScrollSurveyProps) {
         </div>
       ) : null}
 
-      {questions.map((question) => (
+      {questions.map((question, index) => (
         <article key={question.id} className='form-scroll-card rounded-2xl border p-4'>
           <FormQuestionField
             question={question}
             common={common}
             variant='scroll'
+            displayNumber={index + 1}
             answer={answersByQuestionId[question.id] ?? emptyFormAnswerState()}
             onAnswerChange={(patch) => updateAnswerState(question.id, patch)}
           />
@@ -105,7 +100,7 @@ export function FormScrollSurvey({ form, common }: FormScrollSurveyProps) {
       <button
         type='button'
         className='form-scroll-submit es-focus-ring w-full'
-        disabled={!canSubmit || isSaving}
+        disabled={isSaving}
         onClick={() => void handleSubmit()}
       >
         {common.scroll.submitLabel}
@@ -135,6 +130,7 @@ export function FormScrollSurvey({ form, common }: FormScrollSurveyProps) {
 
     setIsSaving(true);
     try {
+      // One PUT per answered question; a mid-loop failure leaves prior rows saved (retry is safe).
       for (const question of questions) {
         const answer = answersByQuestionId[question.id] ?? emptyFormAnswerState();
         if (!shouldPersistAnswer(question, answer)) {
@@ -165,9 +161,15 @@ function shouldPersistAnswer(question: FormQuestion, answer: FormAnswerState): b
     return answer.freeText.trim().length > 0;
   }
   if (question.type === 'consent') {
-    return answer.trueFalseValue === true || isQuestionRequired(question);
+    return answer.trueFalseValue === true;
   }
-  return isFormAnswerValid(question, answer);
+  if (question.type === 'rating') {
+    return answer.ratingValue !== null;
+  }
+  if (question.type === 'select' || question.type === 'segmented') {
+    return answer.selectedOption.trim().length > 0;
+  }
+  return false;
 }
 
 function findFirstValidationError(
@@ -177,21 +179,12 @@ function findFirstValidationError(
 ): string | null {
   for (const question of questions) {
     const answer = answersByQuestionId[question.id] ?? emptyFormAnswerState();
-    if (!isFormAnswerValid(question, answer)) {
-      if (question.type === 'email') {
-        return common.errors.invalidEmail;
-      }
-      if (question.type === 'multiselect' && isQuestionRequired(question)) {
-        return formatMaxSelectionsError(common, question.maxSelections);
-      }
-      return common.errors.required;
+    const error = getFormValidationError(question, answer, common);
+    if (error) {
+      return error;
     }
   }
   return null;
-}
-
-function formatMaxSelectionsError(common: FormsCommonContent, max: number): string {
-  return common.errors.maxSelectionsTemplate.replace('{max}', String(max));
 }
 
 function resolvePersistErrorMessage(error: unknown, common: FormsCommonContent): string {

--- a/apps/training/src/components/forms/form-wizard.tsx
+++ b/apps/training/src/components/forms/form-wizard.tsx
@@ -63,6 +63,7 @@ export function FormWizard({ form, common }: FormWizardProps) {
       <p className='es-text-muted text-sm'>{progressLabel}</p>
       <FormQuestionField
         question={currentQuestion}
+        common={common}
         answer={currentAnswer}
         onAnswerChange={(patch) => updateAnswerState(currentQuestion.id, patch)}
       />

--- a/apps/training/src/content/form-types.ts
+++ b/apps/training/src/content/form-types.ts
@@ -1,10 +1,17 @@
 import formsCommonJson from '@/content/forms-common.json';
+import workshopExitFeedbackJson from '@/content/forms/workshop-exit-feedback.json';
 import workshopFeedbackJson from '@/content/forms/workshop-feedback.json';
 
 export interface FormQuestionBase {
   id: string;
-  screen: string;
+  /** Eyebrow label; optional on scroll-layout forms. */
+  screen?: string;
   question: string;
+  hint?: string;
+  /** When false, the question may be skipped. Defaults to true. */
+  required?: boolean;
+  /** Display order prefix (for example `1` renders as `1.`). */
+  number?: number;
 }
 
 export interface FormSelectQuestion extends FormQuestionBase {
@@ -12,20 +19,84 @@ export interface FormSelectQuestion extends FormQuestionBase {
   options: string[];
 }
 
+export interface FormMultiselectQuestion extends FormQuestionBase {
+  type: 'multiselect';
+  options: string[];
+  /** Maximum number of options the respondent may select. */
+  maxSelections: number;
+}
+
+export interface FormRatingOption {
+  value: number;
+  emoji: string;
+  /** Accessible label when the emoji alone is insufficient. */
+  ariaLabel?: string;
+}
+
+export interface FormRatingQuestion extends FormQuestionBase {
+  type: 'rating';
+  options: FormRatingOption[];
+  minLabel?: string;
+  maxLabel?: string;
+}
+
+export interface FormSegmentedOption {
+  value: string;
+  label: string;
+  variant?: 'yes' | 'maybe' | 'no';
+}
+
+export interface FormSegmentedQuestion extends FormQuestionBase {
+  type: 'segmented';
+  options: FormSegmentedOption[];
+}
+
+export interface FormConsentQuestion extends FormQuestionBase {
+  type: 'consent';
+  consentText: string;
+  followUp?: {
+    placeholder: string;
+    required?: boolean;
+  };
+}
+
 export interface FormTextQuestion extends FormQuestionBase {
   type: 'text';
+  placeholder?: string;
 }
 
 export interface FormEmailQuestion extends FormQuestionBase {
   type: 'email';
+  placeholder?: string;
 }
 
-export type FormQuestion = FormSelectQuestion | FormTextQuestion | FormEmailQuestion;
+export type FormQuestion =
+  | FormSelectQuestion
+  | FormMultiselectQuestion
+  | FormRatingQuestion
+  | FormSegmentedQuestion
+  | FormConsentQuestion
+  | FormTextQuestion
+  | FormEmailQuestion;
+
+export interface FormScrollIntro {
+  subtitle: string;
+  durationLabel: string;
+  partnerName?: string;
+}
 
 export interface FormContent {
   title: string;
   slug: string;
+  /** `wizard` steps one question at a time; `scroll` shows all questions on one page. */
+  layout?: 'wizard' | 'scroll';
+  intro?: FormScrollIntro;
   questions: FormQuestion[];
+  completion?: {
+    description?: string;
+    allowAnother?: boolean;
+    anotherLabel?: string;
+  };
 }
 
 export interface FormsCommonContent {
@@ -38,23 +109,37 @@ export interface FormsCommonContent {
     title: string;
     description: string;
   };
+  multiselect: {
+    pickUpToTemplate: string;
+    lockedAriaLabel: string;
+  };
+  scroll: {
+    submitLabel: string;
+    brandPartnerSeparator: string;
+    submitAnotherLabel: string;
+  };
   errors: {
     required: string;
     invalidEmail: string;
     persistFailed: string;
     missingApiConfig: string;
+    maxSelectionsTemplate: string;
   };
   a11y: {
     progressTemplate: string;
+    ratingGroupTemplate: string;
+    consentCheckboxLabel: string;
   };
 }
 
 export const FORMS_COMMON = formsCommonJson as FormsCommonContent;
 
 const workshopFeedback = workshopFeedbackJson as FormContent;
+const workshopExitFeedback = workshopExitFeedbackJson as FormContent;
 
 const FORMS = {
   'workshop-feedback': workshopFeedback,
+  'workshop-exit-feedback': workshopExitFeedback,
 } satisfies Record<string, FormContent>;
 
 export type FormSlug = keyof typeof FORMS;
@@ -78,4 +163,8 @@ export function getFormContent(slug: string): FormContent | null {
 
 export function buildFormPath(slug: FormSlug | string): string {
   return `/forms/${slug}/`;
+}
+
+export function isQuestionRequired(question: FormQuestion): boolean {
+  return question.required !== false;
 }

--- a/apps/training/src/content/form-types.ts
+++ b/apps/training/src/content/form-types.ts
@@ -82,6 +82,7 @@ export type FormQuestion =
 export interface FormScrollIntro {
   subtitle: string;
   durationLabel: string;
+  brandName?: string;
   partnerName?: string;
 }
 
@@ -116,7 +117,9 @@ export interface FormsCommonContent {
   scroll: {
     submitLabel: string;
     brandPartnerSeparator: string;
+    brandName: string;
     submitAnotherLabel: string;
+    requiredMarker: string;
   };
   errors: {
     required: string;
@@ -127,8 +130,6 @@ export interface FormsCommonContent {
   };
   a11y: {
     progressTemplate: string;
-    ratingGroupTemplate: string;
-    consentCheckboxLabel: string;
   };
 }
 

--- a/apps/training/src/content/form-types.ts
+++ b/apps/training/src/content/form-types.ts
@@ -10,8 +10,6 @@ export interface FormQuestionBase {
   hint?: string;
   /** When false, the question may be skipped. Defaults to true. */
   required?: boolean;
-  /** Display order prefix (for example `1` renders as `1.`). */
-  number?: number;
 }
 
 export interface FormSelectQuestion extends FormQuestionBase {

--- a/apps/training/src/content/forms-common.json
+++ b/apps/training/src/content/forms-common.json
@@ -15,7 +15,9 @@
   "scroll": {
     "submitLabel": "Send my feedback →",
     "brandPartnerSeparator": "×",
-    "submitAnotherLabel": "Submit another (shared device)"
+    "brandName": "Evolve Sprouts",
+    "submitAnotherLabel": "Submit another (shared device)",
+    "requiredMarker": "Required"
   },
   "errors": {
     "required": "Please answer this question before continuing.",
@@ -25,8 +27,6 @@
     "maxSelectionsTemplate": "Please select at most {max} options."
   },
   "a11y": {
-    "progressTemplate": "Question {current} of {total}",
-    "ratingGroupTemplate": "Rating for {question}",
-    "consentCheckboxLabel": "Optional year group"
+    "progressTemplate": "Question {current} of {total}"
   }
 }

--- a/apps/training/src/content/forms-common.json
+++ b/apps/training/src/content/forms-common.json
@@ -8,13 +8,25 @@
     "title": "Thank you",
     "description": "Your responses have been saved."
   },
+  "multiselect": {
+    "pickUpToTemplate": "Pick up to {max}.",
+    "lockedAriaLabel": "maximum selections reached"
+  },
+  "scroll": {
+    "submitLabel": "Send my feedback →",
+    "brandPartnerSeparator": "×",
+    "submitAnotherLabel": "Submit another (shared device)"
+  },
   "errors": {
     "required": "Please answer this question before continuing.",
     "invalidEmail": "Enter a valid email address.",
     "persistFailed": "We could not save your answer. Please try again.",
-    "missingApiConfig": "This form cannot be saved right now. Please try again later."
+    "missingApiConfig": "This form cannot be saved right now. Please try again later.",
+    "maxSelectionsTemplate": "Please select at most {max} options."
   },
   "a11y": {
-    "progressTemplate": "Question {current} of {total}"
+    "progressTemplate": "Question {current} of {total}",
+    "ratingGroupTemplate": "Rating for {question}",
+    "consentCheckboxLabel": "Optional year group"
   }
 }

--- a/apps/training/src/content/forms/workshop-exit-feedback.json
+++ b/apps/training/src/content/forms/workshop-exit-feedback.json
@@ -16,7 +16,6 @@
     {
       "id": "usefulness",
       "type": "rating",
-      "number": 1,
       "question": "How useful was this morning?",
       "hint": "Tap one.",
       "minLabel": "Not really",
@@ -33,9 +32,7 @@
     {
       "id": "most-useful",
       "type": "multiselect",
-      "number": 2,
       "question": "What was most useful?",
-      "hint": "Pick up to 3.",
       "maxSelections": 3,
       "options": [
         "Mealtime scripts",
@@ -50,7 +47,6 @@
     {
       "id": "recommend",
       "type": "segmented",
-      "number": 3,
       "question": "Would you tell another parent to come?",
       "options": [
         { "value": "Yes", "label": "Yes", "variant": "yes" },
@@ -62,7 +58,6 @@
     {
       "id": "missed",
       "type": "text",
-      "number": 4,
       "question": "Anything we missed?",
       "hint": "A topic we didn't cover, or one you wished we'd spent more time on.",
       "placeholder": "e.g. More on fussy toddlers, or what to do at restaurants.",
@@ -71,7 +66,6 @@
     {
       "id": "comments",
       "type": "text",
-      "number": 5,
       "question": "Anything else you'd like to tell us?",
       "hint": "Any other comments — warm or critical. We read every one.",
       "placeholder": "Optional",

--- a/apps/training/src/content/forms/workshop-exit-feedback.json
+++ b/apps/training/src/content/forms/workshop-exit-feedback.json
@@ -1,0 +1,91 @@
+{
+  "title": "Before you go…",
+  "slug": "workshop-exit-feedback",
+  "layout": "scroll",
+  "intro": {
+    "subtitle": "Two minutes of honesty helps us do this better at the next school.",
+    "durationLabel": "about 90 seconds",
+    "partnerName": "Menon Wellness"
+  },
+  "completion": {
+    "description": "That's genuinely useful — it makes the next one better for the families who come after you.",
+    "allowAnother": true,
+    "anotherLabel": "Submit another (shared device)"
+  },
+  "questions": [
+    {
+      "id": "usefulness",
+      "type": "rating",
+      "number": 1,
+      "question": "How useful was this morning?",
+      "hint": "Tap one.",
+      "minLabel": "Not really",
+      "maxLabel": "Loved it",
+      "options": [
+        { "value": 1, "emoji": "😕", "ariaLabel": "Not really" },
+        { "value": 2, "emoji": "😐", "ariaLabel": "Neutral" },
+        { "value": 3, "emoji": "🙂", "ariaLabel": "Somewhat useful" },
+        { "value": 4, "emoji": "😀", "ariaLabel": "Very useful" },
+        { "value": 5, "emoji": "🤩", "ariaLabel": "Loved it" }
+      ],
+      "required": true
+    },
+    {
+      "id": "most-useful",
+      "type": "multiselect",
+      "number": 2,
+      "question": "What was most useful?",
+      "hint": "Pick up to 3.",
+      "maxSelections": 3,
+      "options": [
+        "Mealtime scripts",
+        "The table scenarios",
+        "Practical tips",
+        "The balanced plate",
+        "Helper alignment",
+        "Division of responsibility"
+      ],
+      "required": false
+    },
+    {
+      "id": "recommend",
+      "type": "segmented",
+      "number": 3,
+      "question": "Would you tell another parent to come?",
+      "options": [
+        { "value": "Yes", "label": "Yes", "variant": "yes" },
+        { "value": "Maybe", "label": "Maybe", "variant": "maybe" },
+        { "value": "No", "label": "No", "variant": "no" }
+      ],
+      "required": true
+    },
+    {
+      "id": "missed",
+      "type": "text",
+      "number": 4,
+      "question": "Anything we missed?",
+      "hint": "A topic we didn't cover, or one you wished we'd spent more time on.",
+      "placeholder": "e.g. More on fussy toddlers, or what to do at restaurants.",
+      "required": false
+    },
+    {
+      "id": "comments",
+      "type": "text",
+      "number": 5,
+      "question": "Anything else you'd like to tell us?",
+      "hint": "Any other comments — warm or critical. We read every one.",
+      "placeholder": "Optional",
+      "required": false
+    },
+    {
+      "id": "share-consent",
+      "type": "consent",
+      "question": "Sharing permission",
+      "consentText": "You may share my comments to help reach more families — shown only as \"Parent of a Year [X] student at FIS\". No name needed.",
+      "followUp": {
+        "placeholder": "Which year is your child in? (optional)"
+      },
+      "required": false
+    }
+  ]
+}

--- a/apps/training/src/lib/form-session.ts
+++ b/apps/training/src/lib/form-session.ts
@@ -13,7 +13,15 @@ export function getOrCreateFormSessionId(formSlug: string): string {
   if (existing) {
     return existing;
   }
+  return resetFormSessionId(formSlug);
+}
+
+/** Mint a new session id and persist it for this form slug (shared-device handoff). */
+export function resetFormSessionId(formSlug: string): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
   const created = crypto.randomUUID();
-  window.sessionStorage.setItem(key, created);
+  window.sessionStorage.setItem(storageKey(formSlug), created);
   return created;
 }

--- a/apps/training/src/lib/forms-api.ts
+++ b/apps/training/src/lib/forms-api.ts
@@ -1,5 +1,6 @@
 import type { FormQuestion } from '@/content/form-types';
 import type { FormAnswerState } from '@/components/forms/form-answer-state';
+import { isQuestionRequired } from '@/content/form-types';
 
 const API_BASE_URL_ENV = 'NEXT_PUBLIC_API_BASE_URL';
 const API_KEY_ENV = 'NEXT_PUBLIC_TRAINING_API_KEY';
@@ -36,13 +37,17 @@ export function resolveFormApiConfig(): { baseUrl: string; apiKey: string } | nu
 }
 
 export async function persistFormAnswer(input: PersistFormAnswerInput): Promise<void> {
+  const body = buildPersistBody(input);
+  if (body === null) {
+    return;
+  }
+
   const config = resolveFormApiConfig();
   if (!config) {
     throw new FormApiError('Form API is not configured', 0);
   }
 
   const endpointPath = `${config.baseUrl}/v1/forms/${encodeURIComponent(input.formSlug)}/answers`;
-  const body = buildPersistBody(input);
 
   const response = await fetch(endpointPath, {
     method: 'PUT',
@@ -58,7 +63,9 @@ export async function persistFormAnswer(input: PersistFormAnswerInput): Promise<
   }
 }
 
-function buildPersistBody(input: PersistFormAnswerInput): Record<string, unknown> {
+export function buildPersistBody(
+  input: PersistFormAnswerInput,
+): Record<string, unknown> | null {
   const base = {
     formSlug: input.formSlug,
     sessionId: input.sessionId,
@@ -66,16 +73,60 @@ function buildPersistBody(input: PersistFormAnswerInput): Record<string, unknown
     questionType: input.question.type,
   };
 
-  if (input.question.type === 'select') {
+  if (input.question.type === 'select' || input.question.type === 'segmented') {
+    const selectedOption = input.answer.selectedOption.trim();
+    if (!selectedOption) {
+      return null;
+    }
     return {
       ...base,
-      selectedOption: input.answer.selectedOption.trim(),
+      selectedOption,
     };
+  }
+
+  if (input.question.type === 'multiselect') {
+    if (input.answer.selectedOptions.length === 0) {
+      return null;
+    }
+    return {
+      ...base,
+      selectedOptions: input.answer.selectedOptions,
+    };
+  }
+
+  if (input.question.type === 'rating') {
+    if (input.answer.ratingValue === null) {
+      return null;
+    }
+    return {
+      ...base,
+      ratingValue: input.answer.ratingValue,
+    };
+  }
+
+  if (input.question.type === 'consent') {
+    if (!isQuestionRequired(input.question) && input.answer.trueFalseValue !== true) {
+      return null;
+    }
+    const payload: Record<string, unknown> = {
+      ...base,
+      booleanAnswer: input.answer.trueFalseValue === true,
+    };
+    const followUp = input.answer.freeText.trim();
+    if (followUp) {
+      payload.freeText = followUp;
+    }
+    return payload;
+  }
+
+  const freeText = input.answer.freeText.trim();
+  if (!freeText) {
+    return null;
   }
 
   return {
     ...base,
-    freeText: input.answer.freeText.trim(),
+    freeText,
   };
 }
 

--- a/apps/training/src/lib/training-routes.ts
+++ b/apps/training/src/lib/training-routes.ts
@@ -5,6 +5,7 @@
 export const TRAINING_ROUTES = {
   home: '/',
   formsWorkshopFeedback: '/forms/workshop-feedback',
+  formsWorkshopExitFeedback: '/forms/workshop-exit-feedback',
   pollsWorkshopFoodJun26: '/polls/workshop-food-jun-26',
 } as const;
 

--- a/apps/training/tests/components/forms/form-answer-state.test.ts
+++ b/apps/training/tests/components/forms/form-answer-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  emptyFormAnswerState,
+  isFormAnswerValid,
+  toggleMultiselectOption,
+} from '@/components/forms/form-answer-state';
+import type { FormQuestion } from '@/content/form-types';
+
+describe('form answer state', () => {
+  it('validates rating when required', () => {
+    const question: FormQuestion = {
+      id: 'usefulness',
+      type: 'rating',
+      question: 'How useful?',
+      options: [{ value: 1, emoji: '😕' }],
+      required: true,
+    };
+    expect(isFormAnswerValid(question, emptyFormAnswerState())).toBe(false);
+    expect(
+      isFormAnswerValid(question, { ...emptyFormAnswerState(), ratingValue: 3 }),
+    ).toBe(true);
+  });
+
+  it('enforces multiselect max selections in toggle helper', () => {
+    const current = ['A', 'B'];
+    expect(toggleMultiselectOption(current, 'C', 3)).toEqual(['A', 'B', 'C']);
+    expect(toggleMultiselectOption(current, 'C', 2)).toEqual(['A', 'B']);
+    expect(toggleMultiselectOption(current, 'A', 3)).toEqual(['B']);
+  });
+
+  it('allows optional text to be empty', () => {
+    const question: FormQuestion = {
+      id: 'missed',
+      type: 'text',
+      question: 'Anything missed?',
+      required: false,
+    };
+    expect(isFormAnswerValid(question, emptyFormAnswerState())).toBe(true);
+  });
+
+  it('validates optional consent without follow-up', () => {
+    const question: FormQuestion = {
+      id: 'share',
+      type: 'consent',
+      question: 'Share',
+      consentText: 'May share',
+      required: false,
+    };
+    expect(isFormAnswerValid(question, emptyFormAnswerState())).toBe(true);
+    expect(
+      isFormAnswerValid(question, {
+        ...emptyFormAnswerState(),
+        trueFalseValue: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/training/tests/components/forms/form-answer-state.test.ts
+++ b/apps/training/tests/components/forms/form-answer-state.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import {
   emptyFormAnswerState,
+  getFormValidationError,
   isFormAnswerValid,
   toggleMultiselectOption,
 } from '@/components/forms/form-answer-state';
 import type { FormQuestion } from '@/content/form-types';
+import { FORMS_COMMON } from '@/lib/forms';
 
 describe('form answer state', () => {
   it('validates rating when required', () => {
@@ -37,6 +39,38 @@ describe('form answer state', () => {
       required: false,
     };
     expect(isFormAnswerValid(question, emptyFormAnswerState())).toBe(true);
+  });
+
+  it('returns required message for empty required multiselect', () => {
+    const question: FormQuestion = {
+      id: 'topics',
+      type: 'multiselect',
+      question: 'Topics',
+      options: ['A'],
+      maxSelections: 2,
+      required: true,
+    };
+    expect(getFormValidationError(question, emptyFormAnswerState(), FORMS_COMMON)).toBe(
+      FORMS_COMMON.errors.required,
+    );
+  });
+
+  it('returns max-selection message when multiselect exceeds limit', () => {
+    const question: FormQuestion = {
+      id: 'topics',
+      type: 'multiselect',
+      question: 'Topics',
+      options: ['A', 'B', 'C'],
+      maxSelections: 2,
+      required: false,
+    };
+    expect(
+      getFormValidationError(
+        question,
+        { ...emptyFormAnswerState(), selectedOptions: ['A', 'B', 'C'] },
+        FORMS_COMMON,
+      ),
+    ).toBe('Please select at most 2 options.');
   });
 
   it('validates optional consent without follow-up', () => {

--- a/apps/training/tests/components/forms/form-question-field.test.tsx
+++ b/apps/training/tests/components/forms/form-question-field.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { emptyFormAnswerState } from '@/components/forms/form-answer-state';
+import { FormQuestionField } from '@/components/forms/form-question-field';
+import { FORMS_COMMON } from '@/lib/forms';
+import type { FormQuestion } from '@/content/form-types';
+
+describe('FormQuestionField accessibility', () => {
+  it('includes consent text in the consent control accessible name', () => {
+    const question: FormQuestion = {
+      id: 'share-consent',
+      type: 'consent',
+      question: 'Sharing permission',
+      consentText: 'You may share my comments with other families.',
+      required: false,
+    };
+
+    render(
+      <FormQuestionField
+        question={question}
+        common={FORMS_COMMON}
+        answer={emptyFormAnswerState()}
+        onAnswerChange={vi.fn()}
+        variant='scroll'
+      />,
+    );
+
+    const control = screen.getByRole('button', { name: /You may share my comments with other families/ });
+    expect(control).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('selects segmented options with keyboard on native radios', () => {
+    const onAnswerChange = vi.fn();
+    const question: FormQuestion = {
+      id: 'recommend',
+      type: 'segmented',
+      question: 'Would you recommend?',
+      options: [
+        { value: 'Yes', label: 'Yes', variant: 'yes' },
+        { value: 'No', label: 'No', variant: 'no' },
+      ],
+      required: true,
+    };
+
+    render(
+      <FormQuestionField
+        question={question}
+        common={FORMS_COMMON}
+        answer={emptyFormAnswerState()}
+        onAnswerChange={onAnswerChange}
+        variant='scroll'
+      />,
+    );
+
+    const yesRadio = screen.getByRole('radio', { name: 'Yes' });
+    fireEvent.click(yesRadio);
+    expect(onAnswerChange).toHaveBeenCalledWith({ selectedOption: 'Yes' });
+  });
+
+  it('selects rating options with keyboard on native radios', () => {
+    const onAnswerChange = vi.fn();
+    const question: FormQuestion = {
+      id: 'usefulness',
+      type: 'rating',
+      question: 'How useful?',
+      options: [{ value: 5, emoji: '🤩', ariaLabel: 'Loved it' }],
+      required: true,
+    };
+
+    render(
+      <FormQuestionField
+        question={question}
+        common={FORMS_COMMON}
+        answer={emptyFormAnswerState()}
+        onAnswerChange={onAnswerChange}
+        variant='scroll'
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Loved it' }));
+    expect(onAnswerChange).toHaveBeenCalledWith({ ratingValue: 5 });
+  });
+});

--- a/apps/training/tests/components/forms/form-scroll-survey.test.tsx
+++ b/apps/training/tests/components/forms/form-scroll-survey.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FormScrollSurvey } from '@/components/forms/form-scroll-survey';
+import { FORMS_COMMON, getFormContent } from '@/lib/forms';
+
+const form = getFormContent('workshop-exit-feedback');
+
+describe('FormScrollSurvey', () => {
+  it('renders scroll survey questions and disables submit until required answers', () => {
+    if (!form) {
+      throw new Error('Expected workshop-exit-feedback form');
+    }
+
+    render(<FormScrollSurvey form={form} common={FORMS_COMMON} />);
+
+    expect(screen.getByText(/Two minutes of honesty/)).toBeInTheDocument();
+    expect(screen.getByText(/How useful was this morning/)).toBeInTheDocument();
+    expect(screen.getByText(/What was most useful/)).toBeInTheDocument();
+
+    const submit = screen.getByRole('button', { name: FORMS_COMMON.scroll.submitLabel });
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Loved it' }));
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Yes' }));
+    expect(submit).not.toBeDisabled();
+  });
+
+  it('locks multiselect chips after max selections', () => {
+    if (!form) {
+      throw new Error('Expected workshop-exit-feedback form');
+    }
+
+    render(<FormScrollSurvey form={form} common={FORMS_COMMON} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mealtime scripts' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Practical tips' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Helper alignment' }));
+
+    expect(
+      screen.getByRole('button', { name: /The balanced plate \(maximum selections reached\)/ }),
+    ).toBeDisabled();
+  });
+});

--- a/apps/training/tests/components/forms/form-scroll-survey.test.tsx
+++ b/apps/training/tests/components/forms/form-scroll-survey.test.tsx
@@ -1,31 +1,62 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { FormScrollSurvey } from '@/components/forms/form-scroll-survey';
 import { FORMS_COMMON, getFormContent } from '@/lib/forms';
+import * as formsApi from '@/lib/forms-api';
+import { resetFormSessionId } from '@/lib/form-session';
 
 const form = getFormContent('workshop-exit-feedback');
 
+vi.mock('@/lib/forms-api', () => ({
+  FormApiError: class FormApiError extends Error {
+    statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+  persistFormAnswer: vi.fn().mockResolvedValue(undefined),
+  resolveFormApiConfig: vi.fn(() => ({ baseUrl: '/www', apiKey: 'test-key' })),
+}));
+
 describe('FormScrollSurvey', () => {
-  it('renders scroll survey questions and disables submit until required answers', () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+    vi.mocked(formsApi.persistFormAnswer).mockClear();
+  });
+
+  it('shows required markers and surfaces validation when submit is clicked early', () => {
     if (!form) {
       throw new Error('Expected workshop-exit-feedback form');
     }
 
     render(<FormScrollSurvey form={form} common={FORMS_COMMON} />);
 
-    expect(screen.getByText(/Two minutes of honesty/)).toBeInTheDocument();
-    expect(screen.getByText(/How useful was this morning/)).toBeInTheDocument();
-    expect(screen.getByText(/What was most useful/)).toBeInTheDocument();
+    expect(screen.getAllByText(/\(Required\)/).length).toBeGreaterThanOrEqual(2);
 
     const submit = screen.getByRole('button', { name: FORMS_COMMON.scroll.submitLabel });
-    expect(submit).toBeDisabled();
+    expect(submit).not.toBeDisabled();
+
+    fireEvent.click(submit);
+    expect(screen.getByRole('alert')).toHaveTextContent(FORMS_COMMON.errors.required);
+  });
+
+  it('submits after required answers are provided', async () => {
+    if (!form) {
+      throw new Error('Expected workshop-exit-feedback form');
+    }
+
+    render(<FormScrollSurvey form={form} common={FORMS_COMMON} />);
 
     fireEvent.click(screen.getByRole('radio', { name: 'Loved it' }));
-    expect(submit).toBeDisabled();
-
     fireEvent.click(screen.getByRole('radio', { name: 'Yes' }));
-    expect(submit).not.toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: FORMS_COMMON.scroll.submitLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByText(FORMS_COMMON.completion.title)).toBeInTheDocument();
+    });
+    expect(formsApi.persistFormAnswer).toHaveBeenCalled();
   });
 
   it('locks multiselect chips after max selections', () => {
@@ -42,5 +73,58 @@ describe('FormScrollSurvey', () => {
     expect(
       screen.getByRole('button', { name: /The balanced plate \(maximum selections reached\)/ }),
     ).toBeDisabled();
+  });
+
+  it('derives multiselect hint from maxSelections template', () => {
+    if (!form) {
+      throw new Error('Expected workshop-exit-feedback form');
+    }
+
+    render(<FormScrollSurvey form={form} common={FORMS_COMMON} />);
+
+    expect(screen.getByText('Pick up to 3.')).toBeInTheDocument();
+  });
+
+  it('uses a new session id after Submit another', async () => {
+    if (!form) {
+      throw new Error('Expected workshop-exit-feedback form');
+    }
+
+    resetFormSessionId('workshop-exit-feedback');
+    render(<FormScrollSurvey form={form} common={FORMS_COMMON} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Loved it' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Yes' }));
+    fireEvent.click(screen.getByRole('button', { name: FORMS_COMMON.scroll.submitLabel }));
+
+    await waitFor(() => {
+      expect(screen.getByText(FORMS_COMMON.completion.title)).toBeInTheDocument();
+    });
+
+    const firstSessionId = vi.mocked(formsApi.persistFormAnswer).mock.calls[0]?.[0].sessionId;
+    expect(firstSessionId).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: FORMS_COMMON.scroll.submitAnotherLabel,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Loved it' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Maybe' }));
+    fireEvent.click(screen.getByRole('button', { name: FORMS_COMMON.scroll.submitLabel }));
+
+    await waitFor(() => {
+      const sessionIds = vi
+        .mocked(formsApi.persistFormAnswer)
+        .mock.calls.map((call) => call[0].sessionId);
+      expect(sessionIds.some((id) => id !== firstSessionId)).toBe(true);
+    });
+
+    const secondBatchId = vi
+      .mocked(formsApi.persistFormAnswer)
+      .mock.calls.filter((call) => call[0].sessionId !== firstSessionId)[0]?.[0].sessionId;
+    expect(secondBatchId).toBeTruthy();
+    expect(secondBatchId).not.toBe(firstSessionId);
   });
 });

--- a/apps/training/tests/content/forms-registry.test.ts
+++ b/apps/training/tests/content/forms-registry.test.ts
@@ -14,6 +14,7 @@ describe('forms registry', () => {
   it('returns registered slugs and resolves content', () => {
     const slugs = getAllFormSlugs();
     expect(slugs).toContain('workshop-feedback');
+    expect(slugs).toContain('workshop-exit-feedback');
     const content = getFormContent('workshop-feedback');
     expect(content?.title).toBeTruthy();
     expect(content?.slug).toBe('workshop-feedback');

--- a/apps/training/tests/lib/form-session.test.ts
+++ b/apps/training/tests/lib/form-session.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { getOrCreateFormSessionId } from '@/lib/form-session';
+import {
+  getOrCreateFormSessionId,
+  resetFormSessionId,
+} from '@/lib/form-session';
 
-describe('getOrCreateFormSessionId', () => {
+describe('form session ids', () => {
   afterEach(() => {
     window.sessionStorage.clear();
   });
@@ -17,5 +20,14 @@ describe('getOrCreateFormSessionId', () => {
     );
     expect(second).not.toBe(first);
     expect(firstAgain).toBe(first);
+  });
+
+  it('resetFormSessionId replaces the stored id with a new uuid', () => {
+    const initial = getOrCreateFormSessionId('workshop-exit-feedback');
+    const reset = resetFormSessionId('workshop-exit-feedback');
+    const afterReset = getOrCreateFormSessionId('workshop-exit-feedback');
+
+    expect(reset).not.toBe(initial);
+    expect(afterReset).toBe(reset);
   });
 });

--- a/apps/training/tests/lib/forms-api.test.ts
+++ b/apps/training/tests/lib/forms-api.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { emptyFormAnswerState } from '@/components/forms/form-answer-state';
+import { buildPersistBody } from '@/lib/forms-api';
+import type { FormQuestion } from '@/content/form-types';
+
+describe('buildPersistBody', () => {
+  it('maps rating answers to ratingValue', () => {
+    const question: FormQuestion = {
+      id: 'usefulness',
+      type: 'rating',
+      question: 'How useful?',
+      options: [{ value: 5, emoji: '🤩' }],
+    };
+    const body = buildPersistBody({
+      formSlug: 'workshop-exit-feedback',
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      question,
+      answer: { ...emptyFormAnswerState(), ratingValue: 5 },
+    });
+    expect(body).toMatchObject({
+      questionType: 'rating',
+      ratingValue: 5,
+    });
+  });
+
+  it('skips empty optional text answers', () => {
+    const question: FormQuestion = {
+      id: 'missed',
+      type: 'text',
+      question: 'Missed?',
+      required: false,
+    };
+    expect(
+      buildPersistBody({
+        formSlug: 'workshop-exit-feedback',
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        question,
+        answer: emptyFormAnswerState(),
+      }),
+    ).toBeNull();
+  });
+});

--- a/backend/src/app/api/admin_forms.py
+++ b/backend/src/app/api/admin_forms.py
@@ -141,7 +141,8 @@ def _export_form_answers(
         rating_value = item.get("ratingValue")
         rating_cell = (
             str(int(rating_value))
-            if isinstance(rating_value, (int, float)) and not isinstance(rating_value, bool)
+            if isinstance(rating_value, (int, float))
+            and not isinstance(rating_value, bool)
             else ""
         )
         boolean_answer = item.get("booleanAnswer")

--- a/backend/src/app/api/admin_forms.py
+++ b/backend/src/app/api/admin_forms.py
@@ -120,12 +120,38 @@ def _export_form_answers(
             "Question ID",
             "Question Type",
             "Selected Option",
+            "Selected Options",
+            "Rating Value",
+            "Boolean Answer",
             "Free Text",
             "Created At",
             "Updated At",
         ]
     )
     for item in items:
+        selected_options = item.get("selectedOptions")
+        if isinstance(selected_options, list):
+            options_cell = "; ".join(
+                option
+                for option in selected_options
+                if isinstance(option, str) and option.strip()
+            )
+        else:
+            options_cell = ""
+        rating_value = item.get("ratingValue")
+        rating_cell = (
+            str(int(rating_value))
+            if isinstance(rating_value, (int, float)) and not isinstance(rating_value, bool)
+            else ""
+        )
+        boolean_answer = item.get("booleanAnswer")
+        boolean_cell = (
+            "true"
+            if boolean_answer is True
+            else "false"
+            if boolean_answer is False
+            else ""
+        )
         writer.writerow(
             [
                 item.get("formSlug") or form_slug,
@@ -133,6 +159,9 @@ def _export_form_answers(
                 item.get("questionId") or "",
                 item.get("questionType") or "",
                 item.get("selectedOption") or "",
+                options_cell,
+                rating_cell,
+                boolean_cell,
                 item.get("freeText") or "",
                 item.get("createdAt") or "",
                 item.get("updatedAt") or "",

--- a/backend/src/app/api/public_forms.py
+++ b/backend/src/app/api/public_forms.py
@@ -22,6 +22,9 @@ _WWW_FORM_API_PREFIX = "/www/v1/forms/"
 
 _MAX_SELECTED_OPTION = 500
 _MAX_FREE_TEXT = 4000
+_MAX_SELECTED_OPTIONS = 20
+_MIN_RATING_VALUE = 1
+_MAX_RATING_VALUE = 10
 
 _QUESTION_ID_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _SESSION_ID_PATTERN = re.compile(
@@ -29,7 +32,10 @@ _SESSION_ID_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-_SELECT_TYPES = frozenset({"select"})
+_SELECT_TYPES = frozenset({"select", "segmented"})
+_MULTISELECT_TYPES = frozenset({"multiselect"})
+_RATING_TYPES = frozenset({"rating"})
+_CONSENT_TYPES = frozenset({"consent"})
 _TEXT_TYPES = frozenset({"text"})
 _EMAIL_TYPES = frozenset({"email"})
 
@@ -142,7 +148,55 @@ def _validate_put_body(
         return {
             **base,
             "selected_option": selected_option,
+            "selected_options": None,
+            "boolean_answer": None,
+            "rating_value": None,
             "free_text": None,
+        }
+
+    if question_type in _MULTISELECT_TYPES:
+        selected_options = _require_selected_options(body.get("selectedOptions"))
+        return {
+            **base,
+            "selected_option": None,
+            "selected_options": selected_options,
+            "boolean_answer": None,
+            "rating_value": None,
+            "free_text": None,
+        }
+
+    if question_type in _RATING_TYPES:
+        rating_value = _require_rating_value(body.get("ratingValue"))
+        return {
+            **base,
+            "selected_option": None,
+            "selected_options": None,
+            "boolean_answer": None,
+            "rating_value": rating_value,
+            "free_text": None,
+        }
+
+    if question_type in _CONSENT_TYPES:
+        boolean_answer = _require_boolean(body.get("booleanAnswer"))
+        free_text_raw = body.get("freeText")
+        free_text: str | None = None
+        if free_text_raw is not None:
+            if not isinstance(free_text_raw, str):
+                raise ValidationError("freeText must be a string")
+            normalized_text = free_text_raw.strip()
+            if normalized_text:
+                if len(normalized_text) > _MAX_FREE_TEXT:
+                    raise ValidationError(
+                        f"freeText must be at most {_MAX_FREE_TEXT} characters"
+                    )
+                free_text = normalized_text
+        return {
+            **base,
+            "selected_option": None,
+            "selected_options": None,
+            "boolean_answer": boolean_answer,
+            "rating_value": None,
+            "free_text": free_text,
         }
 
     free_text = _require_non_empty_string(body.get("freeText"), field="freeText")
@@ -158,8 +212,52 @@ def _validate_put_body(
     return {
         **base,
         "selected_option": None,
+        "selected_options": None,
+        "boolean_answer": None,
+        "rating_value": None,
         "free_text": free_text,
     }
+
+
+def _require_selected_options(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        raise ValidationError("selectedOptions is required")
+    if not value:
+        raise ValidationError("selectedOptions must contain at least one option")
+    if len(value) > _MAX_SELECTED_OPTIONS:
+        raise ValidationError(
+            f"selectedOptions must contain at most {_MAX_SELECTED_OPTIONS} options"
+        )
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in value:
+        if not isinstance(raw, str):
+            raise ValidationError("selectedOptions must contain strings")
+        option = raw.strip()
+        if not option:
+            raise ValidationError("selectedOptions must not contain empty strings")
+        if len(option) > _MAX_SELECTED_OPTION:
+            raise ValidationError(
+                "each selectedOptions entry must be at most "
+                f"{_MAX_SELECTED_OPTION} characters"
+            )
+        if option in seen:
+            continue
+        seen.add(option)
+        normalized.append(option)
+    if not normalized:
+        raise ValidationError("selectedOptions must contain at least one option")
+    return normalized
+
+
+def _require_rating_value(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValidationError("ratingValue must be an integer")
+    if value < _MIN_RATING_VALUE or value > _MAX_RATING_VALUE:
+        raise ValidationError(
+            f"ratingValue must be between {_MIN_RATING_VALUE} and {_MAX_RATING_VALUE}"
+        )
+    return value
 
 
 def _require_session_id(value: Any) -> str:
@@ -184,10 +282,26 @@ def _require_question_type(value: Any) -> str:
     if not isinstance(value, str):
         raise ValidationError("questionType is required")
     normalized = value.strip().lower()
-    allowed = _SELECT_TYPES | _TEXT_TYPES | _EMAIL_TYPES
+    allowed = (
+        _SELECT_TYPES
+        | _MULTISELECT_TYPES
+        | _RATING_TYPES
+        | _CONSENT_TYPES
+        | _TEXT_TYPES
+        | _EMAIL_TYPES
+    )
     if normalized not in allowed:
-        raise ValidationError("questionType must be select, text, or email")
+        raise ValidationError(
+            "questionType must be select, multiselect, rating, segmented, "
+            "consent, text, or email"
+        )
     return normalized
+
+
+def _require_boolean(value: Any) -> bool:
+    if not isinstance(value, bool):
+        raise ValidationError("booleanAnswer must be a boolean")
+    return value
 
 
 def _require_non_empty_string(value: Any, *, field: str) -> str:

--- a/backend/src/app/services/form_responses_store.py
+++ b/backend/src/app/services/form_responses_store.py
@@ -63,6 +63,9 @@ def upsert_form_answer(
     question_id: str,
     question_type: str,
     selected_option: str | None = None,
+    selected_options: list[str] | None = None,
+    boolean_answer: bool | None = None,
+    rating_value: int | None = None,
     free_text: str | None = None,
 ) -> dict[str, Any]:
     """Persist one question answer; overwrites prior value for the same session/question."""
@@ -82,6 +85,12 @@ def upsert_form_answer(
     }
     if selected_option is not None:
         item["selectedOption"] = selected_option
+    if selected_options is not None:
+        item["selectedOptions"] = selected_options
+    if boolean_answer is not None:
+        item["booleanAnswer"] = boolean_answer
+    if rating_value is not None:
+        item["ratingValue"] = rating_value
     if free_text is not None:
         item["freeText"] = free_text
 
@@ -188,6 +197,19 @@ def serialize_form_answer_item(item: Mapping[str, Any]) -> dict[str, Any]:
     selected_option = item.get("selectedOption")
     if isinstance(selected_option, str):
         row["selectedOption"] = selected_option
+    selected_options = item.get("selectedOptions")
+    if isinstance(selected_options, list):
+        row["selectedOptions"] = [
+            option
+            for option in selected_options
+            if isinstance(option, str) and option.strip()
+        ]
+    boolean_answer = item.get("booleanAnswer")
+    if isinstance(boolean_answer, bool):
+        row["booleanAnswer"] = boolean_answer
+    rating_value = item.get("ratingValue")
+    if isinstance(rating_value, (int, float)) and not isinstance(rating_value, bool):
+        row["ratingValue"] = int(rating_value)
     free_text = item.get("freeText")
     if isinstance(free_text, str):
         row["freeText"] = free_text

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -8035,10 +8035,29 @@ components:
           pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
         questionType:
           type: string
-          enum: [select, text, email]
+          enum:
+            - select
+            - multiselect
+            - rating
+            - segmented
+            - consent
+            - text
+            - email
         selectedOption:
           type: string
           maxLength: 500
+        selectedOptions:
+          type: array
+          maxItems: 20
+          items:
+            type: string
+            maxLength: 500
+        ratingValue:
+          type: integer
+          minimum: 1
+          maximum: 10
+        booleanAnswer:
+          type: boolean
         freeText:
           type: string
           maxLength: 4000

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -2562,15 +2562,37 @@ components:
           pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
         questionType:
           type: string
-          enum: [select, text, email]
+          enum:
+            - select
+            - multiselect
+            - rating
+            - segmented
+            - consent
+            - text
+            - email
         selectedOption:
           type: string
           maxLength: 500
-          description: Selected option label for `select` questions.
+          description: Selected option label for `select` and `segmented` questions.
+        selectedOptions:
+          type: array
+          maxItems: 20
+          items:
+            type: string
+            maxLength: 500
+          description: Selected option labels for `multiselect` questions.
+        ratingValue:
+          type: integer
+          minimum: 1
+          maximum: 10
+          description: Numeric rating for `rating` questions.
+        booleanAnswer:
+          type: boolean
+          description: Consent checkbox value for `consent` questions.
         freeText:
           type: string
           maxLength: 4000
-          description: Response body for `text` and `email` questions.
+          description: Response body for `text`, `email`, and optional `consent` follow-up.
     FormAnswerPutResponse:
       type: object
       required:

--- a/tests/test_public_forms_api.py
+++ b/tests/test_public_forms_api.py
@@ -73,6 +73,74 @@ def test_put_form_answer_persists_text(api_gateway_event: Any, mock_env: Any) ->
     assert item["freeText"] == "Great workshop"
 
 
+def test_put_form_answer_persists_rating(api_gateway_event: Any, mock_env: Any) -> None:
+    table = MagicMock()
+    table.get_item.return_value = {"Item": None}
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    body = {
+        "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+        "questionId": "usefulness",
+        "questionType": "rating",
+        "ratingValue": 4,
+    }
+    resp = pf.handle_public_forms_request(
+        _event(api_gateway_event, body=body),
+        "PUT",
+        "/www/v1/forms/workshop-exit-feedback/answers",
+    )
+    assert resp["statusCode"] == 200
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["ratingValue"] == 4
+
+
+def test_put_form_answer_persists_multiselect(api_gateway_event: Any, mock_env: Any) -> None:
+    table = MagicMock()
+    table.get_item.return_value = {"Item": None}
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    body = {
+        "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+        "questionId": "most-useful",
+        "questionType": "multiselect",
+        "selectedOptions": ["Mealtime scripts", "Practical tips"],
+    }
+    resp = pf.handle_public_forms_request(
+        _event(api_gateway_event, body=body),
+        "PUT",
+        "/www/v1/forms/workshop-exit-feedback/answers",
+    )
+    assert resp["statusCode"] == 200
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["selectedOptions"] == ["Mealtime scripts", "Practical tips"]
+
+
+def test_put_form_answer_persists_consent(api_gateway_event: Any, mock_env: Any) -> None:
+    table = MagicMock()
+    table.get_item.return_value = {"Item": None}
+    store.configure_table_for_tests(table)
+    mock_env(POLL_RESPONSES_TABLE_NAME="evolvesprouts-poll-responses")
+
+    body = {
+        "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+        "questionId": "share-consent",
+        "questionType": "consent",
+        "booleanAnswer": True,
+        "freeText": "Year 3",
+    }
+    resp = pf.handle_public_forms_request(
+        _event(api_gateway_event, body=body),
+        "PUT",
+        "/www/v1/forms/workshop-exit-feedback/answers",
+    )
+    assert resp["statusCode"] == 200
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["booleanAnswer"] is True
+    assert item["freeText"] == "Year 3"
+
+
 def test_put_form_answer_rejects_truefalse(api_gateway_event: Any, mock_env: Any) -> None:
     table = MagicMock()
     store.configure_table_for_tests(table)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new training-site exit feedback form based on the provided HTML prototype, plus reusable question types for future forms.

**New form:** `/forms/workshop-exit-feedback/` — single-page scroll layout with Evolve Sprouts × Menon Wellness branding, ~90 second copy, and thank-you / submit-another flows.

**New question types:**
- `rating` — emoji scale (1–5) with optional endpoint labels
- `multiselect` — chip selection with `maxSelections` (locks remaining chips when full)
- `segmented` — Yes / Maybe / No buttons with variant styling
- `consent` — share-permission checkbox with optional follow-up text

## Backend / admin

- `PUT /v1/forms/{form_slug}/answers` accepts the new types (`ratingValue`, `selectedOptions`, `booleanAnswer`)
- DynamoDB serialization and admin CSV export include the new fields
- OpenAPI (`docs/api/public.yaml`, `docs/api/admin.yaml`) and generated admin types updated
- Admin Website QR presets include **Workshop exit feedback**

## Testing

- `pytest tests/test_public_forms_api.py`
- `vitest` for form answer state, scroll survey UI, forms API body builder, and forms registry

## How to try locally

1. `cd apps/training && npm run dev`
2. Open `http://localhost:3002/forms/workshop-exit-feedback/`
3. Ensure `NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_TRAINING_API_KEY` are set in `.env.local` for persistence
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20ad6f6e-457a-4184-bd6a-fbda2cb7c9a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20ad6f6e-457a-4184-bd6a-fbda2cb7c9a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

