### PR TITLE
fix: resolve CodeQL alerts #26, #28, #31

### DIFF
--- a/apps/admin_web/src/components/auth-provider.tsx
+++ b/apps/admin_web/src/components/auth-provider.tsx
@@ -181,7 +181,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       try {
         const tokens = await respondToPasswordlessChallenge(cognitoUser, trimmedCode);
-        storeTokensFromPasswordless(tokens);
+        await storeTokensFromPasswordless(tokens);
         const profile = getUserProfile({
           accessToken: tokens.accessToken,
           idToken: tokens.idToken,

--- a/apps/admin_web/src/lib/auth.ts
+++ b/apps/admin_web/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { appConfig, getCognitoDomain } from './config';
 import { generatePkcePair } from './pkce';
+import { decryptFromBase64, encryptToBase64 } from './secure-storage';
 
 /** Cognito group names that may use the admin web app and admin API (see user pool groups in CDK). */
 export const COGNITO_STAFF_ADMIN_GROUPS = ['admin', 'manager', 'instructor'] as const;
@@ -41,7 +42,7 @@ export interface LoginOptions {
   returnTo?: string;
 }
 
-function loadTokens() {
+async function loadTokens(): Promise<StoredTokens | null> {
   if (typeof window === 'undefined') {
     return null;
   }
@@ -49,27 +50,33 @@ function loadTokens() {
   if (!raw) {
     return null;
   }
+  const decrypted = await decryptFromBase64(raw);
+  if (!decrypted) {
+    window.localStorage.removeItem(tokenStorageKey);
+    return null;
+  }
   try {
-    return JSON.parse(raw) as StoredTokens;
+    return JSON.parse(decrypted) as StoredTokens;
   } catch {
     return null;
   }
 }
 
-function storeTokens(tokens: StoredTokens) {
+async function storeTokens(tokens: StoredTokens): Promise<void> {
   if (typeof window === 'undefined') {
     return;
   }
-  window.localStorage.setItem(tokenStorageKey, JSON.stringify(tokens));
+  const encrypted = await encryptToBase64(JSON.stringify(tokens));
+  window.localStorage.setItem(tokenStorageKey, encrypted);
 }
 
-export function storeTokensFromPasswordless(tokens: {
+export async function storeTokensFromPasswordless(tokens: {
   accessToken: string;
   idToken: string;
   refreshToken?: string;
   expiresAt: number;
-}) {
-  storeTokens({
+}): Promise<void> {
+  await storeTokens({
     accessToken: tokens.accessToken,
     idToken: tokens.idToken,
     refreshToken: tokens.refreshToken,
@@ -255,7 +262,7 @@ export async function completeLogin() {
     refreshToken: data.refresh_token,
     expiresAt: Date.now() + expiresIn * 1000,
   };
-  storeTokens(tokens);
+  await storeTokens(tokens);
   window.sessionStorage.removeItem(pkceStorageKey);
   const redirectPath = resolveLoginRedirect();
   window.history.replaceState({}, document.title, url.pathname);
@@ -263,7 +270,7 @@ export async function completeLogin() {
 }
 
 export async function ensureFreshTokens() {
-  const tokens = loadTokens();
+  const tokens = await loadTokens();
   if (!tokens) {
     return null;
   }
@@ -299,7 +306,7 @@ export async function ensureFreshTokens() {
     refreshToken: data.refresh_token ?? tokens.refreshToken,
     expiresAt: Date.now() + expiresIn * 1000,
   };
-  storeTokens(refreshed);
+  await storeTokens(refreshed);
   return refreshed;
 }
 

--- a/apps/admin_web/src/lib/secure-storage.ts
+++ b/apps/admin_web/src/lib/secure-storage.ts
@@ -1,0 +1,179 @@
+/**
+ * Browser-side encryption helpers for data that must be persisted in
+ * `localStorage` (for example Cognito session tokens).
+ *
+ * Sensitive values are encrypted with AES-GCM using a non-extractable
+ * `CryptoKey`. The key is persisted in IndexedDB so it survives reloads but
+ * cannot be serialized out of the browser. When IndexedDB is unavailable the
+ * key is kept in memory only, so values written in one page session can still
+ * be read back during that session without ever being stored in clear text.
+ */
+
+const KEY_DB_NAME = 'admin_auth_secure_store';
+const KEY_DB_STORE = 'keys';
+const KEY_RECORD_ID = 'token_encryption_key';
+const IV_BYTE_LENGTH = 12;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+let cachedKeyPromise: Promise<CryptoKey> | null = null;
+
+function getCryptoSubtle(): SubtleCrypto | null {
+  if (typeof crypto === 'undefined' || !crypto.subtle) {
+    return null;
+  }
+  return crypto.subtle;
+}
+
+function getIndexedDbFactory(): IDBFactory | null {
+  if (typeof indexedDB === 'undefined') {
+    return null;
+  }
+  return indexedDB;
+}
+
+function openKeyDatabase(factory: IDBFactory): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = factory.open(KEY_DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(KEY_DB_STORE)) {
+        db.createObjectStore(KEY_DB_STORE);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function readPersistedKey(): Promise<CryptoKey | null> {
+  const factory = getIndexedDbFactory();
+  if (!factory) {
+    return null;
+  }
+  try {
+    const db = await openKeyDatabase(factory);
+    try {
+      return await new Promise<CryptoKey | null>((resolve, reject) => {
+        const transaction = db.transaction(KEY_DB_STORE, 'readonly');
+        const request = transaction.objectStore(KEY_DB_STORE).get(KEY_RECORD_ID);
+        request.onsuccess = () => {
+          const value = request.result;
+          resolve(value instanceof CryptoKey ? value : null);
+        };
+        request.onerror = () => reject(request.error);
+      });
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+async function persistKey(key: CryptoKey): Promise<void> {
+  const factory = getIndexedDbFactory();
+  if (!factory) {
+    return;
+  }
+  try {
+    const db = await openKeyDatabase(factory);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const transaction = db.transaction(KEY_DB_STORE, 'readwrite');
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        transaction.objectStore(KEY_DB_STORE).put(key, KEY_RECORD_ID);
+      });
+    } finally {
+      db.close();
+    }
+  } catch {
+    // A persistence failure is non-fatal; the in-memory key still works for
+    // the current page session.
+  }
+}
+
+async function resolveEncryptionKey(subtle: SubtleCrypto): Promise<CryptoKey> {
+  const persisted = await readPersistedKey();
+  if (persisted) {
+    return persisted;
+  }
+  const key = await subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, [
+    'encrypt',
+    'decrypt',
+  ]);
+  await persistKey(key);
+  return key;
+}
+
+function getEncryptionKey(subtle: SubtleCrypto): Promise<CryptoKey> {
+  if (!cachedKeyPromise) {
+    cachedKeyPromise = resolveEncryptionKey(subtle).catch((error) => {
+      cachedKeyPromise = null;
+      throw error;
+    });
+  }
+  return cachedKeyPromise;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+/** Returns true when the browser exposes the crypto primitives we depend on. */
+export function isSecureStorageSupported(): boolean {
+  return getCryptoSubtle() !== null;
+}
+
+/** Encrypts a UTF-8 string, returning a base64 payload that bundles the IV. */
+export async function encryptToBase64(plaintext: string): Promise<string> {
+  const subtle = getCryptoSubtle();
+  if (!subtle) {
+    throw new Error('Web Crypto is not available for secure storage.');
+  }
+  const key = await getEncryptionKey(subtle);
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTE_LENGTH));
+  const ciphertext = await subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    textEncoder.encode(plaintext),
+  );
+  const ciphertextBytes = new Uint8Array(ciphertext);
+  const combined = new Uint8Array(iv.length + ciphertextBytes.length);
+  combined.set(iv, 0);
+  combined.set(ciphertextBytes, iv.length);
+  return bytesToBase64(combined);
+}
+
+/** Decrypts a payload produced by {@link encryptToBase64}, or null on failure. */
+export async function decryptFromBase64(payload: string): Promise<string | null> {
+  const subtle = getCryptoSubtle();
+  if (!subtle) {
+    return null;
+  }
+  try {
+    const key = await getEncryptionKey(subtle);
+    const combined = base64ToBytes(payload);
+    const iv = combined.subarray(0, IV_BYTE_LENGTH);
+    const ciphertext = combined.subarray(IV_BYTE_LENGTH);
+    const plaintext = await subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+    return textDecoder.decode(plaintext);
+  } catch {
+    return null;
+  }
+}

--- a/apps/admin_web/tests/lib/auth.test.ts
+++ b/apps/admin_web/tests/lib/auth.test.ts
@@ -29,6 +29,38 @@ async function loadAuthModule() {
   return import('@/lib/auth');
 }
 
+const TOKEN_STORAGE_KEY = 'admin_auth_tokens';
+
+/**
+ * Loads the auth module together with the secure-storage helpers from the same
+ * module registry so encrypt/decrypt share the same in-memory key, then returns
+ * helpers for seeding and reading the encrypted token blob in tests.
+ */
+async function loadAuthWithStorage() {
+  const auth = await loadAuthModule();
+  const secureStorage = await import('@/lib/secure-storage');
+
+  return {
+    auth,
+    async seedStoredTokens(tokens: {
+      accessToken: string;
+      idToken: string;
+      refreshToken?: string;
+      expiresAt: number;
+    }) {
+      await auth.storeTokensFromPasswordless(tokens);
+    },
+    async readStoredTokens() {
+      const raw = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+      const decrypted = await secureStorage.decryptFromBase64(raw);
+      return decrypted ? JSON.parse(decrypted) : null;
+    },
+  };
+}
+
 describe('auth helpers', () => {
   const originalEnv = { ...process.env };
 
@@ -78,19 +110,16 @@ describe('auth helpers', () => {
   });
 
   it('returns current tokens when not near expiry', async () => {
-    const auth = await loadAuthModule();
+    const { auth, seedStoredTokens } = await loadAuthWithStorage();
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
     const fetchMock = vi.mocked(fetch);
 
-    window.localStorage.setItem(
-      'admin_auth_tokens',
-      JSON.stringify({
-        accessToken: 'access',
-        idToken: 'id',
-        refreshToken: 'refresh',
-        expiresAt: 1_700_000_200_000,
-      })
-    );
+    await seedStoredTokens({
+      accessToken: 'access',
+      idToken: 'id',
+      refreshToken: 'refresh',
+      expiresAt: 1_700_000_200_000,
+    });
 
     const tokens = await auth.ensureFreshTokens();
 
@@ -104,20 +133,34 @@ describe('auth helpers', () => {
     nowSpy.mockRestore();
   });
 
+  it('does not persist tokens as clear text in localStorage', async () => {
+    const { seedStoredTokens } = await loadAuthWithStorage();
+
+    await seedStoredTokens({
+      accessToken: 'secret-access',
+      idToken: 'secret-id',
+      refreshToken: 'secret-refresh',
+      expiresAt: 1_700_000_200_000,
+    });
+
+    const raw = window.localStorage.getItem(TOKEN_STORAGE_KEY) ?? '';
+    expect(raw).not.toBe('');
+    expect(raw).not.toContain('secret-access');
+    expect(raw).not.toContain('secret-id');
+    expect(raw).not.toContain('secret-refresh');
+  });
+
   it('refreshes expired tokens using refresh token and stores new values', async () => {
-    const auth = await loadAuthModule();
+    const { auth, seedStoredTokens, readStoredTokens } = await loadAuthWithStorage();
     vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
     const fetchMock = vi.mocked(fetch);
 
-    window.localStorage.setItem(
-      'admin_auth_tokens',
-      JSON.stringify({
-        accessToken: 'old-access',
-        idToken: 'old-id',
-        refreshToken: 'old-refresh',
-        expiresAt: 1_700_000_010_000,
-      })
-    );
+    await seedStoredTokens({
+      accessToken: 'old-access',
+      idToken: 'old-id',
+      refreshToken: 'old-refresh',
+      expiresAt: 1_700_000_010_000,
+    });
 
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -137,23 +180,23 @@ describe('auth helpers', () => {
       refreshToken: 'new-refresh',
     });
 
-    const stored = JSON.parse(window.localStorage.getItem('admin_auth_tokens') ?? '{}');
+    const stored = (await readStoredTokens()) ?? {};
     expect(stored.accessToken).toBe('new-access');
     expect(stored.idToken).toBe('new-id');
     expect(stored.refreshToken).toBe('new-refresh');
   });
 
   it('stores tokens from passwordless flow', async () => {
-    const auth = await loadAuthModule();
+    const { seedStoredTokens, readStoredTokens } = await loadAuthWithStorage();
 
-    auth.storeTokensFromPasswordless({
+    await seedStoredTokens({
       accessToken: 'pwd-access',
       idToken: 'pwd-id',
       refreshToken: 'pwd-refresh',
       expiresAt: 1_700_000_200_000,
     });
 
-    const stored = JSON.parse(window.localStorage.getItem('admin_auth_tokens') ?? '{}');
+    const stored = await readStoredTokens();
     expect(stored).toEqual({
       accessToken: 'pwd-access',
       idToken: 'pwd-id',

--- a/apps/public_www/public/scripts/init-gtm.js
+++ b/apps/public_www/public/scripts/init-gtm.js
@@ -28,7 +28,7 @@
   }
 
   var gtmId = document.documentElement.getAttribute('data-gtm-id');
-  if (!gtmId || gtmId.indexOf('GTM-') !== 0) {
+  if (!gtmId || !/^GTM-[A-Z0-9]+$/.test(gtmId)) {
     return;
   }
 
@@ -37,6 +37,7 @@
 
   var script = document.createElement('script');
   script.async = true;
-  script.src = 'https://www.googletagmanager.com/gtm.js?id=' + gtmId;
+  script.src =
+    'https://www.googletagmanager.com/gtm.js?id=' + encodeURIComponent(gtmId);
   document.head.appendChild(script);
 })();

--- a/apps/public_www/scripts/validate-csp-meta.mjs
+++ b/apps/public_www/scripts/validate-csp-meta.mjs
@@ -98,12 +98,12 @@ async function main() {
     }
 
     const cspValue = cspMetaMatch[1]
-      .replaceAll('&amp;', '&')
       .replaceAll('&quot;', '"')
       .replaceAll('&#x27;', "'")
       .replaceAll('&#39;', "'")
       .replaceAll('&lt;', '<')
-      .replaceAll('&gt;', '>');
+      .replaceAll('&gt;', '>')
+      .replaceAll('&amp;', '&');
     const scriptDirective = cspValue.match(/script-src\s+([^;]+)/i)?.[1] ?? '';
     const styleDirective = cspValue.match(/style-src\s+([^;]+)/i)?.[1] ?? '';
     const cspScriptHashes = collectCspHashes(scriptDirective);

--- a/apps/public_www/tests/components/shared/google-tag-manager.test.tsx
+++ b/apps/public_www/tests/components/shared/google-tag-manager.test.tsx
@@ -86,4 +86,19 @@ describe('GoogleTagManager', () => {
 
     expect(document.querySelector(GTM_REMOTE_SCRIPT_SELECTOR)).toBeNull();
   });
+
+  it('does not inject GTM runtime script when the GTM id contains unexpected characters', () => {
+    document.documentElement.setAttribute(
+      'data-gtm-id',
+      'GTM-ABC"><img src=x onerror=alert(1)>',
+    );
+    document.documentElement.setAttribute(
+      'data-gtm-allowed-hosts',
+      'localhost, www.example.com',
+    );
+
+    runInitGtmScript();
+
+    expect(document.querySelector(GTM_REMOTE_SCRIPT_SELECTOR)).toBeNull();
+  });
 });

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -106,6 +106,17 @@ groups **`admin`**, **`manager`**, or **`instructor`**. Users who complete socia
 or passwordless sign-in without any of these groups must not see the admin
 dashboard; the client shows an access-denied state and sign out instead.
 
+Cognito session tokens (access, id, and refresh) are never written to
+`localStorage` in clear text. `apps/admin_web/src/lib/auth.ts` serializes the
+token bundle and encrypts it with AES-GCM via
+`apps/admin_web/src/lib/secure-storage.ts` before persisting it. The AES key is
+a non-extractable Web Crypto `CryptoKey` kept in IndexedDB so it survives
+reloads but cannot be serialized out of the browser; if IndexedDB is
+unavailable the key stays in memory for the current page session only. This is
+defense-in-depth for data at rest and does not replace standard XSS
+protections (CSP, input sanitization), since any in-page script can still ask
+the browser to decrypt.
+
 ### JWT audience / client verification
 
 Cognito ID tokens carry the app client id in the `aud` claim; access tokens use


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves three open CodeQL alerts.

### #31 — Clear text storage of sensitive information (`apps/admin_web/src/lib/auth.ts`)
Cognito session tokens (access/id/refresh) were written to `localStorage` as clear-text JSON.

- New `apps/admin_web/src/lib/secure-storage.ts` encrypts values with **AES-GCM** using a **non-extractable** Web Crypto `CryptoKey`.
- The key is persisted in **IndexedDB** (survives reloads, cannot be serialized out of the browser). When IndexedDB is unavailable, the key stays in memory for the current page session only — so values are never stored in clear text.
- `auth.ts` now encrypts before `localStorage.setItem` and decrypts on load (`storeTokens`/`loadTokens`/`storeTokensFromPasswordless` became async; callers updated, including `auth-provider.tsx`).
- This is defense-in-depth for data at rest; it does not replace XSS protections (any in-page script can still ask the browser to decrypt).

### #28 — DOM text reinterpreted as HTML (`apps/public_www/public/scripts/init-gtm.js`)
The GTM container id read from the `data-gtm-id` attribute fed into `script.src`.

- The id is now validated against a strict `/^GTM-[A-Z0-9]+$/` allowlist and `encodeURIComponent`-encoded before use.

### #26 — Double escaping or unescaping (`apps/public_www/scripts/validate-csp-meta.mjs`)
HTML entity unescaping decoded `&amp;` first, which can double-unescape values like `&amp;quot;`.

- Reordered so the escape character (`&`) is unescaped **last**, ensuring each entity decodes exactly once.

## Testing
- `apps/admin_web`: `npm run lint` ✅, full `vitest run` (633 tests) ✅
- `apps/public_www`: `npm run lint` ✅, full `vitest run` (790 tests) ✅
- `bash scripts/validate-cursorrules.sh` ✅
- Added regression tests: GTM rejects malformed ids; admin tokens are not persisted as clear text.

## Docs
- Updated `docs/architecture/security.md` (admin web token-at-rest encryption).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-896a356b-3350-4338-8922-a2bcebb61355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-896a356b-3350-4338-8922-a2bcebb61355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

