### PR TITLE
Put organisation type beside partner key on partners admin form

### DIFF
--- a/apps/admin_web/src/components/admin/services/partners-panel.tsx
+++ b/apps/admin_web/src/components/admin/services/partners-panel.tsx
@@ -338,6 +338,22 @@ export function PartnersPanel({
               </p>
             ) : null}
           </div>
+          <div className='lg:col-span-1'>
+            <Label htmlFor='svc-partner-type'>Organisation type</Label>
+            <Select
+              id='svc-partner-type'
+              value={organizationType}
+              onChange={(e) =>
+                setOrganizationType(e.target.value as ApiSchemas['EntityOrganizationType'])
+              }
+            >
+              {ORG_TYPES.map((v) => (
+                <option key={v} value={v}>
+                  {formatEnumLabel(v)}
+                </option>
+              ))}
+            </Select>
+          </div>
           <div className='lg:col-span-2'>
             <Label htmlFor='svc-partner-legal-name'>Legal name</Label>
             <Input
@@ -356,22 +372,6 @@ export function PartnersPanel({
               onChange={(e) => setWebsite(e.target.value)}
               autoComplete='off'
             />
-          </div>
-          <div className='lg:col-span-1'>
-            <Label htmlFor='svc-partner-type'>Organisation type</Label>
-            <Select
-              id='svc-partner-type'
-              value={organizationType}
-              onChange={(e) =>
-                setOrganizationType(e.target.value as ApiSchemas['EntityOrganizationType'])
-              }
-            >
-              {ORG_TYPES.map((v) => (
-                <option key={v} value={v}>
-                  {formatEnumLabel(v)}
-                </option>
-              ))}
-            </Select>
           </div>
           <div className='lg:col-span-1'>
             {editorMode === 'edit' ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the **Organisation type** select to sit on the same row as **Partner key** in the Services → Partners inline editor.

On large screens the first form row is now: Name (2 cols) | Partner key (1 col) | Organisation type (1 col).

## Test plan

- [x] `npx vitest run tests/components/admin/services/partners-panel.test.tsx` (6 passed)
- [ ] Manually verify Services → Partners editor layout on desktop width
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dccd891e-5f89-4894-bfa7-7dac25e81cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dccd891e-5f89-4894-bfa7-7dac25e81cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

