### PR TITLE
fix(admin_web): resolve BufferSource type error breaking production build

### DIFF
--- a/apps/admin_web/src/lib/secure-storage.ts
+++ b/apps/admin_web/src/lib/secure-storage.ts
@@ -126,7 +126,7 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
-function base64ToBytes(value: string): Uint8Array {
+function base64ToBytes(value: string): Uint8Array<ArrayBuffer> {
   const binary = atob(value);
   const bytes = new Uint8Array(binary.length);
   for (let index = 0; index < binary.length; index += 1) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`npm run build` in `apps/admin_web` failed the production TypeScript check:

```
./src/lib/secure-storage.ts:174:63
Type error: Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BufferSource'.
  ...
  Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
    Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer' ...
```

Under the newer typed-array generics (TypeScript 6), `BufferSource` resolves to an `ArrayBuffer`-backed view (`ArrayBufferView<ArrayBuffer> | ArrayBuffer`) and excludes `SharedArrayBuffer`. The `base64ToBytes` helper declared a plain `Uint8Array` (i.e. `Uint8Array<ArrayBufferLike>`), so the `subarray()` slices passed into `subtle.decrypt(...)` no longer satisfied `BufferSource`.

## Fix

Annotate `base64ToBytes` to return `Uint8Array<ArrayBuffer>`, which accurately matches the `ArrayBuffer` it allocates via `new Uint8Array(binary.length)`. This propagates the concrete buffer type through `subarray()`, satisfying the `BufferSource` parameter of `subtle.decrypt`.

## Verification

- `npx tsc --noEmit` — no more `secure-storage` errors.
- `npm run build` — completes successfully (exit code 0).

The pre-existing `js-cookie` import warnings from `amazon-cognito-identity-js` are upstream, non-fatal warnings and were present before this change; they do not fail the build and are out of scope here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f5723c7-2c9b-4cff-84f4-0dd6c27f69e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f5723c7-2c9b-4cff-84f4-0dd6c27f69e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

