### PR TITLE
chore(deps): ignore TypeScript major bumps until toolchain supports TS 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -165,6 +165,11 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript-eslint"
         update-types: ["version-update:semver-major"]
+      # TypeScript 7.0 drops the compiler API used by openapi-typescript, and
+      # typescript-eslint still peers typescript <6.1.0. Keep majors ignored
+      # until both support TS 7 (see PRs #1876 / #1877).
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # NPM - Public website app
   - package-ecosystem: "npm"
@@ -197,4 +202,9 @@ updates:
       - dependency-name: "@eslint/compat"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript-eslint"
+        update-types: ["version-update:semver-major"]
+      # TypeScript 7.0 drops the compiler API used by openapi-typescript, and
+      # typescript-eslint still peers typescript <6.1.0. Keep majors ignored
+      # until both support TS 7 (see PRs #1876 / #1877).
+      - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dependabot PRs #1876 and #1877 bump `typescript` 6.0.3 → 7.0.2 in `admin_web` and `public_www`. Those bumps cannot land yet:

- `openapi-typescript` crashes on TS 7 (`ts.factory` / compiler API removed in 7.0; see [openapi-ts#2841](https://github.com/openapi-ts/openapi-typescript/issues/2841))
- `typescript-eslint` still peers `typescript@>=4.8.4 <6.1.0`

This PR ignores TypeScript major updates for both web apps (same pattern as the existing ESLint 10 ignores) so Dependabot stops opening broken majors.

## Test plan

- [ ] Confirm `.github/dependabot.yml` ignores `typescript` majors under `/apps/admin_web` and `/apps/public_www`
- [ ] Close #1876 and #1877 as blocked by upstream toolchain support

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fee66-e4d8-7218-9595-5ed73e88b86d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fee66-e4d8-7218-9595-5ed73e88b86d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

