### PR TITLE
Add read-only Services section to CRM entity editors

### DIFF
--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -10,6 +10,7 @@ import { InlineLocationEditor } from '@/components/admin/locations/inline-locati
 import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
 import { ContactNotesModal } from '@/components/admin/contacts/contact-notes-modal';
 import { MailchimpSyncCard } from '@/components/admin/contacts/mailchimp-sync-card';
+import { EntityServicesSection } from '@/components/admin/contacts/entity-services-section';
 import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { ArchiveIcon, DeleteIcon, NoteIcon, RestoreIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
@@ -34,6 +35,7 @@ import { Textarea } from '@/components/ui/textarea';
 import {
   type EntityPickerListItem,
   getAdminContact,
+  listAdminContactServices,
   listEntityFamilyPicker,
   listEntityOrganizationPicker,
   searchEntityContactsForPicker,
@@ -242,6 +244,7 @@ export function ContactsPanel({
   const [familySelectId, setFamilySelectId] = useState('');
   const [organizationSelectId, setOrganizationSelectId] = useState('');
   const [tagIds, setTagIds] = useState<string[]>([]);
+  const [serviceLabels, setServiceLabels] = useState<string[]>([]);
   const [active, setActive] = useState(true);
 
   const {
@@ -396,6 +399,33 @@ export function ContactsPanel({
       cancelled = true;
     };
   }, [referralContactId, source]);
+
+  useEffect(() => {
+    if (editorMode !== 'edit' || !selectedId) {
+      queueMicrotask(() => {
+        setServiceLabels([]);
+      });
+      return;
+    }
+    const controller = new AbortController();
+    let cancelled = false;
+    void (async () => {
+      try {
+        const labels = await listAdminContactServices(selectedId, controller.signal);
+        if (!cancelled) {
+          setServiceLabels(labels);
+        }
+      } catch {
+        if (!cancelled) {
+          setServiceLabels([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [selectedId, editorMode]);
 
   async function resetCreateForm() {
     if (editorMode === 'create' && pendingLocationId) {
@@ -888,6 +918,8 @@ export function ContactsPanel({
             disabled={isSaving}
             variant='collapsible'
           />
+
+          <EntityServicesSection id='crm-contact-services' labels={serviceLabels} />
 
           {editorMode === 'edit' && selected ? (
             <div className='text-sm text-slate-600'>

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -244,8 +244,16 @@ export function ContactsPanel({
   const [familySelectId, setFamilySelectId] = useState('');
   const [organizationSelectId, setOrganizationSelectId] = useState('');
   const [tagIds, setTagIds] = useState<string[]>([]);
-  const [serviceLabels, setServiceLabels] = useState<string[]>([]);
+  const [serviceLabelsState, setServiceLabelsState] = useState<{
+    entityId: string;
+    labels: string[];
+  } | null>(null);
   const [active, setActive] = useState(true);
+
+  const serviceLabels =
+    editorMode === 'edit' && selectedId && serviceLabelsState?.entityId === selectedId
+      ? serviceLabelsState.labels
+      : [];
 
   const {
     status: locationSaveStatus,
@@ -402,23 +410,20 @@ export function ContactsPanel({
 
   useEffect(() => {
     if (editorMode !== 'edit' || !selectedId) {
-      queueMicrotask(() => {
-        setServiceLabels([]);
-      });
       return;
     }
+    const entityId = selectedId;
     const controller = new AbortController();
     let cancelled = false;
-    setServiceLabels([]);
     void (async () => {
       try {
-        const labels = await listAdminContactServices(selectedId, controller.signal);
+        const labels = await listAdminContactServices(entityId, controller.signal);
         if (!cancelled) {
-          setServiceLabels(labels);
+          setServiceLabelsState({ entityId, labels });
         }
       } catch {
         if (!cancelled) {
-          setServiceLabels([]);
+          setServiceLabelsState({ entityId, labels: [] });
         }
       }
     })();

--- a/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/contacts-panel.tsx
@@ -409,6 +409,7 @@ export function ContactsPanel({
     }
     const controller = new AbortController();
     let cancelled = false;
+    setServiceLabels([]);
     void (async () => {
       try {
         const labels = await listAdminContactServices(selectedId, controller.signal);

--- a/apps/admin_web/src/components/admin/contacts/entity-services-section.tsx
+++ b/apps/admin_web/src/components/admin/contacts/entity-services-section.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { AdminCollapsibleSection } from '@/components/ui/admin-collapsible-section';
+
+export interface EntityServicesSectionProps {
+  id: string;
+  labels: string[];
+}
+
+export function EntityServicesSection({ id, labels }: EntityServicesSectionProps) {
+  if (labels.length === 0) {
+    return null;
+  }
+
+  return (
+    <AdminCollapsibleSection id={id} title='Services'>
+      <ul className='space-y-1 pt-1 text-sm text-slate-700'>
+        {labels.map((label) => (
+          <li key={label}>{label}</li>
+        ))}
+      </ul>
+    </AdminCollapsibleSection>
+  );
+}

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState, type MouseEvent } from 'react';
+import { useCallback, useEffect, useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminEntityFamilies } from '@/hooks/use-admin-entity-families';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
@@ -8,6 +8,7 @@ import { useGeocodeVenueAddress } from '@/hooks/use-geocode-venue-address';
 import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
 import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
+import { EntityServicesSection } from '@/components/admin/contacts/entity-services-section';
 import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
@@ -28,6 +29,7 @@ import { PaginatedTableCard } from '@/components/ui/paginated-table-card';
 import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import type { EntityTagRef } from '@/lib/entity-api';
+import { listAdminFamilyServices } from '@/lib/entity-api';
 import { contactEligibleForEntityMembership } from '@/lib/entity-contact-eligibility';
 import { formatEnumLabel, formatFamilyOrOrganizationPartyLabel } from '@/lib/format';
 import type { EntityListFilters } from '@/types/entity-list';
@@ -97,6 +99,7 @@ export function FamiliesPanel({
   const [optimisticLocationSummary, setOptimisticLocationSummary] =
     useState<InlineLocationEmbeddedSummary | null>(null);
   const [tagIds, setTagIds] = useState<string[]>([]);
+  const [serviceLabels, setServiceLabels] = useState<string[]>([]);
   const [active, setActive] = useState(true);
 
   const [memberContactId, setMemberContactId] = useState('');
@@ -175,6 +178,33 @@ export function FamiliesPanel({
       return contactEligibleForEntityMembership(row, selectedId, 'family');
     });
   }, [contactOptions, contactsForMembership, selectedId]);
+
+  useEffect(() => {
+    if (editorMode !== 'edit' || !selectedId) {
+      queueMicrotask(() => {
+        setServiceLabels([]);
+      });
+      return;
+    }
+    const controller = new AbortController();
+    let cancelled = false;
+    void (async () => {
+      try {
+        const labels = await listAdminFamilyServices(selectedId, controller.signal);
+        if (!cancelled) {
+          setServiceLabels(labels);
+        }
+      } catch {
+        if (!cancelled) {
+          setServiceLabels([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [selectedId, editorMode]);
 
   const primaryMemberLabel = useCallback((members: ApiSchemas['AdminFamilyMember'][]) => {
     const primary = members.find((m) => m.is_primary_contact);
@@ -423,6 +453,9 @@ export function FamiliesPanel({
               disabled={isSaving}
               variant='collapsible'
             />
+          </div>
+          <div className='lg:col-span-4'>
+            <EntityServicesSection id='crm-family-services' labels={serviceLabels} />
           </div>
           {editorMode === 'edit' && selected ? (
             <div className='lg:col-span-4'>

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -99,8 +99,16 @@ export function FamiliesPanel({
   const [optimisticLocationSummary, setOptimisticLocationSummary] =
     useState<InlineLocationEmbeddedSummary | null>(null);
   const [tagIds, setTagIds] = useState<string[]>([]);
-  const [serviceLabels, setServiceLabels] = useState<string[]>([]);
+  const [serviceLabelsState, setServiceLabelsState] = useState<{
+    entityId: string;
+    labels: string[];
+  } | null>(null);
   const [active, setActive] = useState(true);
+
+  const serviceLabels =
+    editorMode === 'edit' && selectedId && serviceLabelsState?.entityId === selectedId
+      ? serviceLabelsState.labels
+      : [];
 
   const [memberContactId, setMemberContactId] = useState('');
 
@@ -181,23 +189,20 @@ export function FamiliesPanel({
 
   useEffect(() => {
     if (editorMode !== 'edit' || !selectedId) {
-      queueMicrotask(() => {
-        setServiceLabels([]);
-      });
       return;
     }
+    const entityId = selectedId;
     const controller = new AbortController();
     let cancelled = false;
-    setServiceLabels([]);
     void (async () => {
       try {
-        const labels = await listAdminFamilyServices(selectedId, controller.signal);
+        const labels = await listAdminFamilyServices(entityId, controller.signal);
         if (!cancelled) {
-          setServiceLabels(labels);
+          setServiceLabelsState({ entityId, labels });
         }
       } catch {
         if (!cancelled) {
-          setServiceLabels([]);
+          setServiceLabelsState({ entityId, labels: [] });
         }
       }
     })();

--- a/apps/admin_web/src/components/admin/contacts/families-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/families-panel.tsx
@@ -188,6 +188,7 @@ export function FamiliesPanel({
     }
     const controller = new AbortController();
     let cancelled = false;
+    setServiceLabels([]);
     void (async () => {
       try {
         const labels = await listAdminFamilyServices(selectedId, controller.signal);
@@ -443,7 +444,7 @@ export function FamiliesPanel({
               />
             </AdminCollapsibleSection>
           </div>
-          <div className='lg:col-span-4'>
+          <div className='lg:col-span-4 space-y-4'>
             <EntityTagPicker
               id='crm-family-tags'
               label='Tags'
@@ -453,8 +454,6 @@ export function FamiliesPanel({
               disabled={isSaving}
               variant='collapsible'
             />
-          </div>
-          <div className='lg:col-span-4'>
             <EntityServicesSection id='crm-family-services' labels={serviceLabels} />
           </div>
           {editorMode === 'edit' && selected ? (

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -201,6 +201,7 @@ export function OrganizationsPanel({
     }
     const controller = new AbortController();
     let cancelled = false;
+    setServiceLabels([]);
     void (async () => {
       try {
         const labels = await listAdminOrganizationServices(selectedId, controller.signal);

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -111,8 +111,16 @@ export function OrganizationsPanel({
   const [optimisticLocationSummary, setOptimisticLocationSummary] =
     useState<InlineLocationEmbeddedSummary | null>(null);
   const [tagIds, setTagIds] = useState<string[]>([]);
-  const [serviceLabels, setServiceLabels] = useState<string[]>([]);
+  const [serviceLabelsState, setServiceLabelsState] = useState<{
+    entityId: string;
+    labels: string[];
+  } | null>(null);
   const [active, setActive] = useState(true);
+
+  const serviceLabels =
+    editorMode === 'edit' && selectedId && serviceLabelsState?.entityId === selectedId
+      ? serviceLabelsState.labels
+      : [];
 
   const [memberContactId, setMemberContactId] = useState('');
 
@@ -194,23 +202,20 @@ export function OrganizationsPanel({
 
   useEffect(() => {
     if (editorMode !== 'edit' || !selectedId) {
-      queueMicrotask(() => {
-        setServiceLabels([]);
-      });
       return;
     }
+    const entityId = selectedId;
     const controller = new AbortController();
     let cancelled = false;
-    setServiceLabels([]);
     void (async () => {
       try {
-        const labels = await listAdminOrganizationServices(selectedId, controller.signal);
+        const labels = await listAdminOrganizationServices(entityId, controller.signal);
         if (!cancelled) {
-          setServiceLabels(labels);
+          setServiceLabelsState({ entityId, labels });
         }
       } catch {
         if (!cancelled) {
-          setServiceLabels([]);
+          setServiceLabelsState({ entityId, labels: [] });
         }
       }
     })();

--- a/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
+++ b/apps/admin_web/src/components/admin/contacts/organizations-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState, type MouseEvent } from 'react';
+import { useCallback, useEffect, useMemo, useState, type MouseEvent } from 'react';
 
 import type { useAdminEntityOrganizations } from '@/hooks/use-admin-entity-organizations';
 import { useConfirmDialog } from '@/hooks/use-confirm-dialog';
@@ -8,6 +8,7 @@ import { useGeocodeVenueAddress } from '@/hooks/use-geocode-venue-address';
 import { useInlineLocationSave } from '@/hooks/use-inline-location-save';
 import { InlineLocationEditor } from '@/components/admin/locations/inline-location-editor';
 import type { InlineLocationEmbeddedSummary } from '@/components/admin/locations/inline-location-editor';
+import { EntityServicesSection } from '@/components/admin/contacts/entity-services-section';
 import { EntityTagPicker } from '@/components/admin/contacts/entity-tag-picker';
 import { DeleteIcon } from '@/components/icons/action-icons';
 import { Button } from '@/components/ui/button';
@@ -29,6 +30,7 @@ import { AdminTableToolbar } from '@/components/ui/admin-table-toolbar';
 import { Select } from '@/components/ui/select';
 import { contactEligibleForEntityMembership } from '@/lib/entity-contact-eligibility';
 import type { EntityTagRef } from '@/lib/entity-api';
+import { listAdminOrganizationServices } from '@/lib/entity-api';
 import { formatEnumLabel, formatFamilyOrOrganizationPartyLabel } from '@/lib/format';
 import type { EntityListFilters } from '@/types/entity-list';
 import {
@@ -109,6 +111,7 @@ export function OrganizationsPanel({
   const [optimisticLocationSummary, setOptimisticLocationSummary] =
     useState<InlineLocationEmbeddedSummary | null>(null);
   const [tagIds, setTagIds] = useState<string[]>([]);
+  const [serviceLabels, setServiceLabels] = useState<string[]>([]);
   const [active, setActive] = useState(true);
 
   const [memberContactId, setMemberContactId] = useState('');
@@ -188,6 +191,33 @@ export function OrganizationsPanel({
       return contactEligibleForEntityMembership(row, selectedId, 'organization');
     });
   }, [contactOptions, contactsForMembership, selectedId]);
+
+  useEffect(() => {
+    if (editorMode !== 'edit' || !selectedId) {
+      queueMicrotask(() => {
+        setServiceLabels([]);
+      });
+      return;
+    }
+    const controller = new AbortController();
+    let cancelled = false;
+    void (async () => {
+      try {
+        const labels = await listAdminOrganizationServices(selectedId, controller.signal);
+        if (!cancelled) {
+          setServiceLabels(labels);
+        }
+      } catch {
+        if (!cancelled) {
+          setServiceLabels([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [selectedId, editorMode]);
 
   const primaryMemberLabel = useCallback((members: ApiSchemas['AdminOrganizationMember'][]) => {
     const primary = members.find((m) => m.is_primary_contact);
@@ -476,6 +506,7 @@ export function OrganizationsPanel({
                 variant='collapsible'
               />
             </div>
+            <EntityServicesSection id='crm-org-services' labels={serviceLabels} />
           </div>
           {editorMode === 'edit' && selected ? (
             <div className='lg:col-span-4'>

--- a/apps/admin_web/src/lib/entity-api.ts
+++ b/apps/admin_web/src/lib/entity-api.ts
@@ -18,6 +18,7 @@ type ApiOrganizationResponse = ApiSchemas['AdminOrganizationResponse'];
 type ApiTagList = ApiSchemas['EntityTagListResponse'];
 type ApiEntityPickerList = ApiSchemas['EntityPickerListResponse'];
 type ApiNoteList = ApiSchemas['AdminNoteListResponse'];
+type ApiEntityServicesList = ApiSchemas['EntityServicesResponse'];
 
 export type AdminContactRow = ApiSchemas['AdminContact'];
 export type AdminFamilyRow = ApiSchemas['AdminFamily'];
@@ -208,6 +209,60 @@ export async function listAdminContactNotes(
   });
   const root = unwrapPayload(payload);
   return Array.isArray(root.items) ? root.items.map((n) => parseNote(n)) : [];
+}
+
+export async function listAdminContactServices(
+  contactId: string,
+  signal?: AbortSignal
+): Promise<string[]> {
+  const payload = await adminApiRequest<ApiEntityServicesList>({
+    endpointPath: `/v1/admin/contacts/${contactId}/services`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  if (!Array.isArray(root.items)) {
+    return [];
+  }
+  return root.items
+    .map((item) => (typeof item?.label === 'string' ? item.label : null))
+    .filter((label): label is string => label !== null);
+}
+
+export async function listAdminFamilyServices(
+  familyId: string,
+  signal?: AbortSignal
+): Promise<string[]> {
+  const payload = await adminApiRequest<ApiEntityServicesList>({
+    endpointPath: `/v1/admin/families/${familyId}/services`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  if (!Array.isArray(root.items)) {
+    return [];
+  }
+  return root.items
+    .map((item) => (typeof item?.label === 'string' ? item.label : null))
+    .filter((label): label is string => label !== null);
+}
+
+export async function listAdminOrganizationServices(
+  organizationId: string,
+  signal?: AbortSignal
+): Promise<string[]> {
+  const payload = await adminApiRequest<ApiEntityServicesList>({
+    endpointPath: `/v1/admin/organizations/${organizationId}/services`,
+    method: 'GET',
+    signal,
+  });
+  const root = unwrapPayload(payload);
+  if (!Array.isArray(root.items)) {
+    return [];
+  }
+  return root.items
+    .map((item) => (typeof item?.label === 'string' ? item.label : null))
+    .filter((label): label is string => label !== null);
 }
 
 export async function createAdminContactNote(

--- a/apps/admin_web/src/types/generated/admin-api.generated.ts
+++ b/apps/admin_web/src/types/generated/admin-api.generated.ts
@@ -3499,6 +3499,55 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/contacts/{id}/services": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description CRM contact identifier. */
+                id: components["parameters"]["AdminContactId"];
+            };
+            cookie?: never;
+        };
+        /**
+         * List purchased services for a contact
+         * @description Returns invoice-style labels for non-cancelled enrollments attributed to the
+         *     contact. Labels are deduplicated and sorted alphabetically.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description CRM contact identifier. */
+                    id: components["parameters"]["AdminContactId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Service label list. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["EntityServicesResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/contacts/{id}/notes/{noteId}": {
         parameters: {
             query?: never;
@@ -3801,6 +3850,55 @@ export interface paths {
                 404: components["responses"]["NotFound"];
             };
         };
+        trace?: never;
+    };
+    "/v1/admin/families/{id}/services": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description CRM family identifier. */
+                id: components["parameters"]["AdminFamilyId"];
+            };
+            cookie?: never;
+        };
+        /**
+         * List purchased services for a family
+         * @description Returns invoice-style labels for non-cancelled enrollments attributed to the
+         *     family or to any member contact. Labels are deduplicated and sorted alphabetically.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description CRM family identifier. */
+                    id: components["parameters"]["AdminFamilyId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Service label list. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["EntityServicesResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/v1/admin/families/{id}/members": {
@@ -4174,6 +4272,55 @@ export interface paths {
                 404: components["responses"]["NotFound"];
             };
         };
+        trace?: never;
+    };
+    "/v1/admin/organizations/{id}/services": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description CRM organization identifier. */
+                id: components["parameters"]["AdminOrganizationId"];
+            };
+            cookie?: never;
+        };
+        /**
+         * List purchased services for an organization
+         * @description Returns invoice-style labels for non-cancelled enrollments attributed to the
+         *     organization or to any member contact. Labels are deduplicated and sorted alphabetically.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description CRM organization identifier. */
+                    id: components["parameters"]["AdminOrganizationId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Service label list. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["EntityServicesResponse"];
+                    };
+                };
+                400: components["responses"]["BadRequest"];
+                403: components["responses"]["Forbidden"];
+                404: components["responses"]["NotFound"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/v1/admin/organizations/{id}/members": {
@@ -6252,6 +6399,12 @@ export interface components {
         };
         AdminNoteListResponse: {
             items: components["schemas"]["Note"][];
+        };
+        EntityServiceItem: {
+            label: string;
+        };
+        EntityServicesResponse: {
+            items: components["schemas"]["EntityServiceItem"][];
         };
         CreateNoteRequest: {
             content: string;

--- a/apps/admin_web/tests/components/admin/contacts/entity-services-section.test.tsx
+++ b/apps/admin_web/tests/components/admin/contacts/entity-services-section.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { EntityServicesSection } from '@/components/admin/contacts/entity-services-section';
+
+describe('EntityServicesSection', () => {
+  it('renders nothing when labels are empty', () => {
+    const { container } = render(<EntityServicesSection id='crm-test-services' labels={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders Services summary and one list item per label', () => {
+    render(
+      <EntityServicesSection
+        id='crm-test-services'
+        labels={['Event: June Weekend', 'Training course: Course A']}
+      />
+    );
+
+    expect(screen.getByText('Services')).toBeInTheDocument();
+    expect(screen.getByText('Event: June Weekend')).toBeInTheDocument();
+    expect(screen.getByText('Training course: Course A')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+});

--- a/apps/admin_web/tests/lib/entity-api-services.test.ts
+++ b/apps/admin_web/tests/lib/entity-api-services.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAdminApiRequest } = vi.hoisted(() => ({
+  mockAdminApiRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/api-admin-client', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api-admin-client')>(
+    '@/lib/api-admin-client'
+  );
+  return {
+    ...actual,
+    adminApiRequest: mockAdminApiRequest,
+  };
+});
+
+import { listAdminContactServices } from '@/lib/entity-api';
+
+describe('entity-api services', () => {
+  beforeEach(() => {
+    mockAdminApiRequest.mockReset();
+  });
+
+  it('listAdminContactServices maps item labels to string array', async () => {
+    mockAdminApiRequest.mockResolvedValueOnce({
+      items: [{ label: 'Event: June Weekend' }, { label: 42 }, { label: 'Training course: A' }],
+    });
+
+    const labels = await listAdminContactServices('contact-1');
+
+    expect(labels).toEqual(['Event: June Weekend', 'Training course: A']);
+    expect(mockAdminApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointPath: '/v1/admin/contacts/contact-1/services',
+        method: 'GET',
+      })
+    );
+  });
+});

--- a/backend/src/app/api/admin_billing_invoice_draft_helpers.py
+++ b/backend/src/app/api/admin_billing_invoice_draft_helpers.py
@@ -129,6 +129,9 @@ def _build_enrollment_merge_line_description(enrollment: Enrollment) -> str:
     return out[:500]
 
 
+build_enrollment_invoice_line_description = _build_enrollment_merge_line_description
+
+
 _MAX_GEO_AREA_WALK = 32
 
 

--- a/backend/src/app/api/admin_contacts.py
+++ b/backend/src/app/api/admin_contacts.py
@@ -14,6 +14,7 @@ from app.api.admin_contact_notes import (
     list_contact_notes,
     update_contact_note,
 )
+from app.api.admin_entity_services import list_contact_services
 from app.api.admin_contacts_mailchimp_sync import (
     get_mailchimp_sync_summary,
     run_mailchimp_orphan_cleanup,
@@ -131,6 +132,11 @@ def handle_admin_contacts_request(
             return create_contact_note(
                 event, contact_id=contact_id, actor_sub=identity.user_sub
             )
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 4 and parts[3] == "services":
+        if method == "GET":
+            return list_contact_services(event, contact_id=contact_id)
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     if len(parts) == 5 and parts[3] == "notes":

--- a/backend/src/app/api/admin_entity_services.py
+++ b/backend/src/app/api/admin_entity_services.py
@@ -1,0 +1,119 @@
+"""Admin API handlers for purchased services on CRM entities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session, joinedload
+
+from app.api.admin_billing_invoice_draft_helpers import (
+    build_enrollment_invoice_line_description,
+)
+from app.db.engine import get_engine
+from app.db.models import (
+    Enrollment,
+    EnrollmentStatus,
+    FamilyMember,
+    OrganizationMember,
+    ServiceInstance,
+)
+from app.db.repositories import ContactRepository, FamilyRepository, OrganizationRepository
+from app.exceptions import NotFoundError
+from app.utils import json_response
+
+
+def _labels_for_enrollments(session: Session, stmt: Any) -> list[str]:
+    rows = (
+        session.execute(
+            stmt.options(
+                joinedload(Enrollment.instance).joinedload(ServiceInstance.service),
+                joinedload(Enrollment.ticket_tier),
+            )
+        )
+        .unique()
+        .scalars()
+        .all()
+    )
+    labels = {build_enrollment_invoice_line_description(en) for en in rows}
+    return sorted(labels)
+
+
+def list_contact_services(
+    event: Mapping[str, Any],
+    *,
+    contact_id: UUID,
+) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        contact_repo = ContactRepository(session)
+        if contact_repo.get_by_id_for_admin(contact_id) is None:
+            raise NotFoundError("Contact", str(contact_id))
+
+        stmt = select(Enrollment).where(
+            Enrollment.contact_id == contact_id,
+            Enrollment.status != EnrollmentStatus.CANCELLED,
+        )
+        labels = _labels_for_enrollments(session, stmt)
+        return json_response(
+            200,
+            {"items": [{"label": label} for label in labels]},
+            event=event,
+        )
+
+
+def list_family_services(
+    event: Mapping[str, Any],
+    *,
+    family_id: UUID,
+) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        family_repo = FamilyRepository(session)
+        if family_repo.get_by_id_for_admin(family_id) is None:
+            raise NotFoundError("Family", str(family_id))
+
+        member_contact_ids = select(FamilyMember.contact_id).where(
+            FamilyMember.family_id == family_id
+        )
+        stmt = select(Enrollment).where(
+            Enrollment.status != EnrollmentStatus.CANCELLED,
+            or_(
+                Enrollment.family_id == family_id,
+                Enrollment.contact_id.in_(member_contact_ids),
+            ),
+        )
+        labels = _labels_for_enrollments(session, stmt)
+        return json_response(
+            200,
+            {"items": [{"label": label} for label in labels]},
+            event=event,
+        )
+
+
+def list_organization_services(
+    event: Mapping[str, Any],
+    *,
+    organization_id: UUID,
+) -> dict[str, Any]:
+    with Session(get_engine()) as session:
+        org_repo = OrganizationRepository(session)
+        if org_repo.get_non_vendor_organization_by_id(organization_id) is None:
+            raise NotFoundError("Organization", str(organization_id))
+
+        member_contact_ids = select(OrganizationMember.contact_id).where(
+            OrganizationMember.organization_id == organization_id
+        )
+        stmt = select(Enrollment).where(
+            Enrollment.status != EnrollmentStatus.CANCELLED,
+            or_(
+                Enrollment.organization_id == organization_id,
+                Enrollment.contact_id.in_(member_contact_ids),
+            ),
+        )
+        labels = _labels_for_enrollments(session, stmt)
+        return json_response(
+            200,
+            {"items": [{"label": label} for label in labels]},
+            event=event,
+        )

--- a/backend/src/app/api/admin_entity_services.py
+++ b/backend/src/app/api/admin_entity_services.py
@@ -20,7 +20,11 @@ from app.db.models import (
     OrganizationMember,
     ServiceInstance,
 )
-from app.db.repositories import ContactRepository, FamilyRepository, OrganizationRepository
+from app.db.repositories import (
+    ContactRepository,
+    FamilyRepository,
+    OrganizationRepository,
+)
 from app.exceptions import NotFoundError
 from app.utils import json_response
 

--- a/backend/src/app/api/admin_families.py
+++ b/backend/src/app/api/admin_families.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.api.admin_entities_deletes import delete_admin_entity_family
+from app.api.admin_entity_services import list_family_services
 from app.api.admin_entities_helpers import (
     assert_contact_can_join_family,
     request_id,
@@ -82,6 +83,11 @@ def handle_admin_families_request(
             return delete_admin_entity_family(
                 event, family_id=family_id, actor_sub=identity.user_sub
             )
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 4 and parts[3] == "services":
+        if method == "GET":
+            return list_family_services(event, family_id=family_id)
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     if len(parts) == 4 and parts[3] == "members":

--- a/backend/src/app/api/admin_organizations.py
+++ b/backend/src/app/api/admin_organizations.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.admin_entities_deletes import delete_admin_entity_organization
+from app.api.admin_entity_services import list_organization_services
 from app.api.admin_entities_helpers import (
     ORGANIZATION_RELATIONSHIP_TYPES,
     assert_contact_can_join_organization,
@@ -97,6 +98,11 @@ def handle_admin_organizations_request(
                 organization_id=organization_id,
                 actor_sub=identity.user_sub,
             )
+        return json_response(405, {"error": "Method not allowed"}, event=event)
+
+    if len(parts) == 4 and parts[3] == "services":
+        if method == "GET":
+            return list_organization_services(event, organization_id=organization_id)
         return json_response(405, {"error": "Method not allowed"}, event=event)
 
     if len(parts) == 4 and parts[3] == "members":

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -45,14 +45,17 @@ info:
     - `GET|PATCH|DELETE /v1/admin/contacts/{id}`
     - `GET|POST /v1/admin/contacts/{id}/notes`
     - `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`
+    - `GET /v1/admin/contacts/{id}/services`
     - `GET /v1/admin/families/picker`
     - `GET|POST /v1/admin/families`
     - `GET|PATCH|DELETE /v1/admin/families/{id}`
+    - `GET /v1/admin/families/{id}/services`
     - `POST /v1/admin/families/{id}/members`
     - `PATCH|DELETE /v1/admin/families/{id}/members/{memberId}`
     - `GET /v1/admin/organizations/picker`
     - `GET|POST /v1/admin/organizations`
     - `GET|PATCH|DELETE /v1/admin/organizations/{id}`
+    - `GET /v1/admin/organizations/{id}/services`
     - `POST /v1/admin/organizations/{id}/members`
     - `PATCH /v1/admin/organizations/{id}/members/{memberId}`
     - `DELETE /v1/admin/organizations/{id}/members/{memberId}`
@@ -2549,6 +2552,30 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/admin/contacts/{id}/services:
+    parameters:
+      - $ref: "#/components/parameters/AdminContactId"
+    get:
+      summary: List purchased services for a contact
+      description: |
+        Returns invoice-style labels for non-cancelled enrollments attributed to the
+        contact. Labels are deduplicated and sorted alphabetically.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Service label list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityServicesResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /v1/admin/contacts/{id}/notes/{noteId}:
     parameters:
       - $ref: "#/components/parameters/AdminContactId"
@@ -2740,6 +2767,30 @@ paths:
       responses:
         "204":
           description: Family deleted.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/families/{id}/services:
+    parameters:
+      - $ref: "#/components/parameters/AdminFamilyId"
+    get:
+      summary: List purchased services for a family
+      description: |
+        Returns invoice-style labels for non-cancelled enrollments attributed to the
+        family or to any member contact. Labels are deduplicated and sorted alphabetically.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Service label list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityServicesResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -3001,6 +3052,30 @@ paths:
       responses:
         "204":
           description: Organization deleted.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/organizations/{id}/services:
+    parameters:
+      - $ref: "#/components/parameters/AdminOrganizationId"
+    get:
+      summary: List purchased services for an organization
+      description: |
+        Returns invoice-style labels for non-cancelled enrollments attributed to the
+        organization or to any member contact. Labels are deduplicated and sorted alphabetically.
+      security:
+        - AdminBearerAuth: []
+      responses:
+        "200":
+          description: Service label list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityServicesResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -4909,6 +4984,22 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Note"
+    EntityServiceItem:
+      type: object
+      required:
+        - label
+      properties:
+        label:
+          type: string
+    EntityServicesResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/EntityServiceItem"
     CreateNoteRequest:
       type: object
       required:

--- a/docs/architecture/lambdas.md
+++ b/docs/architecture/lambdas.md
@@ -82,12 +82,14 @@ their primary responsibilities.
   `GET /v1/admin/contacts/tags` for tag pickers (active tags only),
   `GET /v1/admin/contacts/search` for contact picker search,
   `GET|POST /v1/admin/contacts/{id}/notes` and `PATCH|DELETE /v1/admin/contacts/{id}/notes/{noteId}`
-  for standalone CRM notes on a contact (not tied to a sales lead), and `DELETE /v1/admin/contacts/{id}`
+  for standalone CRM notes on a contact (not tied to a sales lead), `GET /v1/admin/contacts/{id}/services`
+  for read-only purchased-service labels on a contact, and `DELETE /v1/admin/contacts/{id}`
   for hard-deleting a contact after clearing blocking CRM rows),
   `/v1/admin/families/picker`, `/v1/admin/families/*` (`GET /v1/admin/families` optional `query`
   matches family name and linked member contacts' names or email; `PATCH /v1/admin/families/{id}` with
   `relationship_type` updates that field on the family and on every member contact; including `DELETE /v1/admin/families/{id}`
-  for hard-deleting a family after clearing blocking CRM rows; `POST /v1/admin/families/{id}/members`
+  for hard-deleting a family after clearing blocking CRM rows; `GET /v1/admin/families/{id}/services`
+  for read-only purchased-service labels on a family (including member contacts); `POST /v1/admin/families/{id}/members`
   derives each member's role from the linked contact's `contact_type`; `PATCH /v1/admin/families/{id}/members/{memberId}`
   updates membership fields such as primary contact),
   `/v1/admin/organizations/picker` (optional `relationship_type` query mirrors organisation list
@@ -97,7 +99,8 @@ their primary responsibilities.
   partners with `GET /v1/admin/organizations?relationship_type=partner`; Finance lists vendors with
   `GET /v1/admin/organizations?relationship_type=vendor` (optional `sort=name` for case-insensitive
   alphabetical order by trimmed name); includes `DELETE /v1/admin/organizations/{id}`
-  for non-vendor orgs; `POST /v1/admin/organizations/{id}/members` derives each member's role from the
+  for non-vendor orgs; `GET /v1/admin/organizations/{id}/services` for read-only purchased-service
+  labels on an organisation (including member contacts); `POST /v1/admin/organizations/{id}/members` derives each member's role from the
   linked contact's `contact_type`; `PATCH /v1/admin/organizations/{id}/members/{memberId}` updates
   membership fields such as primary contact; partner rows accept optional `legal_name` for AR
   invoice Bill To entity lines—resolved as `legal_name` or `name` at issue time; pickers and

--- a/tests/api/test_admin_entity_services.py
+++ b/tests/api/test_admin_entity_services.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.api import admin_contacts, admin_entity_services, admin_families, admin_organizations
+from app.api.admin_billing_invoice_draft_helpers import (
+    build_enrollment_invoice_line_description,
+)
+from app.db.models.enums import EnrollmentStatus, ServiceType
+from app.exceptions import NotFoundError
+
+
+def _make_enrollment(
+    *,
+    service_type: ServiceType = ServiceType.EVENT,
+    instance_title: str | None = "June Weekend",
+    service_title: str | None = "Event Parent",
+    tier_name: str | None = None,
+    cohort: str | None = None,
+    status: EnrollmentStatus = EnrollmentStatus.CONFIRMED,
+) -> Any:
+    tier = SimpleNamespace(name=tier_name) if tier_name else None
+    svc = SimpleNamespace(
+        title=service_title,
+        service_tier="ignored",
+        service_type=service_type,
+    )
+    inst = SimpleNamespace(title=instance_title, cohort=cohort, service=svc)
+    return SimpleNamespace(
+        instance=inst,
+        ticket_tier_id=uuid4() if tier else None,
+        ticket_tier=tier,
+        status=status,
+    )
+
+
+class _FakeScalars:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
+class _FakeUnique:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def scalars(self) -> _FakeScalars:
+        return _FakeScalars(self._rows)
+
+
+class _FakeExecuteResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def unique(self) -> _FakeUnique:
+        return _FakeUnique(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def __enter__(self) -> "_FakeSession":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def execute(self, _stmt: Any) -> _FakeExecuteResult:
+        return _FakeExecuteResult(self._rows)
+
+
+def _patch_session(monkeypatch: pytest.MonkeyPatch, rows: list[Any]) -> None:
+    monkeypatch.setattr(
+        admin_entity_services,
+        "Session",
+        lambda *_a, **_k: _FakeSession(rows),
+    )
+    monkeypatch.setattr(admin_entity_services, "get_engine", lambda: object())
+
+
+def test_list_contact_services_returns_labels(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    contact_id = uuid4()
+    en = _make_enrollment()
+    expected = build_enrollment_invoice_line_description(en)  # type: ignore[arg-type]
+
+    class _FakeContactRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_for_admin(self, cid: Any) -> object:
+            assert cid == contact_id
+            return object()
+
+    _patch_session(monkeypatch, [en])
+    monkeypatch.setattr(admin_entity_services, "ContactRepository", _FakeContactRepo)
+
+    resp = admin_entity_services.list_contact_services(
+        api_gateway_event(method="GET", path=f"/v1/admin/contacts/{contact_id}/services"),
+        contact_id=contact_id,
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body == {"items": [{"label": expected}]}
+
+
+def test_list_contact_services_excludes_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    contact_id = uuid4()
+
+    class _FakeContactRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_for_admin(self, _cid: Any) -> object:
+            return object()
+
+    _patch_session(monkeypatch, [])
+    monkeypatch.setattr(admin_entity_services, "ContactRepository", _FakeContactRepo)
+
+    resp = admin_entity_services.list_contact_services(
+        api_gateway_event(method="GET", path=f"/v1/admin/contacts/{contact_id}/services"),
+        contact_id=contact_id,
+    )
+    assert resp["statusCode"] == 200
+    assert json.loads(resp["body"]) == {"items": []}
+
+
+def test_list_contact_services_unknown_contact_404(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    contact_id = uuid4()
+
+    class _FakeContactRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_for_admin(self, _cid: Any) -> None:
+            return None
+
+    _patch_session(monkeypatch, [])
+    monkeypatch.setattr(admin_entity_services, "ContactRepository", _FakeContactRepo)
+
+    with pytest.raises(NotFoundError, match="Contact"):
+        admin_entity_services.list_contact_services(
+            api_gateway_event(method="GET", path=f"/v1/admin/contacts/{contact_id}/services"),
+            contact_id=contact_id,
+        )
+
+
+def test_list_family_services_includes_member_enrollments_and_dedupes(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    family_id = uuid4()
+    en_family = _make_enrollment(instance_title="Shared Label", service_title="Event Parent")
+    en_member = _make_enrollment(instance_title="Shared Label", service_title="Event Parent")
+    label = build_enrollment_invoice_line_description(en_family)  # type: ignore[arg-type]
+
+    class _FakeFamilyRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_for_admin(self, fid: Any) -> object:
+            assert fid == family_id
+            return object()
+
+    _patch_session(monkeypatch, [en_family, en_member])
+    monkeypatch.setattr(admin_entity_services, "FamilyRepository", _FakeFamilyRepo)
+
+    resp = admin_entity_services.list_family_services(
+        api_gateway_event(method="GET", path=f"/v1/admin/families/{family_id}/services"),
+        family_id=family_id,
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body == {"items": [{"label": label}]}
+
+
+def test_list_family_services_unknown_family_404(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    family_id = uuid4()
+
+    class _FakeFamilyRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_for_admin(self, _fid: Any) -> None:
+            return None
+
+    _patch_session(monkeypatch, [])
+    monkeypatch.setattr(admin_entity_services, "FamilyRepository", _FakeFamilyRepo)
+
+    with pytest.raises(NotFoundError, match="Family"):
+        admin_entity_services.list_family_services(
+            api_gateway_event(method="GET", path=f"/v1/admin/families/{family_id}/services"),
+            family_id=family_id,
+        )
+
+
+def test_list_organization_services_includes_member_enrollments(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    organization_id = uuid4()
+    en_org = _make_enrollment(
+        service_type=ServiceType.CONSULTATION,
+        instance_title="Intro",
+        service_title=None,
+    )
+    en_member = _make_enrollment(
+        service_type=ServiceType.TRAINING_COURSE,
+        instance_title="Course A",
+        service_title="Course Parent",
+    )
+    labels = sorted(
+        [
+            build_enrollment_invoice_line_description(en_org),  # type: ignore[arg-type]
+            build_enrollment_invoice_line_description(en_member),  # type: ignore[arg-type]
+        ]
+    )
+
+    class _FakeOrgRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_non_vendor_organization_by_id(self, oid: Any) -> object:
+            assert oid == organization_id
+            return object()
+
+    _patch_session(monkeypatch, [en_org, en_member])
+    monkeypatch.setattr(admin_entity_services, "OrganizationRepository", _FakeOrgRepo)
+
+    resp = admin_entity_services.list_organization_services(
+        api_gateway_event(
+            method="GET",
+            path=f"/v1/admin/organizations/{organization_id}/services",
+        ),
+        organization_id=organization_id,
+    )
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert [item["label"] for item in body["items"]] == labels
+
+
+def test_list_organization_services_unknown_organization_404(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    organization_id = uuid4()
+
+    class _FakeOrgRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_non_vendor_organization_by_id(self, _oid: Any) -> None:
+            return None
+
+    _patch_session(monkeypatch, [])
+    monkeypatch.setattr(admin_entity_services, "OrganizationRepository", _FakeOrgRepo)
+
+    with pytest.raises(NotFoundError, match="Organization"):
+        admin_entity_services.list_organization_services(
+            api_gateway_event(
+                method="GET",
+                path=f"/v1/admin/organizations/{organization_id}/services",
+            ),
+            organization_id=organization_id,
+        )
+
+
+def test_handle_admin_contacts_services_get(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    marker = {"statusCode": 200, "body": "{}"}
+    contact_id = str(uuid4())
+
+    def _fake_list(_event: Any, *, contact_id: Any) -> dict[str, Any]:
+        assert str(contact_id)
+        return marker
+
+    monkeypatch.setattr(admin_contacts, "list_contact_services", _fake_list)
+    monkeypatch.setattr(
+        admin_contacts,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_contacts.handle_admin_contacts_request(
+        api_gateway_event(method="GET", path=f"/v1/admin/contacts/{contact_id}/services"),
+        "GET",
+        f"/v1/admin/contacts/{contact_id}/services",
+    )
+
+    assert response is marker
+
+
+def test_handle_admin_families_services_get(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    marker = {"statusCode": 200, "body": "{}"}
+    family_id = str(uuid4())
+
+    def _fake_list(_event: Any, *, family_id: Any) -> dict[str, Any]:
+        assert str(family_id)
+        return marker
+
+    monkeypatch.setattr(admin_families, "list_family_services", _fake_list)
+    monkeypatch.setattr(
+        admin_families,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_families.handle_admin_families_request(
+        api_gateway_event(method="GET", path=f"/v1/admin/families/{family_id}/services"),
+        "GET",
+        f"/v1/admin/families/{family_id}/services",
+    )
+
+    assert response is marker
+
+
+def test_handle_admin_organizations_services_get(
+    monkeypatch: Any,
+    api_gateway_event: Any,
+) -> None:
+    marker = {"statusCode": 200, "body": "{}"}
+    organization_id = str(uuid4())
+
+    def _fake_list(_event: Any, *, organization_id: Any) -> dict[str, Any]:
+        assert str(organization_id)
+        return marker
+
+    monkeypatch.setattr(admin_organizations, "list_organization_services", _fake_list)
+    monkeypatch.setattr(
+        admin_organizations,
+        "extract_identity",
+        lambda _event: type("Identity", (), {"user_sub": "admin-sub"})(),
+    )
+
+    response = admin_organizations.handle_admin_organizations_request(
+        api_gateway_event(
+            method="GET",
+            path=f"/v1/admin/organizations/{organization_id}/services",
+        ),
+        "GET",
+        f"/v1/admin/organizations/{organization_id}/services",
+    )
+
+    assert response is marker

--- a/tests/api/test_admin_entity_services.py
+++ b/tests/api/test_admin_entity_services.py
@@ -6,13 +6,28 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
-from app.api import admin_contacts, admin_entity_services, admin_families, admin_organizations
+from app.api import (
+    admin_contacts,
+    admin_entity_services,
+    admin_families,
+    admin_organizations,
+)
 from app.api.admin_billing_invoice_draft_helpers import (
     build_enrollment_invoice_line_description,
 )
 from app.db.models.enums import EnrollmentStatus, ServiceType
 from app.exceptions import NotFoundError
+
+
+def _compiled_sql(stmt: Any) -> str:
+    return str(
+        stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
 
 
 def _make_enrollment(
@@ -66,6 +81,7 @@ class _FakeExecuteResult:
 class _FakeSession:
     def __init__(self, rows: list[Any]) -> None:
         self._rows = rows
+        self.statements: list[Any] = []
 
     def __enter__(self) -> "_FakeSession":
         return self
@@ -73,17 +89,23 @@ class _FakeSession:
     def __exit__(self, *_args: Any) -> None:
         return None
 
-    def execute(self, _stmt: Any) -> _FakeExecuteResult:
+    def execute(self, stmt: Any) -> _FakeExecuteResult:
+        self.statements.append(stmt)
         return _FakeExecuteResult(self._rows)
 
 
-def _patch_session(monkeypatch: pytest.MonkeyPatch, rows: list[Any]) -> None:
+def _patch_session(
+    monkeypatch: pytest.MonkeyPatch,
+    rows: list[Any],
+) -> _FakeSession:
+    session = _FakeSession(rows)
     monkeypatch.setattr(
         admin_entity_services,
         "Session",
-        lambda *_a, **_k: _FakeSession(rows),
+        lambda *_a, **_k: session,
     )
     monkeypatch.setattr(admin_entity_services, "get_engine", lambda: object())
+    return session
 
 
 def test_list_contact_services_returns_labels(
@@ -112,6 +134,35 @@ def test_list_contact_services_returns_labels(
     assert resp["statusCode"] == 200
     body = json.loads(resp["body"])
     assert body == {"items": [{"label": expected}]}
+
+
+def test_list_contact_services_query_filters_by_contact_and_non_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    contact_id = uuid4()
+
+    class _FakeContactRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_for_admin(self, _cid: Any) -> object:
+            return object()
+
+    session = _patch_session(monkeypatch, [])
+    monkeypatch.setattr(admin_entity_services, "ContactRepository", _FakeContactRepo)
+
+    admin_entity_services.list_contact_services(
+        api_gateway_event(method="GET", path=f"/v1/admin/contacts/{contact_id}/services"),
+        contact_id=contact_id,
+    )
+
+    assert len(session.statements) == 1
+    sql = _compiled_sql(session.statements[0])
+    assert "enrollments.contact_id" in sql
+    assert str(contact_id) in sql
+    assert "enrollments.status" in sql
+    assert "cancelled" in sql.lower()
 
 
 def test_list_contact_services_excludes_cancelled(
@@ -159,6 +210,36 @@ def test_list_contact_services_unknown_contact_404(
             api_gateway_event(method="GET", path=f"/v1/admin/contacts/{contact_id}/services"),
             contact_id=contact_id,
         )
+
+
+def test_list_family_services_query_includes_family_and_member_contacts(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    family_id = uuid4()
+
+    class _FakeFamilyRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_by_id_for_admin(self, _fid: Any) -> object:
+            return object()
+
+    session = _patch_session(monkeypatch, [])
+    monkeypatch.setattr(admin_entity_services, "FamilyRepository", _FakeFamilyRepo)
+
+    admin_entity_services.list_family_services(
+        api_gateway_event(method="GET", path=f"/v1/admin/families/{family_id}/services"),
+        family_id=family_id,
+    )
+
+    assert len(session.statements) == 1
+    sql = _compiled_sql(session.statements[0])
+    assert "enrollments.family_id" in sql
+    assert str(family_id) in sql
+    assert "family_members" in sql
+    assert "enrollments.contact_id" in sql
+    assert "cancelled" in sql.lower()
 
 
 def test_list_family_services_includes_member_enrollments_and_dedupes(
@@ -211,6 +292,39 @@ def test_list_family_services_unknown_family_404(
             api_gateway_event(method="GET", path=f"/v1/admin/families/{family_id}/services"),
             family_id=family_id,
         )
+
+
+def test_list_organization_services_query_includes_org_and_member_contacts(
+    monkeypatch: pytest.MonkeyPatch,
+    api_gateway_event: Any,
+) -> None:
+    organization_id = uuid4()
+
+    class _FakeOrgRepo:
+        def __init__(self, _session: Any) -> None:
+            pass
+
+        def get_non_vendor_organization_by_id(self, _oid: Any) -> object:
+            return object()
+
+    session = _patch_session(monkeypatch, [])
+    monkeypatch.setattr(admin_entity_services, "OrganizationRepository", _FakeOrgRepo)
+
+    admin_entity_services.list_organization_services(
+        api_gateway_event(
+            method="GET",
+            path=f"/v1/admin/organizations/{organization_id}/services",
+        ),
+        organization_id=organization_id,
+    )
+
+    assert len(session.statements) == 1
+    sql = _compiled_sql(session.statements[0])
+    assert "enrollments.organization_id" in sql
+    assert str(organization_id) in sql
+    assert "organization_members" in sql
+    assert "enrollments.contact_id" in sql
+    assert "cancelled" in sql.lower()
 
 
 def test_list_organization_services_includes_member_enrollments(

--- a/tests/api/test_admin_entity_services.py
+++ b/tests/api/test_admin_entity_services.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a read-only **Services** collapsible section after **Tags** in the Contacts, Families, and Organizations inline editor panels. The section lists purchased service instances using the same invoice-line label format as billing, and hides entirely when there are none.

## Backend

- Public alias `build_enrollment_invoice_line_description` reuses the existing billing formatter (no duplicated label logic).
- New `admin_entity_services.py` handlers:
  - `GET /v1/admin/contacts/{id}/services`
  - `GET /v1/admin/families/{id}/services`
  - `GET /v1/admin/organizations/{id}/services`
- Scope: non-cancelled enrollments by party attribution (`contact_id` / `family_id` / `organization_id`) plus member-contact enrollments for families/orgs; labels deduped and sorted alphabetically.
- Wired into existing Python-side admin dispatchers (no CDK change).

## Frontend

- `EntityServicesSection` collapsible component (self-hides when empty).
- `listAdminContactServices`, `listAdminFamilyServices`, `listAdminOrganizationServices` in `entity-api.ts`.
- Panels fetch labels in edit mode when a row is selected.
- **Review fix:** clears `serviceLabels` synchronously before each fetch to prevent stale labels flashing when switching rows.
- **Review fix:** family panel nests Services inside the Tags grid cell (matches organizations layout).

## Docs / API

- OpenAPI paths + `EntityServicesResponse` / `EntityServiceItem` schemas.
- `lambdas.md` updated for the new `/services` sub-resources.

## Tests

- `tests/api/test_admin_entity_services.py` — contact/family/org label resolution, dedupe, empty list, 404, route wiring, and compiled-SQL assertions for filter criteria.
- `entity-services-section.test.tsx` — render/hide behavior.
- `entity-api-services.test.ts` — API client label mapping.

## Validation

- `pre-commit run ruff-format --all-files`
- `pre-commit run ruff --all-files`
- `pytest tests/` — 1260 passed
- `npm run generate:admin-api-types && npm run check:admin-api-types && npm run lint && npx vitest run`
- `bash scripts/validate-cursorrules.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc8f8dc2-ab2f-4244-a996-5b61afcc2ffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc8f8dc2-ab2f-4244-a996-5b61afcc2ffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

