### PR TITLE
chore(deps): fix js-cookie high-severity alert (GHSA-qjx8-664m-686j)

### DIFF
--- a/apps/admin_web/package-lock.json
+++ b/apps/admin_web/package-lock.json
@@ -8359,9 +8359,9 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
       "license": "MIT"
     },
     "node_modules/js-levenshtein": {

--- a/apps/admin_web/package.json
+++ b/apps/admin_web/package.json
@@ -57,6 +57,7 @@
       "minimatch": "5.1.8"
     },
     "flatted": "^3.4.0",
+    "js-cookie": "^3.0.7",
     "openapi-typescript": {
       "typescript": "$typescript"
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves Dependabot alert #99 — the HIGH-severity advisory **GHSA-qjx8-664m-686j** ("JavaScript Cookie: Per-instance prototype hijack in `assign()` enables cookie-attribute injection"), published 2026-05-21.

`amazon-cognito-identity-js@6.3.16` (in `apps/admin_web`) transitively pins `js-cookie@2.2.1`, which falls in the vulnerable range (`<= 3.0.5`). The advisory's only patched release line is `js-cookie >= 3.0.7`, so there is no patched 2.x to bump to.

## Change

- Added a top-level npm `override` in `apps/admin_web/package.json` pinning `js-cookie` to `^3.0.7`.
- `npm install` re-resolved the transitive dependency to `js-cookie@3.0.8`.

This follows the same pattern already used for other transitive overrides in this `package.json` (e.g. `js-yaml`, `flatted`).

## Why this is safe

- The admin app instantiates `CognitoUserPool` without a custom `Storage`, so it uses the default `localStorage`-backed storage. `js-cookie` is only pulled in transitively via `amazon-cognito-identity-js`'s `CookieStorage` helper and is not exercised at runtime.
- The Cognito library only calls `Cookies.set(key, value, options)`, `Cookies.get(key)`, `Cookies.get()`, and `Cookies.remove(key, options)`, all of which are API-compatible across js-cookie 2.x and 3.x.

## Validation

- `npm audit` no longer reports the `js-cookie` / `amazon-cognito-identity-js` high-severity finding (only unrelated moderate alerts remain).
- `npx vitest run` — 611 tests pass (105 files).
- `npm run lint` — passes.
- `bash scripts/validate-cursorrules.sh` — passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41dfb173-0505-4c05-812c-bc9a2678001d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41dfb173-0505-4c05-812c-bc9a2678001d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

