### PR TITLE
Rename workshop-exit-feedback form title to Workshop feedback

### DIFF
--- a/apps/training/src/content/forms/workshop-exit-feedback.json
+++ b/apps/training/src/content/forms/workshop-exit-feedback.json
@@ -1,5 +1,5 @@
 {
-  "title": "Before you go…",
+  "title": "Workshop feedback",
   "slug": "workshop-exit-feedback",
   "completion": {
     "description": "That's genuinely useful — it makes the next one better for the families who come after you."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the training site exit feedback form (`/forms/workshop-exit-feedback/`) page title from "Before you go…" to "Workshop feedback". This affects the on-page `<h1>` and Next.js page metadata.

## Changes

- `apps/training/src/content/forms/workshop-exit-feedback.json` — `title` field

## Notes

The slug remains `workshop-exit-feedback`. The separate `workshop-feedback` form at `/forms/workshop-feedback/` also uses the title "Workshop feedback"; they differ by route and question set.

## Testing

- `cd apps/training && npx vitest run tests/content/forms-registry.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ee6d34a-7ed8-4fe2-805b-112bd774c40d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ee6d34a-7ed8-4fe2-805b-112bd774c40d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

