### PR TITLE
fix(infra): encrypt poll-responses DynamoDB table with customer-managed KMS

### DIFF
--- a/backend/infrastructure/lib/api-stack.ts
+++ b/backend/infrastructure/lib/api-stack.ts
@@ -1705,12 +1705,24 @@ export class ApiStack extends cdk.Stack {
       )
     );
 
+    // SECURITY: Use customer-managed KMS key for DynamoDB (Checkov CKV_AWS_119)
+    const pollResponsesEncryptionKey = new kms.Key(
+      this,
+      "PollResponsesEncryptionKey",
+      {
+        enableKeyRotation: true,
+        alias: name("poll-responses-encryption-key"),
+        description: "KMS key for DynamoDB poll-responses table encryption",
+      }
+    );
+
     const pollResponsesTable = new dynamodb.Table(this, "PollResponsesTable", {
       tableName: name("poll-responses"),
       partitionKey: { name: "pk", type: dynamodb.AttributeType.STRING },
       sortKey: { name: "sk", type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey: pollResponsesEncryptionKey,
       pointInTimeRecoverySpecification: {
         pointInTimeRecoveryEnabled: true,
       },

--- a/backend/infrastructure/test/api-stack.test.ts
+++ b/backend/infrastructure/test/api-stack.test.ts
@@ -106,11 +106,41 @@ function assertStageHasCheckovCkv120Suppression(template: Template): void {
   }
 }
 
+function assertPollResponsesTableUsesCustomerManagedKms(template: Template): void {
+  const tables = template.findResources("AWS::DynamoDB::Table");
+  const pollTable = Object.entries(tables).find(([logicalId]) =>
+    logicalId.includes("PollResponsesTable"),
+  );
+  if (!pollTable) {
+    throw new Error("Expected PollResponsesTable AWS::DynamoDB::Table resource");
+  }
+  const [logicalId, resource] = pollTable;
+  const sse = (resource.Properties ?? {}).SSESpecification as
+    | Record<string, unknown>
+    | undefined;
+  if (!sse || sse.SSEEnabled !== true) {
+    throw new Error(
+      `PollResponsesTable ${logicalId}: expected SSESpecification.SSEEnabled=true`,
+    );
+  }
+  if (sse.SSEType !== "KMS") {
+    throw new Error(
+      `PollResponsesTable ${logicalId}: expected SSESpecification.SSEType=KMS; got ${String(sse.SSEType)}`,
+    );
+  }
+  if (typeof sse.KMSMasterKeyId !== "object" && typeof sse.KMSMasterKeyId !== "string") {
+    throw new Error(
+      `PollResponsesTable ${logicalId}: expected SSESpecification.KMSMasterKeyId for customer-managed CMK`,
+    );
+  }
+}
+
 function main(): void {
   const template = synthApiTemplate();
   assertStageHasNoApiGatewayCacheCluster(template);
   assertGatewayResponsesHaveNoBodyTemplates(template);
   assertStageHasCheckovCkv120Suppression(template);
+  assertPollResponsesTableUsesCustomerManagedKms(template);
   // eslint-disable-next-line no-console
   console.log("api-stack API Gateway stage cache assertions passed.");
 }

--- a/docs/architecture/aws-assets-map.md
+++ b/docs/architecture/aws-assets-map.md
@@ -168,6 +168,7 @@ automatic annual rotation enabled and a human-readable alias.
 | KMS Key | `SqsEncryptionKey` | `alias/evolvesprouts-sqs-encryption-key` | SQS queue encryption (media and expense parser queues in the messaging nested stack) |
 | KMS Key | `ApiLogEncryptionKey` | `alias/evolvesprouts-api-log-encryption-key` | API Gateway CloudWatch access log encryption |
 | KMS Key | `SecretsEncryptionKey` | `alias/evolvesprouts-secrets-encryption-key` | Secrets Manager encryption (API key rotation secret) |
+| KMS Key | `PollResponsesEncryptionKey` | `alias/evolvesprouts-poll-responses-encryption-key` | DynamoDB `evolvesprouts-poll-responses` table encryption |
 
 **Conditional key** (in `DatabaseConstruct`, created only when managing DB
 credentials):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves code scanning alert #25 — Checkov **CKV_AWS_119** ("Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK") on `AWS::DynamoDB::Table.PollResponsesTableEE62D17D`.

`PollResponsesTable` (`evolvesprouts-poll-responses`) was created with `TableEncryption.AWS_MANAGED`, which does not satisfy the customer-managed CMK requirement.

## Change

- Added `PollResponsesEncryptionKey` (`alias/evolvesprouts-poll-responses-encryption-key`) with rotation enabled.
- Switched the table to `TableEncryption.CUSTOMER_MANAGED` with that key.
- Documented the new CMK in `docs/architecture/aws-assets-map.md`.
- Added an `api-stack` synth assertion that the table SSE spec uses KMS with a `KMSMasterKeyId`.

This follows the same remediation pattern already used for Secrets Manager (**CKV_AWS_149**) via `SecretsEncryptionKey`.

## Why this is safe

- `pollResponsesTable.grantReadWriteData(adminFunction)` continues to grant DynamoDB access; CDK also grants the Lambda role KMS use on the table CMK.
- No application code changes are required — encryption is transparent to the DynamoDB API.
- Deploying this updates the existing table's SSE configuration in place (no table replacement in the synthesized template).

## Validation

- `npm run test:infra` — passes (including new poll-responses KMS assertion).
- `npx tsc --noEmit` — passes.
- `checkov -d cdk.out --check CKV_AWS_119` — **PASSED** for `PollResponsesTableEE62D17D`.
- `bash scripts/validate-cursorrules.sh` — passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e68f6dfc-b5c4-4810-a1ce-e869a81fa8c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e68f6dfc-b5c4-4810-a1ce-e869a81fa8c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

