### PR TITLE
Add partner legal_name for invoice Bill To display

### DIFF
--- a/apps/admin_web/src/components/admin/services/partners-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/partners-panel.tsx
@@ -89,6 +89,7 @@ export function PartnersPanel({
   const [organizationType, setOrganizationType] =
     useState<ApiSchemas['EntityOrganizationType']>('company');
   const [partnerKey, setPartnerKey] = useState('');
+  const [legalName, setLegalName] = useState('');
   const [website, setWebsite] = useState('');
   const [pendingLocationId, setPendingLocationId] = useState<string | null>(null);
   const [optimisticLocationSummary, setOptimisticLocationSummary] =
@@ -187,6 +188,7 @@ export function PartnersPanel({
     setName('');
     setOrganizationType('company');
     setPartnerKey('');
+    setLegalName('');
     setWebsite('');
     setPendingLocationId(null);
     setOptimisticLocationSummary(null);
@@ -204,6 +206,7 @@ export function PartnersPanel({
           organization_type: organizationType,
           relationship_type: 'partner',
           partner_key: partnerKey.trim() || null,
+          legal_name: legalName.trim() || null,
           website: website.trim() || null,
           location_id: loc,
           tag_ids: tagIds,
@@ -219,6 +222,7 @@ export function PartnersPanel({
         organization_type: organizationType,
         relationship_type: 'partner',
         partner_key: partnerKey.trim() || null,
+        legal_name: legalName.trim() || null,
         website: website.trim() || null,
         location_id: loc,
         active,
@@ -265,6 +269,7 @@ export function PartnersPanel({
     setName(row.name);
     setOrganizationType(row.organization_type);
     setPartnerKey(row.partner_key ?? '');
+    setLegalName(row.legal_name ?? '');
     setWebsite(row.website ?? '');
     setPendingLocationId(row.location_id ?? null);
     setOptimisticLocationSummary(null);
@@ -332,6 +337,16 @@ export function PartnersPanel({
                 hyphen).
               </p>
             ) : null}
+          </div>
+          <div className='lg:col-span-2'>
+            <Label htmlFor='svc-partner-legal-name'>Legal name</Label>
+            <Input
+              id='svc-partner-legal-name'
+              value={legalName}
+              onChange={(e) => setLegalName(e.target.value)}
+              autoComplete='off'
+              placeholder='Registered legal entity name (optional)'
+            />
           </div>
           <div className='lg:col-span-2'>
             <Label htmlFor='svc-partner-web'>Website</Label>

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -8123,6 +8123,8 @@ export interface components {
             relationship_type: components["schemas"]["EntityRelationshipType"];
             /** @description Optional URL-safe partner key for partner organisations only (lowercase letters, digits, single hyphens between segments). Null when not a partner or unset. Uniqueness is enforced case-insensitively among partner rows. */
             partner_key?: string | null;
+            /** @description Optional legal entity name for partner organisations only. Used on AR invoice Bill To lines (with fallback to ``name``). Null when not a partner or unset. */
+            legal_name?: string | null;
             website?: string | null;
             /** Format: uuid */
             location_id?: string | null;
@@ -8152,6 +8154,8 @@ export interface components {
             relationship_type?: components["schemas"]["EntityOrganizationRelationshipType"];
             /** @description Optional partner-only key. Omit or null to clear. Must be null when relationship_type is not partner. */
             partner_key?: string | null;
+            /** @description Optional partner-only legal entity name for invoice Bill To display. Omit or null to clear. Must be null when relationship_type is not partner. */
+            legal_name?: string | null;
             website?: string | null;
             /** Format: uuid */
             location_id?: string | null;
@@ -8165,6 +8169,8 @@ export interface components {
             relationship_type?: components["schemas"]["EntityOrganizationRelationshipType"];
             /** @description Optional partner-only key. Omit or null to clear. Must be null when relationship_type is not partner. */
             partner_key?: string | null;
+            /** @description Optional partner-only legal entity name for invoice Bill To display. Omit or null to clear. Must be null when relationship_type is not partner. */
+            legal_name?: string | null;
             website?: string | null;
             /** Format: uuid */
             location_id?: string | null;

--- a/apps/admin_web/tests/components/admin/services/partners-panel.test.tsx
+++ b/apps/admin_web/tests/components/admin/services/partners-panel.test.tsx
@@ -105,8 +105,10 @@ describe('PartnersPanel', () => {
     render(<PartnersPanel partners={partners} {...panelShell} />);
 
     expect(screen.getByLabelText('Partner key')).toBeInTheDocument();
+    expect(screen.getByLabelText('Legal name')).toBeInTheDocument();
     await user.type(screen.getByLabelText('Name'), 'Gamma');
     await user.type(screen.getByLabelText('Partner key'), 'gamma-slug');
+    await user.type(screen.getByLabelText('Legal name'), 'Gamma Learning Limited');
     await user.click(screen.getByRole('button', { name: 'Create partner' }));
 
     expect(createPartner).toHaveBeenCalledWith(
@@ -114,6 +116,7 @@ describe('PartnersPanel', () => {
         name: 'Gamma',
         relationship_type: 'partner',
         partner_key: 'gamma-slug',
+        legal_name: 'Gamma Learning Limited',
       })
     );
   });
@@ -135,6 +138,7 @@ describe('PartnersPanel', () => {
       organization_type: 'company' as const,
       relationship_type: 'partner' as const,
       partner_key: null,
+      legal_name: null,
       website: null,
       location_id: null,
       location_summary: null,
@@ -173,6 +177,7 @@ describe('PartnersPanel', () => {
       organization_type: 'school',
       relationship_type: 'partner',
       partner_key: 'row-slug',
+      legal_name: 'Row Partner Legal Ltd',
       website: 'https://example.com',
       location_id: null,
       location_summary: null,
@@ -191,8 +196,11 @@ describe('PartnersPanel', () => {
     render(<PartnersPanel partners={partners} {...panelShell} />);
 
     await user.click(screen.getByText('Row Partner'));
+    expect(screen.getByLabelText('Legal name')).toHaveValue('Row Partner Legal Ltd');
     await user.clear(screen.getByLabelText('Name'));
     await user.type(screen.getByLabelText('Name'), 'Row Partner Renamed');
+    await user.clear(screen.getByLabelText('Legal name'));
+    await user.type(screen.getByLabelText('Legal name'), 'Row Partner Legal Renamed');
     await user.click(screen.getByRole('button', { name: 'Update partner' }));
 
     expect(updatePartner).toHaveBeenCalledWith(
@@ -201,6 +209,7 @@ describe('PartnersPanel', () => {
         name: 'Row Partner Renamed',
         relationship_type: 'partner',
         partner_key: 'row-slug',
+        legal_name: 'Row Partner Legal Renamed',
       })
     );
   });
@@ -223,6 +232,7 @@ describe('PartnersPanel', () => {
       organization_type: 'company',
       relationship_type: 'partner',
       partner_key: null,
+      legal_name: null,
       website: null,
       location_id: locId,
       location_summary: null,
@@ -294,6 +304,7 @@ describe('PartnersPanel', () => {
       organization_type: 'company',
       relationship_type: 'partner',
       partner_key: 'del',
+      legal_name: null,
       website: null,
       location_id: null,
       location_summary: null,

--- a/backend/db/alembic/versions/0071_partner_legal_name.py
+++ b/backend/db/alembic/versions/0071_partner_legal_name.py
@@ -1,0 +1,37 @@
+"""Add ``organizations.legal_name`` for partner invoice bill-to display.
+
+Seed-data assessment (``backend/db/seed/seed_data.sql``):
+1. Compatible: seed file has no ``organizations`` inserts.
+2. Nullable column; no NOT NULL constraint.
+3. N/A.
+4. No seed rows for organizations.
+5. N/A.
+6. N/A.
+
+Result: No seed updates required (see seed file note).
+
+Revision id: ``0071_partner_legal_name`` (22 chars, <= 32).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0071_partner_legal_name"
+down_revision: Union[str, None] = "0070_cert_audit_trigger"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column("legal_name", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "legal_name")

--- a/backend/db/seed/seed_data.sql
+++ b/backend/db/seed/seed_data.sql
@@ -145,3 +145,6 @@ WHERE lower(s.service_key) = 'intro-call'
   );
   END IF;
 END $$;
+
+-- organizations.legal_name (migration 0071_partner_legal_name): no seed inserts into
+-- organizations; partner legal names are admin-created at runtime.

--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -16,7 +16,7 @@ from app.api.admin_billing_common import (
 )
 from app.db.models import Contact, Enrollment, Family, Organization
 from app.db.models.customer_invoice import CustomerInvoice
-from app.db.models.enums import BillingBillToKind
+from app.db.models.enums import BillingBillToKind, RelationshipType
 from app.db.models.family import FamilyMember
 from app.db.models.geographic_area import GeographicArea
 from app.db.models.location import Location
@@ -295,7 +295,10 @@ def _resolve_bill_to_party_from_invoice_fks(
             .limit(1)
         )
         primary = session.execute(stmt).scalar_one_or_none()
-        entity_nm = (org.name or "").strip()
+        if org.relationship_type == RelationshipType.PARTNER:
+            entity_nm = ((org.legal_name or org.name) or "").strip()
+        else:
+            entity_nm = (org.name or "").strip()
         primary_nm = (contact_display_name(primary) or "").strip()
         if entity_nm and primary_nm:
             inv.bill_to_display_name = f"{entity_nm}\n{primary_nm}"

--- a/backend/src/app/api/admin_entities_serializers.py
+++ b/backend/src/app/api/admin_entities_serializers.py
@@ -217,6 +217,7 @@ def serialize_organization_summary(org: Organization) -> dict[str, Any]:
         "organization_type": org.organization_type.value,
         "relationship_type": org.relationship_type.value,
         "partner_key": org.partner_key,
+        "legal_name": org.legal_name,
         "website": org.website,
         "location_id": str(org.location_id) if org.location_id else None,
         "location_summary": serialize_location_venue(org.location)

--- a/backend/src/app/api/admin_organizations.py
+++ b/backend/src/app/api/admin_organizations.py
@@ -160,6 +160,35 @@ def _apply_organization_partner_key_from_body(
     org.partner_key = partner_key
 
 
+def _apply_organization_legal_name_from_body(
+    org: Organization,
+    body: Mapping[str, Any],
+    *,
+    relationship_type: RelationshipType | None = None,
+) -> None:
+    """Set legal_name from request body; only partner orgs may have a legal name."""
+    if "legal_name" not in body:
+        return
+    legal_name = validate_string_length(
+        body.get("legal_name"),
+        "legal_name",
+        max_length=255,
+        required=False,
+    )
+    effective = (
+        relationship_type if relationship_type is not None else org.relationship_type
+    )
+    if effective != RelationshipType.PARTNER:
+        if legal_name is not None:
+            raise ValidationError(
+                "legal_name is only allowed when relationship_type is partner",
+                field="legal_name",
+            )
+        org.legal_name = None
+        return
+    org.legal_name = legal_name
+
+
 def _parse_organization_list_order(raw: str | None) -> OrganizationListOrder:
     """Parse optional ``sort`` query for ``GET /v1/admin/organizations``."""
     if raw is None or str(raw).strip() == "":
@@ -316,6 +345,9 @@ def _create_organization(event: Mapping[str, Any], *, actor_sub: str) -> dict[st
         _apply_organization_partner_key_from_body(
             org, body, relationship_type=relationship_type
         )
+        _apply_organization_legal_name_from_body(
+            org, body, relationship_type=relationship_type
+        )
         created = repository.create(org)
         if tag_ids:
             replace_organization_tags(
@@ -384,6 +416,7 @@ def _update_organization(
             )
             if org.relationship_type != RelationshipType.PARTNER:
                 org.partner_key = None
+                org.legal_name = None
         if "website" in body:
             org.website = validate_string_length(
                 body.get("website"),
@@ -405,6 +438,7 @@ def _update_organization(
             replace_organization_tags(session, organization_id=org.id, tag_ids=tag_ids)
 
         _apply_organization_partner_key_from_body(org, body)
+        _apply_organization_legal_name_from_body(org, body)
 
         repository.update(org)
         try:

--- a/backend/src/app/db/models/organization.py
+++ b/backend/src/app/db/models/organization.py
@@ -86,6 +86,7 @@ class Organization(Base):
         server_default=text("'prospect'"),
     )
     website: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    legal_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     partner_key: Mapped[str | None] = mapped_column(String(128), nullable=True)
     location_id: Mapped[UUID | None] = mapped_column(
         PG_UUID(as_uuid=True),

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -9147,6 +9147,13 @@ components:
             Optional URL-safe partner key for partner organisations only (lowercase
             letters, digits, single hyphens between segments). Null when not a partner
             or unset. Uniqueness is enforced case-insensitively among partner rows.
+        legal_name:
+          type: string
+          nullable: true
+          maxLength: 255
+          description: >
+            Optional legal entity name for partner organisations only. Used on AR invoice
+            Bill To lines (with fallback to ``name``). Null when not a partner or unset.
         website:
           type: string
           nullable: true
@@ -9226,6 +9233,13 @@ components:
           description: >
             Optional partner-only key. Omit or null to clear. Must be null when
             relationship_type is not partner.
+        legal_name:
+          type: string
+          maxLength: 255
+          nullable: true
+          description: >
+            Optional partner-only legal entity name for invoice Bill To display. Omit or
+            null to clear. Must be null when relationship_type is not partner.
         website:
           type: string
           maxLength: 500
@@ -9261,6 +9275,13 @@ components:
           description: >
             Optional partner-only key. Omit or null to clear. Must be null when
             relationship_type is not partner.
+        legal_name:
+          type: string
+          maxLength: 255
+          nullable: true
+          description: >
+            Optional partner-only legal entity name for invoice Bill To display. Omit or
+            null to clear. Must be null when relationship_type is not partner.
         website:
           type: string
           maxLength: 500

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -484,6 +484,10 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
   `relationship_type` is `partner`; uniqueness is enforced case-insensitively
   among partner rows with a non-null key (partial unique index
   `organizations_partner_key_unique_idx`).
+- `organizations.legal_name` is an optional legal entity name for partner rows
+  only; admin APIs reject non-null values when `relationship_type` is not
+  `partner`. AR invoice Bill To resolution uses `legal_name` with fallback to
+  `name` for partner organisations at issue time.
 - `organizations.location_id` optionally links an organization to a canonical
   row in `locations` for address management.
 - `organization_members` links contacts to organizations with role/title and an optional

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -487,7 +487,10 @@ maps legacy `note.id` to the **first** inserted row’s UUID.
 - `organizations.legal_name` is an optional legal entity name for partner rows
   only; admin APIs reject non-null values when `relationship_type` is not
   `partner`. AR invoice Bill To resolution uses `legal_name` with fallback to
-  `name` for partner organisations at issue time.
+  `name` for partner organisations at issue time. By design, `legal_name` appears
+  only on the issued invoice PDF Bill To line (`bill_to_display_name`); admin
+  pickers/list labels and the structured `bill_to_snapshot` organization trade
+  name keep `organizations.name`.
 - `organizations.location_id` optionally links an organization to a canonical
   row in `locations` for address management.
 - `organization_members` links contacts to organizations with role/title and an optional

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -99,7 +99,8 @@ their primary responsibilities.
   alphabetical order by trimmed name); includes `DELETE /v1/admin/organizations/{id}`
   for non-vendor orgs; `POST /v1/admin/organizations/{id}/members` derives each member's role from the
   linked contact's `contact_type`; `PATCH /v1/admin/organizations/{id}/members/{memberId}` updates
-  membership fields such as primary contact),
+  membership fields such as primary contact; partner rows accept optional `legal_name` for AR
+  invoice Bill To entity lines—resolved as `legal_name` or `name` at issue time),
   `/v1/admin/forms` (lists form slugs with answer counts from DynamoDB
   `evolvesprouts-poll-responses`), `/v1/admin/forms/{form_slug}/answers`
   (`GET` lists all stored answer rows; `DELETE` clears all rows for the form),

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -100,7 +100,8 @@ their primary responsibilities.
   for non-vendor orgs; `POST /v1/admin/organizations/{id}/members` derives each member's role from the
   linked contact's `contact_type`; `PATCH /v1/admin/organizations/{id}/members/{memberId}` updates
   membership fields such as primary contact; partner rows accept optional `legal_name` for AR
-  invoice Bill To entity lines—resolved as `legal_name` or `name` at issue time),
+  invoice Bill To entity lines—resolved as `legal_name` or `name` at issue time; pickers and
+  structured bill-to snapshots keep the trade `name` by design),
   `/v1/admin/forms` (lists form slugs with answer counts from DynamoDB
   `evolvesprouts-poll-responses`), `/v1/admin/forms/{form_slug}/answers`
   (`GET` lists all stored answer rows; `DELETE` clears all rows for the form),

--- a/tests/test_admin_billing.py
+++ b/tests/test_admin_billing.py
@@ -4890,9 +4890,14 @@ def test_resolve_bill_to_party_from_invoice_fks_organization_two_lines() -> None
         _resolve_bill_to_party_from_invoice_fks,
     )
     from app.db.models import Organization
+    from app.db.models.enums import RelationshipType
 
     oid = uuid4()
-    org = SimpleNamespace(name="Acme Learning Ltd")
+    org = SimpleNamespace(
+        name="Acme Learning Ltd",
+        relationship_type=RelationshipType.CLIENT,
+        legal_name=None,
+    )
     primary = SimpleNamespace(
         first_name="Jordan",
         last_name="Lee",
@@ -4920,6 +4925,88 @@ def test_resolve_bill_to_party_from_invoice_fks_organization_two_lines() -> None
     _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
     assert inv.bill_to_display_name == "Acme Learning Ltd\nJordan Lee"
     assert inv.bill_to_email == "jordan@example.com"
+
+
+def test_resolve_bill_to_party_from_invoice_fks_partner_uses_legal_name() -> None:
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Organization
+    from app.db.models.enums import RelationshipType
+
+    oid = uuid4()
+    org = SimpleNamespace(
+        name="Acme Display",
+        legal_name="Acme Learning Limited",
+        relationship_type=RelationshipType.PARTNER,
+    )
+    primary = SimpleNamespace(
+        first_name="Jordan",
+        last_name="Lee",
+        email="jordan@example.com",
+    )
+    session = MagicMock()
+
+    def _get(model: Any, pk: Any) -> Any:
+        if model is Organization and pk == oid:
+            return org
+        return None
+
+    session.get.side_effect = _get
+
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = primary
+    session.execute.return_value = exec_result
+
+    inv = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.ORGANIZATION,
+        bill_to_organization_id=oid,
+        bill_to_display_name=None,
+        bill_to_email=None,
+    )
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
+    assert inv.bill_to_display_name == "Acme Learning Limited\nJordan Lee"
+
+
+def test_resolve_bill_to_party_from_invoice_fks_partner_falls_back_to_name() -> None:
+    from app.api.admin_billing_invoice_draft_helpers import (
+        _resolve_bill_to_party_from_invoice_fks,
+    )
+    from app.db.models import Organization
+    from app.db.models.enums import RelationshipType
+
+    oid = uuid4()
+    org = SimpleNamespace(
+        name="Acme Display",
+        legal_name=None,
+        relationship_type=RelationshipType.PARTNER,
+    )
+    primary = SimpleNamespace(
+        first_name="Jordan",
+        last_name="Lee",
+        email="jordan@example.com",
+    )
+    session = MagicMock()
+
+    def _get(model: Any, pk: Any) -> Any:
+        if model is Organization and pk == oid:
+            return org
+        return None
+
+    session.get.side_effect = _get
+
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = primary
+    session.execute.return_value = exec_result
+
+    inv = SimpleNamespace(
+        bill_to_kind=BillingBillToKind.ORGANIZATION,
+        bill_to_organization_id=oid,
+        bill_to_display_name=None,
+        bill_to_email=None,
+    )
+    _resolve_bill_to_party_from_invoice_fks(session, inv=inv)  # type: ignore[arg-type]
+    assert inv.bill_to_display_name == "Acme Display\nJordan Lee"
 
 
 def test_resolve_bill_to_party_from_invoice_fks_contact_without_email_sets_display_name() -> None:

--- a/tests/test_admin_organizations_handler.py
+++ b/tests/test_admin_organizations_handler.py
@@ -3,11 +3,253 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID, uuid4
 
+import pytest
+
 from app.api import admin_organizations
 from app.api.admin import lambda_handler
+from app.db.models import Organization, OrganizationType, RelationshipType
+from app.exceptions import ValidationError
+
+
+def _install_organizations_persistence_fakes(
+    monkeypatch: Any,
+    *,
+    stored: dict[UUID, Organization],
+) -> None:
+    """Fake DB session/repository so create/update handlers persist in ``stored``."""
+
+    class _FakeSession:
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class _FakeSessionCtx:
+        def __enter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    class _FakeRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        def create(self, org: Organization) -> Organization:
+            if org.id is None:
+                org.id = uuid4()
+            now = datetime.now(UTC)
+            org.created_at = now
+            org.updated_at = now
+            org.organization_tags = []
+            org.organization_members = []
+            stored[org.id] = org
+            return org
+
+        def update(self, org: Organization) -> Organization:
+            org.updated_at = datetime.now(UTC)
+            stored[org.id] = org
+            return org
+
+        def get_non_vendor_organization_by_id(
+            self, organization_id: UUID
+        ) -> Organization | None:
+            return stored.get(organization_id)
+
+    monkeypatch.setattr(admin_organizations, "OrganizationRepository", _FakeRepo)
+    monkeypatch.setattr(admin_organizations, "Session", lambda _engine: _FakeSessionCtx())
+    monkeypatch.setattr(admin_organizations, "get_engine", lambda: object())
+    monkeypatch.setattr(
+        admin_organizations, "set_audit_context", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        admin_organizations, "ensure_location_exists", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        admin_organizations, "replace_organization_tags", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        admin_organizations,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+
+def test_create_partner_with_legal_name_round_trips(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    stored: dict[UUID, Organization] = {}
+    _install_organizations_persistence_fakes(monkeypatch, stored=stored)
+
+    response = admin_organizations.handle_admin_organizations_request(
+        api_gateway_event(
+            method="POST",
+            path="/v1/admin/organizations",
+            body=json.dumps(
+                {
+                    "name": "Acme Display",
+                    "organization_type": "company",
+                    "relationship_type": "partner",
+                    "legal_name": "Acme Learning Limited",
+                }
+            ),
+        ),
+        "POST",
+        "/v1/admin/organizations",
+    )
+
+    assert response["statusCode"] == 201
+    body = json.loads(response["body"])
+    assert body["organization"]["legal_name"] == "Acme Learning Limited"
+    assert body["organization"]["name"] == "Acme Display"
+    assert len(stored) == 1
+    org = next(iter(stored.values()))
+    assert org.legal_name == "Acme Learning Limited"
+
+
+def test_update_partner_legal_name_round_trips(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    stored: dict[UUID, Organization] = {}
+    _install_organizations_persistence_fakes(monkeypatch, stored=stored)
+    org_id = uuid4()
+    now = datetime.now(UTC)
+    stored[org_id] = Organization(
+        id=org_id,
+        name="Acme Display",
+        organization_type=OrganizationType.COMPANY,
+        relationship_type=RelationshipType.PARTNER,
+        legal_name="Old Legal Ltd",
+        created_at=now,
+        updated_at=now,
+    )
+    stored[org_id].organization_tags = []
+    stored[org_id].organization_members = []
+
+    response = admin_organizations.handle_admin_organizations_request(
+        api_gateway_event(
+            method="PATCH",
+            path=f"/v1/admin/organizations/{org_id}",
+            body=json.dumps({"legal_name": "New Legal Limited"}),
+        ),
+        "PATCH",
+        f"/v1/admin/organizations/{org_id}",
+    )
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["organization"]["legal_name"] == "New Legal Limited"
+    assert stored[org_id].legal_name == "New Legal Limited"
+
+
+def test_create_non_partner_with_legal_name_returns_validation_error(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    stored: dict[UUID, Organization] = {}
+    _install_organizations_persistence_fakes(monkeypatch, stored=stored)
+
+    with pytest.raises(ValidationError, match="only allowed when") as exc:
+        admin_organizations.handle_admin_organizations_request(
+            api_gateway_event(
+                method="POST",
+                path="/v1/admin/organizations",
+                body=json.dumps(
+                    {
+                        "name": "Prospect Org",
+                        "organization_type": "company",
+                        "relationship_type": "prospect",
+                        "legal_name": "Not Allowed Ltd",
+                    }
+                ),
+            ),
+            "POST",
+            "/v1/admin/organizations",
+        )
+
+    assert exc.value.field == "legal_name"
+    assert exc.value.status_code == 400
+    assert stored == {}
+
+
+def test_update_non_partner_with_legal_name_returns_validation_error(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    stored: dict[UUID, Organization] = {}
+    _install_organizations_persistence_fakes(monkeypatch, stored=stored)
+    org_id = uuid4()
+    now = datetime.now(UTC)
+    stored[org_id] = Organization(
+        id=org_id,
+        name="Prospect Org",
+        organization_type=OrganizationType.COMPANY,
+        relationship_type=RelationshipType.PROSPECT,
+        created_at=now,
+        updated_at=now,
+    )
+    stored[org_id].organization_tags = []
+    stored[org_id].organization_members = []
+
+    with pytest.raises(ValidationError, match="only allowed when") as exc:
+        admin_organizations.handle_admin_organizations_request(
+            api_gateway_event(
+                method="PATCH",
+                path=f"/v1/admin/organizations/{org_id}",
+                body=json.dumps({"legal_name": "Not Allowed Ltd"}),
+            ),
+            "PATCH",
+            f"/v1/admin/organizations/{org_id}",
+        )
+
+    assert exc.value.field == "legal_name"
+    assert exc.value.status_code == 400
+
+
+def test_update_partner_to_non_partner_clears_legal_name(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    stored: dict[UUID, Organization] = {}
+    _install_organizations_persistence_fakes(monkeypatch, stored=stored)
+    org_id = uuid4()
+    now = datetime.now(UTC)
+    stored[org_id] = Organization(
+        id=org_id,
+        name="Partner Co",
+        organization_type=OrganizationType.COMPANY,
+        relationship_type=RelationshipType.PARTNER,
+        legal_name="Partner Legal Ltd",
+        partner_key="partner-co",
+        created_at=now,
+        updated_at=now,
+    )
+    stored[org_id].organization_tags = []
+    stored[org_id].organization_members = []
+
+    response = admin_organizations.handle_admin_organizations_request(
+        api_gateway_event(
+            method="PATCH",
+            path=f"/v1/admin/organizations/{org_id}",
+            body=json.dumps({"relationship_type": "client"}),
+        ),
+        "PATCH",
+        f"/v1/admin/organizations/{org_id}",
+    )
+
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert body["organization"]["relationship_type"] == "client"
+    assert body["organization"]["legal_name"] is None
+    assert stored[org_id].legal_name is None
+    assert stored[org_id].partner_key is None
 
 
 def test_list_organizations_default_excludes_vendors_from_repository_filter(

--- a/tests/test_admin_organizations_partner_key.py
+++ b/tests/test_admin_organizations_partner_key.py
@@ -1,4 +1,4 @@
-"""Tests for partner-only organization partner_key handling."""
+"""Tests for partner-only organization partner_key and legal_name handling."""
 
 from __future__ import annotations
 
@@ -15,8 +15,13 @@ def _org_stub(
     *,
     relationship_type: RelationshipType,
     partner_key: str | None = None,
+    legal_name: str | None = None,
 ) -> SimpleNamespace:
-    return SimpleNamespace(relationship_type=relationship_type, partner_key=partner_key)
+    return SimpleNamespace(
+        relationship_type=relationship_type,
+        partner_key=partner_key,
+        legal_name=legal_name,
+    )
 
 
 def test_apply_partner_key_partner_sets_normalized_value() -> None:
@@ -51,3 +56,37 @@ def test_apply_partner_key_create_uses_passed_relationship_type() -> None:
         relationship_type=RelationshipType.PARTNER,
     )
     assert org.partner_key == "partner-key"
+
+
+def test_apply_legal_name_partner_sets_trimmed_value() -> None:
+    org = _org_stub(relationship_type=RelationshipType.PARTNER)
+    admin_organizations._apply_organization_legal_name_from_body(
+        org, {"legal_name": "  Acme Learning Limited  "}
+    )
+    assert org.legal_name == "Acme Learning Limited"
+
+
+def test_apply_legal_name_non_partner_clears_when_empty() -> None:
+    org = _org_stub(
+        relationship_type=RelationshipType.PROSPECT, legal_name="should-clear"
+    )
+    admin_organizations._apply_organization_legal_name_from_body(org, {"legal_name": ""})
+    assert org.legal_name is None
+
+
+def test_apply_legal_name_non_partner_rejects_non_empty() -> None:
+    org = _org_stub(relationship_type=RelationshipType.PROSPECT)
+    with pytest.raises(ValidationError, match="only allowed when"):
+        admin_organizations._apply_organization_legal_name_from_body(
+            org, {"legal_name": "Acme Ltd"}
+        )
+
+
+def test_apply_legal_name_create_uses_passed_relationship_type() -> None:
+    org = _org_stub(relationship_type=RelationshipType.PROSPECT)
+    admin_organizations._apply_organization_legal_name_from_body(
+        org,
+        {"legal_name": "Partner Legal"},
+        relationship_type=RelationshipType.PARTNER,
+    )
+    assert org.legal_name == "Partner Legal"

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -916,7 +916,10 @@ def test_bank_block_omitted_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Bank:" not in text
 
 
-def test_partner_legal_name_in_bill_to_block(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_organization_bill_to_two_line_display_renders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Organization Bill To with entity and contact on separate lines renders in PDF."""
     _base_invoice_env(monkeypatch)
     inv = SimpleNamespace(
         invoice_number="N1",
@@ -934,27 +937,6 @@ def test_partner_legal_name_in_bill_to_block(monkeypatch: pytest.MonkeyPatch) ->
     )
     text = _pdf_text(render_invoice_pdf(invoice=inv, lines=[_inv_line()], preview=False))
     assert "Acme Learning Limited" in text
-    assert "Jordan Lee" in text
-
-
-def test_partner_bill_to_falls_back_to_display_name(monkeypatch: pytest.MonkeyPatch) -> None:
-    _base_invoice_env(monkeypatch)
-    inv = SimpleNamespace(
-        invoice_number="N1",
-        currency="HKD",
-        subtotal=Decimal("1"),
-        tax_total=Decimal("0"),
-        total=Decimal("1"),
-        bill_to_display_name="Acme Display\nJordan Lee",
-        bill_to_email="jordan@example.com",
-        bill_to_kind=BillingBillToKind.ORGANIZATION,
-        issued_at=datetime(2026, 1, 1, tzinfo=UTC),
-        invoice_date=date(2026, 1, 1),
-        due_date=date(2026, 1, 8),
-        status=BillingInvoiceStatus.ISSUED,
-    )
-    text = _pdf_text(render_invoice_pdf(invoice=inv, lines=[_inv_line()], preview=False))
-    assert "Acme Display" in text
     assert "Jordan Lee" in text
 
 

--- a/tests/test_customer_invoice_pdf.py
+++ b/tests/test_customer_invoice_pdf.py
@@ -916,6 +916,48 @@ def test_bank_block_omitted_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Bank:" not in text
 
 
+def test_partner_legal_name_in_bill_to_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    _base_invoice_env(monkeypatch)
+    inv = SimpleNamespace(
+        invoice_number="N1",
+        currency="HKD",
+        subtotal=Decimal("1"),
+        tax_total=Decimal("0"),
+        total=Decimal("1"),
+        bill_to_display_name="Acme Learning Limited\nJordan Lee",
+        bill_to_email="jordan@example.com",
+        bill_to_kind=BillingBillToKind.ORGANIZATION,
+        issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+        invoice_date=date(2026, 1, 1),
+        due_date=date(2026, 1, 8),
+        status=BillingInvoiceStatus.ISSUED,
+    )
+    text = _pdf_text(render_invoice_pdf(invoice=inv, lines=[_inv_line()], preview=False))
+    assert "Acme Learning Limited" in text
+    assert "Jordan Lee" in text
+
+
+def test_partner_bill_to_falls_back_to_display_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    _base_invoice_env(monkeypatch)
+    inv = SimpleNamespace(
+        invoice_number="N1",
+        currency="HKD",
+        subtotal=Decimal("1"),
+        tax_total=Decimal("0"),
+        total=Decimal("1"),
+        bill_to_display_name="Acme Display\nJordan Lee",
+        bill_to_email="jordan@example.com",
+        bill_to_kind=BillingBillToKind.ORGANIZATION,
+        issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+        invoice_date=date(2026, 1, 1),
+        due_date=date(2026, 1, 8),
+        status=BillingInvoiceStatus.ISSUED,
+    )
+    text = _pdf_text(render_invoice_pdf(invoice=inv, lines=[_inv_line()], preview=False))
+    assert "Acme Display" in text
+    assert "Jordan Lee" in text
+
+
 def test_bill_to_email_shown_or_omitted(monkeypatch: pytest.MonkeyPatch) -> None:
     _base_invoice_env(monkeypatch)
     inv = SimpleNamespace(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional `organizations.legal_name` for partner organisations. Partner admin CRUD accepts and validates the field (partner-only, max 255 chars). AR invoice bill-to resolution uses `legal_name` or `name` for partner orgs when building `bill_to_display_name`; issued invoices stay immutable via existing snapshot behavior.

## Changes

- **Database:** migration `0071_partner_legal_name` adds nullable `organizations.legal_name`; seed note documents no org seed rows
- **Backend:** model, partner-only CRUD guard (`_apply_organization_legal_name_from_body`), serializer, bill-to resolution in `_resolve_bill_to_party_from_invoice_fks`
- **OpenAPI + admin web:** `legal_name` on organization schemas; optional "Legal name" field on Services → Partners inline editor
- **Tests:** partner-field validation, bill-to resolution (legal name + fallback), PDF Bill To two-line render, partners panel UI/payload, handler round-trip create/update/validation
- **Docs:** note that `legal_name` appears only on invoice PDF Bill To; pickers/snapshots keep trade `name`

## Validation

- `pre-commit run ruff-format --all-files`
- `pre-commit run ruff --all-files`
- `pytest tests/ -x` (1243 passed)
- `npm run generate:admin-api-types && npm run check:admin-api-types && npm run lint && npx vitest run` (partners panel tests)
- `bash scripts/validate-cursorrules.sh`

## Notes

- Plan referenced migration `0065_partner_legal_name`; `0065` was already taken by `bulk_import_jobs`, so this uses `0071_partner_legal_name` chained from `0070_cert_audit_trigger`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c9295f8-2c2c-4e86-8676-8b495f96d4f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c9295f8-2c2c-4e86-8676-8b495f96d4f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

